### PR TITLE
Add FieldDropdown menuGenerator_ getter and setter

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -50,8 +50,7 @@ goog.require('goog.userAgent');
  * @constructor
  */
 Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
-  this.menuGenerator_ = menuGenerator;
-  this.trimOptions_();
+  this.setMenuGenerator_(menuGenerator);
   var firstTuple = this.getOptions()[0];
 
   // Call parent's constructor.
@@ -317,6 +316,35 @@ Blockly.FieldDropdown.prototype.getOptions = function() {
  */
 Blockly.FieldDropdown.prototype.getValue = function() {
   return this.value_;
+};
+
+/**
+ * @return {(!Array.<!Array>|!Function)} The menuGenerator function or array
+ * used to populate the choices of the dropdown.
+ **/
+Blockly.FieldDropdown.prototype.getMenuGenerator = function() {
+  return this.menuGenerator_;
+};
+
+/**
+ * Set the list of 2-tuples or function used to generate the options for the
+ * dropdown field.
+ * @param {(!Array.<!Array>|!Function)} menuGenerator An array of options
+ *     for a dropdown list, or a function which generates these options.
+ **/
+Blockly.FieldDropdown.prototype.setMenuGenerator = function(menuGenerator) {
+  this.setMenuGenerator_(menuGenerator);
+  this.setValue(this.getOptions()[0][1]);
+};
+
+/**
+ * @param {(!Array.<!Array>|!Function)} menuGenerator An array of options
+ *     for a dropdown list, or a function which generates these options.
+ * @private
+ **/
+Blockly.FieldDropdown.prototype.setMenuGenerator_ = function(menuGenerator) {
+  this.menuGenerator_ = menuGenerator;
+  this.trimOptions_();
 };
 
 /**

--- a/tests/jsunit/field_dropdown_test.js
+++ b/tests/jsunit/field_dropdown_test.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+ * @fileoverview Tests for Blockly.FieldDropdown
+ * @author tim.dawborn@gmail.com (Tim Dawborn)
+ */
+'use strict';
+
+function test_menuGenerator_getter_setter_constructor() {
+  var OPTIONS_ARRAY = [
+    ['one', '1'],
+    ['zwei', '2'],
+    ['三', '3'],
+  ];
+  var OPTIONS_FUNCTION = function() {
+    var options = [];
+    for (var i = 10, j = 0; i >= 0; i -= 3, ++j) {
+      options.push(['Option ' + j, i.toString()]);
+    }
+    return options;
+  };
+  var field, menuGenerator;
+
+  // Test array constructor.
+  field = new Blockly.FieldDropdown(OPTIONS_ARRAY.slice());
+  assertFalse(field.isOptionListDynamic());
+  menuGenerator = field.getMenuGenerator();
+  assertTrue(Array.isArray(menuGenerator));
+  assertEquals('1', field.getValue());
+
+  // Change to use a function instead.
+  field.setMenuGenerator(OPTIONS_FUNCTION);
+  assertTrue(field.isOptionListDynamic());
+  menuGenerator = field.getMenuGenerator();
+  assertFalse(Array.isArray(menuGenerator));
+  assertEquals('10', field.getValue());
+
+  // Test function constructor.
+  field = new Blockly.FieldDropdown(OPTIONS_FUNCTION);
+  assertTrue(field.isOptionListDynamic());
+  menuGenerator = field.getMenuGenerator();
+  assertFalse(Array.isArray(menuGenerator));
+  assertEquals('10', field.getValue());
+
+  // Change to use an array instead.
+  field.setMenuGenerator(OPTIONS_ARRAY);
+  assertTrue(field.isOptionListDynamic());
+  menuGenerator = field.getMenuGenerator();
+  assertFalse(Array.isArray(menuGenerator));
+  assertEquals('1', field.getValue());
+};

--- a/tests/jsunit/field_dropdown_test.js
+++ b/tests/jsunit/field_dropdown_test.js
@@ -62,8 +62,8 @@ function test_menuGenerator_getter_setter_constructor() {
 
   // Change to use an array instead.
   field.setMenuGenerator(OPTIONS_ARRAY);
-  assertTrue(field.isOptionListDynamic());
+  assertFalse(field.isOptionListDynamic());
   menuGenerator = field.getMenuGenerator();
-  assertFalse(Array.isArray(menuGenerator));
+  assertTrue(Array.isArray(menuGenerator));
   assertEquals('1', field.getValue());
 };

--- a/tests/jsunit/index.html
+++ b/tests/jsunit/index.html
@@ -12,6 +12,7 @@
     <script src="connection_db_test.js"></script>
     <script src="extensions_test.js"></script>
     <script src="field_angle_test.js"></script>
+    <script src="field_dropdown_test.js"></script>
     <script src="field_number_test.js"></script>
     <script src="generator_test.js"></script>
     <script src="names_test.js"></script>


### PR DESCRIPTION
Add public getter and setter methods to `FieldDropdown` to allow the underlying `menuGenerator_` to be changed. This is needed in the new "JSON + extensions" block definition paradigm so that extensions can change `FieldDropdown` instances to use a function.

One issue that this changeset does not currently fix is that the `FieldDropdown` constructor assumes that the `menuGenerator` argument will be a valid value that contains at least one item for populating the dropdown list. What this means in terms of the "JSON + extensions" paradigm is that the `field_dropdown` entries currently have to have a one-element `options` key in order for the `FieldDropdown` instance to be successfully constructed without throwing an error. E.g. (from [here](https://github.com/groklearning/blockly-blocks/blob/develop/blocks/microbit.js#L275)):

```javascript
Blockly.defineBlocksWithJsonArray([
  ...
  // Block for Image.FOO
  {
    "type": "microbit_image",
    "message0": "%{BKY_MICROBIT_IMAGE_TITLE}",
    "args0": [
      {
        "type": "field_dropdown",
        "name": "CATEGORY",
        "options": [
          ["Animals", "Animals"],
          ["Arrows", "Arrows"],
          ["Clocks", "Clocks"],
          ["Faces", "Faces"],
          ["Music", "Music"],
          ["Other", "Other"],
          ["Symbols", "Symbols"],
        ],
      },
      {
        "type": "field_dropdown",
        "name": "NAME",
        "options": [
          ["", ""],  // Hackedy hack hack
        ],
      },
    ],
    ...
    "extensions": ["microbit_image_dropdown"],
  },
  ...
]);
...
Blockly.Extensions.register('microbit_image_dropdown', function() {
  var self = this;
  this.getField('CATEGORY').setValidator(function(value) {
    // This will cause the NAME dropdown  to call its generator function.
    self.getField('NAME').setValue(IMAGE_CATEGORIES[value][0]);
  });
  this.getField('NAME').setMenuGenerator(function() {
    var field = self.getField('CATEGORY');
    var category = field.getValue();
    if (!category) {
      category = field.getMenuGenerator()[0][0];
    }
    return IMAGE_CATEGORIES[category].map(function(name) {
      return [name, name];
    });
  });
});
...
```

See https://groups.google.com/d/msg/blockly/Ao5QEAV2Ki8/H_s6zkBxAgAJ for context.