### PR TITLE
Use msg references in block JSON for text_charat

### DIFF
--- a/blocks/text.js
+++ b/blocks/text.js
@@ -190,11 +190,11 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_dropdown",
         "name": "WHERE",
-        "options": [[Blockly.Msg.TEXT_CHARAT_FROM_START, 'FROM_START'],
-            [Blockly.Msg.TEXT_CHARAT_FROM_END, 'FROM_END'],
-            [Blockly.Msg.TEXT_CHARAT_FIRST, 'FIRST'],
-            [Blockly.Msg.TEXT_CHARAT_LAST, 'LAST'],
-            [Blockly.Msg.TEXT_CHARAT_RANDOM, 'RANDOM']]
+        "options": [["%{BKY_TEXT_CHARAT_FROM_START}", "FROM_START"],
+            ["%{BKY_TEXT_CHARAT_FROM_END}", "FROM_END"],
+            ["%{BKY_TEXT_CHARAT_FIRST}", "FIRST"],
+            ["%{BKY_TEXT_CHARAT_LAST}", "LAST"],
+            ["%{BKY_TEXT_CHARAT_RANDOM}", "RANDOM"]]
       }
     ],
     "output": "String",


### PR DESCRIPTION
Fixes #1397 for blockly_compiled.js. Had forgotten to update the String refs to use %{} since they're in JSON now.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1426)
<!-- Reviewable:end -->
