### PR TITLE
Better error reporting when the test XML fails to load.

### DIFF
--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -100,7 +100,7 @@ function loadXml() {
   }
   var xmlText = fetchFile(url);
   if (xmlText !== null) {
-    fromXml(xmlText);
+    fromXml(url, xmlText);
   }
 }
 
@@ -124,7 +124,11 @@ function fetchFile(xmlUrl) {
   return xmlHttp.responseText;
 }
 
-function fromXml(xmlText) {
+/**
+ * @param {string} filename The URL (or other name) of the XML, for reporting.
+ * @param {string} xmlText The actual XML text.
+ */
+function fromXml(filename, xmlText) {
   var output = document.getElementById('importExport');
   output.value = xmlText;
   output.scrollTop = 0;
@@ -132,11 +136,16 @@ function fromXml(xmlText) {
   demoWorkspace.clear();
   try {
     var xmlDoc = Blockly.Xml.textToDom(xmlText);
+    Blockly.Xml.domToWorkspace(xmlDoc, demoWorkspace);
   } catch (e) {
-    alert('Error parsing XML:\n' + e);
+    var msg = 'Error parsing XML: ' + filename + '\n\n\t' + e;
+    if (e.stack) {
+      msg += '\n\nSee console for stack trace details.'
+    }
+    console.error(e.stack ? e : msg);
+    alert(msg);
     return;
   }
-  Blockly.Xml.domToWorkspace(xmlDoc, demoWorkspace);
 }
 
 function setOutput(text) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1441

### Proposed Changes

Alerts the user to any loading errors.
Improves the alert message.

### Reason for Changes

Error #1442  in prior mutator correction was missed during testing. Prevent similar oversights.

### Test Coverage

Tested by running the test harness on the current error #1442.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
