### PR TITLE
Fix for issue https://github.com/google/blockly/issues/210

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -610,11 +610,13 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
     // See comment in inject.js Blockly.init_ as to why mouseup events are
     // bound to the document instead of the SVG's surface.
     if ('mouseup' in Blockly.bindEvent_.TOUCH_MAP) {
-      Blockly.onTouchUpWrapper_ =
-          Blockly.bindEvent_(document, 'mouseup', null, Blockly.onMouseUp_);
+      Blockly.onTouchUpWrapper_ = Blockly.onTouchUpWrapper_ || [];
+      Blockly.onTouchUpWrapper_ = Blockly.onTouchUpWrapper_.concat(
+          Blockly.bindEvent_(document, 'mouseup', null, Blockly.onMouseUp_));
     }
-    Blockly.onMouseMoveWrapper_ =
-        Blockly.bindEvent_(document, 'mousemove', null, Blockly.onMouseMove_);
+    Blockly.onMouseMoveWrapper_ = Blockly.onMouseMoveWrapper_ || [];
+    Blockly.onMouseMoveWrapper_ = Blockly.onMouseMoveWrapper_.concat(
+        Blockly.bindEvent_(document, 'mousemove', null, Blockly.onMouseMove_));
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();


### PR DESCRIPTION
On a touch device with multitouch support, multiple `touchStart` events can be fired together. This causes multiple calls to `Blockly.WorkspaceSvg.prototype.onMouseDown_` event handler.

```
    if ('mouseup' in Blockly.bindEvent_.TOUCH_MAP) {
      Blockly.onTouchUpWrapper_ =
          Blockly.bindEvent_(document, 'mouseup', null, Blockly.onMouseUp_);
    }
    Blockly.onMouseMoveWrapper_ =
        Blockly.bindEvent_(document, 'mousemove', null, Blockly.onMouseMove_);
```

This code binds multiple events to the document element but only the last call actually registers the event handler wrapper, which will consequently be called in the global `Blockly.onMouseUp_` handler.

This can cause event handlers for `mouseMove` and `mouseDown` linger in the `document` node, causing other elements on the DOM tree to disfunction.

The fix is relatively straightforward.

I have tested this on iPad and Android phone. Please look into this and merge.

