### PR TITLE
Check flyout in isDragging()

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -774,6 +774,7 @@ Blockly.Flyout.prototype.onMouseDown_ = function(e) {
   this.dragMode_ = Blockly.DRAG_FREE;
   this.startDragMouseY_ = e.clientY;
   this.startDragMouseX_ = e.clientX;
+  Blockly.Flyout.startFlyout_ = this;
   Blockly.Flyout.onMouseMoveWrapper_ = Blockly.bindEvent_(document, 'mousemove',
       this, this.onMouseMove_);
   Blockly.Flyout.onMouseUpWrapper_ = Blockly.bindEvent_(document, 'mouseup',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -715,11 +715,13 @@ Blockly.WorkspaceSvg.prototype.moveDrag = function(e) {
 };
 
 /**
- * Is the user currently dragging a block or scrolling the workspace?
+ * Is the user currently dragging a block or scrolling the flyout/workspace?
  * @return {boolean} True if currently dragging or scrolling.
  */
 Blockly.WorkspaceSvg.prototype.isDragging = function() {
   return Blockly.dragMode_ == Blockly.DRAG_FREE ||
+      (Blockly.Flyout.startFlyout_ &&
+          Blockly.Flyout.startFlyout_.dragMode_ == Blockly.DRAG_FREE) ||
       this.dragMode_ == Blockly.DRAG_FREE;
 };
 


### PR DESCRIPTION
We also have to record startFlyout_ on background scrolls - before
dragMode_ wasn't being reset by terminateDrag() for background scrolls,
which would suppress clicks from that point on.

Fixes #476.