### PR TITLE
Lint rule updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
                 "ignoredNodes": ["ConditionalExpression"]
             }
         ],
+        "keyword-spacing": ["error"],
         "linebreak-style": ["error", "unix"],
         "max-len": [
             "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,15 @@
             }
         ],
         "linebreak-style": ["error", "unix"],
-        "max-len": ["error", 120, 4],
+        "max-len": [
+            "error",
+            {
+                "code": 100,
+                "tabWidth": 4,
+                "ignoreStrings": true,
+                "ignoreRegExpLiterals": true
+            }
+        ],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],
         "no-unused-vars": ["error", {"args": "after-used", "varsIgnorePattern": "^_"}],
         "no-use-before-define": ["error"],

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -103,7 +103,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if(this.isInFlyout){
+    if (this.isInFlyout){
       return;
     }
     // Getter blocks have the option to create a setter block, and vice versa.

--- a/core/block.js
+++ b/core/block.js
@@ -1197,7 +1197,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
       }
     }
   }
-  if(indexCount != args.length) {
+  if (indexCount != args.length) {
     throw new Error('Block "' + this.type + '": ' +
         'Message does not reference all ' + args.length + ' arg(s).');
   }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -611,7 +611,7 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
     Blockly.Events.setGroup(true);
     Blockly.Events.fire(new Blockly.Events.Create(newBlock));
     // Fire a VarCreate event for each (if any) new variable created.
-    for(var i = 0; i < newVariables.length; i++) {
+    for (var i = 0; i < newVariables.length; i++) {
       var thisVariable = newVariables[i];
       Blockly.Events.fire(new Blockly.Events.VarCreate(thisVariable));
     }

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -269,7 +269,8 @@ Blockly.TouchGesture.prototype.handleTouchMove = function(e) {
         gestureScale * Blockly.TouchGesture.ZOOM_IN_MULTIPLIER :
         gestureScale * Blockly.TouchGesture.ZOOM_OUT_MULTIPLIER;
       var workspace = this.startWorkspace_;
-      var position = Blockly.utils.mouseToSvg(e, workspace.getParentSvg(), workspace.getInverseScreenCTM());
+      var position = Blockly.utils.mouseToSvg(
+          e, workspace.getParentSvg(), workspace.getInverseScreenCTM());
       workspace.zoom(position.x, position.y, delta);
     }
     this.previousScale_ = scale;

--- a/core/xml.js
+++ b/core/xml.js
@@ -549,7 +549,7 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
     var newVariables = Blockly.Variables.getAddedVariables(workspace,
         variablesBeforeCreation);
     // Fire a VarCreate event for each (if any) new variable created.
-    for(var i = 0; i < newVariables.length; i++) {
+    for (var i = 0; i < newVariables.length; i++) {
       var thisVariable = newVariables[i];
       Blockly.Events.fire(new Blockly.Events.VarCreate(thisVariable));
     }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

- Add `keyword-spacing` rule to our `.eslintrc`, and fix issues.
- Update `max-len` rule to limit to 100 and ignore strings and regexp.

### Reason for Changes

Updates that @macherel pointed out in #1579.  (Sorry for the delay in adding them.)

### Test Coverage
Tested with `eslint .`

### Additional Information

According to the google style guide we should limit line lengths to 80 characters.  There are too many errors for me to do that right now, but I enforce it for new code where reasonable.