### PR TITLE
Remove all all instances calling setValue on variable fields with the name instead of the id

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -676,7 +676,15 @@ Blockly.Block.prototype.renameVar = function(oldName, newName) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
       if (field instanceof Blockly.FieldVariable &&
           Blockly.Names.equals(oldName, field.getValue())) {
-        field.setValue(newName);
+        if (this.workspace) {
+          var variable = this.workspace.getVariable(newName);
+          if (variable && oldName.toLowerCase() !== newName.toLowerCase()) {
+            // If it is not just a case change, change the value.
+            field.setValue(variable.getId());
+            return;
+          }
+        }
+        field.setText(newName);
       }
     }
   }

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -49,7 +49,7 @@ goog.require('goog.string');
 Blockly.FieldVariable = function(varname, opt_validator, opt_variableTypes) {
   Blockly.FieldVariable.superClass_.constructor.call(this,
       Blockly.FieldVariable.dropdownCreate, opt_validator);
-  this.setValue(varname || '');
+  this.setText(varname || '');
   this.variableTypes = opt_variableTypes;
 };
 goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
@@ -69,19 +69,21 @@ Blockly.FieldVariable.prototype.init = function() {
 };
 
 Blockly.FieldVariable.prototype.initModel = function() {
+  var workspace =
+    this.sourceBlock_.isInFlyout ?
+        this.sourceBlock_.workspace.targetWorkspace :
+        this.sourceBlock_.workspace;
   if (!this.getValue()) {
     // Variables without names get uniquely named for this workspace.
-    var workspace =
-        this.sourceBlock_.isInFlyout ?
-            this.sourceBlock_.workspace.targetWorkspace :
-            this.sourceBlock_.workspace;
-    this.setValue(Blockly.Variables.generateUniqueName(workspace));
+    var variable = workspace.createVariable(
+      Blockly.Variables.generateUniqueName(workspace));
+    this.setValue(variable.getId());
   }
   // If the selected variable doesn't exist yet, create it.
   // For instance, some blocks in the toolbox have variable dropdowns filled
   // in by default.
   if (!this.sourceBlock_.isInFlyout) {
-    this.sourceBlock_.workspace.createVariable(this.getValue());
+    this.sourceBlock_.workspace.createVariable(this.getText());
   }
 };
 
@@ -93,6 +95,11 @@ Blockly.FieldVariable.prototype.setSourceBlock = function(block) {
   goog.asserts.assert(!block.isShadow(),
       'Variable fields are not allowed to exist on shadow blocks.');
   Blockly.FieldVariable.superClass_.setSourceBlock.call(this, block);
+  // Set the value_ of this field since we now have access to a workspace.
+  var variable = block.workspace.getVariable(this.getText());
+  if (variable) {
+    this.setValue(variable.getId());
+  }
 };
 
 /**
@@ -105,30 +112,25 @@ Blockly.FieldVariable.prototype.getValue = function() {
 };
 
 /**
- * Set the variable name.
+ * Set the field value and if the value is a valid variable, update the text.
  * @param {string} value New text.
  */
 Blockly.FieldVariable.prototype.setValue = function(value) {
   var newValue = value;
   var newText = value;
 
-  if (this.sourceBlock_) {
+  if (this.hasSourceBlockWorkspace_()) {
     var variable = this.sourceBlock_.workspace.getVariableById(value);
     if (variable) {
       newText = variable.name;
-    }
-    // TODO(marisaleung): Remove name lookup after converting all Field Variable
-    //     instances to use id instead of name.
-    else if (variable = this.sourceBlock_.workspace.getVariable(value)) {
-      newValue = variable.getId();
     }
     if (Blockly.Events.isEnabled()) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
           this.sourceBlock_, 'field', this.name, this.value_, newValue));
     }
+    this.setText(newText);
   }
   this.value_ = newValue;
