### PR TITLE
Fixing Accessible Blockly block duplication bug.

### DIFF
--- a/accessible/tree.service.js
+++ b/accessible/tree.service.js
@@ -292,7 +292,7 @@ blocklyApp.TreeService = ng.core.Class({
               block);
 
           that.removeBlockAndSetFocus(block, blockRootNode, function() {
-            block.dispose(true);
+            block.dispose(false);
           });
 
           // Invoke a digest cycle, so that the DOM settles.


### PR DESCRIPTION
When moving a stack of blocks to a new place on the workspace, healstack on dispose is currently being set to true, but the full stack is being moved, resulting in any subsequent blocks attached to the original block being in both places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/831)
<!-- Reviewable:end -->
