### PR TITLE
Fix #1521: Issue with Mutator position when nesting blocks

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -382,7 +382,7 @@ Blockly.Bubble.prototype.setAnchorLocation = function(xy) {
  */
 Blockly.Bubble.prototype.layoutBubble_ = function() {
   // Compute the preferred bubble location.
-  var relativeLeft = -this.width_ / 4;
+  var relativeLeft = -this.width_ / 8;
   var relativeTop = -this.height_ - Blockly.BlockSvg.MIN_BLOCK_Y;
   // Prevent the bubble from being off-screen.
   var metrics = this.workspace_.getMetrics();
@@ -415,8 +415,7 @@ Blockly.Bubble.prototype.layoutBubble_ = function() {
   }
   if (this.anchorXY_.y + relativeTop < metrics.viewTop) {
     // Slide the bubble below the block.
-    var bBox = /** @type {SVGLocatable} */ (this.shape_).getBBox();
-    relativeTop = bBox.height;
+    relativeTop = (metrics.viewHeight*0.1);
   }
   this.relativeLeft_ = relativeLeft;
   this.relativeTop_ = relativeTop;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
[Issue #1521](https://github.com/google/blockly/issues/1521)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Solves the issue related to wrong displaying of Mutator with multiple nested blocks: In the old version the bubble position (when sliding below the mutator) would have been calculated from the height of the bounding box surrounding the anchor item. 

`var bBox = (this.shape_).getBBox(); relativeTop = bBox.height;`

If multiple blocks were added, the height of such bounding box would have increased at each addition pushing the bubble position downward, and making the bubble unusable.

The proposed change doesn't calculate the bubble position from the bounding box height of the anchor item but from the viewHeight parameter of the workspace (which is not supposed to change when adding items to a mutator). 

`relativeTop = (metrics.viewHeight*0.1);`

### Reason for Changes

The reason to change is to fix the following wrong behavior:

#### Before

![manyif-before](https://user-images.githubusercontent.com/811834/34750874-c08bbaa2-f5a9-11e7-934a-849fa51b78e9.png)

#### After

![manyif](https://user-images.githubusercontent.com/811834/34750895-dddeea5c-f5a9-11e7-8ba8-27715ec8a6d2.png)

![manyif-bottomup](https://user-images.githubusercontent.com/811834/34750901-e44332f4-f5a9-11e7-979b-d5e423f6b109.png)

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![ut](https://user-images.githubusercontent.com/811834/34751495-4ffef264-f5ad-11e7-9df5-9267083ff96a.png)

Tested on:
Desktop Chrome
Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
