### PR TITLE
Adding an <iframe> wrapper page for testing

### DIFF
--- a/tests/playgrounds/iframe.html
+++ b/tests/playgrounds/iframe.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Blockly &lt;iframe&gt; Playground</title>
+<style>
+  html, body {
+    border: 0;
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+  }
+  h1#title {
+    border: 0;
+    margin: 2px;
+    padding: 0;
+    width: %100;
+  }
+  #playground-iframe {
+    border: 0;
+    width: %100;
+  }
+</style>
+<script type="text/javascript">
+  var onWindowResize = function() {
+    var iframe = document.getElementById('playground-iframe');
+    var top = iframe.getBoundingClientRect().top;
+    iframe.height = window.innerHeight - top;
+    iframe.width = window.innerWidth;
+  };
+  window.addEventListener("resize", onWindowResize);
+  window.addEventListener("load", onWindowResize);
+</script>
+</head>
+<body>
+  <h1 id="title">Outer Frame</h1>
+  <iframe id="playground-iframe" src="../playground.html">
+</body>
+</html>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Adds a iframe host to the Blockly playground.

### Proposed Changes

New `tests/playgrounds/iframe.html` with the `<iframe>` pointing to the standard `playground.html`.

### Reason for Changes

Page to test events, etc in an iframe context.

### Test Coverage

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->