### PR TITLE
fix mutator icon bug (issue #45)

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.Css');
 
 goog.require('goog.cssom');
+goog.require('goog.userAgent');
 
 
 /**
@@ -286,7 +287,8 @@ Blockly.Css.CONTENT = [
   '  fill: #ccc;',
   '  font-family: sans-serif;',
   '  font-size: 9pt;',
-  '  font-weight: bold;',
+  //fix bug with mutator icon in android 4.4.2 webkit
+  (/Android 4.4.2/.test(goog.userAgent.getUserAgentString()) && goog.userAgent.WEBKIT)?'font-weight: normal;':'font-weight: bold;',
   '  text-anchor: middle;',
   '}',
 


### PR DESCRIPTION
Fixes mutator icon bug #45, the problem is that chrome for android don't render character U+2605 'black star'(&#9733;) with `font-weight: bold;` css property.
With this patch the icon is shown but with a different appearance, because the characters are rendered differently. Otherwise might be putting a picture or svg element for uniform rendering in all browsers.

![mutator-icon-bug-fix](https://cloud.githubusercontent.com/assets/5993168/6649673/a4ab37f0-c9be-11e4-8794-cf43107c4d94.jpg)

