### PR TITLE
Fix for code generation for procedures (PHP, Python)

### DIFF
--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -34,7 +34,7 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
   // a local parameter.
   var globals = [];
   var varName;
-  var variables = workspace.getAllVariables();
+  var variables = block.workspace.getAllVariables();
   for (var i = 0, variable; variable = variables[i]; i++) {
     varName = variable.name;
     if (block.arguments_.indexOf(varName) == -1) {

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -35,7 +35,7 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   // a local parameter.
   var globals = [];
   var varName;
-  var variables = workspace.getAllVariables();
+  var variables = block.workspace.getAllVariables();
   for (var i = 0, variable; variable = variables[i]; i++) {
     varName = variable.name;
     if (block.arguments_.indexOf(varName) == -1) {


### PR DESCRIPTION
`variables = workspace.getAllVariables();` does not work. Changed to
`variables = block.workspace.getAllVariables();` Fixes #1219
