### PR TITLE
JSON definitions for colour blocks

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -21,10 +21,10 @@
 /**
  * @fileoverview Colour blocks for Blockly.
  *
- * This file is scrapped to extract .json file definitions. The array passed to
+ * This file is scraped to extract .json file definitions. The array passed to
  * defineBlocksWithJsonArray(..) must be strict JSON: double quotes only, no
- * outside references, no functions, etc. The one exception is end-of-line
- * comments, which the scrapper will remove.
+ * outside references, no functions, no trailing commasa, etc. The one
+ * exception is end-of-line comments, which the scraper will remove.
  * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
@@ -128,4 +128,4 @@ Blockly.defineBlocksWithJsonArray([
     "helpUrl": "%{BKY_COLOUR_BLEND_HELPURL}",
     "tooltip": "%{BKY_COLOUR_BLEND_TOOLTIP}"
   }
-]);  // End defineBlocksWithJsonArray(...)
+]);  // End of defineBlocksWithJsonArray(...) DO NOT DELETE

--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -20,6 +20,11 @@
 
 /**
  * @fileoverview Colour blocks for Blockly.
+ *
+ * This file is scrapped to extract .json file definitions. The array passed to
+ * defineBlocksWithJsonArray(..) must be strict JSON: double quotes only, no
+ * outside references, no functions, etc. The one exception is end-of-line
+ * comments, which the scrapper will remove.
  * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
@@ -34,100 +39,92 @@ goog.require('Blockly.Blocks');
  */
 Blockly.Blocks.colour.HUE = 20;
 
-Blockly.Blocks['colour_picker'] = {
-  /**
-   * Block for colour picker.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit({
-      "message0": "%1",
-      "args0": [
-        {
-          "type": "field_colour",
-          "name": "COLOUR",
-          "colour": "#ff0000"
-        }
-      ],
-      "output": "Colour",
-      "colour": Blockly.Blocks.colour.HUE,
-      "helpUrl": Blockly.Msg.COLOUR_PICKER_HELPURL
-    });
-    // Assign 'this' to a variable for use in the tooltip closure below.
-    var thisBlock = this;
-    // Colour block is trivial.  Use tooltip of parent block if it exists.
-    this.setTooltip(function() {
-      var parent = thisBlock.getParent();
-      return (parent && parent.getInputsInline() && parent.tooltip) ||
-          Blockly.Msg.COLOUR_PICKER_TOOLTIP;
-    });
-  }
-};
+Blockly.defineBlocksWithJsonArray([
+  // Block for colour picker.
+  {
+    "type": "colour_picker",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_colour",
+        "name": "COLOUR",
+        "colour": "#ff0000"
+      }
+    ],
+    "output": "Colour",
+    "colour": "%{BKY_COLOUR_HUE}",
+    "helpUrl": "%{BKY_COLOUR_PICKER_HELPURL}",
+    "tooltip": "%{BKY_COLOUR_PICKER_TOOLTIP}",
+    "extensions": ["parent_tooltip_when_inline"]
+  },
 
-Blockly.Blocks['colour_random'] = {
-  /**
-   * Block for random colour.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.jsonInit({
-      "message0": Blockly.Msg.COLOUR_RANDOM_TITLE,
-      "output": "Colour",
-      "colour": Blockly.Blocks.colour.HUE,
-      "tooltip": Blockly.Msg.COLOUR_RANDOM_TOOLTIP,
-      "helpUrl": Blockly.Msg.COLOUR_RANDOM_HELPURL
-    });
-  }
-};
+  // Block for random colour.
+  {
+    "type": "colour_random",
+    "message0": "%{BKY_COLOUR_RANDOM_TITLE}",
+    "output": "Colour",
+    "colour": "%{BKY_COLOUR_HUE}",
+    "helpUrl": "%{BKY_COLOUR_RANDOM_HELPURL}",
+    "tooltip": "%{BKY_COLOUR_RANDOM_TOOLTIP}"
+  },
 
-Blockly.Blocks['colour_rgb'] = {
-  /**
-   * Block for composing a colour from RGB components.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setHelpUrl(Blockly.Msg.COLOUR_RGB_HELPURL);
-    this.setColour(Blockly.Blocks.colour.HUE);
-    this.appendValueInput('RED')
-        .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_RGB_TITLE)
-        .appendField(Blockly.Msg.COLOUR_RGB_RED);
-    this.appendValueInput('GREEN')
-        .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_RGB_GREEN);
-    this.appendValueInput('BLUE')
-        .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_RGB_BLUE);
-    this.setOutput(true, 'Colour');
-    this.setTooltip(Blockly.Msg.COLOUR_RGB_TOOLTIP);
-  }
-};
+  // Block for composing a colour from RGB components.
+  {
+    "type": "colour_rgb",
+    "message0": "%{BKY_COLOUR_RGB_TITLE} %{BKY_COLOUR_RGB_RED} %1 %{BKY_COLOUR_RGB_GREEN} %2 %{BKY_COLOUR_RGB_BLUE} %3",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "RED",
+        "check": "Number",
+        "align": "RIGHT"
+      },
+      {
+        "type": "input_value",
+        "name": "GREEN",
+        "check": "Number",
+        "align": "RIGHT"
+      },
+      {
+        "type": "input_value",
+        "name": "BLUE",
+        "check": "Number",
+        "align": "RIGHT"
+      }
+    ],
+    "output": "Colour",
+    "colour": "%{BKY_COLOUR_HUE}",
+    "helpUrl": "%{BKY_COLOUR_RGB_HELPURL}",
+    "tooltip": "%{BKY_COLOUR_RGB_TOOLTIP}"
+  },
 
-Blockly.Blocks['colour_blend'] = {
-  /**
-   * Block for blending two colours together.
-   * @this Blockly.Block
-   */
-  init: function() {
-    this.setHelpUrl(Blockly.Msg.COLOUR_BLEND_HELPURL);
-    this.setColour(Blockly.Blocks.colour.HUE);
-    this.appendValueInput('COLOUR1')
-        .setCheck('Colour')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_BLEND_TITLE)
-        .appendField(Blockly.Msg.COLOUR_BLEND_COLOUR1);
-    this.appendValueInput('COLOUR2')
-        .setCheck('Colour')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_BLEND_COLOUR2);
-    this.appendValueInput('RATIO')
-        .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField(Blockly.Msg.COLOUR_BLEND_RATIO);
-    this.setOutput(true, 'Colour');
-    this.setTooltip(Blockly.Msg.COLOUR_BLEND_TOOLTIP);
+  // Block for blending two colours together.
+  {
+    "type": "colour_blend",
+    "message0": "%{BKY_COLOUR_BLEND_TITLE} %{BKY_COLOUR_BLEND_COLOUR1} %1 %{BKY_COLOUR_BLEND_COLOUR2} %2 %{BKY_COLOUR_BLEND_RATIO} %3",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "COLOUR1",
+        "check": "Colour",
+        "align": "RIGHT"
+      },
+      {
+        "type": "input_value",
+        "name": "COLOUR2",
+        "check": "Colour",
+        "align": "RIGHT"
+      },
+      {
+        "type": "input_value",
+        "name": "RATIO",
+        "check": "Number",
+        "align": "RIGHT"
+      }
+    ],
+    "output": "Colour",
+    "colour": "%{BKY_COLOUR_HUE}",
+    "helpUrl": "%{BKY_COLOUR_BLEND_HELPURL}",
+    "tooltip": "%{BKY_COLOUR_BLEND_TOOLTIP}"
   }
