### PR TITLE
Remove additional height to the FieldImage size.

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -46,7 +46,7 @@ Blockly.FieldImage = function(src, width, height, opt_alt) {
   // Ensure height and width are numbers.  Strings are bad at math.
   this.height_ = Number(height);
   this.width_ = Number(width);
-  this.size_ = new goog.math.Size(this.height_ + 10, this.width_);
+  this.size_ = new goog.math.Size(this.height_, this.width_);
   this.text_ = opt_alt || '';
   this.setValue(src);
 };


### PR DESCRIPTION
I'm not quite sure why it was originally added, but with the new zooming feature the overall width of the image area has been increased:

![text](https://cloud.githubusercontent.com/assets/4189262/9413411/a346fdd8-4829-11e5-94f7-0f1d3e12f9fc.png)

I had a quick check on Firefox, Chrome, and IE11, including using different image sizes in the BlocklyFactory, and it seems to be working as expected with this removal.
