### PR TITLE
allow block xml disable tag to be more accepting

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -494,7 +494,7 @@ Blockly.Xml.domToBlockHeadless_ =
   }
   var disabled = xmlBlock.getAttribute('disabled');
   if (disabled) {
-    block.setDisabled(disabled == 'true');
+    block.setDisabled(disabled == 'true' || disabled == 'disabled');
   }
   var deletable = xmlBlock.getAttribute('deletable');
   if (deletable) {


### PR DESCRIPTION
The Blockly docs say in order to disable a block in the toolbox you should set the block element disabled:
`<block type="math_single" disabled="true"></block>`
However, the attribute "disabled" is already an HTML attribute, which can cause issues when it is injected as HTML (e.g., you might be using a framework like angular that sees and acts on "disabled". I hit this issue when using angular to dynamically set the disabled tag, which it sets to "disabled"). IMO, the best practice is to prefix "data" in front of custom attribute or to conform to the standard for that given attribute. In this example, it is standard to see:
`<block type="math_single" disabled></block>`
or
`<block type="math_single" disabled="disabled"></block>`

I saw these options:
- prefix all these custom tags with "data", which seemed less than ideal
- make the code reading "disabled attribute more accepting, which I chose to do (this accepts the mere presence of the attribute

I didn't change the blockToDom_ code when the attribute is written out so it still writes `disabled=true`  but reading in the attribute is now more flexible and follows the standard. For more reference: [stack overflow reference with w3 links](http://stackoverflow.com/questions/6961526/correct-value-for-disabled-attribute)
