### PR TITLE
Making text_count use text block hue

### DIFF
--- a/blocks/text.js
+++ b/blocks/text.js
@@ -717,7 +717,7 @@ Blockly.Blocks['text_count'] = {
       ],
       "output": "Number",
       "inputsInline": true,
-      "colour": Blockly.Blocks.math.HUE,
+      "colour": Blockly.Blocks.texts.HUE,
       "tooltip": Blockly.Msg.TEXT_COUNT_TOOLTIP,
       "helpUrl": Blockly.Msg.TEXT_COUNT_HELPURL
     });


### PR DESCRIPTION
Making text_count use a text block hue (like text_length, which also returns a number).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1027)
<!-- Reviewable:end -->
