### PR TITLE
Improve performance of block dragging.  This is a backport of the blo…

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -116,9 +116,8 @@ Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, sc
   // That is incompatible with translate3d, causing bugs.
   x = x.toFixed(0);
   y = y.toFixed(0);
-  transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px)' +
-    'scale3d(' + scale + ',' + scale + ',' + scale + ')';
-  this.dragGroup_.setAttribute('style', transform);
+  this.dragGroup_.setAttribute('transform', 'translate('+ x + ','+ y + ')' +
+      ' scale(' + scale + ')');
 };
 
 /**

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Functions for injecting Blockly into a web page.
+ * @author picklesrus
+ */
+
+'use strict';
+
+goog.provide('Blockly.BlockDragSurfaceSvg');
+
+goog.require('Blockly.utils');
+
+goog.require('goog.asserts');
+goog.require('goog.math.Coordinate');
+
+/**
+ * Class for a Drag Surface SVG.
+ * @param {Element} container Containing element.
+ * @constructor
+ */
+Blockly.BlockDragSurfaceSvg = function(container) {
+  this.container_ = container;
+};
+
+/**
+ * The SVG drag surface. Set once by Blockly.BlockDragSurfaceSvg.createDom.
+ * @type {Element}
+ * @private
+ */
+Blockly.BlockDragSurfaceSvg.prototype.SVG_ = null;
+
+/**
+ * SVG group inside the drag surface. This is where blocks are moved to.
+ * @type {Element}
+ * @private
+ */
+Blockly.BlockDragSurfaceSvg.prototype.dragGroup_ = null;
+
+/**
+ * Containing HTML element; parent of the workspace and the drag surface.
+ * @type {Element}
+ * @private
+ */
+Blockly.BlockDragSurfaceSvg.prototype.container_ = null;
+
+/**
+ * Cached value for the scale of the drag surface.
+ * Used to set/get the correct translation during and after a drag.
+ * @type {Number}
+ * @private
+ */
+Blockly.BlockDragSurfaceSvg.prototype.scale_ = 1;
+
+
+/**
+ * Create the drag surface and inject it into the container.
+ */
+Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
+  if (this.SVG_) {
+    return;  // Already created.
+  }
+  this.SVG_ = Blockly.createSvgElement('svg', {
+    'xmlns': Blockly.SVG_NS,
+    'xmlns:html': Blockly.HTML_NS,
+    'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+    'version': '1.1',
+    'class': 'blocklyBlockDragSurface'
+  }, this.container_);
+  var defs = Blockly.createSvgElement('defs', {}, this.SVG_);
+  this.dragGroup_ = Blockly.createSvgElement('g', {}, this.SVG_);
+};
+
+/**
+ * Set the SVG blocks on the drag surface's group and show the surface.
+ * Only one block should be on the drag surface at a time.
+ * @param {!Element} blocks Block or group of blocks to place on the drag surface
+ */
+Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
+  goog.asserts.assert(this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
+  // appendChild removes the blocks from the previous parent
+  this.dragGroup_.appendChild(blocks);
+  this.SVG_.style.display = 'block';
+};
+
+/**
+ * Translate and scale the entire drag surface group to keep in sync with the workspace.
+ * @param {Number} x X translation
+ * @param {Number} y Y translation
+ * @param {Number} scale Scale of the group
+ */
+Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, scale) {
+  var transform;
+  this.scale_ = scale;
+  // Force values to have two decimal points.
+  // This is a work-around to prevent a bug in Safari, where numbers close to 0
+  // are sometimes reported as something like "2.9842794901924208e-12".
+  // That is incompatible with translate3d, causing bugs.
+  x = x.toFixed(0);
+  y = y.toFixed(0);
+  transform = 'transform: translate3d(' + x + 'px, ' + y + 'px, 0px)' +
+    'scale3d(' + scale + ',' + scale + ',' + scale + ')';
+  this.dragGroup_.setAttribute('style', transform);
+};
+
+/**
+ * Translate the entire drag surface during a drag.
+ * We translate the drag surface instead of the blocks inside the surface
+ * so that the browser avoids repainting the SVG.
+ * Because of this, the drag coordinates must be adjusted by scale.
+ * @param {Number} x X translation for the entire surface
+ * @param {Number} y Y translation for the entire surface
+ */
+Blockly.BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
+  var transform;
+  x *= this.scale_;
+  y *= this.scale_;
+  // This is a work-around to prevent a the blocks from rendering
+  // fuzzy while they are being dragged on the drag surface.
+  x = x.toFixed(0);
+  y = y.toFixed(0);
+  transform =
+    'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
+  this.SVG_.setAttribute('style', transform);
+};
+
+/**
+ * Reports the surface translation in scaled workspace coordinates.
+ * Use this when finishing a drag to return blocks to the correct position.
+ * @return {goog.math.Coordinate} Current translation of the surface
+ */
+Blockly.BlockDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
+  var xy = Blockly.getRelativeXY_(this.SVG_);
+  return new goog.math.Coordinate(xy.x / this.scale_, xy.y / this.scale_);
+};
+
+/**
+ * Provide a reference to the drag group (primarily for BlockSvg.getRelativeToSurfaceXY).
+ * @return {Element} Drag surface group element
+ */
+Blockly.BlockDragSurfaceSvg.prototype.getGroup = function() {
+  return this.dragGroup_;
+};
+
+/**
+ * Get the current blocks on the drag surface, if any (primarily for BlockSvg.getRelativeToSurfaceXY).
+ * @return {Element} Drag surface block DOM element
+ */
+Blockly.BlockDragSurfaceSvg.prototype.getCurrentBlock = function() {
+  return this.dragGroup_.childNodes[0];
+};
+
+/**
+ * Clear the group and hide the surface; move the blocks off onto the provided element.
+ * @param {!Element} newSurface Surface the dragging blocks should be moved to
+ */
+Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
+  // appendChild removes the node from this.dragGroup_
+  newSurface.appendChild(this.getCurrentBlock());
+  this.SVG_.style.display = 'none';
+  goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
+  	'Drag group was not cleared.');
+};

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -108,10 +108,8 @@ Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
  */
 Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, scale) {
   this.scale_ = scale;
-  // Force values to have two decimal points.
-  // This is a work-around to prevent a bug in Safari, where numbers close to 0
-  // are sometimes reported as something like "2.9842794901924208e-12".
-  // That is incompatible with translate3d, causing bugs.
+  // This is a work-around to prevent a the blocks from rendering
+  // fuzzy while they are being dragged on the drag surface.
   x = x.toFixed(0);
   y = y.toFixed(0);
   this.dragGroup_.setAttribute('transform', 'translate('+ x + ','+ y + ')' +

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -19,7 +19,11 @@
  */
 
 /**
- * @fileoverview Functions for injecting Blockly into a web page.
+ * @fileoverview A class that manages a surface for dragging blocks.  When a
+ * block drag is started, we move the block (and children) to a separate dom
+ * element that we move around using translate3d. At the end of the drag, the
+ * blocks are put back in into the svg they came from. This helps performance by
+ * avoiding repainting the entire svg on every mouse move while dragging blocks.
  * @author picklesrus
  */
 
@@ -32,11 +36,16 @@ goog.require('goog.math.Coordinate');
 
 
 /**
- * Class for a Drag Surface SVG.
+ * Class for a drag surface for the currently dragged block. This is a separate
+ * SVG that contains only the currently moving block, or nothing.
  * @param {!Element} container Containing element.
  * @constructor
  */
 Blockly.BlockDragSurfaceSvg = function(container) {
+  /**
+   * @type {!Element}
+   * @private
+   */
   this.container_ = container;
 };
 
@@ -48,7 +57,8 @@ Blockly.BlockDragSurfaceSvg = function(container) {
 Blockly.BlockDragSurfaceSvg.prototype.SVG_ = null;
 
 /**
- * SVG group inside the drag surface. This is where blocks are moved to.
+ * This is where blocks live while they are being dragged if the drag surface
+ * is enabled.
  * @type {Element}
  * @private
  */
@@ -88,7 +98,7 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
 
 /**
  * Set the SVG blocks on the drag surface's group and show the surface.
- * Only one block should be on the drag surface at a time.
+ * Only one block group should be on the drag surface at a time.
  * @param {!Element} blocks Block or group of blocks to place on the drag
  * surface.
  */
@@ -101,7 +111,8 @@ Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
 };
 
 /**
- * Translate and scale the entire drag surface group to keep in sync with the workspace.
+ * Translate and scale the entire drag surface group to keep in sync with the
+ * workspace.
  * @param {number} x X translation
  * @param {number} y Y translation
  * @param {number} scale Scale of the group.

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -26,15 +26,14 @@
 'use strict';
 
 goog.provide('Blockly.BlockDragSurfaceSvg');
-
 goog.require('Blockly.utils');
-
 goog.require('goog.asserts');
 goog.require('goog.math.Coordinate');
 
+
 /**
  * Class for a Drag Surface SVG.
- * @param {Element} container Containing element.
+ * @param {!Element} container Containing element.
  * @constructor
  */
 Blockly.BlockDragSurfaceSvg = function(container) {
@@ -65,11 +64,10 @@ Blockly.BlockDragSurfaceSvg.prototype.container_ = null;
 /**
  * Cached value for the scale of the drag surface.
  * Used to set/get the correct translation during and after a drag.
- * @type {Number}
+ * @type {number}
  * @private
  */
 Blockly.BlockDragSurfaceSvg.prototype.scale_ = 1;
-
 
 /**
  * Create the drag surface and inject it into the container.
@@ -85,17 +83,18 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
     'version': '1.1',
     'class': 'blocklyBlockDragSurface'
   }, this.container_);
-  var defs = Blockly.createSvgElement('defs', {}, this.SVG_);
   this.dragGroup_ = Blockly.createSvgElement('g', {}, this.SVG_);
 };
 
 /**
  * Set the SVG blocks on the drag surface's group and show the surface.
  * Only one block should be on the drag surface at a time.
- * @param {!Element} blocks Block or group of blocks to place on the drag surface
+ * @param {!Element} blocks Block or group of blocks to place on the drag
+ * surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
-  goog.asserts.assert(this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
+  goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
+    'Already dragging a block.');
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
   this.SVG_.style.display = 'block';
@@ -103,12 +102,11 @@ Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
 
 /**
  * Translate and scale the entire drag surface group to keep in sync with the workspace.
- * @param {Number} x X translation
- * @param {Number} y Y translation
- * @param {Number} scale Scale of the group
+ * @param {number} x X translation
+ * @param {number} y Y translation
+ * @param {number} scale Scale of the group.
  */
 Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, scale) {
-  var transform;
   this.scale_ = scale;
   // Force values to have two decimal points.
   // This is a work-around to prevent a bug in Safari, where numbers close to 0
@@ -125,8 +123,8 @@ Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, sc
  * We translate the drag surface instead of the blocks inside the surface
  * so that the browser avoids repainting the SVG.
  * Because of this, the drag coordinates must be adjusted by scale.
- * @param {Number} x X translation for the entire surface
- * @param {Number} y Y translation for the entire surface
+ * @param {number} x X translation for the entire surface.
+ * @param {number} y Y translation for the entire surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
   var transform;
@@ -144,7 +142,7 @@ Blockly.BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
 /**
  * Reports the surface translation in scaled workspace coordinates.
  * Use this when finishing a drag to return blocks to the correct position.
- * @return {goog.math.Coordinate} Current translation of the surface
+ * @return {!goog.math.Coordinate} Current translation of the surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
   var xy = Blockly.getRelativeXY_(this.SVG_);
@@ -152,29 +150,33 @@ Blockly.BlockDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
 };
 
 /**
- * Provide a reference to the drag group (primarily for BlockSvg.getRelativeToSurfaceXY).
- * @return {Element} Drag surface group element
+ * Provide a reference to the drag group (primarily for
+ * BlockSvg.getRelativeToSurfaceXY).
+ * @return {Element} Drag surface group element.
  */
 Blockly.BlockDragSurfaceSvg.prototype.getGroup = function() {
   return this.dragGroup_;
 };
 
 /**
- * Get the current blocks on the drag surface, if any (primarily for BlockSvg.getRelativeToSurfaceXY).
- * @return {Element} Drag surface block DOM element
+ * Get the current blocks on the drag surface, if any (primarily
+ * for BlockSvg.getRelativeToSurfaceXY).
+ * @return {!Element|undefined} Drag surface block DOM element, or undefined
+ * if no blocks exist.
  */
 Blockly.BlockDragSurfaceSvg.prototype.getCurrentBlock = function() {
-  return this.dragGroup_.childNodes[0];
+  return this.dragGroup_.firstChild;
 };
 
 /**
- * Clear the group and hide the surface; move the blocks off onto the provided element.
- * @param {!Element} newSurface Surface the dragging blocks should be moved to
+ * Clear the group and hide the surface; move the blocks off onto the provided
+ * element.
+ * @param {!Element} newSurface Surface the dragging blocks should be moved to.
  */
 Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   // appendChild removes the node from this.dragGroup_
   newSurface.appendChild(this.getCurrentBlock());
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
-  	'Drag group was not cleared.');
+    'Drag group was not cleared.');
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -419,13 +419,12 @@ Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {
 };
 
 /**
- * Clear the block of style="..." and transform="..." attributes.
+ * Clear the block of transform="..." attributes.
  * Used when the block is switching from 3d to 2d transform or vice versa.
  * @private
  */
 Blockly.BlockSvg.prototype.clearTransformAttributes_ = function() {
   this.getSvgRoot().removeAttribute('transform');
-  this.getSvgRoot().removeAttribute('style');
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -82,10 +82,10 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   /** @type {boolean} */
   this.rendered = false;
 
-  /** 
+  /**
    * Whether to move the block to the drag surface when it is dragged.
    * True if it should move, false if it should be translated directly.
-   * @type {boolean} 
+   * @type {boolean}
    * @private
    */
   this.useDragSurface_ = Blockly.is3dSupported() && workspace.blockDragSurface_;
@@ -331,7 +331,7 @@ Blockly.BlockSvg.prototype.getRelativeToSurfaceXY = function() {
   var y = 0;
 
   var dragSurfaceGroup = this.useDragSurface_ ?
-    this.workspace.blockDragSurface_.getGroup() : null;
+      this.workspace.blockDragSurface_.getGroup() : null;
 
   var element = this.getSvgRoot();
   if (element) {
@@ -373,13 +373,13 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
 
 /**
  * Transforms a block by setting the translation on the transform attribute
- * of the block's svg.
+ * of the block's SVG.
  * @param {number} x The x coordinate of the translation.
  * @param {number} y The y coordinate of the translation.
  */
 Blockly.BlockSvg.prototype.translate = function(x, y) {
   this.getSvgRoot().setAttribute('transform',
-    'translate(' + x + ',' + y + ')');
+      'translate(' + x + ',' + y + ')');
 };
 
 /**
@@ -424,12 +424,8 @@ Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {
  * @private
  */
 Blockly.BlockSvg.prototype.clearTransformAttributes_ = function() {
-   if (this.getSvgRoot().hasAttribute('transform')) {
-      this.getSvgRoot().removeAttribute('transform');
-   }
-  if (this.getSvgRoot().hasAttribute('style')) {
-    this.getSvgRoot().removeAttribute('style');
-  }
+  this.getSvgRoot().removeAttribute('transform');
+  this.getSvgRoot().removeAttribute('style');
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -405,6 +405,7 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
 /**
  * Move this block back to the workspace block canvas.
  * Generally should be called at the same time as setDragging_(false).
+ * Does nothing if useDragSurface_ is false.
  * @private
  */
 Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -125,6 +125,13 @@ Blockly.dragMode_ = Blockly.DRAG_NONE;
 Blockly.flyoutButtonCallbacks_ = {};
 
 /**
+ * Cached value for whether 3D is supported
+ * @type {boolean}
+ * @private
+ */
+Blockly.cache3dSupported_ = null;
+
+/**
  * Register a callback function associated with a given key, for clicks on
  * buttons and labels in the flyout.
  * For instance, a button specified by the XML

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -125,8 +125,8 @@ Blockly.dragMode_ = Blockly.DRAG_NONE;
 Blockly.flyoutButtonCallbacks_ = {};
 
 /**
- * Cached value for whether 3D is supported
- * @type {boolean}
+ * Cached value for whether 3D is supported.
+ * @type {!boolean}
  * @private
  */
 Blockly.cache3dSupported_ = null;

--- a/core/css.js
+++ b/core/css.js
@@ -166,10 +166,6 @@ Blockly.Css.CONTENT = [
     'bottom: 0;',
     'overflow: visible !important;',
     'z-index: 50;', /* Display below toolbox, but everything else. */
-    '-webkit-backface-visibility: hidden;',
-    'backface-visibility: hidden;',
-    '-webkit-perspective: 1000;',
-    'perspective: 1000;',
   '}',
 
   '.blocklyTooltipDiv {',

--- a/core/css.js
+++ b/core/css.js
@@ -147,7 +147,7 @@ Blockly.Css.CONTENT = [
   '.injectionDiv {',
     'height: 100%;',
     'position: relative;',
-    'overflow:hidden', /* So blocks in drag surface disappear at edges */
+    'overflow: hidden;', /* So blocks in drag surface disappear at edges */
   '}',
 
   '.blocklyNonSelectable {',
@@ -463,7 +463,7 @@ Blockly.Css.CONTENT = [
     'overflow-x: visible;',
     'overflow-y: auto;',
     'position: absolute;',
-    'z-index:70;',
+    'z-index: 70;', /* so blocks go under toolbox when dragging */
   '}',
 
   '.blocklyTreeRoot {',

--- a/core/css.js
+++ b/core/css.js
@@ -165,7 +165,7 @@ Blockly.Css.CONTENT = [
     'right: 0;',
     'bottom: 0;',
     'overflow: visible !important;',
-    'z-index: 50;', /* Display below toolbox, but everything else. */
+    'z-index: 50;', /* Display below toolbox, but above everything else. */
   '}',
 
   '.blocklyTooltipDiv {',

--- a/core/css.js
+++ b/core/css.js
@@ -147,6 +147,7 @@ Blockly.Css.CONTENT = [
   '.injectionDiv {',
     'height: 100%;',
     'position: relative;',
+    'overflow:hidden', /* So blocks in drag surface disappear at edges */
   '}',
 
   '.blocklyNonSelectable {',
@@ -154,6 +155,21 @@ Blockly.Css.CONTENT = [
     '-moz-user-select: none;',
     '-webkit-user-select: none;',
     '-ms-user-select: none;',
+  '}',
+
+  '.blocklyBlockDragSurface {',
+    'display: none;',
+    'position: absolute;',
+    'top: 0;',
+    'left: 0;',
+    'right: 0;',
+    'bottom: 0;',
+    'overflow: visible !important;',
+    'z-index: 50;', /* Display below toolbox, but everything else. */
+    '-webkit-backface-visibility: hidden;',
+    'backface-visibility: hidden;',
+    '-webkit-perspective: 1000;',
+    'perspective: 1000;',
   '}',
 
   '.blocklyTooltipDiv {',
@@ -447,6 +463,7 @@ Blockly.Css.CONTENT = [
     'overflow-x: visible;',
     'overflow-y: auto;',
     'position: absolute;',
+    'z-index:70;',
   '}',
 
   '.blocklyTreeRoot {',

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1112,6 +1112,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     block.onMouseDown_(e);
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
+    block.moveToDragSurface_();
     // Disable workspace resizing.  Reenable at the end of the drag.
     flyout.targetWorkspace_.setResizesEnabled(false);
   };

--- a/core/inject.js
+++ b/core/inject.js
@@ -26,8 +26,8 @@
 
 goog.provide('Blockly.inject');
 
-goog.require('Blockly.Css');
 goog.require('Blockly.BlockDragSurfaceSvg');
+goog.require('Blockly.Css');
 goog.require('Blockly.Options');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('goog.dom');

--- a/core/inject.js
+++ b/core/inject.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.inject');
 
 goog.require('Blockly.Css');
+goog.require('Blockly.BlockDragSurfaceSvg');
 goog.require('Blockly.Options');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('goog.dom');
@@ -54,7 +55,9 @@ Blockly.inject = function(container, opt_options) {
   var subContainer = goog.dom.createDom('div', 'injectionDiv');
   container.appendChild(subContainer);
   var svg = Blockly.createDom_(subContainer, options);
-  var workspace = Blockly.createMainWorkspace_(svg, options);
+  var blockDragSurface = new Blockly.BlockDragSurfaceSvg(subContainer);
+  blockDragSurface.createDom();
+  var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface);
   Blockly.init_(workspace);
   workspace.markFocused();
   Blockly.bindEventWithChecks_(svg, 'focus', workspace, workspace.markFocused);
@@ -183,12 +186,13 @@ Blockly.createDom_ = function(container, options) {
  * Create a main workspace and add it to the SVG.
  * @param {!Element} svg SVG element with pattern defined.
  * @param {!Blockly.Options} options Dictionary of options.
+ * @param {!Blockly.BlockDragSurfaceSvg} blockDragSurface Drag surface SVG for the workspace.
  * @return {!Blockly.Workspace} Newly created main workspace.
  * @private
  */
-Blockly.createMainWorkspace_ = function(svg, options) {
+Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface) {
   options.parentWorkspace = null;
-  var mainWorkspace = new Blockly.WorkspaceSvg(options);
+  var mainWorkspace = new Blockly.WorkspaceSvg(options, blockDragSurface);
   mainWorkspace.scale = options.zoomOptions.startScale;
   svg.appendChild(mainWorkspace.createDom('blocklyMainBackground'));
   // A null translation will also apply the correct initial scale.

--- a/core/utils.js
+++ b/core/utils.js
@@ -238,6 +238,7 @@ Blockly.isTargetInput_ = function(e) {
          e.target.type == 'tel' || e.target.type == 'url' ||
          e.target.isContentEditable;
 };
+
 /**
  * Static regex to pull the x,y,z values out of a translate3d() style property.
  * Accounts for same exceptions as XY_REGEXP_.

--- a/core/utils.js
+++ b/core/utils.js
@@ -776,6 +776,6 @@ Blockly.is3dSupported = function() {
   }
 
   document.body.removeChild(el);
-  Blockly.cache3dSupported_ = (has3d !== undefined && has3d.length > 0 && has3d !== "none");
+  Blockly.cache3dSupported_ = !!(has3d && has3d !== 'none');
   return Blockly.cache3dSupported_;
 };

--- a/core/utils.js
+++ b/core/utils.js
@@ -751,7 +751,7 @@ Blockly.is3dSupported = function() {
   }
   // CC-BY-SA Lorenzo Polidori
   // https://stackoverflow.com/questions/5661671/detecting-transform-translate3d-support
-  if (!window.getComputedStyle) {
+  if (!goog.global.getComputedStyle) {
     return false;
   }
 
@@ -771,7 +771,7 @@ Blockly.is3dSupported = function() {
   for (var t in transforms) {
     if (el.style[t] !== undefined) {
       el.style[t] = 'translate3d(1px,1px,1px)';
-      has3d = window.getComputedStyle(el).getPropertyValue(transforms[t]);
+      has3d = goog.global.getComputedStyle(el).getPropertyValue(transforms[t]);
     }
   }
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -275,7 +275,7 @@ Blockly.getRelativeXY_ = function(element) {
     }
   }
 
-    // Third, check for style="transform: translate3d(...)".
+  // Third, check for style="transform: translate3d(...)".
   var style = element.getAttribute('style');
   if (style && style.indexOf('translate3d') > -1) {
     var styleComponents = style.match(Blockly.XY_3D_REGEXP_);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -48,10 +48,12 @@ goog.require('goog.userAgent');
  * Class for a workspace.  This is an onscreen area with optional trashcan,
  * scrollbars, bubbles, and dragging.
  * @param {!Blockly.Options} options Dictionary of options.
+ * @param {Blockly.BlockDragSurfaceSvg=} opt_blockDragSurface Drag surface for
+ * the workspace.
  * @extends {Blockly.Workspace}
  * @constructor
  */
-Blockly.WorkspaceSvg = function(options) {
+Blockly.WorkspaceSvg = function(options, opt_blockDragSurface) {
   Blockly.WorkspaceSvg.superClass_.constructor.call(this, options);
   this.getMetrics =
       options.getMetrics || Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_;
@@ -59,7 +61,11 @@ Blockly.WorkspaceSvg = function(options) {
       options.setMetrics || Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_;
 
   Blockly.ConnectionDB.init(this);
-
+ 
+ if (opt_blockDragSurface) {
+    this.blockDragSurface_ = opt_blockDragSurface;
+ 
+  }
   /**
    * Database of pre-loaded sounds.
    * @private
@@ -166,6 +172,13 @@ Blockly.WorkspaceSvg.prototype.trashcan = null;
  * @type {Blockly.ScrollbarPair}
  */
 Blockly.WorkspaceSvg.prototype.scrollbar = null;
+
+/**
+ * This workspace's drag surface, if it exists.
+ * @type {Blockly.BlockDragSurfaceSvg}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.blockDragSurface_ = null;
 
 /**
  * Time that the last sound was played.
@@ -509,6 +522,9 @@ Blockly.WorkspaceSvg.prototype.translate = function(x, y) {
       'scale(' + this.scale + ')';
   this.svgBlockCanvas_.setAttribute('transform', translation);
   this.svgBubbleCanvas_.setAttribute('transform', translation);
+  if (this.blockDragSurface_) {
+    this.blockDragSurface_.translateAndScaleGroup(x, y, this.scale);
+  }
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -61,11 +61,11 @@ Blockly.WorkspaceSvg = function(options, opt_blockDragSurface) {
       options.setMetrics || Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_;
 
   Blockly.ConnectionDB.init(this);
- 
- if (opt_blockDragSurface) {
+
+  if (opt_blockDragSurface) {
     this.blockDragSurface_ = opt_blockDragSurface;
- 
   }
+
   /**
    * Database of pre-loaded sounds.
    * @private


### PR DESCRIPTION
…ck drag surface from scratch-blocks.  At the beginning of a block drag, blocks get moved to a drag surface which then translates using translate3d to avoid repainting the entire svg on every mouse move.  At the end of the drag, the blocks are dropped back in the svg in their new position.
