### PR TITLE
Blockly Factory: Warning for Undefined Blocks

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -333,10 +333,16 @@ AppController.prototype.onTab = function() {
     // Update block library category.
     var categoryXml = this.exporter.getBlockLibraryCategory();
     this.workspaceFactoryController.setBlockLibraryCategory(categoryXml);
+
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.
     FactoryUtils.show('workspaceFactoryContent');
+    // Update block library category.
+    var categoryXml = this.exporter.getBlockLibCategory();
+    var blockTypes = this.blockLibraryController.getStoredBlockTypes();
+    this.workspaceFactoryController.setBlockLibCategory(categoryXml,
+        blockTypes);
   }
 
   // Resize to render workspaces' toolboxes correctly for all tabs.

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -330,16 +330,12 @@ AppController.prototype.onTab = function() {
     FactoryUtils.hide('workspaceFactoryContent');
 
   } else if (this.selectedTab == AppController.WORKSPACE_FACTORY) {
-    // Update block library category.
-    var categoryXml = this.exporter.getBlockLibraryCategory();
-    this.workspaceFactoryController.setBlockLibraryCategory(categoryXml);
-
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.
     FactoryUtils.show('workspaceFactoryContent');
     // Update block library category.
-    var categoryXml = this.exporter.getBlockLibCategory();
+    var categoryXml = this.exporter.getBlockLibraryCategory();
     var blockTypes = this.blockLibraryController.getStoredBlockTypes();
     this.workspaceFactoryController.setBlockLibCategory(categoryXml,
         blockTypes);

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -228,3 +228,12 @@ BlockLibraryController.prototype.getBlockLibraryStorage = function() {
 BlockLibraryController.prototype.hasEmptyBlockLibrary = function() {
   return this.storage.isEmpty();
 };
+
+/**
+ * Get all block types stored in block library.
+ *
+ * @return {!Array<!string>} Array of block types.
+ */
+BlockLibraryController.prototype.getStoredBlockTypes = function() {
+  return this.storage.getBlockTypes();
+};

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -1173,6 +1173,8 @@ WorkspaceFactoryController.prototype.importBlocks =
  * Updates the block library category in the toolbox workspace toolbox.
  *
  * @param {!Element} categoryXml XML for the block library category.
+ * @param {!Array<!string>} libBlockTypes Array of block types from the block
+ *    library.
  */
 WorkspaceFactoryController.prototype.setBlockLibCategory =
     function(categoryXml, libBlockTypes) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -302,9 +302,7 @@ WorkspaceFactoryController.prototype.clearAndLoadElement = function(id) {
     // Selects the next tab.
     this.view.setCategoryTabSelection(id, true);
 
-    // Mark all shadow blocks laoded and order blocks as if shown in a flyout.
-    this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
-          (this.toolboxWorkspace.getAllBlocks()));
+    // Order blocks as shown in flyout.
     this.toolboxWorkspace.cleanUp();
 
     // Update category editing buttons.
@@ -1023,6 +1021,7 @@ WorkspaceFactoryController.prototype.clearAndLoadXml_ = function(xml) {
   Blockly.Xml.domToWorkspace(xml, this.toolboxWorkspace);
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
       (this.toolboxWorkspace.getAllBlocks()));
+  this.warnForUndefinedBlocks_();
 };
 
 /**
@@ -1156,6 +1155,10 @@ WorkspaceFactoryController.prototype.importBlocks =
       categoryXml.setAttribute('colour', randomColor);
       controller.toolbox.appendChild(categoryXml);
       controller.toolboxWorkspace.updateToolbox(controller.toolbox);
+      // Update imported block types.
+      this.model.addImportedBlocks(blockTypes);
+      // Reload current category to possibly reflect any newly defined blocks.
+      this.clearAndLoadXml_(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     } catch (e) {
       alert('Cannot read blocks from file.');
       window.console.log(e);
@@ -1171,8 +1174,8 @@ WorkspaceFactoryController.prototype.importBlocks =
  *
  * @param {!Element} categoryXml XML for the block library category.
  */
-WorkspaceFactoryController.prototype.setBlockLibraryCategory =
-    function(categoryXml) {
+WorkspaceFactoryController.prototype.setBlockLibCategory =
+    function(categoryXml, libBlockTypes) {
   var blockLibCategory = document.getElementById('blockLibCategory');
 
   // Set category id so that it can be easily replaced, and set a standard,
@@ -1183,6 +1186,13 @@ WorkspaceFactoryController.prototype.setBlockLibraryCategory =
   // Update the toolbox and toolboxWorkspace.
   this.toolbox.replaceChild(categoryXml, blockLibCategory);
   this.toolboxWorkspace.updateToolbox(this.toolbox);
+
+  // Update the block library types.
+  this.model.updateLibBlockTypes(libBlockTypes);
+
+  // Reload XML on page to account for blocks now defined or undefined in block
+  // library.
+  this.clearAndLoadXml_(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
 };
 
 /**
@@ -1193,4 +1203,29 @@ WorkspaceFactoryController.prototype.setBlockLibraryCategory =
  */
 WorkspaceFactoryController.prototype.getAllUsedBlockTypes = function() {
   return this.model.getAllUsedBlockTypes();
+};
+
+/**
+ * Determines if a block loaded in the workspace has a definition (if it
+ * is a standard block, is defined in the block library, or has a definition
+ * imported).
+ *
+ * @param {!Blockly.Block} block The block to examine.
+ */
+WorkspaceFactoryController.prototype.isDefinedBlock = function(block) {
+  return this.model.isDefinedBlockType(block.type);
+};
+
+/**
+ * Sets a warning on blocks loaded to the workspace that are not defined.
+ * @private
+ */
+WorkspaceFactoryController.prototype.warnForUndefinedBlocks_ = function() {
+  var blocks = this.toolboxWorkspace.getAllBlocks();
+  for (var i = 0, block; block = blocks[i]; i++) {
+    if (!this.isDefinedBlock(block)) {
+      block.setWarningText(block.type + ' is not defined (it is not a standard '
+          + 'block, in your block library, or an imported block)');
+    }
+  }
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -1227,7 +1227,7 @@ WorkspaceFactoryController.prototype.warnForUndefinedBlocks_ = function() {
   for (var i = 0, block; block = blocks[i]; i++) {
     if (!this.isDefinedBlock(block)) {
       block.setWarningText(block.type + ' is not defined (it is not a standard '
-          + 'block, in your block library, or an imported block)');
+          + 'block, \nin your block library, or an imported block)');
     }
   }
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -443,7 +443,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         // Enable block editing and remove warnings if the block is not a
         // variable user-generated shadow block.
         document.getElementById('button_editShadow').disabled = false;
-        if (!controller.hasVariableField(selected)) {
+        if (!controller.hasVariableField(selected) &&
+            controller.isDefinedBlock(selected)) {
           selected.setWarningText(null);
         }
       } else {
@@ -473,7 +474,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
           // be a shadow block.
 
           // Remove possible 'invalid shadow block placement' warning.
-          if (selected != null && (!controller.hasVariableField(selected) ||
+          if (selected != null && controller.isDefinedBlock(selected) &&
+              (!controller.hasVariableField(selected) ||
               !controller.isUserGenShadowBlock(selected.id))) {
             selected.setWarningText(null);
           }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -305,7 +305,7 @@ WorkspaceFactoryModel.prototype.getCategoryIdByName = function(name) {
 WorkspaceFactoryModel.prototype.clearToolboxList = function() {
   this.toolboxList = [];
   this.hasVariableCategory = false;
-  this.hasVariableCategory = false;
+  this.hasProcedureCategory = false;
   this.shadowBlocks = [];
   this.selected.xml = Blockly.Xml.textToDom('<xml></xml>');
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -53,6 +53,11 @@ WorkspaceFactoryModel = function() {
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
   // Options object to be configured for Blockly inject call.
   this.options = new Object(null);
+  // Block Library block types.
+  this.libBlockTypes = [];
+  // Imported block types.
+  this.importedBlockTypes = [];
+  //
 };
 
 /**
@@ -468,6 +473,39 @@ WorkspaceFactoryModel.prototype.getAllUsedBlockTypes = function() {
 
   return blockTypeList;
 };
+
+/**
+ * Adds new imported block types to the list of current imported block types.
+ *
+ * @param {!Array<!string>} blockTypes Array of block types imported.
+ */
+WorkspaceFactoryModel.prototype.addImportedBlockTypes = function(blockTypes) {
+  this.importedBlockTypes = this.importedBlockTypes.concat(blockTypes);
+};
+
+/**
+ * Updates block types in block library.
+ *
+ * @param {!Array<!string>} blockTypes Array of block types in block library.
+ */
+WorkspaceFactoryModel.prototype.updateLibBlockTypes = function(blockTypes) {
+  this.libBlockTypes = blockTypes;
+};
+
+/**
+ * Determines if a block type is defined as a standard block, in the block
+ * library, or as an imported block.
+ *
+ * @param {!string} blockType Block type to check.
+ * @return {boolean} True if blockType is defined, false otherwise.
+ */
+WorkspaceFactoryModel.prototype.isDefinedBlockType = function(blockType) {
+  var isStandardBlock = StandardCategories.coreBlockTypes.indexOf(blockType)
+      != -1;
+  var isLibBlock = this.libBlockTypes.indexOf(blockType) != -1;
+  var isImportedBlock = this.importedBlockTypes.indexOf(blockType) != -1;
+  return (isStandardBlock || isLibBlock || isImportedBlock);
+}
 
 /**
  * Class for a ListElement.


### PR DESCRIPTION
Adds a warning to blocks that are not standard blocks, defined in the block library, or imported. These blocks can end up being added to the workspace factory editing area when XML is imported or when a block library block is used and then deleted. This helps the user know when their block definitions and workspace editing is out of sync, and helps the user understand why the block might not be properly rendered. 

![custom block warning](https://cloud.githubusercontent.com/assets/18580768/17908030/7da88264-6933-11e6-9372-697ae0dc8962.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/581)
<!-- Reviewable:end -->
