### PR TITLE
Disable pointer events for the february release

### DIFF
--- a/core/touch.js
+++ b/core/touch.js
@@ -48,13 +48,7 @@ Blockly.Touch.touchIdentifier_ = null;
  * @type {Object}
  */
 Blockly.Touch.TOUCH_MAP = {};
-if (window.PointerEvent) {
-  Blockly.Touch.TOUCH_MAP = {
-    'mousedown': ['pointerdown'],
-    'mousemove': ['pointermove'],
-    'mouseup': ['pointerup', 'pointercancel']
-  };
-} else if (goog.events.BrowserFeature.TOUCH_ENABLED) {
+if (goog.events.BrowserFeature.TOUCH_ENABLED) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['touchstart'],
     'mousemove': ['touchmove'],


### PR DESCRIPTION
Pointer events are causing strange behaviour in iframes and in Chrome 64.  Disable them to get the current release out the door.