### PR TITLE
Change CSS transforms to work with older browsers

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -137,16 +137,15 @@ Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, sc
  * @param {number} y Y translation for the entire surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
-  var transform;
   x *= this.scale_;
   y *= this.scale_;
   // This is a work-around to prevent a the blocks from rendering
   // fuzzy while they are being dragged on the drag surface.
   x = x.toFixed(0);
   y = y.toFixed(0);
-  transform =
+  var transform =
     'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
-  this.SVG_.setAttribute('style', transform);
+  Blockly.utils.setCssTransform(this.SVG_, transform);
 };
 
 /**

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -143,9 +143,9 @@ Blockly.BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
   // fuzzy while they are being dragged on the drag surface.
   x = x.toFixed(0);
   y = y.toFixed(0);
-  var transform =
-    'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
-  Blockly.utils.setCssTransform(this.SVG_, transform);
+  this.SVG_.style.display = 'block';
+  Blockly.utils.setCssTransform(this.SVG_,
+      'translate3d(' + x + 'px, ' + y + 'px, 0px)');
 };
 
 /**

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -500,7 +500,7 @@ Blockly.Flyout.prototype.position = function() {
   this.svgGroup_.setAttribute("width", this.width_);
   this.svgGroup_.setAttribute("height", this.height_);
   var transform = 'translate(' + x + 'px,' + y + 'px)';
-  this.svgGroup_.style.transform = transform;
+  Blockly.utils.setCssTransform(this.svgGroup_, transform);
 
   // Update the scrollbar (if one exists).
   if (this.scrollbar_) {

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -384,7 +384,7 @@ Blockly.Scrollbar.prototype.setPosition = function(x, y) {
   var tempX = this.position_.x + this.origin_.x;
   var tempY = this.position_.y + this.origin_.y;
   var transform = 'translate(' + tempX + 'px,' + tempY + 'px)';
-  this.outerSvg_.style.transform = transform;
+  Blockly.utils.setCssTransform(this.outerSvg_, transform);
 };
 
 /**

--- a/core/utils.js
+++ b/core/utils.js
@@ -856,3 +856,15 @@ Blockly.utils.runAfterPageLoad = function(fn) {
     }, 10);
   }
 };
+
+/**
+ * Sets the CSS transform property on an element. This function sets the
+ * non-vendor-prefixed and vendor-prefixed versions for backwards compatibility
+ * with older browsers. See http://caniuse.com/#feat=transforms2d
+ * @param {!Element} node The node which the CSS transform should be applied.
+ * @param {string} transform The value of the CSS `transform` property.
+ */
+Blockly.utils.setCssTransform = function(node, transform) {
+  node.style['transform'] = transform;
+  node.style['-webkit-transform'] = transform;
+};

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -115,7 +115,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
 
   var transform =
     'transform: translate3d(' + x + 'px, ' + y + 'px, 0px); display: block;';
-  this.SVG_.setAttribute('style', transform);
+  Blockly.utils.setCssTransform(this.SVG_, transform);
 };
 
 /**
@@ -158,7 +158,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.SVG_.childNodes.length == 0,
     'Drag surface was not cleared.');
-  this.SVG_.style.transform = '';
+  Blockly.utils.setCssTransform(this.SVG_, '');
   this.previousSibling_ = null;
 };
 


### PR DESCRIPTION
Sets both the unprefixed version and the `-webkit-` prefixed version of the CSS `transform` property so that Blockly correctly renders in order browsers, such as Safari < 9 and iOS Safari < 9.2. 

For discussion of this issue, see https://groups.google.com/forum/#!topic/blockly/o3pERaRQhSg