### PR TITLE
Modify js_to_json match string to correct one

### DIFF
--- a/i18n/js_to_json.py
+++ b/i18n/js_to_json.py
@@ -48,7 +48,7 @@ import re
 from common import write_files
 
 
-_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg.(\w*)\s*=\s*'([^']*)';?$""")
+_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg.(\w*)\s*=\s*'([^']*)';""")
 
 _INPUT_SYN_PATTERN = re.compile(
     """Blockly.Msg.(\w*)\s*=\s*Blockly.Msg.(\w*);""")


### PR DESCRIPTION
When I add new string to messages.js and run build.py, the en.json will be empty.
So I found that the match string in js_to_json.js has bug. It won't match any string in messages.js.
After I modified it, I can produce en.json correctly.