### PR TITLE
Show context menu on touch screens

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -86,6 +86,8 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   if (!Blockly.readOnly && !this.eventsInit_) {
     Blockly.bindEvent_(this.getSvgRoot(), 'mousedown', this,
                        this.onMouseDown_);
+    Blockly.bindEvent_(this.getSvgRoot(), 'contextmenu', this,
+                       this.onContextMenu_);
   }
   // Bind an onchange function, if it exists.
   if (goog.isFunction(this.onchange) && !this.eventsInit_) {
@@ -424,6 +426,17 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     }
     Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   });
+};
+
+/**
+ * Handle context menu.
+ * @param {!Event} e Contextmenu event.
+ * @private
+ */
+Blockly.BlockSvg.prototype.onContextMenu_ = function(e) {
+  this.showContextMenu_(e);
+  e.stopPropagation();
+  e.preventDefault();
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -503,6 +503,7 @@ Blockly.showContextMenu_ = function(e) {
  */
 Blockly.onContextMenu_ = function(e) {
   if (!Blockly.isTargetInput_(e)) {
+    Blockly.showContextMenu_(e);
     // When focused on an HTML text input widget, don't cancel the context menu.
     e.preventDefault();
   }

--- a/core/utils.js
+++ b/core/utils.js
@@ -112,8 +112,11 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
         e.clientY = touchPoint.clientY;
       }
       func.call(thisObject, e);
-      // Stop the browser from scrolling/zooming the page.
-      e.preventDefault();
+      // No stop when touchstart for show contextmenu
+      if (e.type != 'touchstart') {
+        // Stop the browser from scrolling/zooming the page.
+        e.preventDefault();
+      }
     };
     for (var i = 0, eventName;
          eventName = Blockly.bindEvent_.TOUCH_MAP[name][i]; i++) {


### PR DESCRIPTION
Now there is no way to display context menu on touch screens. This patch detects doubletap event and shows the context menu. I tested it on chrome and firefox for mobile platforms and works well.