### PR TITLE
Update block factory to make setting colour, helpurl, and tooltip easier

### DIFF
--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -52,6 +52,12 @@ Blockly.Blocks['factory_base'] = {
         });
     this.appendDummyInput()
         .appendField(dropdown, 'CONNECTIONS');
+    this.appendValueInput('TOOLTIP')
+        .setCheck('String')
+        .appendField('tooltip');
+    this.appendValueInput('HELPURL')
+        .setCheck('String')
+        .appendField('help url');
     this.appendValueInput('COLOUR')
         .setCheck('Colour')
         .appendField('colour');

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -66,6 +66,12 @@ BlockFactory.oldDir = null;
  */
 BlockFactory.STARTER_BLOCK_XML_TEXT = '<xml><block type="factory_base" ' +
     'deletable="false" movable="false">' +
+    '<value name="TOOLTIP">' +
+    '<block type="text" deletable="false" movable="false">' +
+    '<field name="TEXT"></field></block></value>' +
+    '<value name="HELPURL">' +
+    '<block type="text" deletable="false" movable="false">' +
+    '<field name="TEXT"></field></block></value>' +
     '<value name="COLOUR">' +
     '<block type="colour_hue">' +
     '<mutation colour="#5b67a5"></mutation>' +

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -65,7 +65,12 @@ BlockFactory.oldDir = null;
  * unmovable, undeletable factory_base block.
  */
 BlockFactory.STARTER_BLOCK_XML_TEXT = '<xml><block type="factory_base" ' +
