### PR TITLE
Serialize variable type as all-lowercase

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -340,7 +340,7 @@ Blockly.Variables.generateVariableFieldXml_ = function(variableModel) {
   // to be escaped to create valid XML.
   var element = goog.dom.createDom('field');
   element.setAttribute('name', 'VAR');
-  element.setAttribute('variableType', variableModel.type);
+  element.setAttribute('variabletype', variableModel.type);
   element.setAttribute('id', variableModel.getId());
   element.textContent = variableModel.name;
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -113,7 +113,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
         var variable = block.workspace.getVariable(field.getValue());
         if (variable) {
           container.setAttribute('id', variable.getId());
-          container.setAttribute('variableType', variable.type);
+          container.setAttribute('variabletype', variable.type);
         }
       }
       element.appendChild(container);
@@ -589,7 +589,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           // TODO (marisaleung): When we change setValue and getValue to
           // interact with IDs instead of names, update this so that we get
           // the variable based on ID instead of textContent.
-          var type = xmlChild.getAttribute('variableType') || '';
+          var type = xmlChild.getAttribute('variabletype') || '';
           var variable = workspace.getVariable(text);
           if (!variable) {
             variable = workspace.createVariable(text, type,

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -364,3 +364,28 @@ function test_variablesToDom_noVariables() {
   assertEquals(1, resultDom.children.length);
   xmlTest_tearDown();
 }
+
+function test_variableFieldXml_caseSensitive() {
+  var id = 'testId';
+  var type = 'testType';
+  var name = 'testName';
+
+  var mockVariableModel = {
+    type: type,
+    name: name,
+    getId: function() {
+      return id;
+    }
+  };
+
+  var generatedXml = Blockly.Variables.generateVariableFieldXml_(mockVariableModel);
+  // The field contains this XML tag as a result of how we're generating this
+  // XML.  This is not desirable, but the goal of this test is to make sure
+  // we're preserving case-sensitivity.
+  var xmlns = 'xmlns="http://www.w3.org/1999/xhtml"';
+  var goldenXml =
+      '<field ' + xmlns + ' name="VAR"' +
+      ' variabletype="' + type + '"' +
+      ' id="' + id + '">' + name + '</field>';
+  assertEquals(goldenXml, generatedXml);
+}

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -67,7 +67,7 @@ function xmlTest_setUpWithMockBlocks() {
         'name': 'VAR',
         'variable': 'item'
       }
-    ],
+    ]
   }]);
 }
 
@@ -91,7 +91,7 @@ function xmlTest_checkNonVariableField(fieldDom, name, text) {
   assertEquals(text, fieldDom.textContent);
   assertEquals(name, fieldDom.getAttribute('name'));
   assertNull(fieldDom.getAttribute('id'));
-  assertNull(fieldDom.getAttribute('variableType'));
+  assertNull(fieldDom.getAttribute('variabletype'));
 }
 
 /**
@@ -104,7 +104,7 @@ function xmlTest_checkNonVariableField(fieldDom, name, text) {
  */
 function xmlTest_checkVariableFieldDomValues(fieldDom, name, type, id, text) {
   assertEquals(name, fieldDom.getAttribute('name'));
-  assertEquals(type, fieldDom.getAttribute('variableType'));
+  assertEquals(type, fieldDom.getAttribute('variabletype'));
   assertEquals(id, fieldDom.getAttribute('id'));
   assertEquals(text, fieldDom.textContent);
 }
@@ -166,7 +166,7 @@ function test_domToWorkspace_VariablesAtTop() {
         '    <variable type="" id="id3">name3</variable>' +
         '  </variables>' +
         '  <block type="field_variable_test_block">' +
-        '    <field name="VAR" id="id3" variableType="">name3</field>' +
+        '    <field name="VAR" id="id3" variabletype="">name3</field>' +
         '  </block>' +
         '</xml>');
     Blockly.Xml.domToWorkspace(dom, workspace);
@@ -210,7 +210,7 @@ function test_domToWorkspace_VariablesAtTop_MissingType() {
         '    <variable id="id1">name1</variable>' +
         '  </variables>' +
         '  <block type="field_variable_test_block">' +
-        '    <field name="VAR" id="id1" variableType="">name3</field>' +
+        '    <field name="VAR" id="id1" variabletype="">name3</field>' +
         '  </block>' +
         '</xml>');
     Blockly.Xml.domToWorkspace(dom, workspace);
@@ -233,7 +233,7 @@ function test_domToWorkspace_VariablesAtTop_MismatchBlockType() {
         '    <variable type="type1" id="id1">name1</variable>' +
         '  </variables>' +
         '  <block type="field_variable_test_block">' +
-        '    <field name="VAR" id="id1" variableType="">name1</field>' +
+        '    <field name="VAR" id="id1" variabletype="">name1</field>' +
         '  </block>' +
         '</xml>');
     Blockly.Xml.domToWorkspace(dom, workspace);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/LLK/scratch-blocks/issues/1191

### Proposed Changes

Switch from `variableType` to `variabletype`.  
### Reason for Changes

We were losing case-sensitivity in serialization and didn't notice it.

This is because `goog.dom.createDom` uses the global `document` as the context, which means it creates HTML nodes.  Those are not case-sensitive.  Variables would be serialized with an all-lowercase type, and their type would never be successfully deserialized.

We didn't catch this before because all of the tests that would have covered it use Blockly.Xml.textToDom, which creates XML nodes and preserves case.

### Test Coverage
Added a test to xml_test.js to make sure that variables names, ids etc. have their case preserved.

Manually checked that I can serialized and deserialized a typed variable correctly.

Tested on:
- [x] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information

This fixes the current problem by switching to lowercase, but we need to do a broader audit of all of our uses of `goog.dom.createDom`.  This is a pattern that we use in a lot of places in core Blockly, and it's broken.