### PR TITLE
Make flyout get variables from target workspace's variableMap.

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -253,6 +253,13 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
   // A flyout connected to a workspace doesn't have its own current gesture.
   this.workspace_.getGesture =
       this.targetWorkspace_.getGesture.bind(this.targetWorkspace_);
+
+  // Get variables from the main workspace rather than the target workspace.
+  this.workspace_.getVariable =
+      this.targetWorkspace_.getVariable.bind(this.targetWorkspace_);
+
+  this.workspace_.getVariableById =
+      this.targetWorkspace_.getVariableById.bind(this.targetWorkspace_);
 };
 
 /**


### PR DESCRIPTION
Necessary for the future CL where `fieldVariable`'s `SetValue()` takes in an id.
Because creating a variable takes this path:
`Blockly.flyout.show()` -> `Blockly.Xml.domToBlock()` -> `Blockly.Xml.domToBlockHeadless_()` -> `field.setValue(xmlChild.textContent)` and `setValue` will check that the variable is in `variableMap` before creating the block.  This CL ensures that the main workspace's `variableMap` is checked instead of the flyout's.
