### PR TITLE
Contain the height of the field dropdown to the window viewport height.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -547,6 +547,9 @@ Blockly.Css.CONTENT = [
   '  outline: none;',
   '  padding: 4px 0;',
   '  position: absolute;',
+  '  overflow-y: auto;',
+  '  overflow-x: hidden;',
+  '  max-height: 100%;',
   '  z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -174,6 +174,8 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   Blockly.addClass_(menuDom, 'blocklyDropdownMenu');
   // Record menuSize after adding menu.
   var menuSize = goog.style.getSize(menuDom);
+  // Recalculate height for the total content, not only box height.
+  menuSize.height = menuDom.scrollHeight;
 
   // Position the menu.
   // Flip menu vertically if off the bottom.

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -139,4 +139,5 @@ Blockly.WidgetDiv.position = function(anchorX, anchorY, windowSize,
   }
   Blockly.WidgetDiv.DIV.style.left = anchorX + 'px';
   Blockly.WidgetDiv.DIV.style.top = anchorY + 'px';
+  Blockly.WidgetDiv.DIV.style.height = windowSize.height - anchorY + 'px';
 };


### PR DESCRIPTION
The current field dropdown is anchored to a maximum top position within the browser viewport. However the total height is dependent on the number of items and can get clipped, or forces an expansion of the page height.

You can see an example here: https://blockly-demo.appspot.com/static/demos/code/index.html#dnojq9
If the window viewport height is less than 600px it clips the content (in this case it becomes inaccessible), and if done in a blockly implementation with an expandable body it will trigger the page scrollbars.

This update sets the maximum height of the dropdown menu to be the viewport height and triggers the scrollbar in the menu if there is content overflow

Because the widgetdiv is changed to achieve this (it is given a height, while still having a width of 0) I checked the colour, date, and angle fields and they all have the same behaviour.