### PR TITLE
Fix field_image click handler

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -38,7 +38,8 @@ goog.require('goog.userAgent');
  * @param {number} width Width of the image.
  * @param {number} height Height of the image.
  * @param {string=} opt_alt Optional alt text for when block is collapsed.
- * @param {Function=} opt_onClick Optional function to be called when image is clicked
+ * @param {Function=} opt_onClick Optional function to be called when the image
+ *     is clicked.  If opt_onClick is defined, opt_alt must also be defined.
  * @extends {Blockly.Field}
  * @constructor
  */
@@ -92,6 +93,8 @@ Blockly.FieldImage.prototype.init = function() {
   // Configure the field to be transparent with respect to tooltips.
   this.setTooltip(this.sourceBlock_);
   Blockly.Tooltip.bindMouseEvents(this.imageElement_);
+
+  this.maybeAddClickHandler_();
 };
 
 /**
@@ -101,6 +104,19 @@ Blockly.FieldImage.prototype.dispose = function() {
   goog.dom.removeNode(this.fieldGroup_);
   this.fieldGroup_ = null;
   this.imageElement_ = null;
+};
+
+/**
+ * Bind events for a mouse down on the image, but only if a click handler has
+ * been defined.
+ * @private
+ */
+Blockly.FieldImage.prototype.maybeAddClickHandler_ = function() {
+  if (this.clickHandler_) {
+    this.mouseDownWrapper_ =
+        Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
+        this.onMouseDown_);
+  }
 };
 
 /**
@@ -171,8 +187,8 @@ Blockly.FieldImage.prototype.updateWidth = function() {
  * If field click is called, and click handler defined,
  * call the handler.
  */
- Blockly.FieldImage.prototype.showEditor = function() {
-   if (this.clickHandler_){
-     this.clickHandler_(this);
-   }
- };
+Blockly.FieldImage.prototype.showEditor_ = function() {
+  if (this.clickHandler_){
+    this.clickHandler_(this);
+  }
+};


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1263

### Proposed Changes

Fix the field_image click handler by registering an onMouseDown function for the field if the click handler is defined. 

Based on https://github.com/Microsoft/pxt-blockly/commit/2a1b39c130a7faeff4ffb0614310e899acfb1548

### Reason for Changes

Previously the click handler was defined and called from showEditor, but showEditor would not be called unless a gesture called it.  To do that the gesture needed to know if someone had clicked on the field.

### Test Coverage


Tested on:
- [ ] Desktop:
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  