### PR TITLE
Update RegEx in js-to-json to match windows EOL

### DIFF
--- a/i18n/js_to_json.py
+++ b/i18n/js_to_json.py
@@ -48,7 +48,7 @@ import re
 from common import write_files
 
 
-_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg.(\w*)\s*=\s*'(.*)';?$""")
+_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg.(\w*)\s*=\s*'(.*)';?\r?$""")
 
 _INPUT_SYN_PATTERN = re.compile(
     """Blockly.Msg.(\w*)\s*=\s*Blockly.Msg.(\w*);""")


### PR DESCRIPTION
The current regex only works with the `\n` line endings as it expects a single character at the end of the line
after the `;` and `\r\n` in windows counts as two.

This causes the en.json and qqq.json files to be recreated with 0 string entries after the metadata, so the entire file would just end up being:

```json
{
    "@metadata": {
        "author": "Ellen Spertus ",
        "lastupdated": "2016-02-05 15:45:48.323000",
        "locale": "en",
        "messagedocumentation" : "qqq"
    },
}
```

Which then causes an issue in the `createmessages.js` script as it expects at least a single key after the metadata and end up causing issues like:

```
Error reading .\msg\json\en.json
Traceback (most recent call last):
  File "i18n\create_messages.py", line 149, in <module>
    main()
  File "i18n\create_messages.py", line 65, in main
    source_defs = read_json_file(os.path.join(os.curdir, args.source_lang_file))
  File "C:\Users\***\Documents\GitHub\blockly\i18n\common.py", line 64, in read_json_file
    raise InputError(filename, str(e))
common.InputError: .\msg\json\en.json: Expecting property name enclosed in double quotes: line 9 column 1 (char 176)
('Error running i18n/create_messages.py: ', CalledProcessError())
```

This is similar to #248, with a slightly different implementation, and would fix #447.