### PR TITLE
Fix undo/redo for FieldCheckbox

### DIFF
--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -88,7 +88,7 @@ Blockly.FieldCheckbox.prototype.getValue = function() {
  * @param {string} strBool New state.
  */
 Blockly.FieldCheckbox.prototype.setValue = function(strBool) {
-  var newState = (strBool.toUpperCase() == 'TRUE');
+  var newState = (typeof strBool === 'string') ? (strBool.toUpperCase() == 'TRUE') : !!strBool;
   if (this.state_ !== newState) {
     if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
       Blockly.Events.fire(new Blockly.Events.Change(


### PR DESCRIPTION
When FieldCheckbox is modified, Blockly.Events.Change is emited where oldValue and newValue are booleans. This breaks Undo, because setValue expects a string.

This change fixes the issue. The side effect is that setValue can be called with a boolean