### PR TITLE
Blockly Factory: Warn ONLY if Using Standard Block Name

### DIFF
--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -233,14 +233,13 @@ BlockFactory.updatePreview = function() {
     BlockFactory.previewWorkspace.clearUndo();
     BlockFactory.updateGenerator(previewBlock);
 
-    // Warn user if their block type is already exists in Blockly's standard
+    // Warn user only if their block type is already exists in Blockly's standard
     // library.
     var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
     if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +
           'under this name.');
     } else {
-      // Do not warn.
       rootBlock.setWarningText(null);
     }
   } finally {

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -233,8 +233,8 @@ BlockFactory.updatePreview = function() {
     BlockFactory.previewWorkspace.clearUndo();
     BlockFactory.updateGenerator(previewBlock);
 
-    // Warn user only if their block type is already exists in Blockly's standard
-    // library.
+    // Warn user only if their block type is already exists in Blockly's
+    // standard library.
     var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
     if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -235,10 +235,13 @@ BlockFactory.updatePreview = function() {
 
     // Warn user if their block type is already exists in Blockly's standard
     // library.
+    var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
     if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
-      var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +
           'under this name.');
+    } else {
+      // Do not warn.
+      rootBlock.setWarningText(null);
     }
   } finally {
     Blockly.Blocks = backupBlocks;


### PR DESCRIPTION
Block Factory adds warning text when a user's custom block shares the same type as a standard block. This pull requests removes the warning text after the user addresses the issue.

<img width="438" alt="screen shot 2016-08-17 at 6 56 22 pm" src="https://cloud.githubusercontent.com/assets/10423718/17759527/9059c99e-64ac-11e6-8767-b997d3f7b7df.png">
<img width="556" alt="screen shot 2016-08-17 at 6 56 28 pm" src="https://cloud.githubusercontent.com/assets/10423718/17759528/92f821fa-64ac-11e6-9be0-ff8e28a9b628.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/567)
<!-- Reviewable:end -->
