### PR TITLE
Don't crash on prompt cancel.

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -253,6 +253,9 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
  * @return {?string} A string representing a valid number, or null if invalid.
  */
 Blockly.FieldTextInput.numberValidator = function(text) {
+  if(text === null) {
+    return null;
+  }
   // TODO: Handle cases like 'ten', '1.203,14', etc.
   // 'O' is sometimes mistaken for '0' by inexperienced users.
   text = text.replace(/O/ig, '0');


### PR DESCRIPTION
If the user hits "Cancel" then `window.prompt()` will return `null`.  As-is, the code crashes when that happens (trying to call `null.replace(...)`).
