### PR TITLE
Blockly Factory: Workspace Factory UI

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -263,7 +263,8 @@ AppController.prototype.addTabHandlers = function(tabMap) {
  * Set the selected tab.
  * @private
  *
- * @param {string} tabName AppController.BLOCK_FACTORY, AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
+ * @param {string} tabName AppController.BLOCK_FACTORY,
+ *    AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
  */
 AppController.prototype.setSelected_ = function(tabName) {
   this.selectedTab = tabName;
@@ -273,7 +274,8 @@ AppController.prototype.setSelected_ = function(tabName) {
  * Creates the tab click handler specific to the tab specified.
  * @private
  *
- * @param {string} tabName AppController.BLOCK_FACTORY, AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
+ * @param {string} tabName AppController.BLOCK_FACTORY,
+ *    AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
  * @return {Function} The tab click handler.
  */
 AppController.prototype.makeTabClickHandler_ = function(tabName) {

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -291,6 +291,8 @@ AppController.prototype.onTab = function() {
   this.styleTabs_();
 
   if (this.selectedTab == 'EXPORTER') {
+    // Disable key events in workspace factory.
+    this.workspaceFactoryController.keyEventsEnabled = false;
     // Update toolbox to reflect current block library.
     this.exporter.updateToolbox();
 
@@ -299,6 +301,8 @@ AppController.prototype.onTab = function() {
     FactoryUtils.hide('workspaceFactoryContent');
 
   } else if (this.selectedTab ==  'BLOCK_FACTORY') {
+    // Disable key events in workspace factory.
+    this.workspaceFactoryController.keyEventsEnabled = false;
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     FactoryUtils.hide('workspaceFactoryContent');
@@ -307,6 +311,8 @@ AppController.prototype.onTab = function() {
     // Update block library category.
     var categoryXml = this.exporter.getBlockLibCategory();
     this.workspaceFactoryController.setBlockLibCategory(categoryXml);
+    // Enable key events.
+    this.workspaceFactoryController.keyEventsEnabled = true;
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.
@@ -466,34 +472,6 @@ AppController.prototype.initializeBlocklyStorage = function() {
 };
 
 /**
- * Adds keydown event listener for workspace factory. Needs to be initialized
- * in app controller instead of workspace factory init so that it can
- * check the selectedTab in app controller.
- */
-AppController.prototype.addWorkspaceFactoryKeyEventListeners = function() {
-  var self = this;
-  var controller = this.workspaceFactoryController;
-
-  // Use up and down arrow keys to move categories.
-  window.addEventListener('keydown', function(e) {
-    // Don't let arrow keys have any effect if not in Workspace Factory
-    // editing the toolbox.
-    if (self.selectedTab != 'WORKSPACE_FACTORY' || controller.selectedMode
-        != WorkspaceFactoryController.MODE_TOOLBOX) {
-      return;
-    }
-
-    if (e.keyCode == 38) {
-      // Arrow up.
-      controller.moveElement(-1);
-    } else if (e.keyCode == 40) {
-      // Arrow down.
-      controller.moveElement(1);
-    }
-  });
-}
-
-/**
  * Initialize Blockly and layout.  Called on page load.
  */
 AppController.prototype.init = function() {
@@ -552,7 +530,6 @@ AppController.prototype.init = function() {
 
   // Workspace Factory init.
   WorkspaceFactoryInit.initWorkspaceFactory(this.workspaceFactoryController);
-  this.addWorkspaceFactoryKeyEventListeners();
 };
 
 

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -56,15 +56,22 @@ AppController = function() {
       new BlockExporterController(this.blockLibraryController.storage);
 
   // Map of tab type to the div element for the tab.
-  this.tabMap = {
-    'BLOCK_FACTORY' : goog.dom.getElement('blockFactory_tab'),
-    'WORKSPACE_FACTORY': goog.dom.getElement('workspaceFactory_tab'),
-    'EXPORTER' : goog.dom.getElement('blocklibraryExporter_tab')
-  };
+  this.tabMap = Object.create(null);
+  this.tabMap[AppController.BLOCK_FACTORY] =
+      goog.dom.getElement('blockFactory_tab');
+  this.tabMap[AppController.WORKSPACE_FACTORY] =
+      goog.dom.getElement('workspaceFactory_tab');
+  this.tabMap[AppController.EXPORTER] =
+      goog.dom.getElement('blocklibraryExporter_tab');
 
   // Selected tab.
-  this.selectedTab = 'BLOCK_FACTORY';
+  this.selectedTab = AppController.BLOCK_FACTORY;
 };
+
+// Constant values representing the three tabs in the controller.
+AppController.BLOCK_FACTORY = 'BLOCK_FACTORY';
+AppController.WORKSPACE_FACTORY = 'WORKSPACE_FACTORY';
+AppController.EXPORTER = 'EXPORTER';
 
 /**
  * Tied to the 'Import Block Library' button. Imports block library from file to
@@ -256,7 +263,7 @@ AppController.prototype.addTabHandlers = function(tabMap) {
  * Set the selected tab.
  * @private
  *
- * @param {string} tabName 'BLOCK_FACTORY', 'WORKSPACE_FACTORY', or 'EXPORTER'
+ * @param {string} tabName AppController.BLOCK_FACTORY, AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
  */
 AppController.prototype.setSelected_ = function(tabName) {
   this.selectedTab = tabName;
@@ -266,7 +273,7 @@ AppController.prototype.setSelected_ = function(tabName) {
  * Creates the tab click handler specific to the tab specified.
  * @private
  *
- * @param {string} tabName 'BLOCK_FACTORY', 'WORKSPACE_FACTORY', or 'EXPORTER'
+ * @param {string} tabName AppController.BLOCK_FACTORY, AppController.WORKSPACE_FACTORY, or AppController.EXPORTER
  * @return {Function} The tab click handler.
  */
 AppController.prototype.makeTabClickHandler_ = function(tabName) {
@@ -283,16 +290,19 @@ AppController.prototype.makeTabClickHandler_ = function(tabName) {
  */
 AppController.prototype.onTab = function() {
   // Get tab div elements.
-  var blockFactoryTab = this.tabMap['BLOCK_FACTORY'];
-  var exporterTab = this.tabMap['EXPORTER'];
-  var workspaceFactoryTab = this.tabMap['WORKSPACE_FACTORY'];
+  var blockFactoryTab = this.tabMap[AppController.BLOCK_FACTORY];
+  var exporterTab = this.tabMap[AppController.EXPORTER];
+  var workspaceFactoryTab = this.tabMap[AppController.WORKSPACE_FACTORY];
 
   // Turn selected tab on and other tabs off.
   this.styleTabs_();
 
-  if (this.selectedTab == 'EXPORTER') {
-    // Disable key events in workspace factory.
-    this.workspaceFactoryController.keyEventsEnabled = false;
+  // Only enable key events in workspace factory if workspace factory tab is
+  // selected.
+  this.workspaceFactoryController.keyEventsEnabled =
+      this.selectedTab == AppController.WORKSPACE_FACTORY;
+
+  if (this.selectedTab == AppController.EXPORTER) {
     // Update toolbox to reflect current block library.
     this.exporter.updateToolbox();
 
@@ -300,19 +310,15 @@ AppController.prototype.onTab = function() {
     FactoryUtils.show('blockLibraryExporter');
     FactoryUtils.hide('workspaceFactoryContent');
 
-  } else if (this.selectedTab ==  'BLOCK_FACTORY') {
-    // Disable key events in workspace factory.
-    this.workspaceFactoryController.keyEventsEnabled = false;
+  } else if (this.selectedTab ==  AppController.BLOCK_FACTORY) {
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     FactoryUtils.hide('workspaceFactoryContent');
 
-  } else if (this.selectedTab == 'WORKSPACE_FACTORY') {
+  } else if (this.selectedTab == AppController.WORKSPACE_FACTORY) {
     // Update block library category.
     var categoryXml = this.exporter.getBlockLibCategory();
     this.workspaceFactoryController.setBlockLibCategory(categoryXml);
-    // Enable key events.
-    this.workspaceFactoryController.keyEventsEnabled = true;
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -466,6 +466,34 @@ AppController.prototype.initializeBlocklyStorage = function() {
 };
 
 /**
+ * Adds keydown event listener for workspace factory. Needs to be initialized
+ * in app controller instead of workspace factory init so that it can
+ * check the selectedTab in app controller.
+ */
+AppController.prototype.addWorkspaceFactoryKeyEventListeners = function() {
+  var self = this;
+  var controller = this.workspaceFactoryController;
+
+  // Use up and down arrow keys to move categories.
+  window.addEventListener('keydown', function(e) {
+    // Don't let arrow keys have any effect if not in Workspace Factory
+    // editing the toolbox.
+    if (self.selectedTab != 'WORKSPACE_FACTORY' || controller.selectedMode
+        != WorkspaceFactoryController.MODE_TOOLBOX) {
+      return;
+    }
+
+    if (e.keyCode == 38) {
+      // Arrow up.
+      controller.moveElement(-1);
+    } else if (e.keyCode == 40) {
+      // Arrow down.
+      controller.moveElement(1);
+    }
+  });
+}
+
+/**
  * Initialize Blockly and layout.  Called on page load.
  */
 AppController.prototype.init = function() {
@@ -524,6 +552,7 @@ AppController.prototype.init = function() {
 
   // Workspace Factory init.
   WorkspaceFactoryInit.initWorkspaceFactory(this.workspaceFactoryController);
+  this.addWorkspaceFactoryKeyEventListeners();
 };
 
 

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -273,8 +273,8 @@ aside {
 }
 
 td.tabon {
-  border-bottom-color: #ddd !important;
-  background-color: #ddd;
+  border-bottom-color: #ccc !important;
+  background-color: #ccc;
   padding: 5px 19px;
 }
 
@@ -305,9 +305,15 @@ td {
   z-index: -1;
 }
 
+#workspaceTabs {
+  background-color: #f8f8f8;
+  border: 1px solid #ccc;
+  display: table;
+}
+
 #toolbox_section {
   height: 480px;
-  width: 80%;
+  width: 60%;
   position: relative;
 }
 
@@ -322,15 +328,21 @@ td {
 }
 
 #createDiv {
-  width: 70%;
+  padding: 0.5%;
+  width: 60%;
 }
 
 #previewDiv {
-  width: 30%;
+  padding: 0.5%;
+  width: 36%;
 }
 
 #toolbox_div, #preload_div {
-  width: 20%;
+  width: 40%;
+}
+
+#tab_categoryHeader {
+  border-bottom: 1px solid black;
 }
 
 #disable_div {

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -275,7 +275,7 @@ aside {
 
 td.tabon {
   background-color: #ccc;
-  border-bottom-color: #ccc !important;
+  border-bottom-color: #ccc;
   padding: 5px 19px;
 }
 

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -324,7 +324,7 @@ td {
 }
 
 #preview_blocks {
-  height: 300px;
+  height: 395px;
   width: 100%;
 }
 
@@ -334,14 +334,14 @@ td {
 }
 
 #previewDiv {
-  border: 4px solid #eee;
+  border: 10px solid #eee;
   margin-right: 0.5%;
   width: 35%;
 }
 
 #previewBorder {
-  border: 2px solid #ddd;
-  padding: 1%;
+  border: 5px solid #ddd;
+  padding: 2%;
 }
 
 #toolbox_div, #preload_div {
@@ -352,12 +352,6 @@ td {
 #workspace_options {
   max-height: 250px;
   overflow-y: scroll;
-}
-
-#tab_categoryHeader {
-  border-bottom: 1px solid black;
-  height: 8px;
-  padding: 5px;
 }
 
 #disable_div {

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -274,8 +274,8 @@ aside {
 }
 
 td.tabon {
-  border-bottom-color: #ccc !important;
   background-color: #ccc;
+  border-bottom-color: #ccc !important;
   padding: 5px 19px;
 }
 
@@ -357,6 +357,7 @@ td {
 #tab_categoryHeader {
   border-bottom: 1px solid black;
   height: 8px;
+  padding: 5px;
 }
 
 #disable_div {

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -343,6 +343,7 @@ td {
 
 #tab_categoryHeader {
   border-bottom: 1px solid black;
+  height: 8px;
 }
 
 #disable_div {

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -20,6 +20,7 @@
 
 html, body {
   height: 100%;
+  min-height: 375px;
 }
 
 body {
@@ -312,7 +313,7 @@ td {
 }
 
 #toolbox_section {
-  height: 480px;
+  height: 405px;
   width: 60%;
   position: relative;
 }
@@ -333,12 +334,24 @@ td {
 }
 
 #previewDiv {
-  padding: 0.5%;
-  width: 36%;
+  border: 4px solid #eee;
+  margin-right: 0.5%;
+  width: 35%;
+}
+
+#previewBorder {
+  border: 2px solid #ddd;
+  padding: 1%;
 }
 
 #toolbox_div, #preload_div {
-  width: 40%;
+  margin-right: 5%;
+  width: 35%;
+}
+
+#workspace_options {
+  max-height: 250px;
+  overflow-y: scroll;
 }
 
 #tab_categoryHeader {

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -211,7 +211,7 @@
 
       <aside id='preload_div' style='display:none'>
         <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
-        <button class="small" id="button_standardOptions">Standard Options</button>
+        <button class="small" id="button_standardOptions">Reset Options</button>
         <form id="workspace_options">
           <input type="checkbox" id="option_collapse_checkbox" class="optionsInput">Collapsible Blocks<br>
           <input type="checkbox" id="option_comments_checkbox" class="optionsInput">Comments for Blocks<br>
@@ -247,9 +247,11 @@
     </section>
 
     <aside id="previewDiv">
-      <h3>Preview</h3>
-      <p>This is what your custom workspace will look like.</p>
-      <div id="preview_blocks" class="content"></div>
+      <div id="previewBorder">
+        <h3>Preview</h3>
+        <p>This is what your custom workspace will look like.</p>
+        <div id="preview_blocks" class="content"></div>
+      </div>
     </aside>
   </div>
 

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -169,10 +169,8 @@
         <div id='disable_div'></div>
       </section>
       <aside id="toolbox_div">
+        <p id="categoryHeader">Your categories will appear here</p>
         <table id="categoryTable" style="width:auto">
-          <tr>
-            <td id="tab_help">Your categories will appear here</td>
-          </tr>
         </table>
         <p>&nbsp;</p>
 

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -153,13 +153,13 @@
           </div>
         </div>
 
-      <button id="button_print">Print Toolbox</button>
-      <button id="button_clear">Clear Toolbox</button>
+        <button id="button_clear">Clear</button>
+
     </p>
 
     <section id="createDiv">
-      <h3>Workspace Editor:</h3>
-      <p id="editHelpText">Drag blocks into your toolbox:</p>
+      <h3>Edit</h3>
+      <p id="editHelpText">Drag blocks into the workspace to configure the toolbox in your custom workspace.</p>
       <table id='workspaceTabs' style="width:auto">
         <td id="tab_toolbox" class="tabon">Toolbox</td>
         <td id="tab_preload" class="taboff">Workspace</td>
@@ -188,7 +188,7 @@
         <button id="button_up" class="large">&#8593;</button>
         <button id="button_down" class="large">&#8595;</button>
 
-        <p>&nbsp;</p>
+        <br>
         <div class='dropdown'>
         <button id="button_editCategory">Edit Category</button>
         <div id="dropdownDiv_editCategory" class="dropdown-content">
@@ -247,7 +247,8 @@
     </section>
 
     <aside id="previewDiv">
-      <h3>Preview Workspace:</h3>
+      <h3>Preview</h3>
+      <p>This is what your custom workspace will look like.</p>
       <div id="preview_blocks" class="content"></div>
     </aside>
   </div>

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -170,7 +170,9 @@
       </section>
       <aside id="toolbox_div">
         <table id="categoryTable" style="width:auto">
-          <td id="tab_help">Your categories will appear here</td>
+          <tr>
+            <td id="tab_help">Your categories will appear here</td>
+          </tr>
         </table>
         <p>&nbsp;</p>
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -399,8 +399,12 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
-    this.previewWorkspace.updateToolbox(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
+
+    // Only update the toolbox if not in read only mode.
+    if (!this.model.options['readOnly']) {
+      this.previewWorkspace.updateToolbox(Blockly.Options.parseToolboxTree
+          (this.generator.generateToolboxXml()));
+    }
 
     // Update pre-loaded blocks in the preview workspace to make sure that
     // blocks don't get cleared when updating preview from event listeners while

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -707,9 +707,9 @@ WorkspaceFactoryController.prototype.importFile = function(file, importMode) {
         // Throw error if invalid mode.
         throw new Error("Unknown import mode: " + importMode);
       }
-     // } catch(e) {
-     //   alert('Cannot load XML from file.');
-     //   console.log(e);
+      } catch(e) {
+        alert('Cannot load XML from file.');
+        console.log(e);
      } finally {
       Blockly.Events.enable();
      }

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -828,15 +828,15 @@ WorkspaceFactoryController.prototype.importPreloadFromTree_ = function(tree) {
 }
 
 /**
- * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view. Sets the mode to toolbox mode. Tied to "Clear
- * Toolbox" button.
+ * Clears the editing area completely, deleting all categories and all
+ * blocks in the model and view and all pre-loaded blocks. Tied to the
+ * "Clear" button.
  */
-WorkspaceFactoryController.prototype.clearToolbox = function() {
-  this.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
+WorkspaceFactoryController.prototype.clearAll = function() {
   var hasCategories = this.model.hasElements();
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
+  this.model.savePreloadXml(Blockly.Xml.textToDom('<xml></xml>'));
   this.view.addEmptyCategoryMessage();
   this.view.updateState(-1, null);
   this.toolboxWorkspace.clear();
@@ -998,8 +998,6 @@ WorkspaceFactoryController.prototype.setMode = function(mode) {
 
   if (mode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your toolbox:';
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     this.clearAndLoadXml_(this.model.getSelectedXml());
@@ -1007,8 +1005,6 @@ WorkspaceFactoryController.prototype.setMode = function(mode) {
         (this.model.getSelected()));
   } else {
     // Open the pre-loaded workspace editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your pre-loaded workspace:';
     if (this.model.getSelected()) {
       this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
     }

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -398,7 +398,9 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
   Blockly.Events.disable();
 
   if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
-    // If currently editing the toolbox.
+    this.previewWorkspace.updateToolbox(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+    /*// If currently editing the toolbox.
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml());
@@ -417,7 +419,7 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
       } else {
         this.previewWorkspace.toolbox_.populate_(tree);
       }
-    }
+    }*/
 
     // Update pre-loaded blocks in the preview workspace to make sure that
     // blocks don't get cleared when updating preview from event listeners while

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -398,28 +398,9 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
   Blockly.Events.disable();
 
   if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
+    // If currently editing the toolbox.
     this.previewWorkspace.updateToolbox(Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml()));
-    /*// If currently editing the toolbox.
-    // Get toolbox XML.
-    var tree = Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml());
-    // No categories, creates a simple flyout.
-    if (tree.getElementsByTagName('category').length == 0) {
-      // No categories, creates a simple flyout.
-      if (this.previewWorkspace.toolbox_) {
-        this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
-      } else {
-        this.previewWorkspace.flyout_.show(tree.childNodes);
-      }
-    } else {
-      // Uses categories, creates a toolbox.
-      if (!this.previewWorkspace.toolbox_) {
-        this.reinjectPreview(tree); // Create a toolbox, more expensive.
-      } else {
-        this.previewWorkspace.toolbox_.populate_(tree);
-      }
-    }*/
 
     // Update pre-loaded blocks in the preview workspace to make sure that
     // blocks don't get cleared when updating preview from event listeners while
@@ -427,6 +408,7 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
+
   } else if (this.selectedMode == WorkspaceFactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
@@ -774,8 +756,6 @@ WorkspaceFactoryController.prototype.importToolboxFromTree_ = function(tree) {
   }
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());
-
-  this.saveStateFromWorkspace();
 
   this.saveStateFromWorkspace();
   // Allow the user to set default configuration options for a single flyout

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -391,8 +391,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
   window.addEventListener('keydown', function(e) {
     // Don't let arrow keys have any effect if not in Workspace Factory
     // editing the toolbox.
-    if (!controller.keyEventsEnabled || controller.selectedMode
-        != WorkspaceFactoryController.MODE_TOOLBOX) {
+    if (!(controller.keyEventsEnabled && controller.selectedMode
+        == WorkspaceFactoryController.MODE_TOOLBOX)) {
       return;
     }
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -235,12 +235,6 @@ WorkspaceFactoryInit.assignWorkspaceFactoryClickHandlers_ =
         document.getElementById('dropdownDiv_load').classList.remove("show");
         document.getElementById('dropdownDiv_importBlocks').classList.
             remove("show");
-      })
-
-  document.getElementById('button_print').addEventListener
-      ('click',
-      function() {
-        controller.printConfig();
       });
 
   document.getElementById('button_up').addEventListener
@@ -351,11 +345,11 @@ document.getElementById('button_importBlocks').addEventListener
   document.getElementById('button_clear').addEventListener
       ('click',
       function() {
-        controller.clearToolbox();
         document.getElementById('dropdownDiv_importBlocks').classList.
             remove("show");
         document.getElementById('dropdownDiv_export').classList.remove("show");
         document.getElementById('dropdownDiv_load').classList.remove("show");
+        controller.clearAll();
       });
 
   document.getElementById('dropdown_addShadow').addEventListener

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -387,6 +387,24 @@ document.getElementById('button_importBlocks').addEventListener
  *    factory tab.
  */
 WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
+  // Use up and down arrow keys to move categories.
+  window.addEventListener('keydown', function(e) {
+    // Don't let arrow keys have any effect if not in Workspace Factory
+    // editing the toolbox.
+    if (!controller.keyEventsEnabled || controller.selectedMode
+        != WorkspaceFactoryController.MODE_TOOLBOX) {
+      return;
+    }
+
+    if (e.keyCode == 38) {
+      // Arrow up.
+      controller.moveElement(-1);
+    } else if (e.keyCode == 40) {
+      // Arrow down.
+      controller.moveElement(1);
+    }
+  });
+
   // Determines if a block breaks shadow block placement rules.
   // Breaks rules if (1) a shadow block no longer has a valid
   // parent, or (2) a normal block is inside of a shadow block.
@@ -395,7 +413,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         !block.getSurroundParent()) ||
         (!controller.isUserGenShadowBlock(block.id) && block.getSurroundParent()
         && controller.isUserGenShadowBlock(block.getSurroundParent().id)));
-  }
+  };
 
   // Add change listeners for toolbox workspace in workspace factory.
   controller.toolboxWorkspace.addChangeListener(function(e) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -387,19 +387,6 @@ document.getElementById('button_importBlocks').addEventListener
  *    factory tab.
  */
 WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
-  // Use up and down arrow keys to move categories.
-  // TODO(evd2014): When merge with next CL for editing preloaded blocks, make
-  // sure mode is toolbox.
-  window.addEventListener('keydown', function(e) {
-    if (this.selectedTab != 'WORKSPACE_FACTORY' && e.keyCode == 38) {
-      // Arrow up.
-      controller.moveElement(-1);
-    } else if (this.selectedTab != 'WORKSPACE_FACTORY' && e.keyCode == 40) {
-      // Arrow down.
-      controller.moveElement(1);
-    }
-  });
-
   // Determines if a block breaks shadow block placement rules.
   // Breaks rules if (1) a shadow block no longer has a valid
   // parent, or (2) a normal block is inside of a shadow block.

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -52,8 +52,9 @@ WorkspaceFactoryView.prototype.addCategoryRow =
   var table = document.getElementById('categoryTable');
   // Delete help label and enable category buttons if it's the first category.
   if (firstCategory) {
-    table.rows[0].textContent = 'Categories: ';
-    table.rows[0].id = 'tab_categoryHeader';
+    var labelTab = table.rows[0].cells[0];
+    labelTab.textContent = 'Your Categories:';
+    labelTab.id = 'tab_categoryHeader';
   }
   // Create tab.
   var count = table.rows.length;
@@ -95,8 +96,9 @@ WorkspaceFactoryView.prototype.deleteElementRow = function(id, index) {
 WorkspaceFactoryView.prototype.addEmptyCategoryMessage = function() {
   var table = document.getElementById('categoryTable');
   if (table.rows.length == 1) {
-    table.rows[0].textContent = 'Your categories will appear here';
-    table.rows[0].id = 'tab_help';
+    var helpLabel = table.rows[0].cells[0];
+    helpLabel.textContent = 'Your categories will appear here';
+    helpLabel.id = 'tab_help';
   }
 }
 
@@ -218,13 +220,13 @@ WorkspaceFactoryView.prototype.moveTabToIndex =
     throw new Error('Index out of bounds when moving tab in the view.');
   }
   if (newIndex < oldIndex) {  // Inserting before.
-    var row = table.insertRow(newIndex);
-    row.appendChild(this.tabMap[id]);
-    table.deleteRow(oldIndex + 1);
-  } else {  // Inserting after.
     var row = table.insertRow(newIndex + 1);
     row.appendChild(this.tabMap[id]);
-    table.deleteRow(oldIndex);
+    table.deleteRow(oldIndex + 2);
+  } else {  // Inserting after.
+    var row = table.insertRow(newIndex + 2);
+    row.appendChild(this.tabMap[id]);
+    table.deleteRow(oldIndex + 1);
   }
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -52,7 +52,8 @@ WorkspaceFactoryView.prototype.addCategoryRow =
   var table = document.getElementById('categoryTable');
   // Delete help label and enable category buttons if it's the first category.
   if (firstCategory) {
-    table.deleteRow(0);
+    table.rows[0].textContent = 'Categories: ';
+    table.rows[0].id = 'tab_categoryHeader';
   }
   // Create tab.
   var count = table.rows.length;
@@ -93,9 +94,9 @@ WorkspaceFactoryView.prototype.deleteElementRow = function(id, index) {
  */
 WorkspaceFactoryView.prototype.addEmptyCategoryMessage = function() {
   var table = document.getElementById('categoryTable');
-  if (table.rows.length == 0) {
-    var row = table.insertRow(0);
-    row.textContent = 'Your categories will appear here';
+  if (table.rows.length == 1) {
+    table.rows[0].textContent = 'Your categories will appear here';
+    table.rows[0].id = 'tab_help';
   }
 }
 
@@ -370,8 +371,13 @@ WorkspaceFactoryView.prototype.setModeSelection = function(mode) {
  *    WorkspaceFactoryController.MODE_PRELOAD).
  */
 WorkspaceFactoryView.prototype.updateHelpText = function(mode) {
-  var helpText = 'Drag your blocks into your ' + (mode ==
-      WorkspaceFactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
+  if (mode == WorkspaceFactoryController.MODE_TOOLBOX) {
+    var helpText = 'Drag blocks into the workspace to configure the toolbox '
+        + 'in your custom workspace.';
+  } else {
+    var helpText = 'Drag blocks into the workspace to pre-load them in your '
+        + 'custom workspace.'
+  }
   document.getElementById('editHelpText').textContent = helpText;
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -219,11 +219,16 @@ WorkspaceFactoryView.prototype.moveTabToIndex =
       oldIndex >= table.rows.length) {
     throw new Error('Index out of bounds when moving tab in the view.');
   }
-  if (newIndex < oldIndex) {  // Inserting before.
+
+  // Add 1 to newIndex and oldIndex to get the row with the corresponding tab
+  // in the view to account for the help tab at position 0.
+  if (newIndex < oldIndex) {
+    // Inserting before.
     var row = table.insertRow(newIndex + 1);
     row.appendChild(this.tabMap[id]);
     table.deleteRow(oldIndex + 2);
-  } else {  // Inserting after.
+  } else {
+    // Inserting after.
     var row = table.insertRow(newIndex + 2);
     row.appendChild(this.tabMap[id]);
     table.deleteRow(oldIndex + 1);

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -52,9 +52,7 @@ WorkspaceFactoryView.prototype.addCategoryRow =
   var table = document.getElementById('categoryTable');
   // Delete help label and enable category buttons if it's the first category.
   if (firstCategory) {
-    var labelTab = table.rows[0].cells[0];
-    labelTab.textContent = 'Your Categories:';
-    labelTab.id = 'tab_categoryHeader';
+    document.getElementById('categoryHeader').textContent = 'Your Categories:';
   }
   // Create tab.
   var count = table.rows.length;
@@ -95,10 +93,9 @@ WorkspaceFactoryView.prototype.deleteElementRow = function(id, index) {
  */
 WorkspaceFactoryView.prototype.addEmptyCategoryMessage = function() {
   var table = document.getElementById('categoryTable');
-  if (table.rows.length == 1) {
-    var helpLabel = table.rows[0].cells[0];
-    helpLabel.textContent = 'Your categories will appear here';
-    helpLabel.id = 'tab_help';
+  if (table.rows.length == 0) {
+    document.getElementById('categoryHeader').textContent =
+        'Your categories will appear here';
   }
 }
 
@@ -220,18 +217,16 @@ WorkspaceFactoryView.prototype.moveTabToIndex =
     throw new Error('Index out of bounds when moving tab in the view.');
   }
 
-  // Add 1 to newIndex and oldIndex to get the row with the corresponding tab
-  // in the view to account for the help tab at position 0.
   if (newIndex < oldIndex) {
     // Inserting before.
-    var row = table.insertRow(newIndex + 1);
-    row.appendChild(this.tabMap[id]);
-    table.deleteRow(oldIndex + 2);
-  } else {
-    // Inserting after.
-    var row = table.insertRow(newIndex + 2);
+    var row = table.insertRow(newIndex);
     row.appendChild(this.tabMap[id]);
     table.deleteRow(oldIndex + 1);
+  } else {
+    // Inserting after.
+    var row = table.insertRow(newIndex + 1);
+    row.appendChild(this.tabMap[id]);
+    table.deleteRow(oldIndex);
   }
 };
 
@@ -304,6 +299,7 @@ WorkspaceFactoryView.prototype.clearToolboxTabs = function() {
   var oldCategoryTable = document.getElementById('categoryTable');
   var newCategoryTable = document.createElement('table');
   newCategoryTable.id = 'categoryTable';
+  newCategoryTable.style.width = 'auto';
   oldCategoryTable.parentElement.replaceChild(newCategoryTable,
       oldCategoryTable);
 };


### PR DESCRIPTION
Made small UI changes to workspace factory including: 

- Changing help text for the "toolbox" and "workspace" tabs and style of tabs so that they appear separate from the workspace toolbox.

- Changing the "Clear Toolbox" button to "Clear" and having it clear all state (for both tabs instead of just the toolbox).

- Making options scrollable with a minimum height, and change text of "Standard Options" button to "Reset Options".

- Adding a border around the preview workspace to make it appear separate from the editing area. Changing help text for preview workspace in an attempt to clarify it's relationship to the custom workspace being created.

- Removed "Print Toolbox" button mainly used for debugging. 

- Fixed bug with event listeners for arrow keys so that categories can only be moved up or down when in workspace factory and editing the toolbox.

- Added a"Your Categories:" header to the category list to make it clearer when the user creates and selects their custom categories. 

![screen shot 2016-08-22 at 11 09 49 am](https://cloud.githubusercontent.com/assets/18580768/17865850/0ce27074-6859-11e6-9049-a067f0e1af54.png)
![screen shot 2016-08-22 at 11 10 06 am](https://cloud.githubusercontent.com/assets/18580768/17865852/0e49e97e-6859-11e6-8b87-4510f8bec6ff.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/577)
<!-- Reviewable:end -->
