### PR TITLE
Fix #946. Don't check for presence of constants.js

### DIFF
--- a/build.py
+++ b/build.py
@@ -417,7 +417,7 @@ class Gen_langfiles(threading.Thread):
           "--quiet"]
       json_files = glob.glob(os.path.join("msg", "json", "*.json"))
       json_files = [file for file in json_files if not
-                    (file.endswith(("keys.json", "synonyms.json", "qqq.json")))]
+                    (file.endswith(("keys.json", "synonyms.json", "qqq.json", "constants.json")))]
       cmd.extend(json_files)
       subprocess.check_call(cmd)
     except (subprocess.CalledProcessError, OSError) as e:


### PR DESCRIPTION
Verified constants are still integrated into generated language files.