### PR TITLE
Bugfix/ie text rendering

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1185,6 +1185,17 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     } else {
       flyout.filterForCapacity_();
     }
+
+    // Re-render the blocks before starting the drag:
+    // Force a render on IE and Edge to get around the issue described in
+    // Blockly.Field.getCachedWidth
+    if (goog.userAgent.IE || goog.userAgent.EDGE) {
+      var blocks = block.getDescendants();
+      for (var i = blocks.length - 1; i >= 0; i--) {
+        blocks[i].render(false);
+      }
+    }
+
     // Start a dragging operation on the new block.
     block.onMouseDown_(e);
     Blockly.dragMode_ = Blockly.DRAG_FREE;

--- a/core/xml.js
+++ b/core/xml.js
@@ -32,7 +32,6 @@ goog.provide('Blockly.Xml');
 
 goog.require('goog.asserts');
 goog.require('goog.dom');
-goog.require('goog.userAgent');
 
 
 /**
@@ -430,11 +429,6 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
       setTimeout(function() {
         if (topBlock.workspace) {  // Check that the block hasn't been deleted.
           topBlock.setConnectionsHidden(false);
-          // Force a render on IE and Edge to get around the issue described in
-          // Blockly.Field.getCachedWidth
-          if (goog.userAgent.IE || goog.userAgent.EDGE) {
-            topBlock.render();
-          }
         }
       }, 1);
       topBlock.updateDisabled();


### PR DESCRIPTION
Fixes #969 

Having a render() call in a setTimeout meant that it sometimes changed locations of connections mid-drag, which causes all sorts of rendering problems.  This fix should hopefully preserve the correct block sizing, without the rendering issues.

Context: https://groups.google.com/forum/#!topic/blockly/T8IR4t4xAIY

@timdawborn, @ctrowat I know you use Windows/IE+Edge.  If you get a chance, let me know if you see any problems with this on my test page: https://rachel-fenichel.github.io/blockly/tests/playground.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/982)
<!-- Reviewable:end -->
