### PR TITLE
Update logic block so it is reactive to the input attached to it.

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -299,6 +299,36 @@ Blockly.Blocks['logic_compare'] = {
       };
       return TOOLTIPS[op];
     });
+    var myid = this.id;
+    var bindid = Blockly.addChangeListener(function() {
+      var me = Blockly.mainWorkspace.getBlockById(myid);
+      if(null == me) {
+        Blockly.removeChangeListener(bindid);
+      } else {
+        if (me.getInputTargetBlock('A') && !me.getInputTargetBlock('B')) {
+          if (me.getInputTargetBlock('A').outputConnection.check_) {
+            me.getInput('B').setCheck(me.getInputTargetBlock('A').outputConnection.check_[0]);
+          } else {
+            me.getInput('B').setCheck(null);
+          }
+        } else if (me.getInputTargetBlock('B') && !me.getInputTargetBlock('A')) {
+          if (me.getInputTargetBlock('B').outputConnection.check_) {
+            me.getInputTargetBlock('A').setCheck(me.getInputTargetBlock('B').outputConnection.check_[0]);
+          } else {
+            me.getInput('A').setCheck(null);
+          }
+        } else if (me.getInputTargetBlock('A') && me.getInputTargetBlock('B')) {
+          if (me.getInputTargetBlock('A').outputConnection.check_) {
+            me.getInput('B').setCheck(me.getInputTargetBlock('A').outputConnection.check_[0]);
+          } else if (me.getInput('B').outputConnection.check_) {
+            me.getInput('A').setCheck(me.getInputTargetBlock('B').outputConnection.check_[0]);
+          }
+        } else {
+          me.getInput('A').setCheck(null);
+          me.getInput('B').setCheck(null);
+        }
+      }
+    });
   }
 };
 


### PR DESCRIPTION
if you place a number in an input the other input changes it's type to number as well.
When you remove all inputs it reverts back to allowing any input type.

I really don't like the way this is done because there will be a listener added for each block of this type and it has to check all input connections. It would be preferable if the framework provided a call back when a connection was made or unmade to an input and provided the changed input as a parameter, as this would simplify the code quite considerably.

I also realize I could do this with a single listener that iterates all blocks and calls a method on the block, but that is basically the same code as here.