### PR TITLE
Update eslintrc to more explicitly describe indentation rules.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,28 @@
     "rules": {
         "curly": ["error", "multi-line"],
         "eol-last": ["error"],
-        "indent": ["error", 2, {"SwitchCase": 1}], # Blockly/Google use 2-space indents
+        "indent": [
+            "error", 2,  # Blockly/Google use 2-space indents
+            # Blockly/Google uses +4 space indents for line continuations.
+            {
+                "SwitchCase": 1,
+                "MemberExpression": 2,
+                "ObjectExpression": 1,
+                "FunctionDeclaration": {
+                    "body": 1,
+                    "parameters": 2
+                },
+                "FunctionExpression": {
+                    "body": 1,
+                    "parameters": 2
+                },
+                "CallExpression": {
+                    "arguments": 2
+                },
+                # Ignore default rules for ternary expressions.
+                "ignoredNodes": ["ConditionalExpression"]
+            }
+        ],
         "linebreak-style": ["error", "unix"],
         "max-len": ["error", 120, 4],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
N/A
### Proposed Changes

Updates our eslintrc to work better with ESLint 4.0+

### Reason for Changes

https://eslint.org/docs/user-guide/migrating-to-4.0.0#indent-rewrite

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

This doesn't solve all problems with indentation under 4.0.0, just some major ones.  I will need to do more work before we can change what runs on Travis.