### PR TITLE
Feature event null blockid

### DIFF
--- a/core/events.js
+++ b/core/events.js
@@ -303,8 +303,10 @@ Blockly.Events.Abstract = function(block) {
 Blockly.Events.Abstract.prototype.toJson = function() {
   var json = {
     'type': this.type,
-    'blockId': this.blockId
   };
+  if (this.blockId) {
+    json['blockId'] = this.blockId;
+  }
   if (this.group) {
     json['group'] = this.group;
   }


### PR DESCRIPTION
Prevents 'blockId': undefined in events.
Consider the UI category event.