### PR TITLE
Stop animation from delete all blocks workspace context menu option.

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -830,7 +830,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
     var block = deleteList.shift();
     if (block) {
       if (block.workspace) {
-        block.dispose(false, true);
+        block.dispose(false, false);
         setTimeout(deleteNext, DELAY);
       } else {
         deleteNext();


### PR DESCRIPTION
Reported on scratch blocks https://github.com/LLK/scratch-blocks/issues/341.
As mentioned there, the sound effects from removing a large number of blocks can be annoying/confusing and it is not really necessary on this instance.