### PR TITLE
Fix #1559

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -279,37 +279,37 @@ Blockly.Variables.createVariableButtonHandler = function(
   // This function needs to be named so it can be called recursively.
   var promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(Blockly.Msg.NEW_VARIABLE_TITLE, defaultName,
-      function(text) {
-        if (text) {
-            var existing = Blockly.Variables.nameUsedWithAnyType_(text,
-                workspace);
+        function(text) {
+          if (text) {
+            var existing =
+                Blockly.Variables.nameUsedWithAnyType_(text, workspace);
             if (existing) {
               var lowerCase = text.toLowerCase();
               if (existing.type == type) {
-                var msg = Blockly.Msg.VARIABLE_ALREADY_EXISTS.replace('%1',
-                    lowerCase);
+                var msg = Blockly.Msg.VARIABLE_ALREADY_EXISTS.replace(
+                    '%1', lowerCase);
               } else {
                 var msg = Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE;
                 msg = msg.replace('%1', lowerCase).replace('%2', existing.type);
               }
               Blockly.alert(msg,
-                function() {
-                  promptAndCheckWithAlert(text);  // Recurse
-                });
+                  function() {
+                    promptAndCheckWithAlert(text);  // Recurse
+                  });
+            } else {
+              // No conflict
+              workspace.createVariable(text, type);
+              if (opt_callback) {
+                opt_callback(text);
+              }
+            }
           } else {
-            // No conflict
-            workspace.createVariable(text, type);
+            // User canceled prompt.
             if (opt_callback) {
-              opt_callback(text);
+              opt_callback(null);
             }
           }
-        } else {
-          // User canceled prompt without a value.
-          if (opt_callback) {
-            opt_callback(null);
-          }
-        }
-      });
+        });
   };
   promptAndCheckWithAlert('');
 };
@@ -354,13 +354,13 @@ Blockly.Variables.renameVariable = function(workspace, variable,
             var existing = Blockly.Variables.nameUsedWithOtherType_(newName,
                 variable.type, workspace);
             if (existing) {
-              var msg =
-                  Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE.replace(
-                  '%1', newName.toLowerCase()).replace('%2', existing.type);
+              var msg = Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE
+                  .replace('%1', newName.toLowerCase())
+                  .replace('%2', existing.type);
               Blockly.alert(msg,
-                function() {
-                  promptAndCheckWithAlert(newName);  // Recurse
-                });
+                  function() {
+                    promptAndCheckWithAlert(newName);  // Recurse
+                  });
             } else {
               workspace.renameVariableById(variable.getId(), newName);
               if (opt_callback) {
@@ -368,7 +368,7 @@ Blockly.Variables.renameVariable = function(workspace, variable,
               }
             }
           } else {
-            // User canceled prompt without a value.
+            // User canceled prompt.
             if (opt_callback) {
               opt_callback(null);
             }

--- a/core/variables.js
+++ b/core/variables.js
@@ -401,6 +401,17 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
   });
 };
 
+/**
+ * Check whether there exists a variable with the given name but a different
+ * type.
+ * @param {string} name The name to search for.
+ * @param {string} type The type to exclude from the search.
+ * @param {!Blockly.Workspace} workspace The workspace to search for the
+ *     variable.
+ * @return {?Blockly.VariableModel} The variable with the given name and a
+ *     different type, or null if none was found.
+ * @private
+ */
 Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
   var allVariables = workspace.getVariableMap().getAllVariables();
 
@@ -413,6 +424,15 @@ Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
   return null;
 };
 
+/**
+ * Check whether there exists a variable with the given name of any type.
+ * @param {string} name The name to search for.
+ * @param {!Blockly.Workspace} workspace The workspace to search for the
+ *     variable.
+ * @return {?Blockly.VariableModel} The variable with the given name, or null if
+ *    none was found.
+ * @private
+ */
 Blockly.Variables.nameUsedWithAnyType_ = function(name, workspace) {
   var allVariables = workspace.getVariableMap().getAllVariables();
 

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -136,7 +136,7 @@ Blockly.Msg.NEW_VARIABLE_TITLE = 'New variable name:';
 /// alert - Tells the user that the name they entered is already in use.
 Blockly.Msg.VARIABLE_ALREADY_EXISTS = 'A variable named "%1" already exists.';
 /// alert - Tells the user that the name they entered is already in use for another type.
-Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE = 'A variable named "%1" already exists for another variable of type "%2".';
+Blockly.Msg.VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE = 'A variable named "%1" already exists for another type: "%2".';
 
 // Variable deletion.
 /// confirm -  Ask the user to confirm their deletion of multiple uses of a variable.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1559 

### Proposed Changes

Check whether any variable with the given name already exists when creating or renaming a variable.  
- Renaming to a name used for the same type is fine.  
- Renaming to a name used with a different type is a problem.  
- Creating a variable with a used name of the same type gets a warning and fails.
- Creating a variable with a used name of a different type gets a warning including the type of the conflicting variable and fails.

### Reason for Changes

The variable map has to support variables with the same name and different types internally (for Scratch), but we don't want to actually allow it in Blockly.

### Test Coverage
Tested in the playground.
