### PR TITLE
Blockly Factory: Shadow Block UI

### DIFF
--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -467,6 +467,21 @@ td {
   margin-top: 2%;
 }
 
+#button_addShadow, #button_removeShadow {
+  display: inline-block;
+}
+
+#disable_div {
+  background-color: white;
+  height: 100%;
+  left: 0;
+  opacity: .5;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: -1;  /* Start behind workspace */
+}
+
 /* Rules for Closure popup color picker */
 .goog-palette {
   outline: none;

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -467,10 +467,6 @@ td {
   margin-top: 2%;
 }
 
-#button_addShadow, #button_removeShadow {
-  display: inline-block;
-}
-
 #disable_div {
   background-color: white;
   height: 100%;

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -212,15 +212,8 @@
 
       </aside>
 
-      <div id="shadowBlockDropdown" class='dropdown'>
-      <button id="button_editShadow">Edit Block</button>
-      <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
-        <a id='dropdown_addShadow'>Add Shadow</a>
-      </div>
-      <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
-        <a id='dropdown_removeShadow'>Remove Shadow</a>
-      </div>
-      </div>
+      <button id='button_addShadow' style='display:none'>Make Shadow</button>
+      <button id='button_removeShadow' style='display:none'>Remove Shadow</button>
 
       <aside id='preload_div' style='display:none'>
         <div id="preloadHelp">

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -423,6 +423,9 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
       if (!this.previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Create a toolbox, expensive.
       } else {
+        // Close the toolbox before updating it so that the user has to reopen
+        // the flyout and see their updated toolbox (open flyout doesn't update)
+        this.previewWorkspace.toolbox_.clearSelection();
         this.previewWorkspace.updateToolbox(tree);
       }
     }

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -47,7 +47,6 @@ WorkspaceFactoryInit.initWorkspaceFactory = function(controller) {
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
   document.getElementById('button_editCategory').disabled = true;
-  document.getElementById('button_editShadow').disabled = true;
 
   this.initColorPicker_(controller);
   this.addWorkspaceFactoryEventListeners_(controller);
@@ -258,34 +257,6 @@ WorkspaceFactoryInit.assignWorkspaceFactoryClickHandlers_ =
         toggle("show");
       });
 
-  document.getElementById('button_editShadow').addEventListener
-      ('click',
-      function() {
-        if (Blockly.selected) {
-          // Can only edit blocks when a block is selected.
-
-          if (!controller.isUserGenShadowBlock(Blockly.selected.id) &&
-              Blockly.selected.getSurroundParent() != null) {
-            // If a block is selected that could be a valid shadow block (not a
-            // shadow block, has a surrounding parent), let the user make it a
-            // shadow block. Use toggle instead of add so that the user can
-            // click the button again to make the dropdown disappear without
-            // clicking one of the options.
-            document.getElementById('dropdownDiv_editShadowRemove').classList.
-                remove("show");
-            document.getElementById('dropdownDiv_editShadowAdd').classList.
-                toggle("show");
-          } else {
-            // If the block is a shadow block, let the user make it a normal
-            // block.
-            document.getElementById('dropdownDiv_editShadowAdd').classList.
-                remove("show");
-            document.getElementById('dropdownDiv_editShadowRemove').classList.
-                toggle("show");
-          }
-        }
-      });
-
   document.getElementById('dropdown_name').addEventListener
       ('click',
       function() {
@@ -354,24 +325,25 @@ document.getElementById('button_importBlocks').addEventListener
         controller.clearAll();
       });
 
-  document.getElementById('dropdown_addShadow').addEventListener
+  document.getElementById('button_addShadow').addEventListener
       ('click',
       function() {
         controller.addShadow();
-        document.getElementById('dropdownDiv_editShadowAdd').classList.
-            remove("show");
+        WorkspaceFactoryInit.displayAddShadow_(false);
+        WorkspaceFactoryInit.displayRemoveShadow_(true);
       });
 
-  document.getElementById('dropdown_removeShadow').addEventListener
+  document.getElementById('button_removeShadow').addEventListener
       ('click',
       function() {
         controller.removeShadow();
-        document.getElementById('dropdownDiv_editShadowRemove').classList.
-            remove("show");
+        WorkspaceFactoryInit.displayAddShadow_(true);
+        WorkspaceFactoryInit.displayRemoveShadow_(false);
+
         // Disable shadow editing button if turning invalid shadow block back
         // to normal block.
         if (!Blockly.selected.getSurroundParent()) {
-          document.getElementById('button_editShadow').disabled = true;
+          document.getElementById('button_addShadow').disabled = true;
         }
       });
 
