### PR TITLE
Fix logic bugs related to `e1e9427`

### DIFF
--- a/core/events.js
+++ b/core/events.js
@@ -201,10 +201,15 @@ Blockly.Events.filter = function(queueIn, forward) {
            lastEvent.element == 'warningOpen')) {
         // Merge click events.
         lastEvent.newValue = event.newValue;
+      } else {
+        // Collision: newer events should merge into this event to maintain order
+        hash[key] = event;
+        mergedQueue.push(event);
       }
     }
   }
-  queue = mergedQueue;
+  // Filter out any events that have become null due to merging.
+  queue = mergedQueue.filter(function(e) { return !e.isNull(); });
   if (!forward) {
     // Restore undo order.
     queue.reverse();


### PR DESCRIPTION
Thanks for submitting code to Blockly!  Please fill out the following as part of your pull request so we can review your code more easily.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes #1373 

### Proposed Changes

_Describe what this Pull Request does.  Include screenshots if applicable._

This PR addresses #1373 by adding an else case in the event filter/merge mechanism to add events that collide with an existing hash but don't have paths for merging with existing events still get added to the event queue.

There is also a minor fix for an issue found with mutators where multiple move events are created and merged such that the resulting events are null, but still end up in the event queue and therefore the undo/redo stack. This causes UX problems because one may have to undo/redo twice.

### Reason for Changes

_Explain why these changes should be made.  Include screenshots if applicable._

This commit is made to address #1373 where events that collided based on the hashing algorithm resulted in events being dropped.

### Test Coverage

_Please show how you have added tests to cover your changes, or tell us how you tested it and on which platforms.  If it's plaform-agnostic you can delete these checkboxes._

Two tests were added to tests/jsunit/event_tests.js to test to ensure that the Scratch `stackclick` event doesn't get dropped following a `click` event and another to test that null events caused by merging are dropped.

Tested on:
- [x] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information

_Anything else we should know?_
