### PR TITLE
Don't check typeof == undefined in variable deserialization

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -498,7 +498,7 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
     var id = xmlChild.getAttribute('id');
     var name = xmlChild.textContent;
 
-    if (typeof(type) === undefined || type === null) {
+    if (type == null) {
       throw Error('Variable with id, ' + id + ' is without a type');
     }
     workspace.createVariable(name, type, id);
@@ -597,13 +597,11 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
             variable = workspace.createVariable(text, type,
               xmlChild.getAttribute(id));
           }
-          if (typeof(type) !== undefined && type !== null) {
-            if (type !== variable.type) {
-              throw Error('Serialized variable type with id \'' +
-                variable.getId() + '\' had type ' + variable.type + ', and ' +
-                'does not match variable field that references it: ' +
-                Blockly.Xml.domToText(xmlChild) + '.');
-            }
+          if (type != null && type !== variable.type) {
+            throw Error('Serialized variable type with id \'' +
+              variable.getId() + '\' had type ' + variable.type + ', and ' +
+              'does not match variable field that references it: ' +
+              Blockly.Xml.domToText(xmlChild) + '.');
           }
         }
         if (!field) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1368 
### Proposed Changes

Checks whether the type of a variable is null, but not whether `typeof(type == undefined)`.

### Reason for Changes

`typeof` can never return undefined.  See #1368.

### Test Coverage

Covered by variable tests and xml tests, which still pass after this change.
  
### Additional Information
N/A