### PR TITLE
Add missing comma to Lua reserved words

### DIFF
--- a/generators/lua.js
+++ b/generators/lua.js
@@ -45,7 +45,7 @@ Blockly.Lua = new Blockly.Generator('Lua');
  */
 Blockly.Lua.addReservedWords(
     // Special character
-    '_' +
+    '_,' +
     // From theoriginalbit's script:
     // https://github.com/espertus/blockly-lua/issues/6
     '__inext,assert,bit,colors,colours,coroutine,disk,dofile,error,fs,' +

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -119,12 +119,12 @@ Blockly.Lua['lists_indexOf'] = function(block) {
  * @private
  * @param {string} listname Name of the list, used to calculate length.
  * @param {string} where The method of indexing, selected by dropdown in Blockly
- * @param {=string} opt_at The optional offset when indexing from start/end.
+ * @param {string=} opt_at The optional offset when indexing from start/end.
  * @return {string} Index expression.
  */
 Blockly.Lua.lists.getIndex_ = function(listname, where, opt_at) {
   if (where == 'FIRST') {
-    return 1;
+    return '1';
   } else if (where == 'FROM_END') {
     return '#' + listname + ' + 1 - ' + opt_at;
   } else if (where == 'LAST') {


### PR DESCRIPTION
This meant that variables could be called _, conflicting with use in Lua
as a dummy variable, and in particular with scrubNakedValue.

I've also made some style fixes to Blockly.Lua.lists.