### PR TITLE
Extension controls_if => controls_if_mutator.

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -303,6 +303,9 @@ Blockly.Extensions.register('logic_op_tooltip',
  * @readonly
  */
 Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
+  elseifCount_: 0,
+  elseCount_: 0,
+
   /**
    * Create XML to represent the number of else-if and else inputs.
    * @return {Element} XML storage element.
@@ -460,11 +463,9 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
  * @this Blockly.Block
  * @package
  */
-Blockly.Constants.Logic.CONTROLS_IF_EXTENSION = function() {
+Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_EXTENSION = function() {
   this.setMutator(new Blockly.Mutator(['controls_if_elseif', 'controls_if_else']));
   this.mixin(Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN);
-  this.elseifCount_ = 0;
-  this.elseCount_ = 0;
 
   this.setTooltip(function() {
     if (!this.elseifCount_ && !this.elseCount_) {
@@ -481,7 +482,7 @@ Blockly.Constants.Logic.CONTROLS_IF_EXTENSION = function() {
 };
 
 Blockly.Extensions.register('controls_if_mutator',
-  Blockly.Constants.Logic.CONTROLS_IF_EXTENSION);
+  Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_EXTENSION);
 
 /**
  * Corrects the logic_compate dropdown label with respect to language direction.

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -86,7 +86,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "nextStatement": null,
     "colour": "%{BKY_LOGIC_HUE}",
     "helpUrl": "%{BKY_CONTROLS_IF_HELPURL}",
-    "extensions": ["controls_if"]
+    "extensions": ["controls_if_mutator"]
   },
   // If/else block that does not use a mutator.
   {
@@ -480,7 +480,7 @@ Blockly.Constants.Logic.CONTROLS_IF_EXTENSION = function() {
   }.bind(this));
 };
 
-Blockly.Extensions.register('controls_if',
+Blockly.Extensions.register('controls_if_mutator',
   Blockly.Constants.Logic.CONTROLS_IF_EXTENSION);
 
 /**


### PR DESCRIPTION
Previous extension naming was mixed with respect to "_mutator" suffix. This matches extensions in math.js and iOS implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/931)
<!-- Reviewable:end -->
