### PR TITLE
Fix airstrike by grabbing the correct toolbox element.

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -68,9 +68,7 @@ function start() {
   var match = location.search.match(/dir=([^&]+)/);
   var rtl = match && match[1] == 'rtl';
   document.forms.options.elements.dir.selectedIndex = Number(rtl);
-  var match = location.search.match(/toolbox=([^&]+)/);
-  var toolbox =
-      document.getElementById('toolbox-' + (match ? match[1] : 'categories'));
+  var toolbox = getToolboxElement();
   document.forms.options.elements.toolbox.selectedIndex =
       Number(toolbox.getElementsByTagName('category').length == 0);
   match = location.search.match(/side=([^&]+)/);
@@ -116,6 +114,11 @@ function start() {
     logEvents(false);
   }
   taChange();
+}
+
+function getToolboxElement() {
+  var match = location.search.match(/toolbox=([^&]+)/);
+  return document.getElementById('toolbox-' + (match ? match[1] : 'categories'));
 }
 
 function toXml() {
@@ -175,7 +178,7 @@ function logger(e) {
 
 function airstrike(n) {
   var prototypes = [];
-  var toolbox = document.getElementById('toolbox');
+  var toolbox = getToolboxElement();
   var blocks = toolbox.getElementsByTagName('block');
   for (var i = 0, block; block = blocks[i]; i++) {
     prototypes.push(block.getAttribute('type'));


### PR DESCRIPTION
Probably broken in 266e2ffa9a017d21d7ca2f151730d6ecfcecf173.

Let me know if you'd prefer for the airstrike to be from the full set of blocks all the time instead of the selected toolbox.  Either way, "toolbox" doesn't exist as id anymore.