### PR TITLE
Allow XML DOM nodes to be injected as toolbox in IE

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -76,12 +76,16 @@ Blockly.inject = function(container, opt_options) {
  */
 Blockly.parseToolboxTree_ = function(tree) {
   if (tree) {
-    if (typeof tree != 'string' && typeof XSLTProcessor == 'undefined') {
-      // In this case the tree will not have been properly built by the
-      // browser. The HTML will be contained in the element, but it will
-      // not have the proper DOM structure since the browser doesn't support
-      // XSLTProcessor (XML -> HTML). This is the case in IE 9+.
-      tree = tree.outerHTML;
+    if (typeof tree != 'string') {
+      if (typeof XSLTProcessor == 'undefined' && tree.outerHTML) {
+        // In this case the tree will not have been properly built by the
+        // browser. The HTML will be contained in the element, but it will
+        // not have the proper DOM structure since the browser doesn't support
+        // XSLTProcessor (XML -> HTML). This is the case in IE 9+.
+        tree = tree.outerHTML;
+      } else if (!(tree instanceof Element)) {
+        tree = null;
+      }
     }
     if (typeof tree == 'string') {
       tree = Blockly.Xml.textToDom(tree);


### PR DESCRIPTION
In the current implementation, if the toolbox XML is already converted to a DOM structure (say, by running the XML string through `Blockly.Xml.textToDom()`) before it is inputted into the Blockly injection, it will __silently__ fail in IE and work in Chrome/Firefox.

The main reason should be clear enough in the patch, the silently part is due to `outerHTML` being undefined, which in turn sets `hasCategories` to `false` in `Blockly.parseOptions_()`.

The `else if` statement was added only to safeguard against non-DOM objects, but could be removed so that any invalid object would trigger an error later on, which would clearly identify the issue.
