### PR TITLE
Blockly Factory: Foundation for Integrating Workspace Factory

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -249,6 +249,8 @@ AppController.prototype.makeTabClickHandler_ = function(tabName) {
 /**
  * Called on each tab click. Hides and shows specific content based on which tab
  * (Block Factory, Workspace Factory, or Exporter) is selected.
+ *
+ * TODO(quachtina96): Refactor the code to avoid repetition of addRemove.
  */
 AppController.prototype.onTab = function() {
   // Get tab div elements.

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -90,20 +90,47 @@ BlockExporterController.prototype.getSelectedBlockTypes_ = function() {
 
 /**
  * Get selected blocks from selector workspace, pulls info from the Export
- * Settings form in Block Exporter, and downloads block code accordingly.
+ * Settings form in Block Exporter, and downloads code accordingly.
+ *
+ * TODO(quachtina96): allow export as zip.
  */
-BlockExporterController.prototype.exportBlocks = function() {
+BlockExporterController.prototype.export = function() {
+  // Get selected blocks' information.
   var blockTypes = this.getSelectedBlockTypes_();
   var blockXmlMap = this.blockLibStorage.getBlockXmlMap(blockTypes);
 
-  // Pull inputs from the Export Settings form.
+  // Pull workspace-related settings from the Export Settings form.
+  var wantToolbox = document.getElementById('toolboxCheck').checked;
+  var wantPreloadedWorkspace =
+      document.getElementById('preloadedWorkspaceCheck').checked;
+  var wantWorkspaceOptions =
+      document.getElementById('workspaceOptsCheck').checked;
+
+  // Pull block definition(s) settings from the Export Settings form.
+  var wantBlockDef = document.getElementById('blockDefCheck').checked;
   var definitionFormat = document.getElementById('exportFormat').value;
-  var language = document.getElementById('exportLanguage').value;
   var blockDef_filename = document.getElementById('blockDef_filename').value;
+
+  // Pull block generator stub(s) settings from the Export Settings form.
+  var wantGenStub = document.getElementById('genStubCheck').checked;
+  var language = document.getElementById('exportLanguage').value;
   var generatorStub_filename = document.getElementById(
       'generatorStub_filename').value;
-  var wantBlockDef = document.getElementById('blockDefCheck').checked;
-  var wantGenStub = document.getElementById('genStubCheck').checked;
+
+  if (wantToolbox) {
+    // TODO(quachtina96): create and download file once wfactory has been
+    // integrated.
+  }
+
+  if (wantPreloadedWorkspace) {
+    // TODO(quachtina96): create and download file once wfactory has been
+    // integrated.
+  }
+
+  if (wantWorkspaceOptions) {
+    // TODO(quachtina96): create and download file once wfactory has been
+    // integrated.
+  }
 
   if (wantBlockDef) {
     // User wants to export selected blocks' definitions.
@@ -134,6 +161,7 @@ BlockExporterController.prototype.exportBlocks = function() {
           genStubs, generatorStub_filename, language);
     }
   }
+
 };
 
 /**

--- a/demos/blocklyfactory/block_exporter_tools.js
+++ b/demos/blocklyfactory/block_exporter_tools.js
@@ -179,6 +179,7 @@ BlockExporterTools.prototype.addBlockDefinitions = function(blockXmlMap) {
  * Pulls information about all blocks in the block library to generate xml
  * for the selector workpace's toolbox.
  *
+ * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage object.
  * @return {!Element} Xml representation of the toolbox.
  */
 BlockExporterTools.prototype.generateToolboxFromLibrary

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -161,6 +161,16 @@ button, .buttonStyle {
   width: 50%;
 }
 
+/* Workspace Factory */
+
+#workspaceFactoryContent {
+  clear: both;
+  display: none;
+  height: 100%;
+}
+
+/* Exporter */
+
 #blockLibraryExporter {
   clear: both;
   display: none;
@@ -170,17 +180,25 @@ button, .buttonStyle {
 #exportSelector {
   float: left;
   height: 75%;
-  width: 60%;
+  width: 30%;
 }
 
 #exportSettings {
-  margin: auto;
+  float: left;
   padding: 16px;
+  width: 30%;
   overflow: hidden;
 }
 
 #exporterHiddenWorkspace {
  display: none;
+}
+
+#exporterPreview {
+  float: right;
+  padding: 16px;
+  overflow: hidden;
+  background-color: blue;
 }
 
 /* Tabs */

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -40,27 +40,41 @@
     <a href="../index.html">Demos</a> &gt; Blockly Factory</h1>
 
   <div id="tabContainer">
