### PR TITLE
Fix toolbox scrolling in horizontal layout

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -605,8 +605,10 @@ Blockly.Toolbox.TreeNode.prototype.onDoubleClick_ = function(e) {
 Blockly.Toolbox.TreeNode.prototype.onKeyDown = function(e) {
   if (this.horizontalLayout_) {
     var map = {};
-    map[goog.events.KeyCodes.RIGHT] = goog.events.KeyCodes.DOWN;
-    map[goog.events.KeyCodes.LEFT] = goog.events.KeyCodes.UP;
+    var next = goog.events.KeyCodes.DOWN
+    var prev = goog.events.KeyCodes.UP
+    map[goog.events.KeyCodes.RIGHT] = this.rightToLeft_ ? prev : next;
+    map[goog.events.KeyCodes.LEFT] = this.rightToLeft_ ? next : prev;
     map[goog.events.KeyCodes.UP] = goog.events.KeyCodes.LEFT;
     map[goog.events.KeyCodes.DOWN] = goog.events.KeyCodes.RIGHT;
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -542,7 +542,6 @@ Blockly.Toolbox.TreeControl.prototype.setSelectedItem = function(node) {
 Blockly.Toolbox.TreeNode = function(toolbox, html, opt_config, opt_domHelper) {
   goog.ui.tree.TreeNode.call(this, html, opt_config, opt_domHelper);
   if (toolbox) {
-    this.horizontalLayout_ = toolbox.horizontalLayout_;
     var resize = function() {
       // Even though the div hasn't changed size, the visible workspace
       // surface of the workspace has, so we may need to reposition everything.
@@ -603,7 +602,7 @@ Blockly.Toolbox.TreeNode.prototype.onDoubleClick_ = function(e) {
  * @private
  */
 Blockly.Toolbox.TreeNode.prototype.onKeyDown = function(e) {
-  if (this.horizontalLayout_) {
+  if (this.tree.toolbox_.horizontalLayout_) {
     var map = {};
     var next = goog.events.KeyCodes.DOWN
     var prev = goog.events.KeyCodes.UP


### PR DESCRIPTION
Fix bugs pointed by @NeilFraser in #441:
>  A divider eats the focus. Right and left are reversed in RTL.