### PR TITLE
Don't register mouse events if pointer events are supported (rc/feb_2018)

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -53,7 +53,9 @@ goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.constants');
 goog.require('Blockly.inject');
 goog.require('Blockly.utils');
+
 goog.require('goog.color');
+goog.require('goog.events.BrowserFeature');
 goog.require('goog.userAgent');
 
 
@@ -452,7 +454,8 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
 
   var bindData = [];
   // Don't register the mouse event if an equivalent pointer event is supported.
-  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
+  if (!goog.events.BrowserFeature.POINTER_EVENTS ||
+      !(name in Blockly.Touch.TOUCH_MAP)) {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
   }
@@ -501,7 +504,8 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
 
   var bindData = [];
   // Don't register the mouse event if an equivalent pointer event is supported.
-  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
+  if (!goog.events.BrowserFeature.POINTER_EVENTS ||
+      !(name in Blockly.Touch.TOUCH_MAP)) {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
   }

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -450,10 +450,14 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     }
   };
 
-  node.addEventListener(name, wrapFunc, false);
-  var bindData = [[node, name, wrapFunc]];
+  var bindData = [];
+  // Don't register the mouse event if an equivalent pointer event is supported.
+  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
+    node.addEventListener(name, wrapFunc, false);
+    bindData.push([node, name, wrapFunc]);
+  }
 
-  // Add equivalent touch event.
+  // Add equivalent touch or pointer event.
   if (name in Blockly.Touch.TOUCH_MAP) {
     var touchWrapFunc = function(e) {
       wrapFunc(e);
@@ -495,10 +499,13 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
     }
   };
 
-  node.addEventListener(name, wrapFunc, false);
-  var bindData = [[node, name, wrapFunc]];
-
-  // Add equivalent touch event.
+  var bindData = [];
+  // Don't register the mouse event if an equivalent pointer event is supported.
+  if (!window.PointerEvent || !(name in Blockly.Touch.TOUCH_MAP)) {
+    node.addEventListener(name, wrapFunc, false);
+    bindData.push([node, name, wrapFunc]);
+  }
+  // Add equivalent touch or pointer event.
   if (name in Blockly.Touch.TOUCH_MAP) {
     var touchWrapFunc = function(e) {
       // Punt on multitouch events.

--- a/core/touch.js
+++ b/core/touch.js
@@ -48,7 +48,7 @@ Blockly.Touch.touchIdentifier_ = null;
  * @type {Object}
  */
 Blockly.Touch.TOUCH_MAP = {};
-if (window.PointerEvent) {
+if (goog.events.BrowserFeature.POINTER_EVENTS) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['pointerdown'],
     'mousemove': ['pointermove'],


### PR DESCRIPTION
Equivalent of #1614, cherry-picked into the release branch.

See https://github.com/Microsoft/pxt-blockly/pull/96 for more details.