### PR TITLE
Fix apostrophe in tooltips and helpurls

### DIFF
--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -352,8 +352,8 @@ FactoryUtils.formatJavaScript_ = function(blockType, rootBlock, workspace) {
 
   var tooltip = FactoryUtils.getTooltipFromRootBlock_(rootBlock);
   var helpUrl = FactoryUtils.getHelpUrlFromRootBlock_(rootBlock);
-  code.push("    this.setTooltip('" + tooltip + "');");
-  code.push("    this.setHelpUrl('" + helpUrl + "');");
+  code.push(' this.setTooltip(' + JSON.stringify(tooltip) + ');');
+  code.push(' this.setHelpUrl(' + JSON.stringify(helpUrl) + ');');
   code.push('  }');
   code.push('};');
   return code.join('\n');


### PR DESCRIPTION
Fixes #1045

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1111)
<!-- Reviewable:end -->
