### PR TITLE
Check workspace.isDragging() instead of Blockly.dragMode_

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1458,7 +1458,7 @@ Blockly.BlockSvg.prototype.bumpNeighbours_ = function() {
   if (!this.workspace) {
     return;  // Deleted block.
   }
-  if (Blockly.dragMode_ != Blockly.DRAG_NONE) {
+  if (this.workspace.isDragging()) {
     return;  // Don't bump blocks during a drag.
   }
   var rootBlock = this.getRootBlock();


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1417

### Proposed Changes

Check `workspace.isDragging()` instead of `Blockly.dragMode_`.

### Reason for Changes

`bumpNeighbours_` was referring to a property that no longer exists:
https://github.com/google/blockly/blob/master/core/block_svg.js#L1495

### Test Coverage

Tested by disabling snapping on the playground and dragging an equals block to a repeat block, then verifying that the equals block was bumped.
  
### Additional Information

I missed this because snapping looked like bumping, as Neil mentioned in the bug report.