### PR TITLE
Remove calls to svgResize that don't seem to do anything.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -532,7 +532,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
   }
   this.workspace.markFocused();
   // Update Blockly's knowledge of its own location.
-  Blockly.svgResize(this.workspace);
   Blockly.terminateDrag_();
   this.select();
   Blockly.hideChaff();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -569,7 +569,6 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
   if (Blockly.isTargetInput_(e)) {
     return;
   }
-  Blockly.svgResize(this);
   Blockly.terminateDrag_();  // In case mouse-up event was lost.
   Blockly.hideChaff();
   var isTargetWorkspace = e.target && e.target.nodeName &&


### PR DESCRIPTION
@NeilFraser Do you know why these calls to svgResize are are here?
I can't find a time when removing them causes problems and it feels like I've tested a bunch of cases... but you often just know these things.