### PR TITLE
Clearing the workspace now works even if a field is being edited

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -149,6 +149,7 @@ Blockly.Workspace.prototype.getAllBlocks = function() {
  * Dispose of all blocks in workspace.
  */
 Blockly.Workspace.prototype.clear = function() {
+  Blockly.WidgetDiv.hide();
   var existingGroup = Blockly.Events.getGroup();
   if (!existingGroup) {
     Blockly.Events.setGroup(true);


### PR DESCRIPTION
Previously if a workspace.clear() was executed whilst a field was being edited then the following errors would appear in the console and the blockly workspace would become unresponsive.

    Uncaught TypeError: Cannot read property 'removeChangeListener' of null(anonymous function) @       blockly_compressed.js:19071Blockly.WidgetDiv.hide @ blockly_compressed.js:20609Blockly.WidgetDiv.hideIfOwner @     blockly_compressed.js:20620Blockly.FieldTextInput.dispose @ blockly_compressed.js:18961Blockly.Input.dispose @     blockly_compressed.js:15786Blockly.Block.dispose @ blockly_compressed.js:17275Blockly.BlockSvg.dispose @     blockly_compressed.js:18327Blockly.Block.dispose @ blockly_compressed.js:17272Blockly.BlockSvg.dispose @     blockly_compressed.js:18327Blockly.Block.dispose @ blockly_compressed.js:17272Blockly.BlockSvg.dispose @     blockly_compressed.js:18327Blockly.Block.dispose @ blockly_compressed.js:17272Blockly.BlockSvg.dispose @     blockly_compressed.js:18327Blockly.Workspace.clear @ blockly_compressed.js:14510window.onmessage @ index.html:175
    blockly_compressed.js:19041

    Uncaught TypeError: Cannot read property 'scale' of nullBlockly.FieldTextInput.resizeEditor_ @     blockly_compressed.js:19041Blockly.Workspace.fireChangeListener @ blockly_compressed.js:14544Blockly.Events.fireNow_ @     blockly_compressed.js:18833
 

Explicitly hiding the popup div first avoids this problem.