### PR TITLE
Reduce number of Closure files in App Engine upload.

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -34,7 +34,7 @@ handlers:
   static_dir: static
   secure: always
 
-# Closure library for uncompiled Blockly.
+# Closure library for uncompressed Blockly.
 - url: /closure-library
   static_dir: closure-library
   secure: always
@@ -80,3 +80,8 @@ skip_files:
 - ^static/i18n/.*$
 - ^static/msg/json/.*$
 - ^.+\.soy$
+- ^closure-library/.*_test.html$
+- ^closure-library/.*_test.js$
+- ^closure-library/closure/bin/.*$
+- ^closure-library/doc/.*$
+- ^closure-library/scripts/.*$


### PR DESCRIPTION
This eliminates 1274 unneeded files from being uploaded (40% of Closure) and should result in faster updates.