-    <div id="blockfactory_tab" class="tab tabon"> Block Factory</div>
+    <div id="blockFactory_tab" class="tab tabon"> Block Factory</div>
     <div class="tabGap"></div>
-    <div id="blocklibraryExporter_tab" class="tab taboff"> Block Library Exporter</div>
+    <div id="workspaceFactory_tab" class="tab taboff"> Workspace Factory</div>
+    <div class="tabGap"></div>
+    <div id="blocklibraryExporter_tab" class="tab taboff"> Exporter</div>
   </div>
 
   <div id="blockLibraryExporter">
-    <div id="exporterButtons">
-      <button id="clearSelectedButton"> Clear Blocks </button>
-      <button id="addAllButton"> Add All Stored Blocks </button>
-    </div>
+    <h3> Block Selector </h3>
     <div id="helperTextDiv">
       <p id="helperText"> Drag blocks into your workspace to select them for download.</p>
+    </div>
+    <div id="exporterButtons">
+      <button id="clearSelectedButton"> Clear Blocks </button>
+      <button id="addAllFromLibButton"> Add All Stored Blocks </button>
+      <button id="addAllUsedButton"> Add All Used Blocks </button>
     </div>
     <!-- Inject exportSelectorWorkspace into this div -->
     <div id="exportSelector"></div>
     <!-- Users may customize export settings through this form -->
     <div id="exportSettings">
-      <h3> Block Export Settings </h3>
+      <h3> Export Settings </h3>
       <br>
       <form id="exportSettingsForm">
-        Download Block Definition:
+        Toolbox Xml:
+        <input type="checkbox" id="toolboxCheck">
+        <br>
+        Pre-loaded Workspace:
+        <input type="checkbox" id="preloadedWorkspaceCheck">
+        <br>
+        Workspace Option(s):
+        <input type="checkbox" id="workspaceOptsCheck">
+        <br>
+        <br>
+        Block Definition(s):
         <input type="checkbox" id="blockDefCheck"><br>
               Language code:
                 <select id="exportFormat">
@@ -68,9 +82,10 @@
                   <option value="JavaScript">JavaScript</option>
                 </select><br>
           Block Definition(s) File Name:<br>
-          <input type="text" id="blockDef_filename"><br>
+          <input type="text" id="blockDef_filename">
           <br>
-        Download Generator Stubs:
+          <br>
+        Generator Stub(s):
         <input type="checkbox" id="genStubCheck"><br>
                 <select id="exportLanguage">
                   <option value="JavaScript">JavaScript</option>
@@ -85,6 +100,9 @@
       </form>
         <button id="exporterSubmitButton"> Export </button>
     </div>
+  </div>
+
+  <div id="workspaceFactoryContent">
   </div>
 
   <table id="blockFactoryContent">


### PR DESCRIPTION
### app_controller.js
- refactored the way tabs are implemented to be flexible for adding tabs.

### index.html
Workspace Factory:
- added tab for workspace factory
- added workspace factory content div (integration of workspace factory content will be done in next CL)
Exporter: 
- added button for add all blocks used in toolbox/pre-loaded workspace.  (button handler to be implemented)
- expanded export settings menu
- expanded export function within BlockExporterTools to lay groundwork for workspace factory integration.

<img width="1437" alt="screen shot 2016-08-10 at 12 49 55 pm" src="https://cloud.githubusercontent.com/assets/10423718/17568549/2338a0f0-5ef9-11e6-8963-bf79b981026d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/26)
<!-- Reviewable:end -->
