### PR TITLE
Self mutating array value input type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pyc
 *.komodoproject
+.idea/

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -50,9 +50,27 @@ Blockly.Blocks['lists_create_with'] = {
    * @this Blockly.Block
    */
   init: function () {
+    /**
+     * Flag used in closure below
+     * @type {boolean}
+     * @private
+     */
+    var empty_ = true;
     this.setColour(260);
     this.appendArrayValueInput('ITEMS')
-        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+        .appendField(Blockly.Msg.LISTS_CREATE_EMPTY_TITLE, 'LABEL')
+        .setConnectionCallback(function () {
+          // this refers to input
+          if (this.connectionList.length == 1 && !empty_) {
+            this.removeField('LABEL')
+                .appendField(Blockly.Msg.LISTS_CREATE_EMPTY_TITLE, 'LABEL');
+            empty_ = true;
+          } else if (this.connectionList.length > 1 && empty_) {
+            this.removeField('LABEL')
+                .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH, 'LABEL');
+            empty_ = false;
+          }
+        });
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
   }
@@ -181,36 +199,36 @@ Blockly.Blocks['lists_create_with'] = {
 //  }
 //};
 
-Blockly.Blocks['lists_create_with_container'] = {
-  /**
-   * Mutator block for list container.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setColour(260);
-    this.appendDummyInput()
-        .appendField(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TITLE_ADD);
-    this.appendStatementInput('STACK');
-    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TOOLTIP);
-    this.contextMenu = false;
-  }
-};
-
-Blockly.Blocks['lists_create_with_item'] = {
-  /**
-   * Mutator bolck for adding items.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setColour(260);
-    this.appendDummyInput()
-        .appendField(Blockly.Msg.LISTS_CREATE_WITH_ITEM_TITLE);
-    this.setPreviousStatement(true);
-    this.setNextStatement(true);
-    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_ITEM_TOOLTIP);
-    this.contextMenu = false;
-  }
-};
+//Blockly.Blocks['lists_create_with_container'] = {
+//  /**
+//   * Mutator block for list container.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setColour(260);
+//    this.appendDummyInput()
+//        .appendField(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TITLE_ADD);
+//    this.appendStatementInput('STACK');
+//    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TOOLTIP);
+//    this.contextMenu = false;
+//  }
+//};
+//
+//Blockly.Blocks['lists_create_with_item'] = {
+//  /**
+//   * Mutator bolck for adding items.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setColour(260);
+//    this.appendDummyInput()
+//        .appendField(Blockly.Msg.LISTS_CREATE_WITH_ITEM_TITLE);
+//    this.setPreviousStatement(true);
+//    this.setNextStatement(true);
+//    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_ITEM_TOOLTIP);
+//    this.contextMenu = false;
+//  }
+//};
 
 Blockly.Blocks['lists_repeat'] = {
   /**

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -52,8 +52,9 @@ Blockly.Blocks['lists_create_with'] = {
   init: function () {
     this.setColour(260);
     this.appendArrayValueInput('ITEMS')
-        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH)
-        .appendConnection();
+        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+        //.appendConnection()
+        //.appendConnection();
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
   }

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -53,8 +53,6 @@ Blockly.Blocks['lists_create_with'] = {
     this.setColour(260);
     this.appendArrayValueInput('ITEMS')
         .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
-        //.appendConnection()
-        //.appendConnection();
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
   }

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -52,7 +52,8 @@ Blockly.Blocks['lists_create_with'] = {
   init: function () {
     this.setColour(260);
     this.appendArrayValueInput('ITEMS')
-        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH)
+        .appendConnection();
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
   }

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -49,123 +49,137 @@ Blockly.Blocks['lists_create_with'] = {
    * Block for creating a list with any number of elements of any type.
    * @this Blockly.Block
    */
-  init: function() {
+  init: function () {
     this.setColour(260);
-    this.itemCount_ = 3;
-    this.updateShape_();
+    this.appendArrayValueInput('ITEMS')
+        .appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
     this.setOutput(true, 'Array');
-    this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
     this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
-  },
-  /**
-   * Create XML to represent list inputs.
-   * @return {Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-    var container = document.createElement('mutation');
-    container.setAttribute('items', this.itemCount_);
-    return container;
-  },
-  /**
-   * Parse XML to restore the list inputs.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this.itemCount_ = parseInt(xmlElement.getAttribute('items'), 10);
-    this.updateShape_();
-  },
-  /**
-   * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this Blockly.Block
-   */
-  decompose: function(workspace) {
-    var containerBlock =
-        Blockly.Block.obtain(workspace, 'lists_create_with_container');
-    containerBlock.initSvg();
-    var connection = containerBlock.getInput('STACK').connection;
-    for (var i = 0; i < this.itemCount_; i++) {
-      var itemBlock = Blockly.Block.obtain(workspace, 'lists_create_with_item');
-      itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
-      connection = itemBlock.nextConnection;
-    }
-    return containerBlock;
-  },
-  /**
-   * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this Blockly.Block
-   */
-  compose: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    // Count number of inputs.
-    var connections = [];
-    var i = 0;
-    while (itemBlock) {
-      connections[i] = itemBlock.valueConnection_;
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-      i++;
-    }
-    this.itemCount_ = i;
-    this.updateShape_();
-    // Reconnect any child blocks.
-    for (var i = 0; i < this.itemCount_; i++) {
-      if (connections[i]) {
-        this.getInput('ADD' + i).connection.connect(connections[i]);
-      }
-    }
-  },
-  /**
-   * Store pointers to any connected child blocks.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this Blockly.Block
-   */
-  saveConnections: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    var i = 0;
-    while (itemBlock) {
-      var input = this.getInput('ADD' + i);
-      itemBlock.valueConnection_ = input && input.connection.targetConnection;
-      i++;
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-    }
-  },
-  /**
-   * Modify this block to have the correct number of inputs.
-   * @private
-   * @this Blockly.Block
-   */
-  updateShape_: function() {
-    // Delete everything.
-    if (this.getInput('EMPTY')) {
-      this.removeInput('EMPTY');
-    } else {
-      var i = 0;
-      while (this.getInput('ADD' + i)) {
-        this.removeInput('ADD' + i);
-        i++;
-      }
-    }
-    // Rebuild block.
-    if (this.itemCount_ == 0) {
-      this.appendDummyInput('EMPTY')
-          .appendField(Blockly.Msg.LISTS_CREATE_EMPTY_TITLE);
-    } else {
-      for (var i = 0; i < this.itemCount_; i++) {
-        var input = this.appendValueInput('ADD' + i);
-        if (i == 0) {
-          input.appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
-        }
-      }
-    }
   }
-};
+}
+
+//Blockly.Blocks['lists_create_with'] = {
+//  /**
+//   * Block for creating a list with any number of elements of any type.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setColour(260);
+//    this.itemCount_ = 3;
+//    this.updateShape_();
+//    this.setOutput(true, 'Array');
+//    this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
+//    this.setTooltip(Blockly.Msg.LISTS_CREATE_WITH_TOOLTIP);
+//  },
+//  /**
+//   * Create XML to represent list inputs.
+//   * @return {Element} XML storage element.
+//   * @this Blockly.Block
+//   */
+//  mutationToDom: function() {
+//    var container = document.createElement('mutation');
+//    container.setAttribute('items', this.itemCount_);
+//    return container;
+//  },
+//  /**
+//   * Parse XML to restore the list inputs.
+//   * @param {!Element} xmlElement XML storage element.
+//   * @this Blockly.Block
+//   */
+//  domToMutation: function(xmlElement) {
+//    this.itemCount_ = parseInt(xmlElement.getAttribute('items'), 10);
+//    this.updateShape_();
+//  },
+//  /**
+//   * Populate the mutator's dialog with this block's components.
+//   * @param {!Blockly.Workspace} workspace Mutator's workspace.
+//   * @return {!Blockly.Block} Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  decompose: function(workspace) {
+//    var containerBlock =
+//        Blockly.Block.obtain(workspace, 'lists_create_with_container');
+//    containerBlock.initSvg();
+//    var connection = containerBlock.getInput('STACK').connection;
+//    for (var i = 0; i < this.itemCount_; i++) {
+//      var itemBlock = Blockly.Block.obtain(workspace, 'lists_create_with_item');
+//      itemBlock.initSvg();
+//      connection.connect(itemBlock.previousConnection);
+//      connection = itemBlock.nextConnection;
+//    }
+//    return containerBlock;
+//  },
+//  /**
+//   * Reconfigure this block based on the mutator dialog's components.
+//   * @param {!Blockly.Block} containerBlock Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  compose: function(containerBlock) {
+//    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+//    // Count number of inputs.
+//    var connections = [];
+//    var i = 0;
+//    while (itemBlock) {
+//      connections[i] = itemBlock.valueConnection_;
+//      itemBlock = itemBlock.nextConnection &&
+//          itemBlock.nextConnection.targetBlock();
+//      i++;
+//    }
+//    this.itemCount_ = i;
+//    this.updateShape_();
+//    // Reconnect any child blocks.
+//    for (var i = 0; i < this.itemCount_; i++) {
+//      if (connections[i]) {
+//        this.getInput('ADD' + i).connection.connect(connections[i]);
+//      }
+//    }
+//  },
+//  /**
+//   * Store pointers to any connected child blocks.
+//   * @param {!Blockly.Block} containerBlock Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  saveConnections: function(containerBlock) {
+//    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+//    var i = 0;
+//    while (itemBlock) {
+//      var input = this.getInput('ADD' + i);
+//      itemBlock.valueConnection_ = input && input.connection.targetConnection;
+//      i++;
+//      itemBlock = itemBlock.nextConnection &&
+//          itemBlock.nextConnection.targetBlock();
+//    }
+//  },
+//  /**
+//   * Modify this block to have the correct number of inputs.
+//   * @private
+//   * @this Blockly.Block
+//   */
+//  updateShape_: function() {
+//    // Delete everything.
+//    if (this.getInput('EMPTY')) {
+//      this.removeInput('EMPTY');
+//    } else {
+//      var i = 0;
+//      while (this.getInput('ADD' + i)) {
+//        this.removeInput('ADD' + i);
+//        i++;
+//      }
+//    }
+//    // Rebuild block.
+//    if (this.itemCount_ == 0) {
+//      this.appendDummyInput('EMPTY')
+//          .appendField(Blockly.Msg.LISTS_CREATE_EMPTY_TITLE);
+//    } else {
+//      for (var i = 0; i < this.itemCount_; i++) {
+//        var input = this.appendValueInput('ADD' + i);
+//        if (i == 0) {
+//          input.appendField(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+//        }
+//      }
+//    }
+//  }
+//};
 
 Blockly.Blocks['lists_create_with_container'] = {
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -65,127 +65,142 @@ Blockly.Blocks['text_join'] = {
    * Block for creating a string made up of any number of elements of any type.
    * @this Blockly.Block
    */
-  init: function() {
+  init: function () {
     this.setHelpUrl(Blockly.Msg.TEXT_JOIN_HELPURL);
     this.setColour(160);
-    this.itemCount_ = 2;
-    this.updateShape_();
+    this.appendArrayValueInput('TEXTS')
+        .appendField(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
     this.setOutput(true, 'String');
-    this.setMutator(new Blockly.Mutator(['text_create_join_item']));
     this.setTooltip(Blockly.Msg.TEXT_JOIN_TOOLTIP);
-  },
-  /**
-   * Create XML to represent number of text inputs.
-   * @return {Element} XML storage element.
-   * @this Blockly.Block
-   */
-  mutationToDom: function() {
-    var container = document.createElement('mutation');
-    container.setAttribute('items', this.itemCount_);
-    return container;
-  },
-  /**
-   * Parse XML to restore the text inputs.
-   * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
-   */
-  domToMutation: function(xmlElement) {
-    this.itemCount_ = parseInt(xmlElement.getAttribute('items'), 10);
-    this.updateShape_();
-  },
-  /**
-   * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this Blockly.Block
-   */
-  decompose: function(workspace) {
-    var containerBlock = Blockly.Block.obtain(workspace,
-                                           'text_create_join_container');
-    containerBlock.initSvg();
-    var connection = containerBlock.getInput('STACK').connection;
-    for (var i = 0; i < this.itemCount_; i++) {
-      var itemBlock = Blockly.Block.obtain(workspace, 'text_create_join_item');
-      itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
-      connection = itemBlock.nextConnection;
-    }
-    return containerBlock;
-  },
-  /**
-   * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this Blockly.Block
-   */
-  compose: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    // Count number of inputs.
-    var connections = [];
-    var i = 0;
-    while (itemBlock) {
-      connections[i] = itemBlock.valueConnection_;
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-      i++;
-    }
-    this.itemCount_ = i;
-    this.updateShape_();
-    // Reconnect any child blocks.
-    for (var i = 0; i < this.itemCount_; i++) {
-      if (connections[i]) {
-        this.getInput('ADD' + i).connection.connect(connections[i]);
-      }
-    }
-  },
-  /**
-   * Store pointers to any connected child blocks.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this Blockly.Block
-   */
-  saveConnections: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    var i = 0;
-    while (itemBlock) {
-      var input = this.getInput('ADD' + i);
-      itemBlock.valueConnection_ = input && input.connection.targetConnection;
-      i++;
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-    }
-  },
-  /**
-   * Modify this block to have the correct number of inputs.
-   * @private
-   * @this Blockly.Block
-   */
-  updateShape_: function() {
-    // Delete everything.
-    if (this.getInput('EMPTY')) {
-      this.removeInput('EMPTY');
-    } else {
-      var i = 0;
-      while (this.getInput('ADD' + i)) {
-        this.removeInput('ADD' + i);
-        i++;
-      }
-    }
-    // Rebuild block.
-    if (this.itemCount_ == 0) {
-      this.appendDummyInput('EMPTY')
-          .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
-          'quote0.png', 12, 12, '"'))
-          .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
-          'quote1.png', 12, 12, '"'));
-    } else {
-      for (var i = 0; i < this.itemCount_; i++) {
-        var input = this.appendValueInput('ADD' + i);
-        if (i == 0) {
-          input.appendField(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
-        }
-      }
-    }
   }
 };
