### PR TITLE
Fix scrolling momentum in vertical flyouts

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -214,7 +214,7 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
       delta *= 10;
     }
     var metrics = this.getMetrics_();
-    var pos = metrics.viewTop + delta;
+    var pos = (metrics.viewTop - metrics.contentTop) + delta;
     var limit = metrics.contentHeight - metrics.viewHeight;
     pos = Math.min(pos, limit);
     pos = Math.max(pos, 0);


### PR DESCRIPTION
When scrolling up in a vertical flyout scroll momentum of the trackpad causes the flyout to then scroll back down, as described here https://github.com/google/blockly/issues/1220.

To fix this you must subtract metrics.contentTop from metrics.viewTop so that the flyout does not begin to scroll down once delta - metrics.viewTop > 0.

Once you are scrolled to the top, the value of metrics.viewTop is not necessarily 0. It should always be equal to the value of metrics.contentTop. So, in my case metrics.viewTop was equal to 5 when I was scrolled all the way up. As delta decayed from a large negative value to 0, once it reached -4 it meant that metrics.viewTop + delta would give me a value greater than 0. Once pos ends up greater than 0 you begin to start scrolling back down the page.

Before you start hitting the delta values that cause pos to be positive you have delta values that would cause pos to be negative, but pos is never allowed to be negative. That is why you would experience a short delay before the window started scrolling down again.