### PR TITLE
Workspace comment highlighting

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -189,7 +189,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyResizeLine {',
-    'stroke: #888;',
+    'stroke: #515A5A;',
     'stroke-width: 1;',
   '}',
 
@@ -377,19 +377,40 @@ Blockly.Css.CONTENT = [
     'padding: 0;',
   '}',
 
-  '.blocklyCommentPath {',
-    'fill: #fef49c;',
+  '.blocklyCommentForeignObject {',
+    'position: relative;',
+    'z-index: 0;',
+  '}',
+  
+  '.blocklyCommentRect {',
+    'fill: #E7DE8E;',
     'stroke: #bcA903;',
-    'stroke-width: 10;',
+    'stroke-width: 1px',
+  '}',
+  
+  '.blocklyCommentTarget {',
+    'fill: transparent;',
+    'stroke: #bcA903;',
+  '}',
+
+  '.blocklyFocused>.blocklyCommentRect {',
+    'fill: #B9B272;',
+    'stroke: #B9B272;',
+  '}',
+
+  '.blocklySelected>.blocklyCommentTarget {',
+    'stroke: #fc3;',
+    'stroke-width: 3px;',
   '}',
 
   '.blocklyCommentTextarea {',
     'background-color: #fef49c;',
     'border: 0;',
     'margin: 0;',
-    'padding: 2px;',
+    'padding: 3px;',
     'resize: none;',
     'outline: none;',
+    'display: inline-table;',
   '}',
 
   '.blocklyHtmlInput {',

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -739,7 +739,6 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function() {
  * @private
  */
 Blockly.Gesture.prototype.doCommentClick_ = function() {
-  //this.startComment_.select();
   this.startComment_.setFocus();
 };
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -742,7 +742,6 @@ Blockly.Gesture.prototype.doCommentClick_ = function() {
   this.startComment_.setFocus();
 };
 
-
 /* End functions defining what actions to take to execute clicks on each type
  * of target. */
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -500,6 +500,9 @@ Blockly.Gesture.prototype.doStart = function(e) {
   if (this.targetBlock_) {
     this.targetBlock_.select();
   }
+  if (this.startComment_) {
+    this.startComment_.select();
+  }
 
   // TODO: Select the start comment.
 
@@ -573,6 +576,8 @@ Blockly.Gesture.prototype.handleUp = function(e) {
     this.doBlockClick_();
   } else if (this.isWorkspaceClick_()) {
     this.doWorkspaceClick_();
+  } else if (this.isCommentClick_()) {
+    this.doCommentClick_();
   }
 
   e.preventDefault();
@@ -729,6 +734,16 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function() {
   }
 };
 
+/**
+ * Execute a comment click.
+ * @private
+ */
+Blockly.Gesture.prototype.doCommentClick_ = function() {
+  //this.startComment_.select();
+  this.startComment_.setFocus();
+};
+
+
 /* End functions defining what actions to take to execute clicks on each type
  * of target. */
 
@@ -866,8 +881,20 @@ Blockly.Gesture.prototype.isFieldClick_ = function() {
  * @private
  */
 Blockly.Gesture.prototype.isWorkspaceClick_ = function() {
-  var onlyTouchedWorkspace = !this.startBlock_ && !this.startField_;
+  var onlyTouchedWorkspace = !this.startBlock_ && !this.startComment_ && !this.startField_;
   return onlyTouchedWorkspace && !this.hasExceededDragRadius_;
+};
+
+/**
+ * Whether this gesture is a click on a comment.  This should only be called
+ * when ending a gesture (mouse up, touch end).
+ * @return {boolean} whether this gesture was a click on a workspace.
+ * @private
+ */
+Blockly.Gesture.prototype.isCommentClick_ = function() {
+  // A comment click starts on a comment, never escapes the drag radius
+  var hasStartComment = !!this.startComment_;
+  return hasStartComment && !this.hasExceededDragRadius_;
 };
 
 /* End helper functions defining types of clicks. */

--- a/core/workspace_comment/workspace_comment.js
+++ b/core/workspace_comment/workspace_comment.js
@@ -56,6 +56,18 @@ Blockly.WorkspaceComment = function(workspace, content, opt_id) {
   /** @type {boolean} */
   this.RTL = workspace.RTL;
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.deletable_ = true;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.movable_ = true;
+
   /** @type {!string} */
   this.content_ = content;
 };
@@ -97,6 +109,40 @@ Blockly.WorkspaceComment.prototype.getRelativeToSurfaceXY = function() {
 Blockly.WorkspaceComment.prototype.moveBy = function(dx, dy) {
   // TODO: Fire an event for move
   this.xy_.translate(dx, dy);
+};
+
+/**
+ * Get whether this comment is deletable or not.
+ * @return {boolean} True if deletable.
+ */
+Blockly.WorkspaceComment.prototype.isDeletable = function() {
+  return this.deletable_ &&
+      !(this.workspace && this.workspace.options.readOnly);
+};
+
+/**
+ * Set whether this comment is deletable or not.
+ * @param {boolean} deletable True if deletable.
+ */
+Blockly.WorkspaceComment.prototype.setDeletable = function(deletable) {
+  this.deletable_ = deletable;
+};
+
+/**
+ * Get whether this comment is movable or not.
+ * @return {boolean} True if movable.
+ */
+Blockly.WorkspaceComment.prototype.isMovable = function() {
+  return this.movable_ &&
+      !(this.workspace && this.workspace.options.readOnly);
+};
+
+/**
+ * Set whether this comment is movable or not.
+ * @param {boolean} movable True if movable.
+ */
+Blockly.WorkspaceComment.prototype.setMovable = function(movable) {
+  this.movable_ = movable;
 };
 
 /**

--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -67,7 +67,9 @@ Blockly.WorkspaceCommentSvg.prototype.getHeightWidth = function() {
 };
 
 Blockly.WorkspaceCommentSvg.prototype.render = function() {
-  if (this.rendered_) return;
+  if (this.rendered_) {
+    return;
+  }
 
   var size = this.getHeightWidth();
 

--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -30,23 +30,46 @@ goog.require('Blockly.WorkspaceCommentSvg');
 
 
 /**
- * Width of the border around the text area.
+ * Size of the resize icon.
  * @type {number}
  * @const
  */
-Blockly.WorkspaceCommentSvg.BORDER_WIDTH = 10;
+Blockly.WorkspaceCommentSvg.RESIZE_SIZE = 8;
+
+/**
+ * Radius of the border around the comment.
+ * @type {number}
+ * @const
+ */
+Blockly.WorkspaceCommentSvg.BORDER_RADIUS = 3;
 
 /**
  * Offset from the foreignobject edge to the textarea edge.
  * @type {number}
  * @const
  */
-Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET = 4;
+Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET = 2;
+
+/**
+ * Offset from the top to make room for a top bar.
+ * @type {number}
+ * @const
+ */
+Blockly.WorkspaceCommentSvg.TOP_OFFSET = 10;
+
+/**
+ * Returns a bounding box describing the dimensions of this comment.
+ * @return {!{height: number, width: number}} Object with height and width
+ *    properties in workspace units.
+ */
+Blockly.WorkspaceCommentSvg.prototype.getHeightWidth = function() {
+  return { width: this.getWidth(), height: this.getHeight() };
+};
 
 Blockly.WorkspaceCommentSvg.prototype.render = function() {
-  this.rendered_ = true;
+  if (this.rendered_) return;
 
-  this.setPath_(this.getHeight(), this.getWidth());
+  var size = this.getHeightWidth();
 
   // Add text area
   // TODO: Does this need to happen every time?  Or are we orphaning foreign
@@ -54,38 +77,26 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   this.createEditor_();
   this.svgGroup_.appendChild(this.foreignObject_);
 
-  var borderWidth = Blockly.WorkspaceCommentSvg.BORDER_WIDTH;
-  var textOffset = borderWidth + Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET;
+  this.svgRectTarget_ = Blockly.utils.createSvgElement('rect',
+    {'class': 'blocklyCommentTarget', 'x': 0, 'y': 0,
+    'rx': Blockly.WorkspaceCommentSvg.BORDER_RADIUS,
+    'ry': Blockly.WorkspaceCommentSvg.BORDER_RADIUS});
+  this.svgGroup_.appendChild(this.svgRectTarget_);
 
-  this.foreignObject_.setAttribute('width',
-      this.getWidth() - borderWidth);
-  this.foreignObject_.setAttribute('height',
-      this.getHeight() - borderWidth);
-  this.textarea_.style.width =
-      (this.getWidth() - textOffset) + 'px';
-  this.textarea_.style.height =
-      (this.getHeight() - textOffset) + 'px';
+  // Add the resize icon
+  this.addResizeDom_();
+
+  this.setSize_(size.width, size.height);
 
   // Set the content
   this.textarea_.value = this.content_;
-};
 
-/**
- * Set the path of the comment outline.
- * @param {number} height Height of the container.
- * @param {number} width Width of the container.
- * @private
- */
-Blockly.WorkspaceCommentSvg.prototype.setPath_ = function(height, width) {
-  var steps = [];
-  steps.push('m 0,0');
-  steps.push('H', width);
-  steps.push('v', height);
-  steps.push('H 0');
-  steps.push('z');
+  this.rendered_ = true;
 
-  var pathString = steps.join(' ');
-  this.svgPath_.setAttribute('d', pathString);
+  if (this.resizeGroup_) {
+    Blockly.bindEventWithChecks_(this.resizeGroup_, 'mousedown', this,
+      this.resizeMouseDown_);
+  }
 };
 
 /**
@@ -95,7 +106,7 @@ Blockly.WorkspaceCommentSvg.prototype.setPath_ = function(height, width) {
  */
 Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   /* Create the editor.  Here's the markup that will be generated:
-    <foreignObject x="8" y="8" width="164" height="164">
+    <foreignObject class="blocklyCommentForeignObject" x="0" y="10" width="164" height="164">
       <body xmlns="http://www.w3.org/1999/xhtml" class="blocklyMinimalBody">
         <textarea xmlns="http://www.w3.org/1999/xhtml"
             class="blocklyCommentTextarea"
@@ -104,8 +115,9 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
     </foreignObject>
   */
   this.foreignObject_ = Blockly.utils.createSvgElement('foreignObject',
-      {'x': Blockly.WorkspaceCommentSvg.BORDER_WIDTH / 2,
-       'y': Blockly.WorkspaceCommentSvg.BORDER_WIDTH / 2},
+      {'x': 0,
+       'y': Blockly.WorkspaceCommentSvg.TOP_OFFSET,
+       'class': 'blocklyCommentForeignObject'},
       null);
   var body = document.createElementNS(Blockly.HTML_NS, 'body');
   body.setAttribute('xmlns', Blockly.HTML_NS);
@@ -129,8 +141,196 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
       this.content_ = textarea.value;
     }
   });
+  return this.foreignObject_;
+};
+
+/**
+ * Add the resize icon to the DOM
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
+  this.resizeGroup_ = Blockly.utils.createSvgElement('g',
+    {
+      'class': this.RTL ?
+        'blocklyResizeSW' : 'blocklyResizeSE'
+    },
+    this.svgGroup_);
+  var resizeSize = Blockly.WorkspaceCommentSvg.RESIZE_SIZE;
+  Blockly.utils.createSvgElement('polygon',
+    { 'points': '0,x x,x x,0'.replace(/x/g, resizeSize.toString()) },
+    this.resizeGroup_);
+  Blockly.utils.createSvgElement('line',
+    {
+      'class': 'blocklyResizeLine',
+      'x1': resizeSize / 3, 'y1': resizeSize - 1,
+      'x2': resizeSize - 1, 'y2': resizeSize / 3
+    }, this.resizeGroup_);
+  Blockly.utils.createSvgElement('line',
+    {
+      'class': 'blocklyResizeLine',
+      'x1': resizeSize * 2 / 3, 'y1': resizeSize - 1,
+      'x2': resizeSize - 1, 'y2': resizeSize * 2 / 3
+    }, this.resizeGroup_);
+};
+
+/**
+ * Handle a mouse-down on comment's resize corner.
+ * @param {!Event} e Mouse down event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
+  //this.promote_();
+  this.unbindDragEvents_();
+  if (Blockly.utils.isRightButton(e)) {
+    // No right-click.
+    e.stopPropagation();
+    return;
+  }
+  // Left-click (or middle click)
+  this.workspace.startDrag(e, new goog.math.Coordinate(
+    this.workspace.RTL ? -this.width_ : this.width_, this.height_));
+
+  this.onMouseUpWrapper_ = Blockly.bindEventWithChecks_(document,
+    'mouseup', this, this.resizeMouseUp_);
+  this.onMouseMoveWrapper_ = Blockly.bindEventWithChecks_(document,
+    'mousemove', this, this.resizeMouseMove_);
+  Blockly.hideChaff();
+  // This event has been handled.  No need to bubble up to the document.
+  e.stopPropagation();
+};
+
+/**
+ * Stop binding to the global mouseup and mousemove events.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.unbindDragEvents_ = function() {
+  if (this.onMouseUpWrapper_) {
+    Blockly.unbindEvent_(this.onMouseUpWrapper_);
+    this.onMouseUpWrapper_ = null;
+  }
+  if (this.onMouseMoveWrapper_) {
+    Blockly.unbindEvent_(this.onMouseMoveWrapper_);
+    this.onMouseMoveWrapper_ = null;
+  }
+};
+
+/*
+ * Handle a mouse-up event while dragging a comment's border or resize handle.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.resizeMouseUp_ = function(/*e*/) {
+  Blockly.Touch.clearTouchIdentifier();
+  this.unbindDragEvents_();
+};
+
+/**
+ * Resize this comment to follow the mouse.
+ * @param {!Event} e Mouse move event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.resizeMouseMove_ = function(e) {
+  this.autoLayout_ = false;
+  var newXY = this.workspace.moveDrag(e);
+  this.setSize_(this.RTL ? -newXY.x : newXY.x, newXY.y);
+};
+
+/**
+ * Callback function triggered when the comment has resized.
+ * Resize the text area accordingly.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.resizeComment_ = function() {
+  var size = this.getHeightWidth();
+  var topOffset = Blockly.WorkspaceCommentSvg.TOP_OFFSET;
+  var textOffset = Blockly.WorkspaceCommentSvg.TEXTAREA_OFFSET * 2;
+
+  this.foreignObject_.setAttribute('width',
+      size.width);
+  this.foreignObject_.setAttribute('height',
+      size.height - topOffset);
+  if (this.RTL) {
+    this.foreignObject_.setAttribute('x',
+        -size.width);
+  }
+  this.textarea_.style.width =
+      (size.width - textOffset) + 'px';
+  this.textarea_.style.height =
+      (size.height - textOffset - topOffset) + 'px';
+};
+
+/**
+ * Set size
+ * @param {number} width width of the container
+ * @param {number} height height of the container
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.setSize_ = function(width, height) {
+  // Minimum size of a comment.
+  width = Math.max(width, 45);
+  height = Math.max(height, 20 + Blockly.WorkspaceCommentSvg.TOP_OFFSET);
+  this.width_ = width;
+  this.height_ = height;
+  this.svgRect_.setAttribute('width', width);
+  this.svgRect_.setAttribute('height', height);
+  this.svgRectTarget_.setAttribute('width', width);
+  this.svgRectTarget_.setAttribute('height', height);
+  if (this.RTL) {
+    this.svgRect_.setAttribute('transform', 'scale(-1 1)');
+    this.svgRectTarget_.setAttribute('transform', 'scale(-1 1)');
+  }
+
+  var resizeSize = Blockly.WorkspaceCommentSvg.RESIZE_SIZE;
+  if (this.resizeGroup_) {
+    if (this.RTL) {
+      // Mirror the resize group.
+      this.resizeGroup_.setAttribute('transform', 'translate(' +
+        (-width + resizeSize) + ',' + (height - resizeSize) + ') scale(-1 1)');
+    } else {
+      this.resizeGroup_.setAttribute('transform', 'translate(' +
+        (width - resizeSize) + ',' +
+        (height - resizeSize) + ')');
+    }
+  }
+
+  // Allow the contents to resize.
+  this.resizeComment_();
+};
+
+/**
+ * Dispose of any rendered comment components.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.disposeInternal_ = function() {
+  this.textarea_ = null;
+  this.foreignObject_ = null;
+  this.svgRectTarget_ = null;
+};
+
+/**
+ * Set the focus on the text area.
+ * @public
+ */
+Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
+  this.focused_ = true;
+  var textarea = this.textarea_;
+  this.svgRectTarget_.style.fill = "none";
   setTimeout(function() {
     textarea.focus();
   }, 0);
