### PR TITLE
Don't ignore touch events on iOS 7.1.2 or later.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -267,8 +267,9 @@ Blockly.Field.prototype.setValue = function(text) {
  */
 Blockly.Field.prototype.onMouseUp_ = function(e) {
   if ((goog.userAgent.IPHONE || goog.userAgent.IPAD) &&
-      e.layerX !== 0 && e.layerY !== 0) {
-    // iOS spawns a bogus event on the next touch after a 'prompt()' edit.
+      e.layerX !== 0 && e.layerY !== 0 &&
+      !goog.userAgent.isVersionOrHigher('537.51.2')) {
+    // Old iOS spawns a bogus event on the next touch after a 'prompt()' edit.
     // Unlike the real events, these have a layerX and layerY set.
     return;
   } else if (Blockly.isRightButton(e)) {


### PR DESCRIPTION
As a partial resolution for #17, I'm proposing that iOS touch events not be ignored for versions of iOS known to not exhibit the bug where a bogus event is generated after alert()/prompt() calls.  Unfortunately, I can only test down to iOS 7.1.2, but until I get an iOS 6 device this will at least fix #17 on some devices (without breaking it on others).