### PR TITLE
add osx travis test run job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: node_js
-node_js:
-- "stable"
-sudo: required
-dist: trusty
-addons:
- apt:
-   sources:
-     - google-chrome
-   packages:
-     - google-chrome-stable
+matrix:
+  include: 
+    - os: linux
+      dist: trusty
+      node_js: stable
+      sudo: required
+      addons:
+        apt:
+          packages:
+          - google-chrome-stable
+    - os: osx
+      node_js: stable
+      osx_image: xcode8.3
 
 before_install:
 - npm install google-closure-library
@@ -16,12 +19,11 @@ before_install:
 - ln -s $(npm root)/google-closure-library ../closure-library
 
 before_script:
-  - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then ( scripts/setup_linux_env.sh  ) fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ( scripts/setup_osx_env.sh ) fi
+  - sleep 2 
+
 script:
   - set -x
   - npm test
-
-os:
-  - linux

--- a/scripts/get_chromedriver.sh
+++ b/scripts/get_chromedriver.sh
@@ -5,12 +5,13 @@ if [ ! -d $chromedriver_dir ]; then
   mkdir $chromedriver_dir
 fi
 
-if [[ $os_name == 'Linux' ]]; then
-  cd chromedriver  && curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip > tmp.zip &&  unzip -o tmp.zip && rm tmp.zip
+echo "downloading chromedriver"
+
+if [[ $os_name == 'Linux' && ! -f $chromedriver_dir/chromedriver ]]; then
+  cd chromedriver  && curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip > tmp.zip &&  unzip -o tmp.zip && rm tmp.zip 
   # wait until download finish
   sleep 5
-elif [[ $os_name == 'Darwin' ]]; then
-  cd chromedriver  &&  curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip  | tar xz
-  # wait until download finish
+elif [[ $os_name == 'Darwin' && ! -f $chromedriver_dir/chromedriver ]]; then
+  cd chromedriver  &&  curl -L https://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip  | tar xz 
   sleep 5
 fi

--- a/scripts/get_geckdriver.sh
+++ b/scripts/get_geckdriver.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 os_name=`uname`
+
+if [ -f geckodriver ]; then
+  exit 0
+fi
+echo "downloading gechdriver"
+
 if [[ $os_name == 'Linux' ]]; then
   cd ../ && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz | tar xz
   sleep 5

--- a/scripts/get_selenium.sh
+++ b/scripts/get_selenium.sh
@@ -6,10 +6,9 @@ if [ ! -d $DIR ]; then
   mkdir $DIR
 fi
 
+echo "downloading selenium jar"
+
 if [ ! -f $DIR/$FILE ]; then
   cd $DIR  && curl -O http://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar
   sleep 5
 fi
-
-
-

--- a/scripts/setup_linux_env.sh
+++ b/scripts/setup_linux_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "${TRAVIS_OS_NAME}" == "linux" ]
+  then
+    export CHROME_BIN="/usr/bin/google-chrome"
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start &
+fi

--- a/scripts/setup_osx_env.sh
+++ b/scripts/setup_osx_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+  
+if [ "${TRAVIS_OS_NAME}" == "osx" ]
+  then
+    brew cask install google-chrome 
+    sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+    export CHROME_BIN="/Applications/Google Chrome.app" 
+fi


### PR DESCRIPTION
1. update setup scripts for check if needed files are there already.  if so skip it.
2. add ios chrome test run. 

here's my test run, https://travis-ci.org/shirletan/blockly/builds/228155284

In general, travis osx job takes a longer than linux run. job queue is longer on osx. It now takes about 3 mins for both linux and osx run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1074)
<!-- Reviewable:end -->
