### PR TITLE
More dragging work

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -200,11 +200,17 @@ Blockly.BlockDragSurfaceSvg.prototype.getCurrentBlock = function() {
 /**
  * Clear the group and hide the surface; move the blocks off onto the provided
  * element.
- * @param {!Element} newSurface Surface the dragging blocks should be moved to.
+ * @param {Element} opt_newSurface Surface the dragging blocks should be moved
+ *     to, or null if the blocks should be removed from this surface without
+ *     being moved to a different surface.
  */
-Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
-  // appendChild removes the node from this.dragGroup_
-  newSurface.appendChild(this.getCurrentBlock());
+Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
+  if (opt_newSurface) {
+    // appendChild removes the node from this.dragGroup_
+    opt_newSurface.appendChild(this.getCurrentBlock());
+  } else {
+    this.dragGroup_.removeChild(this.getCurrentBlock());
+  }
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
     'Drag group was not cleared.');

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -134,6 +134,8 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
   }
   // TODO: Can setResizesEnabled be done at the same time for both types of drags?
   this.workspace_.setResizesEnabled(false);
+  Blockly.BlockSvg.disconnectUiStop_();
+
   if (this.draggingBlock_.getParent()) {
     this.draggingBlock_.unplug();
     var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
@@ -190,7 +192,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
 
   var deleted = this.maybeDeleteBlock_();
   if (!deleted) {
-    // setDragging_ is expensive and doesn't need to be done if we're deleting.
+    // These are expensive and don't need to be done if we're deleting.
     this.draggingBlock_.setDragging_(false);
     this.draggedConnectionManager_.applyConnections();
     this.draggingBlock_.render();

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -181,18 +181,20 @@ Blockly.BlockDragger.prototype.dragBlock = function(e, currentDragDeltaXY) {
 Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   // Make sure internal state is fresh.
   this.dragBlock(e, currentDragDeltaXY);
-  this.dragIconData_ = null;
+  this.dragIconData_ = [];
 
   Blockly.BlockSvg.disconnectUiStop_();
-  // TODO: Consider where moveOffDragSurface should live.
-  this.draggingBlock_.moveOffDragSurface_();
 
+  // TODO: Consider where moveOffDragSurface should live.
   var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
-  this.draggingBlock_.moveConnections_(delta.x, delta.y);
+  var newLoc = goog.math.Coordinate.sum(this.startXY_, delta);
+  this.draggingBlock_.moveOffDragSurface_(newLoc);
 
   var deleted = this.maybeDeleteBlock_();
   if (!deleted) {
     // These are expensive and don't need to be done if we're deleting.
+
+    this.draggingBlock_.moveConnections_(delta.x, delta.y);
     this.draggingBlock_.setDragging_(false);
     this.draggedConnectionManager_.applyConnections();
     this.draggingBlock_.render();

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -94,7 +94,6 @@ Blockly.BlockDragger = function(block, workspace) {
    * @private
    */
   this.dragIconData_ = Blockly.BlockDragger.initIconData_(block);
-
 };
 
 /**
@@ -163,7 +162,6 @@ Blockly.BlockDragger.prototype.dragBlock = function(e, currentDragDeltaXY) {
   var newLoc = goog.math.Coordinate.sum(this.startXY_, delta);
 
   this.draggingBlock_.moveDuringDrag(newLoc);
-
   this.dragIcons_(delta);
 
   this.deleteArea_ = this.workspace_.isDeleteArea(e);
@@ -193,7 +191,6 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   var deleted = this.maybeDeleteBlock_();
   if (!deleted) {
     // These are expensive and don't need to be done if we're deleting.
-
     this.draggingBlock_.moveConnections_(delta.x, delta.y);
     this.draggingBlock_.setDragging_(false);
     this.draggedConnectionManager_.applyConnections();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -232,65 +232,11 @@ Blockly.BlockSvg.prototype.getIcons = function() {
 };
 
 /**
- * Wrapper function called when a mouseUp occurs during a drag operation.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.BlockSvg.onMouseUpWrapper_ = null;
-
-/**
- * Wrapper function called when a mouseMove occurs during a drag operation.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.BlockSvg.onMouseMoveWrapper_ = null;
-
-/**
- * Stop binding to the global mouseup and mousemove events.
+ * Stop any pending block disconnection animations and reset the cursor.
  * @package
  */
 Blockly.BlockSvg.terminateDrag = function() {
   Blockly.BlockSvg.disconnectUiStop_();
-  if (Blockly.BlockSvg.onMouseUpWrapper_) {
-    Blockly.unbindEvent_(Blockly.BlockSvg.onMouseUpWrapper_);
-    Blockly.BlockSvg.onMouseUpWrapper_ = null;
-  }
-  if (Blockly.BlockSvg.onMouseMoveWrapper_) {
-    Blockly.unbindEvent_(Blockly.BlockSvg.onMouseMoveWrapper_);
-    Blockly.BlockSvg.onMouseMoveWrapper_ = null;
-  }
-  var selected = Blockly.selected;
-  if (Blockly.dragMode_ == Blockly.DRAG_FREE) {
-    // Terminate a drag operation.
-    if (selected) {
-      // Update the connection locations.
-      var xy = selected.getRelativeToSurfaceXY();
-      var dxy = goog.math.Coordinate.difference(xy, selected.dragStartXY_);
-      var event = new Blockly.Events.Move(selected);
-      event.oldCoordinate = selected.dragStartXY_;
-      event.recordNew();
-      Blockly.Events.fire(event);
-
-      selected.moveConnections_(dxy.x, dxy.y);
-      delete selected.draggedBubbles_;
-      selected.setDragging_(false);
-      selected.moveOffDragSurface_();
-      selected.render();
-      selected.workspace.setResizesEnabled(true);
-      // Ensure that any snap and bump are part of this move's event group.
-      var group = Blockly.Events.getGroup();
-      setTimeout(function() {
-        Blockly.Events.setGroup(group);
-        selected.snapToGrid();
-        Blockly.Events.setGroup(false);
-      }, Blockly.BUMP_DELAY / 2);
-      setTimeout(function() {
-        Blockly.Events.setGroup(group);
-        selected.bumpNeighbours_();
-        Blockly.Events.setGroup(false);
-      }, Blockly.BUMP_DELAY);
-    }
-  }
   Blockly.dragMode_ = Blockly.DRAG_NONE;
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
 };
@@ -653,37 +599,11 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
     this.workspace.resize();
   }
 
-  this.workspace.updateScreenCalculationsIfScrolled();
-  this.workspace.markFocused();
   Blockly.terminateDrag_();
-  this.select();
-  Blockly.hideChaff();
 
   var gesture = Blockly.GestureDB.gestureForEvent(e);
   gesture.handleBlockStart(e, this);
 
-};
-
-/**
- * Handle a mouse-up anywhere in the SVG pane.  Is only registered when a
- * block is clicked.  We can't use mouseUp on the block since a fast-moving
- * cursor can briefly escape the block before it catches up.
- * @param {!Event} e Mouse up event.
- * @private
- */
-Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
-  Blockly.Touch.clearTouchIdentifier();
-  if (Blockly.dragMode_ != Blockly.DRAG_FREE &&
-      !Blockly.WidgetDiv.isVisible()) {
-    Blockly.Events.fire(
-        new Blockly.Events.Ui(this, 'click', undefined, undefined));
-  }
-  Blockly.terminateDrag_();
-
-  Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
-  if (!Blockly.WidgetDiv.isVisible()) {
-    Blockly.Events.setGroup(false);
-  }
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -56,6 +56,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
    * @private
    */
   this.svgGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+  this.svgGroup_.translate_ = '';
 
   /**
    * @type {SVGElement}
@@ -357,16 +358,16 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
  * Move this block back to the workspace block canvas.
  * Generally should be called at the same time as setDragging_(false).
  * Does nothing if useDragSurface_ is false.
+ * @param {!goog.math.Coordinate} newXY The position the block should take on
+ *     on the workspace canvas, in workspace coordinates.
  * @private
  */
-Blockly.BlockSvg.prototype.moveOffDragSurface_ = function() {
+Blockly.BlockSvg.prototype.moveOffDragSurface_ = function(newXY) {
   if (!this.useDragSurface_) {
     return;
   }
   // Translate to current position, turning off 3d.
-  var xy = this.getRelativeToSurfaceXY();
-  this.clearTransformAttributes_();
-  this.translate(xy.x, xy.y);
+  this.translate(newXY.x, newXY.y);
   this.workspace.blockDragSurface_.clearAndHide(this.workspace.getCanvas());
 };
 
@@ -584,6 +585,7 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
     this.workspace.resize();
   }
 
+  // Stop any current gesture associated with this touch identifier.
   Blockly.terminateDrag_();
 
   var gesture = Blockly.GestureDB.gestureForEvent(e);
@@ -864,7 +866,8 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   // If this block is being dragged, unlink the mouse events.
   if (Blockly.selected == this) {
     this.unselect();
-    Blockly.GestureDB.cancelAllGestures();
+    // TODO (fenichel): Decide what to do here.
+    //Blockly.GestureDB.cancelAllGestures();
   }
   // If this block has a context menu open, close it.
   if (Blockly.ContextMenu.currentBlock == this) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -576,9 +576,6 @@ Blockly.BlockSvg.prototype.tab = function(start, forward) {
  * @private
  */
 Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
-  if (this.workspace.options.readOnly) {
-    return;
-  }
   if (this.isInMutator) {
     // Mutator's coordinate system could be out of date because the bubble was
     // dragged, the block was moved, the parent workspace zoomed, etc.
@@ -590,7 +587,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
 
   var gesture = Blockly.GestureDB.gestureForEvent(e);
   gesture.handleBlockStart(e, this);
-
 };
 
 /**
@@ -867,7 +863,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   if (Blockly.selected == this) {
     this.unselect();
     // TODO (fenichel): Decide what to do here.
-    //Blockly.GestureDB.cancelAllGestures();
+    Blockly.terminateDrag_();
   }
   // If this block has a context menu open, close it.
   if (Blockly.ContextMenu.currentBlock == this) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -273,6 +273,8 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
 /**
  * Return the coordinates of the top-left corner of this block relative to the
  * drawing surface's origin (0,0), in workspace units.
+ * If the block is on the workspace, (0, 0) is the origin of the workspace
+ * coordinate system.
  * This does not change with workspace scale.
  * @return {!goog.math.Coordinate} Object with .x and .y properties in
  *     workspace coordinates.
@@ -434,7 +436,7 @@ Blockly.BlockSvg.prototype.snapToGrid = function() {
  * Returns a bounding box describing the dimensions of this block
  * and any blocks stacked below it.
  * @return {!{height: number, width: number}} Object with height and width
- *    properties.
+ *    properties in workspace units.
  */
 Blockly.BlockSvg.prototype.getHeightWidth = function() {
   var height = this.height;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -140,9 +140,6 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   if (!this.workspace.options.readOnly && !this.eventsInit_) {
     Blockly.bindEventWithChecks_(this.getSvgRoot(), 'mousedown', this,
                        this.onMouseDown_);
-    var thisBlock = this;
-    Blockly.bindEvent_(this.getSvgRoot(), 'touchstart', null,
-                       function(e) {Blockly.longStart_(e, thisBlock);});
   }
   this.eventsInit_ = true;
 
@@ -581,20 +578,6 @@ Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
   if (this.workspace.options.readOnly) {
     return;
   }
-  if (this.isInFlyout) {
-    // longStart's simulation of right-clicks for longpresses on touch devices
-    // calls the onMouseDown_ function defined on the prototype of the object
-    // the was longpressed (in this case, a Blockly.BlockSvg).  In this case
-    // that behaviour is wrong, because Blockly.Flyout.prototype.blockMouseDown
-    // should be called for a mousedown on a block in the flyout, which blocks
-    // execution of the block's onMouseDown_ function.
-    if (e.type == 'touchstart' && Blockly.utils.isRightButton(e)) {
-      Blockly.Flyout.blockRightClick_(e, this);
-      e.stopPropagation();
-      e.preventDefault();
-    }
-    return;
-  }
   if (this.isInMutator) {
     // Mutator's coordinate system could be out of date because the bubble was
     // dragged, the block was moved, the parent workspace zoomed, etc.
@@ -881,7 +864,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   // If this block is being dragged, unlink the mouse events.
   if (Blockly.selected == this) {
     this.unselect();
-    Blockly.terminateDrag_();
+    Blockly.GestureDB.cancelAllGestures();
   }
   // If this block has a context menu open, close it.
   if (Blockly.ContextMenu.currentBlock == this) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -259,7 +259,6 @@ Blockly.onKeyDown_ = function(e) {
  */
 Blockly.terminateDrag_ = function() {
   Blockly.BlockSvg.terminateDrag();
-  Blockly.Flyout.terminateDrag_();
 };
 
 /**

--- a/core/constants.js
+++ b/core/constants.js
@@ -33,6 +33,13 @@ goog.provide('Blockly.constants');
 Blockly.DRAG_RADIUS = 5;
 
 /**
+ * Number of pixels the mouse must move before a drag/scroll starts from the
+ * flyout.  Because the drag-intention is determined when this is reached, it is
+ * larger than Blockly.DRAG_RADIUS so that the drag-direction is clearer.
+ */
+Blockly.FLYOUT_DRAG_RADIUS = 10;
+
+/**
  * Maximum misalignment between connections for them to snap together.
  */
 Blockly.SNAP_RADIUS = 20;

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -44,6 +44,12 @@ goog.require('goog.ui.MenuItem');
 Blockly.ContextMenu.currentBlock = null;
 
 /**
+ * @type {Array.<!Array>} Opaque data that can be passed to unbindEvent_.
+ * @private
+ */
+Blockly.ContextMenu.eventWrapper_ = null;
+
+/**
  * Construct the menu based on the list of options and show the menu.
  * @param {!Event} e Mouse event.
  * @param {!Array.<!Object>} options Array of menu options.
@@ -123,6 +129,9 @@ Blockly.ContextMenu.show = function(e, options, rtl) {
 Blockly.ContextMenu.hide = function() {
   Blockly.WidgetDiv.hideIfOwner(Blockly.ContextMenu);
   Blockly.ContextMenu.currentBlock = null;
+  if (Blockly.ContextMenu.eventWrapper_) {
+    Blockly.unbindEvent_(Blockly.ContextMenu.eventWrapper_);
+  }
 };
 
 /**

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -110,20 +110,6 @@ Blockly.Flyout = function(workspaceOptions) {
    * @private
    */
   this.permanentlyDisabled_ = [];
-
-  /**
-   * y coordinate of mousedown - used to calculate scroll distances.
-   * @type {number}
-   * @private
-   */
-  this.startDragMouseY_ = 0;
-
-  /**
-   * x coordinate of mousedown - used to calculate scroll distances.
-   * @type {number}
-   * @private
-   */
-  this.startDragMouseX_ = 0;
 };
 
 /**
@@ -133,44 +119,6 @@ Blockly.Flyout = function(workspaceOptions) {
  * @private
  */
 Blockly.Flyout.startFlyout_ = null;
-
-/**
- * Event that started a drag. Used to determine the drag distance/direction and
- * also passed to BlockSvg.onMouseDown_() after creating a new block.
- * @type {Event}
- * @private
- */
-Blockly.Flyout.startDownEvent_ = null;
-
-/**
- * Flyout block where the drag/click was initiated. Used to fire click events or
- * create a new block.
- * @type {Event}
- * @private
- */
-Blockly.Flyout.startBlock_ = null;
-
-/**
- * Wrapper function called when a mouseup occurs during a background or block
- * drag operation.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.Flyout.onMouseUpWrapper_ = null;
-
-/**
- * Wrapper function called when a mousemove occurs during a background drag.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.Flyout.onMouseMoveWrapper_ = null;
-
-/**
- * Wrapper function called when a mousemove occurs during a block drag.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.Flyout.onMouseMoveBlockWrapper_ = null;
 
 /**
  * Does the flyout automatically close when a block is created?
@@ -1254,20 +1202,7 @@ Blockly.Flyout.terminateDrag_ = function() {
     Blockly.Flyout.startFlyout_.dragMode_ = Blockly.DRAG_NONE;
     Blockly.Flyout.startFlyout_ = null;
   }
-  if (Blockly.Flyout.onMouseUpWrapper_) {
-    Blockly.unbindEvent_(Blockly.Flyout.onMouseUpWrapper_);
-    Blockly.Flyout.onMouseUpWrapper_ = null;
-  }
-  if (Blockly.Flyout.onMouseMoveBlockWrapper_) {
-    Blockly.unbindEvent_(Blockly.Flyout.onMouseMoveBlockWrapper_);
-    Blockly.Flyout.onMouseMoveBlockWrapper_ = null;
-  }
-  if (Blockly.Flyout.onMouseMoveWrapper_) {
-    Blockly.unbindEvent_(Blockly.Flyout.onMouseMoveWrapper_);
-    Blockly.Flyout.onMouseMoveWrapper_ = null;
-  }
   Blockly.Flyout.startDownEvent_ = null;
-  Blockly.Flyout.startBlock_ = null;
 };
 
 /**

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1363,6 +1363,7 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
         block.flyoutRect_.setAttribute('y', blockXY.y);
       }
     }
+    console.log(flyoutWidth);
     // Record the width for .getMetrics_ and .position.
     this.width_ = flyoutWidth;
     // Call this since it is possible the trash and zoom buttons need

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -1363,7 +1363,6 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
         block.flyoutRect_.setAttribute('y', blockXY.y);
       }
     }
-    console.log(flyoutWidth);
     // Record the width for .getMetrics_ and .position.
     this.width_ = flyoutWidth;
     // Call this since it is possible the trash and zoom buttons need

--- a/core/flyout.js
+++ b/core/flyout.js
@@ -936,26 +936,6 @@ Blockly.Flyout.prototype.isDragTowardWorkspace = function(currentDragDeltaXY) {
 };
 
 /**
- * // TODO (fenichel): Delete.
- * Create a copy of this block on the workspace.
- * @param {!Blockly.Block} originBlock The flyout block to copy.
- * @return {!Function} Function to call when block is clicked.
- * @private
- */
-Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
-  return function(e) {
-    if (Blockly.utils.isRightButton(e)) {
-      // Right-click.  Don't create a block, let the context menu show.
-      return;
-    }
-    if (originBlock.disabled) {
-      // Beyond capacity.
-      return;
-    }
-  };
-};
-
-/**
  * Create a copy of this block on the workspace.
  * @param {!Blockly.BlockSvg} originalBlock The block to copy from the flyout.
  * @return {Blockly.BlockSvg} The newly created block, or null if something
@@ -989,7 +969,6 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
     Blockly.Events.fire(new Blockly.Events.Create(this.startBlock_));
   }
 
-  // TODO: Does this code live here?
   if (this.autoClose) {
     this.hide();
   } else {
@@ -1084,7 +1063,8 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(originBlock) {
 
 /**
  * Filter the blocks on the flyout to disable the ones that are above the
- * capacity limit.
+ * capacity limit.  For instance, if the user may only place two more blocks on
+ * the workspace, an "a + b" block that has two shadow blocks would be disabled.
  * @private
  */
 Blockly.Flyout.prototype.filterForCapacity_ = function() {

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -116,6 +116,13 @@ Blockly.FlyoutButton.prototype.width = 0;
 Blockly.FlyoutButton.prototype.height = 0;
 
 /**
+ * Opaque data that can be passed to Blockly.unbindEvent_.
+ * @type {Array.<!Array>}
+ * @private
+ */
+Blockly.FlyoutButton.prototype.onMouseUpWrapper_ = null;
+
+/**
  * Create the button elements.
  * @return {!Element} The button's SVG group.
  */
@@ -163,6 +170,9 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   svgText.setAttribute('y', this.height - Blockly.FlyoutButton.MARGIN);
 
   this.updateTransform_();
+
+  this.mouseUpWrapper_ = Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup',
+      this, this.onMouseUp_);
   return this.svgGroup_;
 };
 
@@ -207,6 +217,9 @@ Blockly.FlyoutButton.prototype.getTargetWorkspace = function() {
  * Dispose of this button.
  */
 Blockly.FlyoutButton.prototype.dispose = function() {
+  if (this.onMouseUpWrapper_) {
+    Blockly.unbindEvent_(this.onMouseUpWrapper_);
+  }
   if (this.svgGroup_) {
     goog.dom.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
@@ -218,15 +231,13 @@ Blockly.FlyoutButton.prototype.dispose = function() {
 /**
  * Do something when the button is clicked.
  * @param {!Event} e Mouse up event.
+ * @private
  */
-Blockly.FlyoutButton.prototype.onMouseUp = function(e) {
-  // Don't scroll the page.
-  e.preventDefault();
-  // Don't propagate mousewheel event (zooming).
-  e.stopPropagation();
-  // Stop binding to mouseup and mousemove events--flyout mouseup would normally
-  // do this, but we're skipping that.
-  Blockly.Flyout.terminateDrag_();
+Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
+  var gesture = Blockly.GestureDB.gestureForEvent(e);
+  if (gesture) {
+    gesture.cancelGesture();
+  }
 
   // Call the callback registered to this button.
   if (this.callback_) {

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -33,6 +33,7 @@ goog.require('Blockly.FlyoutDragger');
 goog.require('Blockly.WorkspaceDragger');
 goog.require('goog.asserts');
 
+
 /**
  * NB: In this file "start" refers to touchstart, mousedown, and pointerstart
  * events.  "End" refers to touchend, mouseup, and pointerend events.
@@ -267,6 +268,15 @@ Blockly.Gesture.prototype.updateIsDraggingBlock_ = function() {
  * @return {boolean} true if anything is being dragged.
  */
 Blockly.Gesture.prototype.updateIsDragging_ = function() {
+  goog.assert(!this.isDragging(),
+      'Don\'t call updateIsDragging_ when a drag is already in progress.');
+  var startBlockMovable = this.startBlock_ && this.startBlock_.isMovable();
+  if (startBlockMovable && this.currentDragDelta_ > Blockly.DRAG_RADIUS) {
+    this.isDraggingBlock_ = true;
+    return true;
+  }
+
+  var workspaceMovable = this.startWorkspace_ && this.startWorkspace_.isMovable();
   // TODO: Assert that the most recent event was a move?
   goog.asserts.assert(!this.isDragging(),
       'Don\'t call updateIsDragging_ when a drag is already in progress.');

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -331,6 +331,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   this.startWorkspace_.markFocused();
   this.mostRecentEvent_ = e;
 
+  // Hide chaff also hides the flyout, so don't do it if the click is in a flyout.
   Blockly.hideChaff(!!this.flyout_);
 
   if (Blockly.utils.isRightButton(e)) {
@@ -465,6 +466,10 @@ Blockly.Gesture.prototype.doFieldClick_ = function() {
 // Block clicks
 Blockly.Gesture.prototype.doBlockClick_ = function() {
   // TODO: Implement.
+  Blockly.Events.fire(
+      new Blockly.Events.Ui(this.startBlock_, 'click', undefined, undefined));
+  Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
+  Blockly.Events.setGroup(false);
 };
 
 // Workspace clicks

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -27,11 +27,13 @@
 
 goog.provide('Blockly.Gesture');
 
-goog.require('goog.math.Coordinate');
 goog.require('Blockly.BlockDragger');
 goog.require('Blockly.FlyoutDragger');
+goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceDragger');
+
 goog.require('goog.asserts');
+goog.require('goog.math.Coordinate');
 
 
 /**
@@ -344,10 +346,10 @@ Blockly.Gesture.prototype.doStart = function(e) {
 
   this.mouseDownXY_ = new goog.math.Coordinate(e.clientX, e.clientY);
 
-  this.onMoveWrapper_ = Blockly.bindEvent_(
+  this.onMoveWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mousemove', null, this.handleMove.bind(this));
 
-  this.onUpWrapper_ = Blockly.bindEvent_(
+  this.onUpWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mouseup', null, this.handleUp.bind(this));
 
   e.preventDefault();
@@ -360,6 +362,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
  */
 Blockly.Gesture.prototype.handleMove = function(e) {
   this.updateFromEvent_(e);
+  console.log(Blockly.Touch.getTouchIdentifierFromEvent(e));
   // TODO: I should probably only call this once, when first exceeding the drag
   // radius.
   if (this.hasExceededDragRadius_) {
@@ -411,6 +414,7 @@ Blockly.Gesture.prototype.endGesture = function(e) {
   Blockly.GestureDB.removeGestureForId(this.touchIdentifier_);
   e.preventDefault();
   e.stopPropagation();
+  Blockly.Touch.clearTouchIdentifier();
 };
 
 /**

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -243,6 +243,10 @@ Blockly.Gesture.prototype.updateDragDelta_ = function(currentXY) {
  * @private
  */
 Blockly.Gesture.prototype.updateIsDraggingFromFlyout_ = function() {
+  // Disabled blocks may not be dragged from the flyout.
+  if (this.startBlock_.disabled) {
+    return false;
+  }
   if (!this.flyout_.isScrollable() ||
       this.flyout_.isDragTowardWorkspace(this.currentDragDeltaXY_)) {
     this.startWorkspace_ = this.flyout_.targetWorkspace_;
@@ -510,9 +514,25 @@ Blockly.Gesture.prototype.doFieldClick_ = function() {
 
 // Block clicks
 Blockly.Gesture.prototype.doBlockClick_ = function() {
-  // TODO: Implement.
-  Blockly.Events.fire(
-      new Blockly.Events.Ui(this.startBlock_, 'click', undefined, undefined));
+  if (this.flyout_) {
+    var newBlock = this.flyout_.createBlock(this.startBlock_);
+    // Ensure that any snap and bump are part of this move's event group.
+    var group = Blockly.Events.getGroup();
+    setTimeout(function() {
+      Blockly.Events.setGroup(group);
+      newBlock.snapToGrid();
+      Blockly.Events.setGroup(false);
+    }, Blockly.BUMP_DELAY / 2);
+    setTimeout(function() {
+      Blockly.Events.setGroup(group);
+      newBlock.bumpNeighbours_();
+      Blockly.Events.setGroup(false);
+    }, Blockly.BUMP_DELAY);
+  } else {
+    // TODO: Implement.
+    Blockly.Events.fire(
+        new Blockly.Events.Ui(this.startBlock_, 'click', undefined, undefined));
+  }
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   Blockly.Events.setGroup(false);
 };

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -28,6 +28,7 @@
 goog.provide('Blockly.Gesture');
 
 goog.require('Blockly.BlockDragger');
+goog.require('Blockly.constants');
 goog.require('Blockly.FlyoutDragger');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WorkspaceDragger');
@@ -169,6 +170,13 @@ Blockly.Gesture = function(e, touchId) {
    * @private
    */
   this.flyout_ = null;
+
+  /**
+   * Boolean for sanity-checking that some code is only called once.
+   * @type {boolean}
+   * @private
+   */
+  this.calledUpdateIsDragging_ = false;
 };
 
 Blockly.Gesture.prototype.dispose = function() {
@@ -189,9 +197,11 @@ Blockly.Gesture.prototype.dispose = function() {
  */
 Blockly.Gesture.prototype.updateFromEvent_ = function(e) {
   var currentXY = new goog.math.Coordinate(e.clientX, e.clientY);
-  this.updateDragDelta_(currentXY);
-  if (!this.isDragging()) {
+  var changed = this.updateDragDelta_(currentXY);
+  // Exceeded the drag radius for the first time.
+  if (changed){
     this.updateIsDragging_();
+    Blockly.longStop_();
   }
   this.mostRecentEvent_ = e;
 };
@@ -200,60 +210,66 @@ Blockly.Gesture.prototype.updateFromEvent_ = function(e) {
  * DO MATH to set currentDragDeltaXY_ based on the most recent mouse position.
  * @param {!goog.math.Coordinate} currentXY The most recent mouse/pointer
  *     position, in pixel units, with (0, 0) at the window's top left corner.
+ * @return {boolean} True if the drag just exceeded the drag radius for the
+ *     first time.
  * @private
  */
 Blockly.Gesture.prototype.updateDragDelta_ = function(currentXY) {
   this.currentDragDeltaXY_ = goog.math.Coordinate.difference(currentXY,
       this.mouseDownXY_);
-  var currentDragDelta = goog.math.Coordinate.magnitude(
-      this.currentDragDeltaXY_);
-  this.hasExceededDragRadius_ = currentDragDelta > Blockly.DRAG_RADIUS;
+
+  if (!this.hasExceededDragRadius_) {
+    var currentDragDelta = goog.math.Coordinate.magnitude(
+        this.currentDragDeltaXY_);
+
+    // The flyout has a different drag radius from the rest of Blockly.
+    var limitRadius = this.flyout_ ? Blockly.FLYOUT_DRAG_RADIUS :
+        Blockly.DRAG_RADIUS;
+
+    this.hasExceededDragRadius_ = currentDragDelta > limitRadius;
+    return this.hasExceededDragRadius_;
+  }
+  return false;
 };
 
 /**
  * Update this gesture to record whether a block is being dragged from the
  * flyout.
- * This function should be called on mouse/touch move events if isDragging
- * fields have not yet been set.
+ * This function should be called on a mouse/touch move event the first time the
+ * drag radius is exceeded.  It should be called no more than once per gesture.
  * If a block should be dragged from the flyout this function creates the new
  * block on the main workspace and updates startBlock_ and startWorkspace_.
+ * @return {boolean} True if a block is being dragged from the flyout.
  * @private
  */
 Blockly.Gesture.prototype.updateIsDraggingFromFlyout_ = function() {
-  if (this.flyout_.isDragTowardWorkspace_(this.currentDragDeltaXY_.x,
-      this.currentDragDeltaXY_.y)) {
-    Blockly.Events.disable();
-    this.flyout_.targetWorkspace_.setResizesEnabled(false);
-    try {
-      this.startBlock_ = this.flyout_.placeNewBlock_(this.startBlock_);
-      this.startBlock_.render();
-      this.startWorkspace_ = this.flyout_.targetWorkspace_;
-      this.isDraggingBlock_ = true;
-      // Close the flyout.
-      Blockly.hideChaff();
-    } finally {
-      Blockly.Events.enable();
-    }
+  if (!this.flyout_.isScrollable() ||
+      this.flyout_.isDragTowardWorkspace(this.currentDragDeltaXY_)) {
+    this.startWorkspace_ = this.flyout_.targetWorkspace_;
+    this.startBlock_ = this.flyout_.createBlock(this.startBlock_);
+    this.startBlock_.select();
+    return true;
   }
+  return false;
 };
 
 /**
  * Update this gesture to record whether a block is being dragged.
- * This function should be called on mouse/touch move events if isDragging
- * fields have not yet been set.
+ * This function should be called on a mouse/touch move event the first time the
+ * drag radius is exceeded.  It should be called no more than once per gesture.
  * If a block should be dragged, either from the flyout or in the workspace,
  * this function creates the necessary BlockDragger and starts the drag.
  * @return {boolean} true if a block is being dragged.
  */
 Blockly.Gesture.prototype.updateIsDraggingBlock_ = function() {
-  var startBlockInFlyout = this.startBlock_ && this.flyout_;
-  if (startBlockInFlyout) {
-    this.updateIsDraggingFromFlyout_();
-  } else {
-    var startBlockMovable = this.startBlock_ && this.startBlock_.isMovable();
-    if (startBlockMovable && this.hasExceededDragRadius_) {
-      this.isDraggingBlock_ = true;
-    }
+  if (!this.startBlock_) {
+    return false;
+  }
+
+  if (this.flyout_) {
+    this.isDraggingBlock_ = this.updateIsDraggingFromFlyout_();
+  } else if (this.startBlock_.isMovable()){
+    this.isDraggingBlock_ = true;
   }
 
   if (this.isDraggingBlock_) {
@@ -264,48 +280,47 @@ Blockly.Gesture.prototype.updateIsDraggingBlock_ = function() {
 };
 
 /**
- * Update this gesture to record whether anything is being dragged.
- * This function should be called on mouse/touch move events if isDragging
- * fields have not yet been set.
- * @return {boolean} true if anything is being dragged.
+ * Update this gesture to record whether a workspace is being dragged.
+ * This function should be called on a mouse/touch move event the first time the
+ * drag radius is exceeded.  It should be called no more than once per gesture.
+ * If a workspace is being dragged this function creates the necessary
+ * WorkspaceDragger or FlyoutDragger and starts the drag.
  */
-Blockly.Gesture.prototype.updateIsDragging_ = function() {
-  goog.assert(!this.isDragging(),
-      'Don\'t call updateIsDragging_ when a drag is already in progress.');
-  var startBlockMovable = this.startBlock_ && this.startBlock_.isMovable();
-  if (startBlockMovable && this.currentDragDelta_ > Blockly.DRAG_RADIUS) {
-    this.isDraggingBlock_ = true;
-    return true;
+Blockly.Gesture.prototype.updateIsDraggingWorkspace_ = function() {
+  var wsMovable = this.flyout_ ? this.flyout_.isScrollable() :
+      this.startWorkspace_ && this.startWorkspace_.isDraggable();
+
+  if (!wsMovable) {
+    return;
   }
 
-  var workspaceMovable = this.startWorkspace_ && this.startWorkspace_.isMovable();
-  // TODO: Assert that the most recent event was a move?
-  goog.asserts.assert(!this.isDragging(),
-      'Don\'t call updateIsDragging_ when a drag is already in progress.');
+  if (this.flyout_) {
+    this.workspaceDragger_ = new Blockly.FlyoutDragger(this.flyout_);
+  } else {
+    this.workspaceDragger_ = new Blockly.WorkspaceDragger(this.startWorkspace_);
+  }
+
+  this.isDraggingWorkspace_ = true;
+  this.workspaceDragger_.startDrag();
+};
+
+/**
+ * Update this gesture to record whether anything is being dragged.
+ * This function should be called on a mouse/touch move event the first time the
+ * drag radius is exceeded.  It should be called no more than once per gesture.
+ */
+Blockly.Gesture.prototype.updateIsDragging_ = function() {
+  // Sanity check.
+  goog.asserts.assert(!this.calledUpdateIsDragging_,
+      "updateIsDragging_ should only be called once per gesture.");
+  this.calledUpdateIsDragging_ = true;
 
   // First check if it was a block drag.
   if (this.updateIsDraggingBlock_()) {
-    return true;
+    return;
   }
-
   // Then check if it's a workspace drag.
-  var wsMovable = this.flyout_ ?
-      this.flyout_ && (this.flyout_.scrollbar_ != null) &&
-      this.flyout_.scrollbar_.isVisible() :
-      this.startWorkspace_ && this.startWorkspace_.isDraggable();
-  if (wsMovable && this.hasExceededDragRadius_) {
-    this.isDraggingWorkspace_ = true;
-
-    if (this.flyout_) {
-      this.workspaceDragger_ = new Blockly.FlyoutDragger(this.flyout_);
-    } else {
-      this.workspaceDragger_ = new Blockly.WorkspaceDragger(this.startWorkspace_);
-    }
-
-    this.workspaceDragger_.startDrag();
-    return true;
-  }
-  return false;
+  this.updateIsDraggingWorkspace_();
 };
 
 /**
@@ -328,7 +343,6 @@ Blockly.Gesture.prototype.startDraggingBlock_ = function() {
  * @param {!Event} e A mouse down or touch start event.
  */
 Blockly.Gesture.prototype.doStart = function(e) {
-  // TODO: Blockly.longStart_()
   this.startWorkspace_.updateScreenCalculationsIfScrolled();
   this.startWorkspace_.markFocused();
   this.mostRecentEvent_ = e;
@@ -336,19 +350,23 @@ Blockly.Gesture.prototype.doStart = function(e) {
   // Hide chaff also hides the flyout, so don't do it if the click is in a flyout.
   Blockly.hideChaff(!!this.flyout_);
 
+  if (this.startBlock_) {
+    this.startBlock_.select();
+  }
+
   if (Blockly.utils.isRightButton(e)) {
     this.handleRightClick(e);
     return;
   }
-  if (this.startBlock_) {
-    this.startBlock_.select();
+
+  if (goog.string.startsWith(e.type, 'touch')) {
+    Blockly.longStart_(e);
   }
 
   this.mouseDownXY_ = new goog.math.Coordinate(e.clientX, e.clientY);
 
   this.onMoveWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mousemove', null, this.handleMove.bind(this));
-
   this.onUpWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mouseup', null, this.handleUp.bind(this));
 
@@ -362,12 +380,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
  */
 Blockly.Gesture.prototype.handleMove = function(e) {
   this.updateFromEvent_(e);
-  console.log(Blockly.Touch.getTouchIdentifierFromEvent(e));
-  // TODO: I should probably only call this once, when first exceeding the drag
-  // radius.
-  if (this.hasExceededDragRadius_) {
-    Blockly.longStop_();
-  }
+
   if (this.isDraggingWorkspace_) {
     // Move the visible workspace
     this.workspaceDragger_.drag(this.currentDragDeltaXY_);
@@ -406,27 +419,55 @@ Blockly.Gesture.prototype.handleUp = function(e) {
 };
 
 /**
- * End the gesture associated with the given event, and remove it from the
- * gesture database.
- * @param {!Event} e A mouse move or touch move event.
+ * Cancel an in-progress gesture.  If a workspace or block drag is in progress,
+ * end the drag at the most recent location.
+ *
  */
-Blockly.Gesture.prototype.endGesture = function(e) {
-  Blockly.GestureDB.removeGestureForId(this.touchIdentifier_);
-  e.preventDefault();
-  e.stopPropagation();
-  Blockly.Touch.clearTouchIdentifier();
+Blockly.Gesture.prototype.cancelGesture = function() {
+  Blockly.longStop_();
+  if (this.isDraggingBlock_) {
+    this.blockDragger_.endBlockDrag(this.mostRecentEvent_,
+        this.currentDragDeltaXY_);
+  } else if (this.isDraggingWorkspace_) {
+    this.workspaceDragger_.endDrag(this.currentDragDeltaXY_);
+  }
+  this.endGesture();
 };
 
 /**
- * Handle a right-click event by showing a context menu.
+ * End the gesture associated and remove it from the gesture database.
+ * If an event is passed in, stop that event from doing anything else on the
+ * page.
+ * @param {Event} opt_e A mouse move or touch move event, if this gesture is
+ *     being ended with an event.
+ */
+Blockly.Gesture.prototype.endGesture = function(opt_e) {
+  Blockly.GestureDB.removeGestureForId(this.touchIdentifier_);
+  Blockly.Touch.clearTouchIdentifier();
+  if (opt_e) {
+    opt_e.preventDefault();
+    opt_e.stopPropagation();
+  }
+};
+
+/**
+ * Handle a real or faked right-click event by showing a context menu.
  * @param {!Event} e A mouse move or touch move event.
  */
 Blockly.Gesture.prototype.handleRightClick = function(e) {
   if (this.startBlock_) {
+    if (this.flyout_) {
+      // TODO: Possibly hide chaff in the non-flyout case as well.
+      Blockly.hideChaff(true);
+    }
     this.startBlock_.showContextMenu_(e);
-  } else if (this.startWorkspace_) {
+  } else if (this.startWorkspace_ && !this.flyout_) {
     this.startWorkspace_.showContextMenu_(e);
   }
+
+  e.preventDefault();
+  e.stopPropagation();
+
   this.endGesture(e);
 };
 

--- a/core/gesture_db.js
+++ b/core/gesture_db.js
@@ -116,3 +116,10 @@ Blockly.GestureDB.getGesturesOnWorkspace = function(ws) {
   }
   return result;
 };
+
+Blockly.GestureDB.cancelAllGestures = function() {
+  for (var id in Blockly.GestureDB.gestureMap_) {
+    var gesture = Blockly.GestureDB.gestureMap_[id];
+    gesture.cancelGesture();
+  }
+};

--- a/core/gesture_db.js
+++ b/core/gesture_db.js
@@ -120,6 +120,12 @@ Blockly.GestureDB.getGesturesOnWorkspace = function(ws) {
 Blockly.GestureDB.cancelAllGestures = function() {
   for (var id in Blockly.GestureDB.gestureMap_) {
     var gesture = Blockly.GestureDB.gestureMap_[id];
-    gesture.cancelGesture();
+    if (gesture) {
+      gesture.cancelGesture();
+    }
   }
+};
+
+Blockly.GestureDB.numGesturesInProgress = function() {
+  return Blockly.GestureDB.numGesturesInProgress_;
 };

--- a/core/icon.js
+++ b/core/icon.js
@@ -170,7 +170,7 @@ Blockly.Icon.prototype.renderIcon = function(cursorX) {
 
 /**
  * Notification that the icon has moved.  Update the arrow accordingly.
- * @param {!goog.math.Coordinate} xy Absolute location.
+ * @param {!goog.math.Coordinate} xy Absolute location in workspace coordinates.
  */
 Blockly.Icon.prototype.setIconLocation = function(xy) {
   this.iconXY_ = xy;
@@ -197,7 +197,8 @@ Blockly.Icon.prototype.computeIconLocation = function() {
 
 /**
  * Returns the center of the block's icon relative to the surface.
- * @return {!goog.math.Coordinate} Object with x and y properties.
+ * @return {!goog.math.Coordinate} Object with x and y properties in workspace
+ *     coordinates.
  */
 Blockly.Icon.prototype.getIconLocation = function() {
   return this.iconXY_;

--- a/core/icon.js
+++ b/core/icon.js
@@ -126,6 +126,7 @@ Blockly.Icon.prototype.iconClick_ = function(e) {
     // Drag operation is concluding.  Don't open the editor.
     return;
   }
+  // TODO (fenichel): Decide if we need the right-click check now.
   if (!this.block_.isInFlyout && !Blockly.utils.isRightButton(e)) {
     this.setVisible(!this.isVisible());
   }

--- a/core/inject.js
+++ b/core/inject.js
@@ -279,6 +279,7 @@ Blockly.init_ = function(mainWorkspace) {
   var options = mainWorkspace.options;
   var svg = mainWorkspace.getParentSvg();
 
+  // Suppress the browser's context menu.
   Blockly.bindEventWithChecks_(svg.parentNode, 'contextmenu', null,
       function(e) {
         if (!Blockly.utils.isTargetInput(e)) {

--- a/core/inject.js
+++ b/core/inject.js
@@ -279,7 +279,6 @@ Blockly.init_ = function(mainWorkspace) {
   var options = mainWorkspace.options;
   var svg = mainWorkspace.getParentSvg();
 
-  // Suppress the browser's context menu.
   Blockly.bindEventWithChecks_(svg.parentNode, 'contextmenu', null,
       function(e) {
         if (!Blockly.utils.isTargetInput(e)) {
@@ -343,10 +342,6 @@ Blockly.inject.bindDocumentEvents_ = function() {
     // should run regardless of what other touch event handlers have run.
     Blockly.bindEvent_(document, 'touchend', null, Blockly.longStop_);
     Blockly.bindEvent_(document, 'touchcancel', null, Blockly.longStop_);
-    // Don't use bindEvent_ for document's mouseup since that would create a
-    // corresponding touch handler that would squelch the ability to interact
-    // with non-Blockly elements.
-    document.addEventListener('mouseup', Blockly.onMouseUp_, false);
     // Some iPad versions don't fire resize after portrait to landscape change.
     if (goog.userAgent.IPAD) {
       Blockly.bindEventWithChecks_(window, 'orientationchange', document,

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -69,7 +69,7 @@ Blockly.RenderedConnection.prototype.distanceFrom = function(otherConnection) {
  * @private
  */
 Blockly.RenderedConnection.prototype.bumpAwayFrom_ = function(staticConnection) {
-  if (Blockly.dragMode_ != Blockly.DRAG_NONE) {
+  if (Blockly.GestureDB.numGesturesInProgress() != 0) {
     // Don't move blocks around while the user is doing the same.
     return;
   }

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -70,6 +70,7 @@ Blockly.RenderedConnection.prototype.distanceFrom = function(otherConnection) {
  */
 Blockly.RenderedConnection.prototype.bumpAwayFrom_ = function(staticConnection) {
   if (Blockly.GestureDB.numGesturesInProgress() != 0) {
+    // TODO (fenichel): Check for in-progress drags or in-progress gestures?
     // Don't move blocks around while the user is doing the same.
     return;
   }

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -674,6 +674,7 @@ Blockly.Scrollbar.prototype.onMouseDownBar_ = function(e) {
   this.workspace_.markFocused();
   Blockly.Touch.clearTouchIdentifier();  // This is really a click.
   this.cleanUp_();
+  // TODO: This is the scrollbar right-click handling.
   if (Blockly.utils.isRightButton(e)) {
     // Right-click.
     // Scrollbars have no context menu.
@@ -713,6 +714,7 @@ Blockly.Scrollbar.prototype.onMouseDownBar_ = function(e) {
 Blockly.Scrollbar.prototype.onMouseDownHandle_ = function(e) {
   this.workspace_.markFocused();
   this.cleanUp_();
+  // TODO: this is the scrollbar right-click handling.
   if (Blockly.utils.isRightButton(e)) {
     // Right-click.
     // Scrollbars have no context menu.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -160,6 +160,7 @@ Blockly.Toolbox.prototype.init = function() {
   // Clicking on toolbox closes popups.
   Blockly.bindEventWithChecks_(this.HtmlDiv, 'mousedown', this,
       function(e) {
+        // TODO: Toolbox right-click handling.
         if (Blockly.utils.isRightButton(e) || e.target == this.HtmlDiv) {
           // Close flyout.
           Blockly.hideChaff(false);

--- a/core/touch.js
+++ b/core/touch.js
@@ -42,13 +42,6 @@ goog.require('goog.string');
 Blockly.Touch.touchIdentifier_ = null;
 
 /**
- * Wrapper function called when a touch mouseUp occurs during a drag operation.
- * @type {Array.<!Array>}
- * @private
- */
-Blockly.Touch.onTouchUpWrapper_ = null;
-
-/**
  * The TOUCH_MAP lookup dictionary specifies additional touch events to fire,
  * in conjunction with mouse events.
  * @type {Object}
@@ -123,15 +116,6 @@ Blockly.onMouseUp_ = function(e) {
   workspace.resetDragSurface();
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
   workspace.dragMode_ = Blockly.DRAG_NONE;
-  // Unbind the touch event if it exists.
-  if (Blockly.Touch.onTouchUpWrapper_) {
-    Blockly.unbindEvent_(Blockly.Touch.onTouchUpWrapper_);
-    Blockly.Touch.onTouchUpWrapper_ = null;
-  }
-  if (Blockly.onMouseMoveWrapper_) {
-    Blockly.unbindEvent_(Blockly.onMouseMoveWrapper_);
-    Blockly.onMouseMoveWrapper_ = null;
-  }
 };
 
 

--- a/core/touch.js
+++ b/core/touch.js
@@ -68,11 +68,9 @@ Blockly.longPid_ = 0;
  * which after about a second opens the context menu.  The tasks is killed
  * if the touch event terminates early.
  * @param {!Event} e Touch start event.
- * @param {!Blockly.Block|!Blockly.WorkspaceSvg} uiObject The block or workspace
- *     under the touchstart event.
  * @private
  */
-Blockly.longStart_ = function(e, uiObject) {
+Blockly.longStart_ = function(e) {
   Blockly.longStop_();
   // Punt on multitouch events.
   if (e.changedTouches.length != 1) {
@@ -83,7 +81,13 @@ Blockly.longStart_ = function(e, uiObject) {
     // e was a touch event.  It needs to pretend to be a mouse event.
     e.clientX = e.changedTouches[0].clientX;
     e.clientY = e.changedTouches[0].clientY;
-    uiObject.onMouseDown_(e);
+
+    // Let the gesture route the right-click correctly.
+    var gesture = Blockly.GestureDB.gestureForEvent(e);
+    if (gesture) {
+      gesture.handleRightClick(e);
+    }
+
   }, Blockly.LONGPRESS);
 };
 
@@ -98,26 +102,6 @@ Blockly.longStop_ = function() {
     Blockly.longPid_ = 0;
   }
 };
-
-
-/**
- * Handle a mouse-up anywhere on the page.
- * @param {!Event} e Mouse up event.
- * @private
- */
-Blockly.onMouseUp_ = function(e) {
-  var workspace = Blockly.getMainWorkspace();
-  if (workspace.dragMode_ == Blockly.DRAG_NONE) {
-    return;
-  }
-  Blockly.Touch.clearTouchIdentifier();
-
-  // TODO(#781): Check whether this needs to be called for all drag modes.
-  workspace.resetDragSurface();
-  Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
-  workspace.dragMode_ = Blockly.DRAG_NONE;
-};
-
 
 /**
  * Clear the touch identifier that tracks which touch stream to pay attention

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -83,6 +83,7 @@ Blockly.WorkspaceDragger.prototype.endDrag = function(currentDragDeltaXY) {
   this.drag(currentDragDeltaXY);
 
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
+  // TODO(#781): Check whether this needs to be called for all drag modes.
   this.workspace_.resetDragSurface();
 };
 

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -81,9 +81,7 @@ Blockly.WorkspaceDragger.prototype.startDrag = function() {
 Blockly.WorkspaceDragger.prototype.endDrag = function(currentDragDeltaXY) {
   // Make sure everything is up to date.
   this.drag(currentDragDeltaXY);
-
   Blockly.Css.setCursor(Blockly.Css.Cursor.OPEN);
-  // TODO(#781): Check whether this needs to be called for all drag modes.
   this.workspace_.resetDragSurface();
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -871,8 +871,10 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
 Blockly.WorkspaceSvg.prototype.createVariable = function(name) {
   Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name);
   // Don't refresh the toolbox if there's a drag in progress.
-  // TODO: Decide if we need to check the equivalent of startFlyout_.
-  if (this.toolbox_ && this.toolbox_.flyout_) {//} && !Blockly.Flyout.startFlyout_) {
+  // TODO: Decide if we need to check the equivalent of startFlyout_, to handle
+  // the case that a new variable is created on the workspace by dragging a
+  // block out of the flyout.
+  if (this.toolbox_ && this.toolbox_.flyout_) {
     this.toolbox_.refreshSelection();
   }
 };
@@ -924,6 +926,7 @@ Blockly.WorkspaceSvg.prototype.onMouseDown_ = function(e) {
     return;
   }
   Blockly.terminateDrag_();  // In case mouse-up event was lost.
+  // TODO: Understand this code.
   var isTargetWorkspace = e.target && e.target.nodeName &&
       (e.target.nodeName.toLowerCase() == 'svg' ||
        e.target == this.svgBackground_);
@@ -995,7 +998,8 @@ Blockly.WorkspaceSvg.prototype.isDraggable = function() {
  * @private
  */
 Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
-  // TODO: Remove terminateDrag and compensate for coordinate skew during zoom.
+  // TODO: Remove cancelAllGestures and compensate for coordinate skew during
+  // zoom.
   Blockly.GestureDB.cancelAllGestures();
   // The vertical scroll distance that corresponds to a click of a zoom button.
   var PIXELS_PER_ZOOM_STEP = 50;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1580,6 +1580,7 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
   var MARGIN = Blockly.Flyout.prototype.CORNER_RADIUS - 1;
   var viewWidth = svgSize.width - MARGIN;
   var viewHeight = svgSize.height - MARGIN;
+
   var blockBox = this.getBlocksBoundingBox();
 
   // Fix scale.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -128,16 +128,6 @@ Blockly.WorkspaceSvg.prototype.isFlyout = false;
 Blockly.WorkspaceSvg.prototype.isMutator = false;
 
 /**
- * TODO: Consider deleting this.
- * Is this workspace currently being dragged around?
- * DRAG_NONE - No drag operation.
- * DRAG_BEGIN - Still inside the initial DRAG_RADIUS.
- * DRAG_FREE - Workspace has been dragged further than DRAG_RADIUS.
- * @private
- */
-Blockly.WorkspaceSvg.prototype.dragMode_ = Blockly.DRAG_NONE;
-
-/**
  * Whether this workspace has resizes enabled.
  * Disable during batch operations for a performance improvement.
  * @type {boolean}
@@ -146,29 +136,25 @@ Blockly.WorkspaceSvg.prototype.dragMode_ = Blockly.DRAG_NONE;
 Blockly.WorkspaceSvg.prototype.resizesEnabled_ = true;
 
 /**
- * Current horizontal scrolling offset.
- * Coordinate system: pixel coordinates.
+ * Current horizontal scrolling offset in pixel units.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.scrollX = 0;
 
 /**
- * Current vertical scrolling offset.
- * Coordinate system: pixel coordinates.
+ * Current vertical scrolling offset in pixel units.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.scrollY = 0;
 
 /**
- * Horizontal scroll value when scrolling started.
- * Coordinate system: pixel coordinates.
+ * Horizontal scroll value when scrolling started in pixel units.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.startScrollX = 0;
 
 /**
- * Vertical scroll value when scrolling started.
- * Coordinate system: pixel coordinates.
+ * Vertical scroll value when scrolling started in pixel units.
  * @type {number}
  */
 Blockly.WorkspaceSvg.prototype.startScrollY = 0;
@@ -377,9 +363,6 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   if (!this.isFlyout) {
     Blockly.bindEventWithChecks_(this.svgGroup_, 'mousedown', this,
         this.onMouseDown_);
-    var thisWorkspace = this;
-    Blockly.bindEvent_(this.svgGroup_, 'touchstart', null,
-                       function(e) {Blockly.longStart_(e, thisWorkspace);});
     if (this.options.zoomOptions && this.options.zoomOptions.wheel) {
       // Mouse-wheel.
       Blockly.bindEventWithChecks_(this.svgGroup_, 'wheel', this,
@@ -823,7 +806,7 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
       this.remainingCapacity()) {
     return;
   }
-  Blockly.terminateDrag_();  // Dragging while pasting?  No.
+  Blockly.GestureDB.cancelAllGestures();  // Dragging while pasting?  No.
   Blockly.Events.disable();
   try {
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
@@ -888,7 +871,8 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
 Blockly.WorkspaceSvg.prototype.createVariable = function(name) {
   Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name);
   // Don't refresh the toolbox if there's a drag in progress.
-  if (this.toolbox_ && this.toolbox_.flyout_ && !Blockly.Flyout.startFlyout_) {
+  // TODO: Decide if we need to check the equivalent of startFlyout_.
+  if (this.toolbox_ && this.toolbox_.flyout_) {//} && !Blockly.Flyout.startFlyout_) {
     this.toolbox_.refreshSelection();
   }
 };
@@ -1012,7 +996,7 @@ Blockly.WorkspaceSvg.prototype.isDraggable = function() {
  */
 Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
   // TODO: Remove terminateDrag and compensate for coordinate skew during zoom.
-  Blockly.terminateDrag_();
+  Blockly.GestureDB.cancelAllGestures();
   // The vertical scroll distance that corresponds to a click of a zoom button.
   var PIXELS_PER_ZOOM_STEP = 50;
   var delta = -e.deltaY / PIXELS_PER_ZOOM_STEP;


### PR DESCRIPTION
Note: I'll want to squash these commits when I merge them.

-- Drag bubbles while dragging blocks
-- Use bindEventWithChecks to work in touch on Android.  Not tested anywhere else yet.
-- Handle dragging blocks while zoomed
-- Handle dragging blocks in mutators
-- Handle right-clicks (I hope)
-- Removed lots of unused code