### PR TITLE
Update build.py with more robust nodejs identification

### DIFF
--- a/build.py
+++ b/build.py
@@ -79,7 +79,8 @@ class Gen_uncompressed(threading.Thread):
     f = open(target_filename, 'w')
     f.write(HEADER)
     f.write("""
-var isNodeJS = !!(typeof module !== 'undefined' && module.exports);
+var isNodeJS = !!(typeof module !== 'undefined' && module.exports &&
+                  typeof window === 'undefined');
 
 if (isNodeJS) {
   var window = {};


### PR DESCRIPTION
Very simple change to add an extra check for the node.js indentification.

The reason this is needed is because with things like Electron, I have `module` exposed to the pages rendered in the chrome engine, so even if I am using closure in the front end, the current implementation assumes it is being executed in the node.js server side.

This stack overflow question suggests this additional check is relatively reliable:
http://stackoverflow.com/questions/4224606/how-to-check-whether-a-script-is-running-under-node-js

Could somebody running closure from within Node confirm this does not break their implementation?