### PR TITLE
Validate field text against XML legal characters

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -61,6 +61,15 @@ Blockly.Field = function(text, opt_validator) {
 Blockly.Field.TYPE_MAP_ = {};
 
 /**
+ * Regular expression matching valid characters from the W3C Extensible Markup Language
+ * 1.0 Recommendation.
+ * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Char
+ * @type {string}
+ * @private
+ */
+Blockly.Field.XML_CHARS_REGEX_ = /^[\t\r\n\u0020-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]*$/;
+
+/**
  * Registers a field type. May also override an existing field type.
  * Blockly.Field.fromJson uses this registry to find the appropriate field.
  * @param {!string} type The field type name as used in the JSON definition.
@@ -324,6 +333,9 @@ Blockly.Field.prototype.callValidator = function(text) {
     return null;
   } else if (classResult !== undefined) {
     text = classResult;
+  }
+  if (!text.match(Blockly.Field.XML_CHARS_REGEX_)) {
+    return null;
   }
   var userValidator = this.getValidator();
   if (userValidator) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -422,6 +422,9 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
             'another location.');
         }
         variablesFirst = false;
+      } else if (name == 'parsererror') {
+        goog.asserts.fail('Parser error reading workspace XML:\n' +
+          xmlChild.textContent);
       }
     }
   } finally {

--- a/tests/jsunit/field_test.js
+++ b/tests/jsunit/field_test.js
@@ -124,3 +124,10 @@ function test_field_register_with_custom_field() {
   assertNotNull(field);
   assertEquals(field.getValue(), 'ok');
 }
+
+function test_field_reject_invalid_xml() {
+  var field = new Blockly.Field("Dummy text");
+
+  // Reject strings with invalid XML characters
+  assertNull(field.callValidator("Invalid char: \u0015"));
+}

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -283,6 +283,23 @@ function test_appendDomToWorkspace() {
   }
 }
 
+function test_domToWorkspace_throwsOnBadXML() {
+  xmlTest_setUpWithMockBlocks();
+  try {
+    var dom = Blockly.Xml.textToDom(
+      '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+      '  <block type="controls_repeat_ext" inline="true" x="21" y="23">\u0015' +
+      '  </block>' +
+      '</xml>');
+    Blockly.Xml.domToWorkspace(dom, workspace);
+    fail();
+  } catch(e) {
+    // expected
+  } finally {
+    xmlTest_tearDownWithMockBlocks();
+  }
+}
+
 function test_blockToDom_fieldToDom_trivial() {
   xmlTest_setUpWithMockBlocks();
   // TODO (#1199): make a similar test where the variable is given a non-empty


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
This PR resolves an issue observed in App Inventor, but also present in Blockly, where pasting a string containing a disallowed XML character results in an XML workspace that parses only up to the field containing the disallowed character. Blockly treats this as successful but any blocks beyond the bad character were missing.

### Proposed Changes

This PR extends the field validator to check field values against those characters specified in the [Extensible Markup Language 1.0](https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Char) recommendation. If the field text does not match the XML spec, it will be rejected.

### Reason for Changes

An App Inventor user pasted a string into a text field that contained an invalid XML character (unicode code point \u0015). Chrome fails to parse the file past the point at which the invalid character appears, but Blockly assumes that this file is valid. This change:

1. Rejects field values that do not meet the XML spec.
2. It throws an assertion error if the XML document contains a `parsererror` tag, indicating that a failure occurred.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Two new unit tests were added to test that bad XML documents result in a thrown error in `domToWorkspace` and that invalid user inputs are rejected by the field validator.

Tested on:
* Desktop Chrome (version 63.0.3239.132 on macOS 10.12.6)
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A