### PR TITLE
Blockly Factory: Block Library bug fix & scroll

### DIFF
--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -161,7 +161,8 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
   // main workspace.
   this.openBlock(blockType);
 
-  this.addOptionSelectHandlers();
+  // Add select handler to the new option.
+  this.addOptionSelectHandler(blockType);
 };
 
 /**
@@ -254,10 +255,13 @@ BlockLibraryController.prototype.setNoneSelected = function() {
 };
 
 /**
- * Add select handlers to each option to update the view and the selected
- * blocks accordingly.
+ * Add select handler for an option of a given block type. The handler will to
+ * update the view and the selected block accordingly.
+ *
+ * @param {!string} blockType - The type of block represented by the option is
+ * for.
  */
-BlockLibraryController.prototype.addOptionSelectHandlers = function() {
+BlockLibraryController.prototype.addOptionSelectHandler = function(blockType) {
   var self = this;
 
   // Click handler for a block option. Sets the block option as the selected
@@ -287,12 +291,21 @@ BlockLibraryController.prototype.addOptionSelectHandlers = function() {
     };
   };
 
+  // Assign a click handler to the block option.
+  var blockOption = this.view.optionMap[blockType];
+  // Use an additional closure to correctly assign the tab callback.
+  blockOption.addEventListener(
+      'click', makeOptionSelectHandler_(blockOption));
+};
+
+/**
+ * Add select handlers to each option to update the view and the selected
+ * blocks accordingly.
+ */
+BlockLibraryController.prototype.addOptionSelectHandlers = function() {
   // Assign a click handler to each block option.
   for (var blockType in this.view.optionMap) {
-    var blockOption = this.view.optionMap[blockType];
-    // Use an additional closure to correctly assign the tab callback.
-    blockOption.addEventListener(
-        'click', makeOptionSelectHandler_(blockOption));
+    this.addOptionSelectHandler(blockType);
   }
 };
 

--- a/demos/blocklyfactory/factory.css
+++ b/demos/blocklyfactory/factory.css
@@ -304,6 +304,11 @@ button, .buttonStyle {
 
 /* Block Library */
 
+#dropdownDiv_blockLib {
+  max-height: 65%;
+  overflow-y: scroll;
+}
+
 #button_blockLib {
   border-color: darkgrey;
   font-size: large;

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -994,7 +994,7 @@ FactoryUtils.warnIfUnsavedChanges = function() {
   if (!BlockFactory.isStarterBlock() &&
       !FactoryUtils.savedBlockChanges(self.blockLibraryController)) {
     return confirm('You have unsaved changes. By proceeding without saving ' +
-      ' your block first, you will lose these changes.');
+        ' your block first, you will lose these changes.');
   }
   return true;
 };


### PR DESCRIPTION
- fix bug where repeated alerts for unsaved changes popped up upon selecting different block from library dropdown (due to assignment of multiple of the same click handler). 
- made the block lib scrollable when it reaches a max height in CSS
<img width="738" alt="screen shot 2016-08-30 at 1 52 26 pm" src="https://cloud.githubusercontent.com/assets/10423718/18106594/5a5a0b12-6eb9-11e6-9e17-1c6c10a00385.png">
