### PR TITLE
Fix #1467

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -176,6 +176,13 @@ Blockly.FieldImage.prototype.render_ = function() {
 };
 
 /**
+ * Images are fixed width, no need to render even if forced.
+ */
+Blockly.FieldImage.prototype.forceRerender = function() {
+  // NOP
+};
+
+/**
  * Images are fixed width, no need to update.
  * @private
  */


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes https://github.com/google/blockly/issues/1467

### Proposed Changes

Make `forceRerender` a no-op on FieldImage.  `render_` is already a no-op there.

### Reason for Changes

`forceRerender` sets the width to 0.  Since `render_` is a no-op, width was never being set correctly.
### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

