### PR TITLE
Bring the most recently edited stack to the front at the end of a drag.

### DIFF
--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -139,6 +139,9 @@ Blockly.DraggedConnectionManager.prototype.applyConnections = function() {
       var inferiorConnection = this.localConnection_.isSuperior() ?
           this.closestConnection_ : this.localConnection_;
       inferiorConnection.getSourceBlock().connectionUiEffect();
+      // Bring the just-edited stack to the front.
+      var rootBlock = this.topBlock_.getRootBlock();
+      rootBlock.bringToFront();
     }
     this.removeHighlighting_();
   }


### PR DESCRIPTION
Blockly version of https://github.com/LLK/scratch-blocks/pull/1050