### PR TITLE
Blockly Factory: Close Toolbox when Updating Block Library

### DIFF
--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -1248,6 +1248,7 @@ WorkspaceFactoryController.prototype.setBlockLibCategory =
 
   // Update the toolbox and toolboxWorkspace.
   this.toolbox.replaceChild(categoryXml, blockLibCategory);
+  this.toolboxWorkspace.toolbox_.clearSelection();
   this.toolboxWorkspace.updateToolbox(this.toolbox);
 
   // Update the block library types.


### PR DESCRIPTION
Close the toolbox workspace toolbox when updating the block library category in the toolbox so that the block library category is never out of sync with the blocks in the block library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/610)
<!-- Reviewable:end -->
