### PR TITLE
Blockly Factory: Check for Unsaved Changes in Workspace Factory

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -626,7 +626,9 @@ AppController.prototype.onresize = function(event) {
  * before actually refreshing.
  */
 AppController.prototype.confirmLeavePage = function() {
-  if (!FactoryUtils.savedBlockChanges(this.blockLibraryController)) {
+  if ((!BlockFactory.isStarterBlock() &&
+      !FactoryUtils.savedBlockChanges(this.blockLibraryController)) ||
+      this.workspaceFactoryController.hasUnsavedChanges()) {>>>>>>> Bug fix for adding variables and procedures categories with prompt, removed blocks from category name, check if unsaved changes in workspace factory before leave
     // When a string is assigned to the returnValue Event property, a dialog box
     // appears, asking the users for confirmation to leave the page.
     return 'You will lose any unsaved changes. Are you sure you want ' +

--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -628,7 +628,7 @@ AppController.prototype.onresize = function(event) {
 AppController.prototype.confirmLeavePage = function() {
   if ((!BlockFactory.isStarterBlock() &&
       !FactoryUtils.savedBlockChanges(this.blockLibraryController)) ||
-      this.workspaceFactoryController.hasUnsavedChanges()) {>>>>>>> Bug fix for adding variables and procedures categories with prompt, removed blocks from category name, check if unsaved changes in workspace factory before leave
+      this.workspaceFactoryController.hasUnsavedChanges()) {
     // When a string is assigned to the returnValue Event property, a dialog box
     // appears, asking the users for confirmation to leave the page.
     return 'You will lose any unsaved changes. Are you sure you want ' +

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -440,6 +440,7 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
 WorkspaceFactoryController.prototype.saveStateFromWorkspace = function() {
   if (this.selectedMode == WorkspaceFactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
+    // Update flags if toolbox has been changed.
     if (this.model.getSelectedXml() !=
         Blockly.Xml.workspaceToDom(this.toolboxWorkspace)) {
       this.hasUnsavedToolboxChanges = true;
@@ -449,6 +450,7 @@ WorkspaceFactoryController.prototype.saveStateFromWorkspace = function() {
 
   } else if (this.selectedMode == WorkspaceFactoryController.MODE_PRELOAD) {
     // If currently editing the pre-loaded workspace.
+    // Update flags if preloaded blocks have been changed.
     if (this.model.getPreloadXml() !=
         Blockly.Xml.workspaceToDom(this.toolboxWorkspace)) {
       this.hasUnsavedPreloadChanges = true;
@@ -910,6 +912,8 @@ WorkspaceFactoryController.prototype.clearAll = function() {
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
   this.saveStateFromWorkspace();
+  this.hasUnsavedToolboxChanges = false;
+  this.hasUnsavedPreloadChanges = false;
   this.view.setCategoryOptions(this.model.hasElements());
   this.generateNewOptions();
   this.updatePreview();

--- a/demos/blocklyfactory/workspacefactory/wfactory_init.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_init.js
@@ -528,13 +528,16 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
         if (confirm('Your new block has a variables field. To use this block '
             + 'fully, you will need a Variables category. Do you want to add '
             + 'a Variables category to your custom toolbox?')) {
+          controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
           controller.loadCategoryByName('variables');
         }
+      }
 
-      } else if (procedureCreated && !controller.hasProceduresCategory()) {
+      if (procedureCreated && !controller.hasProceduresCategory()) {
         if (confirm('Your new block is a function block. To use this block '
             + 'fully, you will need a Functions category. Do you want to add '
             + 'a Functions category to your custom toolbox?')) {
+          controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);
           controller.loadCategoryByName('functions');
         }
       }


### PR DESCRIPTION
Extend check for unsaved changes in Blockly Factory to check for unsaved changes in Workspace Factory (this is especially useful because Workspace Factory doesn't use local or session storage). Also removed blocks from the category name for imported blocks (shortens the name so that it fits more easily on the screen), and fixed bug when adding a variables or functions category from a prompt when in workspace mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/617)
<!-- Reviewable:end -->
