### PR TITLE
Fix FieldTextInput showPromptEditor_

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -153,7 +153,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
  * Mobile browsers have issues with in-line textareas (focus and keyboards).
  * @private
  */
-Blockly.FieldTextInput.showPromptEditor_ = function() {
+Blockly.FieldTextInput.prototype.showPromptEditor_ = function() {
   var fieldText = this;
   Blockly.prompt(Blockly.Msg.CHANGE_VALUE_TITLE, this.text_,
     function(newValue) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

This is also cherry-picked into this month's release candidate.

## The details
### Resolves

https://github.com/google/blockly/issues/1348

### Proposed Changes

Put `showPromptEditor_` on the prototype.

### Reason for Changes

The previous code was a mistake from a cleanup PR.

### Test Coverage

Tested on:

- [x] Smartphone/Tablet/Chromebook:
  - Device: iPad 2
  - OS: iOS
  - Browser: Safari, Chrome
  - Version: 10.3.3
