### PR TITLE
Fix #967 by overriding the updateWidth method in FieldImage blocks to…

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -153,3 +153,10 @@ Blockly.FieldImage.prototype.setText = function(alt) {
 Blockly.FieldImage.prototype.render_ = function() {
   // NOP
 };
+/**
+ * Images are fixed width, no need to update.
+ * @private
+ */
+Blockly.FieldImage.prototype.updateWidth = function() {
+ // NOP
+};


### PR DESCRIPTION
… be a no-op. FieldImage fields should not change size after the width is set in init.  The updateWidth and, therefore, getCachedWidth is now being called by BlockSvg renderFields_ (see commit d55d9cbd9ff308ff5e361cf77acabb61a4bf4695). IIUC, updateWidth/getCachedWidth was only called from render before which is overridden in FieldImage to be a no-op already.