### PR TITLE
Dropdown Create does not create a missing variable twice.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -148,7 +148,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
   if (workspace) {
     // Get a copy of the list, so that adding rename and new variable options
     // doesn't modify the workspace's list.
-    var variableModelList = workspace.getVariablesOfType('');
+    variableModelList = workspace.getVariablesOfType('');
     for (var i = 0; i < variableModelList.length; i++){
       if (createSelectedVariable &&
           goog.string.caseInsensitiveEquals(variableModelList[i].name, name)) {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -211,7 +211,7 @@ Blockly.VariableMap.prototype.getVariablesOfType = function(type) {
   type = type || '';
   var variable_list = this.variableMap_[type];
   if (variable_list) {
-    return variable_list;
+    return variable_list.slice();
   }
   return [];
 };


### PR DESCRIPTION
This fixes the bug where if a variable is selected in the dropdown that doesn't exist, but it's type does, it is created twice in the workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1194)
<!-- Reviewable:end -->