-  this.setText(newText);
 };
 
 /**
@@ -141,7 +143,7 @@ Blockly.FieldVariable.prototype.getVariableTypes_ = function() {
   var variableTypes = this.variableTypes;
   if (variableTypes === null) {
     // If variableTypes is null, return all variable types.
-    if (this.sourceBlock_) {
+    if (this.hasSourceBlockWorkspace_()) {
       var workspace = this.sourceBlock_.workspace;
       return workspace.getVariableTypes();
     }
@@ -217,32 +219,31 @@ Blockly.FieldVariable.dropdownCreate = function() {
  */
 Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   var id = menuItem.getValue();
-  // TODO(marisaleung): change setValue() to take in an id as the parameter.
-  // Then remove itemText.
-  var itemText;
-  if (this.sourceBlock_ && this.sourceBlock_.workspace) {
+  if (this.hasSourceBlockWorkspace_()) {
     var workspace = this.sourceBlock_.workspace;
     var variable = workspace.getVariableById(id);
-    // If the item selected is a variable, set itemText to the variable name.
+    // If the item selected is a variable, set itemId to the variable id.
     if (variable) {
-      itemText = variable.name;
-    }
-    else if (id == Blockly.RENAME_VARIABLE_ID) {
+      var itemId = variable.getId();
+      this.setValue(itemId);
+    } else if (id == Blockly.RENAME_VARIABLE_ID) {
       // Rename variable.
       var currentName = this.getText();
       variable = workspace.getVariable(currentName);
       Blockly.Variables.renameVariable(workspace, variable);
-      return;
     } else if (id == Blockly.DELETE_VARIABLE_ID) {
       // Delete variable.
       workspace.deleteVariable(this.getText());
-      return;
     }
+  }
+};
 
-    // Call any validation function, and allow it to override.
-    itemText = this.callValidator(itemText);
-  }
-  if (itemText !== null) {
-    this.setValue(itemText);
-  }
+/**
+ * Returns whether this field variable has a source block with a workspace.
+ * @return {boolean} True if it has a sourceblock with a workspace. False
+ *     otherwise.
+ * @private
+ */
+Blockly.FieldVariable.prototype.hasSourceBlockWorkspace_ = function() {
+  return (this.sourceBlock_ && this.sourceBlock_.workspace);
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -586,15 +586,15 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         // Fall through.
       case 'field':
         var field = block.getField(name);
-        var text = xmlChild.textContent;
+        var value = xmlChild.textContent;
         if (field instanceof Blockly.FieldVariable) {
           // TODO (marisaleung): When we change setValue and getValue to
           // interact with id's instead of names, update this so that we get
           // the variable based on id instead of textContent.
           var type = xmlChild.getAttribute('variableType') || '';
-          var variable = workspace.getVariable(text);
+          var variable = workspace.getVariable(value);
           if (!variable) {
-            variable = workspace.createVariable(text, type,
+            variable = workspace.createVariable(value, type,
               xmlChild.getAttribute(id));
           }
           if (typeof(type) !== undefined && type !== null) {
@@ -605,13 +605,14 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
                 Blockly.Xml.domToText(xmlChild) + '.');
             }
           }
+          value = variable.getId();
         }
         if (!field) {
           console.warn('Ignoring non-existent field ' + name + ' in block ' +
                        prototypeName);
           break;
         }
-        field.setValue(text);
+        field.setValue(value);
         break;
       case 'value':
       case 'statement':

--- a/tests/jsunit/field_variable_test.js
+++ b/tests/jsunit/field_variable_test.js
@@ -59,7 +59,7 @@ function test_fieldVariable_setValueMatchId() {
   var mockBlock = fieldVariable_mockBlock(workspace);
   fieldVariable.setSourceBlock(mockBlock);
   var event = new Blockly.Events.BlockChange(
-        mockBlock, 'field', undefined, 'name1', 'id2');
+        mockBlock, 'field', undefined, 'RENAME_VARIABLE_ID', 'id2');
   setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
 
   fieldVariable.setValue('id2');
