### PR TITLE
Remove reference to undefined variable

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -346,8 +346,7 @@ Blockly.Connection.prototype.checkConnection_ = function(target) {
 Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
   // Type checking.
   var canConnect = this.canConnectWithReason_(candidate);
-  if (canConnect != Blockly.Connection.CAN_CONNECT &&
-      canConnect != Blockly.Connection.REASON_MUST_DISCONNECT) {
+  if (canConnect != Blockly.Connection.CAN_CONNECT) {
     return false;
   }
 


### PR DESCRIPTION
REASON_MUST_DISCONNECT was removed by a refactor in 2a1ffa1.