### PR TITLE
Make bind/unbindEvent_ public

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -427,7 +427,6 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
  *     opt_noPreventDefault is provided, opt_noCaptureIdentifier must also be
  *     provided.
  * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
- * @package
  */
 Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     opt_noCaptureIdentifier, opt_noPreventDefault) {
@@ -493,7 +492,6 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
  * @param {Object} thisObject The value of 'this' in the function.
  * @param {!Function} func Function to call when event is triggered.
  * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
- * @package
  */
 Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var wrapFunc = function(e) {
@@ -543,7 +541,6 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
  * @param {!Array.<!Array>} bindData Opaque data from bindEvent_.
  *     This list is emptied during the course of calling this function.
  * @return {!Function} The function call.
- * @package
  */
 Blockly.unbindEvent_ = function(bindData) {
   while (bindData.length) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1726 

### Proposed Changes

Make bind/unbindEvent_ and bindEventWithChecks_ public

### Reason for Changes

From the issue:
>While there probably is no reason to allow developers to call this for binding and unbinding events for elements in their applications (Blockly Games was doing so for menus and the like), there is definitely a desire to allow custom fields to call this.

>Here's a concrete example:
https://github.com/google/blockly-games/blob/master/appengine/music/js/field_pitch.js#L97
As such, the current use of @Package breaks the build for Blockly Games.

