### PR TITLE
Update procedure generators for PHP and Python to declare developer v…

### DIFF
--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -43,6 +43,12 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
           Blockly.Variables.NAME_TYPE));
     }
   }
+  // Add developer variables.
+  var devVarList = Blockly.Variables.allDeveloperVariables(workspace);
+  for (var i = 0; i < devVarList.length; i++) {
+    globals.push(Blockly.PHP.variableDB_.getName(devVarList[i],
+        Blockly.Names.DEVELOPER_VARIABLE_TYPE));
+  }
   globals = globals.length ? Blockly.PHP.INDENT + 'global ' + globals.join(', ') + ';\n' : '';
 
   var funcName = Blockly.PHP.variableDB_.getName(

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -44,6 +44,13 @@ Blockly.Python['procedures_defreturn'] = function(block) {
           Blockly.Variables.NAME_TYPE));
     }
   }
+  // Add developer variables.
+  var devVarList = Blockly.Variables.allDeveloperVariables(workspace);
+  for (var i = 0; i < devVarList.length; i++) {
+    globals.push(Blockly.Python.variableDB_.getName(devVarList[i],
+        Blockly.Names.DEVELOPER_VARIABLE_TYPE));
+  }
+
   globals = globals.length ? Blockly.Python.INDENT + 'global ' + globals.join(', ') + '\n' : '';
   var funcName = Blockly.Python.variableDB_.getName(block.getFieldValue('NAME'),
       Blockly.Procedures.NAME_TYPE);


### PR DESCRIPTION
…ariables as globals

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #1535 
### Proposed Changes

Adds developer variables to the globals list at the beginning of PHP and Python functions.

Note that this is still an in-progress API.

### Reason for Changes

See #1535 and https://groups.google.com/forum/#!topic/blockly/7ckP3WmKT0s

### Test Coverage
Tested by forcing some developer variables to exist in the playground, then creating functions and making sure that the generated code looks right in PHP and Python.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Currently if a user has a variable `foo` and a developer has a variable `foo`, the user variable keeps the name `foo` and the developer variable becomes `foo2`.  That is, user variable names have priority.

@CleoQc please take a look and let me know if this meets your needs.