### PR TITLE
Allow blocks in block factory to be imported and exported as files

### DIFF
--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -499,10 +499,7 @@ function init() {
       var file = e.dataTransfer.files[0];
       var reader = new FileReader();
       reader.addEventListener('load', function(e) {
-        var topBlocks = Blockly.mainWorkspace.getTopBlocks();
-        for(var i = 0; i < topBlocks.length; ++i) {
-          topBlocks[i].dispose();
-        }
+        Blockly.mainWorkspace.clear();
         var xml = Blockly.Xml.textToDom(e.target.result);
         Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xml);
       });

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -443,6 +443,15 @@ function init() {
     linkButton.style.display = 'inline-block';
     linkButton.addEventListener('click', BlocklyStorage.link);
   }
+  else {
+    var linkButton = document.getElementById('linkButton');
+    linkButton.style.display = 'inline-block';
+    linkButton.addEventListener('click', function() {
+      var xml = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
+      var xml_text = Blockly.Xml.domToPrettyText(xml);
+      window.open("data:text/plain;base64,"+btoa(xml_text), "xml");
+    });
+  }
 
   document.getElementById('helpButton').addEventListener('click', function() {
       open('https://developers.google.com/blockly/custom-blocks/block-factory',
@@ -476,6 +485,31 @@ function init() {
     rootBlock.render();
     rootBlock.setMovable(false);
     rootBlock.setDeletable(false);
+
+    var cancel = function(e) {
+      e.preventDefault();
+      return false;
+    }
+    document.body.addEventListener('dragover', cancel);
+    document.body.addEventListener('dragend', cancel);
+    document.body.addEventListener('drop', function(e) {
+      if(e.dataTransfer.files.length === 0) { return; }
+      e.preventDefault();
+
+      var file = e.dataTransfer.files[0];
+      var reader = new FileReader();
+      reader.addEventListener('load', function(e) {
+        var topBlocks = Blockly.mainWorkspace.getTopBlocks();
+        for(var i = 0; i < topBlocks.length; ++i) {
+          topBlocks[i].dispose();
+        }
+        var xml = Blockly.Xml.textToDom(e.target.result);
+        Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xml);
+      });
+      reader.readAsText(file);
+
+      return false;
+    });
   }
 
   Blockly.addChangeListener(onchange);

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -448,6 +448,10 @@ function init() {
     linkButton.style.display = 'inline-block';
     linkButton.addEventListener('click', function() {
       var xml = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
+      var nodes = xml.querySelectorAll('[id]');
+      for(var i = 0; i < nodes.length; ++i) {
+        nodes[i].removeAttribute('id');
+      }
       var xml_text = Blockly.Xml.domToPrettyText(xml);
       window.open("data:text/plain;base64,"+btoa(xml_text), "xml");
     });


### PR DESCRIPTION
When cloud storage is not available, the link button will open a new window with xml content representing the current block (for copying&pasting into a local file).

When an xml file is dropped into the browser, it will be loaded as a block.
