### PR TITLE
fix lint in field_angle.js

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -112,13 +112,13 @@ Blockly.FieldAngle.prototype.render_ = function() {
 
   // Update textElement.
   this.textElement_.textContent = this.getDisplayText_();
-  
+
   // Insert degree symbol.
   if (this.sourceBlock_.RTL) {
-     this.textElement_.insertBefore(this.symbol_, this.textElement_.firstChild);
-   } else {
-     this.textElement_.appendChild(this.symbol_);
-   }
+    this.textElement_.insertBefore(this.symbol_, this.textElement_.firstChild);
+  } else {
+    this.textElement_.appendChild(this.symbol_);
+  }
   this.updateWidth();
 };
 
@@ -174,11 +174,11 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   }, svg);
   this.gauge_ = Blockly.utils.createSvgElement('path',
       {'class': 'blocklyAngleGauge'}, svg);
-  this.line_ = Blockly.utils.createSvgElement('line',{
-      'x1': Blockly.FieldAngle.HALF,
-      'y1': Blockly.FieldAngle.HALF,
-      'class': 'blocklyAngleLine',
-     }, svg);
+  this.line_ = Blockly.utils.createSvgElement('line', {
+    'x1': Blockly.FieldAngle.HALF,
+    'y1': Blockly.FieldAngle.HALF,
+    'class': 'blocklyAngleLine'
+  }, svg);
   // Draw markers around the edge.
   for (var angle = 0; angle < 360; angle += 15) {
     Blockly.utils.createSvgElement('line', {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes the following lint errors:
```
/home/travis/build/google/blockly/core/field_angle.js
  118:6   error  Expected indentation of 4 space characters but found 5  indent
  119:4   error  Expected indentation of 2 space characters but found 3  indent
  120:6   error  Expected indentation of 4 space characters but found 5  indent
  121:4   error  Expected indentation of 2 space characters but found 3  indent
  178:7   error  Expected indentation of 4 space characters but found 6  indent
  179:7   error  Expected indentation of 4 space characters but found 6  indent
  180:7   error  Expected indentation of 4 space characters but found 6  indent
  180:34  error  Unexpected trailing comma                               comma-dangle
  181:6   error  Expected indentation of 2 space characters but found 5  indent
  320:2   error  Newline required at end of file but not found           eol-last
```
### Proposed Changes

Change indentation

### Reason for Changes

Fixing all lint errors so we can turn on linting on travis

### Test Coverage
Travis
 
### Additional Information

Failing travis build before: https://travis-ci.org/google/blockly/jobs/296488664