### PR TITLE
Expose block ID in SVG.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -99,6 +99,9 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   Blockly.Tooltip.bindMouseEvents(this.svgPath_);
   Blockly.BlockSvg.superClass_.constructor.call(this,
       workspace, prototypeName, opt_id);
+
+  // Expose this block's ID on its top-level SVG group.
+  this.svgGroup_.id = this.id;
 };
 goog.inherits(Blockly.BlockSvg, Blockly.Block);
 


### PR DESCRIPTION
Useful for debugging.