### PR TITLE
Make cursor stay as a closed hand when dragging blocks around in the …

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -312,7 +312,7 @@ Blockly.Css.CONTENT = [
     Don't allow users to select text.  It gets annoying when trying to
     drag a block and selected text moves instead.
   */
-  '.blocklySvg text {',
+  '.blocklySvg text, .blocklyBlockDragSurface text {',
     'user-select: none;',
     '-moz-user-select: none;',
     '-webkit-user-select: none;',


### PR DESCRIPTION
…drag surface. Do this by applying the same style to text elements in the drag surface that we do in the main svg.