### PR TITLE
Fix css for comment text on Chrome

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -389,6 +389,7 @@ Blockly.Css.CONTENT = [
     'margin: 0;',
     'padding: 2px;',
     'resize: none;',
+    'overflow: hidden;',
   '}',
 
   '.blocklyHtmlInput {',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
https://github.com/google/blockly/issues/1382
### Proposed Changes
Change CSS of class blocklyCommentTextarea
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Change CSS of class blocklyCommentTextarea by adding property "overflow" is "hidden"
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
Desktop Firefox
<!-- * Desktop Safari --> 
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
