### PR TITLE
Add indexing setting for JavaScript Generation

### DIFF
--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -104,6 +104,12 @@ Blockly.JavaScript.ORDER_COMMA = 17;         // ,
 Blockly.JavaScript.ORDER_NONE = 99;          // (...)
 
 /**
+ * Allow for switching between one and zero based indexing, one based by
+ * default.
+ */
+Blockly.JavaScript.ONE_BASED_INDEXING = true;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */


### PR DESCRIPTION
Adding setting to allow for switching between zero and one based indexing for Blockly Blocks such that the generated code will use this flag to determine whether one based or zero based indexing should be used. One based indexing is enabled by default.