### PR TITLE
Fix typo in mixin name

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -295,7 +295,7 @@ Blockly.Extensions.register('controls_forEach_tooltip',
  * @package
  * @readonly
  */
-Blockly.Constants.Loops.CONTROL_FLOW_CHECK_IN_LOOP_MIXIN = {
+Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
   /**
    * List of block types that are loops and thus do not need warnings.
    * To add a new loop type add this to your code:


### PR DESCRIPTION
Fixes #1366

There was a typo in the name of the loop check mixin. Fixes the immediate issue though we should post a warning if trying to register a mixin that doesn't exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1375)
<!-- Reviewable:end -->
