### PR TITLE
Blockly Factory: Global Self Bug Fix  

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -531,7 +531,8 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
     .addEventListener('click', function() {
       // If there are unsaved changes warn user, check if they'd like to
       // proceed with unsaved changes, and act accordingly.
-      var proceedWithUnsavedChanges = FactoryUtils.warnIfUnsavedChanges();
+      var proceedWithUnsavedChanges =
+          FactoryUtils.warnIfUnsavedChanges(self.blockLibraryController);
       if (!proceedWithUnsavedChanges) {
         return;
       }
@@ -649,7 +650,7 @@ AppController.prototype.init = function() {
   this.assignBlockFactoryClickHandlers();
 
   this.onresize();
-  self = this;
+  var self = this;
   window.addEventListener('resize', function() {
     self.onresize();
   });

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -287,7 +287,7 @@ AppController.prototype.onTab = function() {
   if (this.lastSelectedTab == AppController.BLOCK_FACTORY &&
       this.selectedTab != AppController.BLOCK_FACTORY) {
 
-    var hasUnsavedChanges = !BlockFactory.isStarterBlock() &&
+    var hasUnsavedChanges =
         !FactoryUtils.savedBlockChanges(this.blockLibraryController);
     if (hasUnsavedChanges &&
         !confirm('You have unsaved changes in Block Factory.')) {
@@ -532,7 +532,7 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
       // If there are unsaved changes warn user, check if they'd like to
       // proceed with unsaved changes, and act accordingly.
       var proceedWithUnsavedChanges =
-          FactoryUtils.warnIfUnsavedChanges(self.blockLibraryController);
+          self.blockLibraryController.warnIfUnsavedChanges();
       if (!proceedWithUnsavedChanges) {
         return;
       }
@@ -626,8 +626,7 @@ AppController.prototype.onresize = function(event) {
  * before actually refreshing.
  */
 AppController.prototype.confirmLeavePage = function() {
-  if (!BlockFactory.isStarterBlock() &&
-      !FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
+  if (!FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
     // When a string is assigned to the returnValue Event property, a dialog box
     // appears, asking the users for confirmation to leave the page.
     return 'You will lose any unsaved changes. Are you sure you want ' +

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -255,6 +255,21 @@ BlockLibraryController.prototype.setNoneSelected = function() {
 };
 
 /**
+ * If there are unsaved changes to the block in open in Block Factory
+ * and the block is not the starter block, check if user wants to proceed,
+ * knowing that it will cause them to lose their changes.
+ *
+ * @return {boolean} Whether or not to proceed.
+ */
+BlockLibraryController.prototype.warnIfUnsavedChanges = function() {
+  if (!FactoryUtils.savedBlockChanges(this)) {
+    return confirm('You have unsaved changes. By proceeding without saving ' +
+        ' your block first, you will lose these changes.');
+  }
+  return true;
+};
+
+/**
  * Add select handler for an option of a given block type. The handler will to
  * update the view and the selected block accordingly.
  *
@@ -283,7 +298,7 @@ BlockLibraryController.prototype.addOptionSelectHandler = function(blockType) {
     return function() {
       // If there are unsaved changes warn user, check if they'd like to
       // proceed with unsaved changes, and act accordingly.
-      var proceedWithUnsavedChanges = FactoryUtils.warnIfUnsavedChanges(self);
+      var proceedWithUnsavedChanges = self.warnIfUnsavedChanges();
       if (!proceedWithUnsavedChanges) {
         return;
       }

--- a/demos/blocklyfactory/block_library_controller.js
+++ b/demos/blocklyfactory/block_library_controller.js
@@ -283,7 +283,7 @@ BlockLibraryController.prototype.addOptionSelectHandler = function(blockType) {
     return function() {
       // If there are unsaved changes warn user, check if they'd like to
       // proceed with unsaved changes, and act accordingly.
-      var proceedWithUnsavedChanges = FactoryUtils.warnIfUnsavedChanges();
+      var proceedWithUnsavedChanges = FactoryUtils.warnIfUnsavedChanges(self);
       if (!proceedWithUnsavedChanges) {
         return;
       }

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -963,7 +963,8 @@ FactoryUtils.isProcedureBlock = function(block) {
 };
 
 /**
- * Returns whether or not a block's changes has been saved to the Block Library.
+ * Returns whether or not a modified block's changes has been saved to the
+ * Block Library.
  * TODO(quachtina96): move into the Block Factory Controller once made.
  *
  * @param {!BlockLibraryController} blockLibraryController - Block Library
@@ -972,6 +973,9 @@ FactoryUtils.isProcedureBlock = function(block) {
  *    the given Block Library.
  */
 FactoryUtils.savedBlockChanges = function(blockLibraryController) {
+  if (BlockFactory.isStarterBlock()) {
+    return true;
+  }
   var blockType = blockLibraryController.getCurrentBlockType();
   var currentXml = Blockly.Xml.workspaceToDom(BlockFactory.mainWorkspace);
 
@@ -983,20 +987,3 @@ FactoryUtils.savedBlockChanges = function(blockLibraryController) {
   return false;
 };
 
-/**
- * If there are unsaved changes to the block in open in Block Factory
- * and the block is not the starter block, check if user wants to proceed,
- * knowing that it will cause them to lose their changes.
- *
- * @param {!BlockLibraryController} blockLibraryController - Block Library
- *    Controller storing custom blocks.
- * @return {boolean} Whether or not to proceed.
- */
-FactoryUtils.warnIfUnsavedChanges = function(blockLibraryController) {
-  if (!BlockFactory.isStarterBlock() &&
-      !FactoryUtils.savedBlockChanges(blockLibraryController)) {
-    return confirm('You have unsaved changes. By proceeding without saving ' +
-        ' your block first, you will lose these changes.');
-  }
-  return true;
-};

--- a/demos/blocklyfactory/factory_utils.js
+++ b/demos/blocklyfactory/factory_utils.js
@@ -988,11 +988,13 @@ FactoryUtils.savedBlockChanges = function(blockLibraryController) {
  * and the block is not the starter block, check if user wants to proceed,
  * knowing that it will cause them to lose their changes.
  *
+ * @param {!BlockLibraryController} blockLibraryController - Block Library
+ *    Controller storing custom blocks.
  * @return {boolean} Whether or not to proceed.
  */
-FactoryUtils.warnIfUnsavedChanges = function() {
+FactoryUtils.warnIfUnsavedChanges = function(blockLibraryController) {
   if (!BlockFactory.isStarterBlock() &&
-      !FactoryUtils.savedBlockChanges(self.blockLibraryController)) {
+      !FactoryUtils.savedBlockChanges(blockLibraryController)) {
     return confirm('You have unsaved changes. By proceeding without saving ' +
         ' your block first, you will lose these changes.');
   }


### PR DESCRIPTION
The Factory Utils function warnIfUnsavedChanges contained code copied from AppController that referenced self.blockLibraryController. The code worked properly despite self not being defined in the function because of an accidental global self defined. 

Changes made:
- made the global self local to the App Controller init function
- make the block library controller a parameter in the Factory Utils function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/616)
<!-- Reviewable:end -->
