### PR TITLE
Add possibility to add new flyout categories

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -34,6 +34,17 @@ goog.require('goog.events');
 goog.require('goog.math.Rect');
 goog.require('goog.userAgent');
 
+/**
+  * Database for Custom Flyout Categories (like : Procedure and Variable)
+  * @type {Object<String,function(!Blockly.Workspace):!Array.<!Element>>}
+  */
+Blockly.flyoutCategories = {} ;
+Blockly.registerFlyoutCategory = function(category,flyout) {
+	Blockly.flyoutCategories[category] = flyout ;	
+}
+// Register Procedure and Variable Flyout Categories :
+Blockly.registerFlyoutCategory(Blockly.Variables.NAME_TYPE,Blockly.Variables.flyoutCategory) ;
+Blockly.registerFlyoutCategory(Blockly.Procedures.NAME_TYPE,Blockly.Procedures.flyoutCategory) ;
 
 /**
  * Class for a flyout.
@@ -365,14 +376,9 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   }
   this.buttons_.length = 0;
 
-  if (xmlList == Blockly.Variables.NAME_TYPE) {
-    // Special category for variables.
-    xmlList =
-        Blockly.Variables.flyoutCategory(this.workspace_.targetWorkspace);
-  } else if (xmlList == Blockly.Procedures.NAME_TYPE) {
-    // Special category for procedures.
-    xmlList =
-        Blockly.Procedures.flyoutCategory(this.workspace_.targetWorkspace);
+  if ((typeof Blockly.flyoutCategories == 'object') && Blockly.flyoutCategories.hasOwnProperty(xmlList)) {
+    // Special flyout category :
+    xmlList = Blockly.flyoutCategories[xmlList](this.workspace_.targetWorkspace); 
   }
 
   var margin = this.CORNER_RADIUS;


### PR DESCRIPTION
This is to allow user of blockly to create Flyout menu just like we do with Variables and Procedures.

You have to register the new flyout menu with Blockly.registerFlyoutCategory(category, flyout).