### PR TITLE
Block factory: close workspace drop downs and unfocus selections on manual edit.

### DIFF
--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -48,6 +48,7 @@ function formatChange() {
   var languagePre = document.getElementById('languagePre');
   var languageTA = document.getElementById('languageTA');
   if (document.getElementById('format').value == 'Manual') {
+    Blockly.hideChaff();
     mask.style.display = 'block';
     languagePre.style.display = 'none';
     languageTA.style.display = 'block';


### PR DESCRIPTION
Another minuscule update. In this case I noticed that on the block factory when the "manual edit" option is selected any drop down menu, focused input, etch keeps their state and stay on top of the dark overlay.