### PR TITLE
Change the blockly workspace resizing strategy.

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -287,7 +287,7 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
       parentBlock.render(true);
     } else {
       // Top-most block.  Fire an event to allow scrollbars to resize.
-      Blockly.asyncSvgResize(this.workspace);
+      Blockly.resizeSvgContents(this.workspace);
     }
   }
   Blockly.Field.stopCache();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -273,7 +273,7 @@ Blockly.BlockSvg.terminateDrag_ = function() {
           Blockly.Events.setGroup(false);
       }, Blockly.BUMP_DELAY);
       // Fire an event to allow scrollbars to resize.
-      Blockly.asyncSvgResize(this.workspace);
+      Blockly.resizeSvgContents(this.workspace);
     }
   }
   Blockly.dragMode_ = Blockly.DRAG_NONE;
@@ -531,8 +531,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
     return;
   }
   this.workspace.markFocused();
-  // Update Blockly's knowledge of its own location.
-  Blockly.svgResize(this.workspace);
   Blockly.terminateDrag_();
   this.select();
   Blockly.hideChaff();
@@ -615,7 +613,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     // Dropping a block on the trash can will usually cause the workspace to
     // resize to contain the newly positioned block.  Force a second resize
     // now that the block has been deleted.
-    Blockly.asyncSvgResize(this.workspace);
+    Blockly.resizeSvgContents(this.workspace);
   }
   if (Blockly.highlightedConnection_) {
     Blockly.highlightedConnection_.unhighlight();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -232,7 +232,6 @@ Blockly.BlockSvg.onMouseMoveWrapper_ = null;
 
 /**
  * Stop binding to the global mouseup and mousemove events.
- * @private
  */
 Blockly.BlockSvg.terminateDrag_ = function() {
   Blockly.BlockSvg.disconnectUiStop_();
@@ -273,7 +272,7 @@ Blockly.BlockSvg.terminateDrag_ = function() {
           Blockly.Events.setGroup(false);
       }, Blockly.BUMP_DELAY);
       // Fire an event to allow scrollbars to resize.
-      Blockly.resizeSvgContents(this.workspace);
+      Blockly.resizeSvgContents(selected.workspace);
     }
   }
   Blockly.dragMode_ = Blockly.DRAG_NONE;
@@ -609,11 +608,14 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     if (trashcan) {
       goog.Timer.callOnce(trashcan.close, 100, trashcan);
     }
+    // Save the block's workspace temporarily so we can resize the
+    // contents once the block is disposed.
+    var selectedWorkspace = Blockly.selected.workspace;
     Blockly.selected.dispose(false, true);
     // Dropping a block on the trash can will usually cause the workspace to
     // resize to contain the newly positioned block.  Force a second resize
     // now that the block has been deleted.
