### PR TITLE
add checks for lack of event.clientX or event.clientY in onMouseDown_, and use requestAnimationFrame instead of setTimeout for animations

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -356,7 +356,7 @@ Blockly.BlockSvg.disposeUiStep_ = function(clone) {
     var closure = function() {
       Blockly.BlockSvg.disposeUiStep_(clone);
     };
-    window.setTimeout(closure, 10);
+    window.requestAnimationFrame(closure);
   }
 };
 
@@ -401,7 +401,7 @@ Blockly.BlockSvg.connectionUiStep_ = function(ripple) {
     var closure = function() {
       Blockly.BlockSvg.connectionUiStep_(ripple);
     };
-    window.setTimeout(closure, 10);
+    window.requestAnimationFrame(closure);
   }
 };
 

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -268,6 +268,10 @@ Blockly.svgResize = function() {
  * @private
  */
 Blockly.onMouseDown_ = function(e) {
+  // two finger drag events on mobile safari don't contain a clientX or clientY. Ignore these.
+  if (!e.clientX || !e.clientY) {
+    return;
+  }
   Blockly.svgResize();
   Blockly.terminateDrag_();  // In case mouse-up event was lost.
   Blockly.hideChaff();
@@ -332,6 +336,10 @@ Blockly.onMouseUp_ = function(e) {
  * @private
  */
 Blockly.onMouseMove_ = function(e) {
+  // two finger drag events on mobile safari don't contain a clientX or clientY. Ignore these.
+  if (!e.clientX || !e.clientY) {
+    return;
+  }
   if (Blockly.mainWorkspace.dragMode) {
     Blockly.removeAllRanges();
     var dx = e.clientX - Blockly.mainWorkspace.startDragMouseX;


### PR DESCRIPTION
requestAnimationFrame is a better API to use than setTimeout for animations like this, as browsers call this function when it is ready for the next repaint in its event loop.

https://developer.mozilla.org/en-US/docs/Web/API/window.requestAnimationFrame

This would need a polyfill to work with older browsers, but I'm not sure where to stick that in the blockly codebase. I would use this polyfill: https://gist.github.com/paulirish/1579671

Also, I noticed that two finger drag events on my iPad didn't report event.clientX or event.clientY, causing a lot of errors to occur when doing two finger drags.
