### PR TITLE
Remove forceRerender() from FieldDropDown.

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -131,8 +131,6 @@ Blockly.FieldDropdown.prototype.init = function() {
       ' ' + Blockly.FieldDropdown.ARROW_CHAR));
 
   Blockly.FieldDropdown.superClass_.init.call(this);
-  // Make sure the arrow gets rendered.
-  this.forceRerender();
 };
 
 /**


### PR DESCRIPTION
(Cherry-pick #1610 into release candidate.)

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1609 Uncaught TypeError: Cannot read property 'firstChild' of undefined

### Proposed Changes

Do not render block during field init().

### Reason for Changes

The forced block render was causing other fields to render before they initialized, and fail.

### Test Coverage

Manually tested all dropdown blocks and reported block in both LTR and RTL:
 * https://anmatanm.github.io/blockly/20180213-edge/index.html
 * https://anmatanm.github.io/blockly/20180213-edge/index.html?dir=rtl

Also verified proper resize on variable rename (since variable fields are also dropdowns).

Tested on:
 * Desktop Chrome (Mac, Linux, Windows)
<!-- * Desktop Firefox -->
 * Desktop Safari (Mac, iOS 9.3)
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
 * Windows Internet Explorer 11
 * Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
