### PR TITLE
Add margin only for buttons, not labels

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -155,11 +155,11 @@ Blockly.FlyoutButton.prototype.createDom = function() {
       this.svgGroup_);
   svgText.textContent = this.text_;
 
-  this.width = svgText.getComputedTextLength() +
-      2 * Blockly.FlyoutButton.MARGIN;
+  this.width = svgText.getComputedTextLength();    
   this.height = 20;  // Can't compute it :(
 
   if (!this.isLabel_) {
+    this.width += 2 * Blockly.FlyoutButton.MARGIN;
     shadow.setAttribute('width', this.width);
     shadow.setAttribute('height', this.height);
   }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

### Proposed Changes

Buttons and text labels that appear in the flyout are both handled by flyout_button. Previously, a margin was being added to the width of both buttons and labels. This PR only applies the margin to buttons, and not to labels.

### Reason for Changes

Labels that appear in a horizontal flyout were too wide when they had the margin added. 
