### PR TITLE
Updating Closure version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "unused": true
   },
   "dependencies": {
-    "google-closure-library": "^20171203.0.0",
+    "google-closure-library": "^20180204.0.0",
     "install": "^0.8.8",
     "npm": "^4.4.4",
     "webdriverio": "^4.6.2"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Updating closure dependency.

### Reason for Changes

goog.date.fromIsoString was removed upstream and we need to stay up to date to be compatible with other closure apps/libraries. See #1591.

### Test Coverage

Build.py uses online compiler, thus latest Closure. That works, so I suspect this will too.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
