### PR TITLE
Correct bad Portuguese translation.

### DIFF
--- a/msg/json/pt.json
+++ b/msg/json/pt.json
@@ -67,7 +67,7 @@
 	"CONTROLS_WHILEUNTIL_TOOLTIP_WHILE": "Enquanto um valor for verdadeiro, então faça algumas instruções.",
 	"CONTROLS_WHILEUNTIL_TOOLTIP_UNTIL": "Enquanto um valor for falso, então faça algumas instruções.",
 	"CONTROLS_FOR_TOOLTIP": "Faz com que a variável \"%1\" assuma os valores desde o número inicial até ao número final, contando de acordo com o intervalo especificado e executa os blocos especificados.",
-	"CONTROLS_FOR_TITLE": "contar com %1 de %2 até %3 de %3 em %4",
+	"CONTROLS_FOR_TITLE": "contar com %1 de %2 até %3 por %4",
 	"CONTROLS_FOREACH_TITLE": "para cada item %1 na lista %2",
 	"CONTROLS_FOREACH_TOOLTIP": "Para cada item numa lista, define a variável \"%1\" para o item e então faz algumas instruções.",
 	"CONTROLS_FLOW_STATEMENTS_OPERATOR_BREAK": "sair do ciclo",


### PR DESCRIPTION
Corrects bad Portuguese translation with two `%3` references. This is identical to the Brazilian Portuguese message, verified by two native Portuguese.