### PR TITLE
Escape $ in block ID

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -188,8 +188,10 @@ Blockly.Generator.prototype.blockToCode = function(block) {
     return [this.scrub_(block, code[0]), code[1]];
   } else if (goog.isString(code)) {
     if (this.STATEMENT_PREFIX) {
-      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + block.id + '\'') +
-          code;
+      // Escaping all $ signs by $$ for replace function
+      var regexp_ready_block_id = block.id.replace(/\$/g, "$$$$");
+      code = this.STATEMENT_PREFIX.replace(/%1/g,
+          '\'' + regexp_ready_block_id + '\'') + code;
     }
     return this.scrub_(block, code);
   } else if (code === null) {
@@ -297,12 +299,15 @@ Blockly.Generator.prototype.statementToCode = function(block, name) {
  * @return {string} Loop contents, with infinite loop trap added.
  */
 Blockly.Generator.prototype.addLoopTrap = function(branch, id) {
+  // Escaping all $ signs by $$ for replace function
+  var regexp_ready_block_id = id.replace(/\$/g, "$$$$");
   if (this.INFINITE_LOOP_TRAP) {
-    branch = this.INFINITE_LOOP_TRAP.replace(/%1/g, '\'' + id + '\'') + branch;
+    branch = this.INFINITE_LOOP_TRAP.replace(/%1/g,
+        '\'' + regexp_ready_block_id + '\'') + branch;
   }
   if (this.STATEMENT_PREFIX) {
     branch += this.prefixLines(this.STATEMENT_PREFIX.replace(/%1/g,
-        '\'' + id + '\''), this.INDENT);
+        '\'' + regexp_ready_block_id + '\''), this.INDENT);
   }
   return branch;
 };

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -48,14 +48,16 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   var funcName = Blockly.Python.variableDB_.getName(block.getFieldValue('NAME'),
       Blockly.Procedures.NAME_TYPE);
   var branch = Blockly.Python.statementToCode(block, 'STACK');
+  // Escaping all $ signs by $$ for replace function
+  var regexp_ready_block_id = block.id.replace(/\$/g, "$$$$");
   if (Blockly.Python.STATEMENT_PREFIX) {
     branch = Blockly.Python.prefixLines(
         Blockly.Python.STATEMENT_PREFIX.replace(/%1/g,
-        '\'' + block.id + '\''), Blockly.Python.INDENT) + branch;
+        '\'' + regexp_ready_block_id + '\''), Blockly.Python.INDENT) + branch;
   }
   if (Blockly.Python.INFINITE_LOOP_TRAP) {
     branch = Blockly.Python.INFINITE_LOOP_TRAP.replace(/%1/g,
-        '"' + block.id + '"') + branch;
+        '"' + regexp_ready_block_id + '"') + branch;
   }
   var returnValue = Blockly.Python.valueToCode(block, 'RETURN',
       Blockly.Python.ORDER_NONE) || '';


### PR DESCRIPTION
We have found that the $ sign, when in a block ID is not being correctly escaped and was causing this error:

check_status('~t(YxV2@Y^a[cQbz$*G)
                                     ^
SyntaxError: EOL while scanning string literal

When we were reading the Block ID into our check_status function.