### PR TITLE
Switch to parentNode for IE

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -664,7 +664,7 @@ Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
       this.cachedParentSvg_ = element;
       return element;
     }
-    element = element.parentElement;
+    element = element.parentNode;
   }
   return null;
 };


### PR DESCRIPTION
In IE11 parentElement is undefined for SVG elements whereas element.parentNode is defined.