### PR TITLE
Stops duplicating on rename of old ID to old ID.

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -252,8 +252,6 @@ Blockly.Workspace.prototype.renameVariable = function(oldName, newName) {
   } else if (variableIndex != -1 && newVariableIndex != -1) {
     // Renaming one existing variable to another existing variable.
     this.variableList.splice(variableIndex, 1);
-    // The case might have changed.
-    this.variableList[newVariableIndex] = newName;
   } else {
     this.variableList.push(newName);
     console.log('Tried to rename an non-existent variable.');


### PR DESCRIPTION
I was seeing duplicated names in my variables list. Here's a minimal workflow to reproduce the issue:

1. Create a variable named `x`.
2. Create a variable named `y`.
3. Drag two setters to the canvas, one for `x` and one for `y`.
4. Rename `x` to `y`.
5. Find two `y`s listed in the variables flyout and the dropdown menus.

The cause of the trouble seems to be the rename case where both identifiers already exist. The old identifier is properly deleted, but then there's this reassignment:

    // The case might have changed.
    this.variableList[newVariableIndex] = newName;

If only the case had changed, the first branch of the if would handle the rename. Therefore, I don't think this line is needed, but if it is, `newVariableIndex` is stale after the `splice`. It will either clobber another variable or append a duplicate name.