-    'deletable="false" movable="false"></block></xml>';
+    'deletable="false" movable="false">' +
+    '<value name="COLOUR">' +
+    '<block type="colour_hue">' +
+    '<mutation colour="#5b67a5"></mutation>' +
+    '<field name="HUE">230</field>' +
+    '</block></value></block></xml>';
 
 /**
  * Change the language code format.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -250,8 +250,20 @@ FactoryUtils.formatJson_ = function(blockType, rootBlock) {
     var hue = parseInt(colourBlock.getFieldValue('HUE'), 10);
     JS.colour = hue;
   }
-  JS.tooltip = '';
-  JS.helpUrl = 'http://www.example.com/';
+  // Tooltip.
+  var tooltipBlock = rootBlock.getInputTargetBlock('TOOLTIP');
+  if (tooltipBlock && !tooltipBlock.disabled) {
+    JS.tooltip = tooltipBlock.getFieldValue('TEXT');
+  } else {
+    JS.tooltip = '';
+  }
+  // Help URL.
+  var helpUrlBlock = rootBlock.getInputTargetBlock('HELPURL');
+  if (helpUrlBlock && !helpUrlBlock.disabled) {
+    JS.helpUrl = helpUrlBlock.getFieldValue('TEXT');
+  } else {
+    JS.helpUrl = 'http://www.example.com/';
+  }
   return JSON.stringify(JS, null, '  ');
 };
 
@@ -334,6 +346,7 @@ FactoryUtils.formatJavaScript_ = function(blockType, rootBlock, workspace) {
       code.push('    this.setColour(' + hue + ');');
     }
   }
+  // TODO: Rachel: tooltip and helpurl
   code.push("    this.setTooltip('');");
   code.push("    this.setHelpUrl('http://www.example.com/');");
   code.push('  }');

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -250,20 +250,10 @@ FactoryUtils.formatJson_ = function(blockType, rootBlock) {
     var hue = parseInt(colourBlock.getFieldValue('HUE'), 10);
     JS.colour = hue;
   }
-  // Tooltip.
-  var tooltipBlock = rootBlock.getInputTargetBlock('TOOLTIP');
-  if (tooltipBlock && !tooltipBlock.disabled) {
-    JS.tooltip = tooltipBlock.getFieldValue('TEXT');
-  } else {
-    JS.tooltip = '';
-  }
-  // Help URL.
-  var helpUrlBlock = rootBlock.getInputTargetBlock('HELPURL');
-  if (helpUrlBlock && !helpUrlBlock.disabled) {
-    JS.helpUrl = helpUrlBlock.getFieldValue('TEXT');
-  } else {
-    JS.helpUrl = 'http://www.example.com/';
-  }
+
+  JS.tooltip = FactoryUtils.getTooltipFromRootBlock_(rootBlock);
+  JS.helpUrl = FactoryUtils.getHelpUrlFromRootBlock_(rootBlock);
+
   return JSON.stringify(JS, null, '  ');
 };
 
@@ -346,9 +336,11 @@ FactoryUtils.formatJavaScript_ = function(blockType, rootBlock, workspace) {
       code.push('    this.setColour(' + hue + ');');
     }
   }
-  // TODO: Rachel: tooltip and helpurl
-  code.push("    this.setTooltip('');");
-  code.push("    this.setHelpUrl('http://www.example.com/');");
+
+  var tooltip = FactoryUtils.getTooltipFromRootBlock_(rootBlock);
+  var helpUrl = FactoryUtils.getHelpUrlFromRootBlock_(rootBlock);
+  code.push("    this.setTooltip('" + tooltip + "');");
+  code.push("    this.setHelpUrl('" + helpUrl + "');");
   code.push('  }');
   code.push('};');
   return code.join('\n');
@@ -963,4 +955,32 @@ FactoryUtils.savedBlockChanges = function(blockLibraryController) {
     return FactoryUtils.sameBlockXml(savedXml, currentXml);
   }
   return false;
+};
+
+/**
+ * Given the root block of the factory, return the tooltip specified by the user
+ * or the empty string if no tooltip is found.
+ * @param {!Blockly.Block} rootBlock Factory_base block.
+ * @return {string} The tooltip for the generated block, or the empty string.
+ */
+FactoryUtils.getTooltipFromRootBlock_ = function(rootBlock) {
+  var tooltipBlock = rootBlock.getInputTargetBlock('TOOLTIP');
+  if (tooltipBlock && !tooltipBlock.disabled) {
+    return tooltipBlock.getFieldValue('TEXT');
+  }
+  return '';
+};
+
+/**
+ * Given the root block of the factory, return the help url specified by the
+ * user or the empty string if no tooltip is found.
+ * @param {!Blockly.Block} rootBlock Factory_base block.
+ * @return {string} The help url for the generated block, or the empty string.
+ */
+FactoryUtils.getHelpUrlFromRootBlock_ = function(rootBlock) {
+  var helpUrlBlock = rootBlock.getInputTargetBlock('HELPURL');
+  if (helpUrlBlock && !helpUrlBlock.disabled) {
+    return helpUrlBlock.getFieldValue('TEXT');
+  }
+  return '';
 };

--- a/demos/code/index.html
+++ b/demos/code/index.html
@@ -6,7 +6,7 @@
   <title>Blockly Demo:</title>
   <link rel="stylesheet" href="style.css">
   <script src="/storage.js"></script>
-  <script src="../../blockly_compressed.js"></script>
+  <script src="../../blockly_uncompressed.js"></script>
   <script src="../../blocks_compressed.js"></script>
   <script src="../../javascript_compressed.js"></script>
   <script src="../../python_compressed.js"></script>

--- a/demos/code/index.html
+++ b/demos/code/index.html
@@ -6,7 +6,7 @@
   <title>Blockly Demo:</title>
   <link rel="stylesheet" href="style.css">
   <script src="/storage.js"></script>
-  <script src="../../blockly_uncompressed.js"></script>
+  <script src="../../blockly_compressed.js"></script>
   <script src="../../blocks_compressed.js"></script>
   <script src="../../javascript_compressed.js"></script>
   <script src="../../python_compressed.js"></script>


### PR DESCRIPTION
The colour input now automatically has a block attached to it.  HelpUrl and tooltip can now be set on the factory block and saved.