### PR TITLE
Clean up and create test utilities file.

### DIFF
--- a/tests/jsunit/index.html
+++ b/tests/jsunit/index.html
@@ -7,6 +7,7 @@
     <script>goog.require('goog.testing.jsunit');</script>
   </head>
   <body>
+    <script src="test_utilities.js"></script>
     <script src="utils_test.js"></script>
     <script src="connection_test.js"></script>
     <script src="connection_db_test.js"></script>

--- a/tests/jsunit/test_utilities.js
+++ b/tests/jsunit/test_utilities.js
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+ * @fileoverview Test utilities.
+ * @author marisaleung@google.com (Marisa Leung)
+ */
+'use strict';
+
+goog.require('goog.testing');
+
+
+/**
+ * Check that two arrays have the same content.
+ * @param {!Array.<string>} array1 The first array.
+ * @param {!Array.<string>} array2 The second array.
+ */
+function isEqualArrays(array1, array2) {
+  assertEquals(array1.length, array2.length);
+  for (var i = 0; i < array1.length; i++) {
+    assertEquals(array1[i], array2[i]);
+  }
+}
+
+/**
+ * Creates a controlled MethodMock. Sets the expected return values and
+ *     the parameters if any exist. Sets the method to replay.
+ * @param {!goog.testing.MockControl} mockControl Object that holds a set
+ *    of mocks for this test.
+ * @param {!Object} scope The scope of the method to be mocked out.
+ * @param {!string} funcName The name of the function we're going to mock.
+ * @param {Array<Object>} parameters The parameters to call the mock with.
+ * @param {Array<!Object>} return_values The values to return when called.
+ * @return {!goog.testing.MockInterface} The mocked method.
+ */
+function setUpMockMethod(mockControl, scope, funcName, parameters,
+	return_values) {
+  var mockMethod = mockControl.createMethodMock(scope, funcName);
+  if (return_values) {
+    for (var i = 0, return_value; return_value = return_values[i]; i++) {
+      if (parameters && i < parameters.length) {
+        mockMethod(parameters[i]).$returns(return_value);
+      }
+      else {
+        mockMethod().$returns(return_value);
+      }
+    }
+  }
+  // If there are no return values but there are parameters, we are only
+  // recording specific method calls.
+  else if (parameters) {
+    for (var i = 0; i < parameters.length; i++) {
+      mockMethod(parameters[i]);
+    }
+  }
+  mockMethod.$replay();
+  return mockMethod;
+}

