### PR TITLE
Warn conflicts with Blockly.Generator.prototype

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -57,7 +57,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     console.warn('FUTURE ERROR: Block prototypeName "' + prototypeName
         + '`" conflicts with Blockly.Generator members. Registering Generators '
         + 'for this block type will incur errors.'
-        + 'This name will be DISALLOWED in future versions of Blockly.');
+        + '\nThis name will be DISALLOWED (throwing an error) in future '
+        + 'versions of Blockly.');
   }
 
   /** @type {string} */

--- a/core/block.js
+++ b/core/block.js
@@ -30,6 +30,7 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Comment');
 goog.require('Blockly.Connection');
 goog.require('Blockly.Extensions');
+goog.require('Blockly.Generator');
 goog.require('Blockly.Input');
 goog.require('Blockly.Mutator');
 goog.require('Blockly.Warning');
@@ -52,6 +53,13 @@ goog.require('goog.string');
  * @constructor
  */
 Blockly.Block = function(workspace, prototypeName, opt_id) {
+  if (typeof Blockly.Generator.prototype[prototypeName] !== 'undefined') {
+    console.warn('FUTURE ERROR: Block prototypeName "' + prototypeName
+        + '`" conflicts with Blockly.Generator members. Registering Generators '
+        + 'for this block type will incur errors.'
+        + 'This name will be DISALLOWED in future versions of Blockly.');
+  }
+
   /** @type {string} */
   this.id = (opt_id && !workspace.getBlockById(opt_id)) ?
       opt_id : Blockly.utils.genUid();

--- a/core/block.js
+++ b/core/block.js
@@ -55,7 +55,7 @@ goog.require('goog.string');
 Blockly.Block = function(workspace, prototypeName, opt_id) {
   if (typeof Blockly.Generator.prototype[prototypeName] !== 'undefined') {
     console.warn('FUTURE ERROR: Block prototypeName "' + prototypeName
-        + '`" conflicts with Blockly.Generator members. Registering Generators '
+        + '" conflicts with Blockly.Generator members. Registering Generators '
         + 'for this block type will incur errors.'
         + '\nThis name will be DISALLOWED (throwing an error) in future '
         + 'versions of Blockly.');

--- a/core/generator.js
+++ b/core/generator.js
@@ -105,7 +105,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
       line = line[0];
     }
     if (line) {
-      if (block.outputConnection && this.scrubNakedValue) {
+      if (block.outputConnection) {
         // This block is a naked value.  Ask the language's code generator if
         // it wants to append a semicolon, or something.
         line = this.scrubNakedValue(line);
@@ -380,7 +380,9 @@ Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
  * names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
-Blockly.Generator.prototype.init = function(workspace) {
+Blockly.Generator.prototype.init = function(
+    /* eslint-disable no-unused-vars */ workspace
+    /* eslint-enable no-unused-vars */) {
   // Optionally override
 };
 
@@ -395,8 +397,11 @@ Blockly.Generator.prototype.init = function(workspace) {
  * @return {string} JavaScript code with comments and subsequent blocks added.
  * @private
  */
-Blockly.Generator.prototype.scrub_ = function(block, code) {
+Blockly.Generator.prototype.scrub_ = function(
+    /* eslint-disable no-unused-vars */ block, code
+    /* eslint-enable no-unused-vars */) {
   // Optionally override
+  return code;
 };
 
 /**
@@ -406,8 +411,11 @@ Blockly.Generator.prototype.scrub_ = function(block, code) {
  * @param {string} code Generated code.
  * @return {string} Completed code.
  */
-Blockly.Generator.prototype.finish = function(code) {
+Blockly.Generator.prototype.finish = function(
+    /* eslint-disable no-unused-vars */ code
+    /* eslint-enable no-unused-vars */) {
   // Optionally override
+  return code;
 };
 
 /**
@@ -418,6 +426,9 @@ Blockly.Generator.prototype.finish = function(code) {
  * @param {string} line Line of generated code.
  * @return {string} Legal line of code.
  */
-Blockly.Generator.prototype.scrubNakedValue = function(line) {
+Blockly.Generator.prototype.scrubNakedValue = function(
+    /* eslint-disable no-unused-vars */ line
+    /* eslint-enable no-unused-vars */) {
   // Optionally override
+  return line;
 };

--- a/core/generator.js
+++ b/core/generator.js
@@ -380,7 +380,9 @@ Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
  * names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
-Blockly.Generator.prototype.init = undefined;
+Blockly.Generator.prototype.init = function(workspace) {
+  // Optionally override
+};
 
 /**
  * Common tasks for generating code from blocks.  This is called from
@@ -393,7 +395,9 @@ Blockly.Generator.prototype.init = undefined;
  * @return {string} JavaScript code with comments and subsequent blocks added.
  * @private
  */
-Blockly.Generator.prototype.scrub_ = undefined;
+Blockly.Generator.prototype.scrub_ = function(block, code) {
+  // Optionally override
+};
 
 /**
  * Hook for code to run at end of code generation.
@@ -402,7 +406,9 @@ Blockly.Generator.prototype.scrub_ = undefined;
  * @param {string} code Generated code.
  * @return {string} Completed code.
  */
-Blockly.Generator.prototype.finish = undefined;
+Blockly.Generator.prototype.finish = function(code) {
+  // Optionally override
+};
 
 /**
  * Naked values are top-level blocks with outputs that aren't plugged into
@@ -412,4 +418,6 @@ Blockly.Generator.prototype.finish = undefined;
  * @param {string} line Line of generated code.
  * @return {string} Legal line of code.
  */
-Blockly.Generator.prototype.scrubNakedValue = undefined;
+Blockly.Generator.prototype.scrubNakedValue = function(line) {
+  // Optionally override
+};


### PR DESCRIPTION
Console warnings on block prototypeNames that conflict with Blockly.Generator.prototype

First pass at #1558

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Warning on conflicting Block names. Implementing a warning first, since fully banning type names is a breaking change.

### Proposed Changes

Warn on conflict with Blockly.Generator.prototype members.

### Reason for Changes

By convention, we use the Generator instance objects as generator function maps. This will conflict with prototype lookup for name collisions between block names and said members, and needs to be disallowed.  However, this is a breaking changes, so emit a warning in this release.

### Test Coverage

Locally edited Playground test blocks to have conflicting block instances. Saw the expected the error.

Also ran the build script with no bad effect on existing demos.
