### PR TITLE
Adding controls_ifelse block

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -265,6 +265,42 @@ Blockly.Blocks['controls_if_else'] = {
   }
 };
 
+Blockly.Blocks['controls_ifelse'] = {
+  /**
+   * If/else block that does not a mutator.
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": Blockly.Msg.CONTROLS_IFELSE_TITLE,
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "IF",
+          "check": "Boolean",
+          "align": "RIGHT"
+        },
+        {
+          "type": "input_statement",
+          "name": "DO",
+          "check": "Boolean",
+          "align": "RIGHT"
+        },
+        {
+          "type": "input_statement",
+          "name": "ELSE",
+          "check": "Boolean",
+          "align": "RIGHT"
+        }
+      ],
+      "previousStatement": null,
+      "nextStatement": null,
+      "colour": Blockly.Blocks.logic.HUE,
+      "tooltip": Blockly.Msg.CONTROLS_IF_TOOLTIP_2,
+      "helpUrl": Blockly.Msg.CONTROLS_IF_HELPURL
+    });    
+  }
+};
+
 Blockly.Blocks['logic_compare'] = {
   /**
    * Block for comparison operator.

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -267,7 +267,7 @@ Blockly.Blocks['controls_if_else'] = {
 
 Blockly.Blocks['controls_ifelse'] = {
   /**
-   * If/else block that does not a mutator.
+   * If/else block that does not use a mutator.
    */
   init: function() {
     this.jsonInit({
@@ -275,13 +275,13 @@ Blockly.Blocks['controls_ifelse'] = {
       "args0": [
         {
           "type": "input_value",
-          "name": "IF",
+          "name": "IF0",
           "check": "Boolean",
           "align": "RIGHT"
         },
         {
           "type": "input_statement",
-          "name": "DO",
+          "name": "DO0",
           "check": "Boolean",
           "align": "RIGHT"
         },

--- a/generators/dart/logic.js
+++ b/generators/dart/logic.js
@@ -49,6 +49,19 @@ Blockly.Dart['controls_if'] = function(block) {
   return code + '\n';
 };
 
+Blockly.Dart['controls_ifelse'] = function(block) {
+  // If/else condition, without mutation.
+  var argument = Blockly.Dart.valueToCode(block, 'IF',
+      Blockly.Dart.ORDER_NONE) || 'false';
+  var branch = Blockly.Dart.statementToCode(block, 'DO');
+  var code = 'if (' + argument + ') {\n' + branch + '}';
+  branch = Blockly.Dart.statementToCode(block, 'ELSE');
+  if (branch) {
+    code += ' else {\n' + branch + '}';
+  }
+    return code + '\n';
+};
+
 Blockly.Dart['logic_compare'] = function(block) {
   // Comparison operator.
   var OPERATORS = {

--- a/generators/dart/logic.js
+++ b/generators/dart/logic.js
@@ -32,35 +32,25 @@ goog.require('Blockly.Dart');
 Blockly.Dart['controls_if'] = function(block) {
   // If/elseif/else condition.
   var n = 0;
-  var argument = Blockly.Dart.valueToCode(block, 'IF' + n,
+  var code = '', branchCode, conditionCode;
+  do {
+    conditionCode = Blockly.Dart.valueToCode(block, 'IF' + n,
       Blockly.Dart.ORDER_NONE) || 'false';
-  var branch = Blockly.Dart.statementToCode(block, 'DO' + n);
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  for (n = 1; n <= block.elseifCount_; n++) {
-    argument = Blockly.Dart.valueToCode(block, 'IF' + n,
-      Blockly.Dart.ORDER_NONE) || 'false';
-    branch = Blockly.Dart.statementToCode(block, 'DO' + n);
-    code += ' else if (' + argument + ') {\n' + branch + '}';
-  }
-  if (block.elseCount_) {
-    branch = Blockly.Dart.statementToCode(block, 'ELSE');
-    code += ' else {\n' + branch + '}';
+    branchCode = Blockly.Dart.statementToCode(block, 'DO' + n);
+    code += (n > 0 ? 'else ' : '') +
+        'if (' + conditionCode + ') {\n' + branchCode + '}';
+
+    ++n;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    branchCode = Blockly.Dart.statementToCode(block, 'ELSE');
+    code += ' else {\n' + branchCode + '}';
   }
   return code + '\n';
 };
 
-Blockly.Dart['controls_ifelse'] = function(block) {
-  // If/else condition, without mutation.
-  var argument = Blockly.Dart.valueToCode(block, 'IF',
-      Blockly.Dart.ORDER_NONE) || 'false';
-  var branch = Blockly.Dart.statementToCode(block, 'DO');
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  branch = Blockly.Dart.statementToCode(block, 'ELSE');
-  if (branch) {
-    code += ' else {\n' + branch + '}';
-  }
-    return code + '\n';
-};
+Blockly.Dart['controls_ifelse'] = Blockly.Dart['controls_if'];
 
 Blockly.Dart['logic_compare'] = function(block) {
   // Comparison operator.

--- a/generators/javascript/logic.js
+++ b/generators/javascript/logic.js
@@ -32,35 +32,25 @@ goog.require('Blockly.JavaScript');
 Blockly.JavaScript['controls_if'] = function(block) {
   // If/elseif/else condition.
   var n = 0;
-  var argument = Blockly.JavaScript.valueToCode(block, 'IF' + n,
+  var code = '', branchCode, conditionCode;
+  do {
+    conditionCode = Blockly.JavaScript.valueToCode(block, 'IF' + n,
       Blockly.JavaScript.ORDER_NONE) || 'false';
-  var branch = Blockly.JavaScript.statementToCode(block, 'DO' + n);
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  for (n = 1; n <= block.elseifCount_; n++) {
-    argument = Blockly.JavaScript.valueToCode(block, 'IF' + n,
-        Blockly.JavaScript.ORDER_NONE) || 'false';
-    branch = Blockly.JavaScript.statementToCode(block, 'DO' + n);
-    code += ' else if (' + argument + ') {\n' + branch + '}';
-  }
-  if (block.elseCount_) {
-    branch = Blockly.JavaScript.statementToCode(block, 'ELSE');
-    code += ' else {\n' + branch + '}';
+    branchCode = Blockly.JavaScript.statementToCode(block, 'DO' + n);
+    code += (n > 0 ? ' else ' : '') +
+        'if (' + conditionCode + ') {\n' + branchCode + '}';
+
+    ++n;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    branchCode = Blockly.JavaScript.statementToCode(block, 'ELSE');
+    code += ' else {\n' + branchCode + '}';
   }
   return code + '\n';
 };
 
-Blockly.JavaScript['controls_ifelse'] = function(block) {
-  // If/else condition, without mutation.
-  var argument = Blockly.JavaScript.valueToCode(block, 'IF',
-      Blockly.JavaScript.ORDER_NONE) || 'false';
-  var branch = Blockly.JavaScript.statementToCode(block, 'DO');
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  branch = Blockly.JavaScript.statementToCode(block, 'ELSE');
-  if (branch) {
-    code += ' else {\n' + branch + '}';
-  }
-  return code + '\n';
-};
+Blockly.JavaScript['controls_ifelse'] = Blockly.JavaScript['controls_if'];
 
 Blockly.JavaScript['logic_compare'] = function(block) {
   // Comparison operator.

--- a/generators/javascript/logic.js
+++ b/generators/javascript/logic.js
@@ -49,6 +49,19 @@ Blockly.JavaScript['controls_if'] = function(block) {
   return code + '\n';
 };
 
+Blockly.JavaScript['controls_ifelse'] = function(block) {
+  // If/else condition, without mutation.
+  var argument = Blockly.JavaScript.valueToCode(block, 'IF',
+      Blockly.JavaScript.ORDER_NONE) || 'false';
+  var branch = Blockly.JavaScript.statementToCode(block, 'DO');
+  var code = 'if (' + argument + ') {\n' + branch + '}';
+  branch = Blockly.JavaScript.statementToCode(block, 'ELSE');
+  if (branch) {
+    code += ' else {\n' + branch + '}';
+  }
+  return code + '\n';
+};
+
 Blockly.JavaScript['logic_compare'] = function(block) {
   // Comparison operator.
   var OPERATORS = {

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -32,35 +32,25 @@ goog.require('Blockly.Lua');
 Blockly.Lua['controls_if'] = function(block) {
   // If/elseif/else condition.
   var n = 0;
-  var argument = Blockly.Lua.valueToCode(block, 'IF' + n,
+  var code = '', branchCode, conditionCode;
+  do {
+    conditionCode = Blockly.Lua.valueToCode(block, 'IF' + n,
       Blockly.Lua.ORDER_NONE) || 'false';
-  var branch = Blockly.Lua.statementToCode(block, 'DO' + n);
-  var code = 'if ' + argument + ' then\n' + branch;
-  for (n = 1; n <= block.elseifCount_; n++) {
-    argument = Blockly.Lua.valueToCode(block, 'IF' + n,
-        Blockly.Lua.ORDER_NONE) || 'false';
-    branch = Blockly.Lua.statementToCode(block, 'DO' + n);
-    code += 'elseif ' + argument + ' then\n' + branch;
-  }
-  if (block.elseCount_) {
-    branch = Blockly.Lua.statementToCode(block, 'ELSE');
-    code += 'else\n' + branch;
+    branchCode = Blockly.Lua.statementToCode(block, 'DO' + n);
+    code += (n > 0 ? 'else' : '') +
+        'if ' + conditionCode + ' then\n' + branchCode;
+
+    ++n;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    branchCode = Blockly.Lua.statementToCode(block, 'ELSE');
+    code += 'else\n' + branchCode;
   }
   return code + 'end\n';
 };
 
-Blockly.Lua['controls_ifelse'] = function(block) {
-  // If/else condition, without mutation.
-  var argument = Blockly.Lua.valueToCode(block, 'IF',
-      Blockly.Lua.ORDER_NONE) || 'false';
-  var branch = Blockly.Lua.statementToCode(block, 'DO');
-  var code = 'if ' + argument + ' then\n' + branch;
-  branch = Blockly.Lua.statementToCode(block, 'ELSE');
-  if (branch) {
-    code += 'else\n' + branch;
-  }
-  return code + 'end\n';
-};
+Blockly.Lua['controls_ifelse'] = Blockly.Lua['controls_if'];
 
 Blockly.Lua['logic_compare'] = function(block) {
   // Comparison operator.

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -40,11 +40,24 @@ Blockly.Lua['controls_if'] = function(block) {
     argument = Blockly.Lua.valueToCode(block, 'IF' + n,
         Blockly.Lua.ORDER_NONE) || 'false';
     branch = Blockly.Lua.statementToCode(block, 'DO' + n);
-    code += ' elseif ' + argument + ' then\n' + branch;
+    code += 'elseif ' + argument + ' then\n' + branch;
   }
   if (block.elseCount_) {
     branch = Blockly.Lua.statementToCode(block, 'ELSE');
-    code += ' else\n' + branch;
+    code += 'else\n' + branch;
+  }
+  return code + 'end\n';
+};
+
+Blockly.Lua['controls_ifelse'] = function(block) {
+  // If/else condition, without mutation.
+  var argument = Blockly.Lua.valueToCode(block, 'IF',
+      Blockly.Lua.ORDER_NONE) || 'false';
+  var branch = Blockly.Lua.statementToCode(block, 'DO');
+  var code = 'if ' + argument + ' then\n' + branch;
+  branch = Blockly.Lua.statementToCode(block, 'ELSE');
+  if (branch) {
+    code += 'else\n' + branch;
   }
   return code + 'end\n';
 };

--- a/generators/php/logic.js
+++ b/generators/php/logic.js
@@ -32,35 +32,25 @@ goog.require('Blockly.PHP');
 Blockly.PHP['controls_if'] = function(block) {
   // If/elseif/else condition.
   var n = 0;
-  var argument = Blockly.PHP.valueToCode(block, 'IF' + n,
+  var code = '', branchCode, conditionCode;
+  do {
+    conditionCode = Blockly.PHP.valueToCode(block, 'IF' + n,
       Blockly.PHP.ORDER_NONE) || 'false';
-  var branch = Blockly.PHP.statementToCode(block, 'DO' + n);
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  for (n = 1; n <= block.elseifCount_; n++) {
-    argument = Blockly.PHP.valueToCode(block, 'IF' + n,
-        Blockly.PHP.ORDER_NONE) || 'false';
-    branch = Blockly.PHP.statementToCode(block, 'DO' + n);
-    code += ' else if (' + argument + ') {\n' + branch + '}';
-  }
-  if (block.elseCount_) {
-    branch = Blockly.PHP.statementToCode(block, 'ELSE');
-    code += ' else {\n' + branch + '}';
+    branchCode = Blockly.PHP.statementToCode(block, 'DO' + n);
+    code += (n > 0 ? ' else ' : '') +
+        'if (' + conditionCode + ') {\n' + branchCode + '}';
+
+    ++n;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    branchCode = Blockly.PHP.statementToCode(block, 'ELSE');
+    code += ' else {\n' + branchCode + '}';
   }
   return code + '\n';
 };
 
-Blockly.PHP['controls_ifelse'] = function(block) {
-  // If/else condition, without mutation.
-  var argument = Blockly.PHP.valueToCode(block, 'IF',
-      Blockly.PHP.ORDER_NONE) || 'false';
-  var branch = Blockly.PHP.statementToCode(block, 'DO');
-  var code = 'if (' + argument + ') {\n' + branch + '}';
-  branch = Blockly.PHP.statementToCode(block, 'ELSE');
-  if (branch) {
-    code += ' else {\n' + branch + '}';
-  }
-  return code + '\n';
-};
+Blockly.PHP['controls_ifelse'] = Blockly.PHP['controls_if'];
 
 Blockly.PHP['logic_compare'] = function(block) {
   // Comparison operator.

--- a/generators/php/logic.js
+++ b/generators/php/logic.js
@@ -49,6 +49,19 @@ Blockly.PHP['controls_if'] = function(block) {
   return code + '\n';
 };
 
+Blockly.PHP['controls_ifelse'] = function(block) {
+  // If/else condition, without mutation.
+  var argument = Blockly.PHP.valueToCode(block, 'IF',
+      Blockly.PHP.ORDER_NONE) || 'false';
+  var branch = Blockly.PHP.statementToCode(block, 'DO');
+  var code = 'if (' + argument + ') {\n' + branch + '}';
+  branch = Blockly.PHP.statementToCode(block, 'ELSE');
+  if (branch) {
+    code += ' else {\n' + branch + '}';
+  }
+  return code + '\n';
+};
+
 Blockly.PHP['logic_compare'] = function(block) {
   // Comparison operator.
   var OPERATORS = {

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -52,6 +52,19 @@ Blockly.Python['controls_if'] = function(block) {
   return code;
 };
 
+Blockly.Python['controls_ifelse'] = function(block) {
+  // If/else condition, without mutation.
+  var argument = Blockly.Python.valueToCode(block, 'IF',
+      Blockly.Python.ORDER_NONE) || 'false';
+  var branch = Blockly.Python.statementToCode(block, 'DO');
+  var code = 'if ' + argument + ':\n' + branch;
+  branch = Blockly.Python.statementToCode(block, 'ELSE');
+  if (branch) {
+    code += 'else:\n' + branch;
+  }
+  return code;
+};
+
 Blockly.Python['logic_compare'] = function(block) {
   // Comparison operator.
   var OPERATORS = {

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -32,38 +32,48 @@ goog.require('Blockly.Python');
 Blockly.Python['controls_if'] = function(block) {
   // If/elseif/else condition.
   var n = 0;
-  var argument = Blockly.Python.valueToCode(block, 'IF' + n,
-      Blockly.Python.ORDER_NONE) || 'False';
-  var branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
-      Blockly.Python.PASS;
-  var code = 'if ' + argument + ':\n' + branch;
-  for (n = 1; n <= block.elseifCount_; n++) {
-    argument = Blockly.Python.valueToCode(block, 'IF' + n,
-        Blockly.Python.ORDER_NONE) || 'False';
-    branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
+  var code = '', branchCode, conditionCode;
+  do {
+    conditionCode = Blockly.Python.valueToCode(block, 'IF' + n,
+      Blockly.Python.ORDER_NONE) || 'false';
+    branchCode = Blockly.Python.statementToCode(block, 'DO' + n) ||
         Blockly.Python.PASS;
-    code += 'elif ' + argument + ':\n' + branch;
-  }
-  if (block.elseCount_) {
-    branch = Blockly.Python.statementToCode(block, 'ELSE') ||
+    code += (n == 0 ? 'if ' : 'elif ' ) + conditionCode + ':\n' + branchCode;
+
+    ++n;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    branchCode = Blockly.Python.statementToCode(block, 'ELSE') ||
         Blockly.Python.PASS;
-    code += 'else:\n' + branch;
+    code += 'else:\n' + branchCode;
   }
-  return code;
+  return code + '\n';
+
+
+  // // If/elseif/else condition.
+  // var n = 0;
+  // var argument = Blockly.Python.valueToCode(block, 'IF' + n,
+  //     Blockly.Python.ORDER_NONE) || 'False';
+  // var branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
+  //     Blockly.Python.PASS;
+  // var code = 'if ' + argument + ':\n' + branch;
+  // for (n = 1; n <= block.elseifCount_; n++) {
+  //   argument = Blockly.Python.valueToCode(block, 'IF' + n,
+  //       Blockly.Python.ORDER_NONE) || 'False';
+  //   branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
+  //       Blockly.Python.PASS;
+  //   code += 'elif ' + argument + ':\n' + branch;
+  // }
+  // if (block.elseCount_) {
+  //   branch = Blockly.Python.statementToCode(block, 'ELSE') ||
+  //       Blockly.Python.PASS;
+  //   code += 'else:\n' + branch;
+  // }
+  // return code;
 };
 
-Blockly.Python['controls_ifelse'] = function(block) {
-  // If/else condition, without mutation.
-  var argument = Blockly.Python.valueToCode(block, 'IF',
-      Blockly.Python.ORDER_NONE) || 'false';
-  var branch = Blockly.Python.statementToCode(block, 'DO');
-  var code = 'if ' + argument + ':\n' + branch;
-  branch = Blockly.Python.statementToCode(block, 'ELSE');
-  if (branch) {
-    code += 'else:\n' + branch;
-  }
-  return code;
-};
+Blockly.Python['controls_ifelse'] = Blockly.Python['controls_if'];
 
 Blockly.Python['logic_compare'] = function(block) {
   // Comparison operator.

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -48,29 +48,7 @@ Blockly.Python['controls_if'] = function(block) {
         Blockly.Python.PASS;
     code += 'else:\n' + branchCode;
   }
-  return code + '\n';
-
-
-  // // If/elseif/else condition.
-  // var n = 0;
-  // var argument = Blockly.Python.valueToCode(block, 'IF' + n,
-  //     Blockly.Python.ORDER_NONE) || 'False';
-  // var branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
-  //     Blockly.Python.PASS;
-  // var code = 'if ' + argument + ':\n' + branch;
-  // for (n = 1; n <= block.elseifCount_; n++) {
-  //   argument = Blockly.Python.valueToCode(block, 'IF' + n,
-  //       Blockly.Python.ORDER_NONE) || 'False';
-  //   branch = Blockly.Python.statementToCode(block, 'DO' + n) ||
-  //       Blockly.Python.PASS;
-  //   code += 'elif ' + argument + ':\n' + branch;
-  // }
-  // if (block.elseCount_) {
-  //   branch = Blockly.Python.statementToCode(block, 'ELSE') ||
-  //       Blockly.Python.PASS;
-  //   code += 'else:\n' + branch;
-  // }
-  // return code;
+  return code;
 };
 
 Blockly.Python['controls_ifelse'] = Blockly.Python['controls_if'];

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -239,6 +239,9 @@ Blockly.Msg.CONTROLS_IF_ELSE_TITLE_ELSE = Blockly.Msg.CONTROLS_IF_MSG_ELSE;
 /// tooltip - Describes the 'else' subblock during [https://github.com/google/blockly/wiki/IfElse#block-modification if block modification].
 Blockly.Msg.CONTROLS_IF_ELSE_TOOLTIP = 'Add a final, catch-all condition to the if block.';
 
+/// block text - This is a statement that unary operator that executes the statements in %2 if %1 evaluates to true. Otherwise, the statements in %3 are executed.
+Blockly.Msg.CONTROLS_IFELSE_TITLE = 'if %1 do %2 else %3';
+
 /// url - Information about comparisons.
 Blockly.Msg.LOGIC_COMPARE_HELPURL = 'https://en.wikipedia.org/wiki/Inequality_(mathematics)';
 /// tooltip - Describes the equals (=) block.

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -239,7 +239,7 @@ Blockly.Msg.CONTROLS_IF_ELSE_TITLE_ELSE = Blockly.Msg.CONTROLS_IF_MSG_ELSE;
 /// tooltip - Describes the 'else' subblock during [https://github.com/google/blockly/wiki/IfElse#block-modification if block modification].
 Blockly.Msg.CONTROLS_IF_ELSE_TOOLTIP = 'Add a final, catch-all condition to the if block.';
 
-/// block text - This is a statement that unary operator that executes the statements in %2 if %1 evaluates to true. Otherwise, the statements in %3 are executed.
+/// block text - See [https://github.com/google/blockly/wiki/IfElse https://github.com/google/blockly/wiki/IfElse].  The English word "otherwise" would probably be superior to "else", but the latter is used because it is traditional and shorter.
 Blockly.Msg.CONTROLS_IFELSE_TITLE = 'if %1 do %2 else %3';
 
 /// url - Information about comparisons.

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -379,7 +379,7 @@ h1 {
   </p>
 
   <xml id="toolbox-simple" style="display: none">
-    <block type="controls_if"></block>
+    <block type="controls_ifelse"></block>
     <block type="logic_compare"></block>
     <!-- <block type="control_repeat"></block> -->
     <block type="logic_operation"></block>


### PR DESCRIPTION
Adding `controls_ifelse`, an if/else block that is loaded from JSON and does not use mutators.

This solves a pending problem on current Android & iOS implementations.
Added this block to the playground simple toolbox and all generators.

Tested across all languages using the playground and [this workspace XML](https://gist.github.com/AnmAtAnm/af905f5838110873e6a607593d9ef85d).

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/722)

<!-- Reviewable:end -->
