### PR TITLE
Fix "Uncaught TypeError: Cannot read property 'workspace' of undefined"

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -304,7 +304,7 @@ Blockly.Blocks['lists_indexOf'] = {
     var thisBlock = this;
     this.setTooltip(function() {
       return Blockly.Msg.LISTS_INDEX_OF_TOOLTIP.replace('%1',
-          this.workspace.options.oneBasedIndex ? '0' : '-1');
+          thisBlock.workspace.options.oneBasedIndex ? '0' : '-1');
     });
   }
 };


### PR DESCRIPTION
### To reproduce:

1. Visit https://blockly-demo.appspot.com/static/demos/toolbox/index.html
2. Open Lists toolbox
3. Hover on "in list [] find [first] occurrence of item []"
4. Wait for tooltip to attempt to appear

### Expected:

Tooltip should be displayed

### Actual:

Error is thrown:

```
Uncaught TypeError: Cannot read property 'workspace' of undefined
    at blocks_compressed.js:22
    at Blockly.Tooltip.show_ (blockly_compressed.js:987)
```