### PR TITLE
Add workspace dragger

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -490,6 +490,7 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
 /**
  * Returns the coordinates of a bounding box describing the dimensions of this
  * block and any blocks stacked below it.
+ * Coordinate system: workspace coordinates.
  * @return {!{topLeft: goog.math.Coordinate, bottomRight: goog.math.Coordinate}}
  *    Object with top left and bottom right coordinates of the bounding box.
  */

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -51,14 +51,15 @@ Blockly.WorkspaceDragger = function(workspace) {
   /**
    * The workspace's metrics object at the beginning of the drag.  Contains size
    * and position metrics of a workspace.
+   * Coordinate system: pixel coordinates.
    * @type {!Object}
    * @private
    */
   this.startDragMetrics_ = workspace.getMetrics();
 
   /**
-   * The scroll position of the workspace at the beginning of the drag, in
-   * workspace units.
+   * The scroll position of the workspace at the beginning of the drag.
+   * Coordinate system: pixel coordinates.
    * @type {!goog.math.Coordinate}
    * @private
    */

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Methods for dragging a workspace visually.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.WorkspaceDragger');
+
+goog.require('goog.math.Coordinate');
+goog.require('goog.asserts');
+
+
+/**
+ * Class for a workspace dragger.  It moves the workspace around when it is
+ * being dragged by a mouse or touch.
+ * Note that the workspace itself manages whether or not it has a drag surface
+ * and how to do translations based on that.  This simply passes the right
+ * commands based on events.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace to drag.
+ * @constructor
+ */
+Blockly.WorkspaceDragger = function(workspace) {
+  goog.asserts.assert(workspace.isDraggable(),
+      'Tried to drag an undraggable workspace!');
+  /**
+   * @type {!Blockly.WorkspaceSvg}
+   * @private
+   */
+  this.workspace_ = workspace;
+
+  /**
+   * The workspace's metrics object at the beginning of the drag.  Contains size
+   * and position metrics of a workspace.
+   * @type {!Object}
+   * @private
+   */
+  this.startDragMetrics_ = workspace.getMetrics();
+
+  /**
+   * The scroll position of the workspace at the beginning of the drag, in
+   * workspace units.
+   * @type {!goog.math.Coordinate}
+   * @private
+   */
+  this.startScrollXY_ = new goog.math.Coordinate(workspace.scrollX,
+        workspace.scrollY);
+};
+
+/**
+ * Start dragging the workspace.
+ */
+Blockly.WorkspaceDragger.prototype.startDrag = function() {
+  Blockly.Css.setCursor(Blockly.Css.Cursor.CLOSED);
+  this.workspace_.setupDragSurface();
+};
+
+/**
+ * Finish dragging the workspace and put everything back where it belongs.
+ * @param {!goog.math.Coordinate} currentDragDeltaXY How far the pointer has
+ *     moved from the position at the start of the drag, in pixel coordinates.
+ */
+Blockly.WorkspaceDragger.prototype.endDrag = function(currentDragDeltaXY) {
+  // Make sure everything is up to date.
+  this.drag(currentDragDeltaXY);
+
+  Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
+  this.workspace_.resetDragSurface();
+};
+
+/**
+ * Move the workspace based on the most recent mouse movements.
+ * @param {!goog.math.Coordinate} currentDragDeltaXY How far the pointer has
+ *     moved from the position at the start of the drag, in pixel coordinates.
+ */
+Blockly.WorkspaceDragger.prototype.drag = function(currentDragDeltaXY) {
+  var metrics = this.startDragMetrics_;
+  var newXY = goog.math.Coordinate.sum(this.startScrollXY_, currentDragDeltaXY);
+
+  // Bound the new XY based on workspace bounds.
+  var x = Math.min(newXY.x, -metrics.contentLeft);
+  var y = Math.min(newXY.y, -metrics.contentTop);
+  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
+               metrics.contentWidth);
+  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
+               metrics.contentHeight);
+
+  // Move the scrollbars and the page will scroll automatically.
+  this.workspace_.scrollbar.set(-x - metrics.contentLeft,
+                          -y - metrics.contentTop);
+};

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -144,24 +144,28 @@ Blockly.WorkspaceSvg.prototype.resizesEnabled_ = true;
 
 /**
  * Current horizontal scrolling offset.
+ * Coordinate system: pixel coordinates.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.scrollX = 0;
 
 /**
  * Current vertical scrolling offset.
+ * Coordinate system: pixel coordinates.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.scrollY = 0;
 
 /**
  * Horizontal scroll value when scrolling started.
+ * Coordinate system: pixel coordinates.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.startScrollX = 0;
 
 /**
  * Vertical scroll value when scrolling started.
+ * Coordinate system: pixel coordinates.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.startScrollY = 0;
@@ -1037,6 +1041,7 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
 
 /**
  * Calculate the bounding box for the blocks on the workspace.
+ * Coordinate system: workspace coordinates.
  *
  * @return {Object} Contains the position and size of the bounding box
  *   containing the blocks on the workspace.
@@ -1522,6 +1527,7 @@ Blockly.WorkspaceSvg.prototype.updateGridPattern_ = function() {
 /**
  * Return an object with all the metrics required to size scrollbars for a
  * top level workspace.  The following properties are computed:
+ * Coordinate system: pixel coordinates.
  * .viewHeight: Height of the visible rectangle,
  * .viewWidth: Width of the visible rectangle,
  * .contentHeight: Height of the contents,


### PR DESCRIPTION
This is a compatriot of BlockDragger.  It knows how to move a workspace around based on how far the pointer has moved, but doesn't have any logic for deciding when a workspace drag should happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/940)
<!-- Reviewable:end -->
