### PR TITLE
Blockly Factory: Add Pre-loaded blocks tab with import/export to workspace factory

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -45,6 +45,7 @@ goog.require('goog.ui.ColorPicker');
         <div id="dropdownDiv_export" class="dropdown-content">
           <a id='dropdown_exportToolbox'>Toolbox</a>
           <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportOptions'>Inject Options</a>
           <a id='dropdown_exportAll'>All</a>
         </div>
         </div>
@@ -60,12 +61,13 @@ goog.require('goog.ui.ColorPicker');
   <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
-    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+    <td id="tab_preload" class="taboff">Workspace</td>
   </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
+
   <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
@@ -96,8 +98,6 @@ goog.require('goog.ui.ColorPicker');
     </div>
 
   </aside>
-  <aside id='preload_div' style='display:none'>
-  </aside>
 
   <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
@@ -108,6 +108,40 @@ goog.require('goog.ui.ColorPicker');
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
   </div>
+
+  <aside id='preload_div' style='display:none'>
+    <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
+    <button class="small" id="button_standardOptions">Standard Options</button>
+    <form id="workspace_options">
+      <input type="checkbox" id="option_collapse_checkbox" name="collapse">Collapsible Blocks<br>
+      <input type="checkbox" id="option_comments_checkbox" name="comments">Comments for Blocks<br>
+      <input type="checkbox" id="option_css_checkbox" name="css">Use Blockly CSS<br>
+      <input type="checkbox" id="option_disable_checkbox" name="disable">Disabled Blocks<br>
+      <input type="checkbox" id="option_grid_checkbox" name="grid">Use Grid<br>
+      <div id="grid_options" name="grid" style="display:none">
+        Spacing <input type="text" id="gridOption_spacing_text" name="spacing" value="0"><br>
+        Length <input type="text" id="gridOption_length_text" name="length" value="1"><br>
+        Color <input type="text" id="gridOption_colour_text" name="colour" value="#888"><br>
+        <input type="checkbox" id="gridOption_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
+      </div>
+      Max Blocks <input type="text" id="option_maxBlocks_text" name="maxBlocks" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="option_media_text" name="media"><br>
+      <input type="checkbox" id="option_readOnly_checkbox" name="readOnly">Read Only<br>
+      <input type="checkbox" id="option_rtl_checkbox" name="rtl">Layout with RTL<br>
+      <input type="checkbox" id="option_scrollbars_checkbox" name="scrollbars">Scrollbars<br>
+      <input type="checkbox" id="option_sounds_checkbox" name="sounds">Sounds<br>
+      <input type="checkbox" id="option_trashcan_checkbox" name="trashcan">Trashcan<br>
+      <input type="checkbox" id="option_zoom_checkbox" name="zoom">Zoom<br>
+      <div id="zoom_options" name="zoom" style="display:none">
+        <input type="checkbox" id="zoomOption_controls_checkbox" name="controls">Zoom Controls<br>
+        <input type="checkbox" id="zoomOption_wheel_checkbox" name="wheel">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoomOption_startScale_text" name="startScale" value="1.0"><br>
+        Max Scale <input type="text" id="zoomOption_maxScale_text" name="maxScale" value="3"><br>
+        Min Scale <input type="text" id="zoomOption_minScale_text" name="minScale" value="0.3"><br>
+        Scale Speed <input type="text" id="zoomOption_scaleSpeed_text" name="scaleSpeed" value="1.2"><br>
+      </div>
+    </form>
+  </aside>
 
 </section>
 
