### PR TITLE
Fire field variable change event with variable value, not name.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -103,30 +103,29 @@ Blockly.FieldVariable.prototype.getValue = function() {
 
 /**
  * Set the variable name.
- * @param {string} newValue New text.
+ * @param {string} value New text.
  */
-Blockly.FieldVariable.prototype.setValue = function(newValue) {
-  if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.sourceBlock_, 'field', this.name, this.value_, newValue));
-  }
+Blockly.FieldVariable.prototype.setValue = function(value) {
+  var newValue = value;
+  var newText = value;
+
   if (this.sourceBlock_) {
-    var variable = this.sourceBlock_.workspace.getVariableById(newValue);
+    var variable = this.sourceBlock_.workspace.getVariableById(value);
     if (variable) {
-      this.setText(variable.name);
-      this.value_ = newValue;
-      return;
+      newText = variable.name;
     }
     // TODO(marisaleung): Remove name lookup after converting all Field Variable
     //     instances to use id instead of name.
-    else if (variable = this.sourceBlock_.workspace.getVariable(newValue)) {
-      this.setText(newValue);
-      this.value_ = variable.getId();
-      return;
+    else if (variable = this.sourceBlock_.workspace.getVariable(value)) {
+      newValue = variable.getId();
+    }
+    if (Blockly.Events.isEnabled()) {
+      Blockly.Events.fire(new Blockly.Events.BlockChange(
+          this.sourceBlock_, 'field', this.name, this.value_, newValue));
     }
   }
   this.value_ = newValue;
-  this.setText(newValue);
+  this.setText(newText);
 };
 
 /**

--- a/tests/jsunit/field_variable_test.js
+++ b/tests/jsunit/field_variable_test.js
@@ -52,42 +52,71 @@ function test_fieldVariable_Constructor() {
 }
 
 function test_fieldVariable_setValueMatchId() {
-  // Expect the fieldVariable value to be set to variable name
-  workspace = new Blockly.Workspace();
-  workspace.createVariable('name2', null, 'id1');
-  var fieldVariable = new Blockly.FieldVariable('name1');
-  var mockBlock = fieldVariable_mockBlock(workspace);
-  fieldVariable.setSourceBlock(mockBlock);
-  fieldVariable.setValue('id1');
-  assertEquals('name2', fieldVariable.getText());
-  assertEquals('id1', fieldVariable.value_);
-  workspace.dispose();
-}
-
-function test_fieldVariable_setValueMatchName() {
-  // Expect the fieldVariable value to be set to variable name
-  workspace = new Blockly.Workspace();
+ // Expect the fieldVariable value to be set to variable name
+  fieldVariableTestWithMocks_setUp();
   workspace.createVariable('name2', null, 'id2');
   var fieldVariable = new Blockly.FieldVariable('name1');
   var mockBlock = fieldVariable_mockBlock(workspace);
   fieldVariable.setSourceBlock(mockBlock);
+  var event = new Blockly.Events.BlockChange(
+        mockBlock, 'field', undefined, 'name1', 'id2');
+  setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
+
+  fieldVariable.setValue('id2');
+  assertEquals('name2', fieldVariable.getText());
+  assertEquals('id2', fieldVariable.value_);
+  fieldVariableTestWithMocks_tearDown();
+}
+
+function test_fieldVariable_setValueMatchName() {
+  // Expect the fieldVariable value to be set to variable name
+  fieldVariableTestWithMocks_setUp();
+  workspace.createVariable('name2', null, 'id2');
+  var fieldVariable = new Blockly.FieldVariable('name1');
+  var mockBlock = fieldVariable_mockBlock(workspace);
+  fieldVariable.setSourceBlock(mockBlock);
+  var event = new Blockly.Events.BlockChange(
+        mockBlock, 'field', undefined, 'name1', 'id2');
+  setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
+
   fieldVariable.setValue('name2');
   assertEquals('name2', fieldVariable.getText());
   assertEquals('id2', fieldVariable.value_);
-  workspace.dispose();
+  fieldVariableTestWithMocks_tearDown();
 }
 
 function test_fieldVariable_setValueNoVariable() {
   // Expect the fieldVariable value to be set to the passed in string. No error
   // should be thrown.
-  workspace = new Blockly.Workspace();
+  fieldVariableTestWithMocks_setUp();
   var fieldVariable = new Blockly.FieldVariable('name1');
   var mockBlock = {'workspace': workspace,
     'isShadow': function(){return false;}};
   fieldVariable.setSourceBlock(mockBlock);
+  var event = new Blockly.Events.BlockChange(
+        mockBlock, 'field', undefined, 'name1', 'id1');
+  setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
+
   fieldVariable.setValue('id1');
   assertEquals('id1', fieldVariable.getText());
   assertEquals('id1', fieldVariable.value_);
+  fieldVariableTestWithMocks_tearDown();
+}
+
+function test_fieldVariable_dropdownCreateVariablesExist() {
+  // Expect that the dropdown options will contain the variables that exist.
+  workspace = new Blockly.Workspace();
+  workspace.createVariable('name1', '', 'id1');
+  workspace.createVariable('name2', '', 'id2');
+  var result_options = Blockly.FieldVariable.dropdownCreate.call(
+    {
+      'sourceBlock_': {'workspace': workspace},
+      'getText': function(){return 'name1';}
+    });
+  assertEquals(result_options.length, 3);
+  isEqualArrays(result_options[0], ['name1', 'id1']);
+  isEqualArrays(result_options[1], ['name2', 'id2']);
+
   workspace.dispose();
 }
 


### PR DESCRIPTION
Prior, change events for field_variables were sending variables names. We have switched to using id's so this commit sends the new value's variable id instead.

Plus tests.

First part of fix for https://github.com/LLK/scratch-vm/issues/628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1196)
<!-- Reviewable:end -->
