### PR TITLE
Remove Events.disable() / .enable() in .disableOrphan. Fix #1548

### DIFF
--- a/core/events.js
+++ b/core/events.js
@@ -1126,7 +1126,6 @@ Blockly.Events.VarRename.prototype.run = function(forward) {
 Blockly.Events.disableOrphans = function(event) {
   if (event.type == Blockly.Events.MOVE ||
       event.type == Blockly.Events.CREATE) {
-    Blockly.Events.disable();
     var workspace = Blockly.Workspace.getById(event.workspaceId);
     var block = workspace.getBlockById(event.blockId);
     if (block) {
@@ -1143,6 +1142,5 @@ Blockly.Events.disableOrphans = function(event) {
         } while (block);
       }
     }
-    Blockly.Events.enable();
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves #1548

### Proposed Changes

Remove `Events.disable()` / `.enable()` in `.disableOrphan`.

### Reason for Changes

Events not sent that probably should be.

### Test Coverage

Tested with BlockFactory and Blockly Games (both use `disableOrphan`) and ran the jsunit tests.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
