### PR TITLE
Block Factory: set JSON to default language format for block definitions

### DIFF
--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -140,8 +140,8 @@
             <td height="5%">
               <h3>Language code:
                 <select id="format">
-                  <option value="JavaScript">JavaScript</option>
                   <option value="JSON">JSON</option>
+                  <option value="JavaScript">JavaScript</option>
                   <option value="Manual">Manual edit&hellip;</option>
                 </select>
               </h3>


### PR DESCRIPTION
In the dropdown in which you select block definition language format in the Exporter & Block Factory, generate JSON block definition by default.
<img width="1291" alt="screen shot 2016-08-01 at 5 05 03 pm" src="https://cloud.githubusercontent.com/assets/10423718/17312779/2989f698-580a-11e6-965f-f78aac890747.png">
"The JSON format is cross-platform so that the same code may be used to define blocks on web, Android, and iOS. Additionally, the JSON format is designed to simplify the internationalization process when developing for languages with different word orderings. The JSON format is the preferred method of defining blocks" ([Blockly Dev Reference](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#json_format_versus_javascript_api)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/517)
<!-- Reviewable:end -->
