### PR TITLE
Record whether the workspace has been dragged

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -106,9 +106,9 @@ Blockly.clipboardSource_ = null;
 
 /**
  * Is the mouse dragging a block?
- * 0 - No drag operation.
- * 1 - Still inside the sticky DRAG_RADIUS.
- * 2 - Freely draggable.
+ * DRAG_NONE - No drag operation.
+ * DRAG_STICKY - Still inside the sticky DRAG_RADIUS.
+ * DRAG_FREE - Freely draggable.
  * @private
  */
 Blockly.dragMode_ = Blockly.DRAG_NONE;
@@ -190,7 +190,6 @@ Blockly.svgResize = function(workspace) {
 Blockly.onMouseUp_ = function(e) {
   var workspace = Blockly.getMainWorkspace();
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
-  workspace.isScrolling = false;
   workspace.dragMode_ = Blockly.DRAG_NONE;
   // Unbind the touch event if it exists.
   if (Blockly.onTouchUpWrapper_) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -191,6 +191,7 @@ Blockly.onMouseUp_ = function(e) {
   var workspace = Blockly.getMainWorkspace();
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   workspace.isScrolling = false;
+  workspace.dragMode_ = Blockly.DRAG_NONE;
   // Unbind the touch event if it exists.
   if (Blockly.onTouchUpWrapper_) {
     Blockly.unbindEvent_(Blockly.onTouchUpWrapper_);
@@ -212,7 +213,7 @@ Blockly.onMouseMove_ = function(e) {
     return;  // Multi-touch gestures won't have e.clientX.
   }
   var workspace = Blockly.getMainWorkspace();
-  if (workspace.isScrolling) {
+  if (workspace.dragMode_ != Blockly.DRAG_NONE) {
     var dx = e.clientX - workspace.startDragMouseX;
     var dy = e.clientY - workspace.startDragMouseY;
     var metrics = workspace.startDragMetrics;
@@ -231,6 +232,7 @@ Blockly.onMouseMove_ = function(e) {
     // Cancel the long-press if the drag has moved too far.
     if (Math.sqrt(dx * dx + dy * dy) > Blockly.DRAG_RADIUS) {
       Blockly.longStop_();
+      workspace.dragMode_ = Blockly.DRAG_FREE;
     }
     e.stopPropagation();
     e.preventDefault();

--- a/core/constants.js
+++ b/core/constants.js
@@ -154,7 +154,14 @@ Blockly.DRAG_NONE = 0;
 Blockly.DRAG_STICKY = 1;
 
 /**
- * ENUM for freely draggable.
+ * ENUM for inside the non-sticky DRAG_RADIUS, for differentiating between
+ * clicks and drags.
+ * @const
+ */
+Blockly.DRAG_BEGIN = 1;
+
+/**
+ * ENUM for freely draggable (outside the DRAG_RADIUS, if one applies).
  * @const
  */
 Blockly.DRAG_FREE = 2;

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -151,9 +151,9 @@ Blockly.Flyout.prototype.height_ = 0;
 
 /**
  * Is the flyout dragging (scrolling)?
- * 0 - DRAG_NONE - no drag is ongoing or state is undetermined.
- * 1 - DRAG_STICKY - still within the sticky drag radius.
- * 2 - DRAG_FREE - in scroll mode (never create a new block).
+ * DRAG_NONE - no drag is ongoing or state is undetermined.
+ * DRAG_STICKY - still within the sticky drag radius.
+ * DRAG_FREE - in scroll mode (never create a new block).
  * @private
  */
 Blockly.Flyout.prototype.dragMode_ = Blockly.DRAG_NONE;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -84,9 +84,20 @@ Blockly.WorkspaceSvg.prototype.isFlyout = false;
 
 /**
  * Is this workspace currently being dragged around?
+ * Equivalent to dragMode_ != Blockly.DRAG_NONE, but kept for backwards
+ * compatibility.
  * @type {boolean}
  */
 Blockly.WorkspaceSvg.prototype.isScrolling = false;
+
+/**
+ * Is this workspace currently being dragged around?
+ * 0 - DRAG_NONE - no drag operation.
+ * 1 - DRAG_STICKY - still within the sticky DRAG_RADIUS.
+ * 2 - DRAG_FREE - in scroll mode.
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.dragMode_ = Blockly.DRAG_NONE;
 
 /**
  * Current horizontal scrolling offset.
@@ -657,6 +668,7 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
     this.showContextMenu_(e);
   } else if (this.scrollbar) {
     this.isScrolling = true;
+    this.dragMode_ = Blockly.DRAG_STICKY;
     // Record the current mouse position.
     this.startDragMouseX = e.clientX;
     this.startDragMouseY = e.clientY;
@@ -716,7 +728,8 @@ Blockly.WorkspaceSvg.prototype.moveDrag = function(e) {
  * @return {boolean} True if currently dragging or scrolling.
  */
 Blockly.WorkspaceSvg.prototype.isDragging = function() {
-  return Blockly.dragMode_ == Blockly.DRAG_FREE || this.isScrolling;
+  return Blockly.dragMode_ == Blockly.DRAG_FREE ||
+      this.dragMode_ == Blockly.DRAG_FREE;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -84,17 +84,9 @@ Blockly.WorkspaceSvg.prototype.isFlyout = false;
 
 /**
  * Is this workspace currently being dragged around?
- * Equivalent to dragMode_ != Blockly.DRAG_NONE, but kept for backwards
- * compatibility.
- * @type {boolean}
- */
-Blockly.WorkspaceSvg.prototype.isScrolling = false;
-
-/**
- * Is this workspace currently being dragged around?
- * 0 - DRAG_NONE - no drag operation.
- * 1 - DRAG_STICKY - still within the sticky DRAG_RADIUS.
- * 2 - DRAG_FREE - in scroll mode.
+ * DRAG_NONE - No drag operation.
+ * DRAG_BEGIN - Still inside the initial DRAG_RADIUS.
+ * DRAG_FREE - Workspace has been dragged further than DRAG_RADIUS.
  * @private
  */
 Blockly.WorkspaceSvg.prototype.dragMode_ = Blockly.DRAG_NONE;
@@ -667,8 +659,7 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
     // Right-click.
     this.showContextMenu_(e);
   } else if (this.scrollbar) {
-    this.isScrolling = true;
-    this.dragMode_ = Blockly.DRAG_STICKY;
+    this.dragMode_ = Blockly.DRAG_BEGIN;
     // Record the current mouse position.
     this.startDragMouseX = e.clientX;
     this.startDragMouseY = e.clientY;


### PR DESCRIPTION
This fixes #473 by differentiating between a touch on an unmovable block and using it to drag the workspace.

@NeilFraser, would you prefer to remove the `isScrolling` field? I don't know how important it is to keep backwards compatibility on public fields.