### PR TITLE
Require constants in workspaceSvg, which uses them during initialization

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -29,6 +29,7 @@ goog.provide('Blockly.WorkspaceSvg');
 // TODO(scr): Fix circular dependencies
 //goog.require('Blockly.BlockSvg');
 goog.require('Blockly.ConnectionDB');
+goog.require('Blockly.constants');
 goog.require('Blockly.Options');
 goog.require('Blockly.ScrollbarPair');
 goog.require('Blockly.Trashcan');


### PR DESCRIPTION
Without this, dragMode_ is undefined until explicitly set through a use action.