### PR TITLE
Add hook for custom context menus on the workspace

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -269,6 +269,13 @@ Blockly.WorkspaceSvg.prototype.flyoutButtonCallbacks_ = {};
 Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
 
 /**
+ * Developers may define this function to add custom menu options to the
+ * workspace's context menu or edit the workspace-created set of menu options.
+ * @param {!Array.<!Object>} options List of menu options to add to.
+ */
+Blockly.WorkspaceSvg.prototype.configureContextMenu = null;
+
+/**
  * In a flyout, the target workspace where blocks should be placed after a drag.
  * Otherwise null.
  * @type {?Blockly.WorkspaceSvg}
@@ -1309,6 +1316,11 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
     }
   };
   menuOptions.push(deleteOption);
+
+  // Allow the developer to add or modify menuOptions.
+  if (this.configureContextMenu) {
+    this.configureContextMenu(menuOptions);
+  }
 
   Blockly.ContextMenu.show(e, menuOptions, this.RTL);
 };


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #391 
Needs documentation, but so does everything about context menus.

### Proposed Changes

Adds a property to the workspace for a custom context menu function.

Like the one on blocks, it's null by default.  If it's defined it is called with an array of context menu options.  The function can edit the array, including removing items and adding items.

Each item in the array is an object containing:
`enabled`: boolean
`text`: string
`callback`: function


### Reason for Changes

#391 requested it, and so have other people.

### Test Coverage

Tested in the playground by defining this function:
```
function customContextMenuFn(options) {
  var option = {
    enabled: true,
    text: "Custom option",
    callback: function() {
      console.log('Custom context menu option called');
    }
  };
  options.push(option);
}
```
then setting `workspace.configureContextMenu = customContextMenuFn;`

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
