### PR TITLE
Renames Blockly.workspaceDragSurface to Blockly.WorkspaceDragSurface.

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -60,7 +60,7 @@ Blockly.inject = function(container, opt_options) {
   // Create surfaces for dragging things. These are optimizations
   // so that the broowser does not repaint during the drag.
   var blockDragSurface = new Blockly.BlockDragSurfaceSvg(subContainer);
-  var workspaceDragSurface = new Blockly.workspaceDragSurfaceSvg(subContainer);
+  var workspaceDragSurface = new Blockly.WorkspaceDragSurfaceSvg(subContainer);
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -43,17 +43,17 @@ goog.require('goog.math.Coordinate');
  * @param {!Element} container Containing element.
  * @constructor
  */
-Blockly.workspaceDragSurfaceSvg = function(container) {
+Blockly.WorkspaceDragSurfaceSvg = function(container) {
   this.container_ = container;
   this.createDom();
 };
 
 /**
- * The SVG drag surface. Set once by Blockly.workspaceDragSurfaceSvg.createDom.
+ * The SVG drag surface. Set once by Blockly.WorkspaceDragSurfaceSvg.createDom.
  * @type {Element}
  * @private
  */
-Blockly.workspaceDragSurfaceSvg.prototype.SVG_ = null;
+Blockly.WorkspaceDragSurfaceSvg.prototype.SVG_ = null;
 
 /**
  * SVG group inside the drag surface that holds blocks while a drag is in
@@ -63,19 +63,19 @@ Blockly.workspaceDragSurfaceSvg.prototype.SVG_ = null;
  * @type {Element}
  * @private
  */
-Blockly.workspaceDragSurfaceSvg.prototype.dragGroup_ = null;
+Blockly.WorkspaceDragSurfaceSvg.prototype.dragGroup_ = null;
 
 /**
  * Containing HTML element; parent of the workspace and the drag surface.
  * @type {Element}
  * @private
  */
-Blockly.workspaceDragSurfaceSvg.prototype.container_ = null;
+Blockly.WorkspaceDragSurfaceSvg.prototype.container_ = null;
 
 /**
  * Create the drag surface and inject it into the container.
  */
-Blockly.workspaceDragSurfaceSvg.prototype.createDom = function() {
+Blockly.WorkspaceDragSurfaceSvg.prototype.createDom = function() {
   if (this.SVG_) {
     return;  // Already created.
   }
@@ -107,7 +107,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.createDom = function() {
  * @param {number} y Y translation for the entire surface
  * @package
  */
-Blockly.workspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
+Blockly.WorkspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
   // This is a work-around to prevent a the blocks from rendering
   // fuzzy while they are being moved on the drag surface.
   x = x.toFixed(0);
@@ -124,7 +124,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
  * @return {!goog.math.Coordinate} Current translation of the surface
  * @package
  */
-Blockly.workspaceDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
+Blockly.WorkspaceDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
   return Blockly.utils.getRelativeXY(this.SVG_);
 };
 
@@ -135,7 +135,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
  *     into.
  * @package
  */
-Blockly.workspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
+Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   var blockCanvas = this.SVG_.childNodes[0];
   var bubbleCanvas = this.SVG_.childNodes[1];
   if (!blockCanvas || !bubbleCanvas ||
@@ -174,7 +174,7 @@ Blockly.workspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
  * @param {number} scale The scale of the workspace being dragged.
  * @package
  */
-Blockly.workspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
+Blockly.WorkspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
     blockCanvas, bubbleCanvas, previousSibling, width, height, scale) {
   goog.asserts.assert(this.SVG_.childNodes.length == 0,
     'Already dragging a block.');

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -51,7 +51,7 @@ goog.require('goog.userAgent');
  * @param {!Blockly.Options} options Dictionary of options.
  * @param {Blockly.BlockDragSurfaceSvg=} opt_blockDragSurface Drag surface for
  *     blocks.
- * @param {Blockly.workspaceDragSurfaceSvg=} opt_wsDragSurface Drag surface for
+ * @param {Blockly.WorkspaceDragSurfaceSvg=} opt_wsDragSurface Drag surface for
  *     the workspace.
  * @extends {Blockly.Workspace}
  * @constructor


### PR DESCRIPTION
Fixes #880.