### PR TITLE
Get rid of highlighting when releasing the drag would delete instead of connecting

### DIFF
--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -171,6 +171,12 @@ Blockly.DraggedConnectionManager.prototype.update = function(dxy, deleteArea) {
       this.topBlock_.isDeletable();
   this.wouldDeleteBlock_ = wouldDelete && !wouldConnect;
 
+  // Get rid of highlighting so we don't sent mixed messages.
+  if (wouldDelete && this.closestConnection_) {
+    this.closestConnection_.unhighlight();
+    this.closestConnection_ = null;
+  }
+
   if (!this.wouldDeleteBlock_ && closestConnectionChanged &&
       this.closestConnection_) {
     this.addHighlighting_();


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1416

### Proposed Changes

Remove highlighting if releasing the drag would delete instead of connecting.

New behaviour, with all drags happening from the top-left corner of the repeat block.

![1c8e4fa1-da41-40fe-b8e3-e3bcc2d0890a](https://user-images.githubusercontent.com/13686399/32389619-81bf2db4-c088-11e7-9a5d-bbb6fef54653.gif)

### Reason for Changes

https://github.com/google/blockly/issues/1416

### Test Coverage

Tested in the playground (see gif)

### Additional Information
N/A