### PR TITLE
Print a warning if block JSON color value is invalid

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1054,6 +1054,7 @@ Blockly.Block.prototype.appendDummyInput = function(opt_name) {
  * @param {!Object} json Structured data describing the block.
  */
 Blockly.Block.prototype.jsonInit = function(json) {
+  var blockTypeName = json['type'];
 
   // Validate inputs.
   goog.asserts.assert(
@@ -1063,9 +1064,14 @@ Blockly.Block.prototype.jsonInit = function(json) {
   // Set basic properties of block.
   if (json['colour'] !== undefined) {
     var rawValue = json['colour'];
-    var colour = goog.isString(rawValue) ?
-        Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
-    this.setColour(colour);
+    try {
+      var colour = goog.isString(rawValue) ?
+          Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
+      this.setColour(colour);
+    } catch (colorError) {
+      console.warn(
+          'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
+    }
   }
 
   // Interpolate the message blocks.


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1633: If block definition has invalid color, creating/loading fails/throws

### Proposed Changes

Catch the throw error, and print a warning with the block type name.
Without a color assignment, the block defaults to black (same as not having a color property in the JSON).

### Reason for Changes

While it is still illegal to have a bad color value specified in the JSON, the consequences of the thrown error outweighed the functional error. Instead catch the error, allow the block to render. This also allows the the remainder of the toolbox/workspace to load.

### Test Coverage

This is covered in the new playground test blocks, and the "Styles" category fully loads with this change, with the following warning output in the console:

```
block.js:1072 Block "block_colour_hex4": Illegal color value:  #992aff99
block.js:1072 Block "block_colour_hex5": Illegal color value:  #NotHex
```

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
