### PR TITLE
Changed workspace metrics depending on flyout metrics

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -413,7 +413,7 @@ Blockly.hideChaff = function(opt_allowToolbox) {
   }
 };
 
-/**
+/*
  * When something in Blockly's workspace changes, call a function.
  * @param {!Function} func Function to call.
  * @return {!Array.<!Array>} Opaque data that can be passed to

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -435,15 +435,19 @@ Blockly.Flyout.prototype.position = function() {
       targetWorkspaceMetrics.viewHeight);
 
   var x = targetWorkspaceMetrics.absoluteLeft;
+  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+    x -= this.width;
+  }
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT) {
     x += targetWorkspaceMetrics.viewWidth;
-    x -= this.width_;
   }
 
   var y = targetWorkspaceMetrics.absoluteTop;
+  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+    y -= this.height;
+  }
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_BOTTOM) {
     y += targetWorkspaceMetrics.viewHeight;
-    y -= this.height_;
   }
 
   this.svgGroup_.setAttribute('transform', 'translate(' + x + ',' + y + ')');

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -436,7 +436,7 @@ Blockly.Flyout.prototype.position = function() {
 
   var x = targetWorkspaceMetrics.absoluteLeft;
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
-    x -= this.width;
+    x -= this.width_;
   }
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT) {
     x += targetWorkspaceMetrics.viewWidth;
@@ -444,7 +444,7 @@ Blockly.Flyout.prototype.position = function() {
 
   var y = targetWorkspaceMetrics.absoluteTop;
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
-    y -= this.height;
+    y -= this.height_;
   }
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_BOTTOM) {
     y += targetWorkspaceMetrics.viewHeight;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -249,9 +249,6 @@ Blockly.Trashcan.prototype.position = function() {
   this.top_ = metrics.viewHeight + metrics.absoluteTop -
       (this.BODY_HEIGHT_ + this.LID_HEIGHT_) - this.bottom_;
 
-  if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
-    this.top_ -= metrics.flyoutHeight;
-  }
   this.svgGroup_.setAttribute('transform',
       'translate(' + this.left_ + ',' + this.top_ + ')');
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -245,10 +245,6 @@ Blockly.Trashcan.prototype.position = function() {
   } else {
     this.left_ = metrics.viewWidth + metrics.absoluteLeft -
         this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
-
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-      this.left_ -= metrics.flyoutWidth;
-    }
   }
   this.top_ = metrics.viewHeight + metrics.absoluteTop -
       (this.BODY_HEIGHT_ + this.LID_HEIGHT_) - this.bottom_;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1307,6 +1307,14 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
         this.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
       svgSize.width -= this.toolbox_.getWidth();
     }
+  } else if (this.flyout_) {
+    if (this.toolboxPosition == Blockly.TOOLBOX_AT_TOP ||
+        this.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
+      svgSize.height -= this.flyout_.getHeight();
+    } else if (this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT ||
+        this.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
+      svgSize.width -= this.flyout_.getWidth();
+    }
   }
   // Set the margin to match the flyout's margin so that the workspace does
   // not jump as blocks are added.
@@ -1340,10 +1348,14 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
   var absoluteLeft = 0;
   if (this.toolbox_ && this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
     absoluteLeft = this.toolbox_.getWidth();
+  } else if (this.flyout_ && this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+    absoluteLeft = this.flyout_.getWidth();
   }
   var absoluteTop = 0;
   if (this.toolbox_ && this.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
     absoluteTop = this.toolbox_.getHeight();
+  } else if (this.flyout_ && this.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+    absoluteTop = this.flyout_.getHeight();
   }
 
   var metrics = {

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -227,9 +227,6 @@ Blockly.ZoomControls.prototype.position = function() {
   }
   this.top_ = metrics.viewHeight + metrics.absoluteTop -
       this.HEIGHT_ - this.bottom_;
-  if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
-    this.top_ -= metrics.flyoutHeight;
-  }
   this.svgGroup_.setAttribute('transform',
       'translate(' + this.left_ + ',' + this.top_ + ')');
 };

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -224,10 +224,6 @@ Blockly.ZoomControls.prototype.position = function() {
   } else {
     this.left_ = metrics.viewWidth + metrics.absoluteLeft -
         this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
-
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-      this.left_ -= metrics.flyoutWidth;
-    }
   }
   this.top_ = metrics.viewHeight + metrics.absoluteTop -
       this.HEIGHT_ - this.bottom_;


### PR DESCRIPTION
Changed workspace metrics to depend on flyout metrics in the same way that the workspace metrics depend on the toolbox metrics. Reduces some of the special cases in placing the trashcan and zoom controls. Also a step towards solving the problem of being able to scroll blocks over a single flyout of blocks. 

![scroll blocks](https://cloud.githubusercontent.com/assets/18580768/17827468/500806b2-6632-11e6-9659-9fb555d3e0df.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/576)
<!-- Reviewable:end -->
