### PR TITLE
Blockly Factory: Rename WorkspaceFactory Classes

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -48,7 +48,7 @@ AppController = function() {
   this.blockLibraryController.populateBlockLibrary();
 
   // Construct Workspace Factory Controller.
-  this.workspaceFactoryController = new FactoryController
+  this.workspaceFactoryController = new WorkspaceFactoryController
       ('workspacefactory_toolbox', 'toolbox_blocks', 'preview_blocks');
 
   // Initialize Block Exporter

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -235,7 +235,7 @@ BlockFactory.updatePreview = function() {
 
     // Warn user if their block type is already exists in Blockly's standard
     // library.
-    if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1)
+    if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
       var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +
           'under this name.');

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -542,7 +542,7 @@ goog.require('goog.ui.ColorPicker');
         wheel: true}
     });
 
-  var controller = new FactoryController(toolboxWorkspace, previewWorkspace);
+  var controller = new WorkspaceFactoryController(toolboxWorkspace, previewWorkspace);
 
   // Wrappers to attach buttons to method calls for the controller object
   var addWrapper = function() {
@@ -623,31 +623,31 @@ goog.require('goog.ui.ColorPicker');
     controller.clearToolbox();
   };
   var editToolboxWrapper = function() {
-    controller.setMode(FactoryController.MODE_TOOLBOX);
+    controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
   };
   var editPreloadWrapper = function() {
-    controller.setMode(FactoryController.MODE_PRELOAD);
+    controller.setMode(WorkspaceFactoryController.MODE_PRELOAD);
   };
   var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
