### PR TITLE
Create an empty pattern if there is no grid.

### DIFF
--- a/core/grid.js
+++ b/core/grid.js
@@ -219,6 +219,9 @@ Blockly.Grid.createDom = function(rnd, gridOptions, defs) {
           {'stroke': gridOptions['colour']}, gridPattern);
     }
     // x1, y1, x1, x2 properties will be set later in update.
+  } else {
+    // Edge 16 doesn't handle empty patterns
+    Blockly.utils.createSvgElement('line', {}, gridPattern);
   }
   return gridPattern;
 };


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix #1484
### Proposed Changes

Create an empty pattern if there is no grid or the grid spacing/length is 0.

### Reason for Changes

See https://github.com/google/blockly/issues/1484#issuecomment-349158217

### Test Coverage

It works in the playground on Chrome.

@timdawborn can you confirm that this fixes it on Edge?

### Additional Information

This is a workaround for an Edge 16 bug.  Thanks @samelhusseini for the fix.