### PR TITLE
Quotes properly using goog.string.quote instead of the hacky regex

### DIFF
--- a/generators/dart.js
+++ b/generators/dart.js
@@ -149,12 +149,7 @@ Blockly.Dart.scrubNakedValue = function(line) {
  * @private
  */
 Blockly.Dart.quote_ = function(string) {
-  // TODO: This is a quick hack.  Replace with goog.string.quote
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/\$/g, '\\$')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+  return goog.string.quote(string);
 };
 
 /**

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -169,11 +169,7 @@ Blockly.JavaScript.scrubNakedValue = function(line) {
  * @private
  */
 Blockly.JavaScript.quote_ = function(string) {
-  // TODO: This is a quick hack.  Replace with goog.string.quote
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+  return goog.string.quote(string);
 };
 
 /**

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -143,11 +143,7 @@ Blockly.Lua.scrubNakedValue = function(line) {
  * @private
  */
 Blockly.Lua.quote_ = function(string) {
-  // TODO: This is a quick hack.  Replace with goog.string.quote
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+  return goog.string.quote(string);
 };
 
 /**

--- a/generators/php.js
+++ b/generators/php.js
@@ -146,11 +146,7 @@ Blockly.PHP.scrubNakedValue = function(line) {
  * @private
  */
 Blockly.PHP.quote_ = function(string) {
-  // TODO: This is a quick hack.  Replace with goog.string.quote
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+  return goog.string.quote(string);
 };
 
 /**

--- a/generators/python.js
+++ b/generators/python.js
@@ -152,12 +152,7 @@ Blockly.Python.scrubNakedValue = function(line) {
  * @private
  */
 Blockly.Python.quote_ = function(string) {
-  // TODO: This is a quick hack.  Replace with goog.string.quote
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/\%/g, '\\%')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+  return goog.string.quote(string);
 };
 
 /**


### PR DESCRIPTION
This will make it easier for whomever implements multi-line string blocks in the future.