### PR TITLE
Blockly Factory: Warn user when leaving/refreshing page

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -620,6 +620,20 @@ AppController.prototype.onresize = function(event) {
 };
 
 /**
+ * Handler for the window's 'onbeforeunload' event. When a user has unsaved
+ * changes and refreshes or leaves the page, confirm that they want to do so
+ * before actually refreshing.
+ */
+AppController.prototype.confirmLeavePage = function() {
+  console.log('confirmLeavePage');
+  if (!FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
+    console.log('nOT savedBlockChanges');
+    return 'You will lose any unsaved changes. Are you sure you want ' +
+        'to exit this page?';
+  }
+};
+
+/**
  * Initialize Blockly and layout.  Called on page load.
  */
 AppController.prototype.init = function() {

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -625,9 +625,7 @@ AppController.prototype.onresize = function(event) {
  * before actually refreshing.
  */
 AppController.prototype.confirmLeavePage = function() {
-  console.log('confirmLeavePage');
   if (!FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
-    console.log('nOT savedBlockChanges');
     return 'You will lose any unsaved changes. Are you sure you want ' +
         'to exit this page?';
   }

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -625,7 +625,10 @@ AppController.prototype.onresize = function(event) {
  * before actually refreshing.
  */
 AppController.prototype.confirmLeavePage = function() {
-  if (!FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
+  if (!BlockFactory.isStarterBlock() &&
+      !FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
+    // When a string is assigned to the returnValue Event property, a dialog box
+    // appears, asking the users for confirmation to leave the page.
     return 'You will lose any unsaved changes. Are you sure you want ' +
         'to exit this page?';
   }

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -39,9 +39,15 @@
       blocklyFactory.init();
     };
     window.addEventListener('load', init);
+
+    function confirmLeavePage() {
+      return 'You will lose any unsaved changes. Are you sure you want ' +
+          'to exit this page?';
+    }
+
   </script>
 </head>
-<body>
+<body onbeforeunload="return confirmLeavePage()">
 <h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
   <a href="../index.html">Demos</a> &gt; Blockly Factory
   <button id="helpButton" title="View documentation in new window.">

--- a/demos/blocklyfactory/index.html
+++ b/demos/blocklyfactory/index.html
@@ -39,15 +39,9 @@
       blocklyFactory.init();
     };
     window.addEventListener('load', init);
-
-    function confirmLeavePage() {
-      return 'You will lose any unsaved changes. Are you sure you want ' +
-          'to exit this page?';
-    }
-
   </script>
 </head>
-<body onbeforeunload="return confirmLeavePage()">
+<body onbeforeunload="return blocklyFactory.confirmLeavePage()">
 <h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
   <a href="../index.html">Demos</a> &gt; Blockly Factory
   <button id="helpButton" title="View documentation in new window.">


### PR DESCRIPTION
Blockly Factory currently doesn't support automatic saving of work. In order to prevent users from unwittingly losing their work by leaving the page, I've added some alerts.

### On Refresh
<img width="1440" alt="screen shot 2016-08-26 at 6 10 13 pm" src="https://cloud.githubusercontent.com/assets/10423718/18024155/9e7bec6a-6bb8-11e6-9987-531e9c16ccbc.png">

### On Back Button or Closing Window/Tab
<img width="1438" alt="screen shot 2016-08-26 at 6 10 27 pm" src="https://cloud.githubusercontent.com/assets/10423718/18024156/9e8740f6-6bb8-11e6-9eb6-0b6d83989e95.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/607)
<!-- Reviewable:end -->
