### PR TITLE
Field.Variable's dispose should be on the prototype

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -120,7 +120,7 @@ Blockly.FieldVariable.prototype.initModel = function() {
  * Dispose of this field.
  * @public
  */
-Blockly.FieldVariable.dispose = function() {
+Blockly.FieldVariable.prototype.dispose = function() {
   Blockly.FieldVariable.superClass_.dispose.call(this);
   this.workspace_ = null;
   this.variableMap_ = null;


### PR DESCRIPTION
So that it can actually be called.

