### PR TITLE
Blockly Factory: getAllUsedBlockTypes in Workspace Factory Model

### DIFF
--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -66,7 +66,8 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
       });
   if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
-    this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
+    this.loadToHiddenWorkspace_(this.model.getSelectedXml());
+    this.appendHiddenWorkspaceToDom_(xmlDom);
   } else {
     // Toolbox has categories.
     // Assert that selected != null
@@ -100,7 +101,8 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
         }
         // Load that category to hidden workspace, setting user-generated shadow
         // blocks as real shadow blocks.
-        this.loadToHiddenWorkspaceAndSave_(element.xml, nextElement);
+        this.loadToHiddenWorkspace_(element.xml);
+        this.appendHiddenWorkspaceToDom_(nextElement);
       }
       xmlDom.appendChild(nextElement);
     }
@@ -127,22 +129,19 @@ FactoryGenerator.prototype.generateWorkspaceXml = function() {
   generatedXml.setAttribute('id', 'preload_blocks');
   generatedXml.setAttribute('style', 'display:none');
   return generatedXml;
- }
+ };
 
 /**
- * Load the given XML to the hidden workspace, set any user-generated shadow
- * blocks to be actual shadow blocks, then append the XML from the workspace
- * to the DOM element passed in.
+ * Loads the given XML to the hidden workspace and sets any user-generated
+ * shadow blocks to be actual shadow blocks.
  * @private
  *
  * @param {!Element} xml The XML to be loaded to the hidden workspace.
- * @param {!Element} dom The DOM element to append the generated XML to.
  */
-FactoryGenerator.prototype.loadToHiddenWorkspaceAndSave_ = function(xml, dom) {
+FactoryGenerator.prototype.loadToHiddenWorkspace_ = function(xml) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
-  this.appendHiddenWorkspaceToDom_(dom);
 }
 
  /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -423,6 +423,50 @@ FactoryModel.prototype.setOptionsAttribute = function(name, value) {
   this.options[name] = value;
 };
 
+/*
+ * Returns an array of all the block types currently being used in the toolbox
+ * and the pre-loaded blocks. No duplicates.
+ * TODO(evd2014): Move pushBlockTypesToList to FactoryUtils.
+ *
+ * @return {!Array<!string>} Array of block types currently being used.
+ */
+FactoryModel.prototype.getAllUsedBlockTypes = function() {
+  var blockTypeList = [];
+
+  // Given XML for the workspace, adds all block types included in the XML
+  // to the list, not including duplicates.
+  var pushBlockTypesToList = function (xml, list) {
+    // Get all block XML nodes.
+    var blocks = xml.getElementsByTagName('block');
+
+    // Add block types if not already in list.
+    for (var i = 0; i < blocks.length; i++) {
+      var type = blocks[i].getAttribute('type');
+      if (list.indexOf(type) == -1) {
+        list.push(type);
+      }
+    }
+  };
+
+  if (this.flyout) {
+    // If has a single flyout, add block types for the single flyout.
+    this.pushBlockTypesToList(this.getSelectedXml(), blockTypeList);
+  } else {
+    // If has categories, add block types for each category.
+
+    for (var i = 0, category; category = this.toolboxList[i]; i++) {
+      if (category.type == ListElement.TYPE_CATEGORY) {
+        this.pushBlockTypesToList(category.xml, blockTypeList);
+      }
+    }
+  }
+
+  // Add the block types from any pre-loaded blocks.
+  this.pushBlockTypesToList(this.getPreloadXml(), blockTypeList);
+
+  return blockTypeList;
+}
+
 /**
  * Class for a ListElement.
  * @constructor


### PR DESCRIPTION
Added method getAllUsedBlockTypes to Workspace Factory model. CL has LGTM from @vicng and @quachtina96 (https://reviewable.io/reviews/evd2014/blockly/42).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/554)
<!-- Reviewable:end -->
