### PR TITLE
Indentation lint that blocks moving to eslint 4.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
     "rules": {
         "curly": ["error", "multi-line"],
         "eol-last": ["error"],
-        "indent": ["error", 2, {"SwitchCase": 1}], # Blockly/Google use 2-space indents
+        "indent": ["warn", 2, {"SwitchCase": 1}], # Blockly/Google use 2-space indents
         "linebreak-style": ["error", "unix"],
         "max-len": ["error", 120, 4],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -293,8 +293,10 @@ Blockly.Blocks['lists_indexOf'] = {
    */
   init: function() {
     var OPERATORS =
-        [[Blockly.Msg.LISTS_INDEX_OF_FIRST, 'FIRST'],
-         [Blockly.Msg.LISTS_INDEX_OF_LAST, 'LAST']];
+        [
+          [Blockly.Msg.LISTS_INDEX_OF_FIRST, 'FIRST'],
+          [Blockly.Msg.LISTS_INDEX_OF_LAST, 'LAST']
+        ];
     this.setHelpUrl(Blockly.Msg.LISTS_INDEX_OF_HELPURL);
     this.setColour(Blockly.Blocks.lists.HUE);
     this.setOutput(true, 'Number');
@@ -320,15 +322,19 @@ Blockly.Blocks['lists_getIndex'] = {
    */
   init: function() {
     var MODE =
-        [[Blockly.Msg.LISTS_GET_INDEX_GET, 'GET'],
-         [Blockly.Msg.LISTS_GET_INDEX_GET_REMOVE, 'GET_REMOVE'],
-         [Blockly.Msg.LISTS_GET_INDEX_REMOVE, 'REMOVE']];
+        [
+          [Blockly.Msg.LISTS_GET_INDEX_GET, 'GET'],
+          [Blockly.Msg.LISTS_GET_INDEX_GET_REMOVE, 'GET_REMOVE'],
+          [Blockly.Msg.LISTS_GET_INDEX_REMOVE, 'REMOVE']
+        ];
     this.WHERE_OPTIONS =
-        [[Blockly.Msg.LISTS_GET_INDEX_FROM_START, 'FROM_START'],
-         [Blockly.Msg.LISTS_GET_INDEX_FROM_END, 'FROM_END'],
-         [Blockly.Msg.LISTS_GET_INDEX_FIRST, 'FIRST'],
-         [Blockly.Msg.LISTS_GET_INDEX_LAST, 'LAST'],
-         [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']];
+        [
+          [Blockly.Msg.LISTS_GET_INDEX_FROM_START, 'FROM_START'],
+          [Blockly.Msg.LISTS_GET_INDEX_FROM_END, 'FROM_END'],
+          [Blockly.Msg.LISTS_GET_INDEX_FIRST, 'FIRST'],
+          [Blockly.Msg.LISTS_GET_INDEX_LAST, 'LAST'],
+          [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']
+        ];
     this.setHelpUrl(Blockly.Msg.LISTS_GET_INDEX_HELPURL);
     this.setColour(Blockly.Blocks.lists.HUE);
     var modeMenu = new Blockly.FieldDropdown(MODE, function(value) {
@@ -501,14 +507,18 @@ Blockly.Blocks['lists_setIndex'] = {
    */
   init: function() {
     var MODE =
-        [[Blockly.Msg.LISTS_SET_INDEX_SET, 'SET'],
-         [Blockly.Msg.LISTS_SET_INDEX_INSERT, 'INSERT']];
+        [
+          [Blockly.Msg.LISTS_SET_INDEX_SET, 'SET'],
+          [Blockly.Msg.LISTS_SET_INDEX_INSERT, 'INSERT']
+        ];
     this.WHERE_OPTIONS =
-        [[Blockly.Msg.LISTS_GET_INDEX_FROM_START, 'FROM_START'],
-         [Blockly.Msg.LISTS_GET_INDEX_FROM_END, 'FROM_END'],
-         [Blockly.Msg.LISTS_GET_INDEX_FIRST, 'FIRST'],
-         [Blockly.Msg.LISTS_GET_INDEX_LAST, 'LAST'],
-         [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']];
+        [
+          [Blockly.Msg.LISTS_GET_INDEX_FROM_START, 'FROM_START'],
+          [Blockly.Msg.LISTS_GET_INDEX_FROM_END, 'FROM_END'],
+          [Blockly.Msg.LISTS_GET_INDEX_FIRST, 'FIRST'],
+          [Blockly.Msg.LISTS_GET_INDEX_LAST, 'LAST'],
+          [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']
+        ];
     this.setHelpUrl(Blockly.Msg.LISTS_SET_INDEX_HELPURL);
     this.setColour(Blockly.Blocks.lists.HUE);
     this.appendValueInput('LIST')
@@ -637,13 +647,17 @@ Blockly.Blocks['lists_getSublist'] = {
    */
   init: function() {
     this['WHERE_OPTIONS_1'] =
-        [[Blockly.Msg.LISTS_GET_SUBLIST_START_FROM_START, 'FROM_START'],
-         [Blockly.Msg.LISTS_GET_SUBLIST_START_FROM_END, 'FROM_END'],
-         [Blockly.Msg.LISTS_GET_SUBLIST_START_FIRST, 'FIRST']];
+        [
+          [Blockly.Msg.LISTS_GET_SUBLIST_START_FROM_START, 'FROM_START'],
+          [Blockly.Msg.LISTS_GET_SUBLIST_START_FROM_END, 'FROM_END'],
+          [Blockly.Msg.LISTS_GET_SUBLIST_START_FIRST, 'FIRST']
+        ];
     this['WHERE_OPTIONS_2'] =
-        [[Blockly.Msg.LISTS_GET_SUBLIST_END_FROM_START, 'FROM_START'],
-         [Blockly.Msg.LISTS_GET_SUBLIST_END_FROM_END, 'FROM_END'],
-         [Blockly.Msg.LISTS_GET_SUBLIST_END_LAST, 'LAST']];
+        [
+          [Blockly.Msg.LISTS_GET_SUBLIST_END_FROM_START, 'FROM_START'],
+          [Blockly.Msg.LISTS_GET_SUBLIST_END_FROM_END, 'FROM_END'],
+          [Blockly.Msg.LISTS_GET_SUBLIST_END_LAST, 'LAST']
+        ];
     this.setHelpUrl(Blockly.Msg.LISTS_GET_SUBLIST_HELPURL);
     this.setColour(Blockly.Blocks.lists.HUE);
     this.appendValueInput('LIST')
@@ -786,8 +800,10 @@ Blockly.Blocks['lists_split'] = {
     // Assign 'this' to a variable for use in the closures below.
     var thisBlock = this;
     var dropdown = new Blockly.FieldDropdown(
-        [[Blockly.Msg.LISTS_SPLIT_LIST_FROM_TEXT, 'SPLIT'],
-         [Blockly.Msg.LISTS_SPLIT_TEXT_FROM_LIST, 'JOIN']],
+        [
+          [Blockly.Msg.LISTS_SPLIT_LIST_FROM_TEXT, 'SPLIT'],
+          [Blockly.Msg.LISTS_SPLIT_TEXT_FROM_LIST, 'JOIN']
+        ],
         function(newMode) {
           thisBlock.updateType_(newMode);
         });

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -228,7 +228,7 @@ Blockly.Constants.Loops.WHILE_UNTIL_TOOLTIPS = {
 
 Blockly.Extensions.register('controls_whileUntil_tooltip',
     Blockly.Extensions.buildTooltipForDropdown(
-      'MODE', Blockly.Constants.Loops.WHILE_UNTIL_TOOLTIPS));
+        'MODE', Blockly.Constants.Loops.WHILE_UNTIL_TOOLTIPS));
 
 /**
  * Tooltips for the 'controls_flow_statements' block, keyed by FLOW value.
@@ -243,7 +243,7 @@ Blockly.Constants.Loops.BREAK_CONTINUE_TOOLTIPS = {
 
 Blockly.Extensions.register('controls_flow_tooltip',
     Blockly.Extensions.buildTooltipForDropdown(
-      'FLOW', Blockly.Constants.Loops.BREAK_CONTINUE_TOOLTIPS));
+        'FLOW', Blockly.Constants.Loops.BREAK_CONTINUE_TOOLTIPS));
 
 /**
  * Mixin to add a context menu item to create a 'variables_get' block.

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -183,7 +183,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     // Check/uncheck the allow statement box.
     if (this.getInput('RETURN')) {
       containerBlock.setFieldValue(this.hasStatements_ ? 'TRUE' : 'FALSE',
-                                   'STATEMENTS');
+          'STATEMENTS');
     } else {
       containerBlock.getInput('STATEMENT_INPUT').setVisible(false);
     }
@@ -557,10 +557,10 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   renameProcedure: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getProcedureCall())) {
       this.setFieldValue(newName, 'NAME');
-      this.setTooltip(
-          (this.outputConnection ? Blockly.Msg.PROCEDURES_CALLRETURN_TOOLTIP :
-           Blockly.Msg.PROCEDURES_CALLNORETURN_TOOLTIP)
-          .replace('%1', newName));
+      var baseMsg = this.outputConnection ?
+          Blockly.Msg.PROCEDURES_CALLRETURN_TOOLTIP :
+          Blockly.Msg.PROCEDURES_CALLNORETURN_TOOLTIP;
+      this.setTooltip(baseMsg.replace('%1', newName));
     }
   },
   /**
@@ -906,7 +906,7 @@ Blockly.Blocks['procedures_ifreturn'] = {
     if (!this.hasReturnValue_) {
       this.removeInput('VALUE');
       this.appendDummyInput('VALUE')
-        .appendField(Blockly.Msg.PROCEDURES_DEFRETURN_RETURN);
+          .appendField(Blockly.Msg.PROCEDURES_DEFRETURN_RETURN);
     }
   },
   /**

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -182,8 +182,8 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 
     // Check/uncheck the allow statement box.
     if (this.getInput('RETURN')) {
-      containerBlock.setFieldValue(this.hasStatements_ ? 'TRUE' : 'FALSE',
-          'STATEMENTS');
+      containerBlock.setFieldValue(
+          this.hasStatements_ ? 'TRUE' : 'FALSE', 'STATEMENTS');
     } else {
       containerBlock.getInput('STATEMENT_INPUT').setVisible(false);
     }

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -190,11 +190,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_dropdown",
         "name": "WHERE",
-        "options": [["%{BKY_TEXT_CHARAT_FROM_START}", "FROM_START"],
-            ["%{BKY_TEXT_CHARAT_FROM_END}", "FROM_END"],
-            ["%{BKY_TEXT_CHARAT_FIRST}", "FIRST"],
-            ["%{BKY_TEXT_CHARAT_LAST}", "LAST"],
-            ["%{BKY_TEXT_CHARAT_RANDOM}", "RANDOM"]]
+        "options": [
+          ["%{BKY_TEXT_CHARAT_FROM_START}", "FROM_START"],
+          ["%{BKY_TEXT_CHARAT_FROM_END}", "FROM_END"],
+          ["%{BKY_TEXT_CHARAT_FIRST}", "FIRST"],
+          ["%{BKY_TEXT_CHARAT_LAST}", "LAST"],
+          ["%{BKY_TEXT_CHARAT_RANDOM}", "RANDOM"]
+        ]
       }
     ],
     "output": "String",
@@ -629,10 +631,10 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
       this.QUOTE_IMAGE_LEFT_DATAURI :
       this.QUOTE_IMAGE_RIGHT_DATAURI;
     return new Blockly.FieldImage(
-      dataUri,
-      this.QUOTE_IMAGE_WIDTH,
-      this.QUOTE_IMAGE_HEIGHT,
-      isLeft ? '\u201C' : '\u201D');
+        dataUri,
+        this.QUOTE_IMAGE_WIDTH,
+        this.QUOTE_IMAGE_HEIGHT,
+        isLeft ? '\u201C' : '\u201D');
   }
 };
 

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -113,8 +113,8 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
  * surface.
  */
 Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
-  goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
-      'Already dragging a block.');
+  goog.asserts.assert(
+      this.dragGroup_.childNodes.length == 0, 'Already dragging a block.');
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
   this.SVG_.style.display = 'block';
@@ -214,7 +214,7 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
     this.dragGroup_.removeChild(this.getCurrentBlock());
   }
   this.SVG_.style.display = 'none';
-  goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
-      'Drag group was not cleared.');
+  goog.asserts.assert(
+      this.dragGroup_.childNodes.length == 0, 'Drag group was not cleared.');
   this.surfaceXY_ = null;
 };

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -114,7 +114,7 @@ Blockly.BlockDragSurfaceSvg.prototype.createDom = function() {
  */
 Blockly.BlockDragSurfaceSvg.prototype.setBlocksAndShow = function(blocks) {
   goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
-    'Already dragging a block.');
+      'Already dragging a block.');
   // appendChild removes the blocks from the previous parent
   this.dragGroup_.appendChild(blocks);
   this.SVG_.style.display = 'block';
@@ -215,6 +215,6 @@ Blockly.BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
   }
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.dragGroup_.childNodes.length == 0,
-    'Drag group was not cleared.');
+      'Drag group was not cleared.');
   this.surfaceXY_ = null;
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -150,7 +150,7 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   this.updateMovable();
   if (!this.workspace.options.readOnly && !this.eventsInit_) {
     Blockly.bindEventWithChecks_(this.getSvgRoot(), 'mousedown', this,
-                       this.onMouseDown_);
+        this.onMouseDown_);
   }
   this.eventsInit_ = true;
 
@@ -709,11 +709,11 @@ Blockly.BlockSvg.prototype.setDragging = function(adding) {
     Blockly.draggingConnections_ =
         Blockly.draggingConnections_.concat(this.getConnections_(true));
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-                      'blocklyDragging');
+        'blocklyDragging');
   } else {
     Blockly.draggingConnections_ = [];
     Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-                         'blocklyDragging');
+        'blocklyDragging');
   }
   // Recurse through all blocks attached under this one.
   for (var i = 0; i < this.childBlocks_.length; i++) {
@@ -727,10 +727,10 @@ Blockly.BlockSvg.prototype.setDragging = function(adding) {
 Blockly.BlockSvg.prototype.updateMovable = function() {
   if (this.isMovable()) {
     Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-                      'blocklyDraggable');
+        'blocklyDraggable');
   } else {
     Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-                         'blocklyDraggable');
+        'blocklyDraggable');
   }
 };
 
@@ -878,7 +878,7 @@ Blockly.BlockSvg.disposeUiStep_ = function(clone, rtl, start, workspaceScale) {
     clone.setAttribute('transform', 'translate(' + x + ',' + y + ')' +
         ' scale(' + scale + ')');
     setTimeout(Blockly.BlockSvg.disposeUiStep_, 10, clone, rtl, start,
-               workspaceScale);
+        workspaceScale);
   }
 };
 
@@ -901,8 +901,14 @@ Blockly.BlockSvg.prototype.connectionUiEffect = function() {
     xy.y += 3 * this.workspace.scale;
   }
   var ripple = Blockly.utils.createSvgElement('circle',
-      {'cx': xy.x, 'cy': xy.y, 'r': 0, 'fill': 'none',
-       'stroke': '#888', 'stroke-width': 10},
+      {
+        'cx': xy.x,
+        'cy': xy.y,
+        'r': 0,
+        'fill': 'none',
+        'stroke': '#888',
+        'stroke-width': 10
+      },
       this.workspace.getParentSvg());
   // Start the animation.
   Blockly.BlockSvg.connectionUiStep_(ripple, new Date, this.workspace.scale);
@@ -971,7 +977,7 @@ Blockly.BlockSvg.disconnectUiStep_ = function(group, magnitude, start) {
     Blockly.BlockSvg.disconnectUiStop_.group = group;
     Blockly.BlockSvg.disconnectUiStop_.pid =
         setTimeout(Blockly.BlockSvg.disconnectUiStep_, 10, group, magnitude,
-                   start);
+            start);
   }
   group.setAttribute('transform', group.translate_ + group.skew_);
 };
