### PR TITLE
Potential bug fix for issue #661

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -397,7 +397,7 @@ Blockly.Css.CONTENT = [
   '.blocklyFlyoutScrollbar {',
     'z-index: 30;',
   '}',
-  
+
   '.blocklyScrollbarHorizontal, .blocklyScrollbarVertical {',
     'position: absolute;',
     'outline: none;',
@@ -464,6 +464,7 @@ Blockly.Css.CONTENT = [
     'stroke: #f00;',
     'stroke-width: 2;',
     'stroke-linecap: round;',
+    'pointer-events: none;',
   '}',
 
   '.blocklyContextMenu {',

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -57,7 +57,7 @@ goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
  * Round angles to the nearest 15 degrees when using mouse.
  * Set to 0 to disable rounding.
  */
-Blockly.FieldAngle.ROUND = 1;
+Blockly.FieldAngle.ROUND = 15;
 
 /**
  * Half the width of protractor image.
@@ -152,11 +152,11 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   }, svg);
   this.gauge_ = Blockly.utils.createSvgElement('path',
       {'class': 'blocklyAngleGauge'}, svg);
-  this.line_ = Blockly.utils.createSvgElement('line',
-      {'x1': Blockly.FieldAngle.HALF,
+  this.line_ = Blockly.utils.createSvgElement('line',{
+      'x1': Blockly.FieldAngle.HALF,
       'y1': Blockly.FieldAngle.HALF,
       'class': 'blocklyAngleLine',
-      'style': 'pointer-events: none;'}, svg);
+     }, svg);
   // Draw markers around the edge.
   for (var angle = 0; angle < 360; angle += 15) {
     Blockly.utils.createSvgElement('line', {

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -57,7 +57,7 @@ goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
  * Round angles to the nearest 15 degrees when using mouse.
  * Set to 0 to disable rounding.
  */
-Blockly.FieldAngle.ROUND = 15;
+Blockly.FieldAngle.ROUND = 1;
 
 /**
  * Half the width of protractor image.
@@ -155,7 +155,8 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   this.line_ = Blockly.utils.createSvgElement('line',
       {'x1': Blockly.FieldAngle.HALF,
       'y1': Blockly.FieldAngle.HALF,
-      'class': 'blocklyAngleLine'}, svg);
+      'class': 'blocklyAngleLine',
+      'style': 'pointer-events: none;'}, svg);
   // Draw markers around the edge.
   for (var angle = 0; angle < 360; angle += 15) {
     Blockly.utils.createSvgElement('line', {


### PR DESCRIPTION
This is not a math problem. The onMouseMove method was not called when the mouse was over the "line" (representing the angle). Line being 2px thick, for movements smaller than 2px or any movement over the line, the onMouseMove method was not called. Setting pointer-events of that line to none leads to expected behaviour of the angle picker.  
Only thing is I am not sure this is best way of setting the pointer-event  to none.    