### PR TITLE
fix: https://github.com/google/blockly/issues/161

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -294,6 +294,9 @@ Blockly.onMouseUp_ = function(e) {
  * @private
  */
 Blockly.onMouseMove_ = function(e) {
+  if (event.touches && event.touches.length >= 2) {
+    return  // multi-touch gestures won't have e.clientX
+  }
   var workspace = Blockly.getMainWorkspace();
   if (workspace.isScrolling) {
     Blockly.removeAllRanges();


### PR DESCRIPTION
This fixes issue #161, pinch gestures cause errors in console.

There is some difference of opinion on whether this error should be avoided since there is currently work going on for zooming. I propose we include this 3 line change now to keep the code in good shape at all times. When folks work on the pinch gesture, they will see it and can take it out.