### PR TITLE
Blockly Factory: Workspace Factory Import Buttons

### DIFF
--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -141,11 +141,12 @@ BlockExporterController.prototype.export = function() {
       alert('Please enter a filename for your block definition(s) download.');
     } else {
       // Get block definition code in the selected format for the blocks.
+      console.log(definitionFormat);
       var blockDefs = this.tools.getBlockDefs(blockXmlMap,
           definitionFormat);
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          blockDefs, blockDef_filename, definitionFormat);
+          blockDefs, blockDef_filename, 'javascript');
     }
   }
 
@@ -158,9 +159,15 @@ BlockExporterController.prototype.export = function() {
       // Get generator stub code in the selected language for the blocks.
       var genStubs = this.tools.getGeneratorCode(blockXmlMap,
           language);
+      // Get the correct file extension.
+      if (language == 'JavaScript') {
+        var fileType = 'javascript';
+      } else {
+        var fileType = 'plain';
+      }
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          genStubs, generatorStub_filename, language);
+          genStubs, generatorStub_filename, fileType);
     }
   }
 

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -141,10 +141,9 @@ BlockExporterController.prototype.export = function() {
       alert('Please enter a filename for your block definition(s) download.');
     } else {
       // Get block definition code in the selected format for the blocks.
-      console.log(definitionFormat);
       var blockDefs = this.tools.getBlockDefs(blockXmlMap,
           definitionFormat);
-      // Download the file.
+      // Download the file, using .js file ending for JSON or Javascript.
       FactoryUtils.createAndDownloadFile(
           blockDefs, blockDef_filename, 'javascript');
     }

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -129,9 +129,9 @@
         <button id="button_importBlocks">Import Custom Blocks</button>
           <div id="dropdownDiv_importBlocks" class="dropdown-content">
             <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile"</input>
-            <label for="input_importBlocksJson">from JSON</label>
+            <label for="input_importBlocksJson">From JSON</label>
             <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile"</input>
-            <label for="input_importBlocksJs">from Javascript</label>
+            <label for="input_importBlocksJs">From Javascript</label>
           </div>
         </div>
 

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -126,16 +126,22 @@
   <div id="workspaceFactoryContent">
     <p>
         <div class="dropdown">
-        <button id="button_import">Import</button>
-          <div id="dropdownDiv_import" class="dropdown-content">
-            <input type="file" id="input_importToolbox" class="inputfile"></input>
-            <label for="input_importToolbox">Toolbox</label>
-            <input type="file" id="input_importPreload" class="inputfile"</input>
-            <label for="input_importPreload">Workspace Blocks</label>
-            <input type="file" id="input_importCategoryJson" class="inputfile"</input>
-            <label for="input_importCategoryJson">Blocks from JSON</label>
-            <input type="file" id="input_importCategoryJs" class="inputfile"</input>
-            <label for="input_importCategoryJs">Blocks from Javascript</label>
+        <button id="button_importBlocks">Import Custom Blocks</button>
+          <div id="dropdownDiv_importBlocks" class="dropdown-content">
+            <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile"</input>
+            <label for="input_importBlocksJson">from JSON</label>
+            <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile"</input>
+            <label for="input_importBlocksJs">from Javascript</label>
+          </div>
+        </div>
+
+        <div class="dropdown">
+        <button id="button_load">Load to Edit</button>
+          <div id="dropdownDiv_load" class="dropdown-content">
+            <input type="file" id="input_loadToolbox" accept=".xml" class="inputfile"></input>
+            <label for="input_loadToolbox">Toolbox</label>
+            <input type="file" id="input_loadPreload" accept=".xml" class="inputfile"</input>
+            <label for="input_loadPreload">Workspace Blocks</label>
           </div>
         </div>
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -366,7 +366,7 @@ WorkspaceFactoryController.prototype.exportOptionsFile = function() {
   this.generateNewOptions();
   // TODO(evd2014): Use Regex to prettify JSON generated.
   var data = new Blob([JSON.stringify(this.model.options)],
-      {type: 'text/plain'});
+      {type: 'text/javascript'});
   this.view.createAndDownloadFile(fileName, data);
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -232,7 +232,9 @@ WorkspaceFactoryInit.assignWorkspaceFactoryClickHandlers_ =
       ('click',
       function() {
         document.getElementById('dropdownDiv_export').classList.toggle("show");
-        document.getElementById('dropdownDiv_import').classList.remove("show");
+        document.getElementById('dropdownDiv_load').classList.remove("show");
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            remove("show");
       })
 
   document.getElementById('button_print').addEventListener
