### PR TITLE
Implement Blockly.Events.filter in linear time

### DIFF
--- a/core/events.js
+++ b/core/events.js
@@ -174,33 +174,33 @@ Blockly.Events.filter = function(queueIn, forward) {
     // Undo is merged in reverse order.
     queue.reverse();
   }
-  var mergedQueue = [],
-      hash = {},
-      i, event;
+  var mergedQueue = [];
+  var hash = Object.create(null);
   // Merge duplicates.
-  for (i = 0; event = queue[i]; i++) {
+  for (var i = 0, event; event = queue[i]; i++) {
     if (!event.isNull()) {
       var key = [event.type, event.blockId, event.workspaceId].join(' ');
-      if (hash[key] === undefined) {
+      var lastEvent = hash[key];
+      if (!lastEvent) {
         hash[key] = event;
         mergedQueue.push(event);
       } else if (event.type == Blockly.Events.MOVE) {
         // Merge move events.
-        hash[key].newParentId = event.newParentId;
-        hash[key].newInputName = event.newInputName;
-        hash[key].newCoordinate = event.newCoordinate;
+        lastEvent.newParentId = event.newParentId;
+        lastEvent.newInputName = event.newInputName;
+        lastEvent.newCoordinate = event.newCoordinate;
       } else if (event.type == Blockly.Events.CHANGE &&
-          event.element == hash[key].element &&
-          event.name == hash[key].name) {
+          event.element == lastEvent.element &&
+          event.name == lastEvent.name) {
         // Merge change events.
-        hash[key].newValue = event.newValue;
+        lastEvent.newValue = event.newValue;
       } else if (event.type == Blockly.Events.UI &&
-          hash[key].element == 'click' &&
-          (event.element == 'commentOpen' ||
-           event.element == 'mutatorOpen' ||
-           event.element == 'warningOpen')) {
-        // Merge UI events.
-        hash[key].newValue = event.newValue;
+          event.element == 'click' &&
+          (lastEvent.element == 'commentOpen' ||
+           lastEvent.element == 'mutatorOpen' ||
+           lastEvent.element == 'warningOpen')) {
+        // Merge click events.
+        lastEvent.newValue = event.newValue;
       }
     }
   }
@@ -211,7 +211,7 @@ Blockly.Events.filter = function(queueIn, forward) {
   }
   // Move mutation events to the top of the queue.
   // Intentionally skip first event.
-  for (i = 1; event = queue[i]; i++) {
+  for (var i = 1, event; event = queue[i]; i++) {
     if (event.type == Blockly.Events.CHANGE &&
         event.element == 'mutation') {
       queue.unshift(queue.splice(i, 1)[0]);

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -392,3 +392,154 @@ function test_varBackard_runForward() {
   checkVariableValues(workspace, 'name1', 'type1', 'id1');
   eventTest_tearDown();
 }
+
+function test_events_filter() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var events = [
+    new Blockly.Events.BlockCreate(block1),
+    new Blockly.Events.BlockMove(block1),
+    new Blockly.Events.BlockChange(block1, 'field', 'VAR', 'item', 'item1'),
+    new Blockly.Events.Ui(block1, 'click')
+  ];
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(4, filteredEvents.length);  // no event should have been removed.
+  // test that the order hasn't changed
+  assertTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+  assertTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+  assertTrue(filteredEvents[2] instanceof Blockly.Events.BlockChange);
+  assertTrue(filteredEvents[3] instanceof Blockly.Events.Ui);
+}
+
+function test_events_filterForward() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var events = [
+    new Blockly.Events.BlockCreate(block1),
+    new Blockly.Events.BlockMove(block1)
+  ];
+  block1.xy_ = new goog.math.Coordinate(1, 1);
+  events[1].recordNew();
+  events.push(new Blockly.Events.BlockMove(block1));
+  block1.xy_ = new goog.math.Coordinate(2, 2);
+  events[2].recordNew();
+  events.push(new Blockly.Events.BlockMove(block1));
+  block1.xy_ = new goog.math.Coordinate(3, 3);
+  events[3].recordNew();
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(2, filteredEvents.length);  // duplicate event should have been removed.
+  // test that the order hasn't changed
+  assertTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+  assertTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+  assertEquals(3, filteredEvents[1].newCoordinate.x);
+  assertEquals(3, filteredEvents[1].newCoordinate.y);
+  eventTest_tearDownWithMockBlocks();
+}
+
+function test_events_filterBackward() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var events = [
+    new Blockly.Events.BlockCreate(block1),
+    new Blockly.Events.BlockMove(block1)
+  ];
+  block1.xy_ = new goog.math.Coordinate(1, 1);
+  events[1].recordNew();
+  events.push(new Blockly.Events.BlockMove(block1));
+  block1.xy_ = new goog.math.Coordinate(2, 2);
+  events[2].recordNew();
+  events.push(new Blockly.Events.BlockMove(block1));
+  block1.xy_ = new goog.math.Coordinate(3, 3);
+  events[3].recordNew();
+  var filteredEvents = Blockly.Events.filter(events, false);
+  assertEquals(2, filteredEvents.length);  // duplicate event should have been removed.
+  // test that the order hasn't changed
+  assertTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+  assertTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+  assertEquals(1, filteredEvents[1].newCoordinate.x);
+  assertEquals(1, filteredEvents[1].newCoordinate.y);
+  eventTest_tearDownWithMockBlocks();
+}
+
+function test_events_filterDifferentBlocks() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var block2 = workspace.newBlock('field_variable_test_block', '2');
+  var events = [
+    new Blockly.Events.BlockCreate(block1),
+    new Blockly.Events.BlockMove(block1),
+    new Blockly.Events.BlockCreate(block2),
+    new Blockly.Events.BlockMove(block2)
+  ];
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(4, filteredEvents.length);  // no event should have been removed.
+  eventTest_tearDownWithMockBlocks();
+}
+
+function test_events_mergeMove() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var events = [
+    new Blockly.Events.BlockMove(block1)
+  ];
+  block1.xy_.translate(1, 1);
+  events.push(new Blockly.Events.BlockMove(block1));
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(1, filteredEvents.length);
+  assertEquals(1, filteredEvents[0].oldCoordinate.x);
+  assertEquals(1, filteredEvents[0].oldCoordinate.y);
+  eventTest_tearDownWithMockBlocks();
+}
+
+function test_events_mergeChange() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var events = [
+    new Blockly.Events.Change(block1, 'field', 'VAR', 'item', 'item1'),
+    new Blockly.Events.Change(block1, 'field', 'VAR', 'item1', 'item2')
+  ];
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(1, filteredEvents.length);
+  assertEquals('item', filteredEvents[0].oldValue);
+  assertEquals('item2', filteredEvents[0].newValue);
+  eventTest_tearDownWithMockBlocks();
+}
+
+function test_events_mergeUi() {
+  eventTest_setUpWithMockBlocks();
+  var block1 = workspace.newBlock('field_variable_test_block', '1');
+  var block2 = workspace.newBlock('field_variable_test_block', '2');
+  var block3 = workspace.newBlock('field_variable_test_block', '3');
+  var events = [
+    new Blockly.Events.Ui(block1, 'commentOpen', 'false', 'true'),
+    new Blockly.Events.Ui(block1, 'click', 'false', 'true'),
+    new Blockly.Events.Ui(block2, 'mutatorOpen', 'false', 'true'),
+    new Blockly.Events.Ui(block2, 'click', 'false', 'true'),
+    new Blockly.Events.Ui(block3, 'warningOpen', 'false', 'true'),
+    new Blockly.Events.Ui(block3, 'click', 'false', 'true')
+  ];
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(3, filteredEvents.length);
+  assertEquals('commentOpen', filteredEvents[0].element);
+  assertEquals('mutatorOpen', filteredEvents[1].element);
+  assertEquals('warningOpen', filteredEvents[2].element);
+  eventTest_tearDownWithMockBlocks();
+}
+
+/**
+ * Tests that the creation/movement of many unique blocks does not have severe
+ * performance impact. This is based on some issues observed in large projects
+ * in MIT App Inventor.
+ */
+function test_events_filterMany() {
+  eventTest_setUpWithMockBlocks();
+  var topBlocks = 3000;
+  var events = [];
+  for (var i = 0; i < topBlocks; i++) {
+    var block = workspace.newBlock('field_variable_test_block');
+    events.push(new Blockly.Events.BlockCreate(block), new Blockly.Events.BlockMove(block));
+  }
+  var filteredEvents = Blockly.Events.filter(events, true);
+  assertEquals(2 * topBlocks, filteredEvents.length);
+  eventTest_tearDownWithMockBlocks();
+}


### PR DESCRIPTION
For large App Inventor projects (order 1k+ blocks, 100+ top-level
blocks), the O(n^2) behavior of Blockly.Event.filter was causing
performance issues when rearranging blocks or pasting from the
backpack. This commit provides a linear merge implementation using a
key that uniquely identifies a block so that multiple events targeting
the same block are merged. This change benefits from O(1) amortized
lookup using an object as a key-value store.