### PR TITLE
Fix headless

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -272,6 +272,23 @@ Blockly.Block.prototype.dispose = function(healStack) {
 };
 
 /**
+ * Call initModel on all fields on the block.
+ * May be called more than once.
+ * Either initModel or initSvg must be called after creating a block and before
+ * first interaction with it.
+ * @public
+ */
+Blockly.Block.prototype.initModel = function() {
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+      if (field.initModel) {
+        field.initModel();
+      }
+    }
+  }
+};
+
+/**
  * Unplug this block from its superior block.  If this block is a statement,
  * optionally reconnect the block underneath with the block on top.
  * @param {boolean=} opt_healStack Disconnect child statement and reconnect

--- a/core/xml.js
+++ b/core/xml.js
@@ -502,12 +502,11 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
   var variablesBeforeCreation = workspace.getAllVariables();
   try {
     var topBlock = Blockly.Xml.domToBlockHeadless_(xmlBlock, workspace);
+    // Generate list of all blocks.
+    var blocks = topBlock.getDescendants();
     if (workspace.rendered) {
-      // TODO (fenichel): Otherwise call initModel?
       // Hide connections to speed up assembly.
       topBlock.setConnectionsHidden(true);
-      // Generate list of all blocks.
-      var blocks = topBlock.getDescendants();
       // Render each block.
       for (var i = blocks.length - 1; i >= 0; i--) {
         blocks[i].initSvg();
@@ -526,6 +525,10 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
       // Allow the scrollbars to resize and move based on the new contents.
       // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
       workspace.resizeContents();
+    } else {
+      for (var i = blocks.length - 1; i >= 0; i--) {
+        blocks[i].initModel();
+      }
     }
   } finally {
     Blockly.Events.enable();


### PR DESCRIPTION
Create and call `block.initModel` function.  This new function parallels `initSvg`, though for now it's only needed for `fieldvariable`.

This fixes the case when events are disabled and the workspace is non-rendered, which previously meant that the variable field's model was never initialized.