### PR TITLE
Add a read file function to utils.js

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -614,6 +614,24 @@ Blockly.utils.wrapScore_ = function(words, wordBreaks, limit) {
   return score;
 };
 
+Blockly.readPythonFile = function(file) {
+    var rawFile = new XMLHttpRequest();
+    var code = "";
+    rawFile.open("GET", file, false);
+    rawFile.onreadystatechange = function ()
+    {
+        if(rawFile.readyState === 4)
+        {
+            if(rawFile.status === 200 || rawFile.status == 0)
+            {
+                code = rawFile.responseText;
+            }
+        }
+    }
+    rawFile.send(null);
+    return code;
+};
+
 /**
  * Mutate the array of line break locations until an optimal solution is found.
  * No line breaks are added or deleted, they are simply moved around.

--- a/core/utils.js
+++ b/core/utils.js
@@ -614,7 +614,7 @@ Blockly.utils.wrapScore_ = function(words, wordBreaks, limit) {
   return score;
 };
 
-Blockly.readPythonFile = function(file) {
+Blockly.readFile = function(file) {
     var rawFile = new XMLHttpRequest();
     var code = "";
     rawFile.open("GET", file, false);


### PR DESCRIPTION
We have been using blockly with Erle's robot_blockly and found that some of the blocks of code for our more complex blocks were quite large so rather than adding the code into the generators/python js files, we created a folder inside generators/python called scripts where we add python files containing the code for that each block. We added the readFile function to utils.js so that we could then read in these python files. Thought it might be a handy feature to add.

Here is an example :

https://github.com/shadow-robot/blockly/blob/master/generators/python/arm.js#L11