### PR TITLE
Disable workspace resizing at the beginning of cleanup blocks and re-…

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1148,6 +1148,7 @@ Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
  * Clean up the workspace by ordering all the blocks in a column.
  */
 Blockly.WorkspaceSvg.prototype.cleanUp = function() {
+  this.setResizesEnabled(false);
   Blockly.Events.setGroup(true);
   var topBlocks = this.getTopBlocks(true);
   var cursorY = 0;
@@ -1159,8 +1160,7 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function() {
         block.getHeightWidth().height + Blockly.BlockSvg.MIN_BLOCK_Y;
   }
   Blockly.Events.setGroup(false);
-  // Fire an event to allow scrollbars to resize.
-  this.resizeContents();
+  this.setResizesEnabled(true);
 };
 
 /**


### PR DESCRIPTION
…enable at the end.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

### Proposed Changes
Stopping workspace resizes during cleanup removes a browser re-layout for every single block and just does it one time at the end of the batch.  setResizesEnabled was added a while ago for exactly this kind of batch operation so just putting it into use.

### Reason for Changes
Speed!
On my mac I ran the following test:
1. open playground
2. hit airstrike
3. hit airstrike again
4. run cleanup on workspace
5. hit airstrike again (there are now ~300 blocks on the workspace)
6. record in chrome perf developer tools tab
7. run cleanup blocks
8. stop recording

The numbers on my old macbook air
before: 1.5 seconds
after: 50ms

Screenshot of 1 block's timline before (notice the call to MoveBy followed by SnapToGrid which causes 4 angry red rectangles:
![screen shot 2017-09-20 at 12 34 45 pm](https://user-images.githubusercontent.com/15675877/30663720-7405f784-9e00-11e7-87e2-a52e6a2a8ed8.png)

And after. Now the dominant thing is javascript execution :):
![screen shot 2017-09-20 at 12 35 56 pm](https://user-images.githubusercontent.com/15675877/30663773-9e36d384-9e00-11e7-8728-77810a1939fc.png)



### Test Coverage

Tested on:
_Remove this hint: these checkboxes can be checked like this: [x]_
- [x] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