-  return this.foreignObject_;
+  this.addFocus();
+};
+
+/**
+ * Remove focus from the text area.
+ * @public
+ */
+Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
+  this.focused_ = false;
+  var textarea = this.textarea_;
+  this.svgRectTarget_.style.fill = "transparent";
+  setTimeout(function() {
+    textarea.blur();
+  }, 0);
+  this.removeFocus();
 };

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -346,7 +346,6 @@ Blockly.WorkspaceCommentSvg.prototype.clearTransformAttributes_ = function() {
   Blockly.utils.removeAttribute(this.getSvgRoot(), 'transform');
 };
 
-
 /**
  * Returns the coordinates of a bounding box describing the dimensions of this
  * comment.
@@ -360,7 +359,6 @@ Blockly.WorkspaceCommentSvg.prototype.getBoundingRectangle = function() {
   var topLeft;
   var bottomRight;
   if (this.RTL) {
-    // Width has the tab built into it already so subtract it here.
     topLeft = new goog.math.Coordinate(blockXY.x - (commentBounds.width),
         blockXY.y);
     // Add the width of the tab/puzzle piece knob to the x coordinate
@@ -371,7 +369,6 @@ Blockly.WorkspaceCommentSvg.prototype.getBoundingRectangle = function() {
     // Subtract the width of the tab/puzzle piece knob to the x coordinate
     // since X is the corner of the rectangle, not the whole puzzle piece.
     topLeft = new goog.math.Coordinate(blockXY.x, blockXY.y);
-    // Width has the tab built into it already so subtract it here.
     bottomRight = new goog.math.Coordinate(blockXY.x + commentBounds.width,
         blockXY.y + commentBounds.height);
   }
@@ -379,7 +376,7 @@ Blockly.WorkspaceCommentSvg.prototype.getBoundingRectangle = function() {
 };
 
 /**
- * Add or remove the UI indicating if this block is movable or not.
+ * Add or remove the UI indicating if this comment is movable or not.
  */
 Blockly.WorkspaceCommentSvg.prototype.updateMovable = function() {
   if (this.isMovable()) {
@@ -392,7 +389,7 @@ Blockly.WorkspaceCommentSvg.prototype.updateMovable = function() {
 };
 
 /**
- * Set whether this block is movable or not.
+ * Set whether this comment is movable or not.
  * @param {boolean} movable True if movable.
  */
 Blockly.WorkspaceCommentSvg.prototype.setMovable = function(movable) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1150,18 +1150,18 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
 Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
   var topBlocks = this.getTopBlocks(false);
   var topComments = this.getTopComments(false);
-  topBlocks = topBlocks.concat(topComments);
+  var topElements = topBlocks.concat(topComments);
   // There are no blocks, return empty rectangle.
-  if (!topBlocks.length) {
+  if (!topElements.length) {
     return {x: 0, y: 0, width: 0, height: 0};
   }
 
   // Initialize boundary using the first block.
-  var boundary = topBlocks[0].getBoundingRectangle();
+  var boundary = topElements[0].getBoundingRectangle();
 
   // Start at 1 since the 0th block was used for initialization
-  for (var i = 1; i < topBlocks.length; i++) {
-    var blockBoundary = topBlocks[i].getBoundingRectangle();
+  for (var i = 1; i < topElements.length; i++) {
+    var blockBoundary = topElements[i].getBoundingRectangle();
     if (blockBoundary.topLeft.x < boundary.topLeft.x) {
       boundary.topLeft.x = blockBoundary.topLeft.x;
     }
@@ -1237,6 +1237,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
     var addWsComment = function() {
       var comment = ws.newComment('', 100, 100);
 
+      // TODO: move this code into a helper function
       var injectionDiv = ws.getInjectionDiv();
       // Bounding rect coordinates are in client coordinates, meaning that they
       // are in pixels relative to the upper left corner of the visible browser

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1149,6 +1149,8 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
  */
 Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
   var topBlocks = this.getTopBlocks(false);
+  var topComments = this.getTopComments(false);
+  topBlocks = topBlocks.concat(topComments);
   // There are no blocks, return empty rectangle.
   if (!topBlocks.length) {
     return {x: 0, y: 0, width: 0, height: 0};
@@ -1226,6 +1228,54 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   redoOption.callback = this.undo.bind(this, true);
   menuOptions.push(redoOption);
 
+  // Option to add a workspace comment.
+  if (this.options.comments) {
+    /**
+     * Option to add a workspace comment..
+     * @private
+     */
+    var addWsComment = function() {
+      var comment = ws.newComment('', 100, 100);
+
+      var injectionDiv = ws.getInjectionDiv();
+      // Bounding rect coordinates are in client coordinates, meaning that they
+      // are in pixels relative to the upper left corner of the visible browser
+      // window.  These coordinates change when you scroll the browser window.
+      var boundingRect = injectionDiv.getBoundingClientRect();
+
+      // The client coordinates offset by the injection div's upper left corner.
+      var clientOffsetPixels = new goog.math.Coordinate(e.clientX - boundingRect.left,
+          e.clientY - boundingRect.top);
+
+      // The offset in pixels between the main workspace's origin and the upper left
+      // corner of the injection div.
+      var mainOffsetPixels = ws.getOriginOffsetInPixels();
+
+      // The position of the new comment in pixels relative to the origin of the
+      // main workspace.
+      var finalOffsetPixels = goog.math.Coordinate.difference(clientOffsetPixels,
+          mainOffsetPixels);
+
+      // The position of the new comment in main workspace coordinates.
+      var finalOffsetMainWs = finalOffsetPixels.scale(1 / ws.scale);
+
+      var commentX = finalOffsetMainWs.x;
+      var commentY = finalOffsetMainWs.y;
+      comment.moveBy(commentX, commentY);
+      if (ws.rendered) {
+        comment.initSvg();
+        comment.render(false);
+        comment.select();
+      }
+    };
+    var wsCommentOption = {enabled: true};
+    wsCommentOption.text = Blockly.Msg.ADD_COMMENT;
+    wsCommentOption.callback = function() {
+      addWsComment();
+    };
+    menuOptions.push(wsCommentOption);
+  }
+
   // Option to clean up blocks.
   if (this.scrollbar) {
     var cleanOption = {};
@@ -1284,52 +1334,6 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
       toggleOption(false);
     };
     menuOptions.push(expandOption);
-
-    /**
-     * Option to add a workspace comment..
-     * @private
-     */
-    var addWsComment = function() {
-      var comment = ws.newComment('', 100, 100);
-  
-      var injectionDiv = ws.getInjectionDiv();
-      // Bounding rect coordinates are in client coordinates, meaning that they
-      // are in pixels relative to the upper left corner of the visible browser
-      // window.  These coordinates change when you scroll the browser window.
-      var boundingRect = injectionDiv.getBoundingClientRect();
-
-      // The client coordinates offset by the injection div's upper left corner.
-      var clientOffsetPixels = new goog.math.Coordinate(e.clientX - boundingRect.left,
-          e.clientY - boundingRect.top);
-
-      // The offset in pixels between the main workspace's origin and the upper left
-      // corner of the injection div.
-      var mainOffsetPixels = ws.getOriginOffsetInPixels();
-
-      // The position of the new comment in pixels relative to the origin of the
-      // main workspace.
-      var finalOffsetPixels = goog.math.Coordinate.difference(clientOffsetPixels,
-          mainOffsetPixels);
-
-      // The position of the new comment in main workspace coordinates.
-      var finalOffsetMainWs = finalOffsetPixels.scale(1 / ws.scale);
-
-      var commentX = finalOffsetMainWs.x;
-      var commentY = finalOffsetMainWs.y;
-      comment.moveBy(ws.RTL ? commentX - comment.getWidth() : commentX, commentY);
-      if (ws.rendered) {
-        comment.initSvg();
-        comment.render(false);
-      }
-    };
-
-    // Option to add workspace comment.
-    var wsCommentOption = {enabled: true};
-    wsCommentOption.text = Blockly.Msg.ADD_COMMENT;
-    wsCommentOption.callback = function() {
-      addWsComment();
-    };
-    menuOptions.push(wsCommentOption);
   }
 
   // Option to delete all blocks.


### PR DESCRIPTION
Added workspace highlighting of comments.
- Comments can now be selected, added to Blockly.selected
- Only edit comment on click. Otherwise, it can be dragged by click and drag anywhere on the comment
- Added comment resizing, resizing mouse handling logic currently in workspace_comment_svg_render
- Added a stroke for when the comment is highlighted.
- Comment is visually different also when it's focused (ie: on click), separate focused state for that
- Handling readonly and comments options
- Moved "Add comment" option to after Undo/Redo on the workspace context menu

Tested: 
- Chrome Mac, Edge, Firefox Mac, and Safari
- Readonly and comment options

@rachel-fenichel 


![comments](https://user-images.githubusercontent.com/16690124/33147076-511660e0-cf7b-11e7-8f35-a82fa40997dd.gif)
