### PR TITLE
Workspace comments: delete targets and icon

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -295,6 +295,22 @@ Blockly.Bubble.prototype.bubbleMouseDown_ = function(e) {
 };
 
 /**
+ * Show the context menu for this bubble.
+ * @param {!Event} e Mouse event.
+ * @private
+ */
+Blockly.Bubble.prototype.showContextMenu_ = function(/*e*/) {
+};
+
+/**
+ * Whether the bubble is deletable by a drag into delete areas.
+ * @return {!boolean} Whether or not the bubble is deletable.
+ */
+Blockly.Bubble.prototype.isDeletableByDrag = function() {
+  return false;
+};
+
+/**
  * Handle a mouse-down on bubble's resize corner.
  * @param {!Event} e Mouse down event.
  * @private

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -303,10 +303,10 @@ Blockly.Bubble.prototype.showContextMenu_ = function(/*e*/) {
 };
 
 /**
- * Whether the bubble is deletable by a drag into delete areas.
- * @return {!boolean} Whether or not the bubble is deletable.
+ * Get whether this bubble is deletable or not.
+ * @return {boolean} True if deletable.
  */
-Blockly.Bubble.prototype.isDeletableByDrag = function() {
+Blockly.Bubble.prototype.isDeletable = function() {
   return false;
 };
 

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -113,6 +113,13 @@ Blockly.BubbleDragger.prototype.startBubbleDrag = function() {
   }
 
   this.draggingBubble_.setDragging && this.draggingBubble_.setDragging(true);
+
+  var toolbox = this.workspace_.getToolbox();
+  if (toolbox) {
+    var style = this.draggingBubble_.isDeletable() ? 'blocklyToolboxDelete' :
+        'blocklyToolboxGrab';
+    toolbox.addStyle(style);
+  }
 };
 
 /**
@@ -209,6 +216,11 @@ Blockly.BubbleDragger.prototype.endBubbleDrag = function(
   }
   this.workspace_.setResizesEnabled(true);
 
+  if (this.workspace_.toolbox_) {
+    var style = this.draggingBubble_.isDeletable() ? 'blocklyToolboxDelete' :
+        'blocklyToolboxGrab';
+    this.workspace_.toolbox_.removeStyle(style);
+  }
   Blockly.Events.setGroup(false);
 };
 

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -112,7 +112,7 @@ Blockly.BubbleDragger.prototype.startBubbleDrag = function() {
     this.moveToDragSurface_();
   }
 
-  this.draggingBubble_.setDragging(true);
+  this.draggingBubble_.setDragging && this.draggingBubble_.setDragging(true);
 };
 
 /**
@@ -129,7 +129,7 @@ Blockly.BubbleDragger.prototype.dragBubble = function(e, currentDragDeltaXY) {
 
   this.draggingBubble_.moveDuringDrag(this.dragSurface_, newLoc);
 
-  if (this.draggingBubble_.isDeletableByDrag()) {
+  if (this.draggingBubble_.isDeletable()) {
     this.deleteArea_ =  this.workspace_.isDeleteArea(e);
     this.updateCursorDuringBubbleDrag_();
   }
@@ -204,7 +204,7 @@ Blockly.BubbleDragger.prototype.endBubbleDrag = function(
       this.dragSurface_.clearAndHide(this.workspace_.getBubbleCanvas());
     }
 
-    this.draggingBubble_.setDragging(false);
+    this.draggingBubble_.setDragging && this.draggingBubble_.setDragging(false);
     this.fireMoveEvent_();
   }
   this.workspace_.setResizesEnabled(true);

--- a/core/css.js
+++ b/core/css.js
@@ -430,6 +430,16 @@ Blockly.Css.CONTENT = [
     'display: block',
   '}',
 
+  '.blocklyDeleteIconShape {',
+    'fill: #000;',
+    'stroke: #000;',
+    'stroke-width: 1px;',
+  '}',
+
+  '.blocklyDeleteIconShape.blocklyDeleteIconHighlighted {',
+    'stroke: #fc3;',
+  '}',
+
   '.blocklyHtmlInput {',
     'border: none;',
     'border-radius: 4px;',

--- a/core/css.js
+++ b/core/css.js
@@ -420,6 +420,16 @@ Blockly.Css.CONTENT = [
     'overflow: hidden;',
   '}',
 
+  '.blocklyCommentDeleteIcon {',
+    'cursor: pointer;',
+    'fill: #000;',
+    'display: none',
+  '}',
+
+  '.blocklySelected > .blocklyCommentDeleteIcon {',
+    'display: block',
+  '}',
+
   '.blocklyHtmlInput {',
     'border: none;',
     'border-radius: 4px;',

--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -111,6 +111,10 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   if (this.isDeletable()) {
     Blockly.bindEventWithChecks_(
         this.deleteGroup_, 'mousedown', this, this.deleteMouseDown_);
+    Blockly.bindEventWithChecks_(
+        this.deleteGroup_, 'mouseout', this, this.deleteMouseOut_);
+    Blockly.bindEventWithChecks_(
+        this.deleteGroup_, 'mouseup', this, this.deleteMouseUp_);
   }
 };
 
@@ -205,10 +209,10 @@ Blockly.WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
         'class': 'blocklyCommentDeleteIcon'
       },
       this.svgGroup_);
-  Blockly.utils.createSvgElement('circle',
+  this.deleteIconBorder_ = Blockly.utils.createSvgElement('circle',
       {
-        'fill': '#000',
-        'r': '8',
+        'class': 'blocklyDeleteIconShape',
+        'r': '7',
         'cx': '7.5',
         'cy': '7.5'
       },
@@ -266,6 +270,30 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
+  // highlight the delete icon
+  Blockly.utils.addClass(
+      /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
+  // This event has been handled.  No need to bubble up to the document.
+  e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-out on comment's delete icon.
+ * @param {!Event} e Mouse out event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseOut_ = function(e) {
+  // restore highlight on the delete icon
+  Blockly.utils.removeClass(
+    /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
+};
+
+/**
+ * Handle a mouse-up on comment's delete icon.
+ * @param {!Event} e Mouse up event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseUp_ = function(e) {
   // Delete this comment
   this.dispose(true, true);
   // This event has been handled.  No need to bubble up to the document.

--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -91,6 +91,10 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
 
   // Add the resize icon
   this.addResizeDom_();
+  if (this.isDeletable()) {
+    // Add the delete icon
+    this.addDeleteDom_();
+  }
 
   this.setSize_(size.width, size.height);
 
@@ -102,6 +106,11 @@ Blockly.WorkspaceCommentSvg.prototype.render = function() {
   if (this.resizeGroup_) {
     Blockly.bindEventWithChecks_(
         this.resizeGroup_, 'mousedown', this, this.resizeMouseDown_);
+  }
+
+  if (this.isDeletable()) {
+    Blockly.bindEventWithChecks_(
+        this.deleteGroup_, 'mousedown', this, this.deleteMouseDown_);
   }
 };
 
@@ -186,6 +195,46 @@ Blockly.WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
 };
 
 /**
+ * Add the delete icon to the DOM
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
+  this.deleteGroup_ = Blockly.utils.createSvgElement(
+      'g',
+      {
+        'class': 'blocklyCommentDeleteIcon'
+      },
+      this.svgGroup_);
+  Blockly.utils.createSvgElement('circle',
+      {
+        'fill': '#000',
+        'r': '8',
+        'cx': '7.5',
+        'cy': '7.5'
+      },
+      this.deleteGroup_);
+  // x icon.
+  Blockly.utils.createSvgElement(
+      'line',
+      {
+        'x1': '5', 'y1': '10',
+        'x2': '10', 'y2': '5',
+        'stroke': '#fff',
+        'stroke-width': '2'
+      },
+      this.deleteGroup_);
+  Blockly.utils.createSvgElement(
+      'line',
+      {
+        'x1': '5', 'y1': '5',
+        'x2': '10', 'y2': '10',
+        'stroke': '#fff',
+        'stroke-width': '2'
+      },
+      this.deleteGroup_);
+};
+
+/**
  * Handle a mouse-down on comment's resize corner.
  * @param {!Event} e Mouse down event.
  * @private
@@ -207,6 +256,18 @@ Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
   this.onMouseMoveWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mousemove', this, this.resizeMouseMove_);
   Blockly.hideChaff();
+  // This event has been handled.  No need to bubble up to the document.
+  e.stopPropagation();
+};
+
+/**
+ * Handle a mouse-down on comment's delete icon.
+ * @param {!Event} e Mouse down event.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
+  // Delete this comment
+  this.dispose(true, true);
   // This event has been handled.  No need to bubble up to the document.
   e.stopPropagation();
 };
@@ -298,10 +359,15 @@ Blockly.WorkspaceCommentSvg.prototype.setSize_ = function(width, height) {
       // Mirror the resize group.
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (-width + resizeSize) + ',' + (height - resizeSize) + ') scale(-1 1)');
+      this.deleteGroup_.setAttribute('transform', 'translate(' +
+        (-width + resizeSize) + ',' + (-resizeSize) + ') scale(-1 1)');
     } else {
       this.resizeGroup_.setAttribute('transform', 'translate(' +
         (width - resizeSize) + ',' +
         (height - resizeSize) + ')');
+      this.deleteGroup_.setAttribute('transform', 'translate(' +
+        (width - resizeSize) + ',' +
+        (-resizeSize) + ')');
     }
   }
 

--- a/core/workspace_comment/workspace_comment_render_svg.js
+++ b/core/workspace_comment/workspace_comment_render_svg.js
@@ -282,10 +282,10 @@ Blockly.WorkspaceCommentSvg.prototype.deleteMouseDown_ = function(e) {
  * @param {!Event} e Mouse out event.
  * @private
  */
