### PR TITLE
Block rendering performance

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -155,7 +155,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
       this.svgGroup_);
   svgText.textContent = this.text_;
 
-  this.width = svgText.getComputedTextLength();    
+  this.width = Blockly.Field.getCachedWidth(svgText);
   this.height = 20;  // Can't compute it :(
 
   if (!this.isLabel_) {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -248,7 +248,9 @@ Blockly.Tooltip.hide = function() {
       Blockly.Tooltip.DIV.style.display = 'none';
     }
   }
-  clearTimeout(Blockly.Tooltip.showPid_);
+  if (Blockly.Tooltip.showPid_) {
+    clearTimeout(Blockly.Tooltip.showPid_);
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

_What Github issue does this resolve (please include link)?_

Some minor performance improvements from https://github.com/LLK/scratch-blocks/pull/1141

### Proposed Changes

_Describe what this Pull Request does.  Include screenshots if applicable._

2 minor things:
- Check for the timeout pid before clearing it.
- Use the caching `getCachedWidth` from `Blockly.Field` instead of directly reading it from the DOM.
