### PR TITLE
Fixing block deletion and keypresses "falling through" modals.

### DIFF
--- a/accessible/variable-add-modal.component.js
+++ b/accessible/variable-add-modal.component.js
@@ -108,10 +108,11 @@ blocklyApp.VariableAddModalComponent = ng.core.Component({
   // Submits the name change for the variable.
   submit: function() {
     this.workspace.createVariable(this.variableName);
-    this.hideModal_();
+    this.dismissModal();
   },
   // Dismisses and closes the modal.
   dismissModal: function() {
+    this.variableModalService.hideModal();
     this.hideModal_();
   }
 })

--- a/accessible/variable-modal.service.js
+++ b/accessible/variable-modal.service.js
@@ -25,7 +25,6 @@
 
 goog.provide('blocklyApp.VariableModalService');
 
-
 blocklyApp.VariableModalService = ng.core.Class({
   constructor: [
     function() {
@@ -67,12 +66,19 @@ blocklyApp.VariableModalService = ng.core.Class({
   // Show the remove variable modal.
   showRemoveModal_: function(oldName) {
     var count = this.getNumVariables(oldName);
+    this.modalIsShown = true;
     if (count > 1) {
       this.preRemoveShowHook(oldName, count);
-      this.modalIsShown = true;
     } else {
       var variable = blocklyApp.workspace.getVariable(oldName);
       blocklyApp.workspace.deleteVariableInternal_(variable);
+      // Allow the execution loop to finish before "closing" the modal. While
+      // the modal never opens, its being "open" should prevent other keypresses
+      // anyway.
+      var that = this;
+      setTimeout(function() {
+        that.modalIsShown = false;
+      });
     }
   },
   getNumVariables: function(oldName) {

--- a/accessible/variable-remove-modal.component.js
+++ b/accessible/variable-remove-modal.component.js
@@ -28,6 +28,7 @@ goog.provide('blocklyApp.VariableRemoveModalComponent');
 goog.require('blocklyApp.AudioService');
 goog.require('blocklyApp.KeyboardInputService');
 goog.require('blocklyApp.TranslatePipe');
+goog.require('blocklyApp.TreeService');
 goog.require('blocklyApp.VariableModalService');
 
 goog.require('Blockly.CommonModal');
@@ -64,9 +65,13 @@ blocklyApp.VariableRemoveModalComponent = ng.core.Component({
 })
 .Class({
   constructor: [
-    blocklyApp.AudioService, blocklyApp.KeyboardInputService, blocklyApp.VariableModalService,
-    function(audioService, keyboardService, variableService) {
+    blocklyApp.AudioService,
+    blocklyApp.KeyboardInputService,
+    blocklyApp.TreeService,
+    blocklyApp.VariableModalService,
+    function(audioService, keyboardService, treeService, variableService) {
       this.workspace = blocklyApp.workspace;
+      this.treeService = treeService;
       this.variableModalService = variableService;
       this.audioService = audioService;
       this.keyboardInputService = keyboardService
@@ -110,10 +115,11 @@ blocklyApp.VariableRemoveModalComponent = ng.core.Component({
   submit: function() {
     var variable = blocklyApp.workspace.getVariable(this.currentVariableName);
     blocklyApp.workspace.deleteVariableInternal_(variable);
-    this.hideModal_();
+    this.dismissModal();
   },
   // Dismisses and closes the modal.
   dismissModal: function() {
+    this.variableModalService.hideModal();
     this.hideModal_();
   }
 })

--- a/accessible/variable-rename-modal.component.js
+++ b/accessible/variable-rename-modal.component.js
@@ -111,10 +111,11 @@ blocklyApp.VariableRenameModalComponent = ng.core.Component({
   // Submits the name change for the variable.
   submit: function() {
     this.workspace.renameVariable(this.currentVariableName, this.variableName);
-    this.hideModal_();
+    this.dismissModal();
   },
   // Dismisses and closes the modal.
   dismissModal: function() {
+    this.variableModalService.hideModal();
     this.hideModal_();
   }
 })


### PR DESCRIPTION
Fixing the tree service so it doesn't treat unknown block deletion as an error, and turning off keypresses on the workspace when the variable modals are open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1182)
<!-- Reviewable:end -->
