### PR TITLE
Update getScaledBBox_ to return new object to fix issue in IE.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -231,9 +231,9 @@ Blockly.Field.prototype.getSize = function() {
  */
 Blockly.Field.prototype.getScaledBBox_ = function() {
   var bBox = this.borderRect_.getBBox();
-  bBox.width *= this.sourceBlock_.workspace.scale;
-  bBox.height *= this.sourceBlock_.workspace.scale;
-  return bBox;
+  // Create new object, as getBBox can return an uneditable SVGRect.
+  return {width: bBox.width * this.sourceBlock_.workspace.scale,
+          height: bBox.height * this.sourceBlock_.workspace.scale};
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -228,10 +228,8 @@ Blockly.FieldTextInput.prototype.validate_ = function() {
 Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   var div = Blockly.WidgetDiv.DIV;
   var bBox = this.fieldGroup_.getBBox();
-  bBox.width *= this.sourceBlock_.workspace.scale;
-  bBox.height *= this.sourceBlock_.workspace.scale;
-  div.style.width = bBox.width + 'px';
-  div.style.height = bBox.height + 'px';
+  div.style.width = bBox.width * this.sourceBlock_.workspace.scale + 'px';
+  div.style.height = bBox.height * this.sourceBlock_.workspace.scale + 'px';
   var xy = this.getAbsoluteXY_();
   // In RTL mode block fields and LTR input fields the left edge moves,
   // whereas the right edge is fixed.  Reposition the editor.


### PR DESCRIPTION
In IE11, getBBox returns a read-only SVGRect, and throws the NO_MODIFICATION_ALLOWED_ERR exception when trying to edit its attributes.

As this read-only option is left to the browser by design, it seems better to always create a new object instead of doing it only on a catch statement.

https://developer.mozilla.org/en/docs/Web/API/SVGRect