### PR TITLE
Use bindEvent_ instead of bindEventWithChecks_ for longStop

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -339,9 +339,10 @@ Blockly.init_ = function(mainWorkspace) {
 Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
     Blockly.bindEventWithChecks_(document, 'keydown', null, Blockly.onKeyDown_);
-    Blockly.bindEventWithChecks_(document, 'touchend', null, Blockly.longStop_);
-    Blockly.bindEventWithChecks_(document, 'touchcancel', null,
-        Blockly.longStop_);
+    // longStop needs to run to stop the context menu from showing up.  It
+    // should run regardless of what other touch event handlers have run.
+    Blockly.bindEvent_(document, 'touchend', null, Blockly.longStop_);
+    Blockly.bindEvent_(document, 'touchcancel', null, Blockly.longStop_);
     // Don't use bindEvent_ for document's mouseup since that would create a
     // corresponding touch handler that would squelch the ability to interact
     // with non-Blockly elements.


### PR DESCRIPTION
This is equivalent to https://github.com/LLK/scratch-blocks/pull/734