### PR TITLE
Breaking words for CJK strings

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -216,18 +216,10 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
     return;
   }
   if (prefixLength) {
-    var actualLength = prefixLength;
-    if (strings[0][actualLength - 1] == ' ') {
-      actualLength--;
-    }
-    this.prefixField = strings[0].substring(0, actualLength);
+    this.prefixField = strings[0].substring(0, prefixLength).trim();
   }
   if (suffixLength) {
-    var actualLength = suffixLength;
-    if (strings[0][strings[0].length - actualLength] == ' ') {
-      actualLength--;
-    }
-    this.suffixField = strings[0].substr(0 - actualLength);
+    this.suffixField = strings[0].substr(0 - suffixLength).trim();
   }
   // Remove the prefix and suffix from the options.
   var newOptions = [];

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -216,10 +216,18 @@ Blockly.FieldDropdown.prototype.trimOptions_ = function() {
     return;
   }
   if (prefixLength) {
-    this.prefixField = strings[0].substring(0, prefixLength - 1);
+    var actualLength = prefixLength;
+    if (strings[0][actualLength - 1] == ' ') {
+      actualLength--;
+    }
+    this.prefixField = strings[0].substring(0, actualLength);
   }
   if (suffixLength) {
-    this.suffixField = strings[0].substr(1 - suffixLength);
+    var actualLength = suffixLength;
+    if (strings[0][strings[0].length - actualLength] == ' ') {
+      actualLength--;
+    }
+    this.suffixField = strings[0].substr(0 - actualLength);
   }
   // Remove the prefix and suffix from the options.
   var newOptions = [];

--- a/core/utils.js
+++ b/core/utils.js
@@ -338,6 +338,10 @@ Blockly.shortestStringLength = function(array) {
   return len;
 };
 
+Blockly.isCJKChar = function(char) {
+  return (char >= \u3400 && char <= \u9FBF);
+};
+
 /**
  * Given an array of strings, return the length of the common prefix.
  * Words may not be split.  Any space after a word is included in the length.
@@ -361,7 +365,7 @@ Blockly.commonWordPrefix = function(array, opt_shortest) {
       }
     }
     // Chinese and Japanese don't use whitespace to break words.
-    if (letter == ' ' || letter.match(/^[\u3400-\u9FBF]$/)) {
+    if (letter == ' ' || Blockly.isCJKChar(letter)) {
       wordPrefix = len + 1;
     }
   }
@@ -396,7 +400,7 @@ Blockly.commonWordSuffix = function(array, opt_shortest) {
         return wordPrefix;
       }
     }
-    if (letter == ' ' || letter.match(/^[\u3400-\u9FBF]$/)) {
+    if (letter == ' ' || Blockly.isCJKChar(letter)) {
       wordPrefix = len + 1;
     }
   }

--- a/core/utils.js
+++ b/core/utils.js
@@ -360,7 +360,8 @@ Blockly.commonWordPrefix = function(array, opt_shortest) {
         return wordPrefix;
       }
     }
-    if (letter == ' ') {
+    // Chinese and Japanese don't use whitespace to break words.
+    if (letter == ' ' || letter.match(/^[\u3400-\u9FBF]$/)) {
       wordPrefix = len + 1;
     }
   }
@@ -395,7 +396,7 @@ Blockly.commonWordSuffix = function(array, opt_shortest) {
         return wordPrefix;
       }
     }
-    if (letter == ' ') {
+    if (letter == ' ' || letter.match(/^[\u3400-\u9FBF]$/)) {
       wordPrefix = len + 1;
     }
   }

--- a/core/utils.js
+++ b/core/utils.js
@@ -338,8 +338,8 @@ Blockly.shortestStringLength = function(array) {
   return len;
 };
 
-Blockly.isCJKChar = function(char) {
-  return (char >= \u3400 && char <= \u9FBF);
+Blockly.isCJKLetter = function(letter) {
+  return letter.match(/^[\u3400-\u9FBF]$/);
 };
 
 /**
@@ -364,8 +364,8 @@ Blockly.commonWordPrefix = function(array, opt_shortest) {
         return wordPrefix;
       }
     }
-    // Chinese and Japanese don't use whitespace to break words.
-    if (letter == ' ' || Blockly.isCJKChar(letter)) {
+    // CJK strings don't use the whitespace to break words.
+    if (letter == ' ' || Blockly.isCJKLetter(letter)) {
       wordPrefix = len + 1;
     }
   }
@@ -400,7 +400,8 @@ Blockly.commonWordSuffix = function(array, opt_shortest) {
         return wordPrefix;
       }
     }
-    if (letter == ' ' || Blockly.isCJKChar(letter)) {
+    // CJK strings don't use the whitespace to break words.
+    if (letter == ' ' || Blockly.isCJKLetter(letter)) {
       wordPrefix = len + 1;
     }
   }

--- a/tests/jsunit/blockly_test.js
+++ b/tests/jsunit/blockly_test.js
@@ -101,17 +101,19 @@ function test_commonWordPrefix() {
   assertEquals('No prefix due to &amp;nbsp;', 0, len);
   len = Blockly.commonWordPrefix('turn\u00A0left,turn\u00A0right'.split(','));
   assertEquals('No prefix due to \\u00A0', 0, len);
+  len = Blockly.commonWordPrefix('向左转,向右转'.split(','));
+  assertEquals('One Chinese character prefix', 1, len);
 }
 
 function test_commonWordSuffix() {
   var len = Blockly.commonWordSuffix('one,two,three,four,five'.split(','));
-  assertEquals('No prefix', 0, len);
+  assertEquals('No suffix', 0, len);
   len = Blockly.commonWordSuffix('oneX,twoX,threeX,fourX,fiveX'.split(','));
-  assertEquals('No word prefix', 0, len);
+  assertEquals('No word suffix', 0, len);
   len = Blockly.commonWordSuffix('abc de,abc de,abc de,abc de'.split(','));
   assertEquals('Full equality', 6, len);
   len = Blockly.commonWordSuffix('Xabc de,Yabc de'.split(','));
-  assertEquals('One word prefix', 3, len);
+  assertEquals('One word suffix', 3, len);
   len = Blockly.commonWordSuffix('abc de,Yabc de'.split(','));
   assertEquals('Overflow no', 3, len);
   len = Blockly.commonWordSuffix('abc de,Y abc de'.split(','));
@@ -120,6 +122,8 @@ function test_commonWordSuffix() {
   assertEquals('List of one', 11, len);
   len = Blockly.commonWordSuffix([]);
   assertEquals('Empty list', 0, len);
+  len = Blockly.commonWordSuffix('向左转,向右转'.split(','));
+  assertEquals('One Chinese character suffix', 1, len);
 }
 
 function test_tokenizeInterpolation() {


### PR DESCRIPTION
CJK strings don't use whitespace to break the words. We just need to compare the characters one by one to find the common prefix/suffix.

The blocks will change from
<img width="138" alt="screen shot 2016-08-15 at 1 16 05 am" src="https://cloud.githubusercontent.com/assets/3694642/17699287/6586fe54-63f2-11e6-9d71-0d1349e0533e.png">
to
<img width="157" alt="screen shot 2016-08-15 at 8 58 04 pm" src="https://cloud.githubusercontent.com/assets/3694642/17699308/7c5024ee-63f2-11e6-94d6-4dbfd83603ed.png">

