### PR TITLE
When user edits text in a field, set text, not value.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -408,19 +408,19 @@ Blockly.Field.prototype.getText = function() {
 
 /**
  * Set the text in this field.  Trigger a rerender of the source block.
- * @param {*} text New text.
+ * @param {*} newText New text.
  */
-Blockly.Field.prototype.setText = function(text) {
-  if (text === null) {
+Blockly.Field.prototype.setText = function(newText) {
+  if (newText === null) {
     // No change if null.
     return;
   }
-  text = String(text);
-  if (text === this.text_) {
+  newText = String(newText);
+  if (newText === this.text_) {
     // No change.
     return;
   }
-  this.text_ = text;
+  this.text_ = newText;
   // Set width to 0 to force a rerender of this field.
   this.size_.width = 0;
 
@@ -433,7 +433,7 @@ Blockly.Field.prototype.setText = function(text) {
 /**
  * By default there is no difference between the human-readable text and
  * the language-neutral values.  Subclasses (such as dropdown) may define this.
- * @return {string} Current text.
+ * @return {string} Current value.
  */
 Blockly.Field.prototype.getValue = function() {
   return this.getText();
@@ -442,22 +442,22 @@ Blockly.Field.prototype.getValue = function() {
 /**
  * By default there is no difference between the human-readable text and
  * the language-neutral values.  Subclasses (such as dropdown) may define this.
- * @param {string} newText New text.
+ * @param {string} newValue New value.
  */
-Blockly.Field.prototype.setValue = function(newText) {
-  if (newText === null) {
+Blockly.Field.prototype.setValue = function(newValue) {
+  if (newValue === null) {
     // No change if null.
     return;
   }
-  var oldText = this.getValue();
-  if (oldText == newText) {
+  var oldValue = this.getValue();
+  if (oldValue == newValue) {
     return;
   }
   if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.Change(
-        this.sourceBlock_, 'field', this.name, oldText, newText));
+        this.sourceBlock_, 'field', this.name, oldValue, newValue));
   }
-  this.setText(newText);
+  this.setText(newValue);
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -195,7 +195,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(e) {
   var text = htmlInput.value;
   if (text !== htmlInput.oldValue_) {
     htmlInput.oldValue_ = text;
-    this.setValue(text);
+    this.setText(text);
     this.validate_();
   } else if (goog.userAgent.WEBKIT) {
     // Cursor key.  Render the source block to show the caret moving.

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -75,23 +75,23 @@ Blockly.FieldTextInput.prototype.dispose = function() {
 };
 
 /**
- * Set the text in this field.
- * @param {?string} text New text.
+ * Set the value of this field.
+ * @param {?string} newValue New value.
  * @override
  */
-Blockly.FieldTextInput.prototype.setValue = function(text) {
-  if (text === null) {
+Blockly.FieldTextInput.prototype.setValue = function(newValue) {
+  if (newValue === null) {
     return;  // No change if null.
   }
   if (this.sourceBlock_) {
-    var validated = this.callValidator(text);
-    // If the new text is invalid, validation returns null.
+    var validated = this.callValidator(newValue);
+    // If the new value is invalid, validation returns null.
     // In this case we still want to display the illegal result.
     if (validated !== null) {
-      text = validated;
+      newValue = validated;
     }
   }
-  Blockly.Field.prototype.setValue.call(this, text);
+  Blockly.Field.prototype.setValue.call(this, newValue);
 };
 
 /**
@@ -282,7 +282,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
         }
       }
     }
-    thisField.setValue(text);
+    thisField.setText(text);
     thisField.sourceBlock_.rendered && thisField.sourceBlock_.render();
     Blockly.unbindEvent_(htmlInput.onKeyDownWrapper_);
     Blockly.unbindEvent_(htmlInput.onKeyUpWrapper_);


### PR DESCRIPTION
Existing text-editable fields don’t care (dropdown care, but are not
text-editable).  But a note picker needs to set its value to 60 if text
is set to ‘C4’.