### PR TITLE
Remove "fake some drags!"

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -61,7 +61,6 @@
 <script>
 'use strict';
 var workspace = null;
-var fakeDragStack = [];
 
 function start() {
   setBackgroundColor();
@@ -208,65 +207,6 @@ function airstrike(n) {
   }
 }
 
-function fakeDrag(id, dx, dy, opt_workspace) {
-  var ws = opt_workspace || Blockly.getMainWorkspace();
-  var blockToDrag = ws.getBlockById(id);
-
-  if (!blockToDrag) {
-    fakeDragWrapper();
-    return;
-  }
-  var blockTop = blockToDrag.svgGroup_.getBoundingClientRect().top;
-  var blockLeft = blockToDrag.svgGroup_.getBoundingClientRect().left;
-
-  // Click somewhere on the block.
-  var mouseDownEvent = new MouseEvent('mousedown',
-      {clientX: blockLeft + 5, clientY: blockTop + 5});
-  blockToDrag.onMouseDown_(mouseDownEvent);
-
-  // Throw in a move for good measure.
-  setTimeout(
-    function() {
-      var mouseMoveEvent = new MouseEvent('mousemove',
-          {clientX: blockLeft + dx,
-          clientY: blockTop + dy});
-      blockToDrag.onMouseMove_(mouseMoveEvent);
-
-      // Drop at dx, dy.
-      setTimeout(
-        function() {
-          var mouseUpEvent = new MouseEvent('mouseup',
-              {clientX: blockLeft + dx,
-              clientY: blockTop + dy});
-          blockToDrag.onMouseUp_(mouseUpEvent);
-
-          setTimeout(fakeDragWrapper(), 100);
-        }, 100);
-    }, 100);
-};
-
-function fakeDragWrapper() {
-  var dragInfo = fakeDragStack.pop();
-  if (dragInfo) {
-    fakeDrag(dragInfo.id, dragInfo.dx, dragInfo.dy, dragInfo.workspace);
-  }
-}
-
-function fakeManyDrags() {
-  var blockList = workspace.getAllBlocks();
-  for (var i = 0; i < 2 * blockList.length; i++) {
-    fakeDragStack.push(
-      {
-        id: blockList[Math.round(Math.random() * (blockList.length - 1))].id,
-        // Move some blocks up and to the left, but mostly down and to the right.
-        dx: Math.round((Math.random() - 0.25) * 200),
-        dy: Math.round((Math.random() - 0.25) * 200),
-        workspace: workspace
-      });
-  }
-  fakeDragWrapper();
-}
-
 function spaghetti(n) {
   var xml = spaghettiXml;
   for(var i = 0; i < n; i++) {
@@ -389,7 +329,6 @@ h1 {
     Stress test: &nbsp;
     <input type="button" value="Airstrike!" onclick="airstrike(100)">
     <input type="button" value="Spaghetti!" onclick="spaghetti(8)">
-    <input type="button" value="Fake some drags!" onclick="fakeManyDrags()">
   </p>
   <p>
     Log events: &nbsp;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide) (nothing was added, only removed)

## The details
### Resolves

Resolves #1082 

### Proposed Changes

Removed the button, the "fakeDrag" and "fakeManyDrags" and "fakeDragWrapper", and the "fakeDragStack" list.

### Reason for Changes

> Remove or update "fake dragging" code in the playground.
> After landing new dragging code.

### Test Coverage

None, sorry - shouldn't be too bad though.

/cc @rachel-fenichel 