### PR TITLE
Update the comment on eslint quotes checks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,7 @@
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],
         "no-unused-vars": ["error", {"args": "after-used", "varsIgnorePattern": "^_"}],
         "no-use-before-define": ["error"],
-        "quotes": ["off"], # Blockly mixes single and double quotes
+        "quotes": ["off"], # Blockly uses single quotes except for JSON blobs, which must use double quotes.
         "semi": ["error", "always"],
         "space-before-function-paren": ["error", "never"], # Blockly doesn't have space before function paren
         "strict": ["off"], # Blockly uses 'use strict' in files


### PR DESCRIPTION
We turn quotes checking off in eslint because the JSON blobs in Blockly's files must use double quotes. Everywhere else we prefer single quotes. This updates the comment to make that clearer.

Fixes #1588 
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1589)
<!-- Reviewable:end -->