@@ -1045,14 +1051,16 @@ Blockly.BlockSvg.prototype.updateColour = function() {
  */
 Blockly.BlockSvg.prototype.updateDisabled = function() {
   if (this.disabled || this.getInheritedDisabled()) {
-    if (Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-                      'blocklyDisabled')) {
+    var added = Blockly.utils.addClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDisabled');
+    if (added) {
       this.svgPath_.setAttribute('fill',
           'url(#' + this.workspace.options.disabledPatternId + ')');
     }
   } else {
-    if (Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-                         'blocklyDisabled')) {
+    var removed = Blockly.utils.removeClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDisabled');
+    if (removed) {
       this.updateColour();
     }
   }
@@ -1234,7 +1242,7 @@ Blockly.BlockSvg.prototype.setHighlighted = function(highlighted) {
  */
 Blockly.BlockSvg.prototype.addSelect = function() {
   Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-                    'blocklySelected');
+      'blocklySelected');
 };
 
 /**
@@ -1242,7 +1250,7 @@ Blockly.BlockSvg.prototype.addSelect = function() {
  */
 Blockly.BlockSvg.prototype.removeSelect = function() {
   Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-                       'blocklySelected');
+      'blocklySelected');
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -149,8 +149,8 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   this.updateColour();
   this.updateMovable();
   if (!this.workspace.options.readOnly && !this.eventsInit_) {
-    Blockly.bindEventWithChecks_(this.getSvgRoot(), 'mousedown', this,
-        this.onMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.getSvgRoot(), 'mousedown', this, this.onMouseDown_);
   }
   this.eventsInit_ = true;
 
