### PR TITLE
Re-shape blocks when clearing warnings with IDs.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1510,7 +1510,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
       if (!newText) {
         this.warning.dispose();
       }
-      changedState = oldText == newText;
+      changedState = oldText != newText;
     }
   }
   if (changedState && this.rendered) {


### PR DESCRIPTION
When clearing warnings on blocks with IDs, the changedState variable should be true if the text changed. This will trigger the block being reshaped and remove the space for the notification icon (this.bumpNeighbours_).