### PR TITLE
Blockly Factory: Use StandardCategories, No Abbreviations

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -96,7 +96,7 @@ AppController.prototype.importBlockLibraryFromFile = function() {
       var blockXmlTextMap = Object.create(null);
       try {
         // Parse the file to get map of block type to xml text.
-        blockXmlTextMap = self.formatBlockLibForImport_(fileContents);
+        blockXmlTextMap = self.formatBlockLibraryForImport_(fileContents);
       } catch (e) {
         var message = 'Could not load your block library file.\n'
         window.alert(message + '\nFile Name: ' + file.name);
@@ -109,11 +109,11 @@ AppController.prototype.importBlockLibraryFromFile = function() {
 
       // Update block library controller with the new block library
       // storage.
-      self.blockLibraryController.setBlockLibStorage(blockLibStorage);
+      self.blockLibraryController.setBlockLibraryStorage(blockLibStorage);
       // Update the block library dropdown.
       self.blockLibraryController.populateBlockLibrary();
       // Update the exporter's block library storage.
-      self.exporter.setBlockLibStorage(blockLibStorage);
+      self.exporter.setBlockLibraryStorage(blockLibStorage);
     });
     // Read the file.
     fileReader.readAsText(file);
@@ -128,7 +128,7 @@ AppController.prototype.exportBlockLibraryToFile = function() {
   // Get map of block type to xml.
   var blockLib = this.blockLibraryController.getBlockLibrary();
   // Concatenate the xmls, each separated by a blank line.
-  var blockLibText = this.formatBlockLibForExport_(blockLib);
+  var blockLibText = this.formatBlockLibraryForExport_(blockLib);
   // Get file name.
   var filename = prompt('Enter the file name under which to save your block ' +
       'library.');
@@ -148,7 +148,7 @@ AppController.prototype.exportBlockLibraryToFile = function() {
  * @param {!Object} blockXmlMap - Object mapping block type to xml.
  * @return {string} Xml text containing the block xmls.
  */
-AppController.prototype.formatBlockLibForExport_ = function(blockXmlMap) {
+AppController.prototype.formatBlockLibraryForExport_ = function(blockXmlMap) {
   // Create DOM for XML.
   var xmlDom = goog.dom.createDom('xml', {
     'xmlns':"http://www.w3.org/1999/xhtml"
@@ -173,7 +173,7 @@ AppController.prototype.formatBlockLibForExport_ = function(blockXmlMap) {
  *    a child node.
  * @return {!Object} object mapping block type to xml text.
  */
-AppController.prototype.formatBlockLibForImport_ = function(xmlText) {
+AppController.prototype.formatBlockLibraryForImport_ = function(xmlText) {
   var xmlDom = Blockly.Xml.textToDom(xmlText);
 
   // Get array of xmls. Use an asterisk (*) instead of a tag name for the XPath
@@ -330,8 +330,8 @@ AppController.prototype.onTab = function() {
 
   } else if (this.selectedTab == AppController.WORKSPACE_FACTORY) {
     // Update block library category.
-    var categoryXml = this.exporter.getBlockLibCategory();
-    this.workspaceFactoryController.setBlockLibCategory(categoryXml);
+    var categoryXml = this.exporter.getBlockLibraryCategory();
+    this.workspaceFactoryController.setBlockLibraryCategory(categoryXml);
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.

--- a/demos/blocklyfactory/block_exporter_controller.js
+++ b/demos/blocklyfactory/block_exporter_controller.js
@@ -32,6 +32,7 @@
 goog.provide('BlockExporterController');
 
 goog.require('FactoryUtils');
+goog.require('StandardCategories');
 goog.require('BlockExporterView');
 goog.require('BlockExporterTools');
 goog.require('goog.dom.xml');
@@ -64,7 +65,7 @@ BlockExporterController = function(blockLibStorage) {
  * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
  *    that stores the blocks.
  */
-BlockExporterController.prototype.setBlockLibStorage =
+BlockExporterController.prototype.setBlockLibraryStorage =
     function(blockLibStorage) {
   this.blockLibStorage = blockLibStorage;
 };
@@ -75,7 +76,8 @@ BlockExporterController.prototype.setBlockLibStorage =
  * @return {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
  *    that stores the blocks.
  */
-BlockExporterController.prototype.getBlockLibStorage = function() {
+BlockExporterController.prototype.getBlockLibraryStorage =
+    function(blockLibStorage) {
   return this.blockLibStorage;
 };
 
@@ -187,8 +189,7 @@ BlockExporterController.prototype.selectAllBlocks = function() {
  *
  * @return {Element} Xml for a category to be used in toolbox.
  */
-
-BlockExporterController.prototype.getBlockLibCategory = function() {
+BlockExporterController.prototype.getBlockLibraryCategory = function() {
   return this.tools.generateCategoryFromBlockLib(this.blockLibStorage);
 };
 
@@ -244,7 +245,7 @@ BlockExporterController.prototype.selectUsedBlocks = function() {
   for (var i = 0, blockType; blockType = this.usedBlockTypes[i]; i++) {
     if (storedBlockTypes.indexOf(blockType) != -1) {
       sharedBlockTypes.push(blockType);
-    } else if (BlockFactory.standardBlockTypes.indexOf(blockType) == -1) {
+    } else if (StandardCategories.coreBlockTypes.indexOf(blockType) == -1) {
       unstoredCustomBlockTypes.push(blockType);
     }
   }

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -197,7 +197,7 @@ BlockLibraryController.prototype.getBlockLibrary = function() {
  * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage
  *    object.
  */
-BlockLibraryController.prototype.setBlockLibStorage
+BlockLibraryController.prototype.setBlockLibraryStorage
     = function(blockLibStorage) {
   this.storage = blockLibStorage;
 };
@@ -208,7 +208,7 @@ BlockLibraryController.prototype.setBlockLibStorage
  * @return {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
  *    that stores the blocks.
  */
-BlockLibraryController.prototype.getBlockLibStorage = function() {
+BlockLibraryController.prototype.getBlockLibraryStorage = function() {
   return this.blockLibStorage;
 };
 
@@ -217,6 +217,6 @@ BlockLibraryController.prototype.getBlockLibStorage = function() {
  *
  * @return {boolean} True if the Block Library is empty, false otherwise.
  */
-BlockLibraryController.prototype.hasEmptyBlockLib = function() {
+BlockLibraryController.prototype.hasEmptyBlockLibrary = function() {
   return this.storage.isEmpty();
 };

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -35,6 +35,7 @@
 goog.provide('BlockFactory');
 
 goog.require('FactoryUtils');
+goog.require('StandardCategories');
 
 
 /**
@@ -58,28 +59,6 @@ BlockFactory.UNNAMED = 'unnamed';
  * Existing direction ('ltr' vs 'rtl') of preview.
  */
 BlockFactory.oldDir = null;
-
-/**
- * List of block types in standard categories.
- * TODO(quachtina96): Get this list from FactoryController since each
- * FactoryControlelr object has a dictionary containing its standard categories.
- */
- BlockFactory.standardBlockTypes = ["controls_if", "logic_compare",
-    "logic_operation", "logic_negate", "logic_boolean", "logic_null",
-    "logic_ternary", "controls_repeat_ext", "controls_whileUntil",
-    "controls_for", "controls_forEach", "controls_flow_statements",
-    "math_number", "math_arithmetic", "math_single", "math_trig",
-    "math_constant", "math_number_property", "math_change", "math_round",
-    "math_on_list", "math_modulo", "math_constrain", "math_random_int",
-    "math_random_float", "text", "text_join", "text_append", "text_length",
-    "text_isEmpty", "text_indexOf", "variables_get", "text_charAt",
-    "text_getSubstring", "text_changeCase", "text_trim", "text_print",
-    "text_prompt_ext", "colour_picker", "colour_random", "colour_rgb",
-    "colour_blend", "lists_create_with", "lists_repeat", "lists_length",
-    "lists_isEmpty", "lists_indexOf", "lists_getIndex", "lists_setIndex",
-    "lists_getSublist", "lists_split", "lists_sort", "variables_set",
-    "procedures_defreturn", "procedures_ifreturn", "procedures_defnoreturn",
-    "procedures_callreturn"];
 
 /**
  * Inject code into a pre tag, with syntax highlighting.
@@ -236,7 +215,7 @@ BlockFactory.updatePreview = function() {
     // Warn user only if their block type is already exists in Blockly's
     // standard library.
     var rootBlock = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
-    if (BlockFactory.standardBlockTypes.indexOf(blockType) != -1) {
+    if (StandardCategories.coreBlockTypes.indexOf(blockType) != -1) {
       rootBlock.setWarningText('A standard Blockly.Block already exists ' +
           'under this name.');
     } else {

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -737,7 +737,7 @@ FactoryUtils.getDefinedBlock = function(blockType, workspace) {
  * @param {!string} blockDef - A single block definition.
  * @return {string} Type of block defined by the given definition.
  */
-FactoryUtils.getBlockTypeFromJsDef = function(blockDef) {
+FactoryUtils.getBlockTypeFromJsDefinition = function(blockDef) {
   var indexOfStartBracket = blockDef.indexOf('[\'');
   var indexOfEndBracket = blockDef.indexOf('\']');
   if (indexOfStartBracket != -1 && indexOfEndBracket != -1) {
@@ -780,7 +780,7 @@ FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
  * @param {!string} blockDefsString - JavaScript block definition(s).
  * @return {!Array.<string>} - Array of block definitions.
  */
-FactoryUtils.parseJsBlockDefs = function(blockDefsString) {
+FactoryUtils.parseJsBlockDefinitions = function(blockDefsString) {
   var blockDefArray = [];
   var defStart = blockDefsString.indexOf('Blockly.Blocks');
 
@@ -807,7 +807,7 @@ FactoryUtils.parseJsBlockDefs = function(blockDefsString) {
  *    definition(s).
  * @return {!Array.<string>} - Array of block definitions.
  */
-FactoryUtils.parseJsonBlockDefs = function(blockDefsString) {
+FactoryUtils.parseJsonBlockDefinitions = function(blockDefsString) {
   var blockDefArray = [];
   var unbalancedBracketCount = 0;
   var defStart = 0;
@@ -843,7 +843,7 @@ FactoryUtils.defineAndGetBlockTypes = function(blockDefsString, format) {
 
   // Define blocks and get block types.
   if (format == 'JSON') {
-    var blockDefArray = FactoryUtils.parseJsonBlockDefs(blockDefsString);
+    var blockDefArray = FactoryUtils.parseJsonBlockDefinitions(blockDefsString);
 
     // Populate array of blocktypes and define each block.
     for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
@@ -858,11 +858,11 @@ FactoryUtils.defineAndGetBlockTypes = function(blockDefsString, format) {
       };
     }
   } else if (format == 'JavaScript') {
-    var blockDefArray = FactoryUtils.parseJsBlockDefs(blockDefsString);
+    var blockDefArray = FactoryUtils.parseJsBlockDefinitions(blockDefsString);
 
     // Populate array of block types.
     for (var i = 0, blockDef; blockDef = blockDefArray[i]; i++) {
-      var blockType = FactoryUtils.getBlockTypeFromJsDef(blockDef);
+      var blockType = FactoryUtils.getBlockTypeFromJsDefinition(blockDef);
       blockTypes.push(blockType);
     }
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -1184,7 +1184,7 @@ WorkspaceFactoryController.prototype.importBlocks =
  *
  * @param {!Element} categoryXml XML for the block library category.
  */
-WorkspaceFactoryController.prototype.setBlockLibCategory =
+WorkspaceFactoryController.prototype.setBlockLibraryCategory =
     function(categoryXml) {
   var blockLibCategory = document.getElementById('blockLibCategory');
 


### PR DESCRIPTION
- reference StandardCategories.coreBlockTypes in factory.js and blockexporter controller
- remove all abbreviations from function names