@@ -708,12 +708,12 @@ Blockly.BlockSvg.prototype.setDragging = function(adding) {
     group.skew_ = '';
     Blockly.draggingConnections_ =
         Blockly.draggingConnections_.concat(this.getConnections_(true));
-    Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyDragging');
+    Blockly.utils.addClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDragging');
   } else {
     Blockly.draggingConnections_ = [];
-    Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyDragging');
+    Blockly.utils.removeClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDragging');
   }
   // Recurse through all blocks attached under this one.
   for (var i = 0; i < this.childBlocks_.length; i++) {
@@ -726,11 +726,11 @@ Blockly.BlockSvg.prototype.setDragging = function(adding) {
  */
 Blockly.BlockSvg.prototype.updateMovable = function() {
   if (this.isMovable()) {
-    Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyDraggable');
+    Blockly.utils.addClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDraggable');
   } else {
-    Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyDraggable');
+    Blockly.utils.removeClass(
+        /** @type {!Element} */ (this.svgGroup_), 'blocklyDraggable');
   }
 };
 
@@ -877,8 +877,8 @@ Blockly.BlockSvg.disposeUiStep_ = function(clone, rtl, start, workspaceScale) {
     var scale = (1 - percent) * workspaceScale;
     clone.setAttribute('transform', 'translate(' + x + ',' + y + ')' +
         ' scale(' + scale + ')');
-    setTimeout(Blockly.BlockSvg.disposeUiStep_, 10, clone, rtl, start,
-        workspaceScale);
+    setTimeout(
+        Blockly.BlockSvg.disposeUiStep_, 10, clone, rtl, start, workspaceScale);
   }
 };
 
@@ -971,13 +971,13 @@ Blockly.BlockSvg.disconnectUiStep_ = function(group, magnitude, start) {
   if (percent > 1) {
     group.skew_ = '';
   } else {
-    var skew = Math.round(Math.sin(percent * Math.PI * WIGGLES) *
-        (1 - percent) * magnitude);
+    var skew = Math.round(
+        Math.sin(percent * Math.PI * WIGGLES) * (1 - percent) * magnitude);
     group.skew_ = 'skewX(' + skew + ')';
     Blockly.BlockSvg.disconnectUiStop_.group = group;
     Blockly.BlockSvg.disconnectUiStop_.pid =
-        setTimeout(Blockly.BlockSvg.disconnectUiStep_, 10, group, magnitude,
-            start);
+        setTimeout(
+            Blockly.BlockSvg.disconnectUiStep_, 10, group, magnitude, start);
   }
   group.setAttribute('transform', group.translate_ + group.skew_);
 };
@@ -1241,16 +1241,16 @@ Blockly.BlockSvg.prototype.setHighlighted = function(highlighted) {
  * Select this block.  Highlight it visually.
  */
 Blockly.BlockSvg.prototype.addSelect = function() {
-  Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
-      'blocklySelected');
+  Blockly.utils.addClass(
+      /** @type {!Element} */ (this.svgGroup_), 'blocklySelected');
 };
 
 /**
  * Unselect this block.  Remove its highlighting.
  */
 Blockly.BlockSvg.prototype.removeSelect = function() {
-  Blockly.utils.removeClass(/** @type {!Element} */ (this.svgGroup_),
-      'blocklySelected');
+  Blockly.utils.removeClass(
+      /** @type {!Element} */ (this.svgGroup_), 'blocklySelected');
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -120,8 +120,10 @@ Blockly.hueToRgb = function(hue) {
  * @return {!Object} Contains width and height properties.
  */
 Blockly.svgSize = function(svg) {
-  return {width: svg.cachedWidth_,
-          height: svg.cachedHeight_};
+  return {
+    width: svg.cachedWidth_,
+    height: svg.cachedHeight_
+  };
 };
 
 /**
@@ -307,7 +309,7 @@ Blockly.hideChaff = function(opt_allowToolbox) {
 Blockly.addChangeListener = function(func) {
   // Backwards compatibility from before there could be multiple workspaces.
   console.warn('Deprecated call to Blockly.addChangeListener, ' +
-               'use workspace.addChangeListener instead.');
+      'use workspace.addChangeListener instead.');
   return Blockly.getMainWorkspace().addChangeListener(func);
 };
 
@@ -381,7 +383,7 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
     var typename = elem.type;
     if (typename == null || typename === '') {
       console.warn('Block definition #' + i +
-        ' in JSON array is missing a type attribute. Skipping.');
+          ' in JSON array is missing a type attribute. Skipping.');
     } else {
       if (Blockly.Blocks[typename]) {
         console.warn('Block definition #' + i +

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -308,7 +308,8 @@ Blockly.hideChaff = function(opt_allowToolbox) {
  */
 Blockly.addChangeListener = function(func) {
   // Backwards compatibility from before there could be multiple workspaces.
-  console.warn('Deprecated call to Blockly.addChangeListener, ' +
+  console.warn(
+      'Deprecated call to Blockly.addChangeListener, ' +
       'use workspace.addChangeListener instead.');
   return Blockly.getMainWorkspace().addChangeListener(func);
 };
@@ -382,12 +383,14 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
   for (var i = 0, elem; elem = jsonArray[i]; i++) {
     var typename = elem.type;
     if (typename == null || typename === '') {
-      console.warn('Block definition #' + i +
+      console.warn(
+          'Block definition #' + i +
           ' in JSON array is missing a type attribute. Skipping.');
     } else {
       if (Blockly.Blocks[typename]) {
-        console.warn('Block definition #' + i +
-          ' in JSON array overwrites prior definition of "' + typename + '".');
+        console.warn(
+            'Block definition #' + i + ' in JSON array' +
+            ' overwrites prior definition of "' + typename + '".');
       }
       Blockly.Blocks[typename] = {
         init: Blockly.jsonInitFactory_(elem)

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -75,11 +75,11 @@ Blockly.Bubble = function(workspace, content, shape, anchorXY,
   this.rendered_ = true;
 
   if (!workspace.options.readOnly) {
-    Blockly.bindEventWithChecks_(this.bubbleBack_, 'mousedown', this,
-        this.bubbleMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.bubbleBack_, 'mousedown', this, this.bubbleMouseDown_);
     if (this.resizeGroup_) {
-      Blockly.bindEventWithChecks_(this.resizeGroup_, 'mousedown', this,
-          this.resizeMouseDown_);
+      Blockly.bindEventWithChecks_(
+          this.resizeGroup_, 'mousedown', this, this.resizeMouseDown_);
     }
   }
 };

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -47,7 +47,7 @@ goog.require('goog.userAgent');
  * @constructor
  */
 Blockly.Bubble = function(workspace, content, shape, anchorXY,
-                          bubbleWidth, bubbleHeight) {
+    bubbleWidth, bubbleHeight) {
   this.workspace_ = workspace;
   this.content_ = content;
   this.shape_ = shape;
@@ -76,10 +76,10 @@ Blockly.Bubble = function(workspace, content, shape, anchorXY,
 
   if (!workspace.options.readOnly) {
     Blockly.bindEventWithChecks_(this.bubbleBack_, 'mousedown', this,
-                       this.bubbleMouseDown_);
+        this.bubbleMouseDown_);
     if (this.resizeGroup_) {
       Blockly.bindEventWithChecks_(this.resizeGroup_, 'mousedown', this,
-                         this.resizeMouseDown_);
+          this.resizeMouseDown_);
     }
   }
 };
@@ -235,8 +235,13 @@ Blockly.Bubble.prototype.createDom_ = function(content, hasResize) {
       filter, this.bubbleGroup_);
   this.bubbleArrow_ = Blockly.utils.createSvgElement('path', {}, bubbleEmboss);
   this.bubbleBack_ = Blockly.utils.createSvgElement('rect',
-      {'class': 'blocklyDraggable', 'x': 0, 'y': 0,
-      'rx': Blockly.Bubble.BORDER_WIDTH, 'ry': Blockly.Bubble.BORDER_WIDTH},
+      {
+        'class': 'blocklyDraggable',
+        'x': 0,
+        'y': 0,
+        'rx': Blockly.Bubble.BORDER_WIDTH,
+        'ry': Blockly.Bubble.BORDER_WIDTH
+      },
       bubbleEmboss);
   if (hasResize) {
     this.resizeGroup_ = Blockly.utils.createSvgElement('g',
@@ -248,13 +253,19 @@ Blockly.Bubble.prototype.createDom_ = function(content, hasResize) {
         {'points': '0,x x,x x,0'.replace(/x/g, resizeSize.toString())},
         this.resizeGroup_);
     Blockly.utils.createSvgElement('line',
-        {'class': 'blocklyResizeLine',
-        'x1': resizeSize / 3, 'y1': resizeSize - 1,
-        'x2': resizeSize - 1, 'y2': resizeSize / 3}, this.resizeGroup_);
+        {
+          'class': 'blocklyResizeLine',
+          'x1': resizeSize / 3, 'y1': resizeSize - 1,
+          'x2': resizeSize - 1, 'y2': resizeSize / 3
+        }, this.resizeGroup_);
     Blockly.utils.createSvgElement('line',
-        {'class': 'blocklyResizeLine',
-        'x1': resizeSize * 2 / 3, 'y1': resizeSize - 1,
-        'x2': resizeSize - 1, 'y2': resizeSize * 2 / 3}, this.resizeGroup_);
+        {
+          'class': 'blocklyResizeLine',
+          'x1': resizeSize * 2 / 3,
+          'y1': resizeSize - 1,
+          'x2': resizeSize - 1,
+          'y2': resizeSize * 2 / 3
+        }, this.resizeGroup_);
   } else {
     this.resizeGroup_ = null;
   }

--- a/core/comment.js
+++ b/core/comment.js
@@ -75,15 +75,21 @@ Blockly.Comment.prototype.drawIcon_ = function(group) {
   // systems render it differently.
   // Body of question mark.
   Blockly.utils.createSvgElement('path',
-      {'class': 'blocklyIconSymbol',
-      'd': 'm6.8,10h2c0.003,-0.617 0.271,-0.962 0.633,-1.266 2.875,-2.405' +
-      '0.607,-5.534 -3.765,-3.874v1.7c3.12,-1.657 3.698,0.118 2.336,1.25' +
-      '-1.201,0.998 -1.201,1.528 -1.204,2.19z'},
+      {
+        'class': 'blocklyIconSymbol',
+        'd': 'm6.8,10h2c0.003,-0.617 0.271,-0.962 0.633,-1.266 2.875,-2.405' +
+          '0.607,-5.534 -3.765,-3.874v1.7c3.12,-1.657 3.698,0.118 2.336,1.25' +
+          '-1.201,0.998 -1.201,1.528 -1.204,2.19z'},
       group);
   // Dot of question mark.
   Blockly.utils.createSvgElement('rect',
-      {'class': 'blocklyIconSymbol',
-      'x': '6.8', 'y': '10.78', 'height': '2', 'width': '2'},
+      {
+        'class': 'blocklyIconSymbol',
+        'x': '6.8',
+        'y': '10.78',
+        'height': '2',
+        'width': '2'
+      },
       group);
 };
 
@@ -124,7 +130,7 @@ Blockly.Comment.prototype.createEditor_ = function() {
       /* eslint-enable no-unused-vars */) {
     if (this.text_ != textarea.value) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.block_, 'comment', null, this.text_, textarea.value));
+          this.block_, 'comment', null, this.text_, textarea.value));
       this.text_ = textarea.value;
     }
   });
@@ -212,7 +218,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
  * @private
  */
 Blockly.Comment.prototype.textareaFocus_ = function(
-  /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
+    /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
@@ -263,7 +269,7 @@ Blockly.Comment.prototype.getText = function() {
 Blockly.Comment.prototype.setText = function(text) {
   if (this.text_ != text) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
-      this.block_, 'comment', null, this.text_, text));
+        this.block_, 'comment', null, this.text_, text));
     this.text_ = text;
   }
   if (this.textarea_) {

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -109,9 +109,8 @@ Blockly.ConnectionDB.prototype.findConnection = function(conn) {
  * @return {number} The candidate index.
  * @private
  */
-Blockly.ConnectionDB.prototype.findPositionForConnection_ =
-    function(connection) {
-  /* eslint-disable indent */
+Blockly.ConnectionDB.prototype.findPositionForConnection_ = function(
+    connection) {
   if (!this.length) {
     return 0;
   }
@@ -129,7 +128,7 @@ Blockly.ConnectionDB.prototype.findPositionForConnection_ =
     }
   }
   return pointerMin;
-};  /* eslint-enable indent */
+};
 
 /**
  * Remove a connection from the database.  Must already exist in DB.

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -68,7 +68,7 @@ Blockly.ContextMenu.show = function(e, options, rtl) {
   var menu = Blockly.ContextMenu.populate_(options, rtl);
 
   goog.events.listen(menu, goog.ui.Component.EventType.ACTION,
-                     Blockly.ContextMenu.hide);
+      Blockly.ContextMenu.hide);
 
   Blockly.ContextMenu.position_(menu, e, rtl);
   // 1ms delay is required for focusing on context menus because some other
@@ -99,7 +99,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
       goog.events.listen(menuItem, goog.ui.Component.EventType.ACTION,
-                         option.callback);
+          option.callback);
       menuItem.handleContextMenu = function(/* e */) {
         // Right-clicking on menu option should count as a click.
         goog.events.dispatchEvent(this, goog.ui.Component.EventType.ACTION);
@@ -155,7 +155,7 @@ Blockly.ContextMenu.createWidget_ = function(menu) {
   Blockly.utils.addClass(menuDom, 'blocklyContextMenu');
   // Prevent system context menu when right-clicking a Blockly context menu.
   Blockly.bindEventWithChecks_(menuDom, 'contextmenu', null,
-                               Blockly.utils.noEvent);
+      Blockly.utils.noEvent);
   // Enable autofocus after the initial render to avoid issue #1329.
   menu.setAllowAutoFocus(true);
 };

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -67,8 +67,8 @@ Blockly.ContextMenu.show = function(e, options, rtl) {
   }
   var menu = Blockly.ContextMenu.populate_(options, rtl);
 
-  goog.events.listen(menu, goog.ui.Component.EventType.ACTION,
-      Blockly.ContextMenu.hide);
+  goog.events.listen(
+      menu, goog.ui.Component.EventType.ACTION, Blockly.ContextMenu.hide);
 
   Blockly.ContextMenu.position_(menu, e, rtl);
   // 1ms delay is required for focusing on context menus because some other
@@ -98,8 +98,8 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
     menu.addChild(menuItem, true);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
