### PR TITLE
Store workspace scrollbars in bubblecanvas

### DIFF
--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -588,7 +588,7 @@ Blockly.Scrollbar.prototype.createDom_ = function() {
       {'class': 'blocklyScrollbarHandle', 'rx': radius, 'ry': radius},
       this.svgGroup_);
   Blockly.utils.insertAfter_(this.outerSvg_,
-                                 this.workspace_.getParentSvg());
+                                 this.workspace_.getBubbleCanvas());
 };
 
 /**


### PR DESCRIPTION
This patch is supposed to fix #816. From the comment in line 323 of workspace_svg.js this seems to be the way it's supposed to be. Also the scrollbar corner was already treated like this.