### PR TITLE
Blockly Factory: Generate Category Xml

### DIFF
--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -300,3 +300,12 @@ BlockExporterController.prototype.addAllBlocksToWorkspace = function() {
   // Clean up workspace.
   this.view.cleanUpSelectorWorkspace();
 };
+
+/**
+ * Returns the category xml containing all blocks in the block library.
+ *
+ * @return {Element} Xml for a category to be used in toolbox.
+ */
+BlockExporterController.prototype.getBlockLibCategory = function() {
+  return this.tools.generateCategoryFromBlockLib(this.blockLibStorage);
+};

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -91,17 +91,6 @@ BlockExporterController.prototype.getSelectedBlockTypes_ = function() {
 };
 
 /**
- * Unselect a block for export.
- * @private
- *
- * @param {!Blockly.Block} block - block to unselect.
- */
-BlockExporterController.prototype.unselectBlock = function(block) {
-  this.view.removeBlock(block);
-};
-
-
-/**
  * Get selected blocks from selector workspace, pulls info from the Export
  * Settings form in Block Exporter, and downloads code accordingly.
  *

--- a/demos/blocklyfactory/block_exporter_tools.js
+++ b/demos/blocklyfactory/block_exporter_tools.js
@@ -188,26 +188,16 @@ BlockExporterTools.prototype.generateToolboxFromLibrary
   this.addBlockDefinitions(blockXmlMap);
 
   for (var blockType in blockXmlMap) {
-    // Create category DOM element.
-    var categoryElement = goog.dom.createDom('category');
-    categoryElement.setAttribute('name',blockType);
-
     // Get block.
     var block = FactoryUtils.getDefinedBlock(blockType, this.hiddenWorkspace);
-
-    // Get preview block XML.
-    var blockChild = Blockly.Xml.blockToDom(block);
-    blockChild.removeAttribute('id');
-
-    // Add block to category and category to XML.
-    categoryElement.appendChild(blockChild);
-    xmlDom.appendChild(categoryElement);
+    var category = FactoryUtils.generateCategoryXml([block], blockType);
+    xmlDom.appendChild(category);
   }
 
   // If there are no blocks in library, append dummy category.
-  var categoryElement = goog.dom.createDom('category');
-  categoryElement.setAttribute('name','Next Saved Block');
-  xmlDom.appendChild(categoryElement);
+  var category = goog.dom.createDom('category');
+  category.setAttribute('name','Next Saved Block');
+  xmlDom.appendChild(category);
   return xmlDom;
 };
 
@@ -228,6 +218,12 @@ BlockExporterTools.prototype.generateCategoryFromBlockLib =
   // them in the exporter workspace.
   this.addBlockDefinitions(blockXmlMap);
 
-  return FactoryUtils.generateCategoryXml(allBlockTypes,'Block Library',
-      this.hiddenWorkspace);
+  // Get array of defined blocks.
+  var blocks = [];
+  for (var blockType in blockXmlMap) {
+    var block = FactoryUtils.getDefinedBlock(blockType, this.hiddenWorkspace);
+    blocks.push(block);
+  }
+
+  return FactoryUtils.generateCategoryXml(blocks,'Block Library');
 };

--- a/demos/blocklyfactory/block_exporter_tools.js
+++ b/demos/blocklyfactory/block_exporter_tools.js
@@ -194,10 +194,13 @@ BlockExporterTools.prototype.generateToolboxFromLibrary
     xmlDom.appendChild(category);
   }
 
-  // If there are no blocks in library, append dummy category.
-  var category = goog.dom.createDom('category');
-  category.setAttribute('name','Next Saved Block');
-  xmlDom.appendChild(category);
+  // If there are no blocks in library and the map is empty, append dummy
+  // category.
+  if (Object.keys(blockXmlMap).length == 0) {
+    var category = goog.dom.createDom('category');
+    category.setAttribute('name','Next Saved Block');
+    xmlDom.appendChild(category);
+  }
   return xmlDom;
 };
 

--- a/demos/blocklyfactory/block_exporter_tools.js
+++ b/demos/blocklyfactory/block_exporter_tools.js
@@ -210,3 +210,24 @@ BlockExporterTools.prototype.generateToolboxFromLibrary
   xmlDom.appendChild(categoryElement);
   return xmlDom;
 };
+
+/**
+ * Generate xml for the workspace factory's category from imported block
+ * definitions.
+ *
+ * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage object.
+ * @return {!Element} Xml representation of a category.
+ */
+BlockExporterTools.prototype.generateCategoryFromBlockLib =
+    function(blockLibStorage) {
+  var allBlockTypes = blockLibStorage.getBlockTypes();
+  // Object mapping block type to XML.
+  var blockXmlMap = blockLibStorage.getBlockXmlMap(allBlockTypes);
+
+  // Define the custom blocks in order to be able to create instances of
+  // them in the exporter workspace.
+  this.addBlockDefinitions(blockXmlMap);
+
+  return FactoryUtils.generateCategoryXml(allBlockTypes,'Block Library',
+      this.hiddenWorkspace);
+};