@@ -437,6 +409,18 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         e.element == 'selected')) {
       var selected = Blockly.selected;
 
+      // Show shadow button if a block is selected. Show "Add Shadow" if
+      // a block is not a shadow block, show "Remove Shadow" if it is a
+      // shadow block.
+      if (selected) {
+        var isShadow = controller.isUserGenShadowBlock(selected.id);
+        WorkspaceFactoryInit.displayAddShadow_(!isShadow);
+        WorkspaceFactoryInit.displayRemoveShadow_(isShadow);
+      } else {
+        WorkspaceFactoryInit.displayAddShadow_(false);
+        WorkspaceFactoryInit.displayRemoveShadow_(false);
+      }
+
       if (selected != null && selected.getSurroundParent() != null &&
           !controller.isUserGenShadowBlock(selected.getSurroundParent().id)) {
         // Selected block is a valid shadow block or could be a valid shadow
@@ -444,7 +428,9 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
         // Enable block editing and remove warnings if the block is not a
         // variable user-generated shadow block.
-        document.getElementById('button_editShadow').disabled = false;
+        document.getElementById('button_addShadow').disabled = false;
+        document.getElementById('button_removeShadow').disabled = false;
+
         if (!FactoryUtils.hasVariableField(selected) &&
             controller.isDefinedBlock(selected)) {
           selected.setWarningText(null);
@@ -459,7 +445,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
           if (!controller.isUserGenShadowBlock(selected.id)) {
             // Warn if a non-shadow block is nested inside a shadow block.
-            selected.setWarningText('Only shadow blocks can be nested inside '
+            selected.setWarningText('Only shadow blocks can be nested inside\n'
                 + 'other shadow blocks.');
           } else if (!FactoryUtils.hasVariableField(selected)) {
             // Warn if a shadow block is invalid only if not replacing
@@ -470,7 +456,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
           // Give editing options so that the user can make an invalid shadow
           // block a normal block.
-          document.getElementById('button_editShadow').disabled = false;
+          document.getElementById('button_removeShadow').disabled = false;
+          document.getElementById('button_addShadow').disabled = true;
         } else {
           // Selected block does not break any shadow block rules, but cannot
           // be a shadow block.
@@ -484,11 +471,8 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
 
           // No block selected that is a shadow block or could be a valid shadow
           // block. Disable block editing.
-          document.getElementById('button_editShadow').disabled = true;
-          document.getElementById('dropdownDiv_editShadowRemove').classList.
-              remove("show");
-          document.getElementById('dropdownDiv_editShadowAdd').classList.
-              remove("show");
+          document.getElementById('button_addShadow').disabled = true;
+          document.getElementById('button_removeShadow').disabled = true;
         }
       }
     }
@@ -545,6 +529,28 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
     }
   });
 };
+
+/**
+ * Display or hide the add shadow button.
+ *
+ * @param {boolean} show True if the add shadow button should be shown, false
+ *    otherwise.
+ */
+WorkspaceFactoryInit.displayAddShadow_ = function(show) {
+  document.getElementById('button_addShadow').style.display =
+      show ? 'inline-block' : 'none';
+};
+
+/**
+ * Display or hide the remove shadow button.
+ *
+ * @param {boolean} show True if the remove shadow button should be shown, false
+ *    otherwise.
+ */
+WorkspaceFactoryInit.displayRemoveShadow_ = function(show) {
+  document.getElementById('button_removeShadow').style.display =
+      show ? 'inline-block' : 'none';
+}
 
 /**
  * Add listeners for workspace factory options input elements.


### PR DESCRIPTION
Changed UI for making a block a shadow block or not a shadow block. Instead of having an "Edit Block" dropdown that is disabled whenever the selected block cannot be made a shadow block or a block isn't selected, instead a "Add Shadow" or "Remove Shadow" button appears whenever a block is selected ("Add Shadow" if the block is not a shadow block, "Remove Shadow" if it is). The button is disabled if the block is not a shadow block and cannot legally become one. Only one button will ever be displayed at a time. 

Adding this button instead of a dropdown that is usually disabled makes it clearer what the button actually does, and by changing the text of the button instead of the content of the dropdown, it reduces the number of clicks for the user to figure out what the options are. Also, hiding the buttons when a block is not selected reduces confusion over what adding and removing shadows mean. 
![screen shot 2016-08-25 at 3 34 21 pm](https://cloud.githubusercontent.com/assets/18580768/17988343/7b18b138-6ada-11e6-92e5-69f358acbf0c.png)
![screen shot 2016-08-25 at 3 42 15 pm](https://cloud.githubusercontent.com/assets/18580768/17988355/945114a6-6ada-11e6-824d-f4145ead64c4.png)
![screen shot 2016-08-25 at 3 42 23 pm](https://cloud.githubusercontent.com/assets/18580768/17988357/9664d58e-6ada-11e6-87c6-c89ebbfe4183.png)
![screen shot 2016-08-25 at 3 42 29 pm](https://cloud.githubusercontent.com/assets/18580768/17988360/9943d304-6ada-11e6-99df-664da2cfb231.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/602)
<!-- Reviewable:end -->
