### PR TITLE
Comment disposal; tests; tracking in a database

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -62,6 +62,11 @@ Blockly.Workspace = function(opt_options) {
    */
   this.topComments_ = [];
   /**
+   * @type {!Object}
+   * @private
+   */
+  this.commentDB_ = Object.create(null);
+  /**
    * @type {!Array.<!Function>}
    * @private
    */
@@ -179,6 +184,7 @@ Blockly.Workspace.prototype.getTopBlocks = function(ordered) {
 /**
  * Add a comment to the list of top comments.
  * @param {!Blockly.WorkspaceComment} comment comment to add.
+ * @package
  */
 Blockly.Workspace.prototype.addTopComment = function(comment) {
   this.topComments_.push(comment);
@@ -187,6 +193,7 @@ Blockly.Workspace.prototype.addTopComment = function(comment) {
 /**
  * Remove a comment from the list of top comments.
  * @param {!Blockly.WorkspaceComment} comment comment to remove.
+ * @package
  */
 Blockly.Workspace.prototype.removeTopComment = function(comment) {
   if (!goog.array.remove(this.topComments_, comment)) {
@@ -199,6 +206,7 @@ Blockly.Workspace.prototype.removeTopComment = function(comment) {
  * by position; top to bottom (with slight LTR or RTL bias).
  * @param {boolean} ordered Sort the list if true.
  * @return {!Array.<!Blockly.WorkspaceComment>} The top-level comment objects.
+ * @package
  */
 Blockly.Workspace.prototype.getTopComments = function(ordered) {
   // Copy the topComments_ list.
@@ -230,7 +238,7 @@ Blockly.Workspace.prototype.getAllBlocks = function() {
 };
 
 /**
- * Dispose of all blocks in workspace.
+ * Dispose of all blocks and comments in workspace.
  */
 Blockly.Workspace.prototype.clear = function() {
   var existingGroup = Blockly.Events.getGroup();
@@ -239,6 +247,9 @@ Blockly.Workspace.prototype.clear = function() {
   }
   while (this.topBlocks_.length) {
     this.topBlocks_[0].dispose();
+  }
+  while (this.topComments_.length) {
+    this.topComments_[this.topComments_.length - 1].dispose();
   }
   if (!existingGroup) {
     Blockly.Events.setGroup(false);
@@ -509,6 +520,17 @@ Blockly.Workspace.prototype.newBlock = function(prototypeName, opt_id) {
 };
 
 /**
+ * Obtain a newly created comment.
+ * @param {?string} content Content of the comment
+ * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
+ *     create a new ID.
+ * @return {!Blockly.WorkspaceComment} The created comment.
+ */
+Blockly.Workspace.prototype.newComment = function(content, opt_id) {
+  return new Blockly.WorkspaceComment(this, content, opt_id);
+};
+
+/**
  * The number of blocks that may be added to the workspace before reaching
  *     the maxBlocks.
  * @return {number} Number of blocks left.
@@ -605,6 +627,35 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
  */
 Blockly.Workspace.prototype.getBlockById = function(id) {
   return this.blockDB_[id] || null;
+};
+
+/**
+ * Find the comment on this workspace with the specified ID.
+ * @param {string} id ID of comment to find.
+ * @return {Blockly.WorkspaceComment} The sought after comment or null if not
+ *     found.
+ * @package
+ */
+Blockly.Workspace.prototype.getCommentById = function(id) {
+  return this.commentDB_[id] || null;
+};
+
+/**
+ * Add the comment to the comment database.
+ * @param {Blockly.WorkspaceComment} comment The comment to add.
+ * @package
+ */
+Blockly.Workspace.prototype.addCommentById = function(comment) {
+  this.commentDB_[comment.id] = comment;
+};
+
+/**
+ * Remove the comment from the comment database.
+ * @param {string} id The id of the comment to remove.
+ * @package
+ */
+Blockly.Workspace.prototype.removeCommentById = function(id) {
+  delete this.commentDB_[id];
 };
 
 /**

--- a/core/workspace_comment/workspace_comment.js
+++ b/core/workspace_comment/workspace_comment.js
@@ -37,7 +37,11 @@ goog.provide('Blockly.WorkspaceComment');
 Blockly.WorkspaceComment = function(workspace, content, opt_id) {
   console.log('New workspace comment!');
   /** @type {string} */
-  this.id = opt_id;
+  this.id = (opt_id && !workspace.getCommentById(opt_id)) ?
+      opt_id : Blockly.utils.genUid();
+
+  workspace.addCommentById(this);
+  workspace.addTopComment(this);
 
   /**
    * The comment's position in workspace units.  (0, 0) is at the workspace's
@@ -49,10 +53,30 @@ Blockly.WorkspaceComment = function(workspace, content, opt_id) {
 
   /** @type {!Blockly.Workspace} */
   this.workspace = workspace;
-  
+
   /** @type {!string} */
   this.content = content;
 };
+
+/**
+ * Dispose of this comment.
+ * @public
+ */
+Blockly.WorkspaceComment.prototype.dispose = function() {
+  if (!this.workspace) {
+    // The comment has already been deleted.
+    return;
+  }
+
+  // TODO: Fire an event for deletion.
+
+  // Remove from the list of top comments.
+  this.workspace.removeTopComment(this);
+  // Remove from the comment DB.
+  this.workspace.removeCommentById(this.id);
+  this.workspace = null;
+};
+
 
 /**
  * Return the coordinates of the top-left corner of this comment relative to the

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -58,6 +58,20 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width, opt_id
       workspace, content, opt_id);
 }; goog.inherits(Blockly.WorkspaceCommentSvg, Blockly.WorkspaceComment);
 
+/**
+ * Dispose of this comment.
+ * @public
+ */
+Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
+  if (!this.workspace) {
+    // The comment has already been deleted.
+    return;
+  }
+
+  // TODO: Delete any SVG elements.
+
+  Blockly.WorkspaceCommentSvg.superClass_.dispose.call(this);
+};
 
 /**
  * Create and initialize the SVG representation of a workspace comment.

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -87,6 +87,7 @@ Blockly.WorkspaceCommentSvg.prototype.initSvg = function() {
  * @param {number} dy Vertical offset, in workspace units.
  */
 Blockly.WorkspaceCommentSvg.prototype.moveBy = function(dx, dy) {
+  console.log('unimplemented: move by ' + dx + ', ' + dy);
   // Move comment by
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -493,7 +493,7 @@ Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
  * @param {?string} w Width of the comment
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
- * @return {!Blockly.BlockSvg} The created comment.
+ * @return {!Blockly.WorkspaceCommentSvg} The created comment.
  */
 Blockly.WorkspaceSvg.prototype.newComment = function(content, h, w, opt_id) {
   return new Blockly.WorkspaceCommentSvg(this, content, h, w, opt_id);

--- a/core/xml.js
+++ b/core/xml.js
@@ -234,6 +234,9 @@ Blockly.Xml.commentToDom = function(comment, opt_noId) {
   var commentElement = goog.dom.createDom('comment');
   commentElement.setAttribute('h', comment.getHeight());
   commentElement.setAttribute('w', comment.getWidth());
+  if (!opt_noId) {
+    commentElement.setAttribute('id', comment.id);
+  }
   commentElement.textContent = comment.content;
   return commentElement;
 };

--- a/tests/jsunit/index.html
+++ b/tests/jsunit/index.html
@@ -26,6 +26,7 @@
     <script src="variable_map_test.js"></script>
     <script src="variable_model_test.js"></script>
     <script src="widget_div_test.js"></script>
+    <script src="workspace_comment_test.js"></script>
     <script src="workspace_test.js"></script>
     <script src="workspace_undo_redo_test.js"></script>
     <script src="xml_test.js"></script>

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -72,3 +72,15 @@ function test_getWorkspaceCommentById() {
     workspaceCommentTest_tearDown();
   }
 }
+
+function test_disposeWsCommentTwice() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment = workspace.newComment('comment text', 'comment id');
+    comment.dispose();
+    // Nothing should go wrong the second time dispose is called.
+    comment.dispose();
+  }finally {
+    workspaceCommentTest_tearDown();
+  }
+}

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2017 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+goog.require('goog.testing');
+
+var workspace;
+
+function workspaceCommentTest_setUp() {
+  workspace = new Blockly.Workspace();
+}
+
+function workspaceCommentTest_tearDown() {
+  workspace.dispose();
+}
+
+function test_noWorkspaceComments() {
+  workspaceCommentTest_setUp();
+  try {
+    assertEquals('Empty workspace: no comments (1).', 0, workspace.getTopComments(true).length);
+    assertEquals('Empty workspace: no comments (2).', 0, workspace.getTopComments(false).length);
+    workspace.clear();
+    assertEquals('Empty workspace: no comments (3).', 0, workspace.getTopComments(true).length);
+    assertEquals('Empty workspace: no comments (4).', 0, workspace.getTopComments(false).length);
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_oneWorkspaceComment() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment = workspace.newComment('comment text', 'comment id');
+    assertEquals('One comment on workspace (1).', 1, workspace.getTopComments(true).length);
+    assertEquals('One comment on workspace  (2).', 1, workspace.getTopComments(false).length);
+    assertEquals('Comment db contains this comment.', comment, workspace.commentDB_['comment id']);
+    workspace.clear();
+    assertEquals('Cleared workspace: no comments (3).', 0, workspace.getTopComments(true).length);
+    assertEquals('Cleared workspace: no comments (4).', 0, workspace.getTopComments(false).length);
+    assertFalse('Comment DB does not contain this comment.', 'comment id' in workspace.commentDB_);
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_getWorkspaceCommentById() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment = workspace.newComment('comment text', 'comment id');
+    assertEquals('Getting a comment by id.', comment, workspace.getCommentById('comment id'));
+    assertEquals('No comment found.', null, workspace.getCommentById('not a comment'));
+    comment.dispose();
+    assertEquals('Can\'t find the comment.', null, workspace.getCommentById('comment id'));
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}


### PR DESCRIPTION
Add a `commentDB_` property to the workspace to track comments by ID.  Use it.

Implement comment disposal.

Add basic tests for comments on the workspace.