### PR TITLE
Fix #1275 by adding a more specific rule for overflow:visible on the …

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -146,7 +146,7 @@ Blockly.Css.CONTENT = [
     'top: 0;',
     'left: 0;',
   '}',
-  /* Added as a separate rule with mulitple classes to make it more specific
+  /* Added as a separate rule with multiple classes to make it more specific
      than a bootstrap rule that selects svg:root. See issue #1275 for context.
   */
   '.blocklyWsDragSurface.blocklyOverflowVisible {',

--- a/core/css.js
+++ b/core/css.js
@@ -143,9 +143,14 @@ Blockly.Css.CONTENT = [
   '.blocklyWsDragSurface {',
     'display: none;',
     'position: absolute;',
-    'overflow: visible;',
     'top: 0;',
     'left: 0;',
+  '}',
+  /* Added as a separate rule with mulitple classes to make it more specific
+     than a bootstrap rule that selects svg:root. See issue #1275 for context.
+  */
+  '.blocklyWsDragSurface.blocklyOverflowVisible {',
+    'overflow: visible;',
   '}',
 
   '.blocklyBlockDragSurface {',

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -93,7 +93,7 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.createDom = function() {
     'xmlns:html': Blockly.HTML_NS,
     'xmlns:xlink': 'http://www.w3.org/1999/xlink',
     'version': '1.1',
-    'class': 'blocklyWsDragSurface'
+    'class': 'blocklyWsDragSurface blocklyOverflowVisible',
   }, null);
   this.container_.appendChild(this.SVG_);
 };


### PR DESCRIPTION
…drag surface svg.  This wins out over a common bootstrap rule that says: svg:not(:root) {overflow:hidden} and helps avoid a difficult problem for Blockly users to diagnose.