--- a/demos/blocklyfactory/block_exporter_view.js
+++ b/demos/blocklyfactory/block_exporter_view.js
@@ -120,6 +120,16 @@ BlockExporterView.prototype.addBlock = function(blockType) {
 };
 
 /**
+ * Deletes a block from the selector workspace.
+ *
+ * @param {!Blockly.Block} block - Type of block to add to selector workspce.
+ */
+BlockExporterView.prototype.removeBlock = function(block) {
+  block.dispose();
+};
+
+
+/**
  * Clears selector workspace.
  */
 BlockExporterView.prototype.clearSelectorWorkspace = function() {

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -736,7 +736,7 @@ FactoryUtils.getDefinedBlock = function(blockType, workspace) {
  *
  * @param {string} blockDef - A single block definition.
  */
-FactoryUtils.getBlockTypeFromJSDef = function(blockDef) {
+FactoryUtils.getBlockTypeFromJsDef = function(blockDef) {
   var indexOfStartBracket = blockDef.indexOf('[\'');
   var indexOfEndBracket = blockDef.indexOf('\']');
   return blockDef.substring(indexOfStartBracket + 2, indexOfEndBracket);
@@ -790,25 +790,21 @@ FactoryUtils.generateCategoryXml =
  * Parses string containing JavaScript block definition(s) to create an array of
  * block definitions.
  *
- * @param {!string} blockDefs - JavaScript block definition(s) each separated by a new
- *    line.
+ * @param {!string} blockDefsString - JavaScript block definition(s).
  * @return {!Array.<string>} - Array of block definitions.
  */
-FactoryUtils.splitJSBlockDefs = function(blockDefs) {
+FactoryUtils.splitJsBlockDefs = function(blockDefsString) {
   var blockDefArray = [];
-  var blockDefs = goog.string.collapseBreakingSpaces(blockDefs);
-  var defStart = blockDefs.indexOf('Blockly.Blocks');
+  var blockDefsString = goog.string.collapseBreakingSpaces(blockDefsString);
+  var defStart = blockDefsString.indexOf('Blockly.Blocks');
 
-  while (blockDefs.indexOf('Blockly.Blocks', defStart) != -1) {
-    var nextStart = blockDefs.indexOf('Blockly.Blocks', defStart + 1);
+  while (blockDefsString.indexOf('Blockly.Blocks', defStart) != -1) {
+    var nextStart = blockDefsString.indexOf('Blockly.Blocks', defStart + 1);
     if (nextStart == -1) {
       // This is the last block definition.
-      var blockDef = blockDefs.substring(defStart, blockDefs.length);
-      blockDefArray.push(blockDef);
-      break;
-    } else {
-      var blockDef = blockDefs.substring(defStart, nextStart);
+      nextStart = blockDefsString.length;
     }
+    var blockDef = blockDefsString.substring(defStart, nextStart);
     blockDefArray.push(blockDef);
     defStart = nextStart;
   }
@@ -819,33 +815,31 @@ FactoryUtils.splitJSBlockDefs = function(blockDefs) {
  * Parses string containing JSON block definition(s) to create an array of
  * the block definitions.
  *
- * @param {!string} blockDefs - JSON block definition(s) each separated by a new
- *    line.
+ * @param {!string} blockDefs - JSON block definition(s).
  * @return {!Array.<string>} - Array of block definitions.
  */
-FactoryUtils.splitJSONBlockDefs = function(blockDefs) {
-  var blockDefs = goog.string.collapseWhitespace(blockDefs);
+FactoryUtils.splitJsonBlockDefs = function(blockDefsString) {
+  //
+  var blockDefsString = goog.string.collapseWhitespace(blockDefsString);
   var blockDefArray = [];
-  var stack = [];
+  var unbalancedBracketCount = 0;
   var defStart = 0;
   // Iterate through the blockDefs string. Keep track of whether brackets
   // are balanced.
-  var i = 0;
-  while (i < blockDefs.length) {
-    var currentChar = blockDefs[i];
+  for (var i = 0; i < blockDefsString.length; i++) {
+    var currentChar = blockDefsString[i];
     if (currentChar == '{') {
-      stack.push(currentChar);
+      unbalancedBracketCount++;
     }
     else if (currentChar == '}') {
-      stack.pop(currentChar);
+      unbalancedBracketCount--;
+      if (unbalancedBracketCount == 0 && i > 0) {
+        // The brackets are balanced. We've got a complete block defintion.
+        var blockDef = blockDefsString.substring(defStart, i + 1);
+        blockDefArray.push(blockDef);
+        defStart = i + 1;
+      }
     }
-    if (stack.length == 0 && i > 0 && currentChar != " ") {
-      // The brackets are balanced. We've got a complete block defintion.
-      var blockDef = blockDefs.substring(defStart, i + 1);
-      blockDefArray.push(blockDef);
-      defStart = i + 1;
-    }
-    i++;
   }
   return blockDefArray;
 };

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -749,26 +749,20 @@ FactoryUtils.getBlockTypeFromJsDef = function(blockDef) {
 };
 
 /**
- * Generates a category containing blocks of the specified block types, assuming
- * the given blocks have already been defined. Needs a Blockly Workspace in
- * order to get the block's xml.
+ * Generates a category containing blocks of the specified block types.
  *
- * @param {!Array.<string>} blockTypes - Types of the blocks to include in the
- *    category.
+ * @param {!Array.<Blockly.Block>} blocks - Blocks to include in the category.
  * @param {string} categoryName - Name to use for the generated category.
- * @param {!Blockly.Workspace} - Blockly workspace.
  * @return {Element} - Category xml containing the given block types.
  */
 FactoryUtils.generateCategoryXml =
-    function(blockTypes, categoryName, workspace) {
+    function(blocks, categoryName) {
   // Create category DOM element.
   var categoryElement = goog.dom.createDom('category');
   categoryElement.setAttribute('name', categoryName);
 
   // For each block, add block element to category.
-  for (var i = 0, blockType; blockType = blockTypes[i]; i++) {
-    // Get block.
-    var block = FactoryUtils.getDefinedBlock(blockType, workspace);
+  for (var i = 0, block; block = blocks[i]; i++) {
 
     // Get preview block XML.
     var blockXml = Blockly.Xml.blockToDom(block);

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -755,8 +755,7 @@ FactoryUtils.getBlockTypeFromJsDef = function(blockDef) {
  * @param {string} categoryName - Name to use for the generated category.
  * @return {Element} - Category xml containing the given block types.
  */
-FactoryUtils.generateCategoryXml =
-    function(blocks, categoryName) {
+FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
   // Create category DOM element.
   var categoryElement = goog.dom.createDom('category');
   categoryElement.setAttribute('name', categoryName);
@@ -775,8 +774,8 @@ FactoryUtils.generateCategoryXml =
 };
 
 /**
- * Parses string containing JavaScript block definition(s) to create an array of
- * block definitions.
+ * Parses a string containing JavaScript block definition(s) to create an array
+ * in which each element is a single block definition.
  *
  * @param {!string} blockDefsString - JavaScript block definition(s).
  * @return {!Array.<string>} - Array of block definitions.
@@ -799,10 +798,13 @@ FactoryUtils.parseJsBlockDefs = function(blockDefsString) {
 };
 
 /**
- * Parses string containing JSON block definition(s) to create an array of
- * the block definitions.
+ * Parses a string containing JSON block definition(s) to create an array
+ * in which each element is a single block definition. Expected input is
+ * one or more block definitions in the form of concatenated, stringified
+ * JSON objects.
  *
- * @param {!string} blockDefs - JSON block definition(s).
+ * @param {!string} blockDefsString - String containing JSON block
+ *    definition(s).
  * @return {!Array.<string>} - Array of block definitions.
  */
 FactoryUtils.parseJsonBlockDefs = function(blockDefsString) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -178,39 +178,3 @@ FactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ = function() {
   }
 };
 
-/**
- * Generate category xml from imported block definitions. Assumes that each
- * block definition is separated by a single empty line.
- *
- * @param {!string} blockDefsString - Block definition(s).
- * @param {!string} format - Block definition format ('JSON' or 'JavaScript').
- * @param {!string} categoryName - Name for the generated category.
- * @return {!Element} Xml representation of a category.
- */
-FactoryGenerator.prototype.generateCategoryFromBlockDefs =
-    function(blockDefsString, format, categoryName) {
-  var blockTypes = [];
-
-  // Define blocks and get block types.
-  if (format == 'JSON') {
-    var blockDefArray = FactoryUtils.splitJsonBlockDefs(blockDefsString);
-    // Populate array of blocktypes and define each block.
-    for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
-      var json = JSON.parse(blockDef);
-      blockTypes.push(json.type);
-      FactoryUtils.defineBlockWithJson(json);
-    }
-  } else if (format == 'JavaScript') {
-    var blockDefArray = FactoryUtils.splitJsBlockDefs(blockDefsString);
-    // Populate array of block types.
-    for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
-      var blockType = FactoryUtils.getBlockTypeFromJsDef(blockDef);
-      blockTypes.push(blockType);
-    }
-    // Define all blocks.
-    eval(blockDefsString);
-  }
-
-  return FactoryUtils.generateCategoryXml(blockTypes, categoryName,
-      this.hiddenWorkspace);
-};

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -178,3 +178,40 @@ FactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ = function() {
   }
 };
 
+/**
+ * Generate category xml from imported block definitions. Assumes that each
+ * block definition is separated by a single empty line.
+ *
+ * @param {!string} blockDefs - Block definition(s)
+ * @param {!string} format - Block definition format ('JSON' or 'JavaScript').
+ * @param {!string} categoryName - Name for the generated category.
+ * @return {!Element} Xml representation of a category.
+ */
+FactoryGenerator.prototype.generateCategoryFromBlockDefs =
+    function(blockDefs, format, categoryName) {
+  var blockTypes = [];
+  var blockDefArray;
+
+  // Define blocks and get block types.
+  if (format == 'JSON') {
+    blockDefArray = FactoryUtils.splitJSONBlockDefs(blockDefs);
+    // Populate array of blocktypes and define each block.
+    for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
+      var json = JSON.parse(blockDef);
+      blockTypes.push(json.type);
+      FactoryUtils.defineBlockWithJson(json);
+    }
+  } else if (format == 'JavaScript') {
+    blockDefArray = FactoryUtils.splitJSBlockDefs(blockDefs);
+    // Populate array of block types.
+    for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
+      var blockType = FactoryUtils.getBlockTypeFromJSDef(blockDef);
+      blockTypes.push(blockType);
+    }
+    // Define all blocks.
+    eval(blockDefs);
+  }
+
+  return FactoryUtils.generateCategoryXml(blockTypes, categoryName,
+      this.hiddenWorkspace);
+};

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -182,19 +182,18 @@ FactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ = function() {
  * Generate category xml from imported block definitions. Assumes that each
  * block definition is separated by a single empty line.
  *
- * @param {!string} blockDefs - Block definition(s)
+ * @param {!string} blockDefsString - Block definition(s).
  * @param {!string} format - Block definition format ('JSON' or 'JavaScript').
  * @param {!string} categoryName - Name for the generated category.
  * @return {!Element} Xml representation of a category.
  */
 FactoryGenerator.prototype.generateCategoryFromBlockDefs =
-    function(blockDefs, format, categoryName) {
+    function(blockDefsString, format, categoryName) {
   var blockTypes = [];
-  var blockDefArray;
 
   // Define blocks and get block types.
   if (format == 'JSON') {
-    blockDefArray = FactoryUtils.splitJSONBlockDefs(blockDefs);
+    var blockDefArray = FactoryUtils.splitJsonBlockDefs(blockDefsString);
     // Populate array of blocktypes and define each block.
     for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
       var json = JSON.parse(blockDef);
@@ -202,14 +201,14 @@ FactoryGenerator.prototype.generateCategoryFromBlockDefs =
       FactoryUtils.defineBlockWithJson(json);
     }
   } else if (format == 'JavaScript') {
-    blockDefArray = FactoryUtils.splitJSBlockDefs(blockDefs);
+    var blockDefArray = FactoryUtils.splitJsBlockDefs(blockDefsString);
     // Populate array of block types.
     for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
-      var blockType = FactoryUtils.getBlockTypeFromJSDef(blockDef);
+      var blockType = FactoryUtils.getBlockTypeFromJsDef(blockDef);
       blockTypes.push(blockType);
     }
     // Define all blocks.
-    eval(blockDefs);
+    eval(blockDefsString);
   }
 
   return FactoryUtils.generateCategoryXml(blockTypes, categoryName,


### PR DESCRIPTION
In order to allow users to add custom blocks to their toolbox and workspace configurations within Workspace Factory, we generate the xml for those categories.

- can generate category xml from Block Library (BlockExporterTools)
- can generate category xml from imported block definitions (Workspace Factory Generator)
- added helper functions for category xml generation to FactoryUtils
- can get Block Library category xml through BlockExporterController

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/552)
<!-- Reviewable:end -->
