### PR TITLE
Mark bindEvent_ and bindEventWithChecks_ package instead of private

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -426,7 +426,7 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
  *     opt_noPreventDefault is provided, opt_noCaptureIdentifier must also be
  *     provided.
  * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
- * @private
+ * @package
  */
 Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     opt_noCaptureIdentifier, opt_noPreventDefault) {
@@ -484,7 +484,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
  * @param {Object} thisObject The value of 'this' in the function.
  * @param {!Function} func Function to call when event is triggered.
  * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
- * @private
+ * @package
  */
 Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var wrapFunc = function(e) {


### PR DESCRIPTION
Fixes 50 compiler warnings.

