### PR TITLE
Serialize variable IDs in procedure definitions

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -132,9 +132,11 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     if (opt_paramIds) {
       container.setAttribute('name', this.getFieldValue('NAME'));
     }
-    for (var i = 0; i < this.arguments_.length; i++) {
+    for (var i = 0; i < this.argumentVarModels_.length; i++) {
       var parameter = document.createElement('arg');
-      parameter.setAttribute('name', this.arguments_[i]);
+      var argModel = this.argumentVarModels_[i];
+      parameter.setAttribute('name', argModel.name);
+      parameter.setAttribute('varId', argModel.getId());
       if (opt_paramIds && this.paramIds_) {
         parameter.setAttribute('paramId', this.paramIds_[i]);
       }
@@ -158,9 +160,10 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         var varName = childNode.getAttribute('name');
+        var varId = childNode.getAttribute('varId');
         this.arguments_.push(varName);
         var variable = Blockly.Variables.getOrCreateVariablePackage(
-            this.workspace, null, varName, '');
+            this.workspace, varId, varName, '');
         this.argumentVarModels_.push(variable);
       }
     }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1642 

### Proposed Changes

Serialize and deserialize variable IDs for arguments in procedure definitions.

### Reason for Changes

![image](https://user-images.githubusercontent.com/13686399/36449833-e64d25e8-1640-11e8-8fa2-3afde95ecef5.png)

Dragging this block from the toolbox into the workspace failed.  

The initial XML had no variable IDs, so the code to load the blocks in the flyout created a potential variable for "list" (and another potential variable for "x").

Dragging from the flyout to the workspace uses `blockToDom`, then `domToBlock`.  

The serialization of the procedure definition block and its mutation did *not* include a variable ID, so a new variable was created (with a new ID).

The serialization of the "list" reference in the inner blocks *did* include a variable ID, which was the ID of the potential variable in the flyout.

This ID did not match the new ID of the parameter, so there was a crashing error.

### Test Coverage

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Dragged in the above block from the flyout.