### PR TITLE
Blockly Factory: Warn if Using Standard Block Name

### DIFF
--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -150,8 +150,7 @@ BlockFactory.updateGenerator = function(block) {
 };
 
 /**
- * Update the preview display. Add warning to the factory_base block in the
- * main workspace if the block type is a standard block.
+ * Update the preview display.
  */
 BlockFactory.updatePreview = function() {
   // Toggle between LTR/RTL if needed (also used in first display).

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -236,26 +236,13 @@ BlockFactory.updatePreview = function() {
 
     // Warn user if their block type is already exists in Blockly's standard
     // library.
-    if (BlockFactory.isStandardBlockType(blockType)) {
+    if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1)
       var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +
           'under this name.');
     }
   } finally {
     Blockly.Blocks = backupBlocks;
-  }
-};
-
-/**
- * Returns whether or not the block type already exists in Block Factory's list
- * of standard blocks.
- *
- * @param {!string} blockType - Type of block.
- * @return {boolean} Whether or not the block type is a standard block type.
- */
-BlockFactory.isStandardBlockType = function(blockType) {
-  if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
-    return true;
   }
 };
 

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -60,6 +60,28 @@ BlockFactory.UNNAMED = 'unnamed';
 BlockFactory.oldDir = null;
 
 /**
+ * List of block types in standard categories.
+ * TODO(quachtina96): Get this list from FactoryController since each
+ * FactoryControlelr object has a dictionary containing its standard categories.
+ */
+ BlockFactory.standardBlockTypes = ["controls_if", "logic_compare",
+    "logic_operation", "logic_negate", "logic_boolean", "logic_null",
+    "logic_ternary", "controls_repeat_ext", "controls_whileUntil",
+    "controls_for", "controls_forEach", "controls_flow_statements",
+    "math_number", "math_arithmetic", "math_single", "math_trig",
+    "math_constant", "math_number_property", "math_change", "math_round",
+    "math_on_list", "math_modulo", "math_constrain", "math_random_int",
+    "math_random_float", "text", "text_join", "text_append", "text_length",
+    "text_isEmpty", "text_indexOf", "variables_get", "text_charAt",
+    "text_getSubstring", "text_changeCase", "text_trim", "text_print",
+    "text_prompt_ext", "colour_picker", "colour_random", "colour_rgb",
+    "colour_blend", "lists_create_with", "lists_repeat", "lists_length",
+    "lists_isEmpty", "lists_indexOf", "lists_getIndex", "lists_setIndex",
+    "lists_getSublist", "lists_split", "lists_sort", "variables_set",
+    "procedures_defreturn", "procedures_ifreturn", "procedures_defnoreturn",
+    "procedures_callreturn"];
+
+/**
  * Inject code into a pre tag, with syntax highlighting.
  * Safe from HTML/script injection.
  * @param {string} code Lines of code.
@@ -128,7 +150,8 @@ BlockFactory.updateGenerator = function(block) {
 };
 
 /**
- * Update the preview display.
+ * Update the preview display. Add warning to the factory_base block in the
+ * main workspace if the block type is a standard block.
  */
 BlockFactory.updatePreview = function() {
   // Toggle between LTR/RTL if needed (also used in first display).
@@ -210,8 +233,29 @@ BlockFactory.updatePreview = function() {
     previewBlock.moveBy(15, 10);
     BlockFactory.previewWorkspace.clearUndo();
     BlockFactory.updateGenerator(previewBlock);
+
+    // Warn user if their block type is already exists in Blockly's standard
+    // library.
+    if (BlockFactory.isStandardBlockType(blockType)) {
+      var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
+      rootBlock.setWarningText('A standard Blockly.Block already exists ' +
+          'under this name.');
+    }
   } finally {
     Blockly.Blocks = backupBlocks;
+  }
+};
+
+/**
+ * Returns whether or not the block type already exists in Block Factory's list
+ * of standard blocks.
+ *
+ * @param {!string} blockType - Type of block.
+ * @return {boolean} Whether or not the block type is a standard block type.
+ */
+BlockFactory.isStandardBlockType = function(blockType) {
+  if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
+    return true;
   }
 };
 


### PR DESCRIPTION
When a user is creating a block, they have the freedom to specify a type for the block. Having overlapping block types leads to unexpected behavior since one definition will overwrite the other. Block Factory now warns the user in the case that standard blocks may be overwritten.

<img width="1433" alt="screen shot 2016-08-15 at 4 49 23 pm" src="https://cloud.githubusercontent.com/assets/10423718/17684184/556a4790-630e-11e6-8d37-069c2ba5f166.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/550)
<!-- Reviewable:end -->
