### PR TITLE
Don't allow block deletion in the flyout.  Make copy-paste always copy to the main workspace

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -202,6 +202,9 @@ Blockly.onKeyDown_ = function(e) {
     }
     if (Blockly.selected &&
         Blockly.selected.isDeletable() && Blockly.selected.isMovable()) {
+      // Don't allow copying immovable or undeletable blocks. The next step
+      // would be to paste, which would create additional undeletable/immovable
+      // blocks on the workspace.
       if (e.keyCode == 67) {
         // 'c' for copy.
         Blockly.hideChaff();

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -206,8 +206,9 @@ Blockly.onKeyDown_ = function(e) {
         // 'c' for copy.
         Blockly.hideChaff();
         Blockly.copy_(Blockly.selected);
-      } else if (e.keyCode == 88) {
-        // 'x' for cut.
+      } else if (e.keyCode == 88 && !Blockly.selected.workspace.isFlyout) {
+        // 'x' for cut, but not in a flyout.
+        // Don't even copy the selected item in the flyout.
         Blockly.copy_(Blockly.selected);
         deleteBlock = true;
       }
@@ -216,7 +217,13 @@ Blockly.onKeyDown_ = function(e) {
       // 'v' for paste.
       if (Blockly.clipboardXml_) {
         Blockly.Events.setGroup(true);
-        Blockly.clipboardSource_.paste(Blockly.clipboardXml_);
+        // Pasting always pastes to the main workspace, even if the copy started
+        // in a flyout workspace.
+        var workspace = Blockly.clipboardSource_;
+        if (workspace.isFlyout) {
+          workspace = workspace.targetWorkspace;
+        }
+        workspace.paste(Blockly.clipboardXml_);
         Blockly.Events.setGroup(false);
       }
     } else if (e.keyCode == 90) {
@@ -225,8 +232,9 @@ Blockly.onKeyDown_ = function(e) {
       Blockly.mainWorkspace.undo(e.shiftKey);
     }
   }
-  if (deleteBlock) {
-    // Common code for delete and cut.
+  // Common code for delete and cut.
+  // Don't delete in the flyout.
+  if (deleteBlock && !Blockly.selected.workspace.isFlyout) {
     Blockly.Events.setGroup(true);
     Blockly.hideChaff();
     Blockly.selected.dispose(/* heal */ true, true);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -274,6 +274,7 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * @package
  */
 Blockly.WorkspaceSvg.prototype.targetWorkspace = null;
+
 /**
  * Inverted screen CTM, for use in mouseToSvg.
  * @type {SVGMatrix}

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -268,6 +268,13 @@ Blockly.WorkspaceSvg.prototype.flyoutButtonCallbacks_ = {};
 Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
 
 /**
+ * In a flyout, the target workspace where blocks should be placed after a drag.
+ * Otherwise null.
+ * @type {?Blockly.WorkspaceSvg}
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.targetWorkspace = null;
+/**
  * Inverted screen CTM, for use in mouseToSvg.
  * @type {SVGMatrix}
  * @private


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/LLK/scratch-blocks/issues/1373

### Proposed Changes

On keyboard paste, paste to the target workspace.
On keyboard cut, backspace, and delete, block the action if the selected block was in the flyout.

### Reason for Changes

See https://github.com/LLK/scratch-blocks/issues/1373

You could delete and paste blocks in the flyout, which was lovely.

### Test Coverage

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

@kchadha fyi