-    Blockly.resizeSvgContents(this.workspace);
+    Blockly.resizeSvgContents(selectedWorkspace);
   }
   if (Blockly.highlightedConnection_) {
     Blockly.highlightedConnection_.unhighlight();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -232,8 +232,9 @@ Blockly.BlockSvg.onMouseMoveWrapper_ = null;
 
 /**
  * Stop binding to the global mouseup and mousemove events.
+ * @package
  */
-Blockly.BlockSvg.terminateDrag_ = function() {
+Blockly.BlockSvg.terminateDrag = function() {
   Blockly.BlockSvg.disconnectUiStop_();
   if (Blockly.BlockSvg.onMouseUpWrapper_) {
     Blockly.unbindEvent_(Blockly.BlockSvg.onMouseUpWrapper_);

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -143,7 +143,7 @@ Blockly.svgSize = function(svg) {
 /**
  * Size the workspace when the contents change.  This also updates
  * scrollbars accordingly.
- * @param {!Blockly.WorkspaceSvg} workspace. The workspace to resize.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace to resize.
  */
 Blockly.resizeSvgContents = function(workspace) {
   workspace.resizeContents();

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -143,15 +143,9 @@ Blockly.svgSize = function(svg) {
 /**
  * Size the workspace when the contents change.  This also updates
  * scrollbars accordingly.
- * @param {!Blockly.WorkspaceSvg} opt_workspace. The svg group of the workspace
- *   to resize. If the workspace isn't specified, the main workspace will be
- *   used.
+ * @param {!Blockly.WorkspaceSvg} workspace. The workspace to resize.
  */
-Blockly.resizeSvgContents = function(opt_workspace) {
-  var workspace = opt_workspace;
-  if (!workspace) {
-    workspace = Blockly.getMainWorkspace();
-  }
+Blockly.resizeSvgContents = function(workspace) {
   workspace.resizeContents();
 };
 

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -141,36 +141,27 @@ Blockly.svgSize = function(svg) {
 };
 
 /**
- * Schedule a call to the resize handler.  Groups of simultaneous events (e.g.
- * a tree of blocks being deleted) are merged into one call.
- * @param {Blockly.WorkspaceSvg} workspace Any workspace in the SVG.
+ * Size the workspace when the contents change.  This also updates
+ * scrollbars accordingly.
+ * @param {!Blockly.WorkspaceSvg} workspace. Any workspace in teh SVG.
  */
-Blockly.asyncSvgResize = function(workspace) {
-  if (Blockly.svgResizePending_) {
-    return;
-  }
+Blockly.resizeSvgContents = function(workspace) {
   if (!workspace) {
     workspace = Blockly.getMainWorkspace();
   }
-  Blockly.svgResizePending_ = true;
-  setTimeout(function() {Blockly.svgResize(workspace);}, 0);
+  workspace.resizeContents();
 };
 
-/**
- * Flag indicating a resize event is scheduled.
- * Used to fire only one resize after multiple changes.
- * @type {boolean}
- * @private
- */
-Blockly.svgResizePending_ = false;
 
 /**
- * Size the SVG image to completely fill its container.
+ * Size the SVG image to completely fill its container. Call this when the view
+ * actually changes sizes (e.g. on a window resize/device orientation change).
+ * See Blockly.resizeSvgContents to resize the workspace when the contents
+ * change (e.g. when a block is added or removed).
  * Record the height/width of the SVG image.
  * @param {!Blockly.WorkspaceSvg} workspace Any workspace in the SVG.
  */
 Blockly.svgResize = function(workspace) {
-  Blockly.svgResizePending_ = false;
   var mainWorkspace = workspace;
   while (mainWorkspace.options.parentWorkspace) {
     mainWorkspace = mainWorkspace.options.parentWorkspace;

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -143,9 +143,12 @@ Blockly.svgSize = function(svg) {
 /**
  * Size the workspace when the contents change.  This also updates
  * scrollbars accordingly.
- * @param {!Blockly.WorkspaceSvg} workspace. Any workspace in teh SVG.
+ * @param {!Blockly.WorkspaceSvg} opt_workspace. The svg group of the workspace
+ *   to resize. If the workspace isn't specified, the main workspace will be
+ *   used.
  */
-Blockly.resizeSvgContents = function(workspace) {
+Blockly.resizeSvgContents = function(opt_workspace) {
+  var workspace = opt_workspace;
   if (!workspace) {
     workspace = Blockly.getMainWorkspace();
   }

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -304,7 +304,7 @@ Blockly.onKeyDown_ = function(e) {
  * @private
  */
 Blockly.terminateDrag_ = function() {
-  Blockly.BlockSvg.terminateDrag_();
+  Blockly.BlockSvg.terminateDrag();
   Blockly.Flyout.terminateDrag_();
 };
 

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -587,7 +587,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.offsetHorizontalRtlBlocks(this.workspace_.getTopBlocks(false));
   this.filterForCapacity_();
 
-  // To position the flyout's scrollbar when it opens.
+  // Correctly position the flyout's scrollbar when it opens.
   this.position();
 
   this.reflowWrapper_ = this.reflow.bind(this);

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -587,8 +587,9 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.offsetHorizontalRtlBlocks(this.workspace_.getTopBlocks(false));
   this.filterForCapacity_();
 
-  // Fire a resize event to update the flyout's scrollbar.
-  Blockly.svgResize(this.workspace_);
+  // To position the flyout's scrollbar when it opens.
+  this.position();
+
   this.reflowWrapper_ = this.reflow.bind(this);
   this.workspace_.addChangeListener(this.reflowWrapper_);
 };
@@ -1035,7 +1036,7 @@ Blockly.Flyout.prototype.reflowHorizontal = function(blocks) {
     }
     // Record the height for .getMetrics_ and .position.
     this.height_ = flyoutHeight;
-    Blockly.asyncSvgResize(this.workspace_);
+    Blockly.resizeSvgContents(this.workspace_);
   }
 };
 
@@ -1088,7 +1089,7 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
     }
     // Record the width for .getMetrics_ and .position.
     this.width_ = flyoutWidth;
-    Blockly.asyncSvgResize(this.workspace_);
+    Blockly.resizeSvgContents(this.workspace_);
   }
 };
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -56,6 +56,7 @@ Blockly.inject = function(container, opt_options) {
   Blockly.init_(workspace);
   workspace.markFocused();
   Blockly.bindEvent_(svg, 'focus', workspace, workspace.markFocused);
+  Blockly.svgResize(workspace);
   return workspace;
 };
 
@@ -266,7 +267,7 @@ Blockly.init_ = function(mainWorkspace) {
   Blockly.bindEvent_(window, 'resize', null,
       function() {
         Blockly.hideChaff(true);
-        Blockly.asyncSvgResize(mainWorkspace);
+        Blockly.svgResize(mainWorkspace);
       });
 
   Blockly.inject.bindDocumentEvents_();
@@ -322,7 +323,7 @@ Blockly.inject.bindDocumentEvents_ = function() {
     // Some iPad versions don't fire resize after portrait to landscape change.
     if (goog.userAgent.IPAD) {
       Blockly.bindEvent_(window, 'orientationchange', document, function() {
-        Blockly.asyncSvgResize();
+        Blockly.svgResize(Blockly.getMainWorkspace());
       });
     }
   }

--- a/core/inject.js
+++ b/core/inject.js
@@ -323,6 +323,7 @@ Blockly.inject.bindDocumentEvents_ = function() {
     // Some iPad versions don't fire resize after portrait to landscape change.
     if (goog.userAgent.IPAD) {
       Blockly.bindEvent_(window, 'orientationchange', document, function() {
+        // TODO(#397): Fix for multiple blockly workspaces.
         Blockly.svgResize(Blockly.getMainWorkspace());
       });
     }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -348,7 +348,7 @@ Blockly.Toolbox.prototype.populate_ = function(newTree) {
   }
 
   // Fire a resize event since the toolbox may have changed width and height.
-  Blockly.asyncSvgResize(this.workspace_);
+  Blockly.resizeSvgContents(this.workspace_);
 };
 
 /**
@@ -533,7 +533,9 @@ Blockly.Toolbox.TreeNode = function(toolbox, html, opt_config, opt_domHelper) {
   goog.ui.tree.TreeNode.call(this, html, opt_config, opt_domHelper);
   if (toolbox) {
     var resize = function() {
-      Blockly.asyncSvgResize(toolbox.workspace_);
+      // Even though the div hasn't changed size, the visible workspace
+      // surface of the workspace has, so we may need to reposition everything.
+      Blockly.svgResize(Blockly.getMainWorkspace());
     };
     // Fire a resize event since the toolbox may have changed width.
     goog.events.listen(toolbox.tree_,

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -535,7 +535,7 @@ Blockly.Toolbox.TreeNode = function(toolbox, html, opt_config, opt_domHelper) {
     var resize = function() {
       // Even though the div hasn't changed size, the visible workspace
       // surface of the workspace has, so we may need to reposition everything.
-      Blockly.svgResize(Blockly.getMainWorkspace());
+      Blockly.svgResize(toolbox.workspace_);
     };
     // Fire a resize event since the toolbox may have changed width.
     goog.events.listen(toolbox.tree_,

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -301,7 +301,8 @@ Blockly.WorkspaceSvg.prototype.addFlyout_ = function() {
 
 /**
  * Resize the parts of the workspace that change when the workspace
- * contents (e.g. block positions) change.
+ * contents (e.g. block positions) change.  This will also scroll the
+ * workspace contents if needed.
  */
 Blockly.WorkspaceSvg.prototype.resizeContents = function() {
   if (this.scrollbar) {
@@ -312,6 +313,13 @@ Blockly.WorkspaceSvg.prototype.resizeContents = function() {
   }
 };
 
+/**
+ * Resize and reposition all of the workspace chrome (toolbox,
+ * trash, scrollbars etc.)
+ * This should be called when something changes that
+ * requires recalculating dimensions and positions of the
+ * trash, zoom, toolbox, etc. (e.g. window resize).
+ */
 Blockly.WorkspaceSvg.prototype.resize = function() {
   if (this.toolbox_) {
     this.toolbox_.position();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -303,6 +303,7 @@ Blockly.WorkspaceSvg.prototype.addFlyout_ = function() {
  * Resize the parts of the workspace that change when the workspace
  * contents (e.g. block positions) change.  This will also scroll the
  * workspace contents if needed.
+ * @package
  */
 Blockly.WorkspaceSvg.prototype.resizeContents = function() {
   if (this.scrollbar) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -300,8 +300,18 @@ Blockly.WorkspaceSvg.prototype.addFlyout_ = function() {
 };
 
 /**
- * Resize this workspace and its containing objects.
+ * Resize the parts of the workspace that change when the workspace
+ * contents (e.g. block positions) change.
  */
+Blockly.WorkspaceSvg.prototype.resizeContents = function() {
+  if (this.scrollbar) {
+    // TODO(picklesrus): Once rachel-fenichel's scrollbar refactoring
+    // is complete, call the method that only resizes scrollbar
+    // based on contents.
+    this.scrollbar.resize();
+  }
+};
+
 Blockly.WorkspaceSvg.prototype.resize = function() {
   if (this.toolbox_) {
     this.toolbox_.position();
@@ -576,7 +586,6 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
   if (Blockly.isTargetInput_(e)) {
     return;
   }
-  Blockly.svgResize(this);
   Blockly.terminateDrag_();  // In case mouse-up event was lost.
   Blockly.hideChaff();
   var isTargetWorkspace = e.target && e.target.nodeName &&
@@ -716,7 +725,7 @@ Blockly.WorkspaceSvg.prototype.cleanUp_ = function() {
   }
   Blockly.Events.setGroup(false);
   // Fire an event to allow scrollbars to resize.
-  Blockly.asyncSvgResize(this);
+  Blockly.resizeSvgContents(this);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -348,8 +348,8 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
       }
     }, 1);
     topBlock.updateDisabled();
-    // Fire an event to allow scrollbars to resize.
-    Blockly.asyncSvgResize(workspace);
+    // Allow the scrollbars to resize and move based on the new contents.
+    Blockly.resizeSvgContents(workspace);
   }
   Blockly.Events.enable();
   if (Blockly.Events.isEnabled()) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -349,6 +349,7 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
     }, 1);
     topBlock.updateDisabled();
     // Allow the scrollbars to resize and move based on the new contents.
+    // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
     Blockly.resizeSvgContents(workspace);
   }
   Blockly.Events.enable();

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -294,7 +294,7 @@ Code.tabClick = function(clickedName) {
   if (clickedName == 'blocks') {
     Code.workspace.setVisible(true);
   }
-  Blockly.asyncSvgResize(this.workspace_);
+  Blockly.svgResize(Code.workspace);
 };
 
 /**
@@ -380,7 +380,6 @@ Code.init = function() {
           // Account for the 19 pixel margin and on each side.
     }
   };
-  onresize();
   window.addEventListener('resize', onresize, false);
 
   var toolbox = document.getElementById('toolbox');
@@ -432,6 +431,8 @@ Code.init = function() {
     Code.bindClick('tab_' + name,
         function(name_) {return function() {Code.tabClick(name_);};}(name));
   }
+  onresize();
+  Blockly.svgResize(Code.workspace);
 
   // Lazy-load the syntax-highlighting.
   window.setTimeout(Code.importPrettify, 1);

--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -328,7 +328,7 @@ Graph.plot = function(code) {
 Graph.resize = function() {
   var width = Math.max(window.innerWidth - 440, 250);
   document.getElementById('blocklyDiv').style.width = width + 'px';
-  Blockly.svgResize(Blockly.getMainWorkspace());
+  Blockly.svgResize(Graph.workspace);
 };
 
 /**

--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -328,6 +328,7 @@ Graph.plot = function(code) {
 Graph.resize = function() {
   var width = Math.max(window.innerWidth - 440, 250);
   document.getElementById('blocklyDiv').style.width = width + 'px';
+  Blockly.svgResize(Blockly.getMainWorkspace());
 };
 
 /**
@@ -344,6 +345,7 @@ Graph.init = function() {
 
   // When Blockly changes, update the graph.
   Graph.workspace.addChangeListener(Graph.drawVisualization);
+  Graph.resize();
 };
 
 window.addEventListener('load', Graph.init);


### PR DESCRIPTION
This splits the workspace resizing into two pieces:
1. When the blockly div actually changes sizes (e.g. a window resize)
2. When the contents of the workspace change and we need to adjust scrollbars (e.g. new blocks are added)

@NeilFraser I removed asyncSvgResize, but mostly because I didn't see the value as much with this split, though I don't think I knew the motivations for adding it.  Let me know if you want it back.  I'm guessing most developers haven't started using it at this point since it is so recent. If it stays gone, there is some replacement needed in scratchblocks, but it doesn't look that difficult.

@rachel-fenichel Your eyes would be appreciated on this one too.

