### PR TITLE
Fix #1601

### DIFF
--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -178,7 +178,7 @@ WorkspaceFactoryGenerator.prototype.generateInjectString = function() {
       ' workspace blocks XML from Workspace Factory. */\n' +
       'var workspaceBlocks = document.getElementById("workspaceBlocks"); \n\n' +
       '/* Load blocks to workspace. */\n' +
-      'Blockly.Xml.domToWorkspace(workspace, workspaceBlocks);';
+      'Blockly.Xml.domToWorkspace(workspaceBlocks, workspace);';
   return finalStr;
 };
 


### PR DESCRIPTION
Corrected deprecated argument order in domToWorksapce call in WorkspaceFactory.

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1601

### Proposed Changes

Correcting argument order.

### Reason for Changes

Deprecated usage was introducing warnings in developers' apps.

### Test Coverage

Exported code from WorkspaceFactory and checked the results was corrected.