### PR TITLE
Remove flyout scrollbar background.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -326,6 +326,11 @@ Blockly.Css.CONTENT = [
   '  stroke-width: 1;',
   '}',
 
+  '.blocklyFlyout .blocklyScrollbarBackground {',
+  '  fill: none;',
+  '  stroke-width: 0;',
+  '}',
+
   '.blocklyScrollbarKnob {',
   '  fill: #ccc;',
   '}',

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -113,12 +113,13 @@ Blockly.Flyout.prototype.CORNER_RADIUS = 8;
  */
 Blockly.Flyout.prototype.createDom = function() {
   /*
-  <g>
+  <g class="blocklyFlyout">
     <path class="blocklyFlyoutBackground"/>
     <g></g>
   </g>
   */
-  this.svgGroup_ = Blockly.createSvgElement('g', {}, null);
+  this.svgGroup_ = Blockly.createSvgElement('g',
+      {'class': 'blocklyFlyout'}, null);
   this.svgBackground_ = Blockly.createSvgElement('path',
       {'class': 'blocklyFlyoutBackground'}, this.svgGroup_);
   this.svgGroup_.appendChild(this.workspace_.createDom());


### PR DESCRIPTION
A simple visual change to remove the white background of the flyout scrollbar.

This does not affect the background of the rest of scrollbars.

![scrollbar](https://cloud.githubusercontent.com/assets/4189262/8686389/c89ea172-2a7d-11e5-9e13-36b2ef4956c3.png)
