### PR TITLE
Add option to ignore warnings on block redefines.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -372,15 +372,17 @@ Blockly.jsonInitFactory_ = function(jsonDef) {
  * Define blocks from an array of JSON block definitions, as might be generated
  * by the Blockly Developer Tools.
  * @param {!Array.<!Object>} jsonArray An array of JSON block definitions.
+ * @param {boolean} ignoreRedefinitions True if redefinitions of blocks should
+ *     not generate warnings. False by default.
  */
-Blockly.defineBlocksWithJsonArray = function(jsonArray) {
+Blockly.defineBlocksWithJsonArray = function(jsonArray, ignoreRedefinitions) {
   for (var i = 0, elem; elem = jsonArray[i]; i++) {
     var typename = elem.type;
     if (typename == null || typename === '') {
       console.warn('Block definition #' + i +
         ' in JSON array is missing a type attribute. Skipping.');
     } else {
-      if (Blockly.Blocks[typename]) {
+      if (!ignoreRedefinitions && Blockly.Blocks[typename]) {
         console.warn('Block definition #' + i +
           ' in JSON array overwrites prior definition of "' + typename + '".');
       }


### PR DESCRIPTION
Thanks for submitting code to Blockly!  Please fill out the following as part of your pull request so we can review your code more easily.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

I needed to redefine variables_get and variables_set to add a custom context menu. In doing so, I received warnings about redefining these blocks. This was exactly what I wanted to happen, so the warnings were superfluous.

### Proposed Changes

To suppress the warnings when redefinition is desired, I've added an option to `defineBlocksWithJsonArray`. By default the warning behavior is maintained.

### Reason for Changes

Warnings for desired behaviors might obscure more severe warnings. As much as possible we should keep our consoles clear of messages that don't contribute information to developers.

### Test Coverage

I haven't written any unit tests for this. I'm not sure how to test the presence of console output.

Tested on:
- [x] Desktop:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]