@@ -76,10 +76,10 @@ function test_fieldVariable_setValueMatchName() {
   var mockBlock = fieldVariable_mockBlock(workspace);
   fieldVariable.setSourceBlock(mockBlock);
   var event = new Blockly.Events.BlockChange(
-        mockBlock, 'field', undefined, 'name1', 'id2');
+        mockBlock, 'field', undefined, 'RENAME_VARIABLE_ID', 'id2');
   setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
 
-  fieldVariable.setValue('name2');
+  fieldVariable.setValue('id2');
   assertEquals('name2', fieldVariable.getText());
   assertEquals('id2', fieldVariable.value_);
   fieldVariableTestWithMocks_tearDown();
@@ -94,7 +94,7 @@ function test_fieldVariable_setValueNoVariable() {
     'isShadow': function(){return false;}};
   fieldVariable.setSourceBlock(mockBlock);
   var event = new Blockly.Events.BlockChange(
-        mockBlock, 'field', undefined, 'name1', 'id1');
+        mockBlock, 'field', undefined, 'RENAME_VARIABLE_ID', 'id1');
   setUpMockMethod(mockControl_, Blockly.Events, 'fire', [event], null);
 
   fieldVariable.setValue('id1');
@@ -240,4 +240,32 @@ function test_fieldVariable_getVariableTypes_emptyListVariableTypes() {
   } finally {
     workspace.dispose();
   }
+}
+
+function test_fieldVariable_setSourceBlock_ExistingVariable() {
+ // Expect that the fieldVariable's value is set to 'id1'
+  fieldVariableTestWithMocks_setUp();
+  workspace.createVariable('name1', null, 'id1');
+  var fieldVariable = new Blockly.FieldVariable('name1');
+  var mockBlock = fieldVariable_mockBlock(workspace);
+
+  fieldVariable.setSourceBlock(mockBlock);
+
+  assertEquals('name1', fieldVariable.getText());
+  assertEquals('id1', fieldVariable.value_);
+  fieldVariableTestWithMocks_tearDown();
+}
+
+function test_fieldVariable_setSourceBlock_NotExistingVariable() {
+ // Expect that the fieldVariable's value is set to the default
+ // 'RENAME_VARIABLE_ID'
+  fieldVariableTestWithMocks_setUp();
+  var fieldVariable = new Blockly.FieldVariable('name1');
+  var mockBlock = fieldVariable_mockBlock(workspace);
+
+  fieldVariable.setSourceBlock(mockBlock);
+
+  assertEquals('name1', fieldVariable.getText());
+  assertEquals('RENAME_VARIABLE_ID', fieldVariable.value_);
+  fieldVariableTestWithMocks_tearDown();
 }

