### PR TITLE
Remove out-of-date comment

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -656,8 +656,6 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
     // Right-click.
     this.showContextMenu_(e);
   } else if (this.scrollbar) {
-    // If the workspace is editable, only allow scrolling when gripping empty
-    // space.  Otherwise, allow scrolling when gripping anywhere.
     this.isScrolling = true;
     // Record the current mouse position.
     this.startDragMouseX = e.clientX;


### PR DESCRIPTION
This comment made sense [before multiple workspace support](https://github.com/google/blockly/blob/67140282a08b10d0beb8d842a2dc35beadc5d5e0/core/blockly.js#L297), where it was near a (Blockly.readOnly || isTargetSvg) check. Now, this logic is implemented in BlockSvg.onMouseDown_() instead.