--- a/tests/jsunit/variable_map_test.js
+++ b/tests/jsunit/variable_map_test.js
@@ -133,10 +133,9 @@ function test_createVariableNullAndUndefinedType() {
 
 function test_createVariableNullId() {
   variableMapTest_setUp();
-  var mockGenUid = setUpMockMethod(Blockly.utils, 'genUid', null, '1');
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
   try {
     variable_map.createVariable('name1', 'type1', null);
-    mockGenUid.$verify();
     variableMapTest_checkVariableValues('name1', 'type1', '1');
   }
   finally {
@@ -146,10 +145,9 @@ function test_createVariableNullId() {
 
 function test_createVariableUndefinedId() {
   variableMapTest_setUp();
-  var mockGenUid = setUpMockMethod(Blockly.utils, 'genUid', null, '1');
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
   try {
     variable_map.createVariable('name1', 'type1', undefined);
-    mockGenUid.$verify();
     variableMapTest_checkVariableValues('name1', 'type1', '1');
   }
   finally {
@@ -205,8 +203,8 @@ function test_getVariablesOfType_Trivial() {
   variable_map.createVariable('name4', 'type3', 'id4');
   var result_array_1 = variable_map.getVariablesOfType('type1');
   var result_array_2 = variable_map.getVariablesOfType('type5');
-  this.isEqualArrays([var_1, var_2], result_array_1);
-  this.isEqualArrays([], result_array_2);
+  isEqualArrays([var_1, var_2], result_array_1);
+  isEqualArrays([], result_array_2);
   variableMapTest_tearDown();
 }
 
@@ -217,7 +215,7 @@ function test_getVariablesOfType_Null() {
   var var_3 = variable_map.createVariable('name3', '', 'id3');
   variable_map.createVariable('name4', 'type1', 'id4');
   var result_array = variable_map.getVariablesOfType(null);
-  this.isEqualArrays([var_1, var_2, var_3], result_array);
+  isEqualArrays([var_1, var_2, var_3], result_array);
   variableMapTest_tearDown();
 }
 
@@ -226,7 +224,7 @@ function test_getVariablesOfType_EmptyString() {
   var var_1 = variable_map.createVariable('name1', null, 'id1');
   var var_2 = variable_map.createVariable('name2', null, 'id2');
   var result_array = variable_map.getVariablesOfType('');
-  this.isEqualArrays([var_1, var_2], result_array);
+  isEqualArrays([var_1, var_2], result_array);
   variableMapTest_tearDown();
 }
 
@@ -235,14 +233,14 @@ function test_getVariablesOfType_Deleted() {
   var variable = variable_map.createVariable('name1', null, 'id1');
   variable_map.deleteVariable(variable);
   var result_array = variable_map.getVariablesOfType('');
-  this.isEqualArrays([], result_array);
+  isEqualArrays([], result_array);
   variableMapTest_tearDown();
 }
 
 function test_getVariablesOfType_DoesNotExist() {
   variableMapTest_setUp();
   var result_array = variable_map.getVariablesOfType('type1');
-  this.isEqualArrays([], result_array);
+  isEqualArrays([], result_array);
   variableMapTest_tearDown();
 }
 
@@ -253,14 +251,14 @@ function test_getVariableTypes_Trivial() {
   variable_map.createVariable('name3', 'type2', 'id3');
   variable_map.createVariable('name4', 'type3', 'id4');
   var result_array = variable_map.getVariableTypes();
-  this.isEqualArrays(['type1', 'type2', 'type3'], result_array);
+  isEqualArrays(['type1', 'type2', 'type3'], result_array);
   variableMapTest_tearDown();
 }
 
 function test_getVariableTypes_None() {
   variableMapTest_setUp();
   var result_array = variable_map.getVariableTypes();
-  this.isEqualArrays([], result_array);
+  isEqualArrays([], result_array);
   variableMapTest_tearDown();
 }
 
@@ -270,13 +268,13 @@ function test_getAllVariables_Trivial() {
   var var_2 = variable_map.createVariable('name2', 'type1', 'id2');
   var var_3 = variable_map.createVariable('name3', 'type2', 'id3');
   var result_array = variable_map.getAllVariables();
-  this.isEqualArrays([var_1, var_2, var_3], result_array);
+  isEqualArrays([var_1, var_2, var_3], result_array);
   variableMapTest_tearDown();
 }
 
 function test_getAllVariables_None() {
   variableMapTest_setUp();
   var result_array = variable_map.getAllVariables();
-  this.isEqualArrays([], result_array);
+  isEqualArrays([], result_array);
   variableMapTest_tearDown();
 }

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -159,10 +159,7 @@ function test_domToText() {
 function test_domToWorkspace_BackwardCompatibility() {
   // Expect that workspace still loads without serialized variables.
   xmlTest_setUpWithMockBlocks();
-  var mockGenUid = mockControl_.createMethodMock(Blockly.utils, 'genUid');
-  mockGenUid().$returns('1');
-  mockGenUid().$returns('1');
-  mockGenUid().$replay();
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '1']);
   try {
     var dom = Blockly.Xml.textToDom(
         '<xml>' +
@@ -313,15 +310,14 @@ function test_blockToDom_fieldToDom_trivial() {
   var block = new Blockly.Block(workspace, 'field_variable_test_block');
   block.inputList[0].fieldRow[0].setValue('name1');
   var resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
-  xmlTest_checkVariableFieldDomValues(resultFieldDom, 'VAR', 'type1', 'id1', 'name1')
+  xmlTest_checkVariableFieldDomValues(resultFieldDom, 'VAR', 'type1', 'id1',
+    'name1');
   xmlTest_tearDownWithMockBlocks();
 }
 
 function test_blockToDom_fieldToDom_defaultCase() {
   xmlTest_setUpWithMockBlocks();
-  var mockGenUid = mockControl_.createMethodMock(Blockly.utils, 'genUid');
-  mockGenUid().$returns('1');
-  mockGenUid().$replay();
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '1']);
   workspace.createVariable('name1');
   var block = new Blockly.Block(workspace, 'field_variable_test_block');
   block.inputList[0].fieldRow[0].setValue('name1');
@@ -353,9 +349,7 @@ function test_blockToDom_fieldToDom_notAFieldVariable() {
 
 function test_variablesToDom_oneVariable() {
   xmlTest_setUp();
-  var mockGenUid = mockControl_.createMethodMock(Blockly.utils, 'genUid');
-  mockGenUid().$returns('1');
-  mockGenUid().$replay();
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
 
   workspace.createVariable('name1');
   var resultDom = Blockly.Xml.variablesToDom(workspace.getAllVariables());


### PR DESCRIPTION
1. I found I was reusing 'isEqualArrays()' and 'setUpMockMethod()' a lot in different files so I just put it in a test utilities file.
2. 'setUpMockMethod()' is more robust now. It can record multiple calls now rather than just one.
3. Replaced a couple lines that should have been called 'setUpMockMethod().'
4. Removed $verify and $verifyAll(), because it is already run in the teardown.