### PR TITLE
Move some context menu options into contextmenu.js

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -586,35 +586,10 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = [];
 
   if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
-    // Option to duplicate this block.
-    var duplicateOption = {
-      text: Blockly.Msg.DUPLICATE_BLOCK,
-      enabled: true,
-      callback: function() {
-        Blockly.duplicate_(block);
-      }
-    };
-    if (this.getDescendants().length > this.workspace.remainingCapacity()) {
-      duplicateOption.enabled = false;
-    }
-    menuOptions.push(duplicateOption);
-
+    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
     if (this.isEditable() && !this.collapsed_ &&
         this.workspace.options.comments) {
-      // Option to add/remove a comment.
-      var commentOption = {enabled: !goog.userAgent.IE};
-      if (this.comment) {
-        commentOption.text = Blockly.Msg.REMOVE_COMMENT;
-        commentOption.callback = function() {
-          block.setCommentText(null);
-        };
-      } else {
-        commentOption.text = Blockly.Msg.ADD_COMMENT;
-        commentOption.callback = function() {
-          block.setCommentText('');
-        };
-      }
-      menuOptions.push(commentOption);
+      menuOptions.push(Blockly.ContextMenu.blockCommentOption(block));
     }
 
     // Option to make block inline.
@@ -669,35 +644,10 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
       menuOptions.push(disableOption);
     }
 
-    // Option to delete this block.
-    // Count the number of blocks that are nested in this block.
-    var descendantCount = this.getDescendants().length;
-    var nextBlock = this.getNextBlock();
-    if (nextBlock) {
-      // Blocks in the current stack would survive this block's deletion.
-      descendantCount -= nextBlock.getDescendants().length;
-    }
-    var deleteOption = {
-      text: descendantCount == 1 ? Blockly.Msg.DELETE_BLOCK :
-          Blockly.Msg.DELETE_X_BLOCKS.replace('%1', String(descendantCount)),
-      enabled: true,
-      callback: function() {
-        Blockly.Events.setGroup(true);
-        block.dispose(true, true);
-        Blockly.Events.setGroup(false);
-      }
-    };
-    menuOptions.push(deleteOption);
+    menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
   }
 
-  // Option to get help.
-  var url = goog.isFunction(this.helpUrl) ? this.helpUrl() : this.helpUrl;
-  var helpOption = {enabled: !!url};
-  helpOption.text = Blockly.Msg.HELP;
-  helpOption.callback = function() {
-    block.showHelp_();
-  };
-  menuOptions.push(helpOption);
+  menuOptions.push(Blockly.ContextMenu.blockHelpOption(block));
 
   // Allow the block to add or modify menuOptions.
   if (this.customContextMenu) {

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -201,3 +201,99 @@ Blockly.ContextMenu.callbackFactory = function(block, xml) {
     newBlock.select();
   };
 };
+
+// Helper functions for creating context menu options.
+
+/**
+ * Make a context menu option for deleting the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.blockDeleteOption = function(block) {
+  // Option to delete this block but not blocks lower in the stack.
+  // Count the number of blocks that are nested in this block.
+  var descendantCount = block.getDescendants(true).length;
+  var nextBlock = block.getNextBlock();
+  if (nextBlock) {
+    // Blocks in the current stack would survive this block's deletion.
+    descendantCount -= nextBlock.getDescendants(true).length;
+  }
+  var deleteOption = {
+    text: descendantCount == 1 ? Blockly.Msg.DELETE_BLOCK :
+        Blockly.Msg.DELETE_X_BLOCKS.replace('%1', String(descendantCount)),
+    enabled: true,
+    callback: function() {
+      Blockly.Events.setGroup(true);
+      block.dispose(true, true);
+      Blockly.Events.setGroup(false);
+    }
+  };
+  return deleteOption;
+};
+
+/**
+ * Make a context menu option for showing help for the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.blockHelpOption = function(block) {
+  var url = goog.isFunction(block.helpUrl) ? block.helpUrl() : block.helpUrl;
+  var helpOption = {
+    enabled: !!url,
+    text: Blockly.Msg.HELP,
+    callback: function() {
+      block.showHelp_();
+    }
+  };
+  return helpOption;
+};
+
+/**
+ * Make a context menu option for duplicating the current block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.blockDuplicateOption = function(block) {
+  var enabled = true;
+  if (block.getDescendants().length > block.workspace.remainingCapacity()) {
+    enabled = false;
+  }
+  var duplicateOption = {
+    text: Blockly.Msg.DUPLICATE_BLOCK,
+    enabled: enabled,
+    callback: function() {
+      Blockly.duplicate_(block);
+    }
+  };
+  return duplicateOption;
+};
+
+/**
+ * Make a context menu option for adding or removing comments on the current
+ * block.
+ * @param {!Blockly.BlockSvg} block The block where the right-click originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.blockCommentOption = function(block) {
+  var commentOption = {
+    enabled: !goog.userAgent.IE
+  };
+  // If there's already a comment, add an option to delete it.
+  if (block.comment) {
+    commentOption.text = Blockly.Msg.REMOVE_COMMENT;
+    commentOption.callback = function() {
+      block.setCommentText(null);
+    };
+  } else {
+    // If there's no comment, add an option to create a comment.
+    commentOption.text = Blockly.Msg.ADD_COMMENT;
+    commentOption.callback = function() {
+      block.setCommentText('');
+    };
+  }
+  return commentOption;
+};


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No issue, just cleanup.  Similar to https://github.com/LLK/scratch-blocks/pull/1139/files

### Proposed Changes

Creates helper functions for context menu options, and puts them in contextmenu.js.

### Reason for Changes

Readability.  `showContextMenu` is a monster of a function.

### Test Coverage

I checked that I can open up the context menu, that the options are still there, and that they do the same things as they did before.

### Additional Information

I'll be doing more of this in followup PRs.