### PR TITLE
Extract connection dragging code

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -309,7 +309,7 @@ Blockly.Block.prototype.getConnections_ = function() {
 /**
  * Walks down a stack of blocks and finds the last next connection on the stack.
  * @return {Blockly.Connection} The last next connection on the stack, or null.
- * @private
+ * @package
  */
 Blockly.Block.prototype.lastConnectionInStack_ = function() {
   var nextConnection = this.nextConnection;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -28,6 +28,7 @@ goog.provide('Blockly.BlockSvg');
 
 goog.require('Blockly.Block');
 goog.require('Blockly.ContextMenu');
+goog.require('Blockly.DraggedConnectionManager');
 goog.require('Blockly.Touch');
 goog.require('Blockly.RenderedConnection');
 goog.require('goog.Timer');
@@ -290,6 +291,10 @@ Blockly.BlockSvg.terminateDrag = function() {
   }
   Blockly.dragMode_ = Blockly.DRAG_NONE;
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
+
+  // if (Blockly.draggedConnectionManager_) {
+  //   Blockly.draggedConnectionManager_ = null;
+  // }
 };
 
 /**
@@ -693,16 +698,21 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
 
   var deleteArea = this.workspace.isDeleteArea(e);
 
+
+  var manager = Blockly.draggedConnectionManager_;
+  var highlightedConnection = manager.closestConnection_;
+  var localConnection = manager.localConnection_;
+
   // Connect to a nearby block, but not if it's over the toolbox.
-  if (Blockly.selected && Blockly.highlightedConnection_ &&
+  if (Blockly.selected && highlightedConnection &&
       deleteArea != Blockly.DELETE_AREA_TOOLBOX) {
     // Connect two blocks together.
-    Blockly.localConnection_.connect(Blockly.highlightedConnection_);
+    localConnection.connect(highlightedConnection);
     if (this.rendered) {
       // Trigger a connection animation.
       // Determine which connection is inferior (lower in the source stack).
-      var inferiorConnection = Blockly.localConnection_.isSuperior() ?
-          Blockly.highlightedConnection_ : Blockly.localConnection_;
+      var inferiorConnection = localConnection.isSuperior() ?
+          highlightedConnection : localConnection;
       inferiorConnection.getSourceBlock().connectionUiEffect();
     }
     if (this.workspace.trashcan) {
@@ -718,10 +728,13 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     }
     Blockly.selected.dispose(false, true);
   }
-  if (Blockly.highlightedConnection_) {
-    Blockly.highlightedConnection_.unhighlight();
-    Blockly.highlightedConnection_ = null;
-  }
+  manager.removeConnectionHighlighting();
+  // if (Blockly.highlightedConnection_) {
+  //   Blockly.highlightedConnection_.unhighlight();
+  //   Blockly.highlightedConnection_ = null;
+  // }
+  console.trace('deleting connection manager');
+  Blockly.draggedConnectionManager_ = null;
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   if (!Blockly.WidgetDiv.isVisible()) {
     Blockly.Events.setGroup(false);
@@ -965,6 +978,14 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
       }
       this.setDragging_(true);
       this.moveToDragSurface_();
+
+
+      if (!Blockly.draggedConnectionManager_) {
+        Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager();
+        console.log('creating new connection manager');
+      }
+      var manager = Blockly.draggedConnectionManager_;
+      manager.setAvailableConnections(this);
     }
   }
   if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
@@ -984,83 +1005,52 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
           goog.math.Coordinate.sum(commentData, dxy));
     }
 
-    // Check to see if any of this block's connections are within range of
-    // another block's connection.
-    var myConnections = this.getConnections_(false);
-    // Also check the last connection on this stack
-    var lastOnStack = this.lastConnectionInStack_();
-    if (lastOnStack && lastOnStack != this.nextConnection) {
-      myConnections.push(lastOnStack);
-    }
-    var closestConnection = null;
-    var localConnection = null;
-    var radiusConnection = Blockly.SNAP_RADIUS;
-    for (var i = 0; i < myConnections.length; i++) {
-      var myConnection = myConnections[i];
-      var neighbour = myConnection.closest(radiusConnection, dxy);
-      if (neighbour.connection) {
-        closestConnection = neighbour.connection;
-        localConnection = myConnection;
-        radiusConnection = neighbour.radius;
-      }
-    }
+    var manager = Blockly.draggedConnectionManager_;
+    manager.updateClosestConnection(e, dxy);
 
-    // Remove connection highlighting if needed.
-    if (Blockly.highlightedConnection_ &&
-        Blockly.highlightedConnection_ != closestConnection) {
-      Blockly.highlightedConnection_.unhighlight();
-      Blockly.highlightedConnection_ = null;
-      Blockly.localConnection_ = null;
-    }
+    // // Check to see if any of this block's connections are within range of
+    // // another block's connection.
+    // var myConnections = this.getConnections_(false);
+    // // Also check the last connection on this stack
+    // var lastOnStack = this.lastConnectionInStack_();
+    // if (lastOnStack && lastOnStack != this.nextConnection) {
+    //   myConnections.push(lastOnStack);
+    // }
 
-    var wouldDeleteBlock = this.updateCursor_(e, closestConnection);
+    // var closestConnection = null;
+    // var localConnection = null;
+    // var radiusConnection = Blockly.SNAP_RADIUS;
+    // for (var i = 0; i < myConnections.length; i++) {
+    //   var myConnection = myConnections[i];
+    //   var neighbour = myConnection.closest(radiusConnection, dxy);
+    //   if (neighbour.connection) {
+    //     closestConnection = neighbour.connection;
+    //     localConnection = myConnection;
+    //     radiusConnection = neighbour.radius;
+    //   }
+    // }
 
-    // Add connection highlighting if needed.
-    if (!wouldDeleteBlock && closestConnection &&
-        closestConnection != Blockly.highlightedConnection_) {
-      closestConnection.highlight();
-      Blockly.highlightedConnection_ = closestConnection;
-      Blockly.localConnection_ = localConnection;
-    }
+    // // Remove connection highlighting if needed.
+    // if (Blockly.highlightedConnection_ &&
+    //     Blockly.highlightedConnection_ != closestConnection) {
+    //   Blockly.highlightedConnection_.unhighlight();
+    //   Blockly.highlightedConnection_ = null;
+    //   Blockly.localConnection_ = null;
+    // }
+
+    // var wouldDeleteBlock = this.updateCursor_(e, closestConnection);
+
+    // // Add connection highlighting if needed.
+    // if (!wouldDeleteBlock && closestConnection &&
+    //     closestConnection != Blockly.highlightedConnection_) {
+    //   closestConnection.highlight();
+    //   Blockly.highlightedConnection_ = closestConnection;
+    //   Blockly.localConnection_ = localConnection;
+    // }
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();
   e.preventDefault();
-};
-
-/**
- * Provide visual indication of whether the block will be deleted if
- * dropped here.
- * Prefer connecting over dropping into the trash can, but prefer dragging to
- * the toolbox over connecting to other blocks.
- * @param {!Event} e Mouse move event.
- * @param {Blockly.Connection} closestConnection The connection this block would
- *     potentially connect to if dropped here, or null.
- * @return {boolean} True if the block would be deleted if dropped here,
- *     otherwise false.
- * @private
- */
-Blockly.BlockSvg.prototype.updateCursor_ = function(e, closestConnection) {
-  var deleteArea = this.workspace.isDeleteArea(e);
-  var wouldConnect = Blockly.selected && closestConnection &&
-      deleteArea != Blockly.DELETE_AREA_TOOLBOX;
-  var wouldDelete = deleteArea && !this.getParent() &&
-      Blockly.selected.isDeletable();
-  var showDeleteCursor = wouldDelete && !wouldConnect;
-
-  if (showDeleteCursor) {
-    Blockly.Css.setCursor(Blockly.Css.Cursor.DELETE);
-    if (deleteArea == Blockly.DELETE_AREA_TRASH && this.workspace.trashcan) {
-      this.workspace.trashcan.setOpen_(true);
-    }
-    return true;
-  } else {
-    Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
-    if (this.workspace.trashcan) {
-      this.workspace.trashcan.setOpen_(false);
-    }
-    return false;
-  }
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -292,9 +292,9 @@ Blockly.BlockSvg.terminateDrag = function() {
   Blockly.dragMode_ = Blockly.DRAG_NONE;
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
 
-  // if (Blockly.draggedConnectionManager_) {
-  //   Blockly.draggedConnectionManager_ = null;
-  // }
+  if (Blockly.draggedConnectionManager_) {
+    Blockly.draggedConnectionManager_ = null;
+  }
 };
 
 /**
@@ -694,47 +694,46 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
     Blockly.Events.fire(
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
   }
+  // This must be before terminateDrag, which deletes the manager.
+  var manager = Blockly.draggedConnectionManager_;
+  if (manager) {
+    var wasDragging = true;
+    var highlightedConnection = manager.closestConnection_;
+    var localConnection = manager.localConnection_;
+    manager.removeConnectionHighlighting();
+  }
   Blockly.terminateDrag_();
 
   var deleteArea = this.workspace.isDeleteArea(e);
 
-
-  var manager = Blockly.draggedConnectionManager_;
-  var highlightedConnection = manager.closestConnection_;
-  var localConnection = manager.localConnection_;
-
-  // Connect to a nearby block, but not if it's over the toolbox.
-  if (Blockly.selected && highlightedConnection &&
-      deleteArea != Blockly.DELETE_AREA_TOOLBOX) {
-    // Connect two blocks together.
-    localConnection.connect(highlightedConnection);
-    if (this.rendered) {
-      // Trigger a connection animation.
-      // Determine which connection is inferior (lower in the source stack).
-      var inferiorConnection = localConnection.isSuperior() ?
-          highlightedConnection : localConnection;
-      inferiorConnection.getSourceBlock().connectionUiEffect();
+  if (wasDragging) {
+    // Connect to a nearby block, but not if it's over the toolbox.
+    if (Blockly.selected && highlightedConnection &&
+        deleteArea != Blockly.DELETE_AREA_TOOLBOX) {
+      // Connect two blocks together.
+      localConnection.connect(highlightedConnection);
+      if (this.rendered) {
+        // Trigger a connection animation.
+        // Determine which connection is inferior (lower in the source stack).
+        var inferiorConnection = localConnection.isSuperior() ?
+            highlightedConnection : localConnection;
+        inferiorConnection.getSourceBlock().connectionUiEffect();
+      }
+      if (this.workspace.trashcan) {
+        // Don't throw an object in the trash can if it just got connected.
+        this.workspace.trashcan.close();
+      }
+    } else if (deleteArea && !this.getParent() && Blockly.selected.isDeletable()) {
+      // We didn't connect the block, and it was over the trash can or the
+      // toolbox.  Delete it.
+      var trashcan = this.workspace.trashcan;
+      if (trashcan) {
+        goog.Timer.callOnce(trashcan.close, 100, trashcan);
+      }
+      Blockly.selected.dispose(false, true);
     }
-    if (this.workspace.trashcan) {
-      // Don't throw an object in the trash can if it just got connected.
-      this.workspace.trashcan.close();
-    }
-  } else if (deleteArea && !this.getParent() && Blockly.selected.isDeletable()) {
-    // We didn't connect the block, and it was over the trash can or the
-    // toolbox.  Delete it.
-    var trashcan = this.workspace.trashcan;
-    if (trashcan) {
-      goog.Timer.callOnce(trashcan.close, 100, trashcan);
-    }
-    Blockly.selected.dispose(false, true);
   }
-  manager.removeConnectionHighlighting();
-  // if (Blockly.highlightedConnection_) {
-  //   Blockly.highlightedConnection_.unhighlight();
-  //   Blockly.highlightedConnection_ = null;
-  // }
-  console.trace('deleting connection manager');
-  Blockly.draggedConnectionManager_ = null;
+
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   if (!Blockly.WidgetDiv.isVisible()) {
     Blockly.Events.setGroup(false);
@@ -981,11 +980,8 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
 
 
       if (!Blockly.draggedConnectionManager_) {
-        Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager();
-        console.log('creating new connection manager');
+        Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager(this);
       }
-      var manager = Blockly.draggedConnectionManager_;
-      manager.setAvailableConnections(this);
     }
   }
   if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
@@ -1005,48 +1001,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
           goog.math.Coordinate.sum(commentData, dxy));
     }
 
-    var manager = Blockly.draggedConnectionManager_;
-    manager.updateClosestConnection(e, dxy);
-
-    // // Check to see if any of this block's connections are within range of
-    // // another block's connection.
-    // var myConnections = this.getConnections_(false);
-    // // Also check the last connection on this stack
-    // var lastOnStack = this.lastConnectionInStack_();
-    // if (lastOnStack && lastOnStack != this.nextConnection) {
-    //   myConnections.push(lastOnStack);
-    // }
-
-    // var closestConnection = null;
-    // var localConnection = null;
-    // var radiusConnection = Blockly.SNAP_RADIUS;
-    // for (var i = 0; i < myConnections.length; i++) {
-    //   var myConnection = myConnections[i];
-    //   var neighbour = myConnection.closest(radiusConnection, dxy);
-    //   if (neighbour.connection) {
-    //     closestConnection = neighbour.connection;
-    //     localConnection = myConnection;
-    //     radiusConnection = neighbour.radius;
-    //   }
-    // }
-
-    // // Remove connection highlighting if needed.
-    // if (Blockly.highlightedConnection_ &&
-    //     Blockly.highlightedConnection_ != closestConnection) {
-    //   Blockly.highlightedConnection_.unhighlight();
-    //   Blockly.highlightedConnection_ = null;
-    //   Blockly.localConnection_ = null;
-    // }
-
-    // var wouldDeleteBlock = this.updateCursor_(e, closestConnection);
-
-    // // Add connection highlighting if needed.
-    // if (!wouldDeleteBlock && closestConnection &&
-    //     closestConnection != Blockly.highlightedConnection_) {
-    //   closestConnection.highlight();
-    //   Blockly.highlightedConnection_ = closestConnection;
-    //   Blockly.localConnection_ = localConnection;
-    // }
+    Blockly.draggedConnectionManager_.updateClosestConnection(e, dxy);
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1674,7 +1674,7 @@ Blockly.BlockSvg.prototype.appendInput_ = function(type, name) {
  *     Otherwise, for a non-rendered block return an empty list, and for a
  *     collapsed block don't return inputs connections.
  * @return {!Array.<!Blockly.Connection>} Array of connections.
- * @private
+ * @package
  */
 Blockly.BlockSvg.prototype.getConnections_ = function(all) {
   var myConnections = [];

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -980,7 +980,8 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
 
 
       if (!Blockly.draggedConnectionManager_) {
-        Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager(this);
+        Blockly.draggedConnectionManager_ =
+            new Blockly.DraggedConnectionManager(this);
       }
     }
   }
@@ -1001,7 +1002,7 @@ Blockly.BlockSvg.prototype.onMouseMove_ = function(e) {
           goog.math.Coordinate.sum(commentData, dxy));
     }
 
