### PR TITLE
Blockly Factory: UI for Navigation Bar, Help Button, Exporter

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -303,17 +303,27 @@ AppController.prototype.styleTabs_ = function() {
 AppController.prototype.assignExporterClickHandlers = function() {
   var self = this;
   // Export blocks when the user submits the export settings.
-  document.getElementById('exporterSubmitButton').addEventListener('click',
+  document.getElementById('button_setBlocks').addEventListener('click',
+      function() {
+        document.getElementById('dropdownDiv_setBlocks').classList.toggle("show");
+      });
+
+  document.getElementById('dropdown_addAllUsed').addEventListener('click',
       function() {
         self.exporter.export();
+        document.getElementById('dropdownDiv_setBlocks').classList.remove("show");
       });
-  document.getElementById('clearSelectedButton').addEventListener('click',
+
+  document.getElementById('dropdown_clearSelected').addEventListener('click',
       function() {
         self.exporter.clearSelectedBlocks();
+        document.getElementById('dropdownDiv_setBlocks').classList.remove("show");
       });
-  document.getElementById('addAllFromLibButton').addEventListener('click',
+
+  document.getElementById('dropdown_addAllFromLib').addEventListener('click',
       function() {
         self.exporter.addAllBlocksToWorkspace();
+        document.getElementById('dropdownDiv_setBlocks').classList.remove("show");
       });
 };
 

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -124,6 +124,10 @@ button, .buttonStyle {
   display: none;
 }
 
+#helpButton {
+  float: right;
+}
+
 #blockFactoryContent {
   height: 87%;
 }

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -185,8 +185,8 @@ button, .buttonStyle {
 #exportSettings {
   float: left;
   padding-left: 16px;
-  width: 30%;
   overflow: hidden;
+  width: 30%;
 }
 
 #exporterHiddenWorkspace {

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -161,8 +161,6 @@ button, .buttonStyle {
   width: 50%;
 }
 
-/* Workspace Factory */
-
 #workspaceFactoryContent {
   clear: both;
   display: none;
@@ -178,6 +176,7 @@ button, .buttonStyle {
 }
 
 #exportSelector {
+  display: inline-block;
   float: left;
   height: 75%;
   width: 30%;
@@ -185,7 +184,7 @@ button, .buttonStyle {
 
 #exportSettings {
   float: left;
-  padding: 16px;
+  padding-left: 16px;
   width: 30%;
   overflow: hidden;
 }
@@ -208,10 +207,22 @@ button, .buttonStyle {
   padding: 5px 19px;
 }
 
+.tab:hover:not(.tabon){
+  background-color: #e8e8e8;
+}
+
 .tab.tabon {
-  background-color: #ddd;
+  background-color: #ccc;
 }
 
 .tab.taboff {
   cursor: pointer;
+}
+
+#tabContainer {
+  background-color: #f8f8f8;
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  display: table;
+  width: 100%;
 }

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -188,8 +188,8 @@ button, .buttonStyle {
 
 #exportSettings {
   float: left;
-  padding-left: 16px;
   overflow: hidden;
+  padding-left: 16px;
   width: 30%;
 }
 

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -53,8 +53,8 @@
         <div class='dropdown'>
         <button id="button_setBlocks">Select</button>
         <div id="dropdownDiv_setBlocks" class="dropdown-content">
-          <a id='dropdown_addAllFromLib'>Add All Stored</a>
-          <a id='dropdown_addAllUsed'>Add All Used</a>
+          <a id='dropdown_addAllFromLib'>All Stored</a>
+          <a id='dropdown_addAllUsed'>All Used</a>
           <a id='dropdown_clearSelected'>Remove All</a>
         </div>
         </div>

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -32,29 +32,38 @@
 </script>
 </head>
 <body>
-  <h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
-    <a href="../index.html">Demos</a> &gt; Blockly Factory</h1>
-
-  <div id="tabContainer">
+<h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
+  <a href="../index.html">Demos</a> &gt; Blockly Factory
+  <button id="helpButton" title="View documentation in new window." style="float:right;">
+    <span>Help</span>
+  </button>
+</h1>
+ <div id="tabContainer">
     <div id="blockFactory_tab" class="tab tabon"> Block Factory</div>
-    <div class="tabGap"></div>
     <div id="workspaceFactory_tab" class="tab taboff"> Workspace Factory</div>
-    <div class="tabGap"></div>
     <div id="blocklibraryExporter_tab" class="tab taboff"> Exporter</div>
   </div>
 
+
+  <!-- Exporter tab -->
   <div id="blockLibraryExporter">
-    <h3> Block Selector </h3>
-    <div id="helperTextDiv">
+    <div id="exportSelector" style="display:inline-block;">
+      <h3> Block Selector </h3>
       <p id="helperText"> Drag blocks into your workspace to select them for download.</p>
+        <div class='dropdown'>
+        <button id="button_setBlocks">Select</button>
+        <div id="dropdownDiv_setBlocks" class="dropdown-content">
+          <a id='dropdown_addAllFromLib'>Add All Stored</a>
+          <a id='dropdown_addAllUsed'>Add All Used</a>
+          <a id='dropdown_clearSelected'>Remove All</a>
+        </div>
+        </div>
+
+      <!-- Inject exportSelectorWorkspace into this div -->
+      <div id="selectorWorkspace"></div>
+
     </div>
-    <div id="exporterButtons">
-      <button id="clearSelectedButton"> Clear Blocks </button>
-      <button id="addAllFromLibButton"> Add All Stored Blocks </button>
-      <button id="addAllUsedButton"> Add All Used Blocks </button>
-    </div>
-    <!-- Inject exportSelectorWorkspace into this div -->
-    <div id="exportSelector"></div>
+
     <!-- Users may customize export settings through this form -->
     <div id="exportSettings">
       <h3> Export Settings </h3>
@@ -98,9 +107,12 @@
     </div>
   </div>
 
+  <!-- Workspace Factory tab -->
+
   <div id="workspaceFactoryContent">
   </div>
 
+  <!-- Blockly Factory Tab -->
   <table id="blockFactoryContent">
     <tr>
       <td width="50%" height="5%">
@@ -155,9 +167,6 @@
                   accept="application/xml">
               <button id="localSaveButton" title="Save block library xml to a local file.">
                 <span>Download Block Library</span>
-              </button>
-              <button id="helpButton" title="View documentation in new window.">
-                <span>Help</span>
               </button>
             </td>
           </tr>

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -34,7 +34,7 @@
 <body>
 <h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
   <a href="../index.html">Demos</a> &gt; Blockly Factory
-  <button id="helpButton" title="View documentation in new window." style="float:right;">
+  <button id="helpButton" title="View documentation in new window.">
     <span>Help</span>
   </button>
 </h1>
@@ -47,7 +47,7 @@
 
   <!-- Exporter tab -->
   <div id="blockLibraryExporter">
-    <div id="exportSelector" style="display:inline-block;">
+    <div id="exportSelector">
       <h3> Block Selector </h3>
       <p id="helperText"> Drag blocks into your workspace to select them for download.</p>
         <div class='dropdown'>


### PR DESCRIPTION
UI changes: 

- Changed the style of the navigation bar for the 3 tabs

- Moved the help button to the top of the page so that it will be visible for any tab selected

- Unified buttons for the Block Selector in the Exporter into a dropdown. 

- Changed the layout of the Exporter to clearly be 3 columns (Block selector, Export settings, and Preview workspace)

![blockly factory nav bar](https://cloud.githubusercontent.com/assets/18580768/17681876/0ddad072-62fd-11e6-9264-f111a4e870af.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/549)
<!-- Reviewable:end -->
