### PR TITLE
Remove some TODOs; add a variable-referencing block to the simple playground flyout

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -872,6 +872,7 @@ Blockly.Blocks['procedures_callreturn'] = {
   updateShape_: Blockly.Blocks['procedures_callnoreturn'].updateShape_,
   mutationToDom: Blockly.Blocks['procedures_callnoreturn'].mutationToDom,
   domToMutation: Blockly.Blocks['procedures_callnoreturn'].domToMutation,
+  renameVarById: Blockly.Blocks['procedures_callnoreturn'].renameVarById,
   getVarModels: Blockly.Blocks['procedures_callnoreturn'].getVarModels,
   onchange: Blockly.Blocks['procedures_callnoreturn'].onchange,
   customContextMenu:

--- a/core/block.js
+++ b/core/block.js
@@ -738,24 +738,6 @@ Blockly.Block.prototype.getVarModels = function() {
 };
 
 /**
- * Notification that a variable is renaming.
- * TODO (#1498): consider deleting this.
- * If the name matches one of this block's variables, rename it.
- * @param {string} oldName Previous name of variable.
- * @param {string} newName Renamed variable.
- */
-Blockly.Block.prototype.renameVar = function(oldName, newName) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable &&
-          Blockly.Names.equals(oldName, field.getValue())) {
-        field.setValue(newName);
-      }
-    }
-  }
-};
-
-/**
  * Notification that a variable is renaming but keeping the same ID.  If the
  * variable is in use on this block, rerender to show the new name.
  * @param {!Blockly.VariableModel} variable The variable being renamed.

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -155,8 +155,6 @@ Blockly.FieldVariable.prototype.getVariable = function() {
  *     variable.
  */
 Blockly.FieldVariable.prototype.setValue = function(id) {
-  // What do I do when id is null?  That happens when undoing a change event
-  // for the first time the value was set.
   var workspace = this.sourceBlock_.workspace;
   var variable = Blockly.Variables.getVariable(workspace, id);
 
@@ -291,12 +289,7 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       return;
     }
 
-    // TODO: Call any validation function, and allow it to override.
-    // For now it's unclear whether the validator should act on the id.
-    //var validatedId = this.callValidator(variable.getId());
+    // TODO (#1529): Call any validation function, and allow it to override.
   }
-  // if (variable.getId() !== null) {
-  //   this.setValue(validatedId);
-  // }
   this.setValue(id);
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -135,20 +135,6 @@ Blockly.Workspace.SCAN_ANGLE = 3;
  */
 Blockly.Workspace.prototype.addTopBlock = function(block) {
   this.topBlocks_.push(block);
-  if (!this.isFlyout) {
-    return;
-  }
-  // This is for the (unlikely) case where you have a variable in a block in
-  // an always-open flyout.  It needs to be possible to edit the block in the
-  // flyout, so the contents of the dropdown need to be correct.
-  var variableNames = Blockly.Variables.allUsedVariables(block);
-  for (var i = 0, name; name = variableNames[i]; i++) {
-    if (!this.getVariable(name)) {
-      // TODO (fenichel): Is this still necessary?  Is allUsedVariables still
-      // necessary?
-      this.createVariable(name);
-    }
-  }
 };
 
 /**

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -353,6 +353,13 @@ h1 {
     <block type="logic_boolean"></block>
     <block type="logic_null" disabled="true"></block>
     <block type="logic_ternary"></block>
+    <block type="text_charAt">
+      <value name="VALUE">
+        <block type="variables_get">
+          <field name="VAR">text</field>
+        </block>
+      </value>
+    </block>
   </xml>
 
   <xml id="toolbox-categories" style="display: none">


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Cleanup on variables_by_id before merging to develop.

### Proposed Changes

I went through the TODOs that I left for myself and confirmed that some of them marked code that can be safely deleted.

### Reason for Changes

Code cleanup before merge.

### Test Coverage
JSUnit and generator tests pass.

### Additional Information

<!-- Anything else we should know? -->

  