### PR TITLE
Ignore mouseup at end of drag with isDragging

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -429,7 +429,7 @@ Blockly.Field.prototype.onMouseUp_ = function(e) {
   } else if (Blockly.isRightButton(e)) {
     // Right-click.
     return;
-  } else if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
+  } else if (this.sourceBlock_.workspace.isDragging()) {
     // Drag operation is concluding.  Don't open the editor.
     return;
   } else if (this.sourceBlock_.isEditable()) {

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -755,8 +755,7 @@ Blockly.Flyout.prototype.onMouseDown_ = function(e) {
  * @private
  */
 Blockly.Flyout.prototype.onMouseUp_ = function(e) {
-  if (Blockly.dragMode_ != Blockly.DRAG_FREE &&
-      !Blockly.WidgetDiv.isVisible()) {
+  if (!this.workspace_.isDragging() && !Blockly.WidgetDiv.isVisible()) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(Blockly.Flyout.startBlock_, 'click',
                               undefined, undefined));

--- a/core/icon.js
+++ b/core/icon.js
@@ -124,7 +124,7 @@ Blockly.Icon.prototype.isVisible = function() {
  * @private
  */
 Blockly.Icon.prototype.iconClick_ = function(e) {
-  if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
+  if (this.block_.workspace.isDragging()) {
     // Drag operation is concluding.  Don't open the editor.
     return;
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -664,6 +664,14 @@ Blockly.WorkspaceSvg.prototype.moveDrag = function(e) {
 };
 
 /**
+ * Is the user currently dragging a block or scrolling the workspace?
+ * @return {boolean} True if currently dragging or scrolling
+ */
+Blockly.WorkspaceSvg.prototype.isDragging = function() {
+  return Blockly.dragMode_ == Blockly.DRAG_FREE || this.isScrolling;
+};
+
+/**
  * Handle a mouse-wheel on SVG drawing surface.
  * @param {!Event} e Mouse wheel event.
  * @private


### PR DESCRIPTION
This includes both block drags and workspace scrolls and fixes #404. I
used isDragging rather than checking the origin of click so that it can
easily be extended to the case where the flyout is scrolled by dragging
a block, a la LLK/scratch-blocks#206.