### PR TITLE
Fix #1619. buildTooltipWithFieldValue() => buildTooltipWithFieldText()

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -280,11 +280,11 @@ Blockly.Extensions.registerMixin('contextMenu_newGetVariableBlock',
     Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN);
 
 Blockly.Extensions.register('controls_for_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_CONTROLS_FOR_TOOLTIP}', 'VAR'));
 
 Blockly.Extensions.register('controls_forEach_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_CONTROLS_FOREACH_TOOLTIP}', 'VAR'));
 
 /**

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -492,20 +492,9 @@ Blockly.Extensions.registerMutator('math_is_divisibleby_mutator',
     Blockly.Constants.Math.IS_DIVISIBLEBY_MUTATOR_MIXIN,
     Blockly.Constants.Math.IS_DIVISIBLE_MUTATOR_EXTENSION);
 
-/**
- * Update the tooltip of 'math_change' block to reference the variable.
- * @this Blockly.Block
- * @package
- */
-Blockly.Constants.Math.CHANGE_TOOLTIP_EXTENSION = function() {
-  this.setTooltip(function() {
-    return Blockly.Msg.MATH_CHANGE_TOOLTIP.replace('%1',
-        this.getFieldValue('VAR'));
-  }.bind(this));
-};
-
+// Update the tooltip of 'math_change' block to reference the variable.
 Blockly.Extensions.register('math_change_tooltip',
-    Blockly.Extensions.buildTooltipWithFieldValue(
+    Blockly.Extensions.buildTooltipWithFieldText(
         '%{BKY_MATH_CHANGE_TOOLTIP}', 'VAR'));
 
 /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -773,17 +773,10 @@ Blockly.Constants.Text.TEXT_JOIN_EXTENSION = function() {
   this.setMutator(new Blockly.Mutator(['text_create_join_item']));
 };
 
-Blockly.Constants.Text.TEXT_APPEND_TOOLTIP_EXTENSION = function() {
-  // Assign 'this' to a variable for use in the tooltip closure below.
-  var thisBlock = this;
-  this.setTooltip(function() {
-    if (Blockly.Msg.TEXT_APPEND_TOOLTIP) {
-      return Blockly.Msg.TEXT_APPEND_TOOLTIP.replace('%1',
-          thisBlock.getFieldValue('VAR'));
-    }
-    return '';
-  });
-};
+// Update the tooltip of 'text_append' block to reference the variable.
+Blockly.Extensions.register('text_append_tooltip',
+    Blockly.Extensions.buildTooltipWithFieldText(
+        '%{BKY_TEXT_APPEND_TOOLTIP}', 'VAR'));
 
 Blockly.Constants.Text.TEXT_INDEXOF_TOOLTIP_EXTENSION = function() {
   // Assign 'this' to a variable for use in the tooltip closure below.
@@ -888,9 +881,6 @@ Blockly.Extensions.register('text_indexOf_tooltip',
 
 Blockly.Extensions.register('text_quotes',
     Blockly.Constants.Text.TEXT_QUOTES_EXTENSION);
-
-Blockly.Extensions.register('text_append_tooltip',
-    Blockly.Constants.Text.TEXT_APPEND_TOOLTIP_EXTENSION);
 
 Blockly.Extensions.registerMutator('text_join_mutator',
     Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN,

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -422,8 +422,9 @@ Blockly.Extensions.buildTooltipWithFieldText = function(msgTemplate,
    */
   var extensionFn = function() {
     this.setTooltip(function() {
+      var field = this.getField(fieldName);
       return Blockly.utils.replaceMessageReferences(msgTemplate)
-          .replace('%1', this.getField(fieldName).getText());
+          .replace('%1', field ? field.getText() : '');
     }.bind(this));
   };
   return extensionFn;

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -397,13 +397,13 @@ Blockly.Extensions.checkDropdownOptionsInTable_ = function(block, dropdownName,
 /**
  * Builds an extension function that will install a dynamic tooltip. The
  * tooltip message should include the string '%1' and that string will be
- * replaced with the value of the named field.
+ * replaced with the text of the named field.
  * @param {string} msgTemplate The template form to of the message text, with
  *     %1 placeholder.
- * @param {string} fieldName The field with the replacement value.
+ * @param {string} fieldName The field with the replacement text.
  * @returns {Function} The extension function.
  */
-Blockly.Extensions.buildTooltipWithFieldValue = function(msgTemplate,
+Blockly.Extensions.buildTooltipWithFieldText = function(msgTemplate,
     fieldName) {
   // Check the tooltip string messages for invalid references.
   // Wait for load, in case Blockly.Msg is not yet populated.
@@ -423,7 +423,7 @@ Blockly.Extensions.buildTooltipWithFieldValue = function(msgTemplate,
   var extensionFn = function() {
     this.setTooltip(function() {
       return Blockly.utils.replaceMessageReferences(msgTemplate)
-          .replace('%1', this.getFieldValue(fieldName));
+          .replace('%1', this.getField(fieldName).getText());
     }.bind(this));
   };
   return extensionFn;


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix #1619 

The "value" of FieldVariables was the variable id.
However, we want the field text for the human visible tooltip. Refactoring and renaming `buildTooltipWithFieldValue` to use the field text.

### Proposed Changes

 * Refactor `buildTooltipWithFieldValue()` to use field text, instead of value. Rename accordingly.
 * Make sure all use (the blocks in question) use the renamed function.
 * Remove custom functions that were not using this helper.

### Reason for Changes

#1619 

### Test Coverage

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
