### PR TITLE
Add Kabyle locale to code demo

### DIFF
--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -52,6 +52,7 @@ Code.LANGUAGE_NAME = {
   'is': 'Íslenska',
   'it': 'Italiano',
   'ja': '日本語',
+  'kab': 'Kabyle',
   'ko': '한국어',
   'mk': 'Македонски',
   'ms': 'Bahasa Melayu',


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #1265.

### Proposed Changes

Add Kabyle as an option in the dropdown in the code demo.

### Reason for Changes

In #1265 I said I'd add Kabyle to the hosted code demo on the next push to master.

### Test Coverage

I opened the code demo and selected Kabyle in the language dropdown.

Tested on:
- [X] Desktop:
  - [X] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information

This isn't live until the push to master.
