### PR TITLE
Fix for travis-ci testing failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 
 before_install:
 - npm install google-closure-library
+- npm install webdriverio
 # Symlink closure library
 - ln -s $(npm root)/google-closure-library ../closure-library
 


### PR DESCRIPTION
It looks like the default configuration for Travis might have changed. Adding a manual step to install webdriverio.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1141)
<!-- Reviewable:end -->
