### PR TITLE
Blockly.Variables.createVariable(..) → .createVariableButtonHandler(..)

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -144,7 +144,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
   button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
   workspace.registerButtonCallback('CREATE_VARIABLE', function(button) {
-    Blockly.Variables.createVariable(button.getTargetWorkspace());
+    Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());
   });
 
   xmlList.push(button);
@@ -257,16 +257,24 @@ Blockly.Variables.generateUniqueName = function(workspace) {
 };
 
 /**
- * Create a new variable on the given workspace.
+ * Handles "Create Variable" button in the default variables toolbox category.
+ * It will prompt the user for a varibale name, including re-prompts if a name
+ * is already in use among the workspace's variables.
+ *
+ * Custom button handlers can delegate to this function, allowing variables
+ * types and after-creation processing. More complex customization (e.g.,
+ * prompting for variable type) is beyond the scope of this function.
+ *
  * @param {!Blockly.Workspace} workspace The workspace on which to create the
  *     variable.
- * @param {function(?string=)=} opt_callback A callback. It will
- *     be passed an acceptable new variable name, or null if change is to be
- *     aborted (cancel button), or undefined if an existing variable was chosen.
+ * @param {function(?string=)=} opt_callback A callback. It will be passed an
+ *     acceptable new variable name, or null if change is to be aborted (cancel
+ *     button), or undefined if an existing variable was chosen.
  * @param {string=} opt_type The type of the variable like 'int', 'string', or
  *     ''. This will default to '', which is a specific type.
  */
-Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
+Blockly.Variables.createVariableButtonHandler = function(
+    workspace, opt_callback, opt_type) {
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(Blockly.Msg.NEW_VARIABLE_TITLE, defaultName,
@@ -294,6 +302,25 @@ Blockly.Variables.createVariable = function(workspace, opt_callback, opt_type) {
   };
   promptAndCheckWithAlert('');
 };
+goog.exportSymbol('Blockly.Variables.createVariableButtonHandler',
+    Blockly.Variables.createVariableButtonHandler);
+
+/**
+ * Original name of Blockly.Variables.createVariableButtonHandler(..).
+ * @deprecated Use Blockly.Variables.createVariableButtonHandler(..).
+ *
+ * @param {!Blockly.Workspace} workspace The workspace on which to create the
+ *     variable.
+ * @param {function(?string=)=} opt_callback A callback. It will be passed an
+ *     acceptable new variable name, or null if change is to be aborted (cancel
+ *     button), or undefined if an existing variable was chosen.
+ * @param {string=} opt_type The type of the variable like 'int', 'string', or
+ *     ''. This will default to '', which is a specific type.
+ */
+Blockly.Variables.createVariable =
+    Blockly.Variables.createVariableButtonHandler;
+goog.exportSymbol('Blockly.Variables.createVariable',
+    Blockly.Variables.createVariable);
 
 /**
  * Rename a variable with the given workspace, variableType, and oldName.

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -37,13 +37,13 @@ goog.require('goog.string');
 
 
 Blockly.VariablesDynamic.onCreateVariableButtonClick_String = function(button) {
-  Blockly.Variables.createVariable(button.getTargetWorkspace(), null, 'String');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'String');
 };
 Blockly.VariablesDynamic.onCreateVariableButtonClick_Number = function(button) {
-  Blockly.Variables.createVariable(button.getTargetWorkspace(), null, 'Number');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'Number');
 };
 Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
-  Blockly.Variables.createVariable(button.getTargetWorkspace(), null, 'Colour');
+  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'Colour');
 };
 /**
  * Construct the elements (blocks and button) required by the flyout for the


### PR DESCRIPTION
Clarifying the role of Blockly.Variables.createVariableButtonHandler(..).
Updating documentation a making sure it (and its deprecated previous name)
are properly exported.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Confusion about `Blockly.Variables.createVariable(..)` (versus `Blockly.Variables.createVariable_(..)` and `Blockly.Variables.getOrCreateVariablePackage(..)`).

### Proposed Changes

Rename to `Blockly.Variables.createVariableButtonHandler(..)` and add better docs.

### Reason for Changes

It wasn't clear what the function did or what its role was, at a glance.

### Test Coverage

Tested in the playground on both Variable categories.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