+
+//Blockly.Blocks['text_join'] = {
+//  /**
+//   * Block for creating a string made up of any number of elements of any type.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setHelpUrl(Blockly.Msg.TEXT_JOIN_HELPURL);
+//    this.setColour(160);
+//    this.itemCount_ = 2;
+//    this.updateShape_();
+//    this.setOutput(true, 'String');
+//    this.setMutator(new Blockly.Mutator(['text_create_join_item']));
+//    this.setTooltip(Blockly.Msg.TEXT_JOIN_TOOLTIP);
+//  },
+//  /**
+//   * Create XML to represent number of text inputs.
+//   * @return {Element} XML storage element.
+//   * @this Blockly.Block
+//   */
+//  mutationToDom: function() {
+//    var container = document.createElement('mutation');
+//    container.setAttribute('items', this.itemCount_);
+//    return container;
+//  },
+//  /**
+//   * Parse XML to restore the text inputs.
+//   * @param {!Element} xmlElement XML storage element.
+//   * @this Blockly.Block
+//   */
+//  domToMutation: function(xmlElement) {
+//    this.itemCount_ = parseInt(xmlElement.getAttribute('items'), 10);
+//    this.updateShape_();
+//  },
+//  /**
+//   * Populate the mutator's dialog with this block's components.
+//   * @param {!Blockly.Workspace} workspace Mutator's workspace.
+//   * @return {!Blockly.Block} Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  decompose: function(workspace) {
+//    var containerBlock = Blockly.Block.obtain(workspace,
+//                                           'text_create_join_container');
+//    containerBlock.initSvg();
+//    var connection = containerBlock.getInput('STACK').connection;
+//    for (var i = 0; i < this.itemCount_; i++) {
+//      var itemBlock = Blockly.Block.obtain(workspace, 'text_create_join_item');
+//      itemBlock.initSvg();
+//      connection.connect(itemBlock.previousConnection);
+//      connection = itemBlock.nextConnection;
+//    }
+//    return containerBlock;
+//  },
+//  /**
+//   * Reconfigure this block based on the mutator dialog's components.
+//   * @param {!Blockly.Block} containerBlock Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  compose: function(containerBlock) {
+//    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+//    // Count number of inputs.
+//    var connections = [];
+//    var i = 0;
+//    while (itemBlock) {
+//      connections[i] = itemBlock.valueConnection_;
+//      itemBlock = itemBlock.nextConnection &&
+//          itemBlock.nextConnection.targetBlock();
+//      i++;
+//    }
+//    this.itemCount_ = i;
+//    this.updateShape_();
+//    // Reconnect any child blocks.
+//    for (var i = 0; i < this.itemCount_; i++) {
+//      if (connections[i]) {
+//        this.getInput('ADD' + i).connection.connect(connections[i]);
+//      }
+//    }
+//  },
+//  /**
+//   * Store pointers to any connected child blocks.
+//   * @param {!Blockly.Block} containerBlock Root block in mutator.
+//   * @this Blockly.Block
+//   */
+//  saveConnections: function(containerBlock) {
+//    var itemBlock = containerBlock.getInputTargetBlock('STACK');
+//    var i = 0;
+//    while (itemBlock) {
+//      var input = this.getInput('ADD' + i);
+//      itemBlock.valueConnection_ = input && input.connection.targetConnection;
+//      i++;
+//      itemBlock = itemBlock.nextConnection &&
+//          itemBlock.nextConnection.targetBlock();
+//    }
+//  },
+//  /**
+//   * Modify this block to have the correct number of inputs.
+//   * @private
+//   * @this Blockly.Block
+//   */
+//  updateShape_: function() {
+//    // Delete everything.
+//    if (this.getInput('EMPTY')) {
+//      this.removeInput('EMPTY');
+//    } else {
+//      var i = 0;
+//      while (this.getInput('ADD' + i)) {
+//        this.removeInput('ADD' + i);
+//        i++;
+//      }
+//    }
+//    // Rebuild block.
+//    if (this.itemCount_ == 0) {
+//      this.appendDummyInput('EMPTY')
+//          .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+//          'quote0.png', 12, 12, '"'))
+//          .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+//          'quote1.png', 12, 12, '"'));
+//    } else {
+//      for (var i = 0; i < this.itemCount_; i++) {
+//        var input = this.appendValueInput('ADD' + i);
+//        if (i == 0) {
+//          input.appendField(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
+//        }
+//      }
+//    }
+//  }
+//};
 
 Blockly.Blocks['text_create_join_container'] = {
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -66,10 +66,35 @@ Blockly.Blocks['text_join'] = {
    * @this Blockly.Block
    */
   init: function () {
+    /**
+     * Flag used in closure below
+     * @type {boolean}
+     * @private
+     */
+    var empty_ = true;
     this.setHelpUrl(Blockly.Msg.TEXT_JOIN_HELPURL);
     this.setColour(160);
     this.appendArrayValueInput('TEXTS')
-        .appendField(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
+        .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+          'quote0.png', 12, 12, '"'), 'QUOTE0')
+        .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+          'quote1.png', 12, 12, '"'), 'QUOTE1')
+        .setConnectionCallback(function () {
+          // this refers to input
+          if (this.connectionList.length == 1 && !empty_) {
+            this.removeField('LABEL')
+                .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+                  'quote0.png', 12, 12, '"'), 'QUOTE0')
+                .appendField(new Blockly.FieldImage(Blockly.pathToMedia +
+                  'quote1.png', 12, 12, '"'), 'QUOTE1');
+            empty_ = true;
+          } else if (this.connectionList.length > 1 && empty_) {
+            this.removeField('QUOTE0')
+                .removeField('QUOTE1')
+                .appendField(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH, 'LABEL');
+            empty_ = false;
+          }
+        });
     this.setOutput(true, 'String');
     this.setTooltip(Blockly.Msg.TEXT_JOIN_TOOLTIP);
   }
