### PR TITLE
Add grid snap to the additional block functions:

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -228,10 +228,22 @@ Blockly.Block.prototype.unplug = function(healStack, bump) {
     }
   }
   if (bump) {
-    // Bump the block sideways.
-    var dx = Blockly.SNAP_RADIUS * (Blockly.RTL ? -1 : 1);
-    var dy = Blockly.SNAP_RADIUS * 2;
+    // Calculate the bump based on snap radius or grid snap.
+    if (Blockly.gridOptions['snap'] &&
+        Blockly.gridOptions['spacing'] > Blockly.SNAP_RADIUS) {
+      var xOffset = Blockly.gridOptions['spacing'];
+      var yOffset = Blockly.gridOptions['spacing'] * 2;
+    } else {
+      var xOffset = Blockly.SNAP_RADIUS;
+      var yOffset = Blockly.SNAP_RADIUS * 2;
+    }
+    // Bump the block sideways and snap to grid if enabled.
+    var dx = xOffset * (Blockly.RTL ? -1 : 1);
+    var dy = yOffset;
     this.moveBy(dx, dy);
+    if (Blockly.gridOptions['snap']) {
+      block.snapToGrid();
+    }
   }
 };
 
@@ -248,13 +260,22 @@ Blockly.Block.prototype.duplicate_ = function() {
       /** @type {!Blockly.Workspace} */ (this.workspace), xmlBlock);
   // Move the duplicate next to the old block.
   var xy = this.getRelativeToSurfaceXY();
-  if (Blockly.RTL) {
-    xy.x -= Blockly.SNAP_RADIUS;
+  // Calculate the offset based on snap radius or grid snap.
+  if (Blockly.gridOptions['snap'] &&
+      Blockly.gridOptions['spacing'] > Blockly.SNAP_RADIUS) {
+    var xOffset = Blockly.gridOptions['spacing'];
+    var yOffset = Blockly.gridOptions['spacing'] * 2;
   } else {
-    xy.x += Blockly.SNAP_RADIUS;
+    var xOffset = Blockly.SNAP_RADIUS;
+    var yOffset = Blockly.SNAP_RADIUS * 2;
   }
-  xy.y += Blockly.SNAP_RADIUS * 2;
+  // Apply and snap to grid if enabled.
+  xy.x += xOffset * (Blockly.RTL ? -1 : 1);
+  xy.y += yOffset;
   newBlock.moveBy(xy.x, xy.y);
+  if (Blockly.gridOptions['snap']) {
+    newBlock.snapToGrid();
+  }
   newBlock.select();
   return newBlock;
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -200,7 +200,7 @@ Blockly.BlockSvg.terminateDrag_ = function() {
       if (Blockly.gridOptions['snap'] &&
           selected.workspace == Blockly.mainWorkspace) {
         goog.Timer.callOnce(
-            selected.snapToGrid_, Blockly.BUMP_DELAY / 2, selected);
+            selected.snapToGrid, Blockly.BUMP_DELAY / 2, selected);
       }
       goog.Timer.callOnce(
           selected.bumpNeighbours_, Blockly.BUMP_DELAY, selected);
@@ -274,9 +274,8 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
 
 /**
  * Snap this block to the nearest grid point.
- * @private
  */
-Blockly.BlockSvg.prototype.snapToGrid_ = function() {
+Blockly.BlockSvg.prototype.snapToGrid = function() {
   if (!this.workspace) {
     return;  // Deleted block.
   }

--- a/core/connection.js
+++ b/core/connection.js
@@ -299,8 +299,14 @@ Blockly.Connection.prototype.bumpAwayFrom_ = function(staticConnection) {
   }
   // Raise it to the top for extra visibility.
   rootBlock.getSvgRoot().parentNode.appendChild(rootBlock.getSvgRoot());
-  var dx = (staticConnection.x_ + Blockly.SNAP_RADIUS) - this.x_;
-  var dy = (staticConnection.y_ + Blockly.SNAP_RADIUS) - this.y_;
+  if (Blockly.gridOptions['snap'] &&
+      Blockly.gridOptions['spacing'] > Blockly.SNAP_RADIUS) {
+    var offset = Blockly.gridOptions['spacing'];
+  } else {
+    var offset = Blockly.SNAP_RADIUS;
+  }
+  var dx = (staticConnection.x_ + offset) - this.x_;
+  var dy = (staticConnection.y_ + offset) - this.y_;
   if (reverse) {
     // When reversing a bump due to an uneditable block, bump up.
     dy = -dy;
@@ -309,6 +315,9 @@ Blockly.Connection.prototype.bumpAwayFrom_ = function(staticConnection) {
     dx = -dx;
   }
   rootBlock.moveBy(dx, dy);
+  if (Blockly.gridOptions['snap']) {
+    rootBlock.snapToGrid();
+  }
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -333,19 +333,29 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
       var allBlocks = this.getAllBlocks();
       for (var x = 0, otherBlock; otherBlock = allBlocks[x]; x++) {
         var otherXY = otherBlock.getRelativeToSurfaceXY();
-        if (Math.abs(blockX - otherXY.x) <= 1 &&
-            Math.abs(blockY - otherXY.y) <= 1) {
-          if (Blockly.RTL) {
-            blockX -= Blockly.SNAP_RADIUS;
-          } else {
-            blockX += Blockly.SNAP_RADIUS;
+        // Calculate the relative distance based on snap radius or grid snap.
+        var relativeDistance = Blockly.SNAP_RADIUS;
+        var offsetX = Blockly.SNAP_RADIUS + 1;
+        var offsetY = Blockly.SNAP_RADIUS * 2;
+        if (Blockly.gridOptions['snap']) {
+          if (Blockly.gridOptions['spacing'] > Blockly.SNAP_RADIUS) {
+            relativeDistance = Blockly.gridOptions['spacing'];
+            offsetX = Blockly.gridOptions['spacing'] + 1;
+            offsetY = Blockly.gridOptions['spacing'] * 2;
           }
-          blockY += Blockly.SNAP_RADIUS * 2;
+        }
+        if (Math.abs(blockX - otherXY.x) <= relativeDistance &&
+            Math.abs(blockY - otherXY.y) <= relativeDistance) {
+          blockX += offsetX * (Blockly.RTL ? -1 : 1);
+          blockY += offsetY;
           collide = true;
         }
       }
     } while (collide);
     block.moveBy(blockX, blockY);
+    if (Blockly.gridOptions['snap']) {
+      block.snapToGrid();
+    }
   }
   block.select();
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -238,6 +238,9 @@ Blockly.Xml.domToWorkspace = function(workspace, xml) {
       var blockY = parseInt(xmlChild.getAttribute('y'), 10);
       if (!isNaN(blockX) && !isNaN(blockY)) {
         block.moveBy(Blockly.RTL ? width - blockX : blockX, blockY);
+        if (Blockly.gridOptions['snap']) {
+          block.snapToGrid();
+        }
       }
     }
   }


### PR DESCRIPTION
I was playing around with the new grid functionality and noticed there were some cases where the blocks were not snapping to the enabled grid:
- XML to workspace import
- Duplicated blocks
- Pasted blocks
- Bumped away blocks
- Unplugged blocks

So, I've changed the snapToGrid function from private to public and added extra logic to calculate block offsets based on the larger between the grid snap or the snap radius.
