### PR TITLE
Fixed issue with calculating input focus on different input types

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -551,7 +551,10 @@ Blockly.removeAllRanges = function() {
  * @private
  */
 Blockly.isTargetInput_ = function(e) {
-  return e.target.type == 'textarea' || e.target.type == 'text';
+  return e.target.type == 'textarea' || e.target.type == 'text' 
+      || e.target.type == 'number' || e.target.type == 'email'
+      || e.target.type == 'password' || e.target.type == 'search'
+      || e.target.type == 'tel' || e.target.type == 'url';
 };
 
 /**


### PR DESCRIPTION
When adding input elements that have a type other than 'text', Blockly takes over the keyboard control, preventing the backspace key from being used.