### PR TITLE
adding missing type documentation to public fields

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -90,14 +90,23 @@ Blockly.Block.prototype.initialize = function(workspace, prototypeName) {
  * @param {string} prototypeName The typename of the block.
  */
 Blockly.Block.prototype.fill = function(workspace, prototypeName) {
+  /** @type {?Blockly.Connection} */
   this.outputConnection = null;
+  /** @type {?Blockly.Connection} */
   this.nextConnection = null;
+  /** @type {?Blockly.Connection} */
   this.previousConnection = null;
+  /** @type {Blockly.Input[]} */
   this.inputList = [];
+  /** @type {?boolean} */
   this.inputsInline = undefined;
+  /** @type {boolean} */
   this.rendered = false;
+  /** @type {boolean} */
   this.disabled = false;
+  /** @type {(string|Function|object)} */
   this.tooltip = '';
+  /** @type {boolean} */
   this.contextMenu = true;
 
   this.parentBlock_ = null;
@@ -107,16 +116,21 @@ Blockly.Block.prototype.fill = function(workspace, prototypeName) {
   this.editable_ = true;
   this.collapsed_ = false;
 
+  /** @type {?(string|Blockly.Comment)} */
   this.comment = null;
 
   this.xy_ = new goog.math.Coordinate(0, 0);
 
+  /** @type {Blockly.Workspace} */
   this.workspace = workspace;
+  /** @type {boolean} */
   this.isInFlyout = workspace.isFlyout;
+  /** @type {boolean} */
   this.RTL = workspace.RTL;
 
   // Copy the type-specific functions and data from the prototype.
   if (prototypeName) {
+    /** @type {?string} */
     this.type = prototypeName;
     var prototype = Blockly.Blocks[prototypeName];
     goog.asserts.assertObject(prototype,
@@ -1186,7 +1200,7 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
 /**
  * Fetches the named input object.
  * @param {string} name The name of the input.
- * @return {Object} The input object, or null of the input does not exist.
+ * @return {?Blockly.Input} The input object, or null of the input does not exist.
  */
 Blockly.Block.prototype.getInput = function(name) {
   for (var i = 0, input; input = this.inputList[i]; i++) {

--- a/core/connection.js
+++ b/core/connection.js
@@ -38,7 +38,9 @@ goog.require('goog.dom');
  */
 Blockly.Connection = function(source, type) {
   this.sourceBlock_ = source;
+  /** @type {?Blockly.Connection} */
   this.targetConnection = null;
+  /** @type {number} */
   this.type = type;
   this.x_ = 0;
   this.y_ = 0;

--- a/core/field.js
+++ b/core/field.js
@@ -180,7 +180,7 @@ Blockly.Field.prototype.setVisible = function(visible) {
 
 /**
  * Sets a new change handler for editable fields.
- * @param {Function} handler New change handler, or null.
+ * @param {?Function} handler New change handler, or null.
  */
 Blockly.Field.prototype.setChangeHandler = function(handler) {
   this.changeHandler_ = handler;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -39,7 +39,7 @@ goog.require('goog.userAgent');
 
 /**
  * Class for an editable dropdown field.
- * @param {(!Array.<string>|!Function)} menuGenerator An array of options
+ * @param {(!Array.<!Array.<string>>|!Function)} menuGenerator An array of options
  *     for a dropdown list, or a function which generates these options.
  * @param {Function} opt_changeHandler A function that is executed when a new
  *     option is selected, with the newly selected value as its sole argument.

--- a/core/input.js
+++ b/core/input.js
@@ -43,11 +43,16 @@ goog.require('goog.asserts');
  * @constructor
  */
 Blockly.Input = function(type, name, block, connection) {
+  /** @type {number} */
   this.type = type;
+  /** @type {string} */
   this.name = name;
   this.sourceBlock_ = block;
+  /** @type {Blockly.Connection} */
   this.connection = connection;
+  /** @type {Blockly.Field[]} */
   this.fieldRow = [];
+  /** @type {number} */
   this.align = Blockly.ALIGN_LEFT;
 
   this.visible_ = true;


### PR DESCRIPTION
Pull request to address: #124

I've added a number of type docs to publicly accessible fields. The types are nice to grok faster (whether public or private). Also I'm looking at creating a typescript d.ts file for Blockly. This information will help in that process as well.