### PR TITLE
Adding new playground test category "Drag"

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1060,6 +1060,71 @@ h1 {
       <block type="empty_block"></block>
       <block type="empty_block_with_mutator"></block>
     </category>
+    <category name="Drag">
+      <label text="Drag each of to the workspace"></label>
+      <block type="text_print">
+        <value name="TEXT">
+          <block type="text">
+            <field name="TEXT">Drag me by this child</field>
+          </block>
+        </value>
+      </block>
+      <block type="text_print">
+        <value name="TEXT">
+          <shadow type="text">
+            <field name="TEXT">Drag me by this shadow</field>
+          </shadow>
+        </value>
+      </block>
+      <label text="Multiple Variable Refs"></label>
+      <block type="text_print">
+        <value name="TEXT">
+          <block type="variables_get">
+            <field name="VAR" id="item" variabletype="">item</field>
+          </block>
+        </value>
+        <next>
+          <block type="text_print">
+            <value name="TEXT">
+              <block type="variables_get">
+                <field name="VAR" id="item" variabletype="">item</field>
+              </block>
+            </value>
+          </block>
+        </next>
+      </block>
+      <label text="Procedure Definitions"></label>
+      <block type="procedures_defnoreturn">
+        <field name="NAME">without arguments</field>
+        <statement name="STACK">
+          <block type="text_print">
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">No argument reference.</field>
+              </shadow>
+            </value>
+          </block>
+        </statement>
+      </block>
+      <block type="procedures_defnoreturn">
+        <mutation>
+          <arg name="fnArgument"></arg>
+        </mutation>
+        <field name="NAME">with one argument</field>
+        <statement name="STACK">
+          <block type="text_print">
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">Expected an argument reference here.</field>
+              </shadow>
+              <block type="variables_get">
+                <field name="VAR">fnArgument</field>
+              </block>
+            </value>
+          </block>
+        </statement>
+      </block>
+    </category>
     <category name="Fields">
       <label text="Numbers"></label>
       <block type="test_number"></block>

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1061,7 +1061,7 @@ h1 {
       <block type="empty_block_with_mutator"></block>
     </category>
     <category name="Drag">
-      <label text="Drag each of to the workspace"></label>
+      <label text="Drag each to the workspace"></label>
       <block type="text_print">
         <value name="TEXT">
           <block type="text">


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

New toolbox blocks to test #1642 and related "drag block from toolbox" cases.

### Proposed Changes

Adds a new "text blocks" toolbox category "Drag" with entries composed of standard blocks.

### Reason for Changes

#1642 was only identified late in the release cycle, because it only exhibited in the demos, not the playground, JsUnit tests, or generator tests.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<img width="465" alt="screen shot 2018-02-20 at 1 14 57 pm" src="https://user-images.githubusercontent.com/9916202/36449614-27606bb8-1640-11e8-8d5a-45b63e4e2dae.png">

<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