-Blockly.WorkspaceCommentSvg.prototype.deleteMouseOut_ = function(e) {
+Blockly.WorkspaceCommentSvg.prototype.deleteMouseOut_ = function(/*e*/) {
   // restore highlight on the delete icon
   Blockly.utils.removeClass(
-    /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
+      /** @type {!Element} */ (this.deleteIconBorder_), 'blocklyDeleteIconHighlighted');
 };
 
 /**

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -185,6 +185,7 @@ Blockly.WorkspaceCommentSvg.prototype.unselect = function() {
 Blockly.WorkspaceCommentSvg.prototype.addSelect = function() {
   Blockly.utils.addClass(
       /** @type {!Element} */ (this.svgGroup_), 'blocklySelected');
+  this.setFocus();
 };
 
 /**
@@ -193,6 +194,7 @@ Blockly.WorkspaceCommentSvg.prototype.addSelect = function() {
 Blockly.WorkspaceCommentSvg.prototype.removeSelect = function() {
   Blockly.utils.removeClass(
       /** @type {!Element} */ (this.svgGroup_), 'blocklySelected');
+  this.blurFocus();
 };
 
 /**

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -492,6 +492,14 @@ Blockly.WorkspaceCommentSvg.prototype.setContent = function(content) {
 };
 
 /**
+ * Whether the bubble is deletable by a drag into delete areas.
+ * @return {!boolean} Whether or not the bubble is deletable.
+ */
+Blockly.WorkspaceCommentSvg.prototype.isDeletableByDrag = function() {
+  return true;
+};
+
+/**
  * Update the cursor over this comment by adding or removing a class.
  * @param {boolean} enable True if the delete cursor should be shown, false
  *     otherwise.

--- a/core/workspace_comment/workspace_comment_svg.js
+++ b/core/workspace_comment/workspace_comment_svg.js
@@ -492,14 +492,6 @@ Blockly.WorkspaceCommentSvg.prototype.setContent = function(content) {
 };
 
 /**
- * Whether the bubble is deletable by a drag into delete areas.
- * @return {!boolean} Whether or not the bubble is deletable.
- */
-Blockly.WorkspaceCommentSvg.prototype.isDeletableByDrag = function() {
-  return true;
-};
-
-/**
  * Update the cursor over this comment by adding or removing a class.
  * @param {boolean} enable True if the delete cursor should be shown, false
  *     otherwise.


### PR DESCRIPTION
Show an (X) icon on the comment when selected. Delete icon deletes the comment. Comment can be deleted if dragged onto the toolbox or the trash icon. A normal bubble cannot be deleted that way.

Branched of comments_v2

Resolves https://github.com/google/blockly/issues/1662

![deletecomment](https://user-images.githubusercontent.com/16690124/37691283-e248782e-2c6d-11e8-962c-64799d3d359e.gif)

Notes: 
- Only showing the x icon when the comment is selected. (otherwise there was too much clutter)
