### PR TITLE
Fixing combo boxes getting out-of-sync with NVDA.

### DIFF
--- a/accessible/tree.service.js
+++ b/accessible/tree.service.js
@@ -452,9 +452,10 @@ blocklyApp.TreeService = ng.core.Class({
       return;
     }
 
-    if (document.activeElement.tagName == 'INPUT') {
-      // For input fields, only Esc and Tab keystrokes are handled specially.
-      if (e.keyCode == 27 || e.keyCode == 9) {
+    if (document.activeElement.tagName == 'INPUT' ||
+        document.activeElement.tagName == 'SELECT') {
+      // For input fields, Esc, Enter, and Tab keystrokes are handled specially.
+      if (e.keyCode == 9 || e.keyCode == 13 || e.keyCode == 27) {
         // Return the focus to the workspace tree containing the input field.
         document.getElementById(treeId).focus();
 


### PR DESCRIPTION
Combo boxes need to be special cased like text input. Also, Escape is
a reserved button in NVDA, so I added Enter as a way to "submit and
move up a level" in addition to escape, so these boxes can be edited
while NVDA is on.