### PR TITLE
Fix #1553 - .js extension is provided when exporting Generator files

### DIFF
--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -139,7 +139,7 @@ BlockExporterController.prototype.export = function() {
       var fileType = (language == 'JavaScript') ? 'javascript' : 'plain';
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          genStubs, generatorStub_filename, fileType);
+          genStubs, generatorStub_filename + '.js', fileType);
       BlocklyDevTools.Analytics.onExport(
           BlocklyDevTools.Analytics.GENERATOR,
           (fileType == 'javascript' ?

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -132,18 +132,16 @@ BlockExporterController.prototype.export = function() {
       BlocklyDevTools.Analytics.onWarning(msg);
       alert(msg);
     } else {
+      
       // Get generator stub code in the selected language for the blocks.
       var genStubs = this.tools.getGeneratorCode(blockXmlMap,
           language);
-      // Get the correct file extension.
-      var fileType = (language == 'JavaScript') ? 'javascript' : 'plain';
+      
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          genStubs, generatorStub_filename + '.js', fileType);
+          genStubs, generatorStub_filename + '.js', 'javascript');
       BlocklyDevTools.Analytics.onExport(
-          BlocklyDevTools.Analytics.GENERATOR,
-          (fileType == 'javascript' ?
-              { format: BlocklyDevTools.Analytics.FORMAT_JS } : undefined));
+          BlocklyDevTools.Analytics.GENERATOR, { format: BlocklyDevTools.Analytics.FORMAT_JS });
     }
   }
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

In Generator section of Block Exporter, '.js' extension is not provided while exporting unless it is explicitly specified.

### Proposed Changes

'.js' extension is appended to the end of file name.

### Reason for Changes

It would lead to confusion since a file extension is not that of JavaScript.

### Test Coverage

It was not complicated update; hence, no complex test was applied.

Tested on:
Desktop Chrome
  * PC(please complete the following information):
  * Device: Asus
  * OS: W10
  * Browser: Chrome
  * Version: 63