### PR TITLE
No-regex-spaces

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -366,7 +366,7 @@ Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
     var oldCodeText;
     while (oldCodeText != codeText) {
       oldCodeText = codeText;
-      codeText = codeText.replace(/^((  )*)  /gm, '$1\0');
+      codeText = codeText.replace(/^(( {2})*) {2}/gm, '$1\0');
     }
     codeText = codeText.replace(/\0/g, this.INDENT);
     this.definitions_[desiredName] = codeText;


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Clean up the last piece of lint by using ` {2}` instead of `  ` in a regex.
### Reason for Changes

Application of the no-regex-spaces rule.

### Test Coverage
Tested by running through some of the generator tests with different values for Blockly.Python.INDENT and verifying that the correct substitutions were occurring.  Tested with four spaces, two spaces and `words` (random word instead of spaces, should be inserted once for every two spaces in the original code.)

### Additional Information
N/A