### PR TITLE
Pointer Event fixes

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -452,26 +452,32 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
   };
 
   var bindData = [];
-  // Don't register the mouse event if an equivalent pointer event is supported.
-  if ((window && !window.PointerEvent) || !(name in Blockly.Touch.TOUCH_MAP)) {
+  var bindData = [];
+  if (window && window.PointerEvent &&
+      (name in Blockly.Touch.TOUCH_MAP)) {
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, wrapFunc, false);
+        bindData.push([node, type, wrapFunc]);
+      }
+  } else {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
-  }
 
-  // Add equivalent touch or pointer event.
-  if (name in Blockly.Touch.TOUCH_MAP) {
-    var touchWrapFunc = function(e) {
-      wrapFunc(e);
-      // Calling preventDefault stops the browser from scrolling/zooming the
-      // page.
-      var preventDef = !opt_noPreventDefault;
-      if (handled && preventDef) {
-        e.preventDefault();
+    // Add equivalent touch event.
+    if (name in Blockly.Touch.TOUCH_MAP) {
+      var touchWrapFunc = function(e) {
+        wrapFunc(e);
+        // Calling preventDefault stops the browser from scrolling/zooming the
+        // page.
+        var preventDef = !opt_noPreventDefault;
+        if (handled && preventDef) {
+          e.preventDefault();
+        }
+      };
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, touchWrapFunc, false);
+        bindData.push([node, type, touchWrapFunc]);
       }
-    };
-    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
-      node.addEventListener(type, touchWrapFunc, false);
-      bindData.push([node, type, touchWrapFunc]);
     }
   }
   return bindData;
@@ -501,29 +507,35 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
   };
 
   var bindData = [];
