### PR TITLE
Resets zoom to startScale instead of 1.

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -33,6 +33,8 @@ goog.require('Blockly.Blocks');
  * Common HSV hue for all blocks in this category.
  */
 Blockly.Blocks.variables.HUE = 330;
+Blockly.Blocks.variables.GET_HUE = null;
+Blockly.Blocks.variables.SET_HUE = null;
 
 Blockly.Blocks['variables_get'] = {
   /**
@@ -41,7 +43,8 @@ Blockly.Blocks['variables_get'] = {
    */
   init: function() {
     this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-    this.setColour(Blockly.Blocks.variables.HUE);
+    this.setColour(Blockly.Blocks.variables.GET_HUE === null ?
+        Blockly.Blocks.variables.HUE : Blockly.Blocks.variables.GET_HUE);
     this.appendDummyInput()
         .appendField(new Blockly.FieldVariable(
         Blockly.Msg.VARIABLES_DEFAULT_NAME), 'VAR');
@@ -74,6 +77,11 @@ Blockly.Blocks['variables_set'] = {
    * @this Blockly.Block
    */
   init: function() {
+    if (Blockly.Blocks.variables.GET_HUE === null) {
+      this.setColour(Blockly.Blocks.variables.HUE);
+    } else {
+      this.setColour(Blockly.Blocks.variables.GET_HUE);
+    }
     this.jsonInit({
       "message0": Blockly.Msg.VARIABLES_SET,
       "args0": [
@@ -89,7 +97,8 @@ Blockly.Blocks['variables_set'] = {
       ],
       "previousStatement": null,
       "nextStatement": null,
-      "colour": Blockly.Blocks.variables.HUE,
+      "colour": Blockly.Blocks.variables.SET_HUE === null ?
+        Blockly.Blocks.variables.HUE : Blockly.Blocks.variables.SET_HUE,
       "tooltip": Blockly.Msg.VARIABLES_SET_TOOLTIP,
       "helpUrl": Blockly.Msg.VARIABLES_SET_HELPURL
     });

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -163,7 +163,7 @@ Blockly.ZoomControls.prototype.createDom = function() {
 
   // Attach event listeners.
   Blockly.bindEvent_(zoomresetSvg, 'mousedown', null, function(e) {
-    workspace.setScale(1);
+    workspace.setScale(workspace.options.zoomOptions.startScale);
     workspace.scrollCenter();
     e.stopPropagation();  // Don't start a workspace scroll.
     e.preventDefault();  // Stop double-clicking from selecting text.


### PR DESCRIPTION
Hitting the reset zoom button causes the scale to be set to 1. Shouldn't it be set to the client's startScale?