### PR TITLE
Change plane demo readme cli quotation marks for better compatibility.

### DIFF
--- a/demos/plane/README.txt
+++ b/demos/plane/README.txt
@@ -15,7 +15,7 @@ translated strings.  These should be placed in the xlf directory.
 
 Finally, generate all the language versions wih this command:
 
-java -jar soy/SoyToJsSrcCompiler.jar --locales ar,be-tarask,br,ca,da,de,el,en,es,fa,fr,he,hrx,hu,ia,is,it,ja,ko,ms,nb,nl,pl,pms,pt-br,ro,ru,sc,sv,th,tr,uk,vi,zh-hans,zh-hant --messageFilePathFormat xlf/translated_msgs_{LOCALE}.xlf --outputPathFormat 'generated/{LOCALE}.js' template.soy
+java -jar soy/SoyToJsSrcCompiler.jar --locales ar,be-tarask,br,ca,da,de,el,en,es,fa,fr,he,hrx,hu,ia,is,it,ja,ko,ms,nb,nl,pl,pms,pt-br,ro,ru,sc,sv,th,tr,uk,vi,zh-hans,zh-hant --messageFilePathFormat xlf/translated_msgs_{LOCALE}.xlf --outputPathFormat "generated/{LOCALE}.js" template.soy
 
 This is the process that Google uses for maintaining Blockly Games in 40+
 languages.  The XLIFF fromat is simple enough that it is trival to write a


### PR DESCRIPTION
A rather insignificant change, feel free to reject it.

On Windows, copying and pasting the readme file command causes the generated files to end up in a folder named `'generated` and adds the other `'` to all the js files. I did a quick sanity check in Linux and the double quotes work as expected.