### PR TITLE
fix: unit tests were using strict equality testing for numeric results; now check 15 decimals

### DIFF
--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -86,6 +86,8 @@ Blockly.JavaScript['unittest_main'].defineAssert_ = function(block) {
         '  function equals(a, b) {',
         '    if (a === b) {',
         '      return true;',
+        '    } else if ((typeof a == "number") && (typeof b == "number") && (a.toPrecision(15) == b.toPrecision(15))) {',
+        '      return true;',
         '    } else if (a instanceof Array && b instanceof Array) {',
         '      if (a.length != b.length) {',
         '        return false;',


### PR DESCRIPTION
The "exp" test in the Math unit tests was failing, despite expected and actual results being almost identical. I modified the assertEquals function to use 15 decimals of precision when comparing numbers, which seems reasonable based on discussion here:
http://www.w3schools.com/js/js_numbers.asp

I also tried 17 decimals, which still failed, and 16 decimals, which passed but I figured I'd be a little more conservative. All other math unit tests still pass.
