### PR TITLE
Blockly Factory: Added Exporter Options for Workspace Factory

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -53,7 +53,8 @@ AppController = function() {
 
   // Initialize Block Exporter
   this.exporter =
-      new BlockExporterController(this.blockLibraryController.storage);
+      new BlockExporterController(this.blockLibraryController.storage,
+      this.workspaceFactoryController.generator);
 
   // Map of tab type to the div element for the tab.
   this.tabMap = {
@@ -341,7 +342,6 @@ AppController.prototype.assignExporterClickHandlers = function() {
 
   document.getElementById('dropdown_addAllUsed').addEventListener('click',
       function() {
-        self.exporter.export();
         document.getElementById('dropdownDiv_setBlocks').classList.remove("show");
       });
 
@@ -355,6 +355,11 @@ AppController.prototype.assignExporterClickHandlers = function() {
       function() {
         self.exporter.addAllBlocksToWorkspace();
         document.getElementById('dropdownDiv_setBlocks').classList.remove("show");
+      });
+
+  document.getElementById('exporterSubmitButton').addEventListener('click',
+      function() {
+        self.exporter.export();
       });
 };
 

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -168,7 +168,7 @@ BlockExporterController.prototype.export = function() {
       // User needs to enter filename.
       alert('Please enter a filename for your workspace options download.');
     } else {
-      // Get Blockly options object to donwload.
+      // Get Blockly options object to download.
       // TODO(evd2014): Prettify JSON by parsing with regex.
       var options = JSON.stringify(this.workspaceGenerator.getOptions());
       // Download the file.

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -41,8 +41,10 @@ goog.require('goog.dom.xml');
  * @constructor
  *
  * @param {!BlockLibrary.Storage} blockLibStorage - Block Library Storage.
+ * @param {!WorkspaceFactoryGenerator} workspaceGenerator - Generator for
+ *    workspace factory.
  */
-BlockExporterController = function(blockLibStorage) {
+BlockExporterController = function(blockLibStorage, workspaceGenerator) {
   // BlockLibrary.Storage object containing user's saved blocks
   this.blockLibStorage = blockLibStorage;
   // Utils for generating code to export
@@ -51,6 +53,8 @@ BlockExporterController = function(blockLibStorage) {
   this.view = new BlockExporterView(
       //Xml representation of the toolbox
       this.tools.generateToolboxFromLibrary(this.blockLibStorage));
+  // Generator for workspace factory.
+  this.workspaceGenerator = workspaceGenerator;
 };
 
 /**
@@ -101,12 +105,21 @@ BlockExporterController.prototype.export = function() {
   var blockTypes = this.getSelectedBlockTypes_();
   var blockXmlMap = this.blockLibStorage.getBlockXmlMap(blockTypes);
 
-  // Pull workspace-related settings from the Export Settings form.
+  // Pull toolbox settings from the Export Settings form.
   var wantToolbox = document.getElementById('toolboxCheck').checked;
+  var toolbox_filename = document.getElementById('toolbox_filename').value;
+
+  // Pull pre-loaded workspace blocks settings from Export Settings form.
   var wantPreloadedWorkspace =
       document.getElementById('preloadedWorkspaceCheck').checked;
+  var preloadedWorkspace_filename =
+      document.getElementById('preloadedWorkspace_filename').value;
+
+  // Pull workspace inject options from Export Settings form.
   var wantWorkspaceOptions =
       document.getElementById('workspaceOptsCheck').checked;
+  var workspaceOptions_filename =
+      document.getElementById('workspaceOpts_filename').value;
 
   // Pull block definition(s) settings from the Export Settings form.
   var wantBlockDef = document.getElementById('blockDefCheck').checked;
@@ -120,18 +133,48 @@ BlockExporterController.prototype.export = function() {
       'generatorStub_filename').value;
 
   if (wantToolbox) {
-    // TODO(quachtina96): create and download file once wfactory has been
-    // integrated.
+    // User wants to export toolbox.
+    if (!toolbox_filename) {
+      // User needs to enter filename.
+      alert('Please enter a filename for your toolbox download.');
+    } else {
+      // Get toolbox XML to download.
+      var toolboxXml = Blockly.Xml.domToPrettyText
+          (this.workspaceGenerator.generateToolboxXml());
+      // Download the file.
+      FactoryUtils.createAndDownloadFile(
+          toolboxXml, toolbox_filename, 'text/xml');
+    }
   }
 
   if (wantPreloadedWorkspace) {
-    // TODO(quachtina96): create and download file once wfactory has been
-    // integrated.
+    // User wants to export pre-loaded blocks.
+    if (!preloadedWorkspace_filename) {
+      // User needs to enter filename.
+      alert('Please enter a filename for your pre-loaded workspace download.');
+    } else {
+      // Get pre-loaded block XML to download.
+      var workspaceXml = Blockly.Xml.domToPrettyText
+          (this.workspaceGenerator.generateWorkspaceXml());
+      // Download the file.
+      FactoryUtils.createAndDownloadFile(
+          workspaceXml, preloadedWorkspace_filename, 'text/xml');
+    }
   }
 
   if (wantWorkspaceOptions) {
-    // TODO(quachtina96): create and download file once wfactory has been
-    // integrated.
+    // User wants to export workspace options.
+    if (!workspaceOptions_filename) {
+      // User needs to enter filename.
+      alert('Please enter a filename for your workspace options download.');
+    } else {
+      // Get Blockly options object to donwload.
+      // TODO(evd2014): Prettify JSON by parsing with regex.
+      var options = JSON.stringify(this.workspaceGenerator.getOptions());
+      // Download the file.
+      FactoryUtils.createAndDownloadFile(
+          options, workspaceOptions_filename, 'text/json');
+    }
   }
 
   if (wantBlockDef) {

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -79,13 +79,19 @@
       <br>
       <form id="exportSettingsForm">
         Toolbox Xml:
-        <input type="checkbox" id="toolboxCheck">
+        <input type="checkbox" id="toolboxCheck"><br>
+        Toolbox File Name: <br>
+        <input type="text" id="toolbox_filename"><br>
         <br>
         Pre-loaded Workspace:
-        <input type="checkbox" id="preloadedWorkspaceCheck">
+        <input type="checkbox" id="preloadedWorkspaceCheck"><br>
+        Pre-loaded Workspace File Name: <br>
+        <input type="text" id="preloadedWorkspace_filename"><br>
         <br>
-        Workspace Option(s):
-        <input type="checkbox" id="workspaceOptsCheck">
+        Workspace Options:
+        <input type="checkbox" id="workspaceOptsCheck"><br>
+        Workspace Options File Name: <br>
+        <input type="text" id="workspaceOpts_filename"><br>
         <br>
         <br>
         Block Definition(s):

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -359,9 +359,6 @@ WorkspaceFactoryController.prototype.exportOptionsFile = function() {
   if (!fileName) {  // If cancelled.
     return;
   }
-  // Generate new options to remove toolbox XML from options object (if
-  // necessary).
-  this.generateNewOptions();
   // TODO(evd2014): Use Regex to prettify JSON generated.
   var data = new Blob([JSON.stringify(this.model.options)],
       {type: 'text/plain'});
@@ -461,6 +458,7 @@ WorkspaceFactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
   this.model.setOptionsAttribute('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
+  this.model.removeOptionsAttribute('toolbox');
   Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
       this.previewWorkspace);
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -456,9 +456,16 @@ WorkspaceFactoryController.prototype.saveStateFromWorkspace = function() {
  */
 WorkspaceFactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
+
+  // Add the toolbox attribute for the Blockly inject call to ensure that a
+  // toolbox or single flyout is created as necessary. Remove toolbox attribute
+  // afterwards so that when options are exported, the toolbox attribute is
+  // not there (assumed that the user will want to store the toolbox XML
+  // elsewhere).
   this.model.setOptionsAttribute('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
   this.model.removeOptionsAttribute('toolbox');
+
   Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
       this.previewWorkspace);
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -132,6 +132,15 @@ WorkspaceFactoryGenerator.prototype.generateWorkspaceXml = function() {
  };
 
 /**
+ * Get the configured options object to be used to inject a workspace.
+ *
+ * @return {!Object} Blockly options object.
+ */
+WorkspaceFactoryGenerator.prototype.getOptions = function() {
+  return this.model.options;
+};
+
+/**
  * Loads the given XML to the hidden workspace and sets any user-generated
  * shadow blocks to be actual shadow blocks.
  * @private

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -424,6 +424,15 @@ WorkspaceFactoryModel.prototype.setOptionsAttribute = function(name, value) {
   this.options[name] = value;
 };
 
+/**
+ * Removes an attribute of the options object.
+ *
+ * @param {!string} name Name of the attribute to delete.
+ */
+WorkspaceFactoryModel.prototype.removeOptionsAttribute = function(name) {
+  delete this.options[name];
+};
+
 /*
  * Returns an array of all the block types currently being used in the toolbox
  * and the pre-loaded blocks. No duplicates.


### PR DESCRIPTION
Added Workspace Factory export options to the Exporter, allowing the user to export their toolbox XML, pre-loaded blocks XML, and options object from the Exporter. 

![exporter](https://cloud.githubusercontent.com/assets/18580768/17786589/5c4bb106-653a-11e6-8a32-2e8b60778ff1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/569)
<!-- Reviewable:end -->
