### PR TITLE
Allow Blockly.Inject to use a css-style selector instead of elementID.

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -41,7 +41,8 @@ goog.require('goog.userAgent');
  */
 Blockly.inject = function(container, opt_options) {
   if (goog.isString(container)) {
-    container = document.getElementById(container);
+    var selector = container;
+    container = document.querySelector(selector) || document.querySelector('#'+selector);
   }
   // Verify that the container is in document.
   if (!goog.dom.contains(document, container)) {


### PR DESCRIPTION
This patch will fallback to an element ID if the string provided does not select an element within the DOM.