### PR TITLE
Adding warning on duplicate JSON block definition.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -412,7 +412,7 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
     } else {
       if (Blockly.Blocks[typename]) {
         console.warn('Block definition #' + i +
-          ' in JSON array overwrites prior definition of "' + typename + '"');
+          ' in JSON array overwrites prior definition of "' + typename + '".');
       }
       Blockly.Blocks[typename] = {
         init: Blockly.jsonInitFactory_(elem)

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -410,6 +410,10 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
       console.warn('Block definition #' + i +
         ' in JSON array is missing a type attribute. Skipping.');
     } else {
+      if (Blockly.Blocks[typename]) {
+        console.warn('Block definition #' + i +
+          ' in JSON array overwrites prior definition of "' + typename + '"');
+      }
       Blockly.Blocks[typename] = {
         init: Blockly.jsonInitFactory_(elem)
       };


### PR DESCRIPTION
This may not be the desired behavior, but I didn't want to change the behavior.