-    Blockly.draggedConnectionManager_.updateClosestConnection(e, dxy);
+    Blockly.draggedConnectionManager_.update(e, dxy);
   }
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -32,10 +32,11 @@ goog.require('Blockly.RenderedConnection');
  * TODO: Doc
  * @constructor
  */
-Blockly.DraggedConnectionManager = function() {
-  this.topBlock_ = null;
+Blockly.DraggedConnectionManager = function(block) {
+  this.topBlock_ = block;
 
-  this.workspace_ = null;
+  Blockly.selected = block;
+  this.workspace_ = block.workspace;
 
   this.availableConnections_ = [];
   this.availableConnectionsCached_ = false;
@@ -49,20 +50,17 @@ Blockly.DraggedConnectionManager = function() {
   this.radiusConnection_ = -1;
 
   this.wouldDeleteBlock_ = false;
+
+  this.setAvailableConnections();
 };
 
-Blockly.DraggedConnectionManager.prototype.setAvailableConnections = function(
-    block) {
+Blockly.DraggedConnectionManager.prototype.setAvailableConnections = function() {
   if (!this.availableConnectionsCached_) {
-    console.trace('Setting available connections.');
     // TODO: remove?
-    Blockly.selected = block;
-    this.workspace_ = block.workspace;
-    this.topBlock_ = block;
-    this.availableConnections_ = block.getConnections_(false);
+    this.availableConnections_ = this.topBlock_.getConnections_(false);
     // Also check the last connection on this stack
-    var lastOnStack = block.lastConnectionInStack_();
-    if (lastOnStack && lastOnStack != block.nextConnection) {
+    var lastOnStack = this.topBlock_.lastConnectionInStack_();
+    if (lastOnStack && lastOnStack != this.topBlock_.nextConnection) {
       this.availableConnections_.push(lastOnStack);
     }
     this.availableConnectionsCached_ = true;

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -63,7 +63,7 @@ Blockly.DraggedConnectionManager = function(block) {
    * @type {!Array.<!Blockly.RenderedConnection>}
    * @private
    */
-  this.availableConnections_ = [];
+  this.availableConnections_ = this.initAvailableConnections_();
 
   /**
    * The connection that this block would connect to if released immediately.
@@ -90,7 +90,6 @@ Blockly.DraggedConnectionManager = function(block) {
    */
   this.radiusConnection_ = 0;
 
-  this.setAvailableConnections_();
   Blockly.selected = block;
 };
 
@@ -104,10 +103,8 @@ Blockly.DraggedConnectionManager.prototype.update = function(e, dxy) {
   var oldClosestConnection = this.closestConnection_;
   var closestConnectionChanged = this.updateClosest_(dxy);
 
-  if (closestConnectionChanged) {
-    if (oldClosestConnection) {
-      oldClosestConnection.unhighlight();
-    }
+  if (closestConnectionChanged && oldClosestConnection) {
+    oldClosestConnection.unhighlight();
   }
 
   var wouldDeleteBlock = this.updateCursor_(e);
@@ -139,15 +136,18 @@ Blockly.DraggedConnectionManager.prototype.addConnectionHighlighting = function(
 /**
  * Populate the list of available connections on this block stack.  This should
  * only be called once, at the beginning of a drag.
+ * @return {!Array.<!Blockly.RenderedConnection>} a list of available
+ *     connections.
  * @private
  */
-Blockly.DraggedConnectionManager.prototype.setAvailableConnections_ = function() {
-  this.availableConnections_ = this.topBlock_.getConnections_(false);
+Blockly.DraggedConnectionManager.prototype.initAvailableConnections_ = function() {
+  var available = this.topBlock_.getConnections_(false);
   // Also check the last connection on this stack
   var lastOnStack = this.topBlock_.lastConnectionInStack_();
   if (lastOnStack && lastOnStack != this.topBlock_.nextConnection) {
-    this.availableConnections_.push(lastOnStack);
+    available.push(lastOnStack);
   }
+  return available;
 };
 
 /**

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.DraggedConnectionManager');
+
+goog.require('Blockly.RenderedConnection');
+
+/**
+ * TODO: Doc
+ * @constructor
+ */
+Blockly.DraggedConnectionManager = function() {
+  this.topBlock_ = null;
+
+  this.workspace_ = null;
+
+  this.availableConnections_ = [];
+  this.availableConnectionsCached_ = false;
+
+  this.allDraggedConnections_ = [];
+
+  this.closestConnection_ = null;
+
+  this.localConnection_ = null;
+
+  this.radiusConnection_ = -1;
+
+  this.wouldDeleteBlock_ = false;
+};
+
+Blockly.DraggedConnectionManager.prototype.setAvailableConnections = function(
+    block) {
+  if (!this.availableConnectionsCached_) {
+    console.trace('Setting available connections.');
+    // TODO: remove?
+    Blockly.selected = block;
+    this.workspace_ = block.workspace;
+    this.topBlock_ = block;
+    this.availableConnections_ = block.getConnections_(false);
+    // Also check the last connection on this stack
+    var lastOnStack = block.lastConnectionInStack_();
+    if (lastOnStack && lastOnStack != block.nextConnection) {
+      this.availableConnections_.push(lastOnStack);
+    }
+    this.availableConnectionsCached_ = true;
+  } else {
+    console.trace('Tried to set available connections too many times.');
+  }
+};
+
+Blockly.DraggedConnectionManager.prototype.getAvailableConnections = function() {
+  return this.availableConnections_;
+};
+
+Blockly.DraggedConnectionManager.prototype.addDraggedConnections = function(block) {
+  this.allDraggedConnections_ = this.allDraggedConnections_.concat(block.getConnections_(true));
+};
+
+Blockly.DraggedConnectionManager.prototype.clearDraggedConnections = function() {
+  this.allDraggedConnections_ = [];
+};
+
+Blockly.DraggedConnectionManager.prototype.getDraggedConnections = function() {
+  return this.allDraggedConnections_;
+};
+
+Blockly.DraggedConnectionManager.prototype.updateClosestConnection = function(e,
+    dxy) {
+  var oldClosestConnection = this.closestConnection_;
+
+  this.closestConnection_ = null;
+  this.localConnection_ = null;
+  this.radiusConnection_ = Blockly.SNAP_RADIUS;
+  for (var i = 0; i < this.availableConnections_.length; i++) {
+    var myConnection = this.availableConnections_[i];
+    var neighbour = myConnection.closest(this.radiusConnection_, dxy);
+    if (neighbour.connection) {
+      this.closestConnection_ = neighbour.connection;
+      this.localConnection_ = myConnection;
+      this.radiusConnection_ = neighbour.radius;
+    }
+  }
+
+  var closestConnectionChanged =
+      oldClosestConnection != this.closestConnection_;
+
+  if (closestConnectionChanged) {
+    if (oldClosestConnection) {
+      oldClosestConnection.unhighlight();
+    }
+  }
+
+  var wouldDeleteBlock = this.updateCursor(e);
+
+  if (!wouldDeleteBlock && closestConnectionChanged &&
+      this.closestConnection_) {
+    this.closestConnection_.highlight();
+  }
+
+};
+
+Blockly.DraggedConnectionManager.prototype.removeConnectionHighlighting = function() {
+  if (this.closestConnection_) {
+    this.closestConnection_.unhighlight();
+  }
+};
+
+Blockly.DraggedConnectionManager.prototype.addConnectionHighlighting = function() {
+  if (this.closestConnection_) {
+    this.closestConnection_.highlight();
+  }
+};
+
+
+/**
+ * Provide visual indication of whether the block will be deleted if
+ * dropped here.
+ * Prefer connecting over dropping into the trash can, but prefer dragging to
+ * the toolbox over connecting to other blocks.
+ * @param {!Event} e Mouse move event.
+ * @return {boolean} True if the block would be deleted if dropped here,
+ *     otherwise false.
+ */
+Blockly.DraggedConnectionManager.prototype.updateCursor = function(e) {
+  var deleteArea = this.workspace_.isDeleteArea(e);
+  var wouldConnect = this.closestConnection_ &&
+      deleteArea != Blockly.DELETE_AREA_TOOLBOX;
+  var wouldDelete = deleteArea && !this.topBlock_.getParent() &&
+      this.topBlock_.isDeletable();
+  var showDeleteCursor = wouldDelete && !wouldConnect;
+
+  if (showDeleteCursor) {
+    Blockly.Css.setCursor(Blockly.Css.Cursor.DELETE);
+    if (deleteArea == Blockly.DELETE_AREA_TRASH && this.workspace_.trashcan) {
+      this.workspace_.trashcan.setOpen_(true);
+    }
+    return true;
+  } else {
+    Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
+    if (this.workspace_.trashcan) {
+      this.workspace_.trashcan.setOpen_(false);
+    }
+    return false;
+  }
+};

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1190,6 +1190,12 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
     block.moveToDragSurface_();
+    if (!Blockly.draggedConnectionManager_) {
+      Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager();
+      console.log('creating new connection manager');
+    }
+    var manager = Blockly.draggedConnectionManager_;
+    manager.setAvailableConnections(block);
   };
 };
 

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1191,11 +1191,8 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     block.setDragging_(true);
     block.moveToDragSurface_();
     if (!Blockly.draggedConnectionManager_) {
-      Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager();
-      console.log('creating new connection manager');
+      Blockly.draggedConnectionManager_ = new Blockly.DraggedConnectionManager(block);
     }
-    var manager = Blockly.draggedConnectionManager_;
-    manager.setAvailableConnections(block);
   };
 };
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -228,8 +228,8 @@ function fakeDrag(id, dx, dy, opt_workspace) {
           blockToDrag.onMouseUp_(mouseUpEvent);
 
           setTimeout(fakeDragWrapper(), 100);
-        }, 30);
-    }, 30);
+        }, 100);
+    }, 100);
 };
 
 function fakeDragWrapper() {


### PR DESCRIPTION
This PR adds a DraggingConnectionManager that tracks connections during a drag.

There are two goals here: to move large chunks of connection dragging logic out of block_svg, and to stop relying on Blockly.highlightedConnection_ and similar singletons.

In this pass I'm using a global Blockly.draggedConnectionManager_ to store this information.  When using this in new dragging code I will be able to have one of these per touch ID.

This should be a no-op on behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/925)
<!-- Reviewable:end -->
