### PR TITLE
Allow the handling of block mismatches to be configurable.

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -300,6 +300,7 @@ Blockly.Blocks['logic_compare'] = {
       return TOOLTIPS[op];
     });
     this.prevBlocks_ = [null, null];
+    this.types_ = [null, null];
   },
   /**
    * Called whenever anything on the workspace changes.
@@ -332,15 +333,46 @@ Blockly.Blocks['logic_compare'] = {
       // call setCheck so the block being dropped will be rejected if not
       // a match.
       if (blockA) {
+        this.types_[1] = blockA.outputConnection.check_;
         this.getInput('B').setCheck(blockA.outputConnection.check_);
       }
       if (blockB) {
+        this.types_[0] = blockB.outputConnection.check_;
         this.getInput('A').setCheck(blockB.outputConnection.check_);
       }
       if (!blockA && !blockB) {
+        this.types_[0] = null;
         this.getInput('A').setCheck(null);
+        this.types_[1] = null;
         this.getInput('B').setCheck(null);
       }
+    }
+  },
+
+  mutationToDom: function() {
+    if (this.types_[0] || this.types_[1]) {
+      var container = document.createElement('mutation');
+      if (this.types_[0]) {
+        container.setAttribute('datatypeA', this.types_[0].join(';'));
+      }
+      if (this.types_[1]) {
+        container.setAttribute('datatypeB', this.types_[1].join(';'));
+      }
+      return container;
+    }
+    return null;
+  },
+
+  domToMutation: function(xmlElement) {
+    var type = xmlElement.getAttribute('datatypeA');
+    if (type) {
+      this.types_[0] = type.split(';');
+      this.getInput('A').setCheck(this.types_[0]);
+    }
+    type = xmlElement.getAttribute('datatypeB');
+    if (type) {
+      this.types_[1] = type.split(';');
+      this.getInput('B').setCheck(this.types_[1]);
     }
   }
 };

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -313,20 +313,35 @@ Blockly.Blocks['logic_compare'] = {
     }
     var blockA = this.getInputTargetBlock('A');
     var blockB = this.getInputTargetBlock('B');
-    // Kick blocks that existed prior to this change if they don't match.
-    if (blockA && blockB &&
-        !blockA.outputConnection.checkType_(blockB.outputConnection)) {
-      // Mismatch between two inputs.  Disconnect previous and bump it away.
-      for (var i = 0; i < this.prevBlocks_.length; i++) {
-        var block = this.prevBlocks_[i];
-        if (block === blockA || block === blockB) {
-          block.setParent(null);
-          block.bumpNeighbours_();
+    if (Blockly.ejectMismatch) {
+      // Kick blocks that existed prior to this change if they don't match.
+      if (blockA && blockB &&
+          !blockA.outputConnection.checkType_(blockB.outputConnection)) {
+        // Mismatch between two inputs.  Disconnect previous and bump it away.
+        for (var i = 0; i < this.prevBlocks_.length; i++) {
+          var block = this.prevBlocks_[i];
+          if (block === blockA || block === blockB) {
+            block.setParent(null);
+            block.bumpNeighbours_();
+          }
         }
       }
+      this.prevBlocks_[0] = blockA;
+      this.prevBlocks_[1] = blockB;
+    } else {
+      // call setCheck so the block being dropped will be rejected if not
+      // a match.
+      if (blockA) {
+        this.getInput('B').setCheck(blockA.outputConnection.check_);
+      }
+      if (blockB) {
+        this.getInput('A').setCheck(blockB.outputConnection.check_);
+      }
+      if (!blockA && !blockB) {
+        this.getInput('A').setCheck(null);
+        this.getInput('B').setCheck(null);
+      }
     }
-    this.prevBlocks_[0] = blockA;
-    this.prevBlocks_[1] = blockB;
   }
 };
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -132,6 +132,10 @@ Blockly.parseOptions_ = function(options) {
   if (hasCss === undefined) {
     hasCss = true;
   }
+  var ejectMismatch = options['ejectMismatch'];
+  if (ejectMismatch === undefined) {
+    ejectMismatch = true;
+  }
   var enableRealtime = !!options['realtime'];
   var realtimeOptions = enableRealtime ? options['realtimeOptions'] : undefined;
 
@@ -152,6 +156,7 @@ Blockly.parseOptions_ = function(options) {
   Blockly.hasTrashcan = hasTrashcan;
   Blockly.hasSounds = hasSounds;
   Blockly.hasCss = hasCss;
+  Blockly.ejectMismatch = ejectMismatch;
   Blockly.languageTree = tree;
   Blockly.enableRealtime = enableRealtime;
   Blockly.realtimeOptions = realtimeOptions;


### PR DESCRIPTION
I have added an "ejectMistmatch" property to the inject configuration.
This property controls whether the block will eject the other block or will change the datatype of the
valueInputs so the block cannot be attached if the type does not match.

The property defaults to true which performs the eject and setting it to false will set the datatype and therefore disallow connection.
