### PR TITLE
Scale Firefox scrolling for mouse only, not trackpad

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -221,8 +221,9 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
   var delta = e.deltaX;
 
   if (delta) {
-    if (goog.userAgent.GECKO) {
-      // Firefox's deltas are a tenth that of Chrome/Safari.
+    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
+    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
+    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
       delta *= 10;
     }
     // TODO: #1093


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Only scale the scroll events in Firefox for the mouse wheel, not for trackpad scroll events.

### Reason for Changes

Previously, Blockly was applying a scale factor to all scroll events in Firefox. This scaling is correct for mouse wheels, but not for trackpad events. 
