### PR TITLE
Implement typeahead search for blocks with a hotkey

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -375,6 +375,9 @@ Blockly.onKeyDown_ = function(e) {
         Blockly.clipboardSource_.paste(Blockly.clipboardXml_);
       }
     }
+    if (e.keyCode == 32) {
+      Blockly.getMainWorkspace().focusToolboxSearch();
+    }
   }
   if (deleteBlock) {
     // Common code for delete and cut.

--- a/core/css.js
+++ b/core/css.js
@@ -446,6 +446,10 @@ Blockly.Css.CONTENT = [
     'background-position: -16px -1px;',
   '}',
 
+  '.blocklyTreeSearch {',
+    'padding-right: 8px;',
+  '}',
+
   '.blocklyTreeSelected>.blocklyTreeIconClosedLtr {',
     'background-position: -32px -17px;',
   '}',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -910,6 +910,15 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
 };
 
 /**
+ * Set focus to the search field of the toolbox, if it exists.
+ */
+Blockly.WorkspaceSvg.prototype.focusToolboxSearch = function() {
+  if (this.toolbox_) {
+    this.toolbox_.focusSearchField();
+  }
+};
+
+/**
  * When something in this workspace changes, call a function.
  * @param {!Function} func Function to call.
  * @return {!Array.<!Array>} Opaque data that can be passed to


### PR DESCRIPTION
This pull request adds the capability to add a typeahead search field to your toolbox XML, using the tag `<search/>`.  Toolboxes that include this tag will have an HTML search field added to them.  Typing in this field will search for blocks whose field text, type, or tooltip match the given term or terms, and display them in a flyout.

This is useful for situations where you have a large toolbox with many categories and you don't want to have to remember where the block you're looking for is located.

The search field can also be focused using the new hotkey [MODIFIER]-Space.