### PR TITLE
Gesture code for dragging comments

### DIFF
--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -33,6 +33,8 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   this.setPath_(this.getHeight(), this.getWidth());
 
   // Add text area
+  // TODO: Does this need to happen every time?  Or are we orphaning foreign
+  // elements in the code?
   this.createEditor_();
   this.svgGroup_.appendChild(this.foreignObject_);
 

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -71,6 +71,10 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
 
   Blockly.WorkspaceCommentSvg.superClass_.constructor.call(this,
       workspace, content, opt_id);
+
+  this.render();
+  Blockly.bindEventWithChecks_(this.svgPath_, 'mousedown', this,
+                   this.pathMouseDown_);
 }; goog.inherits(Blockly.WorkspaceCommentSvg, Blockly.WorkspaceComment);
 
 /**
@@ -106,6 +110,18 @@ Blockly.WorkspaceCommentSvg.prototype.initSvg = function() {
 
   if (!this.getSvgRoot().parentNode) {
     this.workspace.getCanvas().appendChild(this.getSvgRoot());
+  }
+};
+
+/**
+ * Handle a mouse-down on an SVG comment.
+ * @param {!Event} e Mouse down event or touch start event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.pathMouseDown_ = function(e) {
+  var gesture = this.workspace.getGesture(e);
+  if (gesture) {
+    gesture.handleCommentStart(e, this);
   }
 };
 


### PR DESCRIPTION
Adds a bunch of code in gesture.js for dragging comments.

Most of it is a direct duplication of the code for dragging blocks.  If it remains similar I'll come up with a name for a "draggable thing" and combine the code.

@microsoftsam