@@ -296,47 +298,64 @@ WorkspaceFactoryInit.assignWorkspaceFactoryClickHandlers_ =
             remove("show");
       });
 
-document.getElementById('button_import').addEventListener
+document.getElementById('button_importBlocks').addEventListener
       ('click',
       function() {
-        document.getElementById('dropdownDiv_import').classList.toggle("show");
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            toggle("show");
         document.getElementById('dropdownDiv_export').classList.remove("show");
+        document.getElementById('dropdownDiv_load').classList.remove("show");
       });
 
-  document.getElementById('input_importToolbox').addEventListener
+  document.getElementById('button_load').addEventListener
+      ('click',
+      function() {
+        document.getElementById('dropdownDiv_load').classList.toggle("show");
+        document.getElementById('dropdownDiv_export').classList.remove("show");
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            remove("show");
+      });
+
+  document.getElementById('input_loadToolbox').addEventListener
       ('change',
       function() {
         controller.importFile(event.target.files[0],
             WorkspaceFactoryController.MODE_TOOLBOX);
-        document.getElementById('dropdownDiv_import').classList.remove("show");
+        document.getElementById('dropdownDiv_load').classList.remove("show");
       });
 
-  document.getElementById('input_importPreload').addEventListener
+  document.getElementById('input_loadPreload').addEventListener
       ('change',
       function() {
         controller.importFile(event.target.files[0],
             WorkspaceFactoryController.MODE_PRELOAD);
-        document.getElementById('dropdownDiv_import').classList.remove("show");
+        document.getElementById('dropdownDiv_load').classList.remove("show");
       });
 
-  document.getElementById('input_importCategoryJson').addEventListener
+  document.getElementById('input_importBlocksJson').addEventListener
       ('change',
       function() {
         controller.importBlocks(event.target.files[0],'JSON');
-        document.getElementById('dropdownDiv_import').classList.remove("show");
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            remove("show");
       });
 
-  document.getElementById('input_importCategoryJs').addEventListener
+  document.getElementById('input_importBlocksJs').addEventListener
       ('change',
       function() {
         controller.importBlocks(event.target.files[0],'JavaScript');
-        document.getElementById('dropdownDiv_import').classList.remove("show");
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            remove("show");
       });
 
   document.getElementById('button_clear').addEventListener
       ('click',
       function() {
         controller.clearToolbox();
+        document.getElementById('dropdownDiv_importBlocks').classList.
+            remove("show");
+        document.getElementById('dropdownDiv_export').classList.remove("show");
+        document.getElementById('dropdownDiv_load').classList.remove("show");
       });
 
   document.getElementById('dropdown_addShadow').addEventListener


### PR DESCRIPTION
Split import options into 2 buttons: "Import Custom Blocks" to import block definitions from a file and load them into a toolbox category in the editing workspace, and "Load to Edit" to load toolbox or pre-loaded block XML into the editing workspace. Also changed the file inputs to only accept certain types of files, and updated the block exporter to be consistent with the import types used in workspace factory. 
![screen shot 2016-08-22 at 2 10 03 pm](https://cloud.githubusercontent.com/assets/18580768/17871842/35394070-6872-11e6-802f-0af926aafbcf.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/578)
<!-- Reviewable:end -->
