### PR TITLE
Fix #1487 and only add the delete cursor if the block is not deletabl…

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -168,7 +168,9 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
   this.draggingBlock_.moveToDragSurface_();
 
   if (this.workspace_.toolbox_) {
-    this.workspace_.toolbox_.addDeleteStyle();
+    var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+      'blocklyToolboxGrab';
+    this.workspace_.toolbox_.addStyle(style);
   }
 };
 
@@ -224,7 +226,9 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   this.workspace_.setResizesEnabled(true);
 
   if (this.workspace_.toolbox_) {
-    this.workspace_.toolbox_.removeDeleteStyle();
+    var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+      'blocklyToolboxGrab';
+    this.workspace_.toolbox_.removeStyle(style);
   }
   Blockly.Events.setGroup(false);
 };

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -169,7 +169,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
 
   if (this.workspace_.toolbox_) {
     var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-      'blocklyToolboxGrab';
+        'blocklyToolboxGrab';
     this.workspace_.toolbox_.addStyle(style);
   }
 };
@@ -227,7 +227,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
 
   if (this.workspace_.toolbox_) {
     var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-      'blocklyToolboxGrab';
+        'blocklyToolboxGrab';
     this.workspace_.toolbox_.removeStyle(style);
   }
   Blockly.Events.setGroup(false);

--- a/core/css.js
+++ b/core/css.js
@@ -253,6 +253,12 @@ Blockly.Css.CONTENT = [
     'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
   '}',
 
+  '.blocklyToolboxGrab {',
+    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
+    'cursor: grabbing;',
+    'cursor: -webkit-grabbing;',
+  '}',
+
   '.blocklyDragging>.blocklyPath,',
   '.blocklyDragging>.blocklyPathLight {',
     'fill-opacity: .8;',

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -422,21 +422,23 @@ Blockly.Toolbox.prototype.clearSelection = function() {
 };
 
 /**
- * Adds styles on the toolbox indicating blocks will be deleted.
+ * Adds a style on the toolbox. Usually used to change the cursor.
+ * @param {string} style The name of the class to add.
  * @package
  */
-Blockly.Toolbox.prototype.addDeleteStyle = function() {
+Blockly.Toolbox.prototype.addStyle = function(style) {
   Blockly.utils.addClass(/** @type {!Element} */ (this.HtmlDiv),
-                         'blocklyToolboxDelete');
+                         style);
 };
 
 /**
- * Remove styles from the toolbox that indicate blocks will be deleted.
+ * Removes a style from the toolbox. Usually used to change the cursor.
+ * @param {string} style The name of the class to remove.
  * @package
  */
-Blockly.Toolbox.prototype.removeDeleteStyle = function() {
+Blockly.Toolbox.prototype.removeStyle = function(style) {
   Blockly.utils.removeClass(/** @type {!Element} */ (this.HtmlDiv),
-                            'blocklyToolboxDelete');
+                            style);
 };
 
 /**


### PR DESCRIPTION
…e. Also add a grab cursor when it is not deletable so the cursor keeps the grab hand when over the toolbox.  This changes the toolbox api slightly, but the methods it touches are @package so it should be okay.



## The basics

- [x ] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1487 

Tested on:
 * Desktop Chrome 
 * Desktop Firefox