@@ -602,19 +636,33 @@ goog.require('goog.ui.ColorPicker');
     controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var editToolboxWrapper = function() {
+    controller.setMode(FactoryController.MODE_TOOLBOX);
+  };
+  var editPreloadWrapper = function() {
+    controller.setMode(FactoryController.MODE_PRELOAD);
+  };
   var exportToolboxWrapper = function() {
     controller.exportFile(FactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportPreloadWrapper = function() {
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportOptionsWrapper = function() {
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportAllWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
+  var standardOptionsWrapper = function() {
+    controller.setStandardOptionsAndUpdate();
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -630,6 +678,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', exportToolboxWrapper);
   document.getElementById('dropdown_exportPreload').addEventListener
       ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportOptions').addEventListener
+      ('click', exportOptionsWrapper);
   document.getElementById('dropdown_exportAll').addEventListener
       ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
@@ -662,6 +712,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', editToolboxWrapper);
   document.getElementById('tab_preload').addEventListener
       ('click', editPreloadWrapper);
+  document.getElementById('button_standardOptions').addEventListener
+      ('click', standardOptionsWrapper);
 
   // Use up and down arrow keys to move categories.
   // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure
@@ -744,6 +796,52 @@ goog.require('goog.ui.ColorPicker');
       controller.convertShadowBlocks();
     }
   });
+
+  // Add event listeners for checkboxes and text fields for configuring the Options object.
+
+  // Checking the grid checkbox displays grid options and updates the options
+  // object.
+  document.getElementById('option_grid_checkbox').addEventListener('change', function(e) {
+      document.getElementById('grid_options').style.display = document.getElementById('option_grid_checkbox').checked ? 'block' : 'none';
+      controller.generateNewOptions();
+  });
+
+  // Checking the grid checkbox displays zoom options and updates the options
+  // object.
+  document.getElementById('option_zoom_checkbox').addEventListener('change', function(e) {
+      document.getElementById('zoom_options').style.display = document.getElementById('option_zoom_checkbox').checked ? 'block' : 'none';
+      controller.generateNewOptions();
+  });
+
+  var optionListener = function() {
+    controller.generateNewOptions();
+  };
+
+  // Add event listeners to generate new options for each options input field.
+  document.getElementById('option_collapse_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_comments_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_css_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_disable_checkbox').addEventListener('change', optionListener);
+  document.getElementById('gridOption_spacing_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_length_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_colour_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_snap_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_maxBlocks_text').addEventListener('change', optionListener);
+  document.getElementById('option_media_text').addEventListener('change', optionListener);
+  document.getElementById('option_readOnly_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_rtl_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_scrollbars_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_sounds_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_trashcan_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_controls_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_wheel_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_startScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_maxScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_minScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_scaleSpeed_text').addEventListener('change', optionListener);
+
+  // Check standard options and apply the changes to update the view.
+  controller.setStandardOptionsAndUpdate();
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -30,23 +30,43 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <input type="file" id="input_import" class="inputfile"></input>
-        <label for="input_import">Import</label>
+        <div class="dropdown">
+        <button id="button_import">Import</button>
+        <div id="dropdownDiv_import" class="dropdown-content">
+          <input type="file" id="input_importToolbox" class="inputfile"></input>
+          <label for="input_importToolbox">Toolbox</label>
+          <input type="file" id="input_importPreload" class="inputfile"></input>
+          <label for="input_importPreload">Workspace Blocks</label>
+        </div>
+        </div>
+
+        <div class="dropdown">
         <button id="button_export">Export</button>
-        <button id="button_print">Print</button>
-        <button id="button_clear">Clear</button>
+        <div id="dropdownDiv_export" class="dropdown-content">
+          <a id='dropdown_exportToolbox'>Toolbox</a>
+          <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportAll'>All</a>
+        </div>
+        </div>
+
+        <button id="button_print">Print Toolbox</button>
+        <button id="button_clear">Clear Toolbox</button>
       </p>
     </td>
   </tr>
 </table>
 
 <section id="createDiv">
-  <p>Drag blocks into your toolbox:</p>
+  <p id="editHelpText">Drag blocks into your toolbox:</p>
+  <table id='workspaceTabs'>
+    <td id="tab_toolbox" class="tabon">Toolbox</td>
+    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+  </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
-  <aside id="category_section">
+  <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
     </table>
@@ -75,7 +95,11 @@ goog.require('goog.ui.ColorPicker');
     </div>
     </div>
 
-    <div class='dropdown'>
+  </aside>
+  <aside id='preload_div' style='display:none'>
+  </aside>
+
+  <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
     <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
@@ -83,9 +107,8 @@ goog.require('goog.ui.ColorPicker');
     <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
-    </div>
+  </div>
 
-  </aside>
 </section>
 
 <aside id="previewDiv">
@@ -507,7 +530,8 @@ goog.require('goog.ui.ColorPicker');
     controller.removeElement();
   };
   var exportWrapper = function() {
-    controller.exportConfig();
+    document.getElementById('dropdownDiv_export').classList.toggle("show");
+    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -557,12 +581,40 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function(event) {
-    controller.importFile(event.target.files[0]);
+  var importWrapper = function() {
+    document.getElementById('dropdownDiv_import').classList.toggle("show");
+    document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
-    controller.clear();
+    controller.clearToolbox();
   };
+  var editToolboxWrapper = function() {
+    controller.setMode(FactoryController.MODE_TOOLBOX);
+  };
+  var editPreloadWrapper = function() {
+    controller.setMode(FactoryController.MODE_PRELOAD);
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -574,6 +626,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
+  document.getElementById('dropdown_exportToolbox').addEventListener
+      ('click', exportToolboxWrapper);
+  document.getElementById('dropdown_exportPreload').addEventListener
+      ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportAll').addEventListener
+      ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener
@@ -588,14 +646,22 @@ goog.require('goog.ui.ColorPicker');
       ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
-  document.getElementById('input_import').addEventListener
-      ('change', importWrapper);
+  document.getElementById('button_import').addEventListener
+      ('click', importWrapper);
+  document.getElementById('input_importToolbox').addEventListener
+      ('change', importToolboxWrapper);
+  document.getElementById('input_importPreload').addEventListener
+      ('change', importPreloadWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
   document.getElementById('dropdown_removeShadow').addEventListener
       ('click', shadowRemoveWrapper);
+  document.getElementById('tab_toolbox').addEventListener
+      ('click', editToolboxWrapper);
+  document.getElementById('tab_preload').addEventListener
+      ('click', editPreloadWrapper);
 
   // Use up and down arrow keys to move categories.
   // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure
@@ -635,6 +701,7 @@ goog.require('goog.ui.ColorPicker');
     // blocks when dragging them into workspace. Could cause problems if ever load
     // blocks into workspace directly without calling updatePreview.
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
+      controller.saveStateFromWorkspace();
       controller.updatePreview();
     }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,33 +63,6 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
-label {
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  color: #000;
-  font-size: large;
-  margin: 0 5px;
-  padding: 10px;
-}
-
-label:hover:not(:disabled) {
-  box-shadow: 2px 2px 5px #888;
-}
-
-label:disabled {
-  opacity: .6;
-}
-
-label>* {
-  opacity: .6;
-  vertical-align: text-bottom;
-}
-
-label:hover:not(:disabled)>* {
-  opacity: 1;
-}
-
 table {
   border: none;
   border-collapse: collapse;
@@ -135,7 +108,7 @@ td {
   width: 30%;
 }
 
-#category_section {
+#toolbox_div {
   width: 20%;
 }
 
@@ -200,25 +173,36 @@ td {
 
 /* Dropdown Content (Hidden by Default) */
 .dropdown-content {
-    background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
-    display: none;
-    min-width: 170px;
-    opacity: 1;
-    position: absolute;
-    z-index: 1;
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
+  display: none;
+  min-width: 170px;
+  opacity: 1;
+  position: absolute;
+  z-index: 1;
 }
 
 /* Links inside the dropdown */
 .dropdown-content a {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
+}
+
+.dropdown-content label {
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+.dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -209,7 +209,7 @@ td {
   text-decoration: none;
 }
 
-/* Change color of dropdown links on hover */
+/* Change color of dropdown links on hover. */
 .dropdown-content a:hover, .dropdown-content label:hover {
   background-color: #f1f1f1
 }

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,6 +21,10 @@ aside {
   border-bottom: none;
 }
 
+#workspaceTabs>table {
+  float: right;
+}
+
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;
@@ -61,6 +65,10 @@ button>* {
 
 button:hover:not(:disabled)>* {
   opacity: 1;
+}
+
+button.small {
+  font-size: small;
 }
 
 table {
@@ -109,6 +117,10 @@ td {
 }
 
 #toolbox_div {
+  width: 20%;
+}
+
+#preload_div {
   width: 20%;
 }
 
@@ -198,11 +210,7 @@ td {
 }
 
 /* Change color of dropdown links on hover */
-.dropdown-content a:hover {
-  background-color: #f1f1f1
-}
-
-.dropdown-content label:hover {
+.dropdown-content a:hover, .dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -108,6 +108,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   return xmlDom;
  };
 
+
  /**
   * Generates XML for the workspace (different from generateConfigXml in that
   * it includes XY and ID attributes). Uses a workspace and converts user

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -51,6 +51,8 @@ FactoryModel = function() {
   this.hasProcedureCategory = false;
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
+  // Options object to be configured for Blockly inject call.
+  this.options = new Object(null);
 };
 
 /**
@@ -137,8 +139,10 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
 };
 
 /**
- * Sets selected to be an empty single flyout if toolbox list is empty. Should
- * be called when removing the last element from toolbox list.
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ * If the toolbox list is empty, selected stores the XML for the single flyout
+ * of blocks displayed.
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
@@ -381,7 +385,8 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
-/*
+/**
+ * Have basic pre-loaded workspace working
  * Saves XML as XML to be pre-loaded into the workspace.
  *
  * @param {!Element} xml The XML to be saved.
@@ -397,6 +402,25 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
+};
+
+/**
+ * Sets a new options object for injecting a Blockly workspace.
+ *
+ * @param {Object} options Options object for injecting a Blockly workspace.
+ */
+FactoryModel.prototype.setOptions = function(options) {
+  this.options = options;
+};
+
+/**
+ * Sets an attribute of the options object.
+ *
+ * @param {!string} name Name of the attribute to add.
+ * @param {Object} value The value of the attribute to add.
+ */
+FactoryModel.prototype.setOptionsAttribute = function(name, value) {
+  this.options[name] = value;
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -35,20 +35,23 @@
  * @constructor
  */
 FactoryModel = function() {
-  // Ordered list of ListElement objects.
+  // Ordered list of ListElement objects. Empty if there is a single flyout.
   this.toolboxList = [];
+  // ListElement for blocks in a single flyout. Null if a toolbox exists.
+  this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // String name of current selected list element, null if no list elements.
-  this.selected = null;
+  // Reference to currently selected ListElement. Stored in this.toolboxList if
+  // there are categories, or in this.flyout if blocks are displayed in a single
+  // flyout.
+  this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
   this.hasProcedureCategory = false;
+  // XML to be pre-loaded to workspace. Empty on default;
+  this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
-
-// String name of current selected list element, null if no list elements.
-FactoryModel.prototype.selected = null;
 
 /**
  * Given a name, determines if it is the name of a category already present.
@@ -91,9 +94,9 @@ FactoryModel.prototype.hasProcedures = function() {
  * Determines if the user has any elements in the toolbox. Uses the length of
  * toolboxList.
  *
- * @return {boolean} True if categories exist, false otherwise.
+ * @return {boolean} True if elements exist, false otherwise.
  */
-FactoryModel.prototype.hasToolbox = function() {
+FactoryModel.prototype.hasElements = function() {
   return this.toolboxList.length > 0;
 };
 
@@ -110,6 +113,8 @@ FactoryModel.prototype.addElementToList = function(element) {
       this.hasProcedureCategory;
   // Add element to toolboxList.
   this.toolboxList.push(element);
+  // Empty single flyout.
+  this.flyout = null;
 };
 
 /**
@@ -130,6 +135,18 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
   // Remove element.
   this.toolboxList.splice(index, 1);
 };
+
+/**
+ * Sets selected to be an empty single flyout if toolbox list is empty. Should
+ * be called when removing the last element from toolbox list.
+ *
+ */
+FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
+  if (this.toolboxList.length == 0) {
+    this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
+    this.selected = this.flyout;
+  }
+}
 
 /**
  * Moves a list element to a certain position in toolboxList by removing it
@@ -364,6 +381,23 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
+/*
+ * Saves XML as XML to be pre-loaded into the workspace.
+ *
+ * @param {!Element} xml The XML to be saved.
+ */
+FactoryModel.prototype.savePreloadXml = function(xml) {
+  this.preloadXml = xml
+};
+
+/**
+ * Gets the XML to be pre-loaded into the workspace.
+ *
+ * @return {!Element} The XML for the workspace.
+ */
+FactoryModel.prototype.getPreloadXml = function() {
+  return this.preloadXml;
+};
 
 /**
  * Class for a ListElement.
@@ -386,6 +420,7 @@ ListElement = function(type, opt_name) {
 // List element types.
 ListElement.TYPE_CATEGORY = 'category';
 ListElement.TYPE_SEPARATOR = 'separator';
+ListElement.TYPE_FLYOUT = 'flyout';
 
 /**
  * Saves a category by updating its XML (does not save XML for
@@ -395,11 +430,11 @@ ListElement.TYPE_SEPARATOR = 'separator';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Only save list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
-    return;
+  // Only save XML for categories and flyouts.
+  if (this.type == ListElement.TYPE_FLYOUT ||
+      this.type == ListElement.TYPE_CATEGORY) {
+    this.xml = Blockly.Xml.workspaceToDom(workspace);
   }
-  this.xml = Blockly.Xml.workspaceToDom(workspace);
 };
 
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -369,3 +369,53 @@ FactoryView.prototype.updateHelpText = function(mode) {
       FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
   document.getElementById('editHelpText').textContent = helpText;
 };
+
+/**
+ * Sets the basic options that are not dependent on if there are categories
+ * or a single flyout of blocks. Updates checkboxes and text fields.
+ */
+FactoryView.prototype.setBaseOptions = function() {
+  // Set basic options.
+  document.getElementById('option_css_checkbox').checked = true;
+  document.getElementById('option_maxBlocks_text').value = Infinity;
+  document.getElementById('option_media_text').value =
+      'https://blockly-demo.appspot.com/static/media/';
+  document.getElementById('option_readOnly_checkbox').checked = false;
+  document.getElementById('option_rtl_checkbox').checked = false;
+  document.getElementById('option_sounds_checkbox').checked = true;
+
+  // Uncheck grid and zoom options and hide suboptions.
+  document.getElementById('option_grid_checkbox').checked = false;
+  document.getElementById('grid_options').style.display = 'none';
+  document.getElementById('option_zoom_checkbox').checked = false;
+  document.getElementById('zoom_options').style.display = 'none';
+
+  // Set grid options.
+  document.getElementById('gridOption_spacing_text').value = 0;
+  document.getElementById('gridOption_length_text').value = 1;
+  document.getElementById('gridOption_colour_text').value = '#888';
+  document.getElementById('gridOption_snap_checkbox').checked = false;
+
+  // Set zoom options.
+  document.getElementById('zoomOption_controls_checkbox').checked = false;
+  document.getElementById('zoomOption_wheel_checkbox').checked = false;
+  document.getElementById('zoomOption_startScale_text').value = 1.0;
+  document.getElementById('zoomOption_maxScale_text').value = 3;
+  document.getElementById('zoomOption_minScale_text').value = 0.3;
+  document.getElementById('zoomOption_scaleSpeed_text').value = 1.2;
+};
+
+/**
+ * Updates category specific options depending on if there are categories
+ * currently present. Updates checkboxes and text fields in the view.
+ *
+ * @param {boolean} hasCategories True if categories are present, false if all
+ *    blocks are displayed in a single flyout.
+ */
+FactoryView.prototype.setCategoryOptions = function(hasCategories) {
+  document.getElementById('option_collapse_checkbox').checked = hasCategories;
+  document.getElementById('option_comments_checkbox').checked = hasCategories;
+  document.getElementById('option_disable_checkbox').checked = hasCategories;
+  document.getElementById('option_scrollbars_checkbox').checked = hasCategories;
+  document.getElementById('option_trashcan_checkbox').checked = hasCategories;
+}

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -339,3 +339,33 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
     Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
   }
 };
+
+/**
+ * Sets the tabs for modes according to which mode the user is currenly
+ * editing in.
+ *
+ * @param {!string} mode The mode being switched to
+ *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.setModeSelection = function(mode) {
+  document.getElementById('tab_preload').className = mode ==
+      FactoryController.MODE_PRELOAD ? 'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = mode ==
+      FactoryController.MODE_PRELOAD ? 'block' : 'none';
+  document.getElementById('tab_toolbox').className = mode ==
+      FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = mode ==
+      FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};
+
+/**
+ * Updates the help text above the workspace depending on the selected mode.
+ *
+ * @param {!string} mode The selected mode (FactoryController.MODE_TOOLBOX or
+ *    FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.updateHelpText = function(mode) {
+  var helpText = 'Drag your blocks into your ' + (mode ==
+      FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
+  document.getElementById('editHelpText').textContent = helpText;
+};


### PR DESCRIPTION
Adds tabs to the top of the toolbox workspace to switch between toolbox and workspace editing to allow the user to also edit blocks pre-loaded on to the workspace. Supports importing and exporting. Already reviewed by picklesrus and vicng (https://reviewable.io/reviews/evd2014/blockly/36 and https://reviewable.io/reviews/evd2014/blockly/37).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/546)
<!-- Reviewable:end -->
