### PR TITLE
bugfix: allow user-defined inter-statement notch to be of any width and non-symmetrical

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -755,6 +755,16 @@ Blockly.BlockSvg.TAB_WIDTH = 8;
  */
 Blockly.BlockSvg.NOTCH_WIDTH = 30;
 /**
+ * Width of the notch itself.
+ * @const
+ */
+Blockly.BlockSvg.NOTCH_OWN_WIDTH = 15;
+/**
+ * Width of the horizontal flanking region on both sides of the highlighted notch.
+ * @const
+ */
+Blockly.BlockSvg.NOTCH_HIGHLIGHT_FLANKING_WIDTH = 5;
+/**
  * Rounded corner radius.
  * @const
  */
@@ -784,16 +794,17 @@ Blockly.BlockSvg.DISTANCE_45_OUTSIDE = (1 - Math.SQRT1_2) *
  */
 Blockly.BlockSvg.NOTCH_PATH_LEFT = 'l 6,4 3,0 6,-4';
 /**
- * SVG path for drawing next/previous notch from left to right with
- * highlighting.
- * @const
- */
-Blockly.BlockSvg.NOTCH_PATH_LEFT_HIGHLIGHT = 'l 6.5,4 2,0 6.5,-4';
-/**
  * SVG path for drawing next/previous notch from right to left.
  * @const
  */
 Blockly.BlockSvg.NOTCH_PATH_RIGHT = 'l -6,4 -3,0 -6,-4';
+/**
+ * SVG path for drawing next/previous notch from left to right with 3D effect.
+ * Beware!!! This effect has nothing to do with the "selective" highlighting
+ * as used throughout the rest of the project. It's a dangerous collision of terms.
+ * @const
+ */
+Blockly.BlockSvg.NOTCH_PATH_LEFT_HIGHLIGHT = 'l 6.5,4 2,0 6.5,-4';
 /**
  * SVG path for drawing jagged teeth at the end of collapsed blocks.
  * @const
@@ -869,7 +880,7 @@ Blockly.BlockSvg.TOP_LEFT_CORNER_HIGHLIGHT =
  */
 Blockly.BlockSvg.INNER_TOP_LEFT_CORNER =
     Blockly.BlockSvg.NOTCH_PATH_RIGHT + ' h -' +
-    (Blockly.BlockSvg.NOTCH_WIDTH - 15 - Blockly.BlockSvg.CORNER_RADIUS) +
+    (Blockly.BlockSvg.NOTCH_WIDTH - Blockly.BlockSvg.NOTCH_OWN_WIDTH - Blockly.BlockSvg.CORNER_RADIUS) +
     ' a ' + Blockly.BlockSvg.CORNER_RADIUS + ',' +
     Blockly.BlockSvg.CORNER_RADIUS + ' 0 0,0 -' +
     Blockly.BlockSvg.CORNER_RADIUS + ',' +
@@ -1534,8 +1545,8 @@ Blockly.BlockSvg.prototype.renderDrawTop_ =
 
   // Top edge.
   if (this.previousConnection) {
-    steps.push('H', Blockly.BlockSvg.NOTCH_WIDTH - 15);
-    highlightSteps.push('H', Blockly.BlockSvg.NOTCH_WIDTH - 15);
+    steps.push('H', Blockly.BlockSvg.NOTCH_WIDTH - Blockly.BlockSvg.NOTCH_OWN_WIDTH);
+    highlightSteps.push('H', Blockly.BlockSvg.NOTCH_WIDTH - Blockly.BlockSvg.NOTCH_OWN_WIDTH);
     steps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT);
     highlightSteps.push(Blockly.BlockSvg.NOTCH_PATH_LEFT_HIGHLIGHT);
     // Create previous block connection.

--- a/core/connection.js
+++ b/core/connection.js
@@ -339,16 +339,20 @@ Blockly.Connection.prototype.moveBy = function(dx, dy) {
  */
 Blockly.Connection.prototype.highlight = function() {
   var steps;
+  var maybeFlip = '';
   if (this.type == Blockly.INPUT_VALUE || this.type == Blockly.OUTPUT_VALUE) {
     var tabWidth = Blockly.RTL ? -Blockly.BlockSvg.TAB_WIDTH :
                                  Blockly.BlockSvg.TAB_WIDTH;
     steps = 'm 0,0 v 5 c 0,10 ' + -tabWidth + ',-8 ' + -tabWidth + ',7.5 s ' +
             tabWidth + ',-2.5 ' + tabWidth + ',7.5 v 5';
   } else {
+    steps = 'm '+Blockly.BlockSvg.NOTCH_HIGHLIGHT_FLANKING_WIDTH
+          + ',0 h -'+Blockly.BlockSvg.NOTCH_HIGHLIGHT_FLANKING_WIDTH
+          + ' ' + Blockly.BlockSvg.NOTCH_PATH_RIGHT
+          + ' h -'+Blockly.BlockSvg.NOTCH_HIGHLIGHT_FLANKING_WIDTH;
+
     if (Blockly.RTL) {
-      steps = 'm 20,0 h -5 ' + Blockly.BlockSvg.NOTCH_PATH_RIGHT + ' h -5';
-    } else {
-      steps = 'm -20,0 h 5 ' + Blockly.BlockSvg.NOTCH_PATH_LEFT + ' h 5';
+      maybeFlip = ' scale(-1 1)';
     }
   }
   var xy = this.sourceBlock_.getRelativeToSurfaceXY();
@@ -357,7 +361,7 @@ Blockly.Connection.prototype.highlight = function() {
   Blockly.Connection.highlightedPath_ = Blockly.createSvgElement('path',
       {'class': 'blocklyHighlightedConnectionPath',
        'd': steps,
-       transform: 'translate(' + x + ', ' + y + ')'},
+       transform: 'translate(' + x + ', ' + y + ')'+maybeFlip},
       this.sourceBlock_.getSvgRoot());
 };
 


### PR DESCRIPTION
1) The original code was always assuming that the width of a statement-to-statement notch is 15 pixels (SVG units) - an assumption that could be relaxed.
2) It also had a bug that would only show if a non-symmetric notch were highlighted in RTL mode (but the default notch was symmetrical.

I was trying to create a non-symmetrical notch of a different width and immediately stumbled upon both issues.

The patch introduces (factors out) two more constants:
Blockly.BlockSvg.NOTCH_OWN_WIDTH  (instead of the Magic Constant 15 you could meet in a few places)
and
Blockly.BlockSvg.NOTCH_HIGHLIGHT_FLANKING_WIDTH (another Magic Constant, was 5 by default)

It has been tested using the following snippet, both in LTR and RTL modes:
Blockly.BlockSvg.NOTCH_WIDTH = 60;                      // originally defined as total width, INCLUDING the notch
Blockly.BlockSvg.NOTCH_OWN_WIDTH = 30;           // the width of the notch alone
Blockly.BlockSvg.NOTCH_PATH_LEFT = 'l 6,4 1.5,0 0,-8 1.5,0 12,8 1.5,0 0,-8 1.5,0 6,4';
Blockly.BlockSvg.NOTCH_PATH_LEFT_HIGHLIGHT = 'l 6.5,4 1,0 m 0,-8 1,0 l 13,8 1,0 m 0,-8 1,0 l 6.5,4';
Blockly.BlockSvg.NOTCH_PATH_RIGHT = 'l -6,-4 -1.5,0 0,8 -1.5,0 -12,-8 -1.5,0 0,8 -1.5,0 -6,-4';
