### PR TITLE
Fix iOS toolbox flashing on tap

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -517,6 +517,7 @@ Blockly.Css.CONTENT = [
     'overflow-y: auto;',
     'position: absolute;',
     'z-index: 70;', /* so blocks go under toolbox when dragging */
+    '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
   '}',
 
   '.blocklyTreeRoot {',


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1345

### Proposed Changes

Use CSS to get rid of iOS's default tap higlight color on elements.

### Reason for Changes

Surfacing default browser mousedown events exposed this issue.

### Test Coverage

Tested on iOS
Doesn't do anything on other platforms.

Tested on:

- [x] Smartphone/Tablet/Chromebook 
  - Device: iPad 2
  - OS: iOS
  - Browser: Safari and Chrome
  - Version: 10.3.3
  
### Additional Information
This change was also cherry-picked into rc/sep_2017