### PR TITLE
Move the call to disable resize before placeNewBlock so that it is of…

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1162,6 +1162,10 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
       return;
     }
     Blockly.Events.disable();
+    // Disable workspace resizing.  Reenable at the end of the drag. We do
+    // not need the workspace to resize in the middle of place new block
+    // we need to it happen at the end.
+    flyout.targetWorkspace_.setResizesEnabled(false);
     try {
       var block = flyout.placeNewBlock_(originBlock);
     } finally {
@@ -1181,8 +1185,6 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
     block.moveToDragSurface_();
-    // Disable workspace resizing.  Reenable at the end of the drag.
-    flyout.targetWorkspace_.setResizesEnabled(false);
   };
 };
 

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1162,9 +1162,9 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
       return;
     }
     Blockly.Events.disable();
-    // Disable workspace resizing.  Reenable at the end of the drag. We do
-    // not need the workspace to resize in the middle of place new block
-    // we need to it happen at the end.
+    // Disable workspace resizing. Reenable at the end of the drag. This avoids
+    // a spurious resize between creating the new block and placing it in the
+    // workspace.
     flyout.targetWorkspace_.setResizesEnabled(false);
     try {
       var block = flyout.placeNewBlock_(originBlock);


### PR DESCRIPTION
…f when workspace resizeContents

gets triggered by placeNewBlock.  This fixes a bug in rtl mode where the workspace was being resized
between when the block was added to the workspace and when it was moved to the proper location.