-      goog.events.listen(menuItem, goog.ui.Component.EventType.ACTION,
-          option.callback);
+      goog.events.listen(
+          menuItem, goog.ui.Component.EventType.ACTION, option.callback);
       menuItem.handleContextMenu = function(/* e */) {
         // Right-clicking on menu option should count as a click.
         goog.events.dispatchEvent(this, goog.ui.Component.EventType.ACTION);
@@ -154,8 +154,8 @@ Blockly.ContextMenu.createWidget_ = function(menu) {
   var menuDom = menu.getElement();
   Blockly.utils.addClass(menuDom, 'blocklyContextMenu');
   // Prevent system context menu when right-clicking a Blockly context menu.
-  Blockly.bindEventWithChecks_(menuDom, 'contextmenu', null,
-      Blockly.utils.noEvent);
+  Blockly.bindEventWithChecks_(
+      menuDom, 'contextmenu', null, Blockly.utils.noEvent);
   // Enable autofocus after the initial render to avoid issue #1329.
   menu.setAllowAutoFocus(true);
 };

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -163,8 +163,8 @@ Blockly.DraggedConnectionManager.prototype.update = function(dxy, deleteArea) {
     oldClosestConnection.unhighlight();
   }
 
- // Prefer connecting over dropping into the trash can, but prefer dragging to
- // the toolbox over connecting to other blocks.
+  // Prefer connecting over dropping into the trash can, but prefer dragging to
+  // the toolbox over connecting to other blocks.
   var wouldConnect = !!this.closestConnection_ &&
       deleteArea != Blockly.DELETE_AREA_TOOLBOX;
   var wouldDelete = !!deleteArea && !this.topBlock_.getParent() &&

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -100,10 +100,10 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
   var errorPrefix = 'Error when registering mutator "' + name + '": ';
 
   // Sanity check the mixin object before registering it.
-  Blockly.Extensions.checkHasFunction_(errorPrefix, mixinObj.domToMutation,
-      'domToMutation');
-  Blockly.Extensions.checkHasFunction_(errorPrefix, mixinObj.mutationToDom,
-      'mutationToDom');
+  Blockly.Extensions.checkHasFunction_(
+      errorPrefix, mixinObj.domToMutation, 'domToMutation');
+  Blockly.Extensions.checkHasFunction_(
+      errorPrefix, mixinObj.mutationToDom, 'mutationToDom');
 
   var hasMutatorDialog =
       Blockly.Extensions.checkMutatorDialog_(mixinObj, errorPrefix);

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -101,9 +101,9 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
 
   // Sanity check the mixin object before registering it.
   Blockly.Extensions.checkHasFunction_(errorPrefix, mixinObj.domToMutation,
-                                       'domToMutation');
+      'domToMutation');
   Blockly.Extensions.checkHasFunction_(errorPrefix, mixinObj.mutationToDom,
-                                       'mutationToDom');
+      'mutationToDom');
 
   var hasMutatorDialog =
       Blockly.Extensions.checkMutatorDialog_(mixinObj, errorPrefix);

--- a/core/field.js
+++ b/core/field.js
@@ -157,8 +157,8 @@ Blockly.Field.prototype.init = function() {
   this.updateEditable();
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.mouseDownWrapper_ =
-      Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
-          this.onMouseDown_);
+      Blockly.bindEventWithChecks_(
+          this.fieldGroup_, 'mousedown', this, this.onMouseDown_);
   // Force a render.
   this.render_();
 };

--- a/core/field.js
+++ b/core/field.js
@@ -142,11 +142,13 @@ Blockly.Field.prototype.init = function() {
     this.fieldGroup_.style.display = 'none';
   }
   this.borderRect_ = Blockly.utils.createSvgElement('rect',
-      {'rx': 4,
-       'ry': 4,
-       'x': -Blockly.BlockSvg.SEP_SPACE_X / 2,
-       'y': 0,
-       'height': 16}, this.fieldGroup_);
+      {
+        'rx': 4,
+        'ry': 4,
+        'x': -Blockly.BlockSvg.SEP_SPACE_X / 2,
+        'y': 0,
+        'height': 16
+      }, this.fieldGroup_);
   /** @type {!Element} */
   this.textElement_ = Blockly.utils.createSvgElement('text',
       {'class': 'blocklyText', 'y': this.size_.height - 12.5},
@@ -156,7 +158,7 @@ Blockly.Field.prototype.init = function() {
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.mouseDownWrapper_ =
       Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
-      this.onMouseDown_);
+          this.onMouseDown_);
   // Force a render.
   this.render_();
 };

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -203,8 +203,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   this.moveWrapper1_ =
       Blockly.bindEvent_(circle, 'mousemove', this, this.onMouseMove);
   this.moveWrapper2_ =
-      Blockly.bindEvent_(this.gauge_, 'mousemove', this,
-      this.onMouseMove);
+      Blockly.bindEvent_(this.gauge_, 'mousemove', this, this.onMouseMove);
   this.updateGraph_();
 };
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -181,7 +181,7 @@ Blockly.FieldDropdown.prototype.addTouchStartListener_ = function(menu) {
     control.handleMouseDown(e);
   }
   menu.getHandler().listen(menu.getElement(), goog.events.EventType.TOUCHSTART,
-                           callback);
+      callback);
 };
 
 /**
@@ -197,7 +197,7 @@ Blockly.FieldDropdown.prototype.addTouchEndListener_ = function(menu) {
     control.performActionInternal(e);
   }
   menu.getHandler().listen(menu.getElement(), goog.events.EventType.TOUCHEND,
-                           callbackTouchEnd);
+      callbackTouchEnd);
 };
 
 /**
@@ -485,11 +485,13 @@ Blockly.FieldDropdown.prototype.render_ = function() {
 Blockly.FieldDropdown.prototype.renderSelectedImage_ = function() {
   // Image option is selected.
   this.imageElement_ = Blockly.utils.createSvgElement('image',
-      {'y': 5,
-       'height': this.imageJson_.height + 'px',
-       'width': this.imageJson_.width + 'px'}, this.fieldGroup_);
+      {
+        'y': 5,
+        'height': this.imageJson_.height + 'px',
+        'width': this.imageJson_.width + 'px'
+      }, this.fieldGroup_);
   this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
-                                    'xlink:href', this.imageJson_.src);
+      'xlink:href', this.imageJson_.src);
   // Insert dropdown arrow.
   this.textElement_.appendChild(this.arrow_);
   var arrowWidth = Blockly.Field.getCachedWidth(this.arrow_);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -180,8 +180,8 @@ Blockly.FieldDropdown.prototype.addTouchStartListener_ = function(menu) {
     // Highlight the menu item.
     control.handleMouseDown(e);
   }
-  menu.getHandler().listen(menu.getElement(), goog.events.EventType.TOUCHSTART,
-      callback);
+  menu.getHandler().listen(
+      menu.getElement(), goog.events.EventType.TOUCHSTART, callback);
 };
 
 /**
@@ -196,8 +196,8 @@ Blockly.FieldDropdown.prototype.addTouchEndListener_ = function(menu) {
     // Activate the menu item.
     control.performActionInternal(e);
   }
-  menu.getHandler().listen(menu.getElement(), goog.events.EventType.TOUCHEND,
-      callbackTouchEnd);
+  menu.getHandler().listen(
+      menu.getElement(), goog.events.EventType.TOUCHEND, callbackTouchEnd);
 };
 
 /**
@@ -490,8 +490,8 @@ Blockly.FieldDropdown.prototype.renderSelectedImage_ = function() {
         'height': this.imageJson_.height + 'px',
         'width': this.imageJson_.width + 'px'
       }, this.fieldGroup_);
-  this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink',
-      'xlink:href', this.imageJson_.src);
+  this.imageElement_.setAttributeNS(
+      'http://www.w3.org/1999/xlink', 'xlink:href', this.imageJson_.src);
   // Insert dropdown arrow.
   this.textElement_.appendChild(this.arrow_);
   var arrowWidth = Blockly.Field.getCachedWidth(this.arrow_);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -114,8 +114,8 @@ Blockly.FieldImage.prototype.dispose = function() {
 Blockly.FieldImage.prototype.maybeAddClickHandler_ = function() {
   if (this.clickHandler_) {
     this.mouseDownWrapper_ =
-        Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
-            this.onMouseDown_);
+        Blockly.bindEventWithChecks_(
+            this.fieldGroup_, 'mousedown', this, this.onMouseDown_);
   }
 };
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -81,12 +81,12 @@ Blockly.FieldImage.prototype.init = function() {
   }
   /** @type {SVGElement} */
   this.imageElement_ = Blockly.utils.createSvgElement(
-    'image',
-    {
-      'height': this.height_ + 'px',
-      'width': this.width_ + 'px'
-    },
-    this.fieldGroup_);
+      'image',
+      {
+        'height': this.height_ + 'px',
+        'width': this.width_ + 'px'
+      },
+      this.fieldGroup_);
   this.setValue(this.src_);
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
 
@@ -115,7 +115,7 @@ Blockly.FieldImage.prototype.maybeAddClickHandler_ = function() {
   if (this.clickHandler_) {
     this.mouseDownWrapper_ =
         Blockly.bindEventWithChecks_(this.fieldGroup_, 'mousedown', this,
-        this.onMouseDown_);
+            this.onMouseDown_);
   }
 };
 
