### PR TITLE
Fix #1069

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -38,6 +38,13 @@ goog.require('Blockly.Workspace');
 
 
 /**
+ * Constant to separate procedure names from variables and generated functions
+ * when running generators.
+ * @deprecated Use Blockly.PROCEDURE_CATEGORY_NAME
+ */
+Blockly.Procedures.NAME_TYPE = Blockly.PROCEDURE_CATEOGORY_NAME;
+
+/**
  * Find all user-created procedure definitions in a workspace.
  * @param {!Blockly.Workspace} root Root workspace.
  * @return {!Array.<!Array.<!Array>>} Pair of arrays, the

--- a/core/variables.js
+++ b/core/variables.js
@@ -37,6 +37,13 @@ goog.require('goog.string');
 
 
 /**
+ * Constant to separate variable names from procedures and generated functions
+ * when running generators.
+ * @deprecated Use Blockly.VARIABLE_CATEGORY_NAME
+ */
+Blockly.Variables.NAME_TYPE = Blockly.VARIABLE_CATEGORY_NAME;
+
+/**
  * Find all user-created variables that are in use in the workspace.
  * For use by generators.
  * @param {!Blockly.Block|!Blockly.Workspace} root Root block or workspace.


### PR DESCRIPTION
Turns out the generators rely on these constants.

Since people may have copied the generators and spawned their own versions, I'll just add back the constant instead of changing the generators.