### PR TITLE
Add warning if you do not have required parts of closure available wh…

### DIFF
--- a/demos/blocklyfactory/app_controller.js
+++ b/demos/blocklyfactory/app_controller.js
@@ -640,6 +640,20 @@ AppController.prototype.confirmLeavePage = function() {
  * Initialize Blockly and layout.  Called on page load.
  */
 AppController.prototype.init = function() {
+  // Blockly factory has a dependency on bits of closure that core blockly
+  // doesn't have. When you run this from file:// without a copy of closure,
+  // it breaks it non-obvious ways.  Warning about this for now until the
+  // dependency is broken.
+  // TODO: #668.
+  if (!window.goog.dom.xml) {
+    alert('Sorry: Closure dependency not found. We are working on removing ' +
+      'this dependency.  In the meantime, you can use our hosted demo\n ' + 
+      'https://blockly-demo.appspot.com/static/demos/blocklyfactory/index.html' +
+      '\nor use these instructions to continue running locally:\n' +
+      'https:developers.google.com/blockly/guides/modify/web/closure');
+    return;
+  }
+
   // Handle Blockly Storage with App Engine
   if ('BlocklyStorage' in window) {
     this.initializeBlocklyStorage();


### PR DESCRIPTION
…en loading BlocklyFactory. This should be temporary until #668 is fixed