### PR TITLE
Stop blocks from exploding.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -252,7 +252,7 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
     // Move this block up the DOM.  Keep track of x/y translations.
     var xy = this.getRelativeToSurfaceXY();
     this.workspace.getCanvas().appendChild(svgRoot);
-    svgRoot.setAttribute('transform', 'translate' + xy);
+    svgRoot.setAttribute('transform', 'translate(' + xy.x + ',' + xy.y + ')');
   }
 
   Blockly.Field.startCache();
@@ -383,7 +383,7 @@ Blockly.BlockSvg.prototype.moveDuringDrag = function(newLoc) {
   if (this.useDragSurface_) {
     this.workspace.blockDragSurface_.translateSurface(newLoc.x, newLoc.y);
   } else {
-    this.svgGroup_.translate_ = 'translate' + newLoc;
+    this.svgGroup_.translate_ = 'translate(' + newLoc.x + ',' + newLoc.y + ')';
     this.svgGroup_.setAttribute('transform',
         this.svgGroup_.translate_ + this.svgGroup_.skew_);
   }

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -189,7 +189,8 @@ Blockly.FlyoutButton.prototype.show = function() {
  * @private
  */
 Blockly.FlyoutButton.prototype.updateTransform_ = function() {
-  this.svgGroup_.setAttribute('transform', 'translate' + this.position_);
+  this.svgGroup_.setAttribute('transform',
+      'translate(' + this.position_.x + ',' + this.position_.y + ')');
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -705,7 +705,8 @@ Blockly.WorkspaceSvg.prototype.resetDragSurface = function() {
 
   var trans = this.workspaceDragSurface_.getSurfaceTranslation();
   this.workspaceDragSurface_.clearAndHide(this.svgGroup_);
-  var translation = 'translate' + trans + ' scale(' + this.scale + ')';
+  var translation = 'translate(' + trans.x + ',' + trans.y + ') ' +
+      'scale(' + this.scale + ')';
   this.svgBlockCanvas_.setAttribute('transform', translation);
   this.svgBubbleCanvas_.setAttribute('transform', translation);
 };


### PR DESCRIPTION
Uncompiled a goog.math.Coordinate toStrings as a nice “(1, 2)”, but
complied it toStrings as a useless “[object Object]”.  Fixes #1448.