### PR TITLE
Custom Dialogs demo: Bumping backdrop Z.

### DIFF
--- a/demos/custom-dialogs/custom-dialog.js
+++ b/demos/custom-dialogs/custom-dialog.js
@@ -93,7 +93,8 @@ CustomDialog.show = function(title, message, options) {
     backdropDiv.style.cssText =
         'position: absolute;' +
         'top: 0; left: 0; right: 0; bottom: 0;' +
-        'background-color: rgba(0, 0, 0, .7);';
+        'background-color: rgba(0, 0, 0, .7);' +
+        'z-index: 100;';
     document.body.appendChild(backdropDiv);
 
     dialogDiv = document.createElement('div');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1704

### Proposed Changes

Bumped the backdrop `z-index` to 100. Was previously unset / `auto`. (The CSS is defined dynamically within `CustomDialog` functions.)

### Reason for Changes

The backdrop was not occluding the toolbox or scrollbars.

### Test Coverage

Opened variable name dialog in this demo, seeing the toolbox and scrollbars are now behind the backdrop / mask.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
