### PR TITLE
Add IDs to bubbles.

### DIFF
--- a/build.py
+++ b/build.py
@@ -223,6 +223,7 @@ class Gen_compressed(threading.Thread):
         ("output_info", "warnings"),
         ("output_info", "errors"),
         ("output_info", "statistics"),
+        ("warning_level", "DEFAULT"),
       ]
 
     # Read in all the source files.
@@ -251,6 +252,7 @@ class Gen_compressed(threading.Thread):
         ("output_info", "warnings"),
         ("output_info", "errors"),
         ("output_info", "statistics"),
+        ("warning_level", "DEFAULT"),
       ]
 
     # Read in all the source files.
@@ -277,6 +279,7 @@ class Gen_compressed(threading.Thread):
         ("output_info", "warnings"),
         ("output_info", "errors"),
         ("output_info", "statistics"),
+        ("warning_level", "DEFAULT"),
       ]
 
     # Read in all the source files.
@@ -303,6 +306,7 @@ class Gen_compressed(threading.Thread):
         ("output_info", "warnings"),
         ("output_info", "errors"),
         ("output_info", "statistics"),
+        ("warning_level", "DEFAULT"),
       ]
 
     # Read in all the source files.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -101,7 +101,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
       workspace, prototypeName, opt_id);
 
   // Expose this block's ID on its top-level SVG group.
-  this.svgGroup_.id = 'block' + this.id;
+  this.svgGroup_.dataset.blockId = this.id;
 };
 goog.inherits(Blockly.BlockSvg, Blockly.Block);
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -101,7 +101,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
       workspace, prototypeName, opt_id);
 
   // Expose this block's ID on its top-level SVG group.
-  this.svgGroup_.id = this.id;
+  this.svgGroup_.id = 'block' + this.id;
 };
 goog.inherits(Blockly.BlockSvg, Blockly.Block);
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -101,7 +101,9 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
       workspace, prototypeName, opt_id);
 
   // Expose this block's ID on its top-level SVG group.
-  this.svgGroup_.dataset.blockId = this.id;
+  if (this.svgGroup_.dataset) {
+    this.svgGroup_.dataset.id = this.id;
+  }
 };
 goog.inherits(Blockly.BlockSvg, Blockly.Block);
 

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -287,7 +287,9 @@ Blockly.Bubble.prototype.getSvgRoot = function() {
  * @param {string} id ID of block.
  */
 Blockly.Bubble.prototype.setSvgId = function(id) {
-  this.bubbleGroup_.dataset.id = id;
+  if (this.bubbleGroup_.dataset) {
+    this.bubbleGroup_.dataset.blockId = id;
+  }
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -284,10 +284,10 @@ Blockly.Bubble.prototype.getSvgRoot = function() {
 
 /**
  * Expose the block's ID on the bubble's top-level SVG group.
- * @param {string} id Bubble type and ID of block.
+ * @param {string} id ID of block.
  */
 Blockly.Bubble.prototype.setSvgId = function(id) {
-  this.bubbleGroup_.id = id;
+  this.bubbleGroup_.dataset.id = id;
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -283,6 +283,14 @@ Blockly.Bubble.prototype.getSvgRoot = function() {
 };
 
 /**
+ * Expose the block's ID on the bubble's top-level SVG group.
+ * @param {string} id Bubble type and ID of block.
+ */
+Blockly.Bubble.prototype.setSvgId = function(id) {
+  this.bubbleGroup_.id = id;
+};
+
+/**
  * Handle a mouse-down on bubble's border.
  * @param {!Event} e Mouse down event.
  * @private

--- a/core/comment.js
+++ b/core/comment.js
@@ -200,6 +200,8 @@ Blockly.Comment.prototype.setVisible = function(visible) {
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_,
         this.iconXY_, this.width_, this.height_);
+    // Expose this comment's block's ID on its top-level SVG group.
+    this.bubble_.setSvgId('comment' + this.block_.id);
     this.bubble_.registerResizeEvent(this.resizeBubble_.bind(this));
     this.updateColour();
   } else {

--- a/core/comment.js
+++ b/core/comment.js
@@ -201,7 +201,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
         this.createEditor_(), this.block_.svgPath_,
         this.iconXY_, this.width_, this.height_);
     // Expose this comment's block's ID on its top-level SVG group.
-    this.bubble_.setSvgId('comment' + this.block_.id);
+    this.bubble_.setSvgId(this.block_.id);
     this.bubble_.registerResizeEvent(this.resizeBubble_.bind(this));
     this.updateColour();
   } else {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -250,7 +250,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_, this.iconXY_, null, null);
     // Expose this mutator's block's ID on its top-level SVG group.
-    this.bubble_.setSvgId('mutator' + this.block_.id);
+    this.bubble_.setSvgId(this.block_.id);
     var tree = this.workspace_.options.languageTree;
     if (tree) {
       this.workspace_.flyout_.init(this.workspace_);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -249,6 +249,8 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.bubble_ = new Blockly.Bubble(
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_, this.iconXY_, null, null);
+    // Expose this mutator's block's ID on its top-level SVG group.
+    this.bubble_.setSvgId('mutator' + this.block_.id);
     var tree = this.workspace_.options.languageTree;
     if (tree) {
       this.workspace_.flyout_.init(this.workspace_);

--- a/core/warning.js
+++ b/core/warning.js
@@ -124,6 +124,8 @@ Blockly.Warning.prototype.setVisible = function(visible) {
     this.bubble_ = new Blockly.Bubble(
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         paragraph, this.block_.svgPath_, this.iconXY_, null, null);
+    // Expose this warning's block's ID on its top-level SVG group.
+    this.bubble_.setSvgId('warning' + this.block_.id);
     if (this.block_.RTL) {
       // Right-align the paragraph.
       // This cannot be done until the bubble is rendered on screen.

--- a/core/warning.js
+++ b/core/warning.js
@@ -125,7 +125,7 @@ Blockly.Warning.prototype.setVisible = function(visible) {
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         paragraph, this.block_.svgPath_, this.iconXY_, null, null);
     // Expose this warning's block's ID on its top-level SVG group.
-    this.bubble_.setSvgId('warning' + this.block_.id);
+    this.bubble_.setSvgId(this.block_.id);
     if (this.block_.RTL) {
       // Right-align the paragraph.
       // This cannot be done until the bubble is rendered on screen.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -993,7 +993,7 @@ Blockly.WorkspaceSvg.prototype.createVariable = function(name, opt_type, opt_id)
  * Make a list of all the delete areas for this workspace.
  */
 Blockly.WorkspaceSvg.prototype.recordDeleteAreas = function() {
-  if (this.trashcan) {
+  if (this.trashcan && this.svgGroup_.parentNode) {
     this.deleteAreaTrash_ = this.trashcan.getClientRect();
   } else {
     this.deleteAreaTrash_ = null;


### PR DESCRIPTION
Allows one to associate comments/mutators/warnings with their blocks while inspecting the DOM.

Also adds ‘block’ prefix to prevent possible ID collision between toolbox and workspace.