### PR TITLE
Fix #1369 replaceMessageReferences(..)

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -281,11 +281,11 @@ Blockly.Extensions.registerMixin('contextMenu_newGetVariableBlock',
 
 Blockly.Extensions.register('controls_for_tooltip',
     Blockly.Extensions.buildTooltipWithFieldValue(
-        Blockly.Msg.CONTROLS_FOR_TOOLTIP, 'VAR'));
+        '%{BKY_CONTROLS_FOR_TOOLTIP}', 'VAR'));
 
 Blockly.Extensions.register('controls_forEach_tooltip',
     Blockly.Extensions.buildTooltipWithFieldValue(
-        Blockly.Msg.CONTROLS_FOREACH_TOOLTIP, 'VAR'));
+        '%{BKY_CONTROLS_FOREACH_TOOLTIP}', 'VAR'));
 
 /**
  * This mixin adds a check to make sure the 'controls_flow_statements' block

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -506,7 +506,7 @@ Blockly.Constants.Math.CHANGE_TOOLTIP_EXTENSION = function() {
 
 Blockly.Extensions.register('math_change_tooltip',
     Blockly.Extensions.buildTooltipWithFieldValue(
-        Blockly.Msg.MATH_CHANGE_TOOLTIP, 'VAR'));
+        '%{BKY_MATH_CHANGE_TOOLTIP}', 'VAR'));
 
 /**
  * Mixin with mutator methods to support alternate output based if the

--- a/tests/jsunit/utils_test.js
+++ b/tests/jsunit/utils_test.js
@@ -192,21 +192,12 @@ function test_tokenizeInterpolation() {
 function test_replaceMessageReferences() {
   Blockly.Msg = Blockly.Msg || {};
   Blockly.Msg.STRING_REF = 'test string';
+  Blockly.Msg.SUBREF = 'subref';
+  Blockly.Msg.STRING_REF_WITH_ARG = 'test %1 string';
+  Blockly.Msg.STRING_REF_WITH_SUBREF = 'test %{bky_subref} string';
 
   var resultString = Blockly.utils.replaceMessageReferences('');
   assertEquals('Empty string produces empty string', '', resultString);
-
-  resultString = Blockly.utils.replaceMessageReferences('%{bky_string_ref}');
-  assertEquals('Message ref dereferenced.', 'test string', resultString);
-  resultString = Blockly.utils.replaceMessageReferences('before %{bky_string_ref} after');
-  assertEquals('Message ref dereferenced.', 'before test string after', resultString);
-
-  resultString = Blockly.utils.replaceMessageReferences('%1');
-  assertEquals('Interpolation tokens ignored.', '%1', resultString);
-  resultString = Blockly.utils.replaceMessageReferences('%1 %2');
-  assertEquals('Interpolation tokens ignored.', '%1 %2', resultString);
-  resultString = Blockly.utils.replaceMessageReferences('before %1 after');
-  assertEquals('Interpolation tokens ignored.', 'before %1 after', resultString);
 
   resultString = Blockly.utils.replaceMessageReferences('%%');
   assertEquals('Escaped %', '%', resultString);
@@ -215,4 +206,29 @@ function test_replaceMessageReferences() {
 
   resultString = Blockly.utils.replaceMessageReferences('%a');
   assertEquals('Unrecognized % escape code treated as literal', '%a', resultString);
+
+  resultString = Blockly.utils.replaceMessageReferences('%1');
+  assertEquals('Interpolation tokens ignored.', '%1', resultString);
+  resultString = Blockly.utils.replaceMessageReferences('%1 %2');
+  assertEquals('Interpolation tokens ignored.', '%1 %2', resultString);
+  resultString = Blockly.utils.replaceMessageReferences('before %1 after');
+  assertEquals('Interpolation tokens ignored.', 'before %1 after', resultString);
+
+  // Blockly.Msg.STRING_REF cases:
+  resultString = Blockly.utils.replaceMessageReferences('%{bky_string_ref}');
+  assertEquals('Message ref dereferenced.', 'test string', resultString);
+  resultString = Blockly.utils.replaceMessageReferences('before %{bky_string_ref} after');
+  assertEquals('Message ref dereferenced.', 'before test string after', resultString);
+
+  // Blockly.Msg.STRING_REF_WITH_ARG cases:
+  resultString = Blockly.utils.replaceMessageReferences('%{bky_string_ref_with_arg}');
+  assertEquals('Message ref dereferenced with argument preserved.', 'test %1 string', resultString);
+  resultString = Blockly.utils.replaceMessageReferences('before %{bky_string_ref_with_arg} after');
+  assertEquals('Message ref dereferenced with argument preserved.', 'before test %1 string after', resultString);
+
+  // Blockly.Msg.STRING_REF_WITH_SUBREF cases:
+  resultString = Blockly.utils.replaceMessageReferences('%{bky_string_ref_with_subref}');
+  assertEquals('Message ref and subref dereferenced.', 'test subref string', resultString);
+  resultString = Blockly.utils.replaceMessageReferences('before %{bky_string_ref_with_subref} after');
+  assertEquals('Message ref and subref dereferenced.', 'before test subref string after', resultString);
 }


### PR DESCRIPTION
This fixes race condition in #1369 by using message references instead of explicit string lookups. This required fixing a bug the token interpolation parser that was breaking on the inner '"%1"' for these tooltips.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1369

### Proposed Changes

 * Uses message reference strings in the tooltip, replacing immediate lookups into the string table that might not be loaded yet.
 * Fixes `tokenizeInterpolation_(..)` recursion. Added additional tests.
 * Generalizes the reported errors from `checkMessageReferences(msg)`.

### Reason for Changes

Solves race condition.

### Test Coverage

Tested on:
_Remove this hint: these checkboxes can be checked like this: [x]_
- [ ] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