-};
+]);  // End defineBlocksWithJsonArray(...)

--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -36,6 +36,7 @@ goog.require('Blockly.Blocks');
 
 /**
  * Common HSV hue for all blocks in this category.
+ * This should be the same as Blockly.Msg.COLOUR_HUE.
  */
 Blockly.Blocks.colour.HUE = 20;
 

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -34,31 +34,23 @@ goog.require('Blockly.Blocks');
  */
 Blockly.Blocks.math.HUE = 230;
 
-// Block for numeric value.
-Blockly.defineBlocksWithJsonArray([{
-  "type": "math_number",
-  "message0": "%1",
-  "args0": [{
-    "type": "field_number",
-    "name": "NUM",
-    "value": 0
-  }],
-  "output": "Number",
-  "colour": "%{BKY_MATH_HUE}",
-  "helpUrl": "%{BKY_MATH_NUMBER_HELPURL}",
-  "extensions": ["math_number_tooltip"]
-}]);
-
-Blockly.Extensions.register('math_number_tooltip', function() {
-  // Use the parent's tooltip when attached to an inline value input.
-  this.setTooltip(function() {
-    var parent = this.getParent();
-    return (parent &&
-      parent.getInputsInline() &&
-      parent.tooltip) ||
-      Blockly.Msg.MATH_NUMBER_TOOLTIP;
-  }.bind(this));
-});
+Blockly.defineBlocksWithJsonArray([
+  // Block for numeric value.
+  {
+    "type": "math_number",
+    "message0": "%1",
+    "args0": [{
+      "type": "field_number",
+      "name": "NUM",
+      "value": 0
+    }],
+    "output": "Number",
+    "colour": "%{BKY_MATH_HUE}",
+    "helpUrl": "%{BKY_MATH_NUMBER_HELPURL}",
+    "tooltip": "%{BKY_MATH_NUMBER_TOOLTIP}",
+    "extensions": ["parent_tooltip_when_inline"]
+  }
+]);
 
 Blockly.Blocks['math_arithmetic'] = {
   /**

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -73,3 +73,24 @@ Blockly.Extensions.apply = function(name, block) {
   }
   extensionFn.apply(block);
 };
+
+/**
+ * Configures the tooltip to mimic the parent block when connected. Otherwise,
+ * uses the tooltip text at the time this extension is initialized. This takes
+ * advantage of the fact that all other values from JSON are initialized before
+ * extensions.
+ * @this {Blockly.Block}
+ * @private
+ */
+Blockly.Extensions.extensionParentTooltip_ = function() {
+  this.tooltipWhenNotConnected_ = this.tooltip;
+  this.setTooltip(function() {
+    var parent = this.getParent();
+    return (parent &&
+      parent.getInputsInline() &&
+      parent.tooltip) ||
+      this.tooltipWhenNotConnected_;
+  }.bind(this));
+};
+Blockly.Extensions.register('parent_tooltip_when_inline',
+    Blockly.Extensions.extensionParentTooltip_);


### PR DESCRIPTION
Replaces old colour block definitions with a Blockly.defineBlocksWithJsonArray(..) call. Generator unit tests continue to load and pass, signifying compatibility with prior block definitions.

Replaces extension 'math_number_tooltip' with the reusable 'parent_tooltip_when_inline' extension, also used by colour_picker. Includes tests.