### PR TITLE
Fixed issue with mutated procedure call blocks

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -594,15 +594,15 @@ Blockly.Blocks['procedures_callnoreturn'] = {
       // Initialize caller with the mutator's IDs.
       this.setProcedureParameters(def.arguments_, def.paramIds_);
     } else {
-      this.arguments_ = [];
+      var args = [];
       for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
         if (childNode.nodeName.toLowerCase() == 'arg') {
-          this.arguments_.push(childNode.getAttribute('name'));
+          args.push(childNode.getAttribute('name'));
         }
       }
       // For the second argument (paramIds) use the arguments list as a dummy
       // list.
-      this.setProcedureParameters(this.arguments_, this.arguments_);
+      this.setProcedureParameters(args, args);
     }
   },
   /**


### PR DESCRIPTION
Mutated procedure call blocks are not presented correctly when dragged into the workspace. Steps to reproduce;

1. Create a procedure definition
2. Add arguments
3. Drag in the procedure call block into the main workspace
4. The block appears to have no arguments