--- a/tests/jsunit/workspace_test.js
+++ b/tests/jsunit/workspace_test.js
@@ -47,12 +47,13 @@ function workspaceTest_tearDown() {
 
 /**
  * Create a test get_var_block.
- * @param {?string} variable_name The string to put into the variable field.
+ * @param {string} variableId The id of the variable to put into the variable
+ *     field.
  * @return {!Blockly.Block} The created block.
  */
-function createMockBlock(variable_name) {
+function createMockBlock(variableId) {
   var block = new Blockly.Block(workspace, 'get_var_block');
-  block.inputList[0].fieldRow[0].setValue(variable_name);
+  block.inputList[0].fieldRow[0].setValue(variableId);
   return block;
 }
 
@@ -72,7 +73,7 @@ function test_emptyWorkspace() {
   }
 }
 
-function test_flatWorkspace() {
+function test__WorkspaceTest_flatWorkspace() {
   workspaceTest_setUp();
   try {
     var blockA = workspace.newBlock('');
@@ -161,9 +162,9 @@ function test_deleteVariable_InternalTrivial() {
   workspaceTest_setUp();
   var var_1 = workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type2', 'id2');
-  createMockBlock('name1');
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.deleteVariableInternal_(var_1);
   var variable = workspace.getVariable('name1');
@@ -335,7 +336,7 @@ function test_renameVariable_OnlyOldNameBlockExists() {
   var oldName = 'name1';
   var newName = 'name2';
   workspace.createVariable(oldName, 'type1', 'id1');
-  createMockBlock(oldName);
+  createMockBlock('id1');
 
   workspace.renameVariable(oldName, newName);
   checkVariableValues(workspace, newName, 'type1', 'id1');
@@ -354,8 +355,8 @@ function test_renameVariable_TwoVariablesSameType() {
   var newName = 'name2';
   workspace.createVariable(oldName, 'type1', 'id1');
   workspace.createVariable(newName, 'type1', 'id2');
-  createMockBlock(oldName);
-  createMockBlock(newName);
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.renameVariable(oldName, newName);
   checkVariableValues(workspace, newName, 'type1', 'id2');
@@ -375,8 +376,8 @@ function test_renameVariable_TwoVariablesDifferentType() {
   var newName = 'name2';
   workspace.createVariable(oldName, 'type1', 'id1');
   workspace.createVariable(newName, 'type2', 'id2');
-  createMockBlock(oldName);
-  createMockBlock(newName);
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   try {
     workspace.renameVariable(oldName, newName);
@@ -399,7 +400,7 @@ function test_renameVariable_OldCase() {
   var oldCase = 'Name1';
   var newName = 'name1';
   workspace.createVariable(oldCase, 'type1', 'id1');
-  createMockBlock(oldCase);
+  createMockBlock('id1');
 
   workspace.renameVariable(oldCase, newName);
   checkVariableValues(workspace, newName, 'type1', 'id1');
@@ -416,8 +417,8 @@ function test_renameVariable_TwoVariablesAndOldCase() {
   var newName = 'name2';
   workspace.createVariable(oldName, 'type1', 'id1');
   workspace.createVariable(oldCase, 'type1', 'id2');
-  createMockBlock(oldName);
-  createMockBlock(oldCase);
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.renameVariable(oldName, newName);
 
@@ -443,8 +444,8 @@ function test_renameVariableById_TwoVariablesSameType() {
   var newName = 'name2';
   workspace.createVariable(oldName, 'type1', 'id1');
   workspace.createVariable(newName, 'type1', 'id2');
-  createMockBlock(oldName);
-  createMockBlock(newName);
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.renameVariableById('id1', newName);
   checkVariableValues(workspace, newName, 'type1', 'id2');
@@ -461,8 +462,8 @@ function test_deleteVariable_Trivial() {
   workspaceTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type1', 'id2');
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.deleteVariable('name1');
   checkVariableValues(workspace, 'name2', 'type1', 'id2');
@@ -477,8 +478,8 @@ function test_deleteVariableById_Trivial() {
   workspaceTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type1', 'id2');
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
 
   workspace.deleteVariableById('id1');
   checkVariableValues(workspace, 'name2', 'type1', 'id2');

--- a/tests/jsunit/workspace_undo_redo_test.js
+++ b/tests/jsunit/workspace_undo_redo_test.js
@@ -66,12 +66,13 @@ function undoRedoTest_tearDown() {
 
 /**
  * Create a test get_var_block.
- * @param {string} variableName The string to put into the variable field.
+ * @param {string} variableId The id of the variable to put into the variable
+ *     field.
  * @return {!Blockly.Block} The created block.
  */
-function createMockBlock(variableName) {
+function createMockBlock(variableId) {
   var block = new Blockly.Block(workspace, 'get_var_block');
-  block.inputList[0].fieldRow[0].setValue(variableName);
+  block.inputList[0].fieldRow[0].setValue(variableId);
   return block;
 }
 
@@ -148,8 +149,8 @@ function test_undoDeleteVariable_WithBlocks() {
   undoRedoTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type2', 'id2');
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
   workspace.deleteVariableById('id1');
   workspace.deleteVariableById('id2');
 
@@ -192,8 +193,8 @@ function test_redoAndUndoDeleteVariable_WithBlocks() {
   undoRedoTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type2', 'id2');
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
   workspace.deleteVariableById('id1');
   workspace.deleteVariableById('id2');
 
@@ -242,7 +243,7 @@ function test_redoAndUndoDeleteVariableTwice_NoBlocks() {
 function test_redoAndUndoDeleteVariableTwice_WithBlocks() {
   undoRedoTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
-  createMockBlock('name1');
+  createMockBlock('id1');
   workspace.deleteVariableById('id1');
   workspace.deleteVariableById('id1');
 
@@ -303,7 +304,7 @@ function test_undoRedoRenameVariable_OneExists_NoBlocks() {
 function test_undoRedoRenameVariable_OneExists_WithBlocks() {
   undoRedoTest_setUp();
   workspace.createVariable('name1', '', 'id1');
-  createMockBlock('name1');
+  createMockBlock('id1');
   workspace.renameVariable('name1', 'name2');
 
   workspace.undo();
@@ -335,8 +336,8 @@ function test_undoRedoRenameVariable_BothExist_NoBlocks() {
 function test_undoRedoRenameVariable_BothExist_WithBlocks() {
   undoRedoTest_setUp();
   createTwoVarsEmptyType();
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
   workspace.renameVariable('name1', 'name2');
 
   workspace.undo();
@@ -369,8 +370,8 @@ function test_undoRedoRenameVariable_BothExistCaseChange_NoBlocks() {
 function test_undoRedoRenameVariable_BothExistCaseChange_WithBlocks() {
   undoRedoTest_setUp();
   createTwoVarsEmptyType();
-  createMockBlock('name1');
-  createMockBlock('name2');
+  createMockBlock('id1');
+  createMockBlock('id2');
   workspace.renameVariable('name1', 'Name2');
 
   workspace.undo();
@@ -403,7 +404,7 @@ function test_undoRedoRenameVariable_OnlyCaseChange_NoBlocks() {
 function test_undoRedoRenameVariable_OnlyCaseChange_WithBlocks() {
   undoRedoTest_setUp();
   workspace.createVariable('name1', '', 'id1');
-  createMockBlock('name1');
+  createMockBlock('id1');
   workspace.renameVariable('name1', 'Name1');
 
   workspace.undo();

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -287,7 +287,7 @@ function test_blockToDom_fieldToDom_trivial() {
   xmlTest_setUpWithMockBlocks();
   workspace.createVariable('name1', 'type1', 'id1');
   var block = new Blockly.Block(workspace, 'field_variable_test_block');
-  block.inputList[0].fieldRow[0].setValue('name1');
+  block.inputList[0].fieldRow[0].setValue('id1');
   var resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
   xmlTest_checkVariableFieldDomValues(resultFieldDom, 'VAR', 'type1', 'id1',
     'name1');
@@ -299,7 +299,7 @@ function test_blockToDom_fieldToDom_defaultCase() {
   setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '1']);
   workspace.createVariable('name1');
   var block = new Blockly.Block(workspace, 'field_variable_test_block');
-  block.inputList[0].fieldRow[0].setValue('name1');
+  block.inputList[0].fieldRow[0].setValue('1');
   var resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
   // Expect type is '' and id is '1' since we don't specify type and id.
   xmlTest_checkVariableFieldDomValues(resultFieldDom, 'VAR', '', '1', 'name1');
@@ -346,7 +346,7 @@ function test_variablesToDom_twoVariables_oneBlock() {
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type2', 'id2');
   var block = new Blockly.Block(workspace, 'field_variable_test_block');
-  block.inputList[0].fieldRow[0].setValue('name1');
+  block.inputList[0].fieldRow[0].setValue('id1');
 
   var resultDom = Blockly.Xml.variablesToDom(workspace.getAllVariables());
   assertEquals(2, resultDom.children.length);


### PR DESCRIPTION
- setValue is only called with the id as the parameter now
- setValue's ability to handle names is removed
- FieldVariable.SetSourceBlock() sets the value of the fieldVariable using text_ attribute since setting the source block is when the field variable finally has access to the workspace variables.
- Tests updated to create mock blocks by id instead of name (it was calling setValue() with names)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1254)
<!-- Reviewable:end -->
