### PR TITLE
Change the cursor to a pointer if there is a click handler on the image

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -116,6 +116,10 @@ Blockly.FieldImage.prototype.maybeAddClickHandler_ = function() {
     this.mouseDownWrapper_ =
         Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
         this.onMouseDown_);
+    // Change the cursor to a pointer if there is a click handler on the image.
+    if (this.imageElement_) {
+      this.imageElement_.style.cursor = 'pointer';
+    }
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Blockly version of https://github.com/Microsoft/pxt-blockly/pull/64

### Reason for Changes

Make it clearer when a click handler exists.
