### PR TITLE
Getters for getters for workspace's flyout and flyout's workspace; give blocks unique ID from flyout blocks.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -51,8 +51,11 @@ goog.require('goog.string');
  * @constructor
  */
 Blockly.Block = function(workspace, prototypeName, opt_id) {
+  var flyoutWorkspace = workspace.getFlyout() ?
+    workspace.getFlyout().getWorkspace() : null;
   /** @type {string} */
-  this.id = (opt_id && !workspace.getBlockById(opt_id)) ?
+  this.id = (opt_id && !workspace.getBlockById(opt_id) &&
+      (!flyoutWorkspace || !flyoutWorkspace.getBlockById(opt_id))) ?
       opt_id : Blockly.genUid();
   workspace.blockDB_[this.id] = this;
   /** @type {Blockly.Connection} */

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -231,6 +231,14 @@ Blockly.Flyout.prototype.getHeight = function() {
 };
 
 /**
+ * Get the flyout's workspace.
+ * @return {!Blockly.Workspace} Workspace on which this flyout's blocks are placed.
+ */
+Blockly.Flyout.prototype.getWorkspace = function() {
+  return this.workspace_;
+};
+
+/**
  * Return an object with all the metrics required to size scrollbars for the
  * flyout.  The following properties are computed:
  * .viewHeight: Height of the visible rectangle,

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -393,6 +393,21 @@ Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
 };
 
 /**
+ * Get a flyout associated with this workspace, if one exists.
+ * @return {?Blockly.Flyout} Flyout associated with this workspace.
+ */
+
+Blockly.WorkspaceSvg.prototype.getFlyout = function() {
+  if (this.flyout_) {
+    return this.flyout_;
+  }
+  if (this.toolbox_ && this.toolbox_.flyout_) {
+    return this.toolbox_.flyout_;
+  }
+  return null;
+};
+
+/**
  * Translate this workspace to new coordinates.
  * @param {number} x Horizontal translation.
  * @param {number} y Vertical translation.


### PR DESCRIPTION
Use case for the getters (other than the example given): adding change listeners to the flyout. Now you can just do:

`workspace.getFlyout().getWorkspace().addChangeListener();`

Instead of the previous looking through the toolbox, etc.

About giving blocks unique IDs from their flyout originators: https://github.com/LLK/scratch-blocks/issues/449

If there's a reason not to do this, I'd be curious to hear!

@rachel-fenichel 