### PR TITLE
Procedure block renames variable in mutator if there is a case change.

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -443,7 +443,14 @@ Blockly.Blocks['procedures_mutatorarg'] = {
     var source = this.sourceBlock_;
     if (source && source.workspace && source.workspace.options &&
         source.workspace.options.parentWorkspace) {
-      source.workspace.options.parentWorkspace.createVariable(newText);
+      var workspace = source.workspace.options.parentWorkspace;
+      var variable = workspace.getVariable(newText);
+      // If there is a case change, rename the variable.
+      if (variable && variable.name !== newText) {
+        workspace.renameVariableById(variable.getId(), newText);
+      } else {
+        workspace.createVariable(newText);
+      }
     }
   }
 };


### PR DESCRIPTION
Fixes https://github.com/google/blockly/issues/1115

Procedure block now checks if the variable in its mutator input already exists in the workspace. If it does exist and there is a case change, the variable is renamed. If not, it is created.