### PR TITLE
Add JSDoc for flyout drag state variables

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -99,7 +99,59 @@ Blockly.Flyout = function(workspaceOptions) {
    * @private
    */
   this.permanentlyDisabled_ = [];
+
+  /**
+   * y coordinate of mousedown - used to calculate scroll distances.
+   * @private {number}
+   */
+  this.startDragMouseY_ = 0;
+
+  /**
+   * x coordinate of mousedown - used to calculate scroll distances.
+   * @private {number}
+   */
+  this.startDragMouseX_ = 0;
 };
+
+/**
+ * When a flyout drag is in progress, this is a reference to the flyout being
+ * dragged. This is used by Flyout.terminateDrag_ to reset dragMode_.
+ * @private {Blockly.Flyout}
+ */
+Blockly.Flyout.startFlyout_ = null;
+
+/**
+ * Event that started a drag. Used to determine the drag distance/direction and
+ * also passed to BlockSvg.onMouseDown_() after creating a new block.
+ * @private {Event}
+ */
+Blockly.Flyout.startDownEvent_ = null;
+
+/**
+ * Flyout block where the drag/click was initiated. Used to fire click events or
+ * create a new block.
+ * @private {Event}
+ */
+Blockly.Flyout.startBlock_ = null;
+
+/**
+ * Wrapper function called when a mouseup occurs during a background or block
+ * drag operation.
+ * @private {Array.<!Array>}
+ */
+Blockly.Flyout.onMouseUpWrapper_ = null;
+
+/**
+ * Wrapper function called when a mousemove occurs during a background drag.
+ * @private {Array.<!Array>}
+ */
+Blockly.Flyout.onMouseMoveWrapper_ = null;
+
+/**
+ * Wrapper function called when a mousemove occurs during a block drag.
+ * @private {Array.<!Array>}
+ */
+Blockly.Flyout.onMouseMoveBlockWrapper_ = null;
 
 /**
  * Does the flyout automatically close when a block is created?
@@ -1121,10 +1173,6 @@ Blockly.Flyout.terminateDrag_ = function() {
   if (Blockly.Flyout.onMouseMoveWrapper_) {
     Blockly.unbindEvent_(Blockly.Flyout.onMouseMoveWrapper_);
     Blockly.Flyout.onMouseMoveWrapper_ = null;
-  }
-  if (Blockly.Flyout.onMouseUpWrapper_) {
-    Blockly.unbindEvent_(Blockly.Flyout.onMouseUpWrapper_);
-    Blockly.Flyout.onMouseUpWrapper_ = null;
   }
   Blockly.Flyout.startDownEvent_ = null;
   Blockly.Flyout.startBlock_ = null;


### PR DESCRIPTION
I've chosen to keep these as static members of Flyout, similar to BlockSvg.onMouse*Wrapper_, which are also used by terminateDrag to reset state.

@rachel-fenichel, is this what you were thinking of? Let me know if the docs could be clearer.