### PR TITLE
add own constant for margins, don't use corner radius

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -72,6 +72,11 @@ Blockly.BlockSvg.NOTCH_WIDTH = 30;
  */
 Blockly.BlockSvg.CORNER_RADIUS = 8;
 /**
+ * Margin base unit used to calculate margins
+ * @const
+ */
+Blockly.BlockSvg.MARGIN_BASE = 8;
+/**
  * Do blocks with no previous or output connections have a 'hat' on top?
  * @const
  */

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -416,7 +416,7 @@ Blockly.getMainWorkspaceMetrics_ = function() {
   }
   // Set the margin to match the flyout's margin so that the workspace does
   // not jump as blocks are added.
-  var MARGIN = Blockly.Flyout.prototype.CORNER_RADIUS - 1;
+  var MARGIN = Blockly.Flyout.prototype.MARGIN_BASE - 1;
   var viewWidth = svgSize.width - MARGIN;
   var viewHeight = svgSize.height - MARGIN;
   var blockBox = this.getBlocksBoundingBox();

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -100,6 +100,12 @@ Blockly.Flyout.prototype.autoClose = true;
 Blockly.Flyout.prototype.CORNER_RADIUS = 8;
 
 /**
+ * Margin base unit used to calculate margins
+ * @const
+ */
+Blockly.Flyout.prototype.MARGIN_BASE = 8;
+
+/**
  * Top/bottom padding between scrollbar and edge of flyout background.
  * @type {number}
  * @const
@@ -385,7 +391,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         Blockly.Procedures.flyoutCategory(this.workspace_.targetWorkspace);
   }
 
-  var margin = this.CORNER_RADIUS;
+  var margin = this.MARGIN_BASE;
   this.svgGroup_.style.display = 'block';
   // Create the blocks to be shown in this flyout.
   var blocks = [];
@@ -479,7 +485,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 Blockly.Flyout.prototype.reflow = function() {
   this.workspace_.scale = this.targetWorkspace_.scale;
   var flyoutWidth = 0;
-  var margin = this.CORNER_RADIUS;
+  var margin = this.MARGIN_BASE;
   var blocks = this.workspace_.getTopBlocks(false);
   for (var x = 0, block; block = blocks[x]; x++) {
     var width = block.getHeightWidth().width;

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -220,7 +220,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.rootBlock_.setMovable(false);
     this.rootBlock_.setDeletable(false);
     if (this.workspace_.flyout_) {
-      var margin = this.workspace_.flyout_.CORNER_RADIUS * 2;
+      var margin = this.workspace_.flyout_.MARGIN_BASE * 2;
       var x = this.workspace_.flyout_.width_ + margin;
     } else {
       var margin = 16;


### PR DESCRIPTION
if a user of blockly wants more squared blocks and modifies
CORNER_RADIUS then the margins in menus will all be squeezed since
CORNER_RADIUS constant is used to calculate margins.

to solve this, introduce a MARGIN_BASE constant used for margins so
CORNER_RADIUS can be changed without affecting margins.