### PR TITLE
Escape variable names correctly when serializing to XML

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -352,9 +352,14 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
  * @private
  */
 Blockly.Variables.generateVariableFieldXml_ = function(variableModel) {
-  var xmlString = '<field name="VAR" ' + 'variableType="' +
-      variableModel.type + '" id="' + variableModel.getId() + '">'+
-      variableModel.name +
-      '</field>';
+  // The variable name may be user input, so it may contain characters that need
+  // to be escaped to create valid XML.
+  var element = goog.dom.createDom('field');
+  element.setAttribute('name', 'VAR');
+  element.setAttribute('variableType', variableModel.type);
+  element.setAttribute('id', variableModel.getId());
+  element.textContent = variableModel.name;
+
+  var xmlString = Blockly.Xml.domToText(element);
   return xmlString;
 };


### PR DESCRIPTION
Fixes #1271 