### PR TITLE
Don't show create VAR and create Function context menu options when in the flyout

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -261,6 +261,9 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
+    if (this.isInFlyout){
+      return;
+    }
     var varName = this.getFieldValue('VAR');
     if (!this.isCollapsed() && varName != null) {
       var option = {enabled: true};

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -355,6 +355,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
+    if (this.isInFlyout){
+      return;
+    }
     // Add option to create caller.
     var option = {enabled: true};
     var name = this.getFieldValue('NAME');


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1741

### Proposed Changes

Don't show the 'create get VAR' and 'create Function' context menu options on blocks when in the flyout.

### Reason for Changes

Fixes https://github.com/google/blockly/issues/1741

### Test Coverage

Tested by right clicking on the for, count with, and function blocks in the flyout. Also tested that the option works when not in the flyout.

Tested on:
* Desktop Chrome.

### Additional Information
