### PR TITLE
Add event preventDefault() calls to the end of zoom button handlers s…

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1099,6 +1099,7 @@ Blockly.WorkspaceSvg.prototype.zoomReset = function(e) {
   }
   // This event has been handled.  Don't start a workspace drag.
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -166,10 +166,12 @@ Blockly.ZoomControls.prototype.createDom = function() {
   Blockly.bindEvent_(zoominSvg, 'mousedown', null, function(e) {
     workspace.zoomCenter(1);
     e.stopPropagation();  // Don't start a workspace scroll.
+    e.preventDefault();
   });
   Blockly.bindEvent_(zoomoutSvg, 'mousedown', null, function(e) {
     workspace.zoomCenter(-1);
     e.stopPropagation();  // Don't start a workspace scroll.
+    e.preventDefault();
   });
 
   return this.svgGroup_;


### PR DESCRIPTION
…o the

browser doesn't try to handle them itself.  This keeps it from selecting text
on double clicks.