### PR TITLE
Fix some tooltips for blocks with variables

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -280,11 +280,11 @@ Blockly.Extensions.registerMixin('contextMenu_newGetVariableBlock',
     Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN);
 
 Blockly.Extensions.register('controls_for_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_CONTROLS_FOR_TOOLTIP}', 'VAR'));
 
 Blockly.Extensions.register('controls_forEach_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_CONTROLS_FOREACH_TOOLTIP}', 'VAR'));
 
 /**

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -505,7 +505,7 @@ Blockly.Constants.Math.CHANGE_TOOLTIP_EXTENSION = function() {
 };
 
 Blockly.Extensions.register('math_change_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_MATH_CHANGE_TOOLTIP}', 'VAR'));
 
 /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -773,18 +773,6 @@ Blockly.Constants.Text.TEXT_JOIN_EXTENSION = function() {
   this.setMutator(new Blockly.Mutator(['text_create_join_item']));
 };
 
-Blockly.Constants.Text.TEXT_APPEND_TOOLTIP_EXTENSION = function() {
-  // Assign 'this' to a variable for use in the tooltip closure below.
-  var thisBlock = this;
-  this.setTooltip(function() {
-    if (Blockly.Msg.TEXT_APPEND_TOOLTIP) {
-      return Blockly.Msg.TEXT_APPEND_TOOLTIP.replace('%1',
-          thisBlock.getFieldValue('VAR'));
-    }
-    return '';
-  });
-};
-
 Blockly.Constants.Text.TEXT_INDEXOF_TOOLTIP_EXTENSION = function() {
   // Assign 'this' to a variable for use in the tooltip closure below.
   var thisBlock = this;
@@ -890,7 +878,8 @@ Blockly.Extensions.register('text_quotes',
     Blockly.Constants.Text.TEXT_QUOTES_EXTENSION);
 
 Blockly.Extensions.register('text_append_tooltip',
-    Blockly.Constants.Text.TEXT_APPEND_TOOLTIP_EXTENSION);
+    Blockly.Extensions.buildTooltipWithFieldText(
+        '%{BKY_TEXT_APPEND_TOOLTIP}', 'VAR'));
 
 Blockly.Extensions.registerMutator('text_join_mutator',
     Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN,

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -430,6 +430,45 @@ Blockly.Extensions.buildTooltipWithFieldValue = function(msgTemplate,
 };
 
 /**
+ * Builds an extension function that will install a dynamic tooltip. The
+ * tooltip message should include the string '%1' and that string will be
+ * replaced with the text of the named field.
+ * @param {string} msgTemplate The template form to of the message text, with
+ *     %1 placeholder.
+ * @param {string} fieldName The field with the replacement text.
+ * @returns {Function} The extension function.
+ */
+Blockly.Extensions.buildTooltipWithFieldText = function(msgTemplate,
+    fieldName) {
+  // Check the tooltip string messages for invalid references.
+  // Wait for load, in case Blockly.Msg is not yet populated.
+  // runAfterPageLoad() does not run in a Node.js environment due to lack of
+  // document object, in which case skip the validation.
+  if (typeof document == 'object') {  // Relies on document.readyState
+    Blockly.utils.runAfterPageLoad(function() {
+      // Will print warnings if reference is missing.
+      Blockly.utils.checkMessageReferences(msgTemplate);
+    });
+  }
+
+  /**
+   * The actual extension.
+   * @this {Blockly.Block}
+   */
+  var extensionFn = function() {
+    this.setTooltip(function() {
+      var text = '';
+      var field = this.getField(fieldName);
+      if (field) {
+        text = field.getText();
+      }
+      return Blockly.utils.replaceMessageReferences(msgTemplate)
+          .replace('%1', text);
+    }.bind(this));
+  };
+  return extensionFn;
+};
+/**
  * Configures the tooltip to mimic the parent block when connected. Otherwise,
  * uses the tooltip text at the time this extension is initialized. This takes
  * advantage of the fact that all other values from JSON are initialized before


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1619 

### Proposed Changes

Add an extension that lets you populate a tooltip with a field's text instead of value.  Use it for tooltips that reference variables.

### Reason for Changes

Variable value is now ID, which we don't want to display to the user.
### Test Coverage

Tested by hovering over all blocks in the playground and making sure their tooltips make sense.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

I'm planning to cherry-pick this into the release.