### PR TITLE
Move comment XML functions into the comment files.

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -410,8 +410,8 @@ Blockly.Workspace.prototype.newBlock = function(prototypeName, opt_id) {
 /**
  * Obtain a newly created comment.
  * @param {?string} content Content of the comment
- * @param {?string} h Height of the comment
- * @param {?string} w Width of the comment
+ * @param {number} h Height of the comment
+ * @param {number} w Width of the comment
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @return {!Blockly.WorkspaceComment} The created comment.

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -410,12 +410,14 @@ Blockly.Workspace.prototype.newBlock = function(prototypeName, opt_id) {
 /**
  * Obtain a newly created comment.
  * @param {?string} content Content of the comment
+ * @param {?string} h Height of the comment
+ * @param {?string} w Width of the comment
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @return {!Blockly.WorkspaceComment} The created comment.
  */
-Blockly.Workspace.prototype.newComment = function(content, opt_id) {
-  return new Blockly.WorkspaceComment(this, content, opt_id);
+Blockly.Workspace.prototype.newComment = function(content, h, w, opt_id) {
+  return new Blockly.WorkspaceComment(this, content, h, w, opt_id);
 };
 
 /**

--- a/core/workspace_comment/workspace_comment.js
+++ b/core/workspace_comment/workspace_comment.js
@@ -188,6 +188,8 @@ Blockly.WorkspaceComment.prototype.setContent = function(content) {
 Blockly.WorkspaceComment.prototype.toXmlWithXY = function(opt_noId) {
   var width;  // Not used in LTR.
   if (this.workspace.RTL) {
+    // Here be performance dragons: On a rendered workspace, this will call
+    // getMetrics().
     width = this.workspace.getWidth();
   }
   var element = this.toXml(opt_noId);
@@ -199,9 +201,12 @@ Blockly.WorkspaceComment.prototype.toXmlWithXY = function(opt_noId) {
 };
 
 /**
- * Encode a comment subtree as XML.
+ * Encode a comment subtree as XML, but don't serialize the XY coordinates.
+ * This method avoids some expensive metrics-related calls that are made in
+ * toXmlWithXY().
  * @param {boolean} opt_noId True if the encoder should skip the comment id.
  * @return {!Element} Tree of XML elements.
+ * @package
  */
 Blockly.WorkspaceComment.prototype.toXml = function(opt_noId) {
   var commentElement = goog.dom.createDom('comment');

--- a/core/workspace_comment/workspace_comment.js
+++ b/core/workspace_comment/workspace_comment.js
@@ -223,7 +223,7 @@ Blockly.WorkspaceComment.prototype.toXml = function(opt_noId) {
  * Decode an XML comment tag and create a comment on the workspace.
  * @param {!Element} xmlComment XML comment element.
  * @param {!Blockly.Workspace} workspace The workspace.
- * @return {!Blockly.WorkspaceComment} The workspace comment created.
+ * @return {!Blockly.WorkspaceComment} The created workspace comment.
  * @package
  */
 Blockly.WorkspaceComment.fromXml = function(xmlComment, workspace) {

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -515,7 +515,7 @@ Blockly.WorkspaceCommentSvg.prototype.setAutoLayout = function() {
  * Decode an XML comment tag and create a rendered comment on the workspace.
  * @param {!Element} xmlComment XML comment element.
  * @param {!Blockly.Workspace} workspace The workspace.
- * @return {!Blockly.WorkspaceComment} The workspace comment created.
+ * @return {!Blockly.WorkspaceComment} The created workspace comment.
  * @package
  */
 Blockly.WorkspaceCommentSvg.fromXml = function(xmlComment, workspace) {

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -63,17 +63,7 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
   this.svgGroup_.appendChild(this.svgRect_);
 
   /**
-   * @type {number}
-   * @private
-   */
-  this.height_ = height;
-  /**
-   * @type {number}
-   * @private
-   */
-  this.width_ = width;
-
-  /**
+   * Whether the comment is rendered onscreen and is a part of the DOM.
    * @type {boolean}
    * @private
    */
@@ -88,7 +78,7 @@ Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
   this.useDragSurface_ = Blockly.utils.is3dSupported() && !!workspace.blockDragSurface_;
 
   Blockly.WorkspaceCommentSvg.superClass_.constructor.call(this,
-      workspace, content, opt_id);
+      workspace, content, height, width, opt_id);
 
   this.render();
 }; goog.inherits(Blockly.WorkspaceCommentSvg, Blockly.WorkspaceComment);
@@ -519,4 +509,28 @@ Blockly.WorkspaceCommentSvg.prototype.setDeleteStyle = function(enable) {
 
 Blockly.WorkspaceCommentSvg.prototype.setAutoLayout = function() {
   // NOP for compatibility with the bubble dragger.
+};
+
+/**
+ * Decode an XML comment tag and create a rendered comment on the workspace.
+ * @param {!Element} xmlComment XML comment element.
+ * @param {!Blockly.Workspace} workspace The workspace.
+ * @return {!Blockly.WorkspaceComment} The workspace comment created.
+ * @package
+ */
+Blockly.WorkspaceCommentSvg.fromXml = function(xmlComment, workspace) {
+  // Create top-level comment.
+  Blockly.Events.disable();
+  try {
+    var comment = Blockly.WorkspaceComment.fromXml(xmlComment, workspace);
+    if (workspace.rendered) {
+      comment.initSvg();
+      comment.render(false);
+    }
+  } finally {
+    Blockly.Events.enable();
+  }
+  // TODO (#1580): fire a comment create event.  Possibly should happen in
+  // Blockly.WorkspaceComment.fromXml instead.
+  return comment;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -538,8 +538,8 @@ Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
 /**
  * Obtain a newly created comment.
  * @param {?string} content Content of the comment
- * @param {?string} h Height of the comment
- * @param {?string} w Width of the comment
+ * @param {number} h Height of the comment
+ * @param {number} w Width of the comment
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @return {!Blockly.WorkspaceCommentSvg} The created comment.

--- a/core/xml.js
+++ b/core/xml.js
@@ -46,7 +46,7 @@ Blockly.Xml.workspaceToDom = function(workspace, opt_noId) {
       Blockly.Variables.allUsedVarModels(workspace)));
   var comments = workspace.getTopComments(true);
   for (var i = 0, comment; comment = comments[i]; i++) {
-    xml.appendChild(Blockly.Xml.commentToDomWithXY(comment, opt_noId));
+    xml.appendChild(comment.toXmlWithXY(opt_noId));
   }
   var blocks = workspace.getTopBlocks(true);
   for (var i = 0, block; block = blocks[i]; i++) {
@@ -264,42 +264,6 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
 };
 
 /**
- * Encode a comment subtree as XML with XY coordinates.
- * @param {!Blockly.Comment} comment The workspace comment to encode.
- * @param {boolean} opt_noId True if the encoder should skip the comment id.
- * @return {!Element} Tree of XML elements.
- */
-Blockly.Xml.commentToDomWithXY = function(comment, opt_noId) {
-  var width;  // Not used in LTR.
-  if (comment.workspace.RTL) {
-    width = comment.workspace.getWidth();
-  }
-  var element = Blockly.Xml.commentToDom(comment, opt_noId);
-  var xy = comment.getRelativeToSurfaceXY();
-  element.setAttribute('x',
-      Math.round(comment.workspace.RTL ? width - xy.x : xy.x));
-  element.setAttribute('y', Math.round(xy.y));
-  return element;
-};
-
-/**
- * Encode a comment subtree as XML.
- * @param {!Blockly.Comment} comment The workspace comment to encode.
- * @param {boolean} opt_noId True if the encoder should skip the comment id.
- * @return {!Element} Tree of XML elements.
- */
-Blockly.Xml.commentToDom = function(comment, opt_noId) {
-  var commentElement = goog.dom.createDom('comment');
-  commentElement.setAttribute('h', comment.getHeight());
-  commentElement.setAttribute('w', comment.getWidth());
-  if (!opt_noId) {
-    commentElement.setAttribute('id', comment.id);
-  }
-  commentElement.textContent = comment.getContent();
-  return commentElement;
-};
-
-/**
  * Deeply clone the shadow's DOM so that changes don't back-wash to the block.
  * @param {!Element} shadow A tree of XML elements.
  * @return {!Element} A tree of XML elements.
@@ -411,6 +375,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
     console.warn('Deprecated call to Blockly.Xml.domToWorkspace, ' +
                  'swap the arguments.');
   }
+
   var width;  // Not used in LTR.
   if (workspace.RTL) {
     width = workspace.getWidth();
@@ -452,7 +417,14 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
         goog.asserts.fail('Shadow block cannot be a top-level block.');
         variablesFirst = false;
       } else if (name == 'comment') {
-        var comment = Blockly.Xml.domToComment(xmlChild, workspace);
+        if (workspace.rendered) {
+          var comment =
+            Blockly.WorkspaceCommentSvg.fromXml(xmlChild, workspace);
+        } else {
+          var comment = Blockly.WorkspaceComment.fromXml(xmlChild, workspace);
+        }
+        // Position the comment correctly, taking into account the width of a
+        // rendered RTL workspace.
         var commentX = parseInt(xmlChild.getAttribute('x'), 10);
         var commentY = parseInt(xmlChild.getAttribute('y'), 10);
         if (!isNaN(commentX) && !isNaN(commentY)) {
@@ -602,30 +574,6 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
   return topBlock;
 };
 
-/**
- * Decode an XML block tag and create a comment on the workspace.
- * @param {!Element} xmlComment XML comment element.
- * @param {!Blockly.Workspace} workspace The workspace.
- * @return {!Blockly.Block} The root block created.
- */
-Blockly.Xml.domToComment = function(xmlComment, workspace) {
-  // Create top-level comment.
-  Blockly.Events.disable();
-  try {
-    var comment = Blockly.Xml.domToCommentHeadless_(xmlComment, workspace);
-    if (workspace.rendered) {
-      comment.initSvg();
-      comment.render(false);
-    }
-  } finally {
-    Blockly.Events.enable();
-  }
-  // TODO: fire a comment create event
-  // if (Blockly.Events.isEnabled()) {
-  //   Blockly.Events.fire(new Blockly.Events.BlockCreate(topBlock));
-  // }
-  return comment;
-};
 
 /**
  * Decode an XML list of variables and add the variables to the workspace.
@@ -866,35 +814,6 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
   } else {
     field.setValue(text);
   }
-};
-
-/**
- * Decode an XML comment tag and create a comment on the workspace.
- * @param {!Element} xmlComment XML comment element.
- * @param {!Blockly.Workspace} workspace The workspace.
- * @return {!Blockly.Block} The root block created.
- * @private
- */
-Blockly.Xml.domToCommentHeadless_ = function(xmlComment, workspace) {
-  var comment = null;
-  var id = xmlComment.getAttribute('id');
-  var h = parseInt(xmlComment.getAttribute('h'), 10);
-  var w = parseInt(xmlComment.getAttribute('w'), 10);
-  var content = xmlComment.textContent;
-  // TODO (fenichel): This constructor doesn't work in a headless workspace.
-  comment = workspace.newComment(content, h, w, id);
-
-  // TODO (fenichel): Why are height and width getting parsed twice?
-  // And which time actually matters?
-  var height = parseInt(xmlComment.getAttribute('h'), 10);
-  if (height) {
-    comment.setHeight(height);
-  }
-  var width = parseInt(xmlComment.getAttribute('w'), 10);
-  if (width) {
-    comment.setWidth(width);
-  }
-  return comment;
 };
 
 /**

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -47,7 +47,7 @@ function test_noWorkspaceComments() {
 function test_oneWorkspaceComment() {
   workspaceCommentTest_setUp();
   try {
-    var comment = workspace.newComment('comment text', 'comment id');
+    var comment = workspace.newComment('comment text', 0, 0, 'comment id');
     assertEquals('One comment on workspace (1).', 1, workspace.getTopComments(true).length);
     assertEquals('One comment on workspace  (2).', 1, workspace.getTopComments(false).length);
     assertEquals('Comment db contains this comment.', comment, workspace.commentDB_['comment id']);
@@ -63,7 +63,7 @@ function test_oneWorkspaceComment() {
 function test_getWorkspaceCommentById() {
   workspaceCommentTest_setUp();
   try {
-    var comment = workspace.newComment('comment text', 'comment id');
+    var comment = workspace.newComment('comment text', 0, 0, 'comment id');
     assertEquals('Getting a comment by id.', comment, workspace.getCommentById('comment id'));
     assertEquals('No comment found.', null, workspace.getCommentById('not a comment'));
     comment.dispose();
@@ -76,7 +76,7 @@ function test_getWorkspaceCommentById() {
 function test_disposeWsCommentTwice() {
   workspaceCommentTest_setUp();
   try {
-    var comment = workspace.newComment('comment text', 'comment id');
+    var comment = workspace.newComment('comment text', 0, 0, 'comment id');
     comment.dispose();
     // Nothing should go wrong the second time dispose is called.
     comment.dispose();


### PR DESCRIPTION

## The basics

- [ ] I branched from develop **I branched from comments_v2**
- [ ] My pull request is against develop  **My pull request is against comments_v2**
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Progress on #1476 
Fixes loading comments on headless workspaces.

### Proposed Changes

Move comment serialization and deserialization into the comment files, and rename to `fromXml` and `toXml`.  

Store height and width on non-rendered comments.  No need to destroy that information.

### Reason for Changes

Part of a larger push to move serialization into the objects being serialized.  Might as well do it before the comments code hits develop.

### Test Coverage
Headless:
- built a workspace with a comment on the playground
- exported to XML
- ran `build.py core`
- opened the headless demo
- copied XML from the playground
- confirmed that the comment exists and has the correct properties after the `domToWorkspace` call.

Rendered:
- added comments in the playground
- serialized and deserialized
- edited
- resized
- serialized and deserialized more
- checked RTL as well

Jsunit:
- tests pass.  Small tweaks needed.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

There are more jsunit tests that I could add for this, but that's a problem for tomorrow.