### PR TITLE
Test tokenizeInterpolation('Hello %1 World %2 again!')

### DIFF
--- a/tests/jsunit/utils_test.js
+++ b/tests/jsunit/utils_test.js
@@ -138,6 +138,9 @@ function test_tokenizeInterpolation() {
   tokens = Blockly.utils.tokenizeInterpolation('Hello %1 World');
   assertArrayEquals('Interpolation.', ['Hello ', 1, ' World'], tokens);
 
+  tokens = Blockly.utils.tokenizeInterpolation('Hello %1 World %2 again!');
+  assertArrayEquals('Interpolation.', ['Hello ', 1, ' World ', 2, ' again!'], tokens);
+
   tokens = Blockly.utils.tokenizeInterpolation('%123Hello%456World%789');
   assertArrayEquals('Interpolations.', [123, 'Hello', 456, 'World', 789], tokens);
 


### PR DESCRIPTION
Added a new case that should have reflected the error seen in #1397.