### PR TITLE
An alternate (and less expensive) way to keep stuff outside of the bl…

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -511,7 +511,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
     e.stopPropagation();
     return;
   }
-  Blockly.setPageSelectable(false);
   this.workspace.markFocused();
   // Update Blockly's knowledge of its own location.
   Blockly.svgResize(this.workspace);
@@ -556,6 +555,7 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**
@@ -571,7 +571,6 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
   }
-  Blockly.setPageSelectable(true);
   Blockly.terminateDrag_();
   if (Blockly.selected && Blockly.highlightedConnection_) {
     // Connect two blocks together.
@@ -892,6 +891,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -195,7 +195,6 @@ Blockly.onMouseUp_ = function(e) {
   var workspace = Blockly.getMainWorkspace();
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   workspace.isScrolling = false;
-  Blockly.setPageSelectable(true);
   // Unbind the touch event if it exists.
   if (Blockly.onTouchUpWrapper_) {
     Blockly.unbindEvent_(Blockly.onTouchUpWrapper_);
@@ -238,6 +237,7 @@ Blockly.onMouseMove_ = function(e) {
       Blockly.longStop_();
     }
     e.stopPropagation();
+    e.preventDefault();
   }
 };
 

--- a/core/css.js
+++ b/core/css.js
@@ -143,13 +143,6 @@ Blockly.Css.CONTENT = [
     'z-index: 999;',
   '}',
 
-  '.blocklyNonSelectable {',
-    'user-select: none;',
-    '-moz-user-select: none;',
-    '-webkit-user-select: none;',
-    '-ms-user-select: none;',
-  '}',
-
   '.blocklyTooltipDiv {',
     'background-color: #ffffc7;',
     'border: 1px solid #ddc;',

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -446,6 +446,7 @@ Blockly.Scrollbar.prototype.onMouseDownBar_ = function(e) {
                              this.constrainKnob_(knobValue));
   this.onScroll_();
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**
@@ -462,7 +463,6 @@ Blockly.Scrollbar.prototype.onMouseDownKnob_ = function(e) {
     e.stopPropagation();
     return;
   }
-  Blockly.setPageSelectable(false);
   // Look up the current translation and record it.
   this.startDragKnob = parseFloat(
       this.svgKnob_.getAttribute(this.horizontal_ ? 'x' : 'y'));
@@ -473,6 +473,7 @@ Blockly.Scrollbar.prototype.onMouseDownKnob_ = function(e) {
   Blockly.Scrollbar.onMouseMoveWrapper_ = Blockly.bindEvent_(document,
       'mousemove', this, this.onMouseMoveKnob_);
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**
@@ -495,7 +496,6 @@ Blockly.Scrollbar.prototype.onMouseMoveKnob_ = function(e) {
  * @private
  */
 Blockly.Scrollbar.prototype.onMouseUpKnob_ = function() {
-  Blockly.setPageSelectable(true);
   Blockly.hideChaff(true);
   if (Blockly.Scrollbar.onMouseUpWrapper_) {
     Blockly.unbindEvent_(Blockly.Scrollbar.onMouseUpWrapper_);

--- a/core/utils.js
+++ b/core/utils.js
@@ -290,19 +290,6 @@ Blockly.createSvgElement = function(name, attrs, parent, opt_workspace) {
 };
 
 /**
- * Set css classes to allow/disallow the browser from selecting/highlighting
- * text, etc. on the page.
- * @param {boolean} selectable Whether elements on the page can be selected.
- */
-Blockly.setPageSelectable = function(selectable) {
-    if (selectable) {
-      Blockly.removeClass_(document.body, 'blocklyNonSelectable');
-    } else {
-      Blockly.addClass_(document.body, 'blocklyNonSelectable');
-    }
-};
-
-/**
  * Is this event a right-click?
  * @param {!Event} e Mouse event.
  * @return {boolean} True if right-click.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -565,7 +565,6 @@ Blockly.WorkspaceSvg.prototype.isDeleteArea = function(e) {
  */
 Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
   this.markFocused();
-  Blockly.setPageSelectable(false);
   if (Blockly.isTargetInput_(e)) {
     return;
   }
@@ -608,6 +607,7 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();
+  e.preventDefault();
 };
 
 /**


### PR DESCRIPTION
…ockly div

from getting selected. Use e.preventDefault instead of adding and removing
classes on mousedown and mouseup.  This keeps the browser from having to
potentially recacluate style on mousedown and mouseup events.