### PR TITLE
Generator code problem fixed

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -106,10 +106,9 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       line = line[0];
     }
 
-    if(line == undefined){
+    if (line == undefined) {
       blocksNotGenerated.push(block);
-    }
-    else if (line) {
+    } else if (line) {
       if (block.outputConnection && this.scrubNakedValue) {
         // This block is a naked value.  Ask the language's code generator if
         // it wants to append a semicolon, or something.
@@ -118,7 +117,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       code.push(line);
     }
   }
-  if(blocksNotGenerated.length == 0){
+  if (blocksNotGenerated.length == 0) {
     code = code.join('\n');  // Blank line between each section.
     code = this.finish(code);
     // Final scrubbing of whitespace.
@@ -126,12 +125,12 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
     code = code.replace(/\n\s+$/, '\n');
     code = code.replace(/[ \t]+\n/g, '\n');
     return code;
-  }
-  else{
-    var textToBeLogged = 'The generator code for the following blocks not specified for ' + this.name_ + ': \n';
+  } else {
+    var textToBeLogged = 'The generator code for the following '
+    + 'blocks not specified for ' + this.name_ + ': \n';
     
     //Blocks not specified traversed
-    for(var x = 0; x < blocksNotGenerated.length; x++){
+    for (var x = 0; x < blocksNotGenerated.length; x++) {
       textToBeLogged +=  '* ' + blocksNotGenerated[x].type + '\n';
     }
     textToBeLogged += 'Fix those to be able to generate code';
@@ -197,11 +196,10 @@ Blockly.Generator.prototype.blockToCode = function(block) {
   // Prior to 24 September 2013 'this' was the only way to access the block.
   // The current prefered method of accessing the block is through the second
   // argument to func.call, which becomes the first parameter to the generator.
-  if(func == null || func == undefined){
+  if (func == null || func == undefined) {
     return undefined;
-  }else{
+   } else {
     var code = func.call(block, block);
-    
     if (goog.isArray(code)) {
       // Value blocks return tuples of code and operator order.
       goog.asserts.assert(block.outputConnection,

--- a/core/generator.js
+++ b/core/generator.js
@@ -135,10 +135,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       textToBeLogged +=  '* ' + blocksNotGenerated[x].type + '\n';
     }
     textToBeLogged += 'Fix those to be able to generate code';
-    alert(textToBeLogged);
-
-    //Code area remained empty
-    return '';
+    throw textToBeLogged;
   }
 };
 

--- a/core/generator.js
+++ b/core/generator.js
@@ -95,6 +95,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
     workspace = Blockly.getMainWorkspace();
   }
   var code = [];
+  var blocksNotGenerated = [];
   this.init(workspace);
   var blocks = workspace.getTopBlocks(true);
   for (var x = 0, block; block = blocks[x]; x++) {
@@ -104,7 +105,11 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       // Top-level blocks don't care about operator order.
       line = line[0];
     }
-    if (line) {
+
+    if(line == undefined){
+      blocksNotGenerated.push(block);
+    }
+    else if (line) {
       if (block.outputConnection && this.scrubNakedValue) {
         // This block is a naked value.  Ask the language's code generator if
         // it wants to append a semicolon, or something.
@@ -113,13 +118,28 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       code.push(line);
     }
   }
-  code = code.join('\n');  // Blank line between each section.
-  code = this.finish(code);
-  // Final scrubbing of whitespace.
-  code = code.replace(/^\s+\n/, '');
-  code = code.replace(/\n\s+$/, '\n');
-  code = code.replace(/[ \t]+\n/g, '\n');
-  return code;
+  if(blocksNotGenerated.length == 0){
+    code = code.join('\n');  // Blank line between each section.
+    code = this.finish(code);
+    // Final scrubbing of whitespace.
+    code = code.replace(/^\s+\n/, '');
+    code = code.replace(/\n\s+$/, '\n');
+    code = code.replace(/[ \t]+\n/g, '\n');
+    return code;
+  }
+  else{
+    var textToBeLogged = 'The generator code for the following blocks not specified for ' + this.name_ + ': \n';
+    
+    //Blocks not specified traversed
+    for(var x = 0; x < blocksNotGenerated.length; x++){
+      textToBeLogged +=  '* ' + blocksNotGenerated[x].type + '\n';
+    }
+    textToBeLogged += 'Fix those to be able to generate code';
+    alert(textToBeLogged);
+
+    //Code area remained empty
+    return '';
+  }
 };
 
 // The following are some helpful functions which can be used by multiple
@@ -180,24 +200,29 @@ Blockly.Generator.prototype.blockToCode = function(block) {
   // Prior to 24 September 2013 'this' was the only way to access the block.
   // The current prefered method of accessing the block is through the second
   // argument to func.call, which becomes the first parameter to the generator.
-  var code = func.call(block, block);
-  if (goog.isArray(code)) {
-    // Value blocks return tuples of code and operator order.
-    goog.asserts.assert(block.outputConnection,
-        'Expecting string from statement block "%s".', block.type);
-    return [this.scrub_(block, code[0]), code[1]];
-  } else if (goog.isString(code)) {
-    var id = block.id.replace(/\$/g, '$$$$');  // Issue 251.
-    if (this.STATEMENT_PREFIX) {
-      code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') +
-          code;
+  if(func == null || func == undefined){
+    return undefined;
+  }else{
+    var code = func.call(block, block);
+    
+    if (goog.isArray(code)) {
+      // Value blocks return tuples of code and operator order.
+      goog.asserts.assert(block.outputConnection,
+          'Expecting string from statement block "%s".', block.type);
+      return [this.scrub_(block, code[0]), code[1]];
+    } else if (goog.isString(code)) {
+      var id = block.id.replace(/\$/g, '$$$$');  // Issue 251.
+      if (this.STATEMENT_PREFIX) {
+        code = this.STATEMENT_PREFIX.replace(/%1/g, '\'' + id + '\'') +
+            code;
+      }
+      return this.scrub_(block, code);
+    } else if (code === null) {
+      // Block has handled code generation itself.
+      return '';
+    } else {
+      goog.asserts.fail('Invalid code generated: %s', code);
     }
-    return this.scrub_(block, code);
-  } else if (code === null) {
-    // Block has handled code generation itself.
-    return '';
-  } else {
-    goog.asserts.fail('Invalid code generated: %s', code);
   }
 };
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -139,7 +139,7 @@ BlockExporterController.prototype.export = function() {
       var fileType = (language == 'JavaScript') ? 'javascript' : 'plain';
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          genStubs, generatorStub_filename, fileType);
+          genStubs, generatorStub_filename + '.js', fileType);
       BlocklyDevTools.Analytics.onExport(
           BlocklyDevTools.Analytics.GENERATOR,
           (fileType == 'javascript' ?

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -132,18 +132,16 @@ BlockExporterController.prototype.export = function() {
       BlocklyDevTools.Analytics.onWarning(msg);
       alert(msg);
     } else {
+      
       // Get generator stub code in the selected language for the blocks.
       var genStubs = this.tools.getGeneratorCode(blockXmlMap,
           language);
-      // Get the correct file extension.
-      var fileType = (language == 'JavaScript') ? 'javascript' : 'plain';
+      
       // Download the file.
       FactoryUtils.createAndDownloadFile(
-          genStubs, generatorStub_filename + '.js', fileType);
+          genStubs, generatorStub_filename + '.js', 'javascript');
       BlocklyDevTools.Analytics.onExport(
-          BlocklyDevTools.Analytics.GENERATOR,
-          (fileType == 'javascript' ?
-              { format: BlocklyDevTools.Analytics.FORMAT_JS } : undefined));
+          BlocklyDevTools.Analytics.GENERATOR, { format: BlocklyDevTools.Analytics.FORMAT_JS });
     }
   }
 

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -93,7 +93,7 @@ Code.workspace = null;
  * Extracts a parameter from the URL.
  * If the parameter is absent default_value is returned.
  * @param {string} name The name of the parameter.
- * @param {string} defaultValue Value to return if paramater not found.
+ * @param {string} defaultValue Value to return if parameter not found.
  * @return {string} The parameter value or the default value if not found.
  */
 Code.getStringParamFromUrl = function(name, defaultValue) {
@@ -161,7 +161,7 @@ Code.changeLanguage = function() {
   // This should be skipped for the index page, which has no blocks and does
   // not load Blockly.
   // MSIE 11 does not support sessionStorage on file:// URLs.
-  if (typeof Blockly != 'undefined' && window.sessionStorage) {
+  if (window.sessionStorage) {
     var xml = Blockly.Xml.workspaceToDom(Code.workspace);
     var text = Blockly.Xml.domToText(xml);
     window.sessionStorage.loadOnceBlocks = text;
@@ -298,15 +298,16 @@ Code.tabClick = function(clickedName) {
  */
 Code.renderContent = function() {
   var content = document.getElementById('content_' + Code.selected);
-  // Initialize the pane.
-  if (content.id == 'content_xml') {
-    var xmlTextarea = document.getElementById('content_xml');
-    var xmlDom = Blockly.Xml.workspaceToDom(Code.workspace);
-    var xmlText = Blockly.Xml.domToPrettyText(xmlDom);
-    xmlTextarea.value = xmlText;
-    xmlTextarea.focus();
-  } else if (content.id == 'content_javascript') {
-    try{
+  // Handles the error of not implemented block
+  try {
+    // Initialize the pane.
+    if (content.id == 'content_xml') {
+      var xmlTextarea = document.getElementById('content_xml');
+      var xmlDom = Blockly.Xml.workspaceToDom(Code.workspace);
+      var xmlText = Blockly.Xml.domToPrettyText(xmlDom);
+      xmlTextarea.value = xmlText;
+      xmlTextarea.focus();
+    } else if (content.id == 'content_javascript') {
       var code = Blockly.JavaScript.workspaceToCode(Code.workspace);
       content.textContent = code;
       if (typeof PR.prettyPrintOne == 'function') {
@@ -314,10 +315,7 @@ Code.renderContent = function() {
         code = PR.prettyPrintOne(code, 'js');
         content.innerHTML = code;
       }
-    }catch(err){
-      alert(err);}
-  } else if (content.id == 'content_python') {
-    try{
+    } else if (content.id == 'content_python') {
       var code = Blockly.Python.workspaceToCode(Code.workspace);
       content.textContent = code;
       if (typeof PR.prettyPrintOne == 'function') {
@@ -325,11 +323,7 @@ Code.renderContent = function() {
         code = PR.prettyPrintOne(code, 'py');
         content.innerHTML = code;
       }
-    }catch(err){
-      alert(err);
-    }
-  } else if (content.id == 'content_php') {
-    try{
+    } else if (content.id == 'content_php') {
       var code = Blockly.PHP.workspaceToCode(Code.workspace);
       content.textContent = code;
       if (typeof PR.prettyPrintOne == 'function') {
@@ -337,11 +331,7 @@ Code.renderContent = function() {
         code = PR.prettyPrintOne(code, 'php');
         content.innerHTML = code;
       }
-    }catch(err){
-      alert(err);
-    }
-  } else if (content.id == 'content_dart') {
-    try{
+    } else if (content.id == 'content_dart') {
       var code = Blockly.Dart.workspaceToCode(Code.workspace);
       content.textContent = code;
       if (typeof PR.prettyPrintOne == 'function') {
@@ -349,11 +339,7 @@ Code.renderContent = function() {
         code = PR.prettyPrintOne(code, 'dart');
         content.innerHTML = code;
       }
-    }catch(err){
-      alert(err);
-    }
-  } else if (content.id == 'content_lua') {
-    try{
+    } else if (content.id == 'content_lua') {
       var code = Blockly.Lua.workspaceToCode(Code.workspace);
       content.textContent = code;
       if (typeof PR.prettyPrintOne == 'function') {
@@ -361,8 +347,9 @@ Code.renderContent = function() {
         code = PR.prettyPrintOne(code, 'lua');
         content.innerHTML = code;
       }
-    }catch(err){
-      alert(err);}
+    }
+  } catch(err) {
+    Blockly.alert(err);
   }
 };
 

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -93,7 +93,7 @@ Code.workspace = null;
  * Extracts a parameter from the URL.
  * If the parameter is absent default_value is returned.
  * @param {string} name The name of the parameter.
- * @param {string} defaultValue Value to return if parameter not found.
+ * @param {string} defaultValue Value to return if paramater not found.
  * @return {string} The parameter value or the default value if not found.
  */
 Code.getStringParamFromUrl = function(name, defaultValue) {
@@ -158,8 +158,10 @@ Code.loadBlocks = function(defaultXml) {
  */
 Code.changeLanguage = function() {
   // Store the blocks for the duration of the reload.
+  // This should be skipped for the index page, which has no blocks and does
+  // not load Blockly.
   // MSIE 11 does not support sessionStorage on file:// URLs.
-  if (window.sessionStorage) {
+  if (typeof Blockly != 'undefined' && window.sessionStorage) {
     var xml = Blockly.Xml.workspaceToDom(Code.workspace);
     var text = Blockly.Xml.domToText(xml);
     window.sessionStorage.loadOnceBlocks = text;
@@ -304,45 +306,63 @@ Code.renderContent = function() {
     xmlTextarea.value = xmlText;
     xmlTextarea.focus();
   } else if (content.id == 'content_javascript') {
-    var code = Blockly.JavaScript.workspaceToCode(Code.workspace);
-    content.textContent = code;
-    if (typeof PR.prettyPrintOne == 'function') {
-      code = content.textContent;
-      code = PR.prettyPrintOne(code, 'js');
-      content.innerHTML = code;
-    }
+    try{
+      var code = Blockly.JavaScript.workspaceToCode(Code.workspace);
+      content.textContent = code;
+      if (typeof PR.prettyPrintOne == 'function') {
+        code = content.textContent;
+        code = PR.prettyPrintOne(code, 'js');
+        content.innerHTML = code;
+      }
+    }catch(err){
+      alert(err);}
   } else if (content.id == 'content_python') {
-    code = Blockly.Python.workspaceToCode(Code.workspace);
-    content.textContent = code;
-    if (typeof PR.prettyPrintOne == 'function') {
-      code = content.textContent;
-      code = PR.prettyPrintOne(code, 'py');
-      content.innerHTML = code;
+    try{
+      var code = Blockly.Python.workspaceToCode(Code.workspace);
+      content.textContent = code;
+      if (typeof PR.prettyPrintOne == 'function') {
+        code = content.textContent;
+        code = PR.prettyPrintOne(code, 'py');
+        content.innerHTML = code;
+      }
+    }catch(err){
+      alert(err);
     }
   } else if (content.id == 'content_php') {
-    code = Blockly.PHP.workspaceToCode(Code.workspace);
-    content.textContent = code;
-    if (typeof PR.prettyPrintOne == 'function') {
-      code = content.textContent;
-      code = PR.prettyPrintOne(code, 'php');
-      content.innerHTML = code;
+    try{
+      var code = Blockly.PHP.workspaceToCode(Code.workspace);
+      content.textContent = code;
+      if (typeof PR.prettyPrintOne == 'function') {
+        code = content.textContent;
+        code = PR.prettyPrintOne(code, 'php');
+        content.innerHTML = code;
+      }
+    }catch(err){
+      alert(err);
     }
   } else if (content.id == 'content_dart') {
-    code = Blockly.Dart.workspaceToCode(Code.workspace);
-    content.textContent = code;
-    if (typeof PR.prettyPrintOne == 'function') {
-      code = content.textContent;
-      code = PR.prettyPrintOne(code, 'dart');
-      content.innerHTML = code;
+    try{
+      var code = Blockly.Dart.workspaceToCode(Code.workspace);
+      content.textContent = code;
+      if (typeof PR.prettyPrintOne == 'function') {
+        code = content.textContent;
+        code = PR.prettyPrintOne(code, 'dart');
+        content.innerHTML = code;
+      }
+    }catch(err){
+      alert(err);
     }
   } else if (content.id == 'content_lua') {
-    code = Blockly.Lua.workspaceToCode(Code.workspace);
-    content.textContent = code;
-    if (typeof PR.prettyPrintOne == 'function') {
-      code = content.textContent;
-      code = PR.prettyPrintOne(code, 'lua');
-      content.innerHTML = code;
-    }
+    try{
+      var code = Blockly.Lua.workspaceToCode(Code.workspace);
+      content.textContent = code;
+      if (typeof PR.prettyPrintOne == 'function') {
+        code = content.textContent;
+        code = PR.prettyPrintOne(code, 'lua');
+        content.innerHTML = code;
+      }
+    }catch(err){
+      alert(err);}
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

In code generation, if no generator code is specified for any block in particular language error occurs (printed out on console) and generated code field remains unchanged leading to confusion.

### Proposed Changes

It does not generate the code if there is any block whose implementation is not known to the particular language and warns user.

I created a block 'length_of' whose code implementation for Python is not provided.
And here is the screenshot after clicking Python.
![ss4git](https://user-images.githubusercontent.com/8372277/35181454-15b4b7b4-fdd3-11e7-8ea5-3059bc455c5e.PNG)


### Reason for Changes

Blocks without implementation creates an error and changes in the workspace do not apply anymore.

### Test Coverage


Tested on:
* Desktop Chrome

* PC:
  * Device: Asus
  * OS: W10
  * Browser Chrome
  * Version 63

