### PR TITLE
Fix for Flyout labels causing Flyout scroll issues

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -530,8 +530,9 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
     }
   }
   // Delete any background buttons from a previous showing.
-  for (var j = 0, rect; rect = this.backgroundButtons_[j]; j++) {
-    goog.dom.removeNode(rect);
+  for (var j = 0; j < this.backgroundButtons_.length; j++) {
+    var rect = this.backgroundButtons_[j];
+    if (rect) goog.dom.removeNode(rect);
   }
   this.backgroundButtons_.length = 0;
 


### PR DESCRIPTION
Fixes #1195

When creating Blocks, Flyout_Base creates a rect around each block and records a reference to it in backgroundButtons_
It uses the index of the block to set it in the array, so in the instance there is a FlyoutButton, that takes up an index, but doesn't create a rect and hence it's position in the array is undefined.
ie: Block, Block, FlyoutButton/Label, Block, Block creates this array:
backgroundButtons_ = [rect, rect, undefined, rect, rect].

The issue is the clearOldBlocks_ method in FlyoutBase iterates through the backgroundButtons_ array clearing each rect as it goes, until it reaches an undefined block. This means the last couple of rects are not cleared and remain in the workspace Canvas, causing scrolling issues listed above.

So fix for this is to update the clearOldBlocks_ method in Flyout base to iterate through all the elements, and only clear if the rect is defined.