### PR TITLE
Adds `allInputsFilled` methods to Block and Workspace.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1335,3 +1335,37 @@ Blockly.Block.prototype.moveBy = function(dx, dy) {
 Blockly.Block.prototype.makeConnection_ = function(type) {
   return new Blockly.Connection(this, type);
 };
+
+/**
+ * Recursively checks whether all statement and value inputs are filled with
+ * blocks. Also checks all following statement blocks in this stack.
+ * @param {boolean=} opt_shadowBlocksAreFilled An optional argument controlling
+ *     whether shadow blocks are counted as filled. Defaults to true.
+ * @return {boolean} True if all inputs are filled, false otherwise.
+ */
+Blockly.Block.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
+  // Handle the default value for the optional argument.
+  if (opt_shadowBlocksAreFilled === undefined) {
+    opt_shadowBlocksAreFilled = true;
+  }
+
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    if (!input.connection) {
+      continue;
+    }
+    var target = input.connection.targetBlock();
+    if (!target || !target.allInputsFilled(opt_shadowBlocksAreFilled)) {
+      return false;
+    }
+    if (!opt_shadowBlocksAreFilled && target.isShadow()) {
+      return false;
+    }
+  }
+
+  var next = this.getNextBlock();
+  if (next) {
+    return next.allInputsFilled(opt_shadowBlocksAreFilled);
+  }
+
+  return true;
+};

--- a/core/block.js
+++ b/core/block.js
@@ -1344,11 +1344,15 @@ Blockly.Block.prototype.makeConnection_ = function(type) {
  * @return {boolean} True if all inputs are filled, false otherwise.
  */
 Blockly.Block.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
-  // Handle the default value for the optional argument.
+  // Account for the shadow block filledness toggle.
   if (opt_shadowBlocksAreFilled === undefined) {
     opt_shadowBlocksAreFilled = true;
   }
+  if (!opt_shadowBlocksAreFilled && this.isShadow()) {
+    return false;
+  }
 
+  // Recursively check each input block of the current block.
   for (var i = 0, input; input = this.inputList[i]; i++) {
     if (!input.connection) {
       continue;
@@ -1357,11 +1361,9 @@ Blockly.Block.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
     if (!target || !target.allInputsFilled(opt_shadowBlocksAreFilled)) {
       return false;
     }
-    if (!opt_shadowBlocksAreFilled && target.isShadow()) {
-      return false;
-    }
   }
 
+  // Recursively check the next block after the current block.
   var next = this.getNextBlock();
   if (next) {
     return next.allInputsFilled(opt_shadowBlocksAreFilled);

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -479,6 +479,23 @@ Blockly.Workspace.prototype.getBlockById = function(id) {
 };
 
 /**
+ * Checks whether all value and statement inputs in the workspace are filled
+ * with blocks.
+ * @param {boolean=} opt_shadowBlocksAreFilled An optional argument controlling
+ *     whether shadow blocks are counted as filled. Defaults to true.
+ * @return {boolean} True if all inputs are filled, false otherwise.
+ */
+Blockly.Workspace.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
+  var blocks = this.getTopBlocks(false);
+  for (var i = 0, block; block = blocks[i]; i++) {
+    if (!block.allInputsFilled(opt_shadowBlocksAreFilled)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
  * Database of all workspaces.
  * @private
  */


### PR DESCRIPTION
Add an `allInputsFilled` method to `Block` and `Workspace` to test whether all trees in the block forest have all of their inputs filled. An optional argument controls whether or not shadow blocks are counted as being filled. Recommitting changes off `develop` instead of `master` as per discussion in PR #791.