@@ -202,36 +227,36 @@ Blockly.Blocks['text_join'] = {
 //  }
 //};
 
-Blockly.Blocks['text_create_join_container'] = {
-  /**
-   * Mutator block for container.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setColour(160);
-    this.appendDummyInput()
-        .appendField(Blockly.Msg.TEXT_CREATE_JOIN_TITLE_JOIN);
-    this.appendStatementInput('STACK');
-    this.setTooltip(Blockly.Msg.TEXT_CREATE_JOIN_TOOLTIP);
-    this.contextMenu = false;
-  }
-};
-
-Blockly.Blocks['text_create_join_item'] = {
-  /**
-   * Mutator block for add items.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setColour(160);
-    this.appendDummyInput()
-        .appendField(Blockly.Msg.TEXT_CREATE_JOIN_ITEM_TITLE_ITEM);
-    this.setPreviousStatement(true);
-    this.setNextStatement(true);
-    this.setTooltip(Blockly.Msg.TEXT_CREATE_JOIN_ITEM_TOOLTIP);
-    this.contextMenu = false;
-  }
-};
+//Blockly.Blocks['text_create_join_container'] = {
+//  /**
+//   * Mutator block for container.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setColour(160);
+//    this.appendDummyInput()
+//        .appendField(Blockly.Msg.TEXT_CREATE_JOIN_TITLE_JOIN);
+//    this.appendStatementInput('STACK');
+//    this.setTooltip(Blockly.Msg.TEXT_CREATE_JOIN_TOOLTIP);
+//    this.contextMenu = false;
+//  }
+//};
+//
+//Blockly.Blocks['text_create_join_item'] = {
+//  /**
+//   * Mutator block for add items.
+//   * @this Blockly.Block
+//   */
+//  init: function() {
+//    this.setColour(160);
+//    this.appendDummyInput()
+//        .appendField(Blockly.Msg.TEXT_CREATE_JOIN_ITEM_TITLE_ITEM);
+//    this.setPreviousStatement(true);
+//    this.setNextStatement(true);
+//    this.setTooltip(Blockly.Msg.TEXT_CREATE_JOIN_ITEM_TOOLTIP);
+//    this.contextMenu = false;
+//  }
+//};
 
 Blockly.Blocks['text_append'] = {
   /**

--- a/core/block.js
+++ b/core/block.js
@@ -282,7 +282,9 @@ Blockly.Block.prototype.getConnections_ = function(all) {
     if (all || !this.collapsed_) {
       for (var i = 0, input; input = this.inputList[i]; i++) {
         if (input.connection) {
-          myConnections = myConnections.concat(input.connection);
+          myConnections.push(input.connection);
+        } else if (input.connectionList) {
+          myConnections.push.apply(myConnections, input.connectionList);
         }
       }
     }
@@ -784,6 +786,15 @@ Blockly.Block.prototype.toString = function(opt_maxLength) {
         text.push(child.toString());
       } else {
         text.push('?');
+      }
+    } else if (input.connectionList) {
+      for (var k = 0, conn; conn = input.connectionList[k]; k++) {
+        child = input.connection.targetBlock();
+        if (child) {
+          text.push(child.toString());
+        } else {
+          text.push('?');
+        }
       }
     }
   }

--- a/core/block.js
+++ b/core/block.js
@@ -789,7 +789,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength) {
       }
     } else if (input.connectionList) {
       for (var k = 0, conn; conn = input.connectionList[k]; k++) {
-        child = input.connection.targetBlock();
+        child = conn.targetBlock();
         if (child) {
           text.push(child.toString());
         } else {
@@ -1061,6 +1061,12 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
       if (input.connection && input.connection.targetConnection) {
         // Disconnect any attached block.
         input.connection.targetBlock().setParent(null);
+      } else if (input.connectionList) {
+        for (var j = 0, conn; conn = input.connectionList[j]; j++) {
+          if (conn.targetConnection) {
+            conn.targetBlock().setParent(null);
+          }
+        }
       }
       input.dispose();
       this.inputList.splice(i, 1);

--- a/core/block.js
+++ b/core/block.js
@@ -1081,15 +1081,36 @@ Blockly.Block.prototype.getInput = function(name) {
   return null;
 };
 
+
 /**
  * Fetches the block attached to the named input.
  * @param {string} name The name of the input.
  * @return {Blockly.Block} The attached value block, or null if the input is
- *     either disconnected or if the input does not exist.
+ * either disconnected or if the input does not exist.
  */
 Blockly.Block.prototype.getInputTargetBlock = function(name) {
   var input = this.getInput(name);
   return input && input.connection && input.connection.targetBlock();
+};
+
+/** Fetches all the blocks attached to an array input.
+ * @param {string} name The name of the input.
+ * @return {Array<Blockly.Block> Array of attached value blocks, or empty list
+ *  if no blocks are attached or the input does not exist.
+ */
+Blockly.Block.prototype.getInputTargetBlockList = function (name) {
+  var input = this.getInput(name);
+  if (!input || !input.connectionList) {
+    return [];
+  }
+  var blocks = [];
+  for (var i = 0, conn; conn = input.connectionList[i]; i++) {
+    var block = conn.targetBlock();
+    if (block) {
+      blocks.push(block);
+    }
+  }
+  return blocks;
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -282,7 +282,7 @@ Blockly.Block.prototype.getConnections_ = function(all) {
     if (all || !this.collapsed_) {
       for (var i = 0, input; input = this.inputList[i]; i++) {
         if (input.connection) {
-          myConnections.push(input.connection);
+          myConnections = myConnections.concat(input.connection);
         }
       }
     }
@@ -827,6 +827,16 @@ Blockly.Block.prototype.appendDummyInput = function(opt_name) {
 };
 
 /**
+ * Shortcut for appending an array value input row.
+ * @param {string} name Language-neutral identifier which may be used to find
+ *    this input again. Should be unique to this block.
+ * @return {!Blockly.Input} The input object created
+ */
+Blockly.Block.prototype.appendArrayValueInput = function (name) {
+  return this.appendInput_(Blockly.INPUT_ARRAYVALUE, name);
+};
+
+/**
  * Interpolate a message string, creating fields and inputs.
  * @param {string} msg The message string to parse.  %1, %2, etc. are symbols
  *     for value inputs or for Fields, such as an instance of
@@ -943,7 +953,7 @@ Blockly.Block.prototype.interpolateMsg.INLINE_REGEX_ = /%1\s*$/;
 /**
  * Add a value input, statement input or local variable to this block.
  * @param {number} type Either Blockly.INPUT_VALUE or Blockly.NEXT_STATEMENT or
- *     Blockly.DUMMY_INPUT.
+ *     Blockly.DUMMY_INPUT or Blockly.INPUT_ARRAYVALUE.
  * @param {string} name Language-neutral identifier which may used to find this
  *     input again.  Should be unique to this block.
  * @return {!Blockly.Input} The input object created.
@@ -953,6 +963,8 @@ Blockly.Block.prototype.appendInput_ = function(type, name) {
   var connection = null;
   if (type == Blockly.INPUT_VALUE || type == Blockly.NEXT_STATEMENT) {
     connection = new Blockly.Connection(this, type);
+  } else if (type == Blockly.INPUT_ARRAYVALUE) {
+    connection = new Blockly.Connection(this, Blockly.INPUT_VALUE);
   }
   var input = new Blockly.Input(type, name, this, connection);
   // Append input to list.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1384,7 +1384,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
             if (conn.targetConnection) {
               linkedBlock = conn.targetBlock();
               bBox = linkedBlock.getHeightWidth();
-              row.height = Math.max(Blockly.BlockSvg.MIN_BLOCK_Y, bBox.height);
+              subRow.height = Math.max(Blockly.BlockSvg.MIN_BLOCK_Y, bBox.height);
               input.renderWidth = Math.max(input.renderWidth, bBox.width);
             }
             inputRows.push(subRow);
@@ -1398,6 +1398,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       }
     }
 
+    // FIXME: Need to make this work with array values
     if (i == inputList.length - 1) {
       // Last element should overhang slightly due to shadow.
       input.renderHeight--;
@@ -1474,6 +1475,7 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   inputRows.hasValue = hasValue;
   inputRows.hasStatement = hasStatement;
   inputRows.hasDummy = hasDummy;
+  console.log('IR', inputRows);
   return inputRows;
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -389,8 +389,6 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     Blockly.terminateDrag_();
     if (Blockly.selected && Blockly.highlightedConnection_) {
       // Connect two blocks together.
-      console.log('MU');
-      console.log('L', Blockly.localConnection_.sourceBlock_.type, 'H', Blockly.highlightedConnection_.sourceBlock_.type);
       Blockly.localConnection_.connect(Blockly.highlightedConnection_);
       if (this_.rendered) {
         // Trigger a connection animation.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -389,6 +389,8 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     Blockly.terminateDrag_();
     if (Blockly.selected && Blockly.highlightedConnection_) {
       // Connect two blocks together.
+      console.log('MU');
+      console.log('L', Blockly.localConnection_.sourceBlock_.type, 'H', Blockly.highlightedConnection_.sourceBlock_.type);
       Blockly.localConnection_.connect(Blockly.highlightedConnection_);
       if (this_.rendered) {
         // Trigger a connection animation.
@@ -1363,38 +1365,32 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       input.renderWidth = 0;
     }
     // Expand input size if there are connections.
-    if (input.connection) {
-      if (input.connection.length) {
-        row.index = 0;
-        if (input.connection[0].targetConnection) {
-          var linkedBlock = input.connection[0].targetBlock();
-          var bBox = linkedBlock.getHeightWidth();
-          input.renderHeight = Math.max(input.renderHeight, bBox.height);
-          input.renderWidth = Math.max(input.renderWidth, bBox.width);
-        }
-
-        // Add additional rows for multi-connection inputs
-        if (input.connection.length) {
-          for (var j = 1, conn; conn = input.connection[j]; j++) {
-            var subRow = [input];
-            subRow.height = Blockly.BlockSvg.MIN_BLOCK_Y;
-            subRow.thicker = false;
-            subRow.type = input.type;
-            subRow.index = j;
-            if (conn.targetConnection) {
-              linkedBlock = conn.targetBlock();
-              bBox = linkedBlock.getHeightWidth();
-              subRow.height = Math.max(Blockly.BlockSvg.MIN_BLOCK_Y, bBox.height);
-              input.renderWidth = Math.max(input.renderWidth, bBox.width);
-            }
-            inputRows.push(subRow);
-          }
-        }
-      } else if (input.connection.targetConnection) {
-        linkedBlock = input.connection.targetBlock();
-        bBox = linkedBlock.getHeightWidth();
+    if (input.connection && input.connection.targetConnection) {
+      linkedBlock = input.connection.targetBlock();
+      bBox = linkedBlock.getHeightWidth();
+      input.renderHeight = Math.max(input.renderHeight, bBox.height);
+      input.renderWidth = Math.max(input.renderWidth, bBox.width);
+    } else if (input.connectionList) {
+      row.index = 0;
+      if (input.connectionList[0].targetConnection) {
+        var linkedBlock = input.connectionList[0].targetBlock();
+        var bBox = linkedBlock.getHeightWidth();
         input.renderHeight = Math.max(input.renderHeight, bBox.height);
         input.renderWidth = Math.max(input.renderWidth, bBox.width);
+      }
+      for (var j = 1, conn; conn = input.connectionList[j]; j++) {
+        var subRow = [input];
+        subRow.height = Blockly.BlockSvg.MIN_BLOCK_Y;
+        subRow.thicker = false;
+        subRow.type = input.type;
+        subRow.index = j;
+        if (conn.targetConnection) {
+          linkedBlock = conn.targetBlock();
+          bBox = linkedBlock.getHeightWidth();
+          subRow.height = Math.max(Blockly.BlockSvg.MIN_BLOCK_Y, bBox.height);
+          input.renderWidth = Math.max(input.renderWidth, bBox.width);
+        }
+        inputRows.push(subRow);
       }
     }
 
@@ -1475,7 +1471,6 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
   inputRows.hasValue = hasValue;
   inputRows.hasStatement = hasStatement;
   inputRows.hasDummy = hasDummy;
-  console.log('IR', inputRows);
   return inputRows;
 };
 
@@ -1743,7 +1738,7 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps, highlightSteps,
       }
       // Create external input connection.
       if (typeof row.index != 'undefined') {
-        var conn = input.connection[row.index];
+        var conn = input.connectionList[row.index];
       } else {
         conn = input.connection;
       }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1353,6 +1353,11 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     }
     row.push(input);
 
+    input.fieldWidth = 0;
+    if (inputRows.length == 1) {
+      // The first row gets shifted to accommodate any icons.
+      input.fieldWidth += Blockly.RTL ? -iconWidth : iconWidth;
+    }
     // Compute minimum input size.
     // The width is currently only needed for inline value inputs.
     input.renderHeight = Blockly.BlockSvg.MIN_BLOCK_Y;
@@ -1376,8 +1381,9 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
         input.renderHeight = Math.max(input.renderHeight, bBox.height);
         input.renderWidth = Math.max(input.renderWidth, bBox.width);
       }
+      var subRow = null;
       for (var j = 1, conn; conn = input.connectionList[j]; j++) {
-        var subRow = [input];
+        subRow = [input];
         subRow.height = Blockly.BlockSvg.MIN_BLOCK_Y;
         subRow.thicker = false;
         subRow.type = input.type;
@@ -1392,17 +1398,20 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
       }
     }
 
-    // FIXME: Need to make this work with array values
     if (i == inputList.length - 1) {
       // Last element should overhang slightly due to shadow.
-      input.renderHeight--;
+      if (input.connectionList && subRow) {
+        subRow.height--;
+      } else {
+        input.renderHeight--;
+      }
     }
     row.height = Math.max(row.height, input.renderHeight);
-    input.fieldWidth = 0;
-    if (inputRows.length == 1) {
-      // The first row gets shifted to accommodate any icons.
-      input.fieldWidth += Blockly.RTL ? -iconWidth : iconWidth;
-    }
+    //input.fieldWidth = 0;
+    //if (inputRows.length == 1) {
+    //  // The first row gets shifted to accommodate any icons.
+    //  input.fieldWidth += Blockly.RTL ? -iconWidth : iconWidth;
+    //}
     var previousFieldEditable = false;
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
       if (j != 0) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -131,6 +131,12 @@ Blockly.PREVIOUS_STATEMENT = 4;
 Blockly.DUMMY_INPUT = 5;
 
 /**
+ * ENUM for an arra-valued input. Automatically adds/removes slots as necessary.
+ * @const
+ */
+Blockly.INPUT_ARRAYVALUE = 6;
+
+/**
  * ENUM for left alignment.
  * @const
  */

--- a/core/connection.js
+++ b/core/connection.js
@@ -283,8 +283,10 @@ Blockly.Connection.prototype.disconnect = function() {
   }
   // Remove connection if connection is part of an array
   if (av = parentConnection.arrayValue_()) {
-    av.input.removeConnection(av.index);
-    parentConnection.dispose();
+    if (av.input.connectionList.length > 1) {
+      av.input.removeConnection(av.index);
+      parentConnection.dispose();
+    }
   }
   if (parentBlock.rendered) {
     parentBlock.render();

--- a/core/input.js
+++ b/core/input.js
@@ -56,6 +56,7 @@ Blockly.Input = function(type, name, block, connection) {
   }
 
   this.visible_ = true;
+  this.check_ = null;
 };
 
 /**
@@ -196,10 +197,17 @@ Blockly.Input.prototype.setVisible = function(visible) {
  * @return {!Blockly.Input} The input being modified (to allow chaining).
  */
 Blockly.Input.prototype.setCheck = function(check) {
-  if (!this.connection) {
-    throw 'This input does not have a connection.';
+  if (!this.connection && !this.connectionList) {
+    throw 'This input does not have connections.';
   }
-  this.connection.setCheck(check);
+  this.check_ = check;
+  if (this.connection) {
+    this.connection.setCheck(check);
+  } else {
+    for (var i = 0, conn; conn = this.connectionList[i]; i++) {
+      conn.setCheck(check);
+    }
+  }
   return this;
 };
 
@@ -234,12 +242,10 @@ Blockly.Input.prototype.dispose = function() {
     field.dispose();
   }
   if (this.connection) {
-    if (this.connectionList) {
-      for (var j = 0, conn; conn = this.connectionList[j]; j++) {
-        conn.dispose();
-      }
-    } else {
-        this.connection.dispose();
+    this.connection.dispose();
+  } else if (this.connectionList) {
+    for (var j = 0, conn; conn = this.connectionList[j]; j++) {
+      conn.dispose();
     }
   }
   this.sourceBlock_ = null;
@@ -259,6 +265,7 @@ Blockly.Input.prototype.insertConnection = function (pos) {
     pos = this.connectionList.length;
   }
   var conn = new Blockly.Connection(this.sourceBlock_, Blockly.INPUT_VALUE);
+  conn.setCheck(this.check_);
   this.connectionList.splice(pos, 0, conn);
   return conn;
 };

--- a/core/input.js
+++ b/core/input.js
@@ -232,6 +232,7 @@ Blockly.Input.prototype.dispose = function() {
 
 /**
  * Add an additional connection to this input
+ * @return {Blockly.Input} This input, for chaining
  */
 Blockly.Input.prototype.appendConnection = function () {
   if (!this.connection.length) {
@@ -239,11 +240,13 @@ Blockly.Input.prototype.appendConnection = function () {
   }
   this.connection.push(new Blockly.Connection(this.sourceBlock_,
     Blockly.INPUT_VALUE));
+  return this;
 };
 
 /**
  * Remove connection from this input
  * @param {!Blockly.Connection} connection The connection to remove
+ * @return {Blockly.Input} This input, for chaining
  */
 Blockly.Input.prototype.removeConnection = function (connection) {
   if (!this.connection.length) {
@@ -255,4 +258,5 @@ Blockly.Input.prototype.removeConnection = function (connection) {
       break;
     }
   }
+  return this;
 };

--- a/core/input.js
+++ b/core/input.js
@@ -50,7 +50,7 @@ Blockly.Input = function(type, name, block, connection) {
   this.align = Blockly.ALIGN_LEFT;
 
   if (type === Blockly.INPUT_ARRAYVALUE) {
-    this.connection = [connection];
+    this.connectionList = [connection];
   } else {
     this.connection = connection;
   }
@@ -219,8 +219,8 @@ Blockly.Input.prototype.dispose = function() {
     field.dispose();
   }
   if (this.connection) {
-    if (this.connection.length) {
-      for (var j = 0, conn; conn = this.connection[j]; j++) {
+    if (this.connectionList) {
+      for (var j = 0, conn; conn = this.connectionList[j]; j++) {
         conn.dispose();
       }
     } else {
@@ -232,31 +232,39 @@ Blockly.Input.prototype.dispose = function() {
 
 /**
  * Add an additional connection to this input
- * @return {Blockly.Input} This input, for chaining
+ * @param {number} [pos] Position in connection stack to insert. Append if
+ *  omitted
+ * @return {Blockly.Connection} The new connection
  */
-Blockly.Input.prototype.appendConnection = function () {
-  if (!this.connection.length) {
+Blockly.Input.prototype.insertConnection = function (pos) {
+  if (!this.connectionList) {
     throw 'This input does not support multiple connections.';
   }
-  this.connection.push(new Blockly.Connection(this.sourceBlock_,
-    Blockly.INPUT_VALUE));
-  return this;
+  if (typeof pos == 'undefined') {
+    pos = this.connectionList.length;
+  }
+  var conn = new Blockly.Connection(this.sourceBlock_, Blockly.INPUT_VALUE);
+  this.connectionList.splice(pos, 0, conn);
+  return conn;
 };
 
 /**
  * Remove connection from this input
- * @param {!Blockly.Connection} connection The connection to remove
- * @return {Blockly.Input} This input, for chaining
+ * @param {(number|Blockly.Connection)} connection The connection to remove
+ *  or its index
  */
 Blockly.Input.prototype.removeConnection = function (connection) {
-  if (!this.connection.length) {
+  if (!this.connectionList) {
     throw 'This input does not support multiple connections.';
   }
-  for (var i = 0, conn; conn = this.connection[i]; i++) {
-    if (conn === connection) {
-      this.connection.splice(i, 1);
-      break;
+  if (typeof connection == 'object') {
+    for (var i = 0, conn; conn = this.connectionList[i]; i++) {
+      if (conn === connection) {
+        this.connectionList.splice(i, 1);
+        break;
+      }
     }
+  } else {
+    this.connectionList.splice(connection, 1);
   }
-  return this;
 };

--- a/core/input.js
+++ b/core/input.js
@@ -46,9 +46,14 @@ Blockly.Input = function(type, name, block, connection) {
   this.type = type;
   this.name = name;
   this.sourceBlock_ = block;
-  this.connection = connection;
   this.fieldRow = [];
   this.align = Blockly.ALIGN_LEFT;
+
+  if (type === Blockly.INPUT_ARRAYVALUE) {
+    this.connection = [connection];
+  } else {
+    this.connection = connection;
+  }
 
   this.visible_ = true;
 };
@@ -214,7 +219,40 @@ Blockly.Input.prototype.dispose = function() {
     field.dispose();
   }
   if (this.connection) {
-    this.connection.dispose();
+    if (this.connection.length) {
+      for (var j = 0, conn; conn = this.connection[j]; j++) {
+        conn.dispose();
+      }
+    } else {
+        this.connection.dispose();
+    }
   }
   this.sourceBlock_ = null;
+};
+
+/**
+ * Add an additional connection to this input
+ */
+Blockly.Input.prototype.appendConnection = function () {
+  if (!this.connection.length) {
+    throw 'This input does not support multiple connections.';
+  }
+  this.connection.push(new Blockly.Connection(this.sourceBlock_,
+    Blockly.INPUT_VALUE));
+};
+
+/**
+ * Remove connection from this input
+ * @param {!Blockly.Connection} connection The connection to remove
+ */
+Blockly.Input.prototype.removeConnection = function (connection) {
+  if (!this.connection.length) {
+    throw 'This input does not support multiple connections.';
+  }
+  for (var i = 0, conn; conn = this.connection[i]; i++) {
+    if (conn === connection) {
+      this.connection.splice(i, 1);
+      break;
+    }
+  }
 };

--- a/core/input.js
+++ b/core/input.js
@@ -170,6 +170,21 @@ Blockly.Input.prototype.setVisible = function(visible) {
         child.rendered = false;
       }
     }
+  } else if (this.connectionList) {
+    for (var i = 0, conn; conn = this.connectionList[i]; i++) {
+      if (visible) {
+        renderList.push.apply(renderList, conn.unhideAll());
+      } else {
+        conn.hideAll();
+      }
+      child = conn.targetBlock();
+      if (child) {
+        child.getSvgRoot().style.display = display;
+        if (!visible) {
+          child.rendered = false;
+        }
+      }
+    }
   }
   return renderList;
 };

--- a/core/input.js
+++ b/core/input.js
@@ -57,6 +57,7 @@ Blockly.Input = function(type, name, block, connection) {
 
   this.visible_ = true;
   this.check_ = null;
+  this.connectionCallback_ = null;
 };
 
 /**
@@ -127,7 +128,7 @@ Blockly.Input.prototype.removeField = function(name) {
         // Removing a field will cause the block to change shape.
         this.sourceBlock_.bumpNeighbours_();
       }
-      return;
+      return this;
     }
   }
   goog.asserts.fail('Field "%s" not found.', name);
@@ -267,6 +268,9 @@ Blockly.Input.prototype.insertConnection = function (pos) {
   var conn = new Blockly.Connection(this.sourceBlock_, Blockly.INPUT_VALUE);
   conn.setCheck(this.check_);
   this.connectionList.splice(pos, 0, conn);
+  if (this.connectionCallback_) {
+    this.connectionCallback_.call(this);
+  }
   return conn;
 };
 
@@ -289,4 +293,22 @@ Blockly.Input.prototype.removeConnection = function (connection) {
   } else {
     this.connectionList.splice(connection, 1);
   }
+  if (this.connectionCallback_) {
+    this.connectionCallback_.call(this);
+  }
+};
+
+
+/**
+ * Set a callback to be called when connections are added or dropped from this
+ *   input
+ * @param {function} callback Function to be called on connection add/drop
+ * @return {Blockly.Input} For chaining
+ */
+Blockly.Input.prototype.setConnectionCallback = function (callback) {
+  if (!this.connectionList) {
+    throw 'This input does not support multiple connections.';
+  }
+  this.connectionCallback_ = callback;
+  return this;
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -101,14 +101,27 @@ Blockly.Xml.blockToDom_ = function(block) {
     if (input.type == Blockly.DUMMY_INPUT) {
       continue;
     } else {
-      var childBlock = input.connection.targetBlock();
-      if (input.type == Blockly.INPUT_VALUE) {
+      //var childBlock = input.connection.targetBlock();
+      if (input.type == Blockly.INPUT_VALUE ||
+          input.type == Blockly.INPUT_ARRAYVALUE) {
         container = goog.dom.createDom('value');
         hasValues = true;
       } else if (input.type == Blockly.NEXT_STATEMENT) {
         container = goog.dom.createDom('statement');
       }
-      if (childBlock) {
+      //if (childBlock) {
+      //  container.appendChild(Blockly.Xml.blockToDom_(childBlock));
+      //  empty = false;
+      //}
+      if (input.connection.length) {
+        for (var j = 0, conn; conn = input.connection[j]; j++) {
+          var childBlock = conn.targetBlock();
+          if (childBlock) {
+            container.appendChild(Blockly.Xml.blockToDom_(childBlock));
+            empty = false;
+          }
+        }
+      } else if (childBlock = input.connection.targetBlock()) {
         container.appendChild(Blockly.Xml.blockToDom_(childBlock));
         empty = false;
       }

--- a/core/xml.js
+++ b/core/xml.js
@@ -101,7 +101,6 @@ Blockly.Xml.blockToDom_ = function(block) {
     if (input.type == Blockly.DUMMY_INPUT) {
       continue;
     } else {
-      //var childBlock = input.connection.targetBlock();
       if (input.type == Blockly.INPUT_VALUE ||
           input.type == Blockly.INPUT_ARRAYVALUE) {
         container = goog.dom.createDom('value');
@@ -109,10 +108,6 @@ Blockly.Xml.blockToDom_ = function(block) {
       } else if (input.type == Blockly.NEXT_STATEMENT) {
         container = goog.dom.createDom('statement');
       }
-      //if (childBlock) {
-      //  container.appendChild(Blockly.Xml.blockToDom_(childBlock));
-      //  empty = false;
-      //}
       if (input.connectionList) {
         for (var j = 0, conn; conn = input.connectionList[j]; j++) {
           var childBlock = conn.targetBlock();

--- a/core/xml.js
+++ b/core/xml.js
@@ -113,8 +113,8 @@ Blockly.Xml.blockToDom_ = function(block) {
       //  container.appendChild(Blockly.Xml.blockToDom_(childBlock));
       //  empty = false;
       //}
-      if (input.connection.length) {
-        for (var j = 0, conn; conn = input.connection[j]; j++) {
+      if (input.connectionList) {
+        for (var j = 0, conn; conn = input.connectionList[j]; j++) {
           var childBlock = conn.targetBlock();
           if (childBlock) {
             container.appendChild(Blockly.Xml.blockToDom_(childBlock));

--- a/generators/dart/lists.js
+++ b/generators/dart/lists.js
@@ -38,14 +38,22 @@ Blockly.Dart['lists_create_empty'] = function(block) {
 
 Blockly.Dart['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
-  var code = new Array(block.itemCount_);
-  for (var n = 0; n < block.itemCount_; n++) {
-    code[n] = Blockly.Dart.valueToCode(block, 'ADD' + n,
-        Blockly.Dart.ORDER_NONE) || 'null';
-  }
+  var code = Blockly.Dart.valueToCodeArray(block, 'ITEMS',
+      Blockly.Dart.ORDER_NONE);
   code = '[' + code.join(', ') + ']';
   return [code, Blockly.Dart.ORDER_ATOMIC];
 };
+
+//Blockly.Dart['lists_create_with'] = function(block) {
+//  // Create a list with any number of elements of any type.
+//  var code = new Array(block.itemCount_);
+//  for (var n = 0; n < block.itemCount_; n++) {
+//    code[n] = Blockly.Dart.valueToCode(block, 'ADD' + n,
+//        Blockly.Dart.ORDER_NONE) || 'null';
+//  }
+//  code = '[' + code.join(', ') + ']';
+//  return [code, Blockly.Dart.ORDER_ATOMIC];
+//};
 
 Blockly.Dart['lists_repeat'] = function(block) {
   // Create a list with one element repeated.

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -39,24 +39,41 @@ Blockly.Dart['text'] = function(block) {
 
 Blockly.Dart['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
-  var code;
-  if (block.itemCount_ == 0) {
+  var codeArray = Blockly.Dart.valueToCodeArray(block, 'TEXTS',
+      Blockly.Dart.ORDER_UNARY_POSTFIX);
+  if (codeArray.length == 0) {
     return ['\'\'', Blockly.Dart.ORDER_ATOMIC];
-  } else if (block.itemCount_ == 1) {
-    var argument0 = Blockly.Dart.valueToCode(block, 'ADD0',
-        Blockly.Dart.ORDER_UNARY_POSTFIX) || '\'\'';
-    code = argument0 + '.toString()';
-    return [code, Blockly.Dart.ORDER_UNARY_POSTFIX];
+  } else if (codeArray.length == 1) {
+    return [codeArray[0] + '.tostring()', Blockly.Dart.ORDER_UNARY_POSTFIX];
   } else {
-    code = new Array(block.itemCount_);
-    for (var n = 0; n < block.itemCount_; n++) {
-      code[n] = Blockly.Dart.valueToCode(block, 'ADD' + n,
-          Blockly.Dart.ORDER_NONE) || '\'\'';
-    }
-    code = '[' + code.join(',') + '].join()';
-    return [code, Blockly.Dart.ORDER_UNARY_POSTFIX];
+    // Need to regen array subject to the correct precedence
+    codeArray = Blockly.Dart.valueToCodeArray(block, 'TEXTS',
+        Blockly.Dart.ORDER_NONE);
+    return ['[' + codeArray.join(',') + '].join()',
+      Blockly.Dart.ORDER_UNARY_POSTFIX];
   }
-};
+}
+
+//Blockly.Dart['text_join'] = function(block) {
+//  // Create a string made up of any number of elements of any type.
+//  var code;
+//  if (block.itemCount_ == 0) {
+//    return ['\'\'', Blockly.Dart.ORDER_ATOMIC];
+//  } else if (block.itemCount_ == 1) {
+//    var argument0 = Blockly.Dart.valueToCode(block, 'ADD0',
+//        Blockly.Dart.ORDER_UNARY_POSTFIX) || '\'\'';
+//    code = argument0 + '.toString()';
+//    return [code, Blockly.Dart.ORDER_UNARY_POSTFIX];
+//  } else {
+//    code = new Array(block.itemCount_);
+//    for (var n = 0; n < block.itemCount_; n++) {
+//      code[n] = Blockly.Dart.valueToCode(block, 'ADD' + n,
+//          Blockly.Dart.ORDER_NONE) || '\'\'';
+//    }
+//    code = '[' + code.join(',') + '].join()';
+//    return [code, Blockly.Dart.ORDER_UNARY_POSTFIX];
+//  }
+//};
 
 Blockly.Dart['text_append'] = function(block) {
   // Append to a variable in place.

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -36,14 +36,22 @@ Blockly.JavaScript['lists_create_empty'] = function(block) {
 
 Blockly.JavaScript['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
-  var code = new Array(block.itemCount_);
-  for (var n = 0; n < block.itemCount_; n++) {
-    code[n] = Blockly.JavaScript.valueToCode(block, 'ADD' + n,
-        Blockly.JavaScript.ORDER_COMMA) || 'null';
-  }
+  var code = Blockly.JavaScript.valueToCodeArray(block, 'ITEMS',
+      Blockly.JavaScript.ORDER_COMMA);
   code = '[' + code.join(', ') + ']';
   return [code, Blockly.JavaScript.ORDER_ATOMIC];
 };
+
+//Blockly.JavaScript['lists_create_with'] = function(block) {
+//  // Create a list with any number of elements of any type.
+//  var code = new Array(block.itemCount_);
+//  for (var n = 0; n < block.itemCount_; n++) {
+//    code[n] = Blockly.JavaScript.valueToCode(block, 'ADD' + n,
+//        Blockly.JavaScript.ORDER_COMMA) || 'null';
+//  }
+//  code = '[' + code.join(', ') + ']';
+//  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+//};
 
 Blockly.JavaScript['lists_repeat'] = function(block) {
   // Create a list with one element repeated.

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -37,31 +37,52 @@ Blockly.JavaScript['text'] = function(block) {
 
 Blockly.JavaScript['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
-  var code;
-  if (block.itemCount_ == 0) {
+  var codeArray = Blockly.JavaScript.valueToCodeArray(block, 'TEXTS',
+      Blockly.JavaScript.ORDER_NONE);
+  if (codeArray.length == 0) {
     return ['\'\'', Blockly.JavaScript.ORDER_ATOMIC];
-  } else if (block.itemCount_ == 1) {
-    var argument0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
-        Blockly.JavaScript.ORDER_NONE) || '\'\'';
-    code = 'String(' + argument0 + ')';
-    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-  } else if (block.itemCount_ == 2) {
-    var argument0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
-        Blockly.JavaScript.ORDER_NONE) || '\'\'';
-    var argument1 = Blockly.JavaScript.valueToCode(block, 'ADD1',
-        Blockly.JavaScript.ORDER_NONE) || '\'\'';
-    code = 'String(' + argument0 + ') + String(' + argument1 + ')';
-    return [code, Blockly.JavaScript.ORDER_ADDITION];
+  } else if (codeArray.length == 1) {
+    return ['String(' + codeArray[0] + ')',
+      Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  } else if (codeArray.length == 2) {
+    return ['String(' + codeArray[0] + ') + String(' + codeArray[1] + ')',
+      Blockly.JavaScript.ORDER_ADDITION];
   } else {
-    code = new Array(block.itemCount_);
-    for (var n = 0; n < block.itemCount_; n++) {
-      code[n] = Blockly.JavaScript.valueToCode(block, 'ADD' + n,
-          Blockly.JavaScript.ORDER_COMMA) || '\'\'';
-    }
-    code = '[' + code.join(',') + '].join(\'\')';
-    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+    // Need to regen array subject to the correct precedence
+    codeArray = Blockly.JavaScript.valueToCodeArray(block, 'TEXTS',
+        Blockly.JavaScript.ORDER_COMMA);
+    return ['[' + codeArray.join(',') + '].join(\'\')',
+      Blockly.JavaScript.ORDER_FUNCTION_CALL];
   }
 };
+
+//Blockly.JavaScript['text_join'] = function(block) {
+//  // Create a string made up of any number of elements of any type.
+//  var code;
+//  if (block.itemCount_ == 0) {
+//    return ['\'\'', Blockly.JavaScript.ORDER_ATOMIC];
+//  } else if (block.itemCount_ == 1) {
+//    var argument0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
+//        Blockly.JavaScript.ORDER_NONE) || '\'\'';
+//    code = 'String(' + argument0 + ')';
+//    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+//  } else if (block.itemCount_ == 2) {
+//    var argument0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
+//        Blockly.JavaScript.ORDER_NONE) || '\'\'';
+//    var argument1 = Blockly.JavaScript.valueToCode(block, 'ADD1',
+//        Blockly.JavaScript.ORDER_NONE) || '\'\'';
+//    code = 'String(' + argument0 + ') + String(' + argument1 + ')';
+//    return [code, Blockly.JavaScript.ORDER_ADDITION];
+//  } else {
+//    code = new Array(block.itemCount_);
+//    for (var n = 0; n < block.itemCount_; n++) {
+//      code[n] = Blockly.JavaScript.valueToCode(block, 'ADD' + n,
+//          Blockly.JavaScript.ORDER_COMMA) || '\'\'';
+//    }
+//    code = '[' + code.join(',') + '].join(\'\')';
+//    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+//  }
+//};
 
 Blockly.JavaScript['text_append'] = function(block) {
   // Append to a variable in place.

--- a/generators/python/lists.js
+++ b/generators/python/lists.js
@@ -36,14 +36,22 @@ Blockly.Python['lists_create_empty'] = function(block) {
 
 Blockly.Python['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
-  var code = new Array(block.itemCount_);
-  for (var n = 0; n < block.itemCount_; n++) {
-    code[n] = Blockly.Python.valueToCode(block, 'ADD' + n,
-        Blockly.Python.ORDER_NONE) || 'None';
-  }
+  var code = Blockly.Python.valueToCodeArray(block, 'ITEMS',
+      Blockly.Python.ORDER_NONE);
   code = '[' + code.join(', ') + ']';
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
+
+//Blockly.Python['lists_create_with'] = function(block) {
+//  // Create a list with any number of elements of any type.
+//  var code = new Array(block.itemCount_);
+//  for (var n = 0; n < block.itemCount_; n++) {
+//    code[n] = Blockly.Python.valueToCode(block, 'ADD' + n,
+//        Blockly.Python.ORDER_NONE) || 'None';
+//  }
+//  code = '[' + code.join(', ') + ']';
+//  return [code, Blockly.Python.ORDER_ATOMIC];
+//};
 
 Blockly.Python['lists_repeat'] = function(block) {
   // Create a list with one element repeated.

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -36,36 +36,58 @@ Blockly.Python['text'] = function(block) {
 };
 
 Blockly.Python['text_join'] = function(block) {
-  // Create a string made up of any number of elements of any type.
-  //Should we allow joining by '-' or ',' or any other characters?
-  var code;
-  if (block.itemCount_ == 0) {
-    return ['\'\'', Blockly.Python.ORDER_ATOMIC];
-  } else if (block.itemCount_ == 1) {
-    var argument0 = Blockly.Python.valueToCode(block, 'ADD0',
-        Blockly.Python.ORDER_NONE) || '\'\'';
-    code = 'str(' + argument0 + ')';
-    return [code, Blockly.Python.ORDER_FUNCTION_CALL];
-  } else if (block.itemCount_ == 2) {
-    var argument0 = Blockly.Python.valueToCode(block, 'ADD0',
-        Blockly.Python.ORDER_NONE) || '\'\'';
-    var argument1 = Blockly.Python.valueToCode(block, 'ADD1',
-        Blockly.Python.ORDER_NONE) || '\'\'';
-    var code = 'str(' + argument0 + ') + str(' + argument1 + ')';
-    return [code, Blockly.Python.ORDER_UNARY_SIGN];
-  } else {
-    var code = [];
-    for (var n = 0; n < block.itemCount_; n++) {
-      code[n] = Blockly.Python.valueToCode(block, 'ADD' + n,
-          Blockly.Python.ORDER_NONE) || '\'\'';
+    // Create a string made up of any number of elements of any type.
+    //Should we allow joining by '-' or ',' or any other characters?
+    var codeArray = Blockly.Python.valueToCodeArray(block, 'TEXTS',
+        Blockly.Python.ORDER_NONE);
+    if (codeArray.length == 0) {
+        return ['\'\'', Blockly.Python.ORDER_ATOMIC];
+    } else if (codeArray.length == 1) {
+        return ['str(' + codeArray[0] + ')',
+            Blockly.Python.ORDER_FUNCTION_CALL];
+    } else if (codeArray.length == 2) {
+        return ['str(' + codeArray[0] + ') + str(' + codeArray[1] + ')',
+            Blockly.Python.ORDER_UNARY_SIGN];
+    } else {
+        var tempVar = Blockly.Python.variableDB_.getDistinctName('temp_value',
+            Blockly.Variables.NAME_TYPE);
+        var code = '\'\'.join([str(' + tempVar + ') for ' + tempVar +
+                ' in [' + codeArray.join(', ') + ']])';
+        return [code, Blockly.Python.ORDER_FUNCTION_CALL];
     }
-    var tempVar = Blockly.Python.variableDB_.getDistinctName('temp_value',
-        Blockly.Variables.NAME_TYPE);
-    code = '\'\'.join([str(' + tempVar + ') for ' + tempVar + ' in [' +
-        code.join(', ') + ']])';
-    return [code, Blockly.Python.ORDER_FUNCTION_CALL];
-  }
 };
+
+//Blockly.Python['text_join'] = function(block) {
+//  // Create a string made up of any number of elements of any type.
+//  //Should we allow joining by '-' or ',' or any other characters?
+//  var code;
+//  if (block.itemCount_ == 0) {
+//    return ['\'\'', Blockly.Python.ORDER_ATOMIC];
+//  } else if (block.itemCount_ == 1) {
+//    var argument0 = Blockly.Python.valueToCode(block, 'ADD0',
+//        Blockly.Python.ORDER_NONE) || '\'\'';
+//    code = 'str(' + argument0 + ')';
+//    return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+//  } else if (block.itemCount_ == 2) {
+//    var argument0 = Blockly.Python.valueToCode(block, 'ADD0',
+//        Blockly.Python.ORDER_NONE) || '\'\'';
+//    var argument1 = Blockly.Python.valueToCode(block, 'ADD1',
+//        Blockly.Python.ORDER_NONE) || '\'\'';
+//    var code = 'str(' + argument0 + ') + str(' + argument1 + ')';
+//    return [code, Blockly.Python.ORDER_UNARY_SIGN];
+//  } else {
+//    var code = [];
+//    for (var n = 0; n < block.itemCount_; n++) {
+//      code[n] = Blockly.Python.valueToCode(block, 'ADD' + n,
+//          Blockly.Python.ORDER_NONE) || '\'\'';
+//    }
+//    var tempVar = Blockly.Python.variableDB_.getDistinctName('temp_value',
+//        Blockly.Variables.NAME_TYPE);
+//    code = '\'\'.join([str(' + tempVar + ') for ' + tempVar + ' in [' +
+//        code.join(', ') + ']])';
+//    return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+//  }
+//};
 
 Blockly.Python['text_append'] = function(block) {
   // Append to a variable in place.

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -276,43 +276,43 @@ h1 {
     <category name="Lists">
       <block type="lists_create_empty"></block>
       <block type="lists_create_with"></block>
-      <!--<block type="lists_repeat">-->
-        <!--<value name="NUM">-->
-          <!--<block type="math_number">-->
-            <!--<field name="NUM">5</field>-->
-          <!--</block>-->
-        <!--</value>-->
-      <!--</block>-->
-      <!--<block type="lists_length"></block>-->
-      <!--<block type="lists_isEmpty"></block>-->
-      <!--<block type="lists_indexOf">-->
-        <!--<value name="VALUE">-->
-          <!--<block type="variables_get">-->
-            <!--<field name="VAR">list</field>-->
-          <!--</block>-->
-        <!--</value>-->
-      <!--</block>-->
-      <!--<block type="lists_getIndex">-->
-        <!--<value name="VALUE">-->
-          <!--<block type="variables_get">-->
-            <!--<field name="VAR">list</field>-->
-          <!--</block>-->
-        <!--</value>-->
-      <!--</block>-->
-      <!--<block type="lists_setIndex">-->
-        <!--<value name="LIST">-->
-          <!--<block type="variables_get">-->
-            <!--<field name="VAR">list</field>-->
-          <!--</block>-->
-        <!--</value>-->
-      <!--</block>-->
-      <!--<block type="lists_getSublist">-->
-        <!--<value name="LIST">-->
-          <!--<block type="variables_get">-->
-            <!--<field name="VAR">list</field>-->
-          <!--</block>-->
-        <!--</value>-->
-      <!--</block>-->
+      <block type="lists_repeat">
+        <value name="NUM">
+          <block type="math_number">
+            <field name="NUM">5</field>
+          </block>
+        </value>
+      </block>
+      <block type="lists_length"></block>
+      <block type="lists_isEmpty"></block>
+      <block type="lists_indexOf">
+        <value name="VALUE">
+          <block type="variables_get">
+            <field name="VAR">list</field>
+          </block>
+        </value>
+      </block>
+      <block type="lists_getIndex">
+        <value name="VALUE">
+          <block type="variables_get">
+            <field name="VAR">list</field>
+          </block>
+        </value>
+      </block>
+      <block type="lists_setIndex">
+        <value name="LIST">
+          <block type="variables_get">
+            <field name="VAR">list</field>
+          </block>
+        </value>
+      </block>
+      <block type="lists_getSublist">
+        <value name="LIST">
+          <block type="variables_get">
+            <field name="VAR">list</field>
+          </block>
+        </value>
+      </block>
     </category>
     <category name="Colour">
       <block type="colour_picker"></block>

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -276,43 +276,43 @@ h1 {
     <category name="Lists">
       <block type="lists_create_empty"></block>
       <block type="lists_create_with"></block>
-      <block type="lists_repeat">
-        <value name="NUM">
-          <block type="math_number">
-            <field name="NUM">5</field>
-          </block>
-        </value>
-      </block>
-      <block type="lists_length"></block>
-      <block type="lists_isEmpty"></block>
-      <block type="lists_indexOf">
-        <value name="VALUE">
-          <block type="variables_get">
-            <field name="VAR">list</field>
-          </block>
-        </value>
-      </block>
-      <block type="lists_getIndex">
-        <value name="VALUE">
-          <block type="variables_get">
-            <field name="VAR">list</field>
-          </block>
-        </value>
-      </block>
-      <block type="lists_setIndex">
-        <value name="LIST">
-          <block type="variables_get">
-            <field name="VAR">list</field>
-          </block>
-        </value>
-      </block>
-      <block type="lists_getSublist">
-        <value name="LIST">
-          <block type="variables_get">
-            <field name="VAR">list</field>
-          </block>
-        </value>
-      </block>
+      <!--<block type="lists_repeat">-->
+        <!--<value name="NUM">-->
+          <!--<block type="math_number">-->
+            <!--<field name="NUM">5</field>-->
+          <!--</block>-->
+        <!--</value>-->
+      <!--</block>-->
+      <!--<block type="lists_length"></block>-->
+      <!--<block type="lists_isEmpty"></block>-->
+      <!--<block type="lists_indexOf">-->
+        <!--<value name="VALUE">-->
+          <!--<block type="variables_get">-->
+            <!--<field name="VAR">list</field>-->
+          <!--</block>-->
+        <!--</value>-->
+      <!--</block>-->
+      <!--<block type="lists_getIndex">-->
+        <!--<value name="VALUE">-->
+          <!--<block type="variables_get">-->
+            <!--<field name="VAR">list</field>-->
+          <!--</block>-->
+        <!--</value>-->
+      <!--</block>-->
+      <!--<block type="lists_setIndex">-->
+        <!--<value name="LIST">-->
+          <!--<block type="variables_get">-->
+            <!--<field name="VAR">list</field>-->
+          <!--</block>-->
+        <!--</value>-->
+      <!--</block>-->
+      <!--<block type="lists_getSublist">-->
+        <!--<value name="LIST">-->
+          <!--<block type="variables_get">-->
+            <!--<field name="VAR">list</field>-->
+          <!--</block>-->
+        <!--</value>-->
+      <!--</block>-->
     </category>
     <category name="Colour">
       <block type="colour_picker"></block>


### PR DESCRIPTION
This is my first pull request; I apologize for any errors in protocol.

This implements an array value field type as a partial alternative to mutator-based blocks. Array value inputs start with a single open connection. Whenever a block is attached, a new connection is added, so there is always an empty connection at the bottom of the stack.

I also reimplemented the 'list_create_with' and 'text_join' blocks using the new input type. The semantics are almost identical to the mutator based blocks, except that lists don't get implicit nulls since array inputs don't have unused connections (except for the one at the bottom for new elements).

There is probably room to improve on the visuals for array value inputs. In the current implementation there are no cues for their special behavior.

I hope this you'll consider this feature as a useful addition to Blockly.