+    controller.importFile(event.target.files[0], WorkspaceFactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
+    controller.importFile(event.target.files[0], WorkspaceFactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var editToolboxWrapper = function() {
-    controller.setMode(FactoryController.MODE_TOOLBOX);
+    controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
   };
   var editPreloadWrapper = function() {
-    controller.setMode(FactoryController.MODE_PRELOAD);
+    controller.setMode(WorkspaceFactoryController.MODE_PRELOAD);
   };
   var exportToolboxWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(WorkspaceFactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportPreloadWrapper = function() {
-    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(WorkspaceFactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportOptionsWrapper = function() {
@@ -655,8 +655,8 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportAllWrapper = function() {
-    controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
-    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(WorkspaceFactoryController.MODE_TOOLBOX);
+    controller.exportXmlFile(WorkspaceFactoryController.MODE_PRELOAD);
     controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }

--- a/demos/blocklyfactory/workspacefactory/standard_categories.js
+++ b/demos/blocklyfactory/workspacefactory/standard_categories.js
@@ -27,11 +27,11 @@
  * @author Emma Dauterman (evd2014)
  */
 
-FactoryController.prototype.standardCategories = Object.create(null);
+WorkspaceFactoryController.prototype.standardCategories = Object.create(null);
 
-FactoryController.prototype.standardCategories['logic'] =
+WorkspaceFactoryController.prototype.standardCategories['logic'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Logic');
-FactoryController.prototype.standardCategories['logic'].xml =
+WorkspaceFactoryController.prototype.standardCategories['logic'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_if"></block>' +
@@ -42,11 +42,12 @@ FactoryController.prototype.standardCategories['logic'].xml =
     '<block type="logic_null"></block>' +
     '<block type="logic_ternary"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['logic'].color = '#5C81A6';
+WorkspaceFactoryController.prototype.standardCategories['logic'].color =
+    '#5C81A6';
 
-FactoryController.prototype.standardCategories['loops'] =
+WorkspaceFactoryController.prototype.standardCategories['loops'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Loops');
-FactoryController.prototype.standardCategories['loops'].xml =
+WorkspaceFactoryController.prototype.standardCategories['loops'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_repeat_ext">' +
@@ -77,11 +78,12 @@ FactoryController.prototype.standardCategories['loops'].xml =
     '<block type="controls_forEach"></block>' +
     '<block type="controls_flow_statements"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['loops'].color = '#5CA65C';
+WorkspaceFactoryController.prototype.standardCategories['loops'].color =
+    '#5CA65C';
 
-FactoryController.prototype.standardCategories['math'] =
+WorkspaceFactoryController.prototype.standardCategories['math'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Math');
-FactoryController.prototype.standardCategories['math'].xml =
+WorkspaceFactoryController.prototype.standardCategories['math'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="math_number"></block>' +
@@ -177,11 +179,12 @@ FactoryController.prototype.standardCategories['math'].xml =
     '</block>' +
     '<block type="math_random_float"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['math'].color = '#5C68A6';
+WorkspaceFactoryController.prototype.standardCategories['math'].color =
+    '#5C68A6';
 
-FactoryController.prototype.standardCategories['text'] =
+WorkspaceFactoryController.prototype.standardCategories['text'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Text');
-FactoryController.prototype.standardCategories['text'].xml =
+WorkspaceFactoryController.prototype.standardCategories['text'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="text"></block>' +
@@ -260,11 +263,12 @@ FactoryController.prototype.standardCategories['text'].xml =
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['text'].color = '#5CA68D';
+WorkspaceFactoryController.prototype.standardCategories['text'].color =
+    '#5CA68D';
 
-FactoryController.prototype.standardCategories['lists'] =
+WorkspaceFactoryController.prototype.standardCategories['lists'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Lists');
-FactoryController.prototype.standardCategories['lists'].xml =
+WorkspaceFactoryController.prototype.standardCategories['lists'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="lists_create_with">' +
@@ -317,11 +321,12 @@ FactoryController.prototype.standardCategories['lists'].xml =
     '</block>' +
     '<block type="lists_sort"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['lists'].color = '#745CA6';
+WorkspaceFactoryController.prototype.standardCategories['lists'].color =
+    '#745CA6';
 
-FactoryController.prototype.standardCategories['colour'] =
+WorkspaceFactoryController.prototype.standardCategories['colour'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Colour');
-FactoryController.prototype.standardCategories['colour'].xml =
+WorkspaceFactoryController.prototype.standardCategories['colour'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="colour_picker"></block>' +
@@ -361,15 +366,19 @@ FactoryController.prototype.standardCategories['colour'].xml =
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['colour'].color = '#A6745C';
+WorkspaceFactoryController.prototype.standardCategories['colour'].color =
+    '#A6745C';
 
-FactoryController.prototype.standardCategories['functions'] =
+WorkspaceFactoryController.prototype.standardCategories['functions'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Functions');
-FactoryController.prototype.standardCategories['functions'].color = '#9A5CA6'
-FactoryController.prototype.standardCategories['functions'].custom =
+WorkspaceFactoryController.prototype.standardCategories['functions'].color =
+    '#9A5CA6'
+WorkspaceFactoryController.prototype.standardCategories['functions'].custom =
     'PROCEDURE';
 
-FactoryController.prototype.standardCategories['variables'] =
+WorkspaceFactoryController.prototype.standardCategories['variables'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Variables');
-FactoryController.prototype.standardCategories['variables'].color = '#A65C81';
-FactoryController.prototype.standardCategories['variables'].custom = 'VARIABLE';
+WorkspaceFactoryController.prototype.standardCategories['variables'].color =
+    '#A65C81';
+WorkspaceFactoryController.prototype.standardCategories['variables'].custom =
+    'VARIABLE';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -35,14 +35,14 @@
  */
 
 /**
- * Class for a FactoryController.
+ * Class for a WorkspaceFactoryController
  * @constructor
  *
  * @param {!string} toolboxName Name of workspace toolbox XML.
  * @param {!string} toolboxDiv Name of div to inject toolbox workspace in.
  * @param {!string} previewDiv Name of div to inject preview workspace in.
  */
-FactoryController = function(toolboxName, toolboxDiv, previewDiv) {
+WorkspaceFactoryController = function(toolboxName, toolboxDiv, previewDiv) {
   var toolbox = document.getElementById(toolboxName);
 
   // Workspace for user to drag blocks in for a certain category.
@@ -71,27 +71,27 @@ FactoryController = function(toolboxName, toolboxDiv, previewDiv) {
     });
 
   // Model to keep track of categories and blocks.
-  this.model = new FactoryModel();
+  this.model = new WorkspaceFactoryModel();
   // Updates the category tabs.
-  this.view = new FactoryView();
+  this.view = new WorkspaceFactoryView();
   // Generates XML for categories.
-  this.generator = new FactoryGenerator(this.model);
+  this.generator = new WorkspaceFactoryGenerator(this.model);
   // Tracks which editing mode the user is in. Toolbox mode on start.
-  this.selectedMode = FactoryController.MODE_TOOLBOX;
+  this.selectedMode = WorkspaceFactoryController.MODE_TOOLBOX;
 };
 
 // Toolbox editing mode. Changes the user makes to the workspace updates the
 // toolbox.
-FactoryController.MODE_TOOLBOX = 'toolbox';
+WorkspaceFactoryController.MODE_TOOLBOX = 'toolbox';
 // Pre-loaded workspace editing mode. Changes the user makes to the workspace
 // udpates the pre-loaded blocks.
-FactoryController.MODE_PRELOAD = 'preload';
+WorkspaceFactoryController.MODE_PRELOAD = 'preload';
 
 /**
  * Currently prompts the user for a name, checking that it's valid (not used
  * before), and then creates a tab and switches to it.
  */
-FactoryController.prototype.addCategory = function() {
+WorkspaceFactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
   var isFirstCategory = !this.model.hasElements();
   // Give the option to save blocks if their workspace is not empty and they
@@ -151,7 +151,8 @@ FactoryController.prototype.addCategory = function() {
  * @param {boolean} isFirstCategory True if it's the first category created,
  * false otherwise.
  */
-FactoryController.prototype.createCategory = function(name, isFirstCategory) {
+WorkspaceFactoryController.prototype.createCategory = function(name,
+    isFirstCategory) {
   // Create empty category
   var category = new ListElement(ListElement.TYPE_CATEGORY, name);
   this.model.addElementToList(category);
@@ -168,7 +169,7 @@ FactoryController.prototype.createCategory = function(name, isFirstCategory) {
  * @param {!Element} tab The DOM element to add the listener to.
  * @param {!string} id The ID of the element to switch to when tab is clicked.
  */
-FactoryController.prototype.addClickToSwitch = function(tab, id) {
+WorkspaceFactoryController.prototype.addClickToSwitch = function(tab, id) {
   var self = this;
   var clickFunction = function(id) {  // Keep this in scope for switchElement
     return function() {
@@ -184,7 +185,7 @@ FactoryController.prototype.addClickToSwitch = function(tab, id) {
  * When the last element is removed, it switches to a single flyout mode.
  *
  */
-FactoryController.prototype.removeElement = function() {
+WorkspaceFactoryController.prototype.removeElement = function() {
   // Check that there is a currently selected category to remove.
   if (!this.model.getSelected()) {
     return;
@@ -237,7 +238,8 @@ FactoryController.prototype.removeElement = function() {
  * @param {!string} promptString Prompt for the user to enter a name.
  * @return {string} Valid name for a new category, or null if cancelled.
  */
-FactoryController.prototype.promptForNewCategoryName = function(promptString) {
+WorkspaceFactoryController.prototype.promptForNewCategoryName =
+    function(promptString) {
   do {
     var name = prompt(promptString);
     if (!name) {  // If cancelled.
@@ -254,7 +256,7 @@ FactoryController.prototype.promptForNewCategoryName = function(promptString) {
  *
  * @param {!string} id ID of tab to be opened, must be valid element ID.
  */
-FactoryController.prototype.switchElement = function(id) {
+WorkspaceFactoryController.prototype.switchElement = function(id) {
   // Disables events while switching so that Blockly delete and create events
   // don't update the preview repeatedly.
   Blockly.Events.disable();
@@ -275,7 +277,7 @@ FactoryController.prototype.switchElement = function(id) {
  *
  * @param {!string} id ID of category to load
  */
-FactoryController.prototype.clearAndLoadElement = function(id) {
+WorkspaceFactoryController.prototype.clearAndLoadElement = function(id) {
   // Unselect current tab if switching to and from an element.
   if (this.model.getSelectedId() != null && id != null) {
     this.view.setCategoryTabSelection(this.model.getSelectedId(), false);
@@ -315,17 +317,18 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  * the corresponding configuration xml to that file.
  *
  * @param {!string} exportMode The type of file to export
- *    (FactoryController.MODE_TOOLBOX for the toolbox configuration, and
- *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
+ *    (WorkspaceFactoryController.MODE_TOOLBOX for the toolbox configuration,
+ *    and WorkspaceFactoryController.MODE_PRELOAD for the pre-loaded workspace
+ *    configuration)
  */
-FactoryController.prototype.exportXmlFile = function(exportMode) {
+WorkspaceFactoryController.prototype.exportXmlFile = function(exportMode) {
   // Generate XML.
-  if (exportMode == FactoryController.MODE_TOOLBOX) {
+  if (exportMode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
 
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateToolboxXml());
-  } else if (exportMode == FactoryController.MODE_PRELOAD) {
+  } else if (exportMode == WorkspaceFactoryController.MODE_PRELOAD) {
     // Export the pre-loaded block XML.
 
     var configXml = Blockly.Xml.domToPrettyText
@@ -337,7 +340,7 @@ FactoryController.prototype.exportXmlFile = function(exportMode) {
 
   // Get file name.
   var fileName = prompt('File Name for ' + (exportMode ==
-      FactoryController.MODE_TOOLBOX ? 'toolbox XML: ' :
+      WorkspaceFactoryController.MODE_TOOLBOX ? 'toolbox XML: ' :
       'pre-loaded workspace XML: '));
   if (!fileName) { // If cancelled
     return;
@@ -351,7 +354,7 @@ FactoryController.prototype.exportXmlFile = function(exportMode) {
  * Export the options object to be used for the Blockly inject call. Gets a
  * file name from the user and downloads the options object to that file.
  */
-FactoryController.prototype.exportOptionsFile = function() {
+WorkspaceFactoryController.prototype.exportOptionsFile = function() {
   var fileName = prompt('File Name for options object for injecting: ');
   if (!fileName) {  // If cancelled.
     return;
@@ -369,7 +372,7 @@ FactoryController.prototype.exportOptionsFile = function() {
  * Tied to "Print" button. Mainly used for debugging purposes. Prints
  * the configuration XML to the console.
  */
-FactoryController.prototype.printConfig = function() {
+WorkspaceFactoryController.prototype.printConfig = function() {
   // Capture any changes made by user before generating XML.
   this.saveStateFromWorkspace();
   // Print XML.
@@ -387,12 +390,12 @@ FactoryController.prototype.printConfig = function() {
  * that no changes have been made to the workspace since updating the model
  * (if this might be the case, call saveStateFromWorkspace).
  */
-FactoryController.prototype.updatePreview = function() {
+WorkspaceFactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
 
-  if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+  if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
@@ -420,7 +423,7 @@ FactoryController.prototype.updatePreview = function() {
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
-  } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
+  } else if (this.selectedMode == WorkspaceFactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
@@ -435,11 +438,11 @@ FactoryController.prototype.updatePreview = function() {
  * Saves the state from the workspace depending on the current mode. Should
  * be called after making changes to the workspace.
  */
-FactoryController.prototype.saveStateFromWorkspace = function() {
-  if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+WorkspaceFactoryController.prototype.saveStateFromWorkspace = function() {
+  if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-  } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
+  } else if (this.selectedMode == WorkspaceFactoryController.MODE_PRELOAD) {
     // If currently editing the pre-loaded workspace.
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
@@ -454,7 +457,7 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
  * @param {!Element} tree of xml elements
  * @package
  */
-FactoryController.prototype.reinjectPreview = function(tree) {
+WorkspaceFactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
   this.model.setOptionsAttribute('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
@@ -467,7 +470,7 @@ FactoryController.prototype.reinjectPreview = function(tree) {
  * Continues prompting the user until they input a category name that is not
  * currently in use, exits if user presses cancel.
  */
-FactoryController.prototype.changeCategoryName = function() {
+WorkspaceFactoryController.prototype.changeCategoryName = function() {
   // Return if a category is not selected.
   if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
@@ -495,7 +498,7 @@ FactoryController.prototype.changeCategoryName = function() {
  * to swap with. Positive if the element to be swapped with is below, negative
  * if the element to be swapped with is above.
  */
-FactoryController.prototype.moveElement = function(offset) {
+WorkspaceFactoryController.prototype.moveElement = function(offset) {
   var curr = this.model.getSelected();
   if (!curr) {  // Return if no selected element.
     return;
@@ -523,8 +526,8 @@ FactoryController.prototype.moveElement = function(offset) {
  * @param {int} newIndex The index to insert the element at.
  * @param {int} oldIndex The index the element is currently at.
  */
-FactoryController.prototype.moveElementToIndex = function(element, newIndex,
-    oldIndex) {
+WorkspaceFactoryController.prototype.moveElementToIndex = function(element,
+    newIndex, oldIndex) {
   this.model.moveElementToIndex(element, newIndex, oldIndex);
   this.view.moveTabToIndex(element.id, newIndex, oldIndex);
 };
@@ -536,7 +539,8 @@ FactoryController.prototype.moveElementToIndex = function(element, newIndex,
  * @param {!string} color The color to change the selected category. Must be
  * a valid CSS string.
  */
-FactoryController.prototype.changeSelectedCategoryColor = function(color) {
+WorkspaceFactoryController.prototype.changeSelectedCategoryColor =
+    function(color) {
   // Return if category is not selected.
   if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
@@ -553,7 +557,7 @@ FactoryController.prototype.changeSelectedCategoryColor = function(color) {
  * loads it as a new category and switches to it. Leverages standardCategories
  * map in standard_categories.js.
  */
-FactoryController.prototype.loadCategory = function() {
+WorkspaceFactoryController.prototype.loadCategory = function() {
   // Prompt user for the name of the standard category to load.
   do {
     var name = prompt('Enter the name of the category you would like to import '
@@ -619,7 +623,7 @@ FactoryController.prototype.loadCategory = function() {
  * in standardCategories
  * @return {boolean} True if name is a standard category name, false otherwise.
  */
-FactoryController.prototype.isStandardCategoryName = function(name) {
+WorkspaceFactoryController.prototype.isStandardCategoryName = function(name) {
   for (var category in this.standardCategories) {
     if (name.toLowerCase() == category) {
       return true;
@@ -633,7 +637,7 @@ FactoryController.prototype.isStandardCategoryName = function(name) {
  * exist, adds a separator to the model and view. Does not switch to select
  * the separator, and updates the preview.
  */
-FactoryController.prototype.addSeparator = function() {
+WorkspaceFactoryController.prototype.addSeparator = function() {
   // Don't allow the user to add a separator if a category has not been created.
   if (!this.model.hasElements()) {
     alert('Add a category before adding a separator.');
@@ -662,10 +666,10 @@ FactoryController.prototype.addSeparator = function() {
  * @param {string} file The path for the file to be imported into the workspace.
  * Should contain valid toolbox XML.
  * @param {!string} importMode The mode corresponding to the type of file the
- *    user is importing (FactoryController.MODE_TOOLBOX or
- *    FactoryController.MODE_PRELOAD).
+ *    user is importing (WorkspaceFactoryController.MODE_TOOLBOX or
+ *    WorkspaceFactoryController.MODE_PRELOAD).
  */
-FactoryController.prototype.importFile = function(file, importMode) {
+WorkspaceFactoryController.prototype.importFile = function(file, importMode) {
   // Exit if cancelled.
   if (!file) {
     return;
@@ -679,13 +683,13 @@ FactoryController.prototype.importFile = function(file, importMode) {
     // Print error message if fail.
     try {
       var tree = Blockly.Xml.textToDom(reader.result);
-      if (importMode == FactoryController.MODE_TOOLBOX) {
+      if (importMode == WorkspaceFactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
-        controller.setMode(FactoryController.MODE_TOOLBOX);
+        controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
         controller.importToolboxFromTree_(tree);
-      } else if (importMode == FactoryController.MODE_PRELOAD) {
+      } else if (importMode == WorkspaceFactoryController.MODE_PRELOAD) {
         // Switch mode and import pre-loaded workspace XML.
-        controller.setMode(FactoryController.MODE_PRELOAD);
+        controller.setMode(WorkspaceFactoryController.MODE_PRELOAD);
         controller.importPreloadFromTree_(tree);
       } else {
         // Throw error if invalid mode.
@@ -709,7 +713,7 @@ FactoryController.prototype.importFile = function(file, importMode) {
  *
  * @param {!Element} tree XML tree to be loaded to toolbox editing area.
  */
-FactoryController.prototype.importToolboxFromTree_ = function(tree) {
+WorkspaceFactoryController.prototype.importToolboxFromTree_ = function(tree) {
   // Clear current editing area.
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
@@ -785,7 +789,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
  * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
  *    area.
  */
-FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+WorkspaceFactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
   this.updatePreview();
@@ -799,7 +803,7 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
  * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
  *    area.
  */
-FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+WorkspaceFactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
   this.saveStateFromWorkspace();
@@ -814,7 +818,7 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
  * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
  *    area.
  */
-FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+WorkspaceFactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
   this.saveStateFromWorkspace();
@@ -826,8 +830,8 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
  * blocks in the model and view. Sets the mode to toolbox mode. Tied to "Clear
  * Toolbox" button.
  */
-FactoryController.prototype.clearToolbox = function() {
-  this.setMode(FactoryController.MODE_TOOLBOX);
+WorkspaceFactoryController.prototype.clearToolbox = function() {
+  this.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
   var hasCategories = this.model.hasElements();
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
@@ -850,7 +854,7 @@ FactoryController.prototype.clearToolbox = function() {
  * preview when done.
  *
  */
-FactoryController.prototype.addShadow = function() {
+WorkspaceFactoryController.prototype.addShadow = function() {
   // No block selected to make a shadow block.
   if (!Blockly.selected) {
     return;
@@ -867,7 +871,7 @@ FactoryController.prototype.addShadow = function() {
  * shadow blocks and loading the workspace again. Updates the preview again.
  *
  */
-FactoryController.prototype.removeShadow = function() {
+WorkspaceFactoryController.prototype.removeShadow = function() {
   // No block selected to modify.
   if (!Blockly.selected) {
     return;
@@ -886,7 +890,7 @@ FactoryController.prototype.removeShadow = function() {
  * @return {boolean} True if the block is a user-generated shadow block, false
  *    otherwise.
  */
-FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
+WorkspaceFactoryController.prototype.isUserGenShadowBlock = function(blockId) {
   return this.model.isShadowBlock(blockId);
 }
 
@@ -896,7 +900,7 @@ FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * blocks, meaning they are marked as shadow blocks by the model and appear as
  * shadow blocks in the view but are still editable and movable.
  */
-FactoryController.prototype.convertShadowBlocks = function() {
+WorkspaceFactoryController.prototype.convertShadowBlocks = function() {
   var blocks = this.toolboxWorkspace.getAllBlocks();
   for (var i = 0, block; block = blocks[i]; i++) {
     if (block.isShadow()) {
@@ -913,9 +917,10 @@ FactoryController.prototype.convertShadowBlocks = function() {
  * to and from the toolbox and updates the help text.
  *
  * @param {!string} tab The type of tab being switched to
- *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ *    (WorkspaceFactoryController.MODE_TOOLBOX or
+ *    WorkspaceFactoryController.MODE_PRELOAD).
  */
-FactoryController.prototype.setMode = function(mode) {
+WorkspaceFactoryController.prototype.setMode = function(mode) {
   // No work to change mode that's currently set.
   if (this.selectedMode == mode) {
     return;
@@ -935,7 +940,7 @@ FactoryController.prototype.setMode = function(mode) {
   // Update help text above workspace.
   this.view.updateHelpText(mode);
 
-  if (mode == FactoryController.MODE_TOOLBOX) {
+  if (mode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
     document.getElementById('editHelpText').textContent =
         'Drag blocks into your toolbox:';
@@ -963,7 +968,7 @@ FactoryController.prototype.setMode = function(mode) {
  *
  * @param {!Element} xml The XML to be loaded to the workspace.
  */
-FactoryController.prototype.clearAndLoadXml_ = function(xml) {
+WorkspaceFactoryController.prototype.clearAndLoadXml_ = function(xml) {
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
   Blockly.Xml.domToWorkspace(xml, this.toolboxWorkspace);
@@ -976,7 +981,7 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
  * the preview workspace. The default values depends on if categories are
  * present.
  */
-FactoryController.prototype.setStandardOptionsAndUpdate = function() {
+WorkspaceFactoryController.prototype.setStandardOptionsAndUpdate = function() {
   this.view.setBaseOptions();
   this.view.setCategoryOptions(this.model.hasElements());
   this.generateNewOptions();
@@ -990,7 +995,7 @@ FactoryController.prototype.setStandardOptionsAndUpdate = function() {
  * options, not the base default options that are set regardless of if
  * categories or a single flyout are used.
  */
-FactoryController.prototype.allowToSetDefaultOptions = function() {
+WorkspaceFactoryController.prototype.allowToSetDefaultOptions = function() {
   if (!this.model.hasElements() && !confirm('Do you want to use the default ' +
       'workspace configuration options for injecting a workspace without ' +
       'categories?')) {
@@ -1009,7 +1014,7 @@ FactoryController.prototype.allowToSetDefaultOptions = function() {
  * on user input. Should be called every time a change has been made to
  * an input field. Updates the model and reinjects the preview workspace.
  */
-FactoryController.prototype.generateNewOptions = function() {
+WorkspaceFactoryController.prototype.generateNewOptions = function() {
   var optionsObj = new Object(null);
 
   // Add all standard options to the options object.

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -29,10 +29,10 @@
  */
 
 /**
- * Class for a FactoryGenerator
+ * Class for a WorkspaceFactoryGenerator
  * @constructor
  */
-FactoryGenerator = function(model) {
+WorkspaceFactoryGenerator = function(model) {
   // Model to share information about categories and shadow blocks.
   this.model = model;
   // Create hidden workspace to load saved XML to generate toolbox XML.
@@ -57,7 +57,7 @@ FactoryGenerator = function(model) {
  * @return {!Element} XML element representing toolbox or flyout corresponding
  * to toolbox workspace.
  */
-FactoryGenerator.prototype.generateToolboxXml = function() {
+WorkspaceFactoryGenerator.prototype.generateToolboxXml = function() {
   // Create DOM for XML.
   var xmlDom = goog.dom.createDom('xml',
       {
@@ -117,7 +117,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   * generated shadow blocks to actual shadow blocks.
   *
   */
-FactoryGenerator.prototype.generateWorkspaceXml = function() {
+WorkspaceFactoryGenerator.prototype.generateWorkspaceXml = function() {
   // Load workspace XML to hidden workspace with user-generated shadow blocks
   // as actual shadow blocks.
   this.hiddenWorkspace.clear();
@@ -138,7 +138,7 @@ FactoryGenerator.prototype.generateWorkspaceXml = function() {
  *
  * @param {!Element} xml The XML to be loaded to the hidden workspace.
  */
-FactoryGenerator.prototype.loadToHiddenWorkspace_ = function(xml) {
+WorkspaceFactoryGenerator.prototype.loadToHiddenWorkspace_ = function(xml) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
@@ -152,7 +152,8 @@ FactoryGenerator.prototype.loadToHiddenWorkspace_ = function(xml) {
  *
  * @param {!Element} xmlDom Tree of XML elements to be appended to.
  */
-FactoryGenerator.prototype.appendHiddenWorkspaceToDom_ = function(xmlDom) {
+WorkspaceFactoryGenerator.prototype.appendHiddenWorkspaceToDom_ =
+    function(xmlDom) {
   var blocks = this.hiddenWorkspace.getTopBlocks();
   for (var i = 0, block; block = blocks[i]; i++) {
     var blockChild = Blockly.Xml.blockToDom(block);
@@ -168,7 +169,8 @@ FactoryGenerator.prototype.appendHiddenWorkspaceToDom_ = function(xmlDom) {
  * @private
  *
  */
-FactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ = function() {
+WorkspaceFactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ =
+    function() {
   var blocks = this.hiddenWorkspace.getAllBlocks();
   for (var i = 0; i < blocks.length; i++) {
     if (this.model.isShadowBlock(blocks[i].id)) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -31,10 +31,10 @@
  */
 
 /**
- * Class for a FactoryModel
+ * Class for a WorkspaceFactoryModel
  * @constructor
  */
-FactoryModel = function() {
+WorkspaceFactoryModel = function() {
   // Ordered list of ListElement objects. Empty if there is a single flyout.
   this.toolboxList = [];
   // ListElement for blocks in a single flyout. Null if a toolbox exists.
@@ -62,7 +62,7 @@ FactoryModel = function() {
  * @param {string} name String name to be compared against.
  * @return {boolean} True if string is a used category name, false otherwise.
  */
-FactoryModel.prototype.hasCategoryByName = function(name) {
+WorkspaceFactoryModel.prototype.hasCategoryByName = function(name) {
   for (var i = 0; i < this.toolboxList.length; i++) {
     if (this.toolboxList[i].type == ListElement.TYPE_CATEGORY &&
         this.toolboxList[i].name == name) {
@@ -78,7 +78,7 @@ FactoryModel.prototype.hasCategoryByName = function(name) {
  * @return {boolean} True if there exists a category with the Variables tag,
  * false otherwise.
  */
-FactoryModel.prototype.hasVariables = function() {
+WorkspaceFactoryModel.prototype.hasVariables = function() {
   return this.hasVariableCategory;
 };
 
@@ -88,7 +88,7 @@ FactoryModel.prototype.hasVariables = function() {
  * @return {boolean} True if there exists a category with the Procedures tag,
  * false otherwise.
  */
-FactoryModel.prototype.hasProcedures = function() {
+WorkspaceFactoryModel.prototype.hasProcedures = function() {
   return this.hasFunctionCategory;
 };
 
@@ -98,7 +98,7 @@ FactoryModel.prototype.hasProcedures = function() {
  *
  * @return {boolean} True if elements exist, false otherwise.
  */
-FactoryModel.prototype.hasElements = function() {
+WorkspaceFactoryModel.prototype.hasElements = function() {
   return this.toolboxList.length > 0;
 };
 
@@ -107,7 +107,7 @@ FactoryModel.prototype.hasElements = function() {
  *
  * @param {!ListElement} element The element to be added to the list.
  */
-FactoryModel.prototype.addElementToList = function(element) {
+WorkspaceFactoryModel.prototype.addElementToList = function(element) {
   // Update state if the copied category has a custom tag.
   this.hasVariableCategory = element.custom == 'VARIABLE' ? true :
       this.hasVariableCategory;
@@ -124,7 +124,7 @@ FactoryModel.prototype.addElementToList = function(element) {
  *
  * @param {int} index The index of the list element to delete.
  */
-FactoryModel.prototype.deleteElementFromList = function(index) {
+WorkspaceFactoryModel.prototype.deleteElementFromList = function(index) {
   // Check if index is out of bounds.
   if (index < 0 || index >= this.toolboxList.length) {
     return; // No entry to delete.
@@ -145,7 +145,7 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
  * of blocks displayed.
  *
  */
-FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
+WorkspaceFactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
     this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
     this.selected = this.flyout;
@@ -162,7 +162,7 @@ FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
  * @param {int} newIndex The index to insert the element at.
  * @param {int} oldIndex The index the element is currently at.
  */
-FactoryModel.prototype.moveElementToIndex = function(element, newIndex,
+WorkspaceFactoryModel.prototype.moveElementToIndex = function(element, newIndex,
     oldIndex) {
   // Check that indexes are in bounds.
   if (newIndex < 0 || newIndex >= this.toolboxList.length || oldIndex < 0 ||
@@ -179,7 +179,7 @@ FactoryModel.prototype.moveElementToIndex = function(element, newIndex,
  *
  * @return {string} The ID of the element currently selected.
  */
-FactoryModel.prototype.getSelectedId = function() {
+WorkspaceFactoryModel.prototype.getSelectedId = function() {
   return this.selected ? this.selected.id : null;
 };
 
@@ -190,7 +190,7 @@ FactoryModel.prototype.getSelectedId = function() {
  *
  * @return {string} The name of the category currently selected.
  */
-FactoryModel.prototype.getSelectedName = function() {
+WorkspaceFactoryModel.prototype.getSelectedName = function() {
   return this.selected ? this.selected.name : null;
 };
 
@@ -199,7 +199,7 @@ FactoryModel.prototype.getSelectedName = function() {
  *
  * @return {ListElement} The currently selected ListElement
  */
-FactoryModel.prototype.getSelected = function() {
+WorkspaceFactoryModel.prototype.getSelected = function() {
   return this.selected;
 };
 
@@ -208,7 +208,7 @@ FactoryModel.prototype.getSelected = function() {
  *
  * @param {string} id ID of list element that should now be selected.
  */
-FactoryModel.prototype.setSelectedById = function(id) {
+WorkspaceFactoryModel.prototype.setSelectedById = function(id) {
   this.selected = this.getElementById(id);
 };
 
@@ -221,7 +221,7 @@ FactoryModel.prototype.setSelectedById = function(id) {
  * doesn't exist.
  */
 
-FactoryModel.prototype.getIndexByElementId = function(id) {
+WorkspaceFactoryModel.prototype.getIndexByElementId = function(id) {
   for (var i = 0; i < this.toolboxList.length; i++) {
     if (this.toolboxList[i].id == id) {
       return i;
@@ -237,7 +237,7 @@ FactoryModel.prototype.getIndexByElementId = function(id) {
  * @return {ListElement} Corresponding ListElement object in toolboxList, or
  *     null if that element does not exist.
  */
-FactoryModel.prototype.getElementById = function(id) {
+WorkspaceFactoryModel.prototype.getElementById = function(id) {
   for (var i = 0; i < this.toolboxList.length; i++) {
     if (this.toolboxList[i].id == id) {
       return this.toolboxList[i];
@@ -253,7 +253,7 @@ FactoryModel.prototype.getElementById = function(id) {
  * @param {int} index The index of the element to return.
  * @return {ListElement} The corresponding ListElement object in toolboxList.
  */
-FactoryModel.prototype.getElementByIndex = function(index) {
+WorkspaceFactoryModel.prototype.getElementByIndex = function(index) {
   if (index < 0 || index >= this.toolboxList.length) {
     return null;
   }
@@ -266,7 +266,7 @@ FactoryModel.prototype.getElementByIndex = function(index) {
  * @return {!Element} The XML of the selected element, or null if there is
  * no selected element.
  */
-FactoryModel.prototype.getSelectedXml = function() {
+WorkspaceFactoryModel.prototype.getSelectedXml = function() {
   return this.selected ? this.selected.xml : null;
 };
 
@@ -275,7 +275,7 @@ FactoryModel.prototype.getSelectedXml = function() {
  *
  * @return {!Array<!ListElement>} ordered list of ListElement objects
  */
-FactoryModel.prototype.getToolboxList = function() {
+WorkspaceFactoryModel.prototype.getToolboxList = function() {
   return this.toolboxList;
 };
 
@@ -285,7 +285,7 @@ FactoryModel.prototype.getToolboxList = function() {
  * @param {string} name Name of category.
  * @return {int} ID of category
  */
-FactoryModel.prototype.getCategoryIdByName = function(name) {
+WorkspaceFactoryModel.prototype.getCategoryIdByName = function(name) {
   for (var i = 0; i < this.toolboxList.length; i++) {
     if (this.toolboxList[i].name == name) {
       return this.toolboxList[i].id;
@@ -297,7 +297,7 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
 /**
  * Clears the toolbox list, deleting all ListElements.
  */
-FactoryModel.prototype.clearToolboxList = function() {
+WorkspaceFactoryModel.prototype.clearToolboxList = function() {
   this.toolboxList = [];
   this.hasVariableCategory = false;
   this.hasVariableCategory = false;
@@ -310,7 +310,7 @@ FactoryModel.prototype.clearToolboxList = function() {
  *
  * @param {!string} blockId The unique ID of block to be added.
  */
-FactoryModel.prototype.addShadowBlock = function(blockId) {
+WorkspaceFactoryModel.prototype.addShadowBlock = function(blockId) {
   this.shadowBlocks.push(blockId);
 };
 
@@ -320,7 +320,7 @@ FactoryModel.prototype.addShadowBlock = function(blockId) {
  *
  * @param {!string} blockId The unique ID of block to be removed.
  */
-FactoryModel.prototype.removeShadowBlock = function(blockId) {
+WorkspaceFactoryModel.prototype.removeShadowBlock = function(blockId) {
   for (var i = 0; i < this.shadowBlocks.length; i++) {
     if (this.shadowBlocks[i] == blockId) {
       this.shadowBlocks.splice(i, 1);
@@ -336,7 +336,7 @@ FactoryModel.prototype.removeShadowBlock = function(blockId) {
  * @return {boolean} True if the block is a user-generated shadow block, false
  *    otherwise.
  */
-FactoryModel.prototype.isShadowBlock = function(blockId) {
+WorkspaceFactoryModel.prototype.isShadowBlock = function(blockId) {
   for (var i = 0; i < this.shadowBlocks.length; i++) {
     if (this.shadowBlocks[i] == blockId) {
       return true;
@@ -353,7 +353,8 @@ FactoryModel.prototype.isShadowBlock = function(blockId) {
  * @return {!<Blockly.Block>} Array of user-generated shadow blocks currently
  * loaded.
  */
-FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
+WorkspaceFactoryModel.prototype.getShadowBlocksInWorkspace =
+    function(workspaceBlocks) {
   var shadowsInWorkspace = [];
   for (var i = 0; i < workspaceBlocks.length; i++) {
     if (this.isShadowBlock(workspaceBlocks[i].id)) {
@@ -370,7 +371,7 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
  * @param {!ListElement} category The category to add the tag to.
  * @param {!string} tag The custom tag to add to the category.
  */
-FactoryModel.prototype.addCustomTag = function(category, tag) {
+WorkspaceFactoryModel.prototype.addCustomTag = function(category, tag) {
   // Only update list elements that are categories.
   if (category.type != ListElement.TYPE_CATEGORY) {
     return;
@@ -391,7 +392,7 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
  *
  * @param {!Element} xml The XML to be saved.
  */
-FactoryModel.prototype.savePreloadXml = function(xml) {
+WorkspaceFactoryModel.prototype.savePreloadXml = function(xml) {
   this.preloadXml = xml
 };
 
@@ -400,7 +401,7 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  *
  * @return {!Element} The XML for the workspace.
  */
-FactoryModel.prototype.getPreloadXml = function() {
+WorkspaceFactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
 };
 
@@ -409,7 +410,7 @@ FactoryModel.prototype.getPreloadXml = function() {
  *
  * @param {Object} options Options object for injecting a Blockly workspace.
  */
-FactoryModel.prototype.setOptions = function(options) {
+WorkspaceFactoryModel.prototype.setOptions = function(options) {
   this.options = options;
 };
 
@@ -419,7 +420,7 @@ FactoryModel.prototype.setOptions = function(options) {
  * @param {!string} name Name of the attribute to add.
  * @param {Object} value The value of the attribute to add.
  */
-FactoryModel.prototype.setOptionsAttribute = function(name, value) {
+WorkspaceFactoryModel.prototype.setOptionsAttribute = function(name, value) {
   this.options[name] = value;
 };
 
@@ -430,7 +431,7 @@ FactoryModel.prototype.setOptionsAttribute = function(name, value) {
  *
  * @return {!Array<!string>} Array of block types currently being used.
  */
-FactoryModel.prototype.getAllUsedBlockTypes = function() {
+WorkspaceFactoryModel.prototype.getAllUsedBlockTypes = function() {
   var blockTypeList = [];
 
   // Given XML for the workspace, adds all block types included in the XML

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -29,11 +29,11 @@
  */
 
  /**
-  * Class for a FactoryView
+  * Class for a WorkspaceFactoryView
   * @constructor
   */
 
-FactoryView = function() {
+WorkspaceFactoryView = function() {
   // For each tab, maps ID of a ListElement to the td DOM element.
   this.tabMap = Object.create(null);
 };
@@ -47,7 +47,8 @@ FactoryView = function() {
  * otherwise
  * @return {!Element} DOM element created for tab
  */
-FactoryView.prototype.addCategoryRow = function(name, id, firstCategory) {
+WorkspaceFactoryView.prototype.addCategoryRow =
+    function(name, id, firstCategory) {
   var table = document.getElementById('categoryTable');
   // Delete help label and enable category buttons if it's the first category.
   if (firstCategory) {
@@ -72,7 +73,7 @@ FactoryView.prototype.addCategoryRow = function(name, id, firstCategory) {
  * @param {!string} id ID of category to be deleted.
  * @param {!string} name The name of the category to be deleted.
  */
-FactoryView.prototype.deleteElementRow = function(id, index) {
+WorkspaceFactoryView.prototype.deleteElementRow = function(id, index) {
   // Delete tab entry.
   delete this.tabMap[id];
   // Delete tab row.
@@ -90,7 +91,7 @@ FactoryView.prototype.deleteElementRow = function(id, index) {
  * where categories will appear. Should be called when deleting list elements
  * in case the last element is deleted.
  */
-FactoryView.prototype.addEmptyCategoryMessage = function() {
+WorkspaceFactoryView.prototype.addEmptyCategoryMessage = function() {
   var table = document.getElementById('categoryTable');
   if (table.rows.length == 0) {
     var row = table.insertRow(0);
@@ -110,7 +111,7 @@ FactoryView.prototype.addEmptyCategoryMessage = function() {
  * -1 if no categories created.
  * @param {ListElement} selected The selected ListElement.
  */
-FactoryView.prototype.updateState = function(selectedIndex, selected) {
+WorkspaceFactoryView.prototype.updateState = function(selectedIndex, selected) {
   // Disable/enable editing buttons as necessary.
   document.getElementById('button_editCategory').disabled = selectedIndex < 0 ||
       selected.type != ListElement.TYPE_CATEGORY;
@@ -130,7 +131,7 @@ FactoryView.prototype.updateState = function(selectedIndex, selected) {
  * @param {!string} name Name of category
  * @return {!string} ID of category tab
  */
-FactoryView.prototype.createCategoryIdName = function(name) {
+WorkspaceFactoryView.prototype.createCategoryIdName = function(name) {
   return 'tab_' + name;
 };
 
@@ -141,7 +142,8 @@ FactoryView.prototype.createCategoryIdName = function(name) {
  * @param {boolean} selected True if tab should be on, false if tab should be
  * off.
  */
-FactoryView.prototype.setCategoryTabSelection = function(id, selected) {
+WorkspaceFactoryView.prototype.setCategoryTabSelection =
+    function(id, selected) {
   if (!this.tabMap[id]) {
     return;   // Exit if tab does not exist.
   }
@@ -155,7 +157,7 @@ FactoryView.prototype.setCategoryTabSelection = function(id, selected) {
  * @param {string|!Element} e1 tab element or corresponding id string
  * @param {!Function} func Function to be executed on click
  */
-FactoryView.prototype.bindClick = function(el, func) {
+WorkspaceFactoryView.prototype.bindClick = function(el, func) {
   if (typeof el == 'string') {
     el = document.getElementById(el);
   }
@@ -170,7 +172,8 @@ FactoryView.prototype.bindClick = function(el, func) {
  * @param {!string} filename Name of file
  * @param {!Blob} data Blob containing contents to download
  */
-FactoryView.prototype.createAndDownloadFile = function(filename, data) {
+WorkspaceFactoryView.prototype.createAndDownloadFile =
+    function(filename, data) {
    var clickEvent = new MouseEvent("click", {
      "view": window,
      "bubbles": true,
@@ -191,7 +194,7 @@ FactoryView.prototype.createAndDownloadFile = function(filename, data) {
  * @param {!string} id ID of category to be updated
  *
  */
-FactoryView.prototype.updateCategoryName = function(newName, id) {
+WorkspaceFactoryView.prototype.updateCategoryName = function(newName, id) {
   this.tabMap[id].textContent = newName;
   this.tabMap[id].id = this.createCategoryIdName(newName);
 };
@@ -205,7 +208,8 @@ FactoryView.prototype.updateCategoryName = function(newName, id) {
  * @param {int} newIndex The index to move the category to.
  * @param {int} oldIndex The index the category is currently at.
  */
-FactoryView.prototype.moveTabToIndex = function(id, newIndex, oldIndex) {
+WorkspaceFactoryView.prototype.moveTabToIndex =
+    function(id, newIndex, oldIndex) {
   var table = document.getElementById('categoryTable');
   // Check that indexes are in bounds
   if (newIndex < 0 || newIndex >= table.rows.length || oldIndex < 0 ||
@@ -231,7 +235,7 @@ FactoryView.prototype.moveTabToIndex = function(id, newIndex, oldIndex) {
  * @param {!string} color The color for to be used for the border of the tab.
  * Must be a valid CSS string.
  */
-FactoryView.prototype.setBorderColor = function(id, color) {
+WorkspaceFactoryView.prototype.setBorderColor = function(id, color) {
   var tab = this.tabMap[id];
   tab.style.borderLeftWidth = "8px";
   tab.style.borderLeftStyle = "solid";
@@ -245,7 +249,7 @@ FactoryView.prototype.setBorderColor = function(id, color) {
  * @param {!string} id The ID of the separator.
  * @param {!Element} The td DOM element representing the separator.
  */
-FactoryView.prototype.addSeparatorTab = function(id) {
+WorkspaceFactoryView.prototype.addSeparatorTab = function(id) {
   // Create separator.
   var table = document.getElementById('categoryTable');
   var count = table.rows.length;
@@ -267,7 +271,7 @@ FactoryView.prototype.addSeparatorTab = function(id) {
  * @param {boolean} disable True if the workspace should be disabled, false
  * if it should be enabled.
  */
-FactoryView.prototype.disableWorkspace = function(disable) {
+WorkspaceFactoryView.prototype.disableWorkspace = function(disable) {
   document.getElementById('disable_div').style.zIndex = disable ? 1 : -1;
 };
 
@@ -277,7 +281,7 @@ FactoryView.prototype.disableWorkspace = function(disable) {
  *
  * @return {boolean} True if the workspace should be disabled, false otherwise.
  */
-FactoryView.prototype.shouldDisableWorkspace = function(category) {
+WorkspaceFactoryView.prototype.shouldDisableWorkspace = function(category) {
   return category != null && (category.type == ListElement.TYPE_SEPARATOR ||
       category.custom == 'VARIABLE' || category.custom == 'PROCEDURE');
 };
@@ -286,7 +290,7 @@ FactoryView.prototype.shouldDisableWorkspace = function(category) {
  * Removes all categories and separators in the view. Clears the tabMap to
  * reflect this.
  */
-FactoryView.prototype.clearToolboxTabs = function() {
+WorkspaceFactoryView.prototype.clearToolboxTabs = function() {
   this.tabMap = [];
   var oldCategoryTable = document.getElementById('categoryTable');
   var newCategoryTable = document.createElement('table');
@@ -303,7 +307,7 @@ FactoryView.prototype.clearToolboxTabs = function() {
  * @param {!<Blockly.Block>} blocks Array of user-generated shadow blocks
  * currently loaded.
  */
-FactoryView.prototype.markShadowBlocks = function(blocks) {
+WorkspaceFactoryView.prototype.markShadowBlocks = function(blocks) {
   for (var i = 0; i < blocks.length; i++) {
     this.markShadowBlock(blocks[i]);
   }
@@ -317,7 +321,7 @@ FactoryView.prototype.markShadowBlocks = function(blocks) {
  * @param {!Blockly.Block} block The block that should be marked as a shadow
  *    block (must be rendered).
  */
-FactoryView.prototype.markShadowBlock = function(block) {
+WorkspaceFactoryView.prototype.markShadowBlock = function(block) {
   // Add Blockly CSS for user-generated shadow blocks.
   Blockly.addClass_(block.svgGroup_, 'shadowBlock');
   // If not a valid shadow block, add a warning message.
@@ -333,7 +337,7 @@ FactoryView.prototype.markShadowBlock = function(block) {
  * @param {!Blockly.Block} block The block that should be unmarked as a shadow
  *    block (must be rendered).
  */
-FactoryView.prototype.unmarkShadowBlock = function(block) {
+WorkspaceFactoryView.prototype.unmarkShadowBlock = function(block) {
   // Remove Blockly CSS for user-generated shadow blocks.
   if (Blockly.hasClass_(block.svgGroup_, 'shadowBlock')) {
     Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
@@ -347,7 +351,7 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
  * @param {!string} mode The mode being switched to
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
-FactoryView.prototype.setModeSelection = function(mode) {
+WorkspaceFactoryView.prototype.setModeSelection = function(mode) {
   document.getElementById('tab_preload').className = mode ==
       FactoryController.MODE_PRELOAD ? 'tabon' : 'taboff';
   document.getElementById('preload_div').style.display = mode ==
@@ -364,7 +368,7 @@ FactoryView.prototype.setModeSelection = function(mode) {
  * @param {!string} mode The selected mode (FactoryController.MODE_TOOLBOX or
  *    FactoryController.MODE_PRELOAD).
  */
-FactoryView.prototype.updateHelpText = function(mode) {
+WorkspaceFactoryView.prototype.updateHelpText = function(mode) {
   var helpText = 'Drag your blocks into your ' + (mode ==
       FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
   document.getElementById('editHelpText').textContent = helpText;
@@ -374,7 +378,7 @@ FactoryView.prototype.updateHelpText = function(mode) {
  * Sets the basic options that are not dependent on if there are categories
  * or a single flyout of blocks. Updates checkboxes and text fields.
  */
-FactoryView.prototype.setBaseOptions = function() {
+WorkspaceFactoryView.prototype.setBaseOptions = function() {
   // Set basic options.
   document.getElementById('option_css_checkbox').checked = true;
   document.getElementById('option_maxBlocks_text').value = Infinity;
@@ -412,7 +416,7 @@ FactoryView.prototype.setBaseOptions = function() {
  * @param {boolean} hasCategories True if categories are present, false if all
  *    blocks are displayed in a single flyout.
  */
-FactoryView.prototype.setCategoryOptions = function(hasCategories) {
+WorkspaceFactoryView.prototype.setCategoryOptions = function(hasCategories) {
   document.getElementById('option_collapse_checkbox').checked = hasCategories;
   document.getElementById('option_comments_checkbox').checked = hasCategories;
   document.getElementById('option_disable_checkbox').checked = hasCategories;


### PR DESCRIPTION
Rename FactoryController to WorkspaceFactoryController, FactoryModel to WorkspaceFactoryModel, and FactoryView to WorkspaceFactoryView to distinguish between Block Factory and Workspace Factory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/553)
<!-- Reviewable:end -->
