### PR TITLE
Added scrollable functionality to dropdown menu

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -499,6 +499,9 @@ Blockly.Css.CONTENT = [
 
   '.blocklyDropdownMenu {',
     'padding: 0 !important;',
+    /* max-height value is same as the constant
+     * Blockly.FieldDropdown.MAX_MENU_HEIGHT defined in field_dropdown.js. */
+    'max-height: 300px !important;',
   '}',
 
   /* Override the default Closure URL. */

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -69,6 +69,12 @@ goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 Blockly.FieldDropdown.CHECKMARK_OVERHANG = 25;
 
 /**
+ * Maximum height of the dropdown menu,it's also referenced in css.js as
+ * part of .blocklyDropdownMenu.
+ */
+Blockly.FieldDropdown.MAX_MENU_HEIGHT = 300;
+
+/**
  * Android can't (in 2014) display "▾", so use "▼" instead.
  */
 Blockly.FieldDropdown.ARROW_CHAR = goog.userAgent.ANDROID ? '\u25BC' : '\u25BE';
@@ -238,6 +244,10 @@ Blockly.FieldDropdown.prototype.positionMenu_ = function(menu) {
 
   this.createWidget_(menu);
   var menuSize = Blockly.utils.uiMenu.getSize(menu);
+
+  if (menuSize.height > Blockly.FieldDropdown.MAX_MENU_HEIGHT) {
+    menuSize.height = Blockly.FieldDropdown.MAX_MENU_HEIGHT;
+  }
 
   if (this.sourceBlock_.RTL) {
     Blockly.utils.uiMenu.adjustBBoxesForRTL(viewportBBox, anchorBBox, menuSize);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fix #1454 : Dropdown fields with a large number of options become unscrollable and get cut offscreen
### Proposed Changes

Added scrollable functionality to dropdown menu of logic_compare.
![screenshot from 2017-11-26 15 41 49](https://user-images.githubusercontent.com/16653571/33239072-67a0b5fc-d2c0-11e7-8e2b-a891c589b021.png)

### Reason for Changes
On small screens the dropdown with more options (eg. 15 options) the portion of the list becomes inaccessible and get cut offscreen.
### Test Coverage

1. Added more options in blocks/logic.js for type = logic_compare.
2. started build.py
3. Ran demos/fixed/index.html

Tested on:
* Desktop Chrome
* Desktop Firefox


### Additional Information

Thanks @vicng for such a descriptive issue and hack which helped me to make my first PR at blockly.