### PR TITLE
Make dropdowns update correctly when you switch between images.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -462,6 +462,17 @@ Blockly.Field.prototype.setText = function(newText) {
     return;
   }
   this.text_ = newText;
+  this.forceRerender();
+};
+
+/**
+ * Force a rerender of the block that this field is installed on, which will
+ * rerender this field and adjust for any sizing changes.
+ * Other fields on the same block will not rerender, because their sizes have
+ * already been recorded.
+ * @package
+ */
+Blockly.Field.prototype.forceRerender = function() {
   // Set width to 0 to force a rerender of this field.
   this.size_.width = 0;
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -413,17 +413,20 @@ Blockly.FieldDropdown.prototype.setValue = function(newValue) {
       var content = options[i][0];
       if (typeof content == 'object') {
         this.imageJson_ = content;
-        this.setText(content.alt);
+        this.text_ = content.alt;
       } else {
         this.imageJson_ = null;
-        this.setText(content);
+        this.text_ = content;
       }
+      // Always rerender if either the value or the text has changed.
+      this.forceRerender();
       return;
     }
   }
   // Value not found.  Add it, maybe it will become valid once set
   // (like variable names).
-  this.setText(newValue);
+  this.text_ = newValue;
+  this.forceRerender();
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1047
and its dupes: https://github.com/google/blockly/issues/1232 and https://github.com/google/blockly/issues/1287

### Proposed Changes

Force a rerender of the parent block if the value of a dropdown changed, instead of only when the text changed.  The text of an image item in a dropdown is the alt-text.  If the developer didn't specify alt-text, the image wouldn't update.

### Reason for Changes

The previous behaviour was incorrect in a user-facing way.

### Test Coverage

Tested in the playground.

Tested on:
- [ ] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
