### PR TITLE
Use the empty field placeholder for dropdowns that do not have a value selected.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -922,7 +922,11 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
   } else {
     for (var i = 0, input; input = this.inputList[i]; i++) {
       for (var j = 0, field; field = input.fieldRow[j]; j++) {
-        text.push(field.getText());
+        if (field instanceof Blockly.FieldDropdown && !field.getValue()) {
+          text.push(emptyFieldPlaceholder);
+        } else {
+          text.push(field.getText());
+        }
       }
       if (input.connection) {
         var child = input.connection.targetBlock();


### PR DESCRIPTION
In commit d362c73a041cf0859d0cb33a346426c291174174, we added functionality for replacing empty field descriptions with "BLANK". This commit extends this functionality for dropdowns whose value is empty.

/cc @rachel-fenichel @CoryDCode since this is an update to core Blockly.