### PR TITLE
Use @nocompress annotation to fix advanced compilation.

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -58,6 +58,7 @@ goog.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
  * @param {!Object} options A JSON object with options (angle).
  * @returns {!Blockly.FieldAngle} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldAngle.fromJson = function(options) {
   return new Blockly.FieldAngle(options['angle']);

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -51,6 +51,7 @@ goog.inherits(Blockly.FieldCheckbox, Blockly.Field);
  * @param {!Object} options A JSON object with options (checked).
  * @returns {!Blockly.FieldCheckbox} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldCheckbox.fromJson = function(options) {
   return new Blockly.FieldCheckbox(options['checked'] ? 'TRUE' : 'FALSE');

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -57,6 +57,7 @@ goog.inherits(Blockly.FieldColour, Blockly.Field);
  * @param {!Object} options A JSON object with options (colour).
  * @returns {!Blockly.FieldColour} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldColour.fromJson = function(options) {
   return new Blockly.FieldColour(options['colour']);

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -64,6 +64,7 @@ goog.inherits(Blockly.FieldDate, Blockly.Field);
  * @param {!Object} options A JSON object with options (date).
  * @returns {!Blockly.FieldDate} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldDate.fromJson = function(options) {
   return new Blockly.FieldDate(options['date']);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -68,6 +68,7 @@ goog.inherits(Blockly.FieldDropdown, Blockly.Field);
  * @param {!Object} options A JSON object with options (options).
  * @returns {!Blockly.FieldDropdown} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldDropdown.fromJson = function(options) {
   return new Blockly.FieldDropdown(options['options']);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -67,6 +67,7 @@ goog.inherits(Blockly.FieldImage, Blockly.Field);
  *                          alt).
  * @returns {!Blockly.FieldImage} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldImage.fromJson = function(options) {
   var src = Blockly.utils.replaceMessageReferences(options['src']);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -52,6 +52,7 @@ goog.inherits(Blockly.FieldLabel, Blockly.Field);
  * @param {!Object} options A JSON object with options (text, and class).
  * @returns {!Blockly.FieldLabel} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldLabel.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -59,6 +59,7 @@ goog.inherits(Blockly.FieldNumber, Blockly.FieldTextInput);
  *                          precision).
  * @returns {!Blockly.FieldNumber} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldNumber.fromJson = function(options) {
   return new Blockly.FieldNumber(options['value'],

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -57,6 +57,7 @@ goog.inherits(Blockly.FieldTextInput, Blockly.Field);
  *                          spellcheck).
  * @returns {!Blockly.FieldTextInput} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldTextInput.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -68,6 +68,7 @@ goog.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
  *                          variableTypes, and defaultType).
  * @returns {!Blockly.FieldVariable} The new field instance.
  * @package
+ * @nocollapse
  */
 Blockly.FieldVariable.fromJson = function(options) {
   var varname = Blockly.utils.replaceMessageReferences(options['variable']);
@@ -120,7 +121,7 @@ Blockly.FieldVariable.prototype.initModel = function() {
  * Dispose of this field.
  * @public
  */
-Blockly.FieldVariable.dispose = function() {
+Blockly.FieldVariable.prototype.dispose = function() {
   Blockly.FieldVariable.superClass_.dispose.call(this);
   this.workspace_ = null;
   this.variableMap_ = null;


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1671
### Proposed Changes

Adds the @nocompress annotation to subclass implementations of `fromJson`.

### Reason for Changes

See bullet two in "[Implications of object property flattening](https://developers.google.com/closure/compiler/docs/limitations#implications-of-object-property-flattening)" in the closure compiler documentation: 

![image](https://user-images.githubusercontent.com/13686399/36868538-7f6cac7c-1d4d-11e8-8de7-c0d6542d98bb.png)

### Test Coverage
Tested by running `tests/compile/compile.sh` and confirming that I can open and interact with `tests/compile/index.html`.


### Additional Information

Is this also a problem with event `fromJson`?  I will investigate before merging #1672.