@@ -187,7 +187,7 @@ Blockly.FieldImage.prototype.forceRerender = function() {
  * @private
  */
 Blockly.FieldImage.prototype.updateWidth = function() {
- // NOP
+  // NOP
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -206,16 +206,16 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
 Blockly.FieldTextInput.prototype.bindEvents_ = function(htmlInput) {
   // Bind to keydown -- trap Enter without IME and Esc to hide.
   htmlInput.onKeyDownWrapper_ =
-      Blockly.bindEventWithChecks_(htmlInput, 'keydown', this,
-          this.onHtmlInputKeyDown_);
+      Blockly.bindEventWithChecks_(
+          htmlInput, 'keydown', this, this.onHtmlInputKeyDown_);
   // Bind to keyup -- trap Enter; resize after every keystroke.
   htmlInput.onKeyUpWrapper_ =
-      Blockly.bindEventWithChecks_(htmlInput, 'keyup', this,
-          this.onHtmlInputChange_);
+      Blockly.bindEventWithChecks_(
+          htmlInput, 'keyup', this, this.onHtmlInputChange_);
   // Bind to keyPress -- repeatedly resize when holding down a key.
   htmlInput.onKeyPressWrapper_ =
-      Blockly.bindEventWithChecks_(htmlInput, 'keypress', this,
-          this.onHtmlInputChange_);
+      Blockly.bindEventWithChecks_(
+          htmlInput, 'keypress', this, this.onHtmlInputChange_);
   htmlInput.onWorkspaceChangeWrapper_ = this.resizeEditor_.bind(this);
   this.workspace_.addChangeListener(htmlInput.onWorkspaceChangeWrapper_);
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -156,12 +156,12 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
 Blockly.FieldTextInput.prototype.showPromptEditor_ = function() {
   var fieldText = this;
   Blockly.prompt(Blockly.Msg.CHANGE_VALUE_TITLE, this.text_,
-    function(newValue) {
-      if (fieldText.sourceBlock_) {
-        newValue = fieldText.callValidator(newValue);
-      }
-      fieldText.setValue(newValue);
-    });
+      function(newValue) {
+        if (fieldText.sourceBlock_) {
+          newValue = fieldText.callValidator(newValue);
+        }
+        fieldText.setValue(newValue);
+      });
 };
 
 /**
@@ -207,15 +207,15 @@ Blockly.FieldTextInput.prototype.bindEvents_ = function(htmlInput) {
   // Bind to keydown -- trap Enter without IME and Esc to hide.
   htmlInput.onKeyDownWrapper_ =
       Blockly.bindEventWithChecks_(htmlInput, 'keydown', this,
-      this.onHtmlInputKeyDown_);
+          this.onHtmlInputKeyDown_);
   // Bind to keyup -- trap Enter; resize after every keystroke.
   htmlInput.onKeyUpWrapper_ =
       Blockly.bindEventWithChecks_(htmlInput, 'keyup', this,
-      this.onHtmlInputChange_);
+          this.onHtmlInputChange_);
   // Bind to keyPress -- repeatedly resize when holding down a key.
   htmlInput.onKeyPressWrapper_ =
       Blockly.bindEventWithChecks_(htmlInput, 'keypress', this,
-      this.onHtmlInputChange_);
+          this.onHtmlInputChange_);
   htmlInput.onWorkspaceChangeWrapper_ = this.resizeEditor_.bind(this);
   this.workspace_.addChangeListener(htmlInput.onWorkspaceChangeWrapper_);
 };

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -301,8 +301,12 @@ Blockly.FieldVariable.dropdownCreate = function() {
   }
   options.push([Blockly.Msg.RENAME_VARIABLE, Blockly.RENAME_VARIABLE_ID]);
   if (Blockly.Msg.DELETE_VARIABLE) {
-    options.push([Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
-        Blockly.DELETE_VARIABLE_ID]);
+    options.push(
+        [
+          Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          Blockly.DELETE_VARIABLE_ID
+        ]
+    );
   }
 
   return options;

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -242,7 +242,7 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
   // Dragging the flyout up and down.
   Array.prototype.push.apply(this.eventWrappers_,
       Blockly.bindEventWithChecks_(this.svgBackground_, 'mousedown', this,
-      this.onMouseDown_));
+          this.onMouseDown_));
 
   // A flyout connected to a workspace doesn't have its own current gesture.
   this.workspace_.getGesture =
@@ -315,7 +315,7 @@ Blockly.Flyout.prototype.isVisible = function() {
   return this.isVisible_;
 };
 
- /**
+/**
  * Set whether the flyout is visible. A value of true does not necessarily mean
  * that the flyout is shown. It could be hidden because its container is hidden.
  * @param {boolean} visible True if visible.
@@ -637,7 +637,7 @@ Blockly.Flyout.prototype.initFlyoutButton_ = function(button, x, y) {
   // Clicking on a flyout button or label is a lot like clicking on the
   // flyout background.
   this.listeners_.push(Blockly.bindEventWithChecks_(buttonSvg, 'mousedown',
-       this, this.onMouseDown_));
+      this, this.onMouseDown_));
 
   this.buttons_.push(button);
 };
@@ -659,13 +659,13 @@ Blockly.Flyout.prototype.createRect_ = function(block, x, y, blockHW, index) {
   // Create an invisible rectangle under the block to act as a button.  Just
   // using the block as a button is poor, since blocks have holes in them.
   var rect = Blockly.utils.createSvgElement('rect',
-    {
-      'fill-opacity': 0,
-      'x': x,
-      'y': y,
-      'height': blockHW.height,
-      'width': blockHW.width
-    }, null);
+      {
+        'fill-opacity': 0,
+        'x': x,
+        'y': y,
+        'height': blockHW.height,
+        'width': blockHW.width
+      }, null);
   rect.tooltip = block;
   Blockly.Tooltip.bindMouseEvents(rect);
   // Add the rectangles under the blocks, so that the blocks' tooltips work.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -241,8 +241,8 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
 
   // Dragging the flyout up and down.
   Array.prototype.push.apply(this.eventWrappers_,
-      Blockly.bindEventWithChecks_(this.svgBackground_, 'mousedown', this,
-          this.onMouseDown_));
+      Blockly.bindEventWithChecks_(
+          this.svgBackground_, 'mousedown', this, this.onMouseDown_));
 
   // A flyout connected to a workspace doesn't have its own current gesture.
   this.workspace_.getGesture =
@@ -636,8 +636,9 @@ Blockly.Flyout.prototype.initFlyoutButton_ = function(button, x, y) {
   button.show();
   // Clicking on a flyout button or label is a lot like clicking on the
   // flyout background.
-  this.listeners_.push(Blockly.bindEventWithChecks_(buttonSvg, 'mousedown',
-      this, this.onMouseDown_));
+  this.listeners_.push(
+      Blockly.bindEventWithChecks_(
+          buttonSvg, 'mousedown', this, this.onMouseDown_));
 
   this.buttons_.push(button);
 };

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -148,7 +148,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   var rect = Blockly.utils.createSvgElement('rect',
       {
         'class': this.isLabel_ ?
-          'blocklyFlyoutLabelBackground' : 'blocklyFlyoutButtonBackground',
+            'blocklyFlyoutLabelBackground' : 'blocklyFlyoutButtonBackground',
         'rx': 4, 'ry': 4
       },
       this.svgGroup_);

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -138,20 +138,28 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   if (!this.isLabel_) {
     // Shadow rectangle (light source does not mirror in RTL).
     var shadow = Blockly.utils.createSvgElement('rect',
-        {'class': 'blocklyFlyoutButtonShadow',
-         'rx': 4, 'ry': 4, 'x': 1, 'y': 1},
-         this.svgGroup_);
+        {
+          'class': 'blocklyFlyoutButtonShadow',
+          'rx': 4, 'ry': 4, 'x': 1, 'y': 1
+        },
+        this.svgGroup_);
   }
   // Background rectangle.
   var rect = Blockly.utils.createSvgElement('rect',
-      {'class': this.isLabel_ ?
-       'blocklyFlyoutLabelBackground' : 'blocklyFlyoutButtonBackground',
-       'rx': 4, 'ry': 4},
+      {
+        'class': this.isLabel_ ?
+          'blocklyFlyoutLabelBackground' : 'blocklyFlyoutButtonBackground',
+        'rx': 4, 'ry': 4
+      },
       this.svgGroup_);
 
   var svgText = Blockly.utils.createSvgElement('text',
-      {'class': this.isLabel_ ? 'blocklyFlyoutLabelText' : 'blocklyText',
-       'x': 0, 'y': 0, 'text-anchor': 'middle'},
+      {
+        'class': this.isLabel_ ? 'blocklyFlyoutLabelText' : 'blocklyText',
+        'x': 0,
+        'y': 0,
+        'text-anchor': 'middle'
+      },
       this.svgGroup_);
   svgText.textContent = this.text_;
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -193,7 +193,7 @@ Blockly.HorizontalFlyout.prototype.setBackgroundPath_ = function(width,
     path.push('a', this.CORNER_RADIUS, this.CORNER_RADIUS, 0, 0, 1,
         this.CORNER_RADIUS, -this.CORNER_RADIUS);
     path.push('h', width);
-     // Right.
+    // Right.
     path.push('a', this.CORNER_RADIUS, this.CORNER_RADIUS, 0, 0, 1,
         this.CORNER_RADIUS, this.CORNER_RADIUS);
     path.push('v', height);

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -560,8 +560,8 @@ Blockly.Gesture.prototype.handleRightClick = function(e) {
  */
 Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
   goog.asserts.assert(!this.hasStarted_,
-     'Tried to call gesture.handleWsStart, but the gesture had already been ' +
-     'started.');
+      'Tried to call gesture.handleWsStart, but the gesture had already been ' +
+      'started.');
   this.setStartWorkspace_(ws);
   this.mostRecentEvent_ = e;
   this.doStart(e);
@@ -575,8 +575,8 @@ Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
  */
 Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
   goog.asserts.assert(!this.hasStarted_,
-     'Tried to call gesture.handleFlyoutStart, but the gesture had already been ' +
-     'started.');
+      'Tried to call gesture.handleFlyoutStart, but the gesture had already ' +
+      'been started.');
   this.setStartFlyout_(flyout);
   this.handleWsStart(e, flyout.getWorkspace());
 };
@@ -589,8 +589,8 @@ Blockly.Gesture.prototype.handleFlyoutStart = function(e, flyout) {
  */
 Blockly.Gesture.prototype.handleBlockStart = function(e, block) {
   goog.asserts.assert(!this.hasStarted_,
-     'Tried to call gesture.handleBlockStart, but the gesture had already been ' +
-     'started.');
+      'Tried to call gesture.handleBlockStart, but the gesture had already ' +
+      'been started.');
   this.setStartBlock(block);
   this.mostRecentEvent_ = e;
 };
