### PR TITLE
IE deselect exception fix.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -537,7 +537,6 @@ Blockly.removeAllRanges = function() {
   if (window.getSelection) {  // W3
     var sel = window.getSelection();
     if (sel && sel.removeAllRanges) {
-      sel.removeAllRanges();
       setTimeout(function() {
           try {
             window.getSelection().removeAllRanges();


### PR DESCRIPTION
IE11 with the developer tools open will still throw an exception on this line of code, so remove it as it is also executed and caught in the setTimeout.
If for some reason this line should be executed twice, then the first one should also be wrapped in a try/catch statement.