### PR TITLE
Fix #1444 - broken mutator for text_charat

### DIFF
--- a/blocks/text.js
+++ b/blocks/text.js
@@ -806,7 +806,7 @@ Blockly.Constants.Text.TEXT_CHARAT_MUTATOR_MIXIN = {
    */
   mutationToDom: function() {
     var container = document.createElement('mutation');
-    var isAt = this.getInput('AT').type == Blockly.INPUT_VALUE;
+    var isAt = !!this.isAt_; // coerce to boolean
     container.setAttribute('at', isAt);
     return container;
   },


### PR DESCRIPTION
There might no longer be an input named AT on a text_charat block
which the mutator had been depending on. There is now a boolean on
the block for isAt, though, so use that directly instead.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1444 

### Test Coverage

_Please show how you have added tests to cover your changes, or tell us how you tested it and on which platforms.  If it's plaform-agnostic you can delete these checkboxes._

Tested on:
_Remove this hint: these checkboxes can be checked like this: [x]_
- [x] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information

_Anything else we should know?_
