### PR TITLE
Trigger a contents resize in block's moveBy.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -343,6 +343,7 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
       'translate(' + (xy.x + dx) + ',' + (xy.y + dy) + ')');
   this.moveConnections_(dx, dy);
   event.recordNew();
+  Blockly.resizeSvgContents(this.workspace);
   Blockly.Events.fire(event);
 };
 


### PR DESCRIPTION
This fixes #420 but and it also fixes some other similar problems
with copy/paste and other users of moveBy.