### PR TITLE
Don't factor in checkmark size for LTR dropdowns

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -173,7 +173,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
       xy.x = scrollOffset.x + menuSize.width;
     }
   } else {
-    xy.x -= Blockly.FieldDropdown.CHECKMARK_OVERHANG;
     // Don't go offscreen right.
     if (xy.x > windowSize.width + scrollOffset.x - menuSize.width) {
       xy.x = windowSize.width + scrollOffset.x - menuSize.width;


### PR DESCRIPTION
Dropdowns are drawn 25px to the left of where they should be in left-to-right layouts.  This fixes that.
