### PR TITLE
Add basic lint options for npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+node_modules
+npm-debug.log
 .DS_Store
+.settings
+.project
 *.pyc
 *.komodoproject

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,6 @@
+node_modules/
+tests/
+demos/
+**/*_compressed.js
+**/*_uncompressed.js
+**/*_test.js

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -679,7 +679,7 @@ Blockly.Msg.TEXT_GET_SUBSTRING_END_LAST = 'to last letter';
 Blockly.Msg.TEXT_GET_SUBSTRING_TAIL = '';
 
 /// url - Information about the case of letters (upper-case and lower-case).
-Blockly.Msg.TEXT_CHANGECASE_HELPURL = 'https://github.com/google/blockly/wiki/Text#adjusting-text-case'
+Blockly.Msg.TEXT_CHANGECASE_HELPURL = 'https://github.com/google/blockly/wiki/Text#adjusting-text-case';
 /// tooltip - Describes a block to adjust the case of letters.  For more information on this block,
 /// see [https://github.com/google/blockly/wiki/Text#adjusting-text-case
 /// https://github.com/google/blockly/wiki/Text#adjusting-text-case].
@@ -979,7 +979,7 @@ Blockly.Msg.LISTS_GET_SUBLIST_TOOLTIP = 'Creates a copy of the specified portion
 /// url - Information describing splitting text into a list, or joining a list into text.
 Blockly.Msg.LISTS_SPLIT_HELPURL = 'https://github.com/google/blockly/wiki/Lists#splitting-strings-and-joining-lists';
 /// dropdown - Indicates that text will be split up into a list (e.g. "a-b-c" -> ["a", "b", "c"]).
-Blockly.Msg.LISTS_SPLIT_LIST_FROM_TEXT = 'make list from text'
+Blockly.Msg.LISTS_SPLIT_LIST_FROM_TEXT = 'make list from text';
 /// dropdown - Indicates that a list will be joined together to form text (e.g. ["a", "b", "c"] -> "a-b-c").
 Blockly.Msg.LISTS_SPLIT_TEXT_FROM_LIST = 'make text from list';
 /// block text - Prompts for a letter to be used as a separator when splitting or joining text.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Blockly is a library for building visual programming editors.",
   "keywords": ["blockly"],
+  "scripts": {
+    "lint": "jshint ."
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/google/blockly.git"
@@ -15,5 +18,15 @@
     "name": "Neil Fraser"
   },
   "license": "Apache-2.0",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "jshint": "latest"
+  },
+  "jshintConfig": {
+	"unused": true,
+	"undef": true,
+	"globalstrict": true,
+	"sub": true,
+	"predef": ["Blockly", "goog", "window", "document", "soy", "XMLHttpRequest"]
+  }
 }


### PR DESCRIPTION
To use this linter, make sure npm is installed and execute the following
commands inside the main folder.

1.) Only once to update the package "npm install"
2.) To run the linter "npm run lint"

This would make it easier to clean up some of the code.