### PR TITLE
Fix: Make variable add set/get block in context menu obey block limits

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -111,7 +111,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
       var contextMenuMsg = Blockly.Msg.VARIABLES_SET_CREATE_GET;
     }
 
-    var option = {enabled: true};
+    var option = {enabled: this.workspace.remainingCapacity() > 0};
     var name = this.getFieldValue('VAR');
     option.text = contextMenuMsg.replace('%1', name);
     var xmlField = goog.dom.createDom('field', null, name);


### PR DESCRIPTION
The context menu of variable blocks "set" and "get" allows to create the other block, respectively. Unfortunately, it even allows so if the current block limit `maxBlocks` is already exhausted.

This fix deactivates the menu entries if `remainingCapacity()` returns zero or less.

As we want to use Blockly for a competition, we would appreciate this fix to be applied to the master branch as soon as possible.