### PR TITLE
Offset pasted block if in range of a snap connection.

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -396,7 +396,8 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
     if (this.RTL) {
       blockX = -blockX;
     }
-    // Offset block until not clobbering another block.
+    // Offset block until not clobbering another block and not in connection
+    // distance with neighbouring blocks.
     do {
       var collide = false;
       var allBlocks = this.getAllBlocks();
@@ -404,14 +405,28 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
         var otherXY = otherBlock.getRelativeToSurfaceXY();
         if (Math.abs(blockX - otherXY.x) <= 1 &&
             Math.abs(blockY - otherXY.y) <= 1) {
-          if (this.RTL) {
-            blockX -= Blockly.SNAP_RADIUS;
-          } else {
-            blockX += Blockly.SNAP_RADIUS;
-          }
-          blockY += Blockly.SNAP_RADIUS * 2;
           collide = true;
         }
+      }
+      if (!collide) {
+        // Check for blocks in snap range to any of its connections
+        var blockConnections = block.getConnections_(false);
+        for (var i = 0; i < blockConnections.length; i++) {
+          var blockConnection = blockConnections[i];
+          var neighbour =
+              blockConnection.closest(Blockly.SNAP_RADIUS, blockX, blockY);
+          if (neighbour.connection) {
+            collide = true;
+          }
+        }
+      }
+      if (collide) {
+        if (this.RTL) {
+          blockX -= Blockly.SNAP_RADIUS;
+        } else {
+          blockX += Blockly.SNAP_RADIUS;
+        }
+        blockY += Blockly.SNAP_RADIUS * 2;
       }
     } while (collide);
     block.moveBy(blockX, blockY);


### PR DESCRIPTION
In the current situation, when a block is pasted it does not take in consideration if it is close enough to connect with another block. 

This can be confusing in cases where it might erroneously look as if the blocks are "physically connected". For example, if a block already connected is cut and pasted, it will be placed in exactly the same position, visually appearing to be connected.

This pull request offsets the block until it is not within connection range to any neighbouring blocks.