### PR TITLE
Problem under Firefox 47.0 if runs in the frame

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -166,7 +166,8 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
  * Update the inverted screen CTM.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  this.inverseScreenCTM_ = this.getParentSvg().getScreenCTM().inverse();
+  var _screenCTM = this.getParentSvg().getScreenCTM();
+  this.inverseScreenCTM_ = _screenCTM ? _screenCTM.inverse() : null;
 };
 
 /**


### PR DESCRIPTION
The function getScreenCTM returns nothing if used on div in some iFrame under firefox . 
It must be bug of FF, but actually it is not possible to use blockly in iFrame in FF.
Chrome runs perfect.