### PR TITLE
Fixed JS/PHP generators for math_number

### DIFF
--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -32,7 +32,9 @@ goog.require('Blockly.JavaScript');
 Blockly.JavaScript['math_number'] = function(block) {
   // Numeric value.
   var code = parseFloat(block.getFieldValue('NUM'));
-  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+  var order = code >= 0 ? Blockly.JavaScript.ORDER_ATOMIC : 
+              Blockly.JavaScript.ORDER_UNARY_NEGATION;
+  return [code, order];
 };
 
 Blockly.JavaScript['math_arithmetic'] = function(block) {

--- a/generators/php/math.js
+++ b/generators/php/math.js
@@ -32,12 +32,14 @@ goog.require('Blockly.PHP');
 Blockly.PHP['math_number'] = function(block) {
   // Numeric value.
   var code = parseFloat(block.getFieldValue('NUM'));
+  var order = code >= 0 ? Blockly.PHP.ORDER_ATOMIC : 
+              Blockly.PHP.ORDER_UNARY_NEGATION;
   if (code == Infinity) {
     code = 'INF';
   } else if (code == -Infinity) {
     code = '-INF';
   }
-  return [code, Blockly.PHP.ORDER_ATOMIC];
+  return [code, order];
 };
 
 Blockly.PHP['math_arithmetic'] = function(block) {


### PR DESCRIPTION
It was returning ``ORDER_ATOMIC`` for the block for any number; changed it so that it now returns ``ORDER_UNARY_NEGATION`` for negative numbers.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves #1563