### PR TITLE
Change string quoting in Python codegen to match what `repr` does.

### DIFF
--- a/generators/python.js
+++ b/generators/python.js
@@ -193,9 +193,18 @@ Blockly.Python.quote_ = function(string) {
   // Can't use goog.string.quote since % must also be escaped.
   string = string.replace(/\\/g, '\\\\')
                  .replace(/\n/g, '\\\n')
-                 .replace(/\%/g, '\\%')
-                 .replace(/'/g, '\\\'');
-  return '\'' + string + '\'';
+                 .replace(/\%/g, '\\%');
+
+  // Follow the CPython behaviour of repr() for a non-byte string.
+  var quote = '\'';
+  if (string.indexOf('\'') !== -1) {
+    if (string.indexOf('"') === -1) {
+      quote = '"';
+    } else {
+      string = string.replace(/'/g, '\\\'');
+    }
+  };
+  return quote + string + quote;
 };
 
 /**


### PR DESCRIPTION
Change the Python codegen for string quoting to match the behaviour of what `repr` does for string objects in CPython.

```
$ python3
Python 3.5.0 (default, Sep 23 2015, 04:42:00)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.72)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> print(repr('hello'))
'hello'
>>> print(repr('hello "world"'))
'hello "world"'
>>> print(repr("hello 'world'"))
"hello 'world'"
>>> print(repr("\"hello\" 'world'"))
'"hello" \'world\''
>>> print(['hello', 'hello "world"', "hello 'world'", "\"hello\" 'world'"])
['hello', 'hello "world"', "hello 'world'", '"hello" \'world\'']
>>>
```

Using the same quoting approach has the advantage for students who are also learning Python that they see the same escaping behaviour in the code generated by Blockly in what the Python interpreter spits out for `repr`'d strings.

Reference behaviour from CPython: [Objects/unicodeobject.c:12408](https://github.com/python/cpython/blob/3.5/Objects/unicodeobject.c#L12408).