### PR TITLE
Add generators for dynamic variable blocks.

### DIFF
--- a/generators/dart/variables_dynamic.js
+++ b/generators/dart/variables_dynamic.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Visual Blocks Language
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Generating Dart for dynamic variable blocks.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.Dart.variablesDynamic');
+
+goog.require('Blockly.Dart');
+goog.require('Blockly.Dart.variables');
+
+
+// Dart is dynamically typed.
+Blockly.Dart['variables_get_dynamic'] = Blockly.Dart['variables_get'];
+Blockly.Dart['variables_set_dynamic'] = Blockly.Dart['variables_set'];

--- a/generators/javascript/variables_dynamic.js
+++ b/generators/javascript/variables_dynamic.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Visual Blocks Language
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Generating JavaScript for dynamic variable blocks.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.JavaScript.variablesDynamic');
+
+goog.require('Blockly.JavaScript');
+goog.require('Blockly.JavaScript.variables');
+
+
+// JavaScript is dynamically typed.
+Blockly.JavaScript['variables_get_dynamic'] =
+    Blockly.JavaScript['variables_get'];
+Blockly.JavaScript['variables_set_dynamic'] =
+    Blockly.JavaScript['variables_set'];

--- a/generators/lua/variables_dynamic.js
+++ b/generators/lua/variables_dynamic.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Visual Blocks Language
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Generating Lua for dynamic variable blocks.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.Lua.variablesDynamic');
+
+goog.require('Blockly.Lua');
+goog.require('Blockly.Lua.variables');
+
+
+// Lua is dynamically typed.
+Blockly.Lua['variables_get_dynamic'] = Blockly.Lua['variables_get'];
+Blockly.Lua['variables_set_dynamic'] = Blockly.Lua['variables_set'];

--- a/generators/php/variables_dynamic.js
+++ b/generators/php/variables_dynamic.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Visual Blocks Language
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Generating PHP for dynamic variable blocks.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.PHP.variablesDynamic');
+
+goog.require('Blockly.PHP');
+goog.require('Blockly.PHP.variables');
+
+
+// PHP is dynamically typed.
+Blockly.PHP['variables_get_dynamic'] = Blockly.PHP['variables_get'];
+Blockly.PHP['variables_set_dynamic'] = Blockly.PHP['variables_set'];

--- a/generators/python/variables_dynamic.js
+++ b/generators/python/variables_dynamic.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Visual Blocks Language
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Generating Python for dynamic variable blocks.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+'use strict';
+
+goog.provide('Blockly.Python.variablesDynamic');
+
+goog.require('Blockly.Python');
+goog.require('Blockly.Python.variables');
+
+
+// Python is dynamically typed.
+Blockly.Python['variables_get_dynamic'] = Blockly.Python['variables_get'];
+Blockly.Python['variables_set_dynamic'] = Blockly.Python['variables_set'];

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -12,6 +12,7 @@
 <script src="../generators/javascript/lists.js"></script>
 <script src="../generators/javascript/colour.js"></script>
 <script src="../generators/javascript/variables.js"></script>
+<script src="../generators/javascript/variables_dynamic.js"></script>
 <script src="../generators/javascript/procedures.js"></script>
 <script src="../generators/python.js"></script>
 <script src="../generators/python/logic.js"></script>
@@ -21,6 +22,7 @@
 <script src="../generators/python/lists.js"></script>
 <script src="../generators/python/colour.js"></script>
 <script src="../generators/python/variables.js"></script>
+<script src="../generators/python/variables_dynamic.js"></script>
 <script src="../generators/python/procedures.js"></script>
 <script src="../generators/php.js"></script>
 <script src="../generators/php/logic.js"></script>
@@ -30,6 +32,7 @@
 <script src="../generators/php/lists.js"></script>
 <script src="../generators/php/colour.js"></script>
 <script src="../generators/php/variables.js"></script>
+<script src="../generators/php/variables_dynamic.js"></script>
 <script src="../generators/php/procedures.js"></script>
 <script src="../generators/lua.js"></script>
 <script src="../generators/lua/logic.js"></script>
@@ -39,6 +42,7 @@
 <script src="../generators/lua/lists.js"></script>
 <script src="../generators/lua/colour.js"></script>
 <script src="../generators/lua/variables.js"></script>
+<script src="../generators/lua/variables_dynamic.js"></script>
 <script src="../generators/lua/procedures.js"></script>
 <script src="../generators/dart.js"></script>
 <script src="../generators/dart/logic.js"></script>
@@ -48,6 +52,7 @@
 <script src="../generators/dart/lists.js"></script>
 <script src="../generators/dart/colour.js"></script>
 <script src="../generators/dart/variables.js"></script>
+<script src="../generators/dart/variables_dynamic.js"></script>
 <script src="../generators/dart/procedures.js"></script>
 <script src="../msg/messages.js"></script>
 <script src="../blocks/logic.js"></script>


### PR DESCRIPTION

## The basics
Fixes #1574 

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1574 

### Proposed Changes

Add generators for dynamic variable blocks.
They're just mappings to the normal variable generators, because all of our languages are dynamic.  That means this pull request is almost entirely licenses on new files.

### Reason for Changes

The blocks aren't that useful without the generators.

### Test Coverage
I checked that I can generate code for each language with the dynamic getters and setters (in the playground), and that it's the same as for the normal getters and setters.

