### PR TITLE
Add a test for domToWorkspace

### DIFF
--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -59,6 +59,29 @@ function test_domToText() {
       text.replace(/\s+/g, ''));
 }
 
+function test_domToWorkspace() {
+  Blockly.Blocks.test_block = {
+    init: function() {
+      this.jsonInit({
+        message0: 'test',
+      });
+    }
+  };
+
+  try {
+    var dom = Blockly.Xml.textToDom(
+        '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+        '  <block type="test_block" inline="true" x="21" y="23">' +
+        '  </block>' +
+        '</xml>');
+    var workspace = new Blockly.Workspace();
+    Blockly.Xml.domToWorkspace(dom, workspace);
+    assertEquals('Block count', 1, workspace.getAllBlocks().length);
+  } finally {
+    delete Blockly.Blocks.test_block;
+  }
+}
+
 function test_domToPrettyText() {
   var dom = Blockly.Xml.textToDom(XML_TEXT);
   var text = Blockly.Xml.domToPrettyText(dom);


### PR DESCRIPTION
This would have caught a recent [Scratch Blocks regression](https://github.com/LLK/scratch-blocks/pull/557) where domToWorkspace failed unless given a WorkspaceSvg instance.