### PR TITLE
Revert "Convert createDom calls to createUntypedDom"

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -178,9 +178,9 @@ Blockly.Blocks['controls_for'] = {
       var option = {enabled: true};
       var name = this.getFieldValue('VAR');
       option.text = Blockly.Msg.VARIABLES_SET_CREATE_GET.replace('%1', name);
-      var xmlField = goog.dom.createUntypedDom('field', null, name);
+      var xmlField = goog.dom.createDom('field', null, name);
       xmlField.setAttribute('name', 'VAR');
-      var xmlBlock = goog.dom.createUntypedDom('block', null, xmlField);
+      var xmlBlock = goog.dom.createDom('block', null, xmlField);
       xmlBlock.setAttribute('type', 'variables_get');
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -295,14 +295,14 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     var option = {enabled: true};
     var name = this.getFieldValue('NAME');
     option.text = Blockly.Msg.PROCEDURES_CREATE_DO.replace('%1', name);
-    var xmlMutation = goog.dom.createUntypedDom('mutation');
+    var xmlMutation = goog.dom.createDom('mutation');
     xmlMutation.setAttribute('name', name);
     for (var i = 0; i < this.arguments_.length; i++) {
-      var xmlArg = goog.dom.createUntypedDom('arg');
+      var xmlArg = goog.dom.createDom('arg');
       xmlArg.setAttribute('name', this.arguments_[i]);
       xmlMutation.appendChild(xmlArg);
     }
-    var xmlBlock = goog.dom.createUntypedDom('block', null, xmlMutation);
+    var xmlBlock = goog.dom.createDom('block', null, xmlMutation);
     xmlBlock.setAttribute('type', this.callType_);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
     options.push(option);
@@ -313,9 +313,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
         var option = {enabled: true};
         var name = this.arguments_[i];
         option.text = Blockly.Msg.VARIABLES_SET_CREATE_GET.replace('%1', name);
-        var xmlField = goog.dom.createUntypedDom('field', null, name);
+        var xmlField = goog.dom.createDom('field', null, name);
         xmlField.setAttribute('name', 'VAR');
-        var xmlBlock = goog.dom.createUntypedDom('block', null, xmlField);
+        var xmlBlock = goog.dom.createDom('block', null, xmlField);
         xmlBlock.setAttribute('type', 'variables_get');
         option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
         options.push(option);
@@ -687,8 +687,8 @@ Blockly.Blocks['procedures_callnoreturn'] = {
          *   </block>
          * </xml>
          */
-        var xml = goog.dom.createUntypedDom('xml');
-        var block = goog.dom.createUntypedDom('block');
+        var xml = goog.dom.createDom('xml');
+        var block = goog.dom.createDom('block');
         block.setAttribute('type', this.defType_);
         var xy = this.getRelativeToSurfaceXY();
         var x = xy.x + Blockly.SNAP_RADIUS * (this.RTL ? -1 : 1);
@@ -697,7 +697,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         block.setAttribute('y', y);
         var mutation = this.mutationToDom();
         block.appendChild(mutation);
-        var field = goog.dom.createUntypedDom('field');
+        var field = goog.dom.createDom('field');
         field.setAttribute('name', 'NAME');
         field.appendChild(document.createTextNode(this.getProcedureCall()));
         block.appendChild(field);

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -59,9 +59,9 @@ Blockly.Blocks['variables_get'] = {
     var option = {enabled: true};
     var name = this.getFieldValue('VAR');
     option.text = this.contextMenuMsg_.replace('%1', name);
-    var xmlField = goog.dom.createUntypedDom('field', null, name);
+    var xmlField = goog.dom.createDom('field', null, name);
     xmlField.setAttribute('name', 'VAR');
-    var xmlBlock = goog.dom.createUntypedDom('block', null, xmlField);
+    var xmlBlock = goog.dom.createDom('block', null, xmlField);
     xmlBlock.setAttribute('type', this.contextMenuType_);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
     options.push(option);

--- a/core/events.js
+++ b/core/events.js
@@ -388,7 +388,7 @@ Blockly.Events.Create.prototype.fromJson = function(json) {
 Blockly.Events.Create.prototype.run = function(forward) {
   var workspace = Blockly.Workspace.getById(this.workspaceId);
   if (forward) {
-    var xml = goog.dom.createUntypedDom('xml');
+    var xml = goog.dom.createDom('xml');
     xml.appendChild(this.xml);
     Blockly.Xml.domToWorkspace(xml, workspace);
   } else {
@@ -465,7 +465,7 @@ Blockly.Events.Delete.prototype.run = function(forward) {
       }
     }
   } else {
-    var xml = goog.dom.createUntypedDom('xml');
+    var xml = goog.dom.createDom('xml');
     xml.appendChild(this.oldXml);
     Blockly.Xml.domToWorkspace(xml, workspace);
   }

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -30,7 +30,6 @@ goog.require('Blockly.Field');
 goog.require('Blockly.Msg');
 goog.require('goog.asserts');
 goog.require('goog.dom');
-goog.require('goog.dom.TagName');
 goog.require('goog.userAgent');
 
 
@@ -125,8 +124,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
   Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, this.widgetDispose_());
   var div = Blockly.WidgetDiv.DIV;
   // Create the input.
-  var htmlInput =
-      goog.dom.createDom(goog.dom.TagName.INPUT, 'blocklyHtmlInput');
+  var htmlInput = goog.dom.createDom('input', 'blocklyHtmlInput');
   htmlInput.setAttribute('spellcheck', this.spellcheck_);
   var fontSize =
       (Blockly.FieldTextInput.FONTSIZE * this.workspace_.scale) + 'pt';

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -110,10 +110,9 @@ Blockly.Mutator.prototype.createEditor_ = function() {
       null);
   // Convert the list of names into a list of XML objects for the flyout.
   if (this.quarkNames_.length) {
-    var quarkXml = goog.dom.createUntypedDom('xml');
+    var quarkXml = goog.dom.createDom('xml');
     for (var i = 0, quarkName; quarkName = this.quarkNames_[i]; i++) {
-      quarkXml.appendChild(
-          goog.dom.createUntypedDom('block', {'type': quarkName}));
+      quarkXml.appendChild(goog.dom.createDom('block', {'type': quarkName}));
     }
   } else {
     var quarkXml = null;

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -162,21 +162,21 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
   var xmlList = [];
   if (Blockly.Blocks['procedures_defnoreturn']) {
     // <block type="procedures_defnoreturn" gap="16"></block>
-    var block = goog.dom.createUntypedDom('block');
+    var block = goog.dom.createDom('block');
     block.setAttribute('type', 'procedures_defnoreturn');
     block.setAttribute('gap', 16);
     xmlList.push(block);
   }
   if (Blockly.Blocks['procedures_defreturn']) {
     // <block type="procedures_defreturn" gap="16"></block>
-    var block = goog.dom.createUntypedDom('block');
+    var block = goog.dom.createDom('block');
     block.setAttribute('type', 'procedures_defreturn');
     block.setAttribute('gap', 16);
     xmlList.push(block);
   }
   if (Blockly.Blocks['procedures_ifreturn']) {
     // <block type="procedures_ifreturn" gap="16"></block>
-    var block = goog.dom.createUntypedDom('block');
+    var block = goog.dom.createDom('block');
     block.setAttribute('type', 'procedures_ifreturn');
     block.setAttribute('gap', 16);
     xmlList.push(block);
@@ -195,14 +195,14 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
       //     <arg name="x"></arg>
       //   </mutation>
       // </block>
-      var block = goog.dom.createUntypedDom('block');
+      var block = goog.dom.createDom('block');
       block.setAttribute('type', templateName);
       block.setAttribute('gap', 16);
-      var mutation = goog.dom.createUntypedDom('mutation');
+      var mutation = goog.dom.createDom('mutation');
       mutation.setAttribute('name', name);
       block.appendChild(mutation);
       for (var j = 0; j < args.length; j++) {
-        var arg = goog.dom.createUntypedDom('arg');
+        var arg = goog.dom.createDom('arg');
         arg.setAttribute('name', args[j]);
         mutation.appendChild(arg);
       }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.Toolbox');
 
 goog.require('Blockly.Flyout');
 goog.require('goog.dom');
-goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.events.BrowserFeature');
 goog.require('goog.html.SafeHtml');
@@ -147,8 +146,7 @@ Blockly.Toolbox.prototype.init = function() {
   var workspace = this.workspace_;
 
   // Create an HTML container for the Toolbox menu.
-  this.HtmlDiv =
-      goog.dom.createDom(goog.dom.TagName.DIV, 'blocklyToolboxDiv');
+  this.HtmlDiv = goog.dom.createDom('div', 'blocklyToolboxDiv');
   this.HtmlDiv.setAttribute('dir', workspace.RTL ? 'RTL' : 'LTR');
   document.body.appendChild(this.HtmlDiv);
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -32,7 +32,6 @@
 goog.provide('Blockly.Tooltip');
 
 goog.require('goog.dom');
-goog.require('goog.dom.TagName');
 
 
 /**
@@ -121,8 +120,7 @@ Blockly.Tooltip.createDom = function() {
     return;  // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
-  Blockly.Tooltip.DIV =
-      goog.dom.createDom(goog.dom.TagName.DIV, 'blocklyTooltipDiv');
+  Blockly.Tooltip.DIV = goog.dom.createDom('div', 'blocklyTooltipDiv');
   document.body.appendChild(Blockly.Tooltip.DIV);
 };
 

--- a/core/variables.js
+++ b/core/variables.js
@@ -108,12 +108,12 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       // <block type="variables_set" gap="8">
       //   <field name="VAR">item</field>
       // </block>
-      var block = goog.dom.createUntypedDom('block');
+      var block = goog.dom.createDom('block');
       block.setAttribute('type', 'variables_set');
       if (Blockly.Blocks['variables_get']) {
         block.setAttribute('gap', 8);
       }
-      var field = goog.dom.createUntypedDom('field', null, variableList[i]);
+      var field = goog.dom.createDom('field', null, variableList[i]);
       field.setAttribute('name', 'VAR');
       block.appendChild(field);
       xmlList.push(block);
@@ -122,12 +122,12 @@ Blockly.Variables.flyoutCategory = function(workspace) {
       // <block type="variables_get" gap="24">
       //   <field name="VAR">item</field>
       // </block>
-      var block = goog.dom.createUntypedDom('block');
+      var block = goog.dom.createDom('block');
       block.setAttribute('type', 'variables_get');
       if (Blockly.Blocks['variables_set']) {
         block.setAttribute('gap', 24);
       }
-      var field = goog.dom.createUntypedDom('field', null, variableList[i]);
+      var field = goog.dom.createDom('field', null, variableList[i]);
       field.setAttribute('name', 'VAR');
       block.appendChild(field);
       xmlList.push(block);

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -30,7 +30,6 @@ goog.provide('Blockly.WidgetDiv');
 
 goog.require('Blockly.Css');
 goog.require('goog.dom');
-goog.require('goog.dom.TagName');
 goog.require('goog.style');
 
 
@@ -62,8 +61,7 @@ Blockly.WidgetDiv.createDom = function() {
     return;  // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
-  Blockly.WidgetDiv.DIV =
-      goog.dom.createDom(goog.dom.TagName.DIV, 'blocklyWidgetDiv');
+  Blockly.WidgetDiv.DIV = goog.dom.createDom('div', 'blocklyWidgetDiv');
   document.body.appendChild(Blockly.WidgetDiv.DIV);
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -36,7 +36,7 @@ goog.require('goog.dom');
  * @return {!Element} XML document.
  */
 Blockly.Xml.workspaceToDom = function(workspace) {
-  var xml = goog.dom.createUntypedDom('xml');
+  var xml = goog.dom.createDom('xml');
   var blocks = workspace.getTopBlocks(true);
   for (var i = 0, block; block = blocks[i]; i++) {
     xml.appendChild(Blockly.Xml.blockToDomWithXY(block));
@@ -68,8 +68,7 @@ Blockly.Xml.blockToDomWithXY = function(block) {
  * @return {!Element} Tree of XML elements.
  */
 Blockly.Xml.blockToDom = function(block) {
-  var element = goog.dom.createUntypedDom(
-      block.isShadow() ? 'shadow' : 'block');
+  var element = goog.dom.createDom(block.isShadow() ? 'shadow' : 'block');
   element.setAttribute('type', block.type);
   element.setAttribute('id', block.id);
   if (block.mutationToDom) {
@@ -81,8 +80,7 @@ Blockly.Xml.blockToDom = function(block) {
   }
   function fieldToDom(field) {
     if (field.name && field.EDITABLE) {
-      var container =
-          goog.dom.createUntypedDom('field', null, field.getValue());
+      var container = goog.dom.createDom('field', null, field.getValue());
       container.setAttribute('name', field.name);
       element.appendChild(container);
     }
@@ -95,8 +93,7 @@ Blockly.Xml.blockToDom = function(block) {
 
   var commentText = block.getCommentText();
   if (commentText) {
-    var commentElement =
-        goog.dom.createUntypedDom('comment', null, commentText);
+    var commentElement = goog.dom.createDom('comment', null, commentText);
     if (typeof block.comment == 'object') {
       commentElement.setAttribute('pinned', block.comment.isVisible());
       var hw = block.comment.getBubbleSize();
@@ -107,7 +104,7 @@ Blockly.Xml.blockToDom = function(block) {
   }
 
   if (block.data) {
-    var dataElement = goog.dom.createUntypedDom('data', null, block.data);
+    var dataElement = goog.dom.createDom('data', null, block.data);
     element.appendChild(dataElement);
   }
 
@@ -119,9 +116,9 @@ Blockly.Xml.blockToDom = function(block) {
     } else {
       var childBlock = input.connection.targetBlock();
       if (input.type == Blockly.INPUT_VALUE) {
-        container = goog.dom.createUntypedDom('value');
+        container = goog.dom.createDom('value');
       } else if (input.type == Blockly.NEXT_STATEMENT) {
-        container = goog.dom.createUntypedDom('statement');
+        container = goog.dom.createDom('statement');
       }
       var shadow = input.connection.getShadowDom();
       if (shadow && (!childBlock || !childBlock.isShadow())) {
@@ -158,8 +155,8 @@ Blockly.Xml.blockToDom = function(block) {
 
   var nextBlock = block.getNextBlock();
   if (nextBlock) {
-    var container = goog.dom.createUntypedDom(
-        'next', null, Blockly.Xml.blockToDom(nextBlock));
+    var container = goog.dom.createDom('next', null,
+        Blockly.Xml.blockToDom(nextBlock));
     element.appendChild(container);
   }
   var shadow = block.nextConnection && block.nextConnection.getShadowDom();


### PR DESCRIPTION
Reverts google/blockly#481

I believe the compiler might not handle these yet - the demos that use blockly_compressed.js are mostly broken even when I try rebuilding them.