### PR TITLE
Generic array support

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -270,6 +270,58 @@ Blockly.Blocks['lists_indexOf'] = {
         .appendField(new Blockly.FieldDropdown(OPERATORS), 'END');
     this.setInputsInline(true);
     this.setTooltip(Blockly.Msg.LISTS_INDEX_OF_TOOLTIP);
+    this.types_ = [null, null];
+  },
+
+  onchange: function() {
+    if (!this.workspace) {
+      // Block has been deleted.
+      return;
+    }
+    var valueBlock = this.getInputTargetBlock('VALUE');
+    var findBlock = this.getInputTargetBlock('FIND');
+    if (valueBlock) {
+      var type = valueBlock.outputConnection.check_[0];
+      if (type == 'Array') {
+        this.types_[1] = null;
+        this.getInput('FIND').setCheck(this.types_[1]);
+      } else if (type.indexOf('Array<') == 0) {
+        this.types_[1] = type.replace(/.*<(.*)>/, '$1').split(',');
+        this.getInput('FIND').setCheck(this.types_[1]);
+      }
+    } else if (!valueBlock && !findBlock) {
+      this.types_[0] = 'Array';
+      this.getInput('VALUE').setCheck(this.types_[0]);
+      this.types_[1] = null;
+      this.getInput('FIND').setCheck(this.types_[1]);
+    }
+  },
+
+  mutationToDom: function() {
+    if (this.types_[0] || this.types_[1]) {
+      var container = document.createElement('mutation');
+      if (this.types_[0]) {
+        container.setAttribute('valueType', this.types_[0].join(';'));
+      }
+      if (this.types_[1]) {
+        container.setAttribute('findType', this.types_[1].join(';'));
+      }
+      return container;
+    }
+    return null;
+  },
+
+  domToMutation: function(xmlElement) {
+  	var type = xmlElement.getAttribute('valueType');
+  	if (type) {
+      this.types_[0] = type.split(';');
+      this.getInput('VALUE').setCheck(this.types_[0]);
+	}
+  	type = xmlElement.getAttribute('findType');
+  	if (type) {
+      this.types_[1] = type.split(';');
+      this.getInput('FIND').setCheck(this.types_[1]);
+	}
   }
 };
 

--- a/core/connection.js
+++ b/core/connection.js
@@ -535,6 +535,23 @@ Blockly.Connection.prototype.checkType_ = function(otherConnection) {
       return true;
     }
   }
+  // Find any promiscuous array matches in the check lists.
+  for (var x = 0; x < this.check_.length; x++) {
+    if (this.check_[x] == 'Array') {
+      for (var y = 0; y < otherConnection.check_.length; y++) {
+        if (otherConnection.check_[y].indexOf('Array<') == 0) {
+          return true;
+        }
+      }
+    }
+    if (this.check_[x].indexOf('Array<') == 0) {
+      for (var y = 0; y < otherConnection.check_.length; y++) {
+        if (otherConnection.check_[y].indexOf('Array') == 0) {
+          return true;
+        }
+      }
+    }
+  }
   // No intersection.
   return false;
 };

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -673,6 +673,18 @@ Blockly.Blocks['type_list'] = {
   }
 };
 
+Blockly.Blocks['type_list_of'] = {
+  // List of type.
+  valueType: 'Array',
+  init: function() {
+    this.setColour(230);
+    this.appendValueInput("TYPE")
+        .appendField("list of");
+    this.setOutput(true, 'Type');
+    this.setTooltip('Arrays (lists) of a given type are allowed.');
+  }
+};
+
 Blockly.Blocks['type_other'] = {
   // Other type.
   init: function() {

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -255,11 +255,11 @@ function getOptTypesFrom(block, name) {
   if (types.length == 0) {
     return '';
   } else if (types.length == 1) {
-    return types[0];
+    return escapeString(types[0]);
   } else if (types.indexOf('null') != -1) {
-    return 'null';
+    return escapeString('null');
   } else {
-    return '[' + types.join(', ') + ']';
+    return '[' + types.map(function(e){return escapeString(e)}).join(', ') + ']';
   }
 }
 
@@ -276,7 +276,7 @@ function getTypesFrom_(block, name) {
   if (!typeBlock || typeBlock.disabled) {
     types = [];
   } else if (typeBlock.type == 'type_other') {
-    types = [escapeString(typeBlock.getFieldValue('TYPE'))];
+    types = [typeBlock.getFieldValue('TYPE')];
   } else if (typeBlock.type == 'type_group') {
     types = [];
     for (var n = 0; n < typeBlock.typeCount_; n++) {
@@ -290,8 +290,16 @@ function getTypesFrom_(block, name) {
       }
       hash[types[n]] = true;
     }
+  } else if (typeBlock.type == 'type_list_of') {
+    var target = typeBlock.getInputTargetBlock('TYPE');
+    var subtypes = getTypesFrom_(typeBlock, 'TYPE');
+    if (target && subtypes.indexOf('null')==-1) {
+      types = [typeBlock.valueType + '<' + subtypes + '>'];
+    } else {
+      types = [typeBlock.valueType];
+    }
   } else {
-    types = [escapeString(typeBlock.valueType)];
+    types = [typeBlock.valueType];
   }
   return types;
 }

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -175,6 +175,7 @@
       <block type="type_number"></block>
       <block type="type_string"></block>
       <block type="type_list"></block>
+      <block type="type_list_of"></block>
       <block type="type_other"></block>
     </category>
     <category name="Colour" id="colourCategory">


### PR DESCRIPTION
This code allows the Array type specify the type of objects it can contain. Similar to Java generics.
i.e. the type could be Array<Number> or Array<Number,String>
in the latter case the Array can contain Numbers and/or Strings.

This functionality becomes extremely useful in custom block editors where you have an Array of certain type of object and want a "contains" block that limits the type of the contained type to what the Array can contain.
