### PR TITLE
Block Factory: Nit UI Changes

### DIFF
--- a/demos/blocklyfactory/block_exporter_view.js
+++ b/demos/blocklyfactory/block_exporter_view.js
@@ -103,8 +103,8 @@ BlockExporterView.prototype.updateHelperText = function(newText, opt_append) {
  * @param {!Array.<string>} selectedBlockTypes - Array of blocks selected in workspace.
  */
 BlockExporterView.prototype.listSelectedBlocks = function(selectedBlockTypes) {
-  var selectedBlocksText = selectedBlockTypes.join(', ');
-  this.updateHelperText('Currently Selected: ' + selectedBlocksText);
+  var selectedBlocksText = selectedBlockTypes.join(",\n ");
+  goog.dom.getElement('selectedBlocksText').textContent = selectedBlocksText;
 };
 
 /**

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -164,7 +164,7 @@ button, .buttonStyle {
   visibility: hidden;
 }
 
-#toolbox {
+.toolbox {
   display: none;
 }
 
@@ -415,5 +415,3 @@ td {
 .shadowBlock>.blocklyPathDark {
   display: none;
 }
-
->>>>>>> Starting to integrate workspacefactory

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -191,7 +191,7 @@ button, .buttonStyle {
 #exportSelector {
   display: inline-block;
   float: left;
-  height: 75%;
+  height: 60%;
   width: 30%;
 }
 

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -199,7 +199,23 @@ button, .buttonStyle {
   float: left;
   overflow: hidden;
   padding-left: 16px;
-  width: 30%;
+  width: 20%;
+}
+
+#selectedBlocksTextContainer {
+  max-height: 200px;
+  overflow-y: scroll;
+  padding-bottom: 2em;
+}
+
+::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+}
+::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: #ccc;
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
 #exporterHiddenWorkspace {

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -56,6 +56,7 @@
   <!-- Exporter tab -->
   <div id="blockLibraryExporter">
     <div id="exportSelector">
+      <br>
       <h3> Block Selector </h3>
       <p id="helperText"> Select blocks from your block library by dragging them into your workspace.
         <br>
@@ -78,6 +79,7 @@
 
     <!-- Users may customize export settings through this form -->
     <div id="exportSettings">
+      <br>
       <h3> Export Settings </h3>
       <br>
       <form id="exportSettingsForm">
@@ -118,6 +120,7 @@
         <button id="exporterSubmitButton"> Export </button>
     </div>
     <div id="exportPreview">
+      <br>
       <h3>Preview Workspace: </h3>
       <div id="exportpreview_blocks">
       </div>
@@ -363,7 +366,7 @@
       </td>
   </table>
 
-  <xml id="blockfactory_toolbox">
+  <xml id="blockfactory_toolbox" class="toolbox">
     <category name="Input">
       <block type="input_value">
         <value name="TYPE">
@@ -415,7 +418,7 @@
     </category>
   </xml>
 
-  <xml id="workspacefactory_toolbox" style="display: none">
+  <xml id="workspacefactory_toolbox" class="toolbox">
     <category name="Logic" colour="210">
       <block type="controls_if"></block>
       <block type="logic_compare"></block>

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -276,7 +276,7 @@
             </button>
             <button id="createNewBlockButton" title="Create a new block.">
               <span> Create Block</span>
-             </button>
+            </button>
             </td>
           </tr>
         </table>

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -55,14 +55,12 @@
 
   <!-- Exporter tab -->
   <div id="blockLibraryExporter">
+    <br>
+    <p id="helperText"> First, select blocks from your block library by dragging them into your workspace. Then, use the Export Settings form to download starter code for selected blocks.
+    </p>
     <div id="exportSelector">
       <br>
       <h3> Block Selector </h3>
-      <p id="helperText"> Select blocks from your block library by dragging them into your workspace.
-        <br>
-        <br>
-       Use the Export Settings form to download starter code for selected blocks.
-      </p>
       <div class='dropdown'>
         <button id="button_setBlocks">Select From Library</button>
         <div id="dropdownDiv_setBlocks" class="dropdown-content">
@@ -83,16 +81,10 @@
       <h3> Export Settings </h3>
       <br>
       <form id="exportSettingsForm">
-        Toolbox Xml:
-        <input type="checkbox" id="toolboxCheck">
-        <br>
-        Pre-loaded Workspace:
-        <input type="checkbox" id="preloadedWorkspaceCheck">
-        <br>
-        Workspace Option(s):
-        <input type="checkbox" id="workspaceOptsCheck">
-        <br>
-        <br>
+        <div id="selectedBlocksTextContainer">
+          <p>Currently Selected:</p>
+          <p id="selectedBlocksText"></p>
+        </div>
         Block Definition(s):
         <input type="checkbox" id="blockDefCheck"><br>
               Language code:

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -53,20 +53,23 @@
     <div id="blocklibraryExporter_tab" class="tab taboff"> Exporter</div>
   </div>
 
-
   <!-- Exporter tab -->
   <div id="blockLibraryExporter">
     <div id="exportSelector">
       <h3> Block Selector </h3>
-      <p id="helperText"> Drag blocks into your workspace to select them for download.</p>
-        <div class='dropdown'>
-        <button id="button_setBlocks">Select</button>
+      <p id="helperText"> Select blocks from your block library by dragging them into your workspace.
+        <br>
+        <br>
+       Use the Export Settings form to download starter code for selected blocks.
+      </p>
+      <div class='dropdown'>
+        <button id="button_setBlocks">Select From Library</button>
         <div id="dropdownDiv_setBlocks" class="dropdown-content">
           <a id='dropdown_addAllFromLib'>All Stored</a>
           <a id='dropdown_addAllUsed'>All Used</a>
           <a id='dropdown_clearSelected'>Remove All</a>
         </div>
-        </div>
+      </div>
 
       <!-- Inject exportSelectorWorkspace into this div -->
       <div id="selectorWorkspace"></div>
@@ -268,9 +271,9 @@
             <button id="removeBlockFromLibraryButton" title="Remove block from Block Library.">
               <span>Delete Block</span>
             </button>
-            <button id="clearBlockLibraryButton" title="Clear Block Library.">
-              <span>Clear Library</span>
-            </button>
+            <button id="createNewBlockButton" title="Create a new block.">
+              <span> Create Block</span>
+             </button>
             </td>
           </tr>
         </table>
@@ -293,8 +296,8 @@
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
-              <button id="createNewBlockButton" title="Create a new block.">
-                <span> Create Block</span>
+              <button id="clearBlockLibraryButton" title="Clear Block Library.">
+                <span>Clear Library</span>
               </button>
               <label for="files" class="buttonStyle">
                 <span class=>Import Block Library</span>


### PR DESCRIPTION
### All the "Block" buttons are grouped on the left and all "Block Library" buttons are grouped on right.
<img width="1440" alt="screen shot 2016-08-18 at 11 42 25 pm" src="https://cloud.githubusercontent.com/assets/10423718/17801254/b603e566-659d-11e6-8808-cce68f7174d6.png">

### Helper text is now more detailed. 'Select From Library' rather than 'Select'. Block Selector fits better on page.
<img width="1437" alt="screen shot 2016-08-18 at 11 42 44 pm" src="https://cloud.githubusercontent.com/assets/10423718/17801270/cff3f6c8-659d-11e6-9d81-5eb253e59894.png">

<img width="1431" alt="screen shot 2016-08-18 at 11 43 14 pm" src="https://cloud.githubusercontent.com/assets/10423718/17801297/0d6ee878-659e-11e6-9a1b-2da45b311683.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/570)
<!-- Reviewable:end -->
