### PR TITLE
Move ordinal in block 'text_getSubstring'

### DIFF
--- a/blocks/text.js
+++ b/blocks/text.js
@@ -313,6 +313,8 @@ Blockly.Blocks['text_getSubstring'] = {
         .appendField(menu, 'WHERE' + n);
     if (n == 1) {
       this.moveInputBefore('AT1', 'AT2');
+      if (this.getInput('ORDINAL1')) {
+        this.moveInputBefore('ORDINAL1', 'AT2');
     }
   }
 };

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -315,6 +315,7 @@ Blockly.Blocks['text_getSubstring'] = {
       this.moveInputBefore('AT1', 'AT2');
       if (this.getInput('ORDINAL1')) {
         this.moveInputBefore('ORDINAL1', 'AT2');
+      }
     }
   }
 };


### PR DESCRIPTION
On updating the block 'text_getSubstring', the ordinal string 'ORDINAL1' is moved when the corresponding corresponding input field is moved so that the ordinal string does not end up at the end of the block.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

None

### Proposed Changes

Reordering the ordinal sign in the block to the right place, even after selecting different entries in the block input fields. Here in German:

![image](https://user-images.githubusercontent.com/17168083/36603327-b1611b1a-18ba-11e8-93b7-0df2f7ce4b7f.png)

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

In languages with ordinal sign, the ordinal sign ends up on the wrong place in this block, if you first select "get substring from first letter" and then select "get substring from letter #". Here in German:

![image](https://user-images.githubusercontent.com/17168083/36603276-90063bf8-18ba-11e8-8bcc-31401ec2b584.png)

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