@@ -665,8 +665,8 @@ Blockly.Gesture.prototype.bringBlockToFront_ = function() {
  */
 Blockly.Gesture.prototype.setStartField = function(field) {
   goog.asserts.assert(!this.hasStarted_,
-     'Tried to call gesture.setStartField, but the gesture had already been ' +
-     'started.');
+      'Tried to call gesture.setStartField, but the gesture had already been ' +
+      'started.');
   if (!this.startField_) {
     this.startField_ = field;
   }

--- a/core/grid.js
+++ b/core/grid.js
@@ -207,8 +207,10 @@ Blockly.Grid.createDom = function(rnd, gridOptions, defs) {
     </pattern>
   */
   var gridPattern = Blockly.utils.createSvgElement('pattern',
-      {'id': 'blocklyGridPattern' + rnd,
-       'patternUnits': 'userSpaceOnUse'}, defs);
+      {
+        'id': 'blocklyGridPattern' + rnd,
+        'patternUnits': 'userSpaceOnUse'
+      }, defs);
   if (gridOptions['length'] > 0 && gridOptions['spacing'] > 0) {
     Blockly.utils.createSvgElement('line',
         {'stroke': gridOptions['colour']}, gridPattern);

--- a/core/icon.js
+++ b/core/icon.js
@@ -80,7 +80,7 @@ Blockly.Icon.prototype.createIcon = function() {
       {'class': 'blocklyIconGroup'}, null);
   if (this.block_.isInFlyout) {
     Blockly.utils.addClass(/** @type {!Element} */ (this.iconGroup_),
-                      'blocklyIconGroupReadonly');
+        'blocklyIconGroupReadonly');
   }
   this.drawIcon_(this.iconGroup_);
 

--- a/core/icon.js
+++ b/core/icon.js
@@ -79,14 +79,14 @@ Blockly.Icon.prototype.createIcon = function() {
   this.iconGroup_ = Blockly.utils.createSvgElement('g',
       {'class': 'blocklyIconGroup'}, null);
   if (this.block_.isInFlyout) {
-    Blockly.utils.addClass(/** @type {!Element} */ (this.iconGroup_),
-        'blocklyIconGroupReadonly');
+    Blockly.utils.addClass(
+        /** @type {!Element} */ (this.iconGroup_), 'blocklyIconGroupReadonly');
   }
   this.drawIcon_(this.iconGroup_);
 
   this.block_.getSvgRoot().appendChild(this.iconGroup_);
-  Blockly.bindEventWithChecks_(this.iconGroup_, 'mouseup', this,
-      this.iconClick_);
+  Blockly.bindEventWithChecks_(
+      this.iconGroup_, 'mouseup', this, this.iconClick_);
   this.updateEditable();
 };
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -137,17 +137,34 @@ Blockly.createDom_ = function(container, options) {
   Blockly.utils.createSvgElement('feGaussianBlur',
       {'in': 'SourceAlpha', 'stdDeviation': 1, 'result': 'blur'}, embossFilter);
   var feSpecularLighting = Blockly.utils.createSvgElement('feSpecularLighting',
-      {'in': 'blur', 'surfaceScale': 1, 'specularConstant': 0.5,
-       'specularExponent': 10, 'lighting-color': 'white', 'result': 'specOut'},
+      {
+        'in': 'blur',
+        'surfaceScale': 1,
+        'specularConstant': 0.5,
+        'specularExponent': 10,
+        'lighting-color': 'white',
+        'result': 'specOut'
+      },
       embossFilter);
   Blockly.utils.createSvgElement('fePointLight',
       {'x': -5000, 'y': -10000, 'z': 20000}, feSpecularLighting);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'specOut', 'in2': 'SourceAlpha', 'operator': 'in',
-       'result': 'specOut'}, embossFilter);
+      {
+        'in': 'specOut',
+        'in2': 'SourceAlpha',
+        'operator': 'in',
+        'result': 'specOut'
+      }, embossFilter);
   Blockly.utils.createSvgElement('feComposite',
-      {'in': 'SourceGraphic', 'in2': 'specOut', 'operator': 'arithmetic',
-       'k1': 0, 'k2': 1, 'k3': 1, 'k4': 0}, embossFilter);
+      {
+        'in': 'SourceGraphic',
+        'in2': 'specOut',
+        'operator': 'arithmetic',
+        'k1': 0,
+        'k2': 1,
+        'k3': 1,
+        'k4': 0
+      }, embossFilter);
   options.embossFilterId = embossFilter.id;
   /*
     <pattern id="blocklyDisabledPattern837493" patternUnits="userSpaceOnUse"
@@ -157,9 +174,12 @@ Blockly.createDom_ = function(container, options) {
     </pattern>
   */
   var disabledPattern = Blockly.utils.createSvgElement('pattern',
-      {'id': 'blocklyDisabledPattern' + rnd,
-       'patternUnits': 'userSpaceOnUse',
-       'width': 10, 'height': 10}, defs);
+      {
+        'id': 'blocklyDisabledPattern' + rnd,
+        'patternUnits': 'userSpaceOnUse',
+        'width': 10,
+        'height': 10
+      }, defs);
   Blockly.utils.createSvgElement('rect',
       {'width': 10, 'height': 10, 'fill': '#aaa'}, disabledPattern);
   Blockly.utils.createSvgElement('path',
@@ -346,17 +366,23 @@ Blockly.inject.bindDocumentEvents_ = function() {
 Blockly.inject.loadSounds_ = function(pathToMedia, workspace) {
   var audioMgr = workspace.getAudioManager();
   audioMgr.load(
-      [pathToMedia + 'click.mp3',
-       pathToMedia + 'click.wav',
-       pathToMedia + 'click.ogg'], 'click');
+      [
+        pathToMedia + 'click.mp3',
+        pathToMedia + 'click.wav',
+        pathToMedia + 'click.ogg'
+      ], 'click');
   audioMgr.load(
-      [pathToMedia + 'disconnect.wav',
-       pathToMedia + 'disconnect.mp3',
-       pathToMedia + 'disconnect.ogg'], 'disconnect');
+      [
+        pathToMedia + 'disconnect.wav',
+        pathToMedia + 'disconnect.mp3',
+        pathToMedia + 'disconnect.ogg'
+      ], 'disconnect');
   audioMgr.load(
-      [pathToMedia + 'delete.mp3',
-       pathToMedia + 'delete.ogg',
-       pathToMedia + 'delete.wav'], 'delete');
+      [
+        pathToMedia + 'delete.mp3',
+        pathToMedia + 'delete.ogg',
+        pathToMedia + 'delete.wav'
+      ], 'delete');
 
   // Bind temporary hooks that preload the sounds.
   var soundBinds = [];

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -209,7 +209,7 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
     this.workspaceHeight_ = height;
     // Resize the bubble.
     this.bubble_.setBubbleSize(width + doubleBorderWidth,
-        height + doubleBorderWidth);
+        width + doubleBorderWidth, height + doubleBorderWidth);
     this.svgDialog_.setAttribute('width', this.workspaceWidth_);
     this.svgDialog_.setAttribute('height', this.workspaceHeight_);
   }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -88,8 +88,15 @@ Blockly.Mutator.prototype.drawIcon_ = function(group) {
       },
       group);
   // Axle hole.
-  Blockly.utils.createSvgElement('circle',
-      {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'}, group);
+  Blockly.utils.createSvgElement(
+      'circle',
+      {
+        'class': 'blocklyIconShape',
+        'r': '2.7',
+        'cx': '8',
+        'cy': '8'
+      },
+      group);
 };
 
 /**
@@ -165,14 +172,16 @@ Blockly.Mutator.prototype.updateEditable = function() {
   if (!this.block_.isInFlyout) {
     if (this.block_.isEditable()) {
       if (this.iconGroup_) {
-        Blockly.utils.removeClass(/** @type {!Element} */ (this.iconGroup_),
+        Blockly.utils.removeClass(
+            /** @type {!Element} */ (this.iconGroup_),
             'blocklyIconGroupReadonly');
       }
     } else {
       // Close any mutator bubble.  Icon is not clickable.
       this.setVisible(false);
       if (this.iconGroup_) {
-        Blockly.utils.addClass(/** @type {!Element} */ (this.iconGroup_),
+        Blockly.utils.addClass(
+            /** @type {!Element} */ (this.iconGroup_),
             'blocklyIconGroupReadonly');
       }
     }
@@ -208,7 +217,7 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
     this.workspaceWidth_ = width;
     this.workspaceHeight_ = height;
     // Resize the bubble.
-    this.bubble_.setBubbleSize(width + doubleBorderWidth,
+    this.bubble_.setBubbleSize(
         width + doubleBorderWidth, height + doubleBorderWidth);
     this.svgDialog_.setAttribute('width', this.workspaceWidth_);
     this.svgDialog_.setAttribute('height', this.workspaceHeight_);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -66,25 +66,30 @@ Blockly.Mutator.prototype.workspaceHeight_ = 0;
 Blockly.Mutator.prototype.drawIcon_ = function(group) {
   // Square with rounded corners.
   Blockly.utils.createSvgElement('rect',
-      {'class': 'blocklyIconShape',
-       'rx': '4', 'ry': '4',
-       'height': '16', 'width': '16'},
-       group);
+      {
+        'class': 'blocklyIconShape',
+        'rx': '4',
+        'ry': '4',
+        'height': '16',
+        'width': '16'
+      },
+      group);
   // Gear teeth.
   Blockly.utils.createSvgElement('path',
-      {'class': 'blocklyIconSymbol',
-       'd': 'm4.203,7.296 0,1.368 -0.92,0.677 -0.11,0.41 0.9,1.559 0.41,' +
-            '0.11 1.043,-0.457 1.187,0.683 0.127,1.134 0.3,0.3 1.8,0 0.3,' +
-            '-0.299 0.127,-1.138 1.185,-0.682 1.046,0.458 0.409,-0.11 0.9,' +
-            '-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,' +
-            '-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 ' +
-            '-0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,' +
-            '0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z'},
-       group);
+      {
+        'class': 'blocklyIconSymbol',
+        'd': 'm4.203,7.296 0,1.368 -0.92,0.677 -0.11,0.41 0.9,1.559 0.41,' +
+             '0.11 1.043,-0.457 1.187,0.683 0.127,1.134 0.3,0.3 1.8,0 0.3,' +
+             '-0.299 0.127,-1.138 1.185,-0.682 1.046,0.458 0.409,-0.11 0.9,' +
+             '-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,' +
+             '-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 ' +
+             '-0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,' +
+             '0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z'
+      },
+      group);
   // Axle hole.
   Blockly.utils.createSvgElement('circle',
-      {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'},
-       group);
+      {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'}, group);
 };
 
 /**
@@ -161,14 +166,14 @@ Blockly.Mutator.prototype.updateEditable = function() {
     if (this.block_.isEditable()) {
       if (this.iconGroup_) {
         Blockly.utils.removeClass(/** @type {!Element} */ (this.iconGroup_),
-                             'blocklyIconGroupReadonly');
+            'blocklyIconGroupReadonly');
       }
     } else {
       // Close any mutator bubble.  Icon is not clickable.
       this.setVisible(false);
       if (this.iconGroup_) {
         Blockly.utils.addClass(/** @type {!Element} */ (this.iconGroup_),
-                          'blocklyIconGroupReadonly');
+            'blocklyIconGroupReadonly');
       }
     }
   }
