### PR TITLE
Blockly Factory: Clean Up Workspace on Save Block, Import Lowercase Types

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -197,7 +197,8 @@ AppController.prototype.formatBlockLibForImport_ = function(xmlText) {
     xmlDom.appendChild(blockNode);
 
     var xmlText = Blockly.Xml.domToText(xmlDom);
-    var blockType = this.getBlockTypeFromXml_(xmlText);
+    // All block types should be lowercase.
+    var blockType = this.getBlockTypeFromXml_(xmlText).toLowerCase();
 
     blockXmlTextMap[blockType] = xmlText;
   }

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -139,12 +139,17 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
     }
   }
 
-  // Save block.
+  // Create block xml.
   var xmlElement = goog.dom.createDom('xml');
   var block = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
   xmlElement.appendChild(Blockly.Xml.blockToDomWithXY(block));
+
+  // Save block.
   this.storage.addBlock(blockType, xmlElement);
   this.storage.saveToLocalStorage();
+
+  // Show saved block without other stray blocks sitting in Block Factory's
+  // main workspace.
   this.openBlock(blockType);
 
   // Do not add another option to dropdown if replacing.

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -140,9 +140,12 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
   }
 
   // Save block.
-  var xmlElement = Blockly.Xml.workspaceToDom(BlockFactory.mainWorkspace);
+  var xmlElement = goog.dom.createDom('xml');
+  var block = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
+  xmlElement.appendChild(Blockly.Xml.blockToDomWithXY(block));
   this.storage.addBlock(blockType, xmlElement);
   this.storage.saveToLocalStorage();
+  this.openBlock(blockType);
 
   // Do not add another option to dropdown if replacing.
   if (replace) {


### PR DESCRIPTION
## Block Library
### Clean Up Workspace on Save to Library
Before save:
<img width="1430" alt="screen shot 2016-08-23 at 1 56 43 pm" src="https://cloud.githubusercontent.com/assets/10423718/17910340/4b5367d4-693d-11e6-9031-fa012420d61f.png">
After save:
<img width="1440" alt="screen shot 2016-08-23 at 1 57 02 pm" src="https://cloud.githubusercontent.com/assets/10423718/17910344/4fc88f60-693d-11e6-84c5-3669bbd19e7b.png">

### Import Lowercase Types
Fixed bug where a block type that is capitalized in the exported xml gets imported as a block of a different type: 'color_Sea' is different from 'color_sea'. To match the generated code, block types are always saved as lowercase in the library. With this CL, the same is done for each block upon importing a block library.