### PR TITLE
Call forceRerender instead of setText

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1032,9 +1032,10 @@ Blockly.BlockSvg.prototype.updateColour = function() {
   }
 
   // Bump every dropdown to change its colour.
+  // TODO (#1456)
   for (var x = 0, input; input = this.inputList[x]; x++) {
     for (var y = 0, field; field = input.fieldRow[y]; y++) {
-      field.setText(null);
+      field.forceRerender();
     }
   }
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -115,10 +115,8 @@ Blockly.FieldDropdown.prototype.init = function() {
       ' ' + Blockly.FieldDropdown.ARROW_CHAR));
 
   Blockly.FieldDropdown.superClass_.init.call(this);
-  // Force a reset of the text to add the arrow.
-  var text = this.text_;
-  this.text_ = null;
-  this.setText(text);
+  // Make sure the arrow gets rendered.
+  this.forceRerender();
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None

### Proposed Changes

Call `forceRerender` instead of `setText` to make a field rerender.

### Reason for Changes

Mixing up rendering and model changes caused problems when trying to make dropdowns and variables distinguish between `setText` and `setValue`.

### Test Coverage

I can render all blocks in the playground correctly.  JSUnit tests still pass.

Tested on:
- [x] Desktop:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE
- [ ] Smartphone/Tablet/Chromebook 
