### PR TITLE
Blockly Factory: Disable Disconnected Blocks, Nit UI, Bug fix

### DIFF
--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -29,7 +29,7 @@ Blockly.Blocks['factory_base'] = {
     this.setColour(120);
     this.appendDummyInput()
         .appendField('name')
-        .appendField(new Blockly.FieldTextInput('math_foo'), 'NAME');
+        .appendField(new Blockly.FieldTextInput('block_type'), 'NAME');
     this.appendStatementInput('INPUTS')
         .setCheck('Input')
         .appendField('inputs');

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -306,12 +306,6 @@ AppController.prototype.onTab = function() {
       this.selectedTab == AppController.WORKSPACE_FACTORY;
 
   if (this.selectedTab == AppController.EXPORTER) {
-    // Warn user that they will lose unsaved changes upon creating a
-    // new block.
-    if (!confirm('You will lose any unsaved changes.')) {
-      return;
-    }
-
     // Show container of exporter.
     FactoryUtils.show('blockLibraryExporter');
     FactoryUtils.hide('workspaceFactoryContent');
@@ -336,12 +330,6 @@ AppController.prototype.onTab = function() {
     FactoryUtils.hide('workspaceFactoryContent');
 
   } else if (this.selectedTab == AppController.WORKSPACE_FACTORY) {
-    // Warn user that they will lose unsaved changes upon creating a
-    // new block.
-    if (!confirm('You will lose any unsaved changes.')) {
-      return;
-    }
-
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.
@@ -531,12 +519,8 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
 
   document.getElementById('createNewBlockButton')
     .addEventListener('click', function() {
-      // Warn user that they will lose unsaved changes upon creating a
-      // new block.
-      if (confirm('You will lose any unsaved changes.')) {
-        BlockFactory.showStarterBlock();
-        BlockLibraryView.selectDefaultOption('blockLibraryDropdown');
-      }
+      BlockFactory.showStarterBlock();
+      BlockLibraryView.selectDefaultOption('blockLibraryDropdown');
     });
 };
 

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -306,6 +306,12 @@ AppController.prototype.onTab = function() {
       this.selectedTab == AppController.WORKSPACE_FACTORY;
 
   if (this.selectedTab == AppController.EXPORTER) {
+    // Warn user that they will lose unsaved changes upon creating a
+    // new block.
+    if (!confirm('You will lose any unsaved changes.')) {
+      return;
+    }
+
     // Show container of exporter.
     FactoryUtils.show('blockLibraryExporter');
     FactoryUtils.hide('workspaceFactoryContent');
@@ -321,7 +327,7 @@ AppController.prototype.onTab = function() {
     // Update exporter's block selector to reflect current block library.
     this.exporter.updateSelector();
 
-    // Update the preview to reflect any changes made to the blocks.
+    // Update the exporter's preview to reflect any changes made to the blocks.
     this.exporter.updatePreview();
 
   } else if (this.selectedTab ==  AppController.BLOCK_FACTORY) {
@@ -330,6 +336,12 @@ AppController.prototype.onTab = function() {
     FactoryUtils.hide('workspaceFactoryContent');
 
   } else if (this.selectedTab == AppController.WORKSPACE_FACTORY) {
+    // Warn user that they will lose unsaved changes upon creating a
+    // new block.
+    if (!confirm('You will lose any unsaved changes.')) {
+      return;
+    }
+
     // Hide container of exporter.
     FactoryUtils.hide('blockLibraryExporter');
     // Show workspace factory container.

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -519,8 +519,12 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
 
   document.getElementById('createNewBlockButton')
     .addEventListener('click', function() {
+      // Warn user that they will lose unsaved changes upon creating a
+      // new block.
+      if (confirm('You will lose any unsaved changes.')) {
         BlockFactory.showStarterBlock();
         BlockLibraryView.selectDefaultOption('blockLibraryDropdown');
+      }
     });
 };
 
@@ -529,6 +533,7 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
  */
 AppController.prototype.addBlockFactoryEventListeners = function() {
   BlockFactory.mainWorkspace.addChangeListener(BlockFactory.updateLanguage);
+  BlockFactory.mainWorkspace.addChangeListener(Blockly.Events.disableOrphans);
   document.getElementById('direction')
       .addEventListener('change', BlockFactory.updatePreview);
   document.getElementById('languageTA')

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -86,10 +86,14 @@ BlockLibraryController.prototype.removeFromBlockLibrary = function() {
  * @param {string} blockType - Block to edit on block factory.
  */
 BlockLibraryController.prototype.openBlock = function(blockType) {
-  var xml = this.storage.getBlockXml(blockType);
-  BlockFactory.mainWorkspace.clear();
-  Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
-  BlockFactory.mainWorkspace.clearUndo();
+  if (blockType =='BLOCK_LIBRARY_DEFAULT_BLANK') {
+    BlockFactory.showStarterBlock();
+  } else {
+    var xml = this.storage.getBlockXml(blockType);
+    BlockFactory.mainWorkspace.clear();
+    Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
+    BlockFactory.mainWorkspace.clearUndo();
+  }
 };
 
 /**
@@ -132,8 +136,9 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
   // If block under that name already exists, confirm that user wants to replace
   // saved block.
   if (this.isInBlockLibrary(blockType)) {
-    if(!confirm('You already have a block called "' + blockType +
-      '" in your library. Replace this block?')) {
+    var replace = confirm('You already have a block called "' + blockType +
+      '" in your library. Replace this block?');
+    if ( !replace) {
       // Do not save if user doesn't want to replace the saved block.
       return;
     }

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -86,9 +86,10 @@ BlockLibraryController.prototype.removeFromBlockLibrary = function() {
  * @param {string} blockType - Block to edit on block factory.
  */
 BlockLibraryController.prototype.openBlock = function(blockType) {
-   var xml = this.storage.getBlockXml(blockType);
-   BlockFactory.mainWorkspace.clear();
-   Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
+  var xml = this.storage.getBlockXml(blockType);
+  BlockFactory.mainWorkspace.clear();
+  Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
+  BlockFactory.mainWorkspace.clearUndo();
 };
 
 /**
@@ -107,8 +108,7 @@ BlockLibraryController.prototype.getSelectedBlockType =
  * updating the dropdown and displaying the starter block (factory_base).
  */
 BlockLibraryController.prototype.clearBlockLibrary = function() {
-  var check = confirm(
-      'Click OK to clear your block library.');
+  var check = confirm('Delete all blocks from library?');
   if (check) {
     // Clear Block Library Storage.
     this.storage.clear();
@@ -128,12 +128,12 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
  */
 BlockLibraryController.prototype.saveToBlockLibrary = function() {
   var blockType = this.getCurrentBlockType_();
+
   // If block under that name already exists, confirm that user wants to replace
   // saved block.
   if (this.isInBlockLibrary(blockType)) {
-    var replace = confirm('You already have a block called ' + blockType +
-      ' in your library. Click OK to replace.');
-    if (!replace) {
+    if(!confirm('You already have a block called "' + blockType +
+      '" in your library. Replace this block?')) {
       // Do not save if user doesn't want to replace the saved block.
       return;
     }

--- a/demos/blocklyfactory/block_library_view.js
+++ b/demos/blocklyfactory/block_library_view.js
@@ -61,7 +61,7 @@ BlockLibraryView.addOption
  */
 BlockLibraryView.addDefaultOption = function(dropdownID) {
   BlockLibraryView.addOption(
-      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
+      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, true);
 };
 
 /**

--- a/demos/blocklyfactory/factory.js
+++ b/demos/blocklyfactory/factory.js
@@ -249,4 +249,3 @@ BlockFactory.showStarterBlock = function() {
     Blockly.Xml.domToWorkspace(
         Blockly.Xml.textToDom(xml), BlockFactory.mainWorkspace);
 };
-

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -337,7 +337,7 @@
           </tr>
           <tr>
             <td height="5%">
-              <h3>Language code:
+              <h3>Block Definition:
                 <select id="format">
                   <option value="JSON">JSON</option>
                   <option value="JavaScript">JavaScript</option>


### PR DESCRIPTION
## Block Factory
- disable blocks if they aren't connected to the factory_base block
- clear undo in the main workspace on load of each block
- changed 'Language Code' to 'Block Definition'
- changed 'math_foo' to 'block_type
- changed confirm messages to not reference 'OK'

<img width="1260" alt="screen shot 2016-08-24 at 4 52 40 pm" src="https://cloud.githubusercontent.com/assets/10423718/17951991/360d3aba-6a1b-11e6-811e-265dd0f1dbd0.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/595)
<!-- Reviewable:end -->
