### PR TITLE
Add buttons to download parts of block factory to a local file.

### DIFF
--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -722,14 +722,90 @@ function getRootBlock() {
   }
   return null;
 }
+/**
+ * Generate a file from the contents of a given text area and
+ * download that file.
+ * @param {string} filename The name of the file to create.
+ * @param {string} id The text area to download.
+*/
+function downloadTextArea(filename, id) {
+  var code = document.getElementById(id).textContent;
+  createAndDownloadFile_(code, filename, 'plain');
+}
 
 /**
- * Disable the link button if the format is 'Manual', enable otherwise.
+ * Create a file with the given attributes and download it.
+ * @param {string} contents The contents of the file.
+ * @param {string} filename The name of the file to save to.
+ * @param {string} The type of the file to save.
+ * @private
+ */
+function createAndDownloadFile_(contents, filename, fileType) {
+  var data = new Blob([contents], {type: 'text/' + fileType});
+  var clickEvent = new MouseEvent("click", {
+    "view": window,
+    "bubbles": true,
+    "cancelable": false
+  });
+
+  var a = document.createElement('a');
+  a.href = window.URL.createObjectURL(data);
+  a.download = filename;
+  a.textContent = 'Download file!';
+  a.dispatchEvent(clickEvent); 
+}
+
+/**
+ * Save the workspace's xml representation to a file.
+ * @private
+ */
+function saveWorkspaceToFile() {
+  var xmlElement = Blockly.Xml.workspaceToDom(mainWorkspace);
+  var prettyXml = Blockly.Xml.domToPrettyText(xmlElement);
+  createAndDownloadFile_(prettyXml, 'blockXml', 'xml'); 
+}
+
+/**
+ * Disable link and save buttons if the format is 'Manual', enable otherwise.
  */
 function disableEnableLink() {
   var linkButton = document.getElementById('linkButton');
-  linkButton.disabled = document.getElementById('format').value == 'Manual';
+  var saveBlockButton = document.getElementById('localSaveButton');
+  var disabled = document.getElementById('format').value == 'Manual';
+  linkButton.disabled = buttonDisabled;
+  saveBlockButton.disabled = buttonDisabled;
 }
+
+/**
+ * Imports xml file for a block to the workspace.
+ */
+function importBlockFromFile() {
+  var files = document.getElementById('files');
+  // If the file list is empty, they user likely canceled in the dialog.
+  if (files.files.length > 0) {
+    // The input tag doesn't have the "mulitple" attribute
+    // so the user can only choose 1 file.
+    var file = files.files[0];
+    var fileReader = new FileReader();
+    fileReader.addEventListener('load', function(event) {
+      var fileContents = event.target.result;
+      var xml = '';
+      try {
+        xml = Blockly.Xml.textToDom(fileContents);
+      } catch (e) {
+        var message = 'Could not load your saved file.\n'+
+          'Perhaps it was created with a different version of Blockly?';
+        window.alert(message + '\nXML: ' + fileContents);
+        return;
+      }
+      mainWorkspace.clear();
+      Blockly.Xml.domToWorkspace(xml, mainWorkspace);
+    });
+
+    fileReader.readAsText(file);
+  }
+}
+
 
 /**
  * Initialize Blockly and layout.  Called on page load.
@@ -751,10 +827,31 @@ function init() {
     disableEnableLink();
   }
 
+  document.getElementById('localSaveButton')
+    .addEventListener('click', saveWorkspaceToFile);
+
+  document.getElementById('files').addEventListener('change',
+    function() {
+      importBlockFromFile();      
+      // Clear this so that the change event still fires even if the
+      // same file is chosen again. If the user re-imports a file, we
+      // want to reload the workspace with its contents.
+      this.value = null;
+    });
+
   document.getElementById('helpButton').addEventListener('click',
     function() {
       open('https://developers.google.com/blockly/custom-blocks/block-factory',
            'BlockFactoryHelp');
+    });
+  document.getElementById('downloadBlocks').addEventListener('click',
+    function() {
+      downloadTextArea('blocks', 'languagePre');
+    });
+
+  document.getElementById('downloadGenerator').addEventListener('click',
+    function() {
+      downloadTextArea('generator', 'generatorPre')
     });
 
   var expandList = [

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -61,8 +61,18 @@
       font-family: monospace;
       font-size: 10pt;
     }
+    .downloadButton {
+      padding: 5px;
+    }
+    button:disabled, .buttonStyle:disabled {
+      opacity: 0.6;
+    }
+    button>*, .buttonStyle>* {
+      opacity: 0.6;
+      vertical-align: text-bottom;
+    }
 
-    button {
+    button, .buttonStyle {
       border-radius: 4px;
       border: 1px solid #ddd;
       background-color: #eee;
@@ -71,17 +81,10 @@
       margin: 0 5px;
       font-size: large;
     }
-    button:hover:not(:disabled) {
+    .buttonStyle:hover:not(:disabled), button:hover:not(:disabled) {
       box-shadow: 2px 2px 5px #888;
     }
-    button:disabled {
-      opacity: 0.6;
-    }
-    button>* {
-      opacity: 0.6;
-      vertical-align: text-bottom;
-    }
-    button:hover:not(:disabled)>* {
+    .buttonStyle:hover:not(:disabled)>*, button:hover:not(:disabled)>* {
       opacity: 1;
     }
     #linkButton {
@@ -116,6 +119,12 @@
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
+              <label for="files" class="buttonStyle"> <span class=>Import block</span></label>
+              <input style="visibility: hidden; position: absolute;" id="files"  type="file"
+                     name="files" accept="application/xml">
+              <button id="localSaveButton" title="Save block xml to a local file.">
+                <span>Download block</span>
+              </button>
               <button id="helpButton" title="View documentation in new window.">
                 <span>Help</span>
               </button>
@@ -144,6 +153,10 @@
                   <option value="JSON">JSON</option>
                   <option value="Manual">Manual edit&hellip;</option>
                 </select>
+                <button class ="downloadButton" id="downloadBlocks"
+                        title="Download block definition to a file.">
+                 <span>Download</span>
+               </button>
               </h3>
             </td>
           </tr>
@@ -163,6 +176,10 @@
                   <option value="Lua">Lua</option>
                   <option value="Dart">Dart</option>
                 </select>
+                <button id="downloadGenerator" class="downloadButton"
+                        title="Downloadgenerator stub to a file.">
+                  <span>Download</span>
+                </button>
               </h3>
             </td>
           </tr>


### PR DESCRIPTION
These things can now be downloaded to a local file:
 - block definition
 - generator
 - xml of the block itself

Also add an import button so you can import a block from a local file.

Note that browsers that don't support these html5 file input types tend to open a new tab with the contents of the downloaded file rather than actually downloading it. Not great, but also not terrible.