### PR TITLE
Enforcing non-empty names on value inputs and statement inputs.

### DIFF
--- a/core/input.js
+++ b/core/input.js
@@ -41,6 +41,10 @@ goog.require('goog.asserts');
  * @constructor
  */
 Blockly.Input = function(type, name, block, connection) {
+  if (!name &&
+    (type == Blockly.INPUT_VALUE || type == Blockly.NEXT_STATEMENT)) {
+    throw "Value inputs and statement inputs must have non-empty name.";
+  }
   /** @type {number} */
   this.type = type;
   /** @type {string} */


### PR DESCRIPTION
Block connections on such inputs do not save/restore correctly, so it is better to fail early.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1054)
<!-- Reviewable:end -->