-  // Don't register the mouse event if an equivalent pointer event is supported.
-  if ((window && !window.PointerEvent) || !(name in Blockly.Touch.TOUCH_MAP)) {
+  if (window && window.PointerEvent &&
+      (name in Blockly.Touch.TOUCH_MAP)) {
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, wrapFunc, false);
+        bindData.push([node, type, wrapFunc]);
+      }
+  } else {
     node.addEventListener(name, wrapFunc, false);
     bindData.push([node, name, wrapFunc]);
-  }
-  // Add equivalent touch or pointer event.
-  if (name in Blockly.Touch.TOUCH_MAP) {
-    var touchWrapFunc = function(e) {
-      // Punt on multitouch events.
-      if (e.changedTouches && e.changedTouches.length == 1) {
-        // Map the touch event's properties to the event.
-        var touchPoint = e.changedTouches[0];
-        e.clientX = touchPoint.clientX;
-        e.clientY = touchPoint.clientY;
-      }
-      wrapFunc(e);
 
-      // Stop the browser from scrolling/zooming the page.
-      e.preventDefault();
-    };
-    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
-      node.addEventListener(type, touchWrapFunc, false);
-      bindData.push([node, type, touchWrapFunc]);
+    // Add equivalent touch event.
+    if (name in Blockly.Touch.TOUCH_MAP) {
+      var touchWrapFunc = function(e) {
+        // Punt on multitouch events.
+        if (e.changedTouches && e.changedTouches.length == 1) {
+          // Map the touch event's properties to the event.
+          var touchPoint = e.changedTouches[0];
+          e.clientX = touchPoint.clientX;
+          e.clientY = touchPoint.clientY;
+        }
+        wrapFunc(e);
+
+        // Stop the browser from scrolling/zooming the page.
+        e.preventDefault();
+      };
+      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+        node.addEventListener(type, touchWrapFunc, false);
+        bindData.push([node, type, touchWrapFunc]);
+      }
     }
   }
   return bindData;

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -345,11 +345,16 @@ Blockly.Bubble.prototype.registerResizeEvent = function(callback) {
 
 /**
  * Move this bubble to the top of the stack.
+ * @return {!boolean} Whether or not the bubble has been moved.
  * @private
  */
 Blockly.Bubble.prototype.promote_ = function() {
   var svgGroup = this.bubbleGroup_.parentNode;
-  svgGroup.appendChild(this.bubbleGroup_);
+  if (svgGroup.lastChild !== this.bubbleGroup_) {
+    svgGroup.appendChild(this.bubbleGroup_);
+    return true;
+  }
+  return false;
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -122,7 +122,7 @@ Blockly.Comment.prototype.createEditor_ = function() {
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.foreignObject_.appendChild(body);
-  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_);
+  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_, true, true);
   // Don't zoom with mousewheel.
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();
@@ -224,10 +224,11 @@ Blockly.Comment.prototype.textareaFocus_ = function(
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
-  this.bubble_.promote_();
-  // Since the act of moving this node within the DOM causes a loss of focus,
-  // we need to reapply the focus.
-  this.textarea_.focus();
+  if (this.bubble_.promote_()) {
+    // Since the act of moving this node within the DOM causes a loss of focus,
+    // we need to reapply the focus.
+    this.textarea_.focus();
+  }
 };
 
 /**

--- a/core/css.js
+++ b/core/css.js
@@ -386,9 +386,12 @@ Blockly.Css.CONTENT = [
   '.blocklyCommentTextarea {',
     'background-color: #ffc;',
     'border: 0;',
+    'outline: 0;',
     'margin: 0;',
     'padding: 2px;',
     'resize: none;',
+    'display: block;',
+    'overflow: none;',
   '}',
 
   '.blocklyHtmlInput {',

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -498,7 +498,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   }
 
   if (goog.string.caseInsensitiveEquals(e.type, 'touchstart') ||
-      goog.string.caseInsensitiveEquals(e.type, 'pointerdown')) {
+      (goog.string.caseInsensitiveEquals(e.type, 'pointerdown') && e.pointerType != 'mouse')) {
     Blockly.longStart_(e, this);
   }
 

--- a/core/touch.js
+++ b/core/touch.js
@@ -51,8 +51,14 @@ Blockly.Touch.TOUCH_MAP = {};
 if (window && window.PointerEvent) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['pointerdown'],
+    'mouseenter': ['pointerenter'],
+    'mouseleave': ['pointerleave'],
     'mousemove': ['pointermove'],
-    'mouseup': ['pointerup', 'pointercancel']
+    'mouseout': ['pointerout'],
+    'mouseover': ['pointerover'],
+    'mouseup': ['pointerup', 'pointercancel'],
+    'touchend': ['pointerup'],
+    'touchcancel': ['pointercancel']
   };
 } else if (goog.events.BrowserFeature.TOUCH_ENABLED) {
   Blockly.Touch.TOUCH_MAP = {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -402,7 +402,7 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
 
   if (!this.isFlyout) {
     Blockly.bindEventWithChecks_(this.svgGroup_, 'mousedown', this,
-        this.onMouseDown_);
+        this.onMouseDown_, false, true);
     if (this.options.zoomOptions && this.options.zoomOptions.wheel) {
       // Mouse-wheel.
       Blockly.bindEventWithChecks_(this.svgGroup_, 'wheel', this,


### PR DESCRIPTION
Fix pointer event (edge case) issues described in https://github.com/google/blockly/issues/1655

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1655

### Proposed Changes

** Pointer events **:
A couple of major changes with the way we're handling pointer events: 
- Always use pointer events, and no other mouse event. We were using a mixture of those, since we only had 'mousedown', 'mousemove' and 'mouseup' defined in the map. I added the rest of the mouse events, there were a couple of places where we attached events to mouseover, and so I just added mapping for the suite of mouse events. I also added a couple of mappings for touchend and touchcancel (this is really a workaround) since there are a couple of events that we register only for touch (eg: longstop) that we want to register for pointer events. 

Another major change is how we register pointer events. If they're available, they should be a replacement to mouse events. and in the same way that we don't add additionally hooks to preventDefault on mouse events (only for touch), we don't need to do that for pointer events. So I've shuffled the event registration code a little so that it registers pointer events with the wrapFunc function and not the touchWrapFunc function. 
(In other cases, we register both mouse and touch, if mappings exist). 

**Comments**:
Another fix to comments was to pass opt_noPreventDefault with the registered mouseup event. This was causing the gesture code to capture the event (even though the gesture code cancels on native elements like textarea) it was still capturing the event since the event (as far as it was concerned) was "handled". This was only affecting touch events, such as IOS.

Added an optimization to the bubble logic, only bumping it if it's not currently the top bubble. This also feeds into the comment focus logic where I only re-focus the text area if it has been moved within the bubble canvas.
 
** Context menu **:
Regarding the issue with the longStop: I just added a check to ensure the pointer type is not a mouse (since pointer events can be 'mouse', 'touch' or 'pen).

### Reason for Changes

Fixes issues described in https://github.com/google/blockly/issues/1655

### Test Coverage

Tested on:
Desktop Chrome on Mac (latest)
Desktop Firefox (latest) and (beta, Firefox 59) on Mac.
Desktop Safari on Mac.
Desktop Chrome on Surface Book (Windows).
Desktop Firefox on Sufrace Book (Windows).
IE 11 on Surface Book
Edge 16 on Surface Book
IOS (Safari latest). 
Chrome Android (although there is a known issue with pointer events on Android, we might want to either exclude that specific version of Android or Android altogether from using pointer events until the next version of Chrome is released). 
Firefox Android

### Additional Information

Note, with my changes all interactions with text areas inside comments are handled completely by the browser. Blockly usually tries to limit this behaviour so that the browser doesn't do some fancy zoom, but in this case, in order to allow things like selecting parts of the text or jumping to a different section in the comment, we need to let the browser take care of that.