### PR TITLE
Add option to set id on toolbox

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -197,6 +197,10 @@ Blockly.Toolbox.prototype.populate_ = function(newTree) {
             childOut.setExpanded(true);
           }
           treeOut.add(childOut);
+          var customId = childIn.getAttribute('id');
+          if (customId) {
+            childOut.setId(customId);
+          }
           var custom = childIn.getAttribute('custom');
           if (custom) {
             // Variables and procedures are special dynamic categories.


### PR DESCRIPTION
This adds an ```id``` option to toolbox categories, which allows the id of the category to be specified. This in turn allows a known element id which can be styled.
Without this, the tree uses an incrementing number, which is potentially usable, but in a single page app the number doesn't get reset, so the number isn't fixed each time blockly is displayed - making it useless.

EG:
```xml
<category name="Logic" id="toolbox-blue">
```