@@ -204,7 +209,7 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
     this.workspaceHeight_ = height;
     // Resize the bubble.
     this.bubble_.setBubbleSize(width + doubleBorderWidth,
-                               height + doubleBorderWidth);
+        height + doubleBorderWidth);
     this.svgDialog_.setAttribute('width', this.workspaceWidth_);
     this.svgDialog_.setAttribute('height', this.workspaceHeight_);
   }

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -210,7 +210,7 @@ Blockly.RenderedConnection.prototype.highlight = function() {
         'class': 'blocklyHighlightedConnectionPath',
         'd': steps,
         transform: 'translate(' + x + ',' + y + ')' +
-           (this.sourceBlock_.RTL ? ' scale(-1 1)' : '')
+            (this.sourceBlock_.RTL ? ' scale(-1 1)' : '')
       },
       this.sourceBlock_.getSvgRoot());
 };

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -205,7 +205,8 @@ Blockly.RenderedConnection.prototype.highlight = function() {
   var xy = this.sourceBlock_.getRelativeToSurfaceXY();
   var x = this.x_ - xy.x;
   var y = this.y_ - xy.y;
-  Blockly.Connection.highlightedPath_ = Blockly.utils.createSvgElement('path',
+  Blockly.Connection.highlightedPath_ = Blockly.utils.createSvgElement(
+      'path',
       {
         'class': 'blocklyHighlightedConnectionPath',
         'd': steps,

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -206,10 +206,12 @@ Blockly.RenderedConnection.prototype.highlight = function() {
   var x = this.x_ - xy.x;
   var y = this.y_ - xy.y;
   Blockly.Connection.highlightedPath_ = Blockly.utils.createSvgElement('path',
-      {'class': 'blocklyHighlightedConnectionPath',
-       'd': steps,
-       transform: 'translate(' + x + ',' + y + ')' +
-           (this.sourceBlock_.RTL ? ' scale(-1 1)' : '')},
+      {
+        'class': 'blocklyHighlightedConnectionPath',
+        'd': steps,
+        transform: 'translate(' + x + ',' + y + ')' +
+           (this.sourceBlock_.RTL ? ' scale(-1 1)' : '')
+      },
       this.sourceBlock_.getSvgRoot());
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -190,7 +190,7 @@ Blockly.Toolbox.prototype.init = function() {
     this.flyout_ = new Blockly.VerticalFlyout(workspaceOptions);
   }
   goog.dom.insertSiblingAfter(this.flyout_.createDom('svg'),
-                              this.workspace_.getParentSvg());
+      this.workspace_.getParentSvg());
   this.flyout_.init(workspace);
 
   this.config_['cleardotPath'] = workspace.options.pathToMedia + '1x1.gif';
@@ -315,7 +315,7 @@ Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
         // Decode the category name for any potential message references
         // (eg. `%{BKY_CATEGORY_NAME_LOGIC}`).
         var categoryName = Blockly.utils.replaceMessageReferences(
-          childIn.getAttribute('name'));
+            childIn.getAttribute('name'));
         var childOut = this.tree_.createNode(categoryName);
         childOut.blocks = [];
         treeOut.add(childOut);
@@ -428,7 +428,7 @@ Blockly.Toolbox.prototype.clearSelection = function() {
  */
 Blockly.Toolbox.prototype.addStyle = function(style) {
   Blockly.utils.addClass(/** @type {!Element} */ (this.HtmlDiv),
-                         style);
+      style);
 };
 
 /**
@@ -438,7 +438,7 @@ Blockly.Toolbox.prototype.addStyle = function(style) {
  */
 Blockly.Toolbox.prototype.removeStyle = function(style) {
   Blockly.utils.removeClass(/** @type {!Element} */ (this.HtmlDiv),
-                            style);
+      style);
 };
 
 /**
@@ -542,8 +542,9 @@ Blockly.Toolbox.TreeControl.prototype.handleTouchEvent_ = function(e) {
  * @override
  */
 Blockly.Toolbox.TreeControl.prototype.createNode = function(opt_html) {
-  return new Blockly.Toolbox.TreeNode(this.toolbox_, opt_html ?
-      goog.html.SafeHtml.htmlEscape(opt_html) : goog.html.SafeHtml.EMPTY,
+  var html = opt_html ?
+      goog.html.SafeHtml.htmlEscape(opt_html) : goog.html.SafeHtml.EMPTY;
+  return new Blockly.Toolbox.TreeNode(this.toolbox_, html,
       this.getConfig(), this.getDomHelper());
 };
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -189,8 +189,8 @@ Blockly.Toolbox.prototype.init = function() {
   } else {
     this.flyout_ = new Blockly.VerticalFlyout(workspaceOptions);
   }
-  goog.dom.insertSiblingAfter(this.flyout_.createDom('svg'),
-      this.workspace_.getParentSvg());
+  goog.dom.insertSiblingAfter(
+      this.flyout_.createDom('svg'), this.workspace_.getParentSvg());
   this.flyout_.init(workspace);
 
   this.config_['cleardotPath'] = workspace.options.pathToMedia + '1x1.gif';
@@ -427,8 +427,7 @@ Blockly.Toolbox.prototype.clearSelection = function() {
  * @package
  */
 Blockly.Toolbox.prototype.addStyle = function(style) {
-  Blockly.utils.addClass(/** @type {!Element} */ (this.HtmlDiv),
-      style);
+  Blockly.utils.addClass(/** @type {!Element} */ (this.HtmlDiv), style);
 };
 
 /**
@@ -437,8 +436,7 @@ Blockly.Toolbox.prototype.addStyle = function(style) {
  * @package
  */
 Blockly.Toolbox.prototype.removeStyle = function(style) {
-  Blockly.utils.removeClass(/** @type {!Element} */ (this.HtmlDiv),
-      style);
+  Blockly.utils.removeClass(/** @type {!Element} */ (this.HtmlDiv), style);
 };
 
 /**

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -172,13 +172,20 @@ Blockly.Trashcan.prototype.createDom = function() {
       {'id': 'blocklyTrashBodyClipPath' + rnd},
       this.svgGroup_);
   Blockly.utils.createSvgElement('rect',
-      {'width': this.WIDTH_, 'height': this.BODY_HEIGHT_,
-       'y': this.LID_HEIGHT_},
+      {
+        'width': this.WIDTH_,
+        'height': this.BODY_HEIGHT_,
+        'y': this.LID_HEIGHT_
+      },
       clip);
   var body = Blockly.utils.createSvgElement('image',
-      {'width': Blockly.SPRITE.width, 'x': -this.SPRITE_LEFT_,
-       'height': Blockly.SPRITE.height, 'y': -this.SPRITE_TOP_,
-       'clip-path': 'url(#blocklyTrashBodyClipPath' + rnd + ')'},
+      {
+        'width': Blockly.SPRITE.width,
+        'x': -this.SPRITE_LEFT_,
+        'height': Blockly.SPRITE.height,
+        'y': -this.SPRITE_TOP_,
+        'clip-path': 'url(#blocklyTrashBodyClipPath' + rnd + ')'
+      },
       this.svgGroup_);
   body.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
@@ -189,9 +196,13 @@ Blockly.Trashcan.prototype.createDom = function() {
   Blockly.utils.createSvgElement('rect',
       {'width': this.WIDTH_, 'height': this.LID_HEIGHT_}, clip);
   this.svgLid_ = Blockly.utils.createSvgElement('image',
-      {'width': Blockly.SPRITE.width, 'x': -this.SPRITE_LEFT_,
-       'height': Blockly.SPRITE.height, 'y': -this.SPRITE_TOP_,
-       'clip-path': 'url(#blocklyTrashLidClipPath' + rnd + ')'},
+      {
+        'width': Blockly.SPRITE.width,
+        'x': -this.SPRITE_LEFT_,
+        'height': Blockly.SPRITE.height,
+        'y': -this.SPRITE_TOP_,
+        'clip-path': 'url(#blocklyTrashLidClipPath' + rnd + ')'
+      },
       this.svgGroup_);
   this.svgLid_.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);

--- a/core/utils.js
+++ b/core/utils.js
@@ -269,7 +269,7 @@ Blockly.utils.getScale_REGEXP_ = /scale\(\s*([-+\d.e]+)\s*\)/;
  * @private
  */
 Blockly.utils.getRelativeXY.XY_3D_REGEX_ =
-  /transform:\s*translate3d\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
+    /transform:\s*translate3d\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
 
 /**
  * Static regex to pull the x,y,z values out of a translate3d() style property.
@@ -278,7 +278,7 @@ Blockly.utils.getRelativeXY.XY_3D_REGEX_ =
  * @private
  */
 Blockly.utils.getRelativeXY.XY_2D_REGEX_ =
-  /transform:\s*translate\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
+    /transform:\s*translate\(\s*([-+\d.e]+)px([ ,]\s*([-+\d.e]+)\s*)px\)?/;
 
 /**
  * Helper method for creating SVG elements.
@@ -288,8 +288,8 @@ Blockly.utils.getRelativeXY.XY_2D_REGEX_ =
  * @return {!SVGElement} Newly created SVG element.
  */
 Blockly.utils.createSvgElement = function(name, attrs, parent) {
-  var e = /** @type {!SVGElement} */ (
-      document.createElementNS(Blockly.SVG_NS, name));
+  var e = /** @type {!SVGElement} */
+      (document.createElementNS(Blockly.SVG_NS, name));
   for (var key in attrs) {
     e.setAttribute(key, attrs[key]);
   }

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
- /**
+/**
  * @fileoverview Object representing a map of variables and their types.
  * @author marisaleung@google.com (Marisa Leung)
  */
@@ -35,7 +35,7 @@ goog.provide('Blockly.VariableMap');
  * @constructor
  */
 Blockly.VariableMap = function(workspace) {
- /**
+  /**
    * A map from variable type to list of variable names.  The lists contain all
    * of the named variables in the workspace, including variables
    * that are not currently in use.

--- a/core/warning.js
+++ b/core/warning.js
@@ -57,21 +57,27 @@ Blockly.Warning.prototype.collapseHidden = false;
 Blockly.Warning.prototype.drawIcon_ = function(group) {
   // Triangle with rounded corners.
   Blockly.utils.createSvgElement('path',
-      {'class': 'blocklyIconShape',
-       'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z'},
-       group);
+      {
+        'class': 'blocklyIconShape',
+        'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z'
+      },
+      group);
   // Can't use a real '!' text character since different browsers and operating
   // systems render it differently.
   // Body of exclamation point.
   Blockly.utils.createSvgElement('path',
-      {'class': 'blocklyIconSymbol',
-       'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z'},
-       group);
+      {
+        'class': 'blocklyIconSymbol',
+        'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z'
+      },
+      group);
   // Dot of exclamation point.
   Blockly.utils.createSvgElement('rect',
-      {'class': 'blocklyIconSymbol',
-       'x': '7', 'y': '11', 'height': '2', 'width': '2'},
-       group);
+      {
+        'class': 'blocklyIconSymbol',
+        'x': '7', 'y': '11', 'height': '2', 'width': '2'
+      },
+      group);
 };
 
 /**

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -134,7 +134,7 @@ Blockly.WidgetDiv.hideIfOwner = function(oldOwner) {
  * @param {boolean} rtl True if RTL, false if LTR.
  */
 Blockly.WidgetDiv.position = function(anchorX, anchorY, windowSize,
-                                      scrollOffset, rtl) {
+    scrollOffset, rtl) {
   // Don't let the widget go above the top edge of the window.
   if (anchorY < scrollOffset.y) {
     anchorY = scrollOffset.y;

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -88,13 +88,14 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.createDom = function() {
   *   <g class="blocklyBubbleCanvas">/g>
   * </svg>
   */
-  this.SVG_ = Blockly.utils.createSvgElement('svg', {
-    'xmlns': Blockly.SVG_NS,
-    'xmlns:html': Blockly.HTML_NS,
-    'xmlns:xlink': 'http://www.w3.org/1999/xlink',
-    'version': '1.1',
-    'class': 'blocklyWsDragSurface blocklyOverflowVisible'
-  }, null);
+  this.SVG_ = Blockly.utils.createSvgElement('svg',
+      {
+        'xmlns': Blockly.SVG_NS,
+        'xmlns:html': Blockly.HTML_NS,
+        'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+        'version': '1.1',
+        'class': 'blocklyWsDragSurface blocklyOverflowVisible'
+      }, null);
   this.container_.appendChild(this.SVG_);
 };
 
@@ -115,7 +116,7 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
 
   this.SVG_.style.display = 'block';
   Blockly.utils.setCssTransform(this.SVG_,
-    'translate3d(' + x + 'px, ' + y + 'px, 0px)');
+      'translate3d(' + x + 'px, ' + y + 'px, 0px)');
 };
 
 /**
@@ -157,7 +158,7 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   // Hide the drag surface.
   this.SVG_.style.display = 'none';
   goog.asserts.assert(this.SVG_.childNodes.length == 0,
-    'Drag surface was not cleared.');
+      'Drag surface was not cleared.');
   Blockly.utils.setCssTransform(this.SVG_, '');
   this.previousSibling_ = null;
 };
@@ -177,12 +178,12 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
 Blockly.WorkspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
     blockCanvas, bubbleCanvas, previousSibling, width, height, scale) {
   goog.asserts.assert(this.SVG_.childNodes.length == 0,
-    'Already dragging a block.');
+      'Already dragging a block.');
   this.previousSibling_ = previousSibling;
   // Make sure the blocks and bubble canvas are scaled appropriately.
   blockCanvas.setAttribute('transform', 'translate(0, 0) scale(' + scale + ')');
   bubbleCanvas.setAttribute('transform',
-    'translate(0, 0) scale(' + scale + ')');
+      'translate(0, 0) scale(' + scale + ')');
   this.SVG_.setAttribute('width', width);
   this.SVG_.setAttribute('height', height);
   this.SVG_.appendChild(blockCanvas);

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -115,8 +115,8 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
   y = y.toFixed(0);
 
   this.SVG_.style.display = 'block';
-  Blockly.utils.setCssTransform(this.SVG_,
-      'translate3d(' + x + 'px, ' + y + 'px, 0px)');
+  Blockly.utils.setCssTransform(
+      this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0px)');
 };
 
 /**
@@ -157,8 +157,8 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
   Blockly.utils.insertAfter_(bubbleCanvas, blockCanvas);
   // Hide the drag surface.
   this.SVG_.style.display = 'none';
-  goog.asserts.assert(this.SVG_.childNodes.length == 0,
-      'Drag surface was not cleared.');
+  goog.asserts.assert(
+      this.SVG_.childNodes.length == 0, 'Drag surface was not cleared.');
   Blockly.utils.setCssTransform(this.SVG_, '');
   this.previousSibling_ = null;
 };
@@ -177,13 +177,13 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.clearAndHide = function(newSurface) {
  */
 Blockly.WorkspaceDragSurfaceSvg.prototype.setContentsAndShow = function(
     blockCanvas, bubbleCanvas, previousSibling, width, height, scale) {
-  goog.asserts.assert(this.SVG_.childNodes.length == 0,
-      'Already dragging a block.');
+  goog.asserts.assert(
+      this.SVG_.childNodes.length == 0, 'Already dragging a block.');
   this.previousSibling_ = previousSibling;
   // Make sure the blocks and bubble canvas are scaled appropriately.
   blockCanvas.setAttribute('transform', 'translate(0, 0) scale(' + scale + ')');
-  bubbleCanvas.setAttribute('transform',
-      'translate(0, 0) scale(' + scale + ')');
+  bubbleCanvas.setAttribute(
+      'transform', 'translate(0, 0) scale(' + scale + ')');
   this.SVG_.setAttribute('width', width);
   this.SVG_.setAttribute('height', height);
   this.SVG_.appendChild(blockCanvas);

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -62,7 +62,7 @@ Blockly.WorkspaceDragger = function(workspace) {
    * @private
    */
   this.startScrollXY_ = new goog.math.Coordinate(workspace.scrollX,
-        workspace.scrollY);
+      workspace.scrollY);
 };
 
 /**

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -61,8 +61,8 @@ Blockly.WorkspaceDragger = function(workspace) {
    * @type {!goog.math.Coordinate}
    * @private
    */
-  this.startScrollXY_ = new goog.math.Coordinate(workspace.scrollX,
-      workspace.scrollY);
+  this.startScrollXY_ = new goog.math.Coordinate(
+      workspace.scrollX, workspace.scrollY);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -965,8 +965,8 @@ Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id) {
-  var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name,
-      opt_type, opt_id);
+  var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(
+      this, name, opt_type, opt_id);
   this.refreshToolboxSelection_();
   return newVar;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -634,7 +634,7 @@ Blockly.WorkspaceSvg.prototype.resize = function() {
  */
 Blockly.WorkspaceSvg.prototype.updateScreenCalculationsIfScrolled =
     function() {
-  /* eslint-disable indent */
+    /* eslint-disable indent */
   var currScroll = goog.dom.getDocumentScroll();
   if (!goog.math.Coordinate.equals(this.lastRecordedPageScroll_,
      currScroll)) {
@@ -966,7 +966,7 @@ Blockly.WorkspaceSvg.prototype.deleteVariableById = function(id) {
  */
 Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id) {
   var newVar = Blockly.WorkspaceSvg.superClass_.createVariable.call(this, name,
-    opt_type, opt_id);
+      opt_type, opt_id);
   this.refreshToolboxSelection_();
   return newVar;
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -585,7 +585,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   var block = null;
   var prototypeName = xmlBlock.getAttribute('type');
   goog.asserts.assert(prototypeName, 'Block type unspecified: %s',
-                      xmlBlock.outerHTML);
+      xmlBlock.outerHTML);
   var id = xmlBlock.getAttribute('id');
   block = workspace.newBlock(prototypeName, id);
 
@@ -600,13 +600,12 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     // Find any enclosed blocks or shadows in this tag.
     var childBlockElement = null;
     var childShadowElement = null;
-    for (var j = 0, grandchildNode; grandchildNode = xmlChild.childNodes[j];
-         j++) {
-      if (grandchildNode.nodeType == 1) {
-        if (grandchildNode.nodeName.toLowerCase() == 'block') {
-          childBlockElement = /** @type {!Element} */ (grandchildNode);
-        } else if (grandchildNode.nodeName.toLowerCase() == 'shadow') {
-          childShadowElement = /** @type {!Element} */ (grandchildNode);
+    for (var j = 0, grandchild; grandchild = xmlChild.childNodes[j]; j++) {
+      if (grandchild.nodeType == 1) {
+        if (grandchild.nodeName.toLowerCase() == 'block') {
+          childBlockElement = /** @type {!Element} */ (grandchild);
+        } else if (grandchild.nodeName.toLowerCase() == 'shadow') {
+          childShadowElement = /** @type {!Element} */ (grandchild);
         }
       }
     }
@@ -731,7 +730,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     var children = block.getChildren();
     for (var i = 0, child; child = children[i]; i++) {
       goog.asserts.assert(child.isShadow(),
-                          'Shadow block not allowed non-shadow child.');
+          'Shadow block not allowed non-shadow child.');
     }
     // Ensure this block doesn't have any variable inputs.
     goog.asserts.assert(block.getVarModels().length == 0,

--- a/core/xml.js
+++ b/core/xml.js
@@ -584,8 +584,8 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
 Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   var block = null;
   var prototypeName = xmlBlock.getAttribute('type');
-  goog.asserts.assert(prototypeName, 'Block type unspecified: %s',
-      xmlBlock.outerHTML);
+  goog.asserts.assert(
+      prototypeName, 'Block type unspecified: %s', xmlBlock.outerHTML);
   var id = xmlBlock.getAttribute('id');
   block = workspace.newBlock(prototypeName, id);
 
@@ -729,8 +729,8 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     // Ensure all children are also shadows.
     var children = block.getChildren();
     for (var i = 0, child; child = children[i]; i++) {
-      goog.asserts.assert(child.isShadow(),
-          'Shadow block not allowed non-shadow child.');
+      goog.asserts.assert(
+          child.isShadow(), 'Shadow block not allowed non-shadow child.');
     }
     // Ensure this block doesn't have any variable inputs.
     goog.asserts.assert(block.getVarModels().length == 0,

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -125,10 +125,12 @@ Blockly.ZoomControls.prototype.createDom = function() {
       {'width': 32, 'height': 32, 'y': 77},
       clip);
   var zoomoutSvg = Blockly.utils.createSvgElement('image',
-      {'width': Blockly.SPRITE.width,
-       'height': Blockly.SPRITE.height, 'x': -64,
-       'y': -15,
-       'clip-path': 'url(#blocklyZoomoutClipPath' + rnd + ')'},
+      {
+        'width': Blockly.SPRITE.width,
+        'height': Blockly.SPRITE.height, 'x': -64,
+        'y': -15,
+        'clip-path': 'url(#blocklyZoomoutClipPath' + rnd + ')'
+      },
       this.svgGroup_);
   zoomoutSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       workspace.options.pathToMedia + Blockly.SPRITE.url);
@@ -140,11 +142,13 @@ Blockly.ZoomControls.prototype.createDom = function() {
       {'width': 32, 'height': 32, 'y': 43},
       clip);
   var zoominSvg = Blockly.utils.createSvgElement('image',
-      {'width': Blockly.SPRITE.width,
-       'height': Blockly.SPRITE.height,
-       'x': -32,
-       'y': -49,
-       'clip-path': 'url(#blocklyZoominClipPath' + rnd + ')'},
+      {
+        'width': Blockly.SPRITE.width,
+        'height': Blockly.SPRITE.height,
+        'x': -32,
+        'y': -49,
+        'clip-path': 'url(#blocklyZoominClipPath' + rnd + ')'
+      },
       this.svgGroup_);
   zoominSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       workspace.options.pathToMedia + Blockly.SPRITE.url);
@@ -156,9 +160,11 @@ Blockly.ZoomControls.prototype.createDom = function() {
       {'width': 32, 'height': 32},
       clip);
   var zoomresetSvg = Blockly.utils.createSvgElement('image',
-      {'width': Blockly.SPRITE.width,
-       'height': Blockly.SPRITE.height, 'y': -92,
-       'clip-path': 'url(#blocklyZoomresetClipPath' + rnd + ')'},
+      {
+        'width': Blockly.SPRITE.width,
+        'height': Blockly.SPRITE.height, 'y': -92,
+        'clip-path': 'url(#blocklyZoomresetClipPath' + rnd + ')'
+      },
       this.svgGroup_);
   zoomresetSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       workspace.options.pathToMedia + Blockly.SPRITE.url);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Progress on #1556

### Proposed Changes

Enforce line continuations of +4 spaces.

Pick a style for object declarations in functions that eslint can check, and apply it:

If the object declaration is short enough it can fit on one line
* Follow normal rules for function arguments: indent line continuations +4 spaces
```
Blockly.utils.createSvgElement('g',
    {'class': 'blocklyTrash'}, null);
```

If the object declaration does not fit on a single line:
* Indent the opening and closing braces +4 spaces.
* Indent the object properties +2 spaces from the opening and closing braces.

For example:
```
Blockly.utils.createSvgElement('rect',
    {
      'width': this.WIDTH_,
      'height': this.BODY_HEIGHT_,
      'y': this.LID_HEIGHT_
    },
    clip);
```
### Reason for Changes

Move toward eslint 4.0, which will give us stronger indentation checking.
Automate telling developers to indent lines an extra two spaces.

### Test Coverage
I removed some eslint errors and added no new errors with the configuration proposed in #1541.
