### PR TITLE
Fix more compiler warnings

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -36,7 +36,7 @@ goog.require('goog.asserts');
 /**
  * Class for a block dragger.  It moves blocks around the workspace when they
  * are being dragged by a mouse or touch.
- * @param {!Blockly.Block} block The block to drag.
+ * @param {!Blockly.BlockSvg} block The block to drag.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace to drag on.
  * @constructor
  */
@@ -168,10 +168,11 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
   // surface.
   this.draggingBlock_.moveToDragSurface_();
 
-  if (this.workspace_.toolbox_) {
+  var toolbox = this.workspace_.getToolbox();
+  if (toolbox) {
     var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
         'blocklyToolboxGrab';
-    this.workspace_.toolbox_.addStyle(style);
+    toolbox.addStyle(style);
   }
 };
 
@@ -226,10 +227,11 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   }
   this.workspace_.setResizesEnabled(true);
 
-  if (this.workspace_.toolbox_) {
+  var toolbox = this.workspace_.getToolbox();
+  if (toolbox) {
     var style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
         'blocklyToolboxGrab';
-    this.workspace_.toolbox_.removeStyle(style);
+    toolbox.removeStyle(style);
   }
   Blockly.Events.setGroup(false);
 };

--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -608,8 +608,8 @@ Blockly.BlockSvg.prototype.renderMoveConnections_ = function() {
 
 /**
  * Render the top edge of the block.
- * @param {!Array.<string>} steps Path of block outline.
- * @param {!Array.<string>} highlightSteps Path of block highlights.
+ * @param {!Array.<string|number>} steps Path of block outline.
+ * @param {!Array.<string|number>} highlightSteps Path of block highlights.
  * @param {number} rightEdge Minimum width of block.
  * @private
  */
@@ -653,10 +653,10 @@ Blockly.BlockSvg.prototype.renderDrawTop_ = function(steps,
 
 /**
  * Render the right edge of the block.
- * @param {!Array.<string>} steps Path of block outline.
- * @param {!Array.<string>} highlightSteps Path of block highlights.
- * @param {!Array.<string>} inlineSteps Inline block outlines.
- * @param {!Array.<string>} highlightInlineSteps Inline block highlights.
+ * @param {!Array.<string|number>} steps Path of block outline.
+ * @param {!Array.<string|number>} highlightSteps Path of block highlights.
+ * @param {!Array.<string|number>} inlineSteps Inline block outlines.
+ * @param {!Array.<string|number>} highlightInlineSteps Inline block highlights.
  * @param {!Array.<!Array.<!Object>>} inputRows 2D array of objects, each
  *     containing position information.
  * @param {number} iconWidth Offset of first row due to icons.
@@ -909,8 +909,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(steps, highlightSteps,
 
 /**
  * Render the bottom edge of the block.
- * @param {!Array.<string>} steps Path of block outline.
- * @param {!Array.<string>} highlightSteps Path of block highlights.
+ * @param {!Array.<string|number>} steps Path of block outline.
+ * @param {!Array.<string|number>} highlightSteps Path of block highlights.
  * @param {number} cursorY Height of block.
  * @private
  */
@@ -955,8 +955,8 @@ Blockly.BlockSvg.prototype.renderDrawBottom_ = function(steps,
 
 /**
  * Render the left edge of the block.
- * @param {!Array.<string>} steps Path of block outline.
- * @param {!Array.<string>} highlightSteps Path of block highlights.
+ * @param {!Array.<string|number>} steps Path of block outline.
+ * @param {!Array.<string|number>} highlightSteps Path of block highlights.
  * @private
  */
 Blockly.BlockSvg.prototype.renderDrawLeft_ = function(steps, highlightSteps) {

--- a/core/icon.js
+++ b/core/icon.js
@@ -52,14 +52,14 @@ Blockly.Icon.prototype.SIZE = 17;
 /**
  * Bubble UI (if visible).
  * @type {Blockly.Bubble}
- * @private
+ * @protected
  */
 Blockly.Icon.prototype.bubble_ = null;
 
 /**
  * Absolute coordinate of icon's center.
  * @type {goog.math.Coordinate}
- * @private
+ * @protected
  */
 Blockly.Icon.prototype.iconXY_ = null;
 
@@ -119,7 +119,7 @@ Blockly.Icon.prototype.isVisible = function() {
 /**
  * Clicking on the icon toggles if the bubble is visible.
  * @param {!Event} e Mouse click event.
- * @private
+ * @protected
  */
 Blockly.Icon.prototype.iconClick_ = function(e) {
   if (this.block_.workspace.isDragging()) {

--- a/core/utils.js
+++ b/core/utils.js
@@ -122,7 +122,7 @@ Blockly.utils.removeClass = function(element, className) {
  * @param {!Element} element DOM element to check.
  * @param {string} className Name of class to check.
  * @return {boolean} True if class exists, false otherwise.
- * @private
+ * @package
  */
 Blockly.utils.hasClass = function(element, className) {
   var classes = element.getAttribute('class');

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -582,6 +582,15 @@ Blockly.WorkspaceSvg.prototype.getFlyout_ = function() {
 };
 
 /**
+ * Getter for the toolbox associated with this workspace, if one exists.
+ * @return {Blockly.Toolbox} The toolbox on this workspace.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.getToolbox = function() {
+  return this.toolbox_;
+};
+
+/**
  * Update items that use screen coordinate calculations
  * because something has changed (e.g. scroll position, window size).
  * @private
@@ -755,8 +764,8 @@ Blockly.WorkspaceSvg.prototype.setupDragSurface = function() {
   // Figure out where we want to put the canvas back.  The order
   // in the is important because things are layered.
   var previousElement = this.svgBlockCanvas_.previousSibling;
-  var width = this.getParentSvg().getAttribute('width');
-  var height = this.getParentSvg().getAttribute('height');
+  var width = parseInt(this.getParentSvg().getAttribute('width'), 10);
+  var height = parseInt(this.getParentSvg().getAttribute('height'), 10);
   var coord = Blockly.utils.getRelativeXY(this.svgBlockCanvas_);
   this.workspaceDragSurface_.setContentsAndShow(this.svgBlockCanvas_,
       this.svgBubbleCanvas_, previousElement, width, height, this.scale);


### PR DESCRIPTION
In the first commit:
- In `block_render_svg` we pass around arrays that we use to build up the pieces of the SVG paths.  Once we have every piece, we concatenate everything in the arrays to build a string.  The items in the array can be numbers or strings, not just strings.
- In `Blockly.utils`, `hasClass` should be package instead of private.

Gets rid of 35 compiler warnings.

In the second commit:
- The block dragger can only drag BlockSvgs, not Blocks.
- Add a getter for toolboxes on the workspace, and use it.
- Mark some stuff protected in `icon.js` so that subclasses can access them.

Gets rid of about 30 more warnings.
