### PR TITLE
Blockly Factory: Show Starter Block on Delete from and Clearing of Block Library

### DIFF
--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -76,6 +76,8 @@ BlockLibraryController.prototype.removeFromBlockLibrary = function() {
   this.storage.removeBlock(blockType);
   this.storage.saveToLocalStorage();
   this.populateBlockLibrary();
+  // Show default block.
+  BlockFactory.showStarterBlock();
 };
 
 /**
@@ -102,7 +104,7 @@ BlockLibraryController.prototype.getSelectedBlockType =
 
 /**
  * Confirms with user before clearing the block library in local storage and
- * updating the dropdown.
+ * updating the dropdown and displaying the starter block (factory_base).
  */
 BlockLibraryController.prototype.clearBlockLibrary = function() {
   var check = confirm(
@@ -116,6 +118,8 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
     // Add a default, blank option to dropdown for when no block from library is
     // selected.
     BlockLibraryView.addDefaultOption('blockLibraryDropdown');
+    // Show default block.
+    BlockFactory.showStarterBlock();
   }
 };
 

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -945,6 +945,7 @@ BlockFactory.disableEnableLink = function() {
  * Render starter block (factory_base).
  */
  BlockFactory.showStarterBlock = function() {
+    BlockFactory.mainWorkspace.clear();
     var xml = '<xml><block type="factory_base" deletable="false" ' +
         'movable="false"></block></xml>';
     Blockly.Xml.domToWorkspace(


### PR DESCRIPTION
Deleting from and clearing Block Library now visibly affect the Block Factory workspace by showing the starter block as seen below. This makes the Block Factory/Block Library experience less confusing since the Block Factory better reflects the state of the Block Library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/548)
<!-- Reviewable:end -->
