### PR TITLE
Blockly Factory: Removing Old Download Buttons and Alert

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -360,14 +360,6 @@ AppController.prototype.assignFactoryClickHandlers = function() {
         open('https://developers.google.com/blockly/custom-blocks/block-factory',
              'BlockFactoryHelp');
       });
-  document.getElementById('downloadBlocks').addEventListener('click',
-      function() {
-        BlockFactory.downloadTextArea('blocks', 'languagePre');
-      });
-  document.getElementById('downloadGenerator').addEventListener('click',
-      function() {
-        BlockFactory.downloadTextArea('generator', 'generatorPre');
-      });
   document.getElementById('files').addEventListener('change',
       function() {
         // Warn user.

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -1,4 +1,4 @@
-<!-- TODO(quacht): move the CSS out to a separate file -->
+<!-- TODO(quachtina96): move the CSS out to a separate file -->
 
 <!DOCTYPE html>
 <html>
@@ -27,10 +27,6 @@
     var init = function() {
       blocklyFactory = new AppController();
       blocklyFactory.init();
-    if (blocklyFactory.blockLibraryController.hasEmptyBlockLib()) {
-      alert('Your block library is empty! Click "Save to Block Library" so ' +
-         'you can reopen it the next time you visit Block Factory!');
-    }
     };
     window.addEventListener('load', init);
 </script>
@@ -150,7 +146,7 @@
                 <img src="link.png" height="21" width="21">
               </button>
               <button id="createNewBlockButton" title="Create a new block.">
-                <span> Create New Block</span>
+                <span> Create Block</span>
               </button>
               <label for="files" class="buttonStyle">
                 <span class=>Import Block Library</span>
@@ -188,10 +184,6 @@
                   <option value="JavaScript">JavaScript</option>
                   <option value="Manual">Manual edit&hellip;</option>
                 </select>
-                <button class ="downloadButton" id="downloadBlocks"
-                        title="Download block definition to a file.">
-                 <span>Download</span>
-               </button>
               </h3>
             </td>
           </tr>
@@ -211,10 +203,6 @@
                   <option value="Lua">Lua</option>
                   <option value="Dart">Dart</option>
                 </select>
-                <button id="downloadGenerator" class="downloadButton"
-                        title="Downloadgenerator stub to a file.">
-                  <span>Download</span>
-                </button>
               </h3>
             </td>
           </tr>


### PR DESCRIPTION
Previously, there were download buttons in the Block Factory Tab next to the block's Language Code and Generator Stub. Now that there is the Exporter, we would like to keep block definition and generator stub export there. This also simplifies the UI.

<img width="1438" alt="screen shot 2016-08-11 at 12 03 08 am" src="https://cloud.githubusercontent.com/assets/10423718/17580917/255161e8-5f57-11e6-9fd4-1d6895b2e35d.png">

In addition, there is no longer an alert every time Blockly Factory is loaded with an empty block library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/547)
<!-- Reviewable:end -->
