### PR TITLE
Blockly Factory: Prompt User to Add Variables/Functions Category

### DIFF
--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -430,8 +430,9 @@ td {
   padding-right: 20px;
 }
 
-.test {
-  border: 1px solid black;
+.disabled {
+  background-color: white;
+  opacity: 0.5;
 }
 
 #toolbox_div {
@@ -464,17 +465,6 @@ td {
 #workspace_options {
   display: table-row;
   margin-top: 2%;
-}
-
-#disable_div {
-  background-color: white;
-  height: 100%;
-  left: 0;
-  opacity: .5;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: -1;  /* Start behind workspace */
 }
 
 /* Rules for Closure popup color picker */

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -913,3 +913,22 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
   return blockXmlText1 == blockXmlText2;
 };
 
+/*
+ * Checks if a block has a variable field. Blocks with variable fields cannot
+ * be shadow blocks.
+ *
+ * @param {Blockly.Block} block The block to check if a variable field exists.
+ * @return {boolean} True if the block has a variable field, false otherwise.
+ */
+FactoryUtils.hasVariableField = function(block) {
+  if (!block) {
+    return false;
+  }
+  for (var i = 0; i < block.inputList.length; i++) {
+    if (block.inputList[i].fieldRow.length > 0 &&
+        block.inputList[i].fieldRow[0].name == 'VAR') {
+      return true;
+    }
+  }
+  return false;
+};

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -924,11 +924,29 @@ FactoryUtils.hasVariableField = function(block) {
   if (!block) {
     return false;
   }
-  for (var i = 0; i < block.inputList.length; i++) {
-    if (block.inputList[i].fieldRow.length > 0 &&
-        block.inputList[i].fieldRow[0].name == 'VAR') {
-      return true;
+  for (var i = 0, input; input = block.inputList[i]; i++) {
+    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+      if (field.name == 'VAR') {
+        return true;
+      }
     }
   }
   return false;
+};
+
+/**
+ * Checks if a block is a procedures block. If procedures block names are
+ * ever updated or expanded, this function should be updated as well (no
+ * other known markers for procedure blocks beyond name).
+ *
+ * @param {Blockly.Block} block The block to check.
+ * @return {boolean} True if hte block is a procedure block, false otherwise.
+ */
+FactoryUtils.isProcedureBlock = function(block) {
+  return block &&
+      (block.type == 'procedures_defnoreturn' ||
+      block.type == 'procedures_defreturn' ||
+      block.type == 'procedures_callnoreturn' ||
+      block.type == 'procedures_callreturn' ||
+      block.type == 'procedures_ifreturn');
 };

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -180,7 +180,6 @@
       </table>
       <section id="toolbox_section">
         <div id="toolbox_blocks"></div>
-        <div id='disable_div'></div>
       </section>
       <aside id="toolbox_div">
         <p id="categoryHeader">Your categories will appear here</p>

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -881,7 +881,7 @@ WorkspaceFactoryController.prototype.addShadowForBlockAndChildren_ =
   this.view.markShadowBlock(block);
   this.model.addShadowBlock(block.id);
 
-  if (this.hasVariableField(block)) {
+  if (FactoryUtils.hasVariableField(block)) {
     block.setWarningText('Cannot make variable blocks shadow blocks.');
   }
 
@@ -890,26 +890,6 @@ WorkspaceFactoryController.prototype.addShadowForBlockAndChildren_ =
   for (var i = 0; i < children.length; i++) {
     this.addShadowForBlockAndChildren_(children[i]);
   }
-};
-
-/**
- * Checks if a block has a variable field. Blocks with variable fields cannot
- * be shadow blocks.
- *
- * @param {Blockly.Block} block The block to check if a variable field exists.
- * @return {boolean} True if the block has a variable field, false otherwise.
- */
-WorkspaceFactoryController.prototype.hasVariableField = function(block) {
-  if (!block) {
-    return false;
-  }
-  for (var i = 0; i < block.inputList.length; i++) {
-    if (block.inputList[i].fieldRow.length > 0 &&
-        block.inputList[i].fieldRow[0].name == 'VAR') {
-      return true;
-    }
-  }
-  return false;
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -98,38 +98,10 @@ WorkspaceFactoryController.MODE_PRELOAD = 'preload';
  * before), and then creates a tab and switches to it.
  */
 WorkspaceFactoryController.prototype.addCategory = function() {
-  // Check if it's the first category added.
-  var isFirstCategory = !this.model.hasElements();
-  // Give the option to save blocks if their workspace is not empty and they
-  // are creating their first category.
-  if (isFirstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
-    var confirmCreate = confirm('Do you want to save your work in another '
-        + 'category? If you don\'t, the blocks in your workspace will be ' +
-        'deleted.');
-
-    // Create a new category for current blocks.
-    if (confirmCreate) {
-      var name = prompt('Enter the name of the category for your ' +
-          'current blocks: ');
-      if (!name) {  // Exit if cancelled.
-        return;
-      }
-
-      // Create the new category.
-      this.createCategory(name, true);
-      // Set the new category as selected.
-      var id = this.model.getCategoryIdByName(name);
-      this.model.setSelectedById(id);
-      this.view.setCategoryTabSelection(id, true);
-      // Allow user to use the default options for injecting with categories.
-      this.allowToSetDefaultOptions();
-      // Update preview here in case exit early.
-      this.updatePreview();
-    }
-  }
+  this.allowToTransferFlyoutBlocksToCategory();
 
   // After possibly creating a category, check again if it's the first category.
-  isFirstCategory = !this.model.hasElements();
+  var isFirstCategory = !this.model.hasElements();
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
@@ -185,6 +157,44 @@ WorkspaceFactoryController.prototype.addClickToSwitch = function(tab, id) {
     };
   };
   this.view.bindClick(tab, clickFunction(id));
+};
+
+/**
+ * Allows the user to transfer blocks in their flyout to a new category if
+ * the user is creating their first category and their workspace is not
+ * empty. Should be called whenever it is possible to switch from single flyout
+ * to categories (not including importing).
+ */
+WorkspaceFactoryController.prototype.allowToTransferFlyoutBlocksToCategory =
+    function() {
+  // Give the option to save blocks if their workspace is not empty and they
+  // are creating their first category.
+  if (!this.model.hasElements() &&
+        this.toolboxWorkspace.getAllBlocks().length > 0) {
+    var confirmCreate = confirm('Do you want to save your work in another '
+        + 'category? If you don\'t, the blocks in your workspace will be ' +
+        'deleted.');
+
+    // Create a new category for current blocks.
+    if (confirmCreate) {
+      var name = prompt('Enter the name of the category for your ' +
+          'current blocks: ');
+      if (!name) {  // Exit if cancelled.
+        return;
+      }
+
+      // Create the new category.
+      this.createCategory(name, true);
+      // Set the new category as selected.
+      var id = this.model.getCategoryIdByName(name);
+      this.model.setSelectedById(id);
+      this.view.setCategoryTabSelection(id, true);
+      // Allow user to use the default options for injecting with categories.
+      this.allowToSetDefaultOptions();
+      // Update preview here in case exit early.
+      this.updatePreview();
+    }
+  }
 };
 
 /**
@@ -562,7 +572,21 @@ WorkspaceFactoryController.prototype.loadCategory = function() {
     }
   } while (!this.isStandardCategoryName(name));
 
-  // Check if the user can create that standard category.
+  // Load category.
+  this.loadCategoryByName(name);
+};
+
+/**
+ * Loads a Standard Category by name and switches to it. Leverages
+ * StandardCategories. Returns if cannot load standard category.
+ *
+ * @param {string} name Name of the standard category to load.
+ */
+WorkspaceFactoryController.prototype.loadCategoryByName = function(name) {
+  // Check if the user can load that standard category.
+  if (!this.isStandardCategoryName(name)) {
+    return;
+  }
   if (this.model.hasVariables() && name.toLowerCase() == 'variables') {
     alert('A Variables category already exists. You cannot create multiple' +
         ' variables categories.');
@@ -580,6 +604,8 @@ WorkspaceFactoryController.prototype.loadCategory = function() {
         + '. Rename your category and try again.');
     return;
   }
+  // Allow user to transfer current flyout blocks to a category.
+  this.allowToTransferFlyoutBlocksToCategory();
 
   var isFirstCategory = !this.model.hasElements();
   // Copy the standard category in the model.
@@ -633,11 +659,9 @@ WorkspaceFactoryController.prototype.isStandardCategoryName = function(name) {
  * the separator, and updates the preview.
  */
 WorkspaceFactoryController.prototype.addSeparator = function() {
-  // Don't allow the user to add a separator if a category has not been created.
-  if (!this.model.hasElements()) {
-    alert('Add a category before adding a separator.');
-    return;
-  }
+  // If adding the first element in the toolbox, allow the user to transfer
+  // their flyout blocks to a category.
+  this.allowToTransferFlyoutBlocksToCategory();
   // Create the separator in the model.
   var separator = new ListElement(ListElement.TYPE_SEPARATOR);
   this.model.addElementToList(separator);
@@ -936,6 +960,14 @@ WorkspaceFactoryController.prototype.convertShadowBlocks = function() {
   for (var i = 0, block; block = blocks[i]; i++) {
     if (block.isShadow()) {
       block.setShadow(false);
+      // Delete the shadow DOM attached to the block so that the shadow block
+      // does not respawn. Dependent on implementation details.
+      var parentConnection = block.outputConnection ?
+          block.outputConnection.targetConnection :
+          block.previousConnection.targetConnection;
+      if (parentConnection) {
+        parentConnection.shadowDom_ = null;
+      }
       this.model.addShadowBlock(block.id);
       this.view.markShadowBlock(block);
     }
@@ -1210,4 +1242,22 @@ WorkspaceFactoryController.prototype.warnForUndefinedBlocks_ = function() {
           + 'block, \nin your block library, or an imported block)');
     }
   }
+};
+
+/*
+ * Determines if a standard variable category is in the custom toolbox.
+ *
+ * @return {boolean} True if a variables category is in use, false otherwise.
+ */
+WorkspaceFactoryController.prototype.hasVariablesCategory = function() {
+  return this.model.hasVariables();
+};
+
+/**
+ * Determines if a standard procedures category is in the custom toolbox.
+ *
+ * @return {boolean} True if a procedures category is in use, false otherwise.
+ */
+WorkspaceFactoryController.prototype.hasProceduresCategory = function() {
+  return this.model.hasProcedures();
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -966,7 +966,7 @@ WorkspaceFactoryController.prototype.convertShadowBlocks = function() {
           block.outputConnection.targetConnection :
           block.previousConnection.targetConnection;
       if (parentConnection) {
-        parentConnection.shadowDom_ = null;
+        parentConnection.setShadowDom(null);
       }
       this.model.addShadowBlock(block.id);
       this.view.markShadowBlock(block);

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -108,7 +108,7 @@ WorkspaceFactoryController.prototype.addCategory = function() {
     return;
   }
   // Create category.
-  this.createCategory(name, isFirstCategory);
+  this.createCategory(name);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
 
@@ -128,16 +128,13 @@ WorkspaceFactoryController.prototype.addCategory = function() {
  *
  * @param {!string} name Name of category being added.
  * @param {!string} id The ID of the category being added.
- * @param {boolean} isFirstCategory True if it's the first category created,
- * false otherwise.
  */
-WorkspaceFactoryController.prototype.createCategory = function(name,
-    isFirstCategory) {
+WorkspaceFactoryController.prototype.createCategory = function(name) {
   // Create empty category
   var category = new ListElement(ListElement.TYPE_CATEGORY, name);
   this.model.addElementToList(category);
   // Create new category.
-  var tab = this.view.addCategoryRow(name, category.id, isFirstCategory);
+  var tab = this.view.addCategoryRow(name, category.id);
   this.addClickToSwitch(tab, category.id);
 };
 
@@ -615,7 +612,7 @@ WorkspaceFactoryController.prototype.loadCategoryByName = function(name) {
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id, isFirstCategory);
+  var tab = this.view.addCategoryRow(copy.name, copy.id);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -500,9 +500,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
       // Let the user create a Variables or Functions category if they use
       // blocks from either category.
-      var newBaseBlock = controller.toolboxWorkspace.getBlockById(e.blockId);
 
-      // Get all children of the newly created block.
+      // Get all children of a block and add them to childList.
       var getAllChildren = function(block, childList) {
         childList.push(block);
         var children = block.getChildren();
@@ -511,6 +510,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         }
       };
 
+      var newBaseBlock = controller.toolboxWorkspace.getBlockById(e.blockId);
       var allNewBlocks = [];
       getAllChildren(newBaseBlock, allNewBlocks);
       var variableCreated = false;
@@ -530,15 +530,15 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
       // prompt the user to create the corresponding standard category.
       if (variableCreated && !controller.hasVariablesCategory()) {
         if (confirm('Your new block has a variables field. To use this block '
-            + 'fully, you will need a Variables category. Click OK to add '
-            + 'a Variables category to your custom toolbox.')) {
+            + 'fully, you will need a Variables category. Do you want to add '
+            + 'a Variables category to your custom toolbox?')) {
           controller.loadCategoryByName('variables');
         }
 
       } else if (procedureCreated && !controller.hasProceduresCategory()) {
         if (confirm('Your new block is a function block. To use this block '
-            + 'fully, you will need a Functions category. Click OK to add '
-            + 'a Functions category to your custom toolbox.')) {
+            + 'fully, you will need a Functions category. Do you want to add '
+            + 'a Functions category to your custom toolbox?')) {
           controller.loadCategoryByName('functions');
         }
       }

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -27,6 +27,8 @@
  * @author Emma Dauterman (evd2014)
  */
 
+ goog.require('FactoryUtils');
+
 /**
  * Namespace for workspace factory initialization methods.
  * @namespace
@@ -443,7 +445,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         // Enable block editing and remove warnings if the block is not a
         // variable user-generated shadow block.
         document.getElementById('button_editShadow').disabled = false;
-        if (!controller.hasVariableField(selected) &&
+        if (!FactoryUtils.hasVariableField(selected) &&
             controller.isDefinedBlock(selected)) {
           selected.setWarningText(null);
         }
@@ -459,7 +461,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
             // Warn if a non-shadow block is nested inside a shadow block.
             selected.setWarningText('Only shadow blocks can be nested inside '
                 + 'other shadow blocks.');
-          } else if (!controller.hasVariableField(selected)) {
+          } else if (!FactoryUtils.hasVariableField(selected)) {
             // Warn if a shadow block is invalid only if not replacing
             // warning for variables.
             selected.setWarningText('Shadow blocks must be nested inside other'
@@ -475,7 +477,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
           // Remove possible 'invalid shadow block placement' warning.
           if (selected != null && controller.isDefinedBlock(selected) &&
-              (!controller.hasVariableField(selected) ||
+              (!FactoryUtils.hasVariableField(selected) ||
               !controller.isUserGenShadowBlock(selected.id))) {
             selected.setWarningText(null);
           }

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -497,6 +497,51 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
     // shadow blocks.
     if (e.type == Blockly.Events.CREATE) {
       controller.convertShadowBlocks();
+
+      // Let the user create a Variables or Functions category if they use
+      // blocks from either category.
+      var newBaseBlock = controller.toolboxWorkspace.getBlockById(e.blockId);
+
+      // Get all children of the newly created block.
+      var getAllChildren = function(block, childList) {
+        childList.push(block);
+        var children = block.getChildren();
+        for (var i = 0, child; child = children[i]; i++) {
+          getAllChildren(child, childList);
+        }
+      };
+
+      var allNewBlocks = [];
+      getAllChildren(newBaseBlock, allNewBlocks);
+      var variableCreated = false;
+      var procedureCreated = false;
+
+      // Check if the newly created block or any of its children are variable
+      // or procedure blocks.
+      for (var i = 0, block; block = allNewBlocks[i]; i++) {
+        if (FactoryUtils.hasVariableField(block)) {
+          variableCreated = true;
+        } else if (FactoryUtils.isProcedureBlock(block)) {
+          procedureCreated = true;
+        }
+      }
+
+      // If any of the newly created blocks are variable or procedure blocks,
+      // prompt the user to create the corresponding standard category.
+      if (variableCreated && !controller.hasVariablesCategory()) {
+        if (confirm('Your new block has a variables field. To use this block '
+            + 'fully, you will need a Variables category. Click OK to add '
+            + 'a Variables category to your custom toolbox.')) {
+          controller.loadCategoryByName('variables');
+        }
+
+      } else if (procedureCreated && !controller.hasProceduresCategory()) {
+        if (confirm('Your new block is a function block. To use this block '
+            + 'fully, you will need a Functions category. Click OK to add '
+            + 'a Functions category to your custom toolbox.')) {
+          controller.loadCategoryByName('functions');
+        }
+      }
     }
   });
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -28,6 +28,8 @@
  * @author Emma Dauterman (edauterman)
  */
 
+ goog.require('FactoryUtils');
+
  /**
   * Class for a WorkspaceFactoryView
   * @constructor
@@ -333,6 +335,10 @@ WorkspaceFactoryView.prototype.markShadowBlock = function(block) {
   if (!block.getSurroundParent()) {
       block.setWarningText('Shadow blocks must be nested inside' +
           ' other blocks to be displayed.');
+  }
+
+  if (FactoryUtils.hasVariableField(block)) {
+    block.setWarningText('Cannot make variable blocks shadow blocks.');
   }
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -45,19 +45,18 @@ WorkspaceFactoryView = function() {
  *
  * @param {!string} name The name of the category being created
  * @param {!string} id ID of category being created
- * @param {boolean} firstCategory true if it's the first category, false
- * otherwise
  * @return {!Element} DOM element created for tab
  */
-WorkspaceFactoryView.prototype.addCategoryRow =
-    function(name, id, firstCategory) {
+WorkspaceFactoryView.prototype.addCategoryRow = function(name, id) {
   var table = document.getElementById('categoryTable');
+  var count = table.rows.length;
+
   // Delete help label and enable category buttons if it's the first category.
-  if (firstCategory) {
+  if (count == 0) {
     document.getElementById('categoryHeader').textContent = 'Your Categories:';
   }
+
   // Create tab.
-  var count = table.rows.length;
   var row = table.insertRow(count);
   var nextEntry = row.insertCell(0);
   // Configure tab.
@@ -255,9 +254,13 @@ WorkspaceFactoryView.prototype.setBorderColor = function(id, color) {
  * @param {!Element} The td DOM element representing the separator.
  */
 WorkspaceFactoryView.prototype.addSeparatorTab = function(id) {
-  // Create separator.
   var table = document.getElementById('categoryTable');
   var count = table.rows.length;
+
+  if (count == 0) {
+    document.getElementById('categoryHeader').textContent = 'Your Categories:';
+  }
+  // Create separator.
   var row = table.insertRow(count);
   var nextEntry = row.insertCell(0);
   // Configure separator.
@@ -277,7 +280,14 @@ WorkspaceFactoryView.prototype.addSeparatorTab = function(id) {
  * if it should be enabled.
  */
 WorkspaceFactoryView.prototype.disableWorkspace = function(disable) {
-  document.getElementById('disable_div').style.zIndex = disable ? 1 : -1;
+  if (disable) {
+    document.getElementById('toolbox_section').className = 'disabled';
+    document.getElementById('toolbox_blocks').style.pointerEvents = 'none';
+  } else {
+    document.getElementById('toolbox_section').className = '';
+    document.getElementById('toolbox_blocks').style.pointerEvents = 'auto';
+  }
+
 };
 
 /**


### PR DESCRIPTION
Prompt the user to add a variables or functions category if they add a variables or functions block to their toolbox without having a variables or functions category in their toolbox already. Also allowed user to save their work from a single flyout in a new category not just when an empty category is created, but also when a standard category is loaded or when a separator is added. Also moved checks for variables field and procedure blocks to Factory Utils. 

![screen shot 2016-08-24 at 11 14 20 am](https://cloud.githubusercontent.com/assets/18580768/17942479/62758d16-69ec-11e6-8953-f8c27799acc0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/589)
<!-- Reviewable:end -->
