### PR TITLE
Fix for #521.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -128,6 +128,9 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   /** @type {boolean} */
   this.isInFlyout = workspace.isFlyout;
   /** @type {boolean} */
+  this.isInMutator = workspace.isMutator;
+
+  /** @type {boolean} */
   this.RTL = workspace.RTL;
 
   // Copy the type-specific functions and data from the prototype.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -533,6 +533,12 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
   if (this.isInFlyout) {
     return;
   }
+  if (this.isInMutator) {
+    // Mutator's coordinate system could be out of date because the bubble was
+    // dragged, the block was moved, the parent workspace zoomed, etc.
+    this.workspace.resize();
+  }
+
   this.workspace.updateScreenCalculationsIfScrolled();
   this.workspace.markFocused();
   Blockly.terminateDrag_();

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -129,6 +129,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
     setMetrics: null
   };
   this.workspace_ = new Blockly.WorkspaceSvg(workspaceOptions);
+  this.workspace_.isMutator = true;
   this.svgDialog_.appendChild(
       this.workspace_.createDom('blocklyMutatorBackground'));
   return this.svgDialog_;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -83,6 +83,13 @@ Blockly.WorkspaceSvg.prototype.rendered = true;
 Blockly.WorkspaceSvg.prototype.isFlyout = false;
 
 /**
+ * Is this workspace the surface for a mutator?
+ * @type {boolean}
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.isMutator = false;
+
+/**
  * Is this workspace currently being dragged around?
  * DRAG_NONE - No drag operation.
  * DRAG_BEGIN - Still inside the initial DRAG_RADIUS.


### PR DESCRIPTION
Add a isMutator member similar to isFlyout to workspace_svg so it knows whether
it is mutator or not. Allow blocks to access that property so that they can recalculate
coordinates appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/540)
<!-- Reviewable:end -->
