### PR TITLE
Separates hues for variables_get and variables_set.

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -33,6 +33,8 @@ goog.require('Blockly.Blocks');
  * Common HSV hue for all blocks in this category.
  */
 Blockly.Blocks.variables.HUE = 330;
+Blockly.Blocks.variables.GET_HUE = null;
+Blockly.Blocks.variables.SET_HUE = null;
 
 Blockly.Blocks['variables_get'] = {
   /**
@@ -41,7 +43,8 @@ Blockly.Blocks['variables_get'] = {
    */
   init: function() {
     this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-    this.setColour(Blockly.Blocks.variables.HUE);
+    this.setColour(Blockly.Blocks.variables.GET_HUE === null ?
+        Blockly.Blocks.variables.HUE : Blockly.Blocks.variables.GET_HUE);
     this.appendDummyInput()
         .appendField(new Blockly.FieldVariable(
         Blockly.Msg.VARIABLES_DEFAULT_NAME), 'VAR');
@@ -89,7 +92,8 @@ Blockly.Blocks['variables_set'] = {
       ],
       "previousStatement": null,
       "nextStatement": null,
-      "colour": Blockly.Blocks.variables.HUE,
+      "colour": Blockly.Blocks.variables.SET_HUE === null ?
+        Blockly.Blocks.variables.HUE : Blockly.Blocks.variables.SET_HUE,
       "tooltip": Blockly.Msg.VARIABLES_SET_TOOLTIP,
       "helpUrl": Blockly.Msg.VARIABLES_SET_HELPURL
     });


### PR DESCRIPTION
It'd be nice to be able to color setters and getters differently. For instance, a language may emphasize the difference between statements and expressions. Currently, the builtin variable blocks are all colored the same by Blockly.Blocks.variables.HUE.

This commit allows the client to optionally assign to Blockly.Blocks.variables.{SET_HUE,GET_HUE} to color them differently. If the values are not set, it falls back to HUE.
