### PR TITLE
Making all blocks use the MSG colour values.

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -37,13 +37,10 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * This should be the same as Blockly.Msg.COLOUR_HUE.
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.COLOUR_HUE.
  */
 Blockly.Constants.Colour.HUE = 20;
-/** @deprecated Use Blockly.Constants.Colour.HUE */
-Blockly.Blocks.colour.HUE = Blockly.Constants.Colour.HUE;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for colour picker.

--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -38,7 +38,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.COLOUR_HUE.
+ * @deprecated Use Blockly.Msg.COLOUR_HUE. (2018 April 5)
  */
 Blockly.Constants.Colour.HUE = 20;
 

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -35,16 +35,11 @@ goog.provide('Blockly.Constants.Lists');
 goog.require('Blockly.Blocks');
 goog.require('Blockly');
 
-
 /**
- * Common HSV hue for all blocks in this category.
- * This should be the same as Blockly.Msg.LISTS_HUE.
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.LISTS_HUE
  */
 Blockly.Constants.Lists.HUE = 260;
-/** @deprecated Use Blockly.Constants.Lists.HUE */
-Blockly.Blocks.lists.HUE = Blockly.Constants.Lists.HUE;
-
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for creating an empty list
@@ -138,7 +133,7 @@ Blockly.Blocks['lists_create_with'] = {
    */
   init: function() {
     this.setHelpUrl(Blockly.Msg.LISTS_CREATE_WITH_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.itemCount_ = 3;
     this.updateShape_();
     this.setOutput(true, 'Array');
@@ -261,7 +256,7 @@ Blockly.Blocks['lists_create_with_container'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.appendDummyInput()
         .appendField(Blockly.Msg.LISTS_CREATE_WITH_CONTAINER_TITLE_ADD);
     this.appendStatementInput('STACK');
@@ -276,7 +271,7 @@ Blockly.Blocks['lists_create_with_item'] = {
    * @this Blockly.Block
    */
   init: function() {
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.appendDummyInput()
         .appendField(Blockly.Msg.LISTS_CREATE_WITH_ITEM_TITLE);
     this.setPreviousStatement(true);
@@ -298,7 +293,7 @@ Blockly.Blocks['lists_indexOf'] = {
           [Blockly.Msg.LISTS_INDEX_OF_LAST, 'LAST']
         ];
     this.setHelpUrl(Blockly.Msg.LISTS_INDEX_OF_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.setOutput(true, 'Number');
     this.appendValueInput('VALUE')
         .setCheck('Array')
@@ -336,7 +331,7 @@ Blockly.Blocks['lists_getIndex'] = {
           [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']
         ];
     this.setHelpUrl(Blockly.Msg.LISTS_GET_INDEX_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     var modeMenu = new Blockly.FieldDropdown(MODE, function(value) {
       var isStatement = (value == 'REMOVE');
       this.sourceBlock_.updateStatement_(isStatement);
@@ -520,7 +515,7 @@ Blockly.Blocks['lists_setIndex'] = {
           [Blockly.Msg.LISTS_GET_INDEX_RANDOM, 'RANDOM']
         ];
     this.setHelpUrl(Blockly.Msg.LISTS_SET_INDEX_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.appendValueInput('LIST')
         .setCheck('Array')
         .appendField(Blockly.Msg.LISTS_SET_INDEX_INPUT_IN_LIST);
@@ -659,7 +654,7 @@ Blockly.Blocks['lists_getSublist'] = {
           [Blockly.Msg.LISTS_GET_SUBLIST_END_LAST, 'LAST']
         ];
     this.setHelpUrl(Blockly.Msg.LISTS_GET_SUBLIST_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.appendValueInput('LIST')
         .setCheck('Array')
         .appendField(Blockly.Msg.LISTS_GET_SUBLIST_INPUT_IN_LIST);
@@ -784,7 +779,7 @@ Blockly.Blocks['lists_sort'] = {
         }
       ],
       "output": "Array",
-      "colour": Blockly.Blocks.lists.HUE,
+      "colour": Blockly.Msg.LISTS_HUE,
       "tooltip": Blockly.Msg.LISTS_SORT_TOOLTIP,
       "helpUrl": Blockly.Msg.LISTS_SORT_HELPURL
     });
@@ -808,7 +803,7 @@ Blockly.Blocks['lists_split'] = {
           thisBlock.updateType_(newMode);
         });
     this.setHelpUrl(Blockly.Msg.LISTS_SPLIT_HELPURL);
-    this.setColour(Blockly.Blocks.lists.HUE);
+    this.setColour(Blockly.Msg.LISTS_HUE);
     this.appendValueInput('INPUT')
         .setCheck('String')
         .appendField(dropdown, 'MODE');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -37,7 +37,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.LISTS_HUE
+ * @deprecated Use Blockly.Msg.LISTS_HUE. (2018 April 5)
  */
 Blockly.Constants.Lists.HUE = 260;
 

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -37,9 +37,9 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.LOGIC_HUE.
+ * @deprecated Use Blockly.Msg.LOGIC_HUE. (2018 April 5)
  */
-Blockly.Constants.Logic.HUE = 160;
+Blockly.Constants.Logic.HUE = 210;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for boolean data type: true and false.

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -35,15 +35,11 @@ goog.provide('Blockly.Constants.Logic');
 goog.require('Blockly.Blocks');
 goog.require('Blockly');
 
-
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.LOGIC_HUE.
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.LOGIC_HUE.
  */
-Blockly.Constants.Logic.HUE = 210;
-/** @deprecated Use Blockly.Constants.Logic.HUE */
-Blockly.Blocks.logic.HUE = Blockly.Constants.Logic.HUE;
+Blockly.Constants.Logic.HUE = 160;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for boolean data type: true and false.

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -38,7 +38,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.LOOPS_HUE.
+ * @deprecated Use Blockly.Msg.LOOPS_HUE. (2018 April 5)
  */
 Blockly.Constants.Loops.HUE = 120;
 

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -37,13 +37,10 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.LOOPS_HUE
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.LOOPS_HUE.
  */
 Blockly.Constants.Loops.HUE = 120;
-/** @deprecated Use Blockly.Constants.Loops.HUE */
-Blockly.Blocks.loops.HUE = Blockly.Constants.Loops.HUE;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for repeat n times (external number).

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -37,13 +37,10 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.MATH_HUE
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.MATH_HUE.
  */
 Blockly.Constants.Math.HUE = 230;
-/** @deprecated Use Blockly.Constants.Math.HUE */
-Blockly.Blocks.math.HUE = Blockly.Constants.Math.HUE;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for numeric value.

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -38,7 +38,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.MATH_HUE.
+ * @deprecated Use Blockly.Msg.MATH_HUE. (2018 April 5)
  */
 Blockly.Constants.Math.HUE = 230;
 

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -30,12 +30,6 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly');
 
 
-/**
- * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.PROCEDURES_HUE.
- */
-Blockly.Blocks.procedures.HUE = 290;
-
 Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Block for defining a procedure with no return value.

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -31,7 +31,8 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.PROCEDURES_HUE.
  */
 Blockly.Blocks.procedures.HUE = 290;
 
@@ -55,7 +56,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
         Blockly.Msg.PROCEDURES_DEFNORETURN_COMMENT) {
       this.setCommentText(Blockly.Msg.PROCEDURES_DEFNORETURN_COMMENT);
     }
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     this.setTooltip(Blockly.Msg.PROCEDURES_DEFNORETURN_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.PROCEDURES_DEFNORETURN_HELPURL);
     this.arguments_ = [];
@@ -415,7 +416,7 @@ Blockly.Blocks['procedures_defreturn'] = {
         Blockly.Msg.PROCEDURES_DEFRETURN_COMMENT) {
       this.setCommentText(Blockly.Msg.PROCEDURES_DEFRETURN_COMMENT);
     }
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     this.setTooltip(Blockly.Msg.PROCEDURES_DEFRETURN_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.PROCEDURES_DEFRETURN_HELPURL);
     this.arguments_ = [];
@@ -461,7 +462,7 @@ Blockly.Blocks['procedures_mutatorcontainer'] = {
     this.appendDummyInput('STATEMENT_INPUT')
         .appendField(Blockly.Msg.PROCEDURES_ALLOW_STATEMENTS)
         .appendField(new Blockly.FieldCheckbox('TRUE'), 'STATEMENTS');
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     this.setTooltip(Blockly.Msg.PROCEDURES_MUTATORCONTAINER_TOOLTIP);
     this.contextMenu = false;
   }
@@ -488,7 +489,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
         .appendField(field, 'NAME');
     this.setPreviousStatement(true);
     this.setNextStatement(true);
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     this.setTooltip(Blockly.Msg.PROCEDURES_MUTATORARG_TOOLTIP);
     this.contextMenu = false;
 
@@ -561,7 +562,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         .appendField(this.id, 'NAME');
     this.setPreviousStatement(true);
     this.setNextStatement(true);
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     // Tooltip is set in renameProcedure.
     this.setHelpUrl(Blockly.Msg.PROCEDURES_CALLNORETURN_HELPURL);
     this.arguments_ = [];
@@ -879,7 +880,7 @@ Blockly.Blocks['procedures_callreturn'] = {
     this.appendDummyInput('TOPROW')
         .appendField('', 'NAME');
     this.setOutput(true);
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     // Tooltip is set in domToMutation.
     this.setHelpUrl(Blockly.Msg.PROCEDURES_CALLRETURN_HELPURL);
     this.arguments_ = [];
@@ -914,7 +915,7 @@ Blockly.Blocks['procedures_ifreturn'] = {
     this.setInputsInline(true);
     this.setPreviousStatement(true);
     this.setNextStatement(true);
-    this.setColour(Blockly.Blocks.procedures.HUE);
+    this.setColour(Blockly.Msg.PROCEDURES_HUE);
     this.setTooltip(Blockly.Msg.PROCEDURES_IFRETURN_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.PROCEDURES_IFRETURN_HELPURL);
     this.hasReturnValue_ = true;

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -32,13 +32,10 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.TEXTS_HUE
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.TEXTS_HUE.
  */
 Blockly.Constants.Text.HUE = 160;
-/** @deprecated Use Blockly.Constants.Text.HUE */
-Blockly.Blocks.texts.HUE = Blockly.Constants.Text.HUE;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for text value
@@ -224,7 +221,7 @@ Blockly.Blocks['text_getSubstring'] = {
       [Blockly.Msg.TEXT_GET_SUBSTRING_END_LAST, 'LAST']
     ];
     this.setHelpUrl(Blockly.Msg.TEXT_GET_SUBSTRING_HELPURL);
-    this.setColour(Blockly.Blocks.texts.HUE);
+    this.setColour(Blockly.Msg.TEXTS_HUE);
     this.appendValueInput('STRING')
         .setCheck('String')
         .appendField(Blockly.Msg.TEXT_GET_SUBSTRING_INPUT_IN_TEXT);
@@ -332,7 +329,7 @@ Blockly.Blocks['text_changeCase'] = {
       [Blockly.Msg.TEXT_CHANGECASE_OPERATOR_TITLECASE, 'TITLECASE']
     ];
     this.setHelpUrl(Blockly.Msg.TEXT_CHANGECASE_HELPURL);
-    this.setColour(Blockly.Blocks.texts.HUE);
+    this.setColour(Blockly.Msg.TEXTS_HUE);
     this.appendValueInput('TEXT')
         .setCheck('String')
         .appendField(new Blockly.FieldDropdown(OPERATORS), 'CASE');
@@ -353,7 +350,7 @@ Blockly.Blocks['text_trim'] = {
       [Blockly.Msg.TEXT_TRIM_OPERATOR_RIGHT, 'RIGHT']
     ];
     this.setHelpUrl(Blockly.Msg.TEXT_TRIM_HELPURL);
-    this.setColour(Blockly.Blocks.texts.HUE);
+    this.setColour(Blockly.Msg.TEXTS_HUE);
     this.appendValueInput('TEXT')
         .setCheck('String')
         .appendField(new Blockly.FieldDropdown(OPERATORS), 'MODE');
@@ -378,7 +375,7 @@ Blockly.Blocks['text_print'] = {
       ],
       "previousStatement": null,
       "nextStatement": null,
-      "colour": Blockly.Blocks.texts.HUE,
+      "colour": Blockly.Msg.TEXTS_HUE,
       "tooltip": Blockly.Msg.TEXT_PRINT_TOOLTIP,
       "helpUrl": Blockly.Msg.TEXT_PRINT_HELPURL
     });
@@ -396,7 +393,7 @@ Blockly.Blocks['text_prompt_ext'] = {
       [Blockly.Msg.TEXT_PROMPT_TYPE_NUMBER, 'NUMBER']
     ];
     this.setHelpUrl(Blockly.Msg.TEXT_PROMPT_HELPURL);
-    this.setColour(Blockly.Blocks.texts.HUE);
+    this.setColour(Blockly.Msg.TEXTS_HUE);
     // Assign 'this' to a variable for use in the closures below.
     var thisBlock = this;
     var dropdown = new Blockly.FieldDropdown(TYPES, function(newOp) {
@@ -456,7 +453,7 @@ Blockly.Blocks['text_prompt'] = {
     // Assign 'this' to a variable for use in the closures below.
     var thisBlock = this;
     this.setHelpUrl(Blockly.Msg.TEXT_PROMPT_HELPURL);
-    this.setColour(Blockly.Blocks.texts.HUE);
+    this.setColour(Blockly.Msg.TEXTS_HUE);
     var dropdown = new Blockly.FieldDropdown(TYPES, function(newOp) {
       thisBlock.updateType_(newOp);
     });
@@ -499,7 +496,7 @@ Blockly.Blocks['text_count'] = {
       ],
       "output": "Number",
       "inputsInline": true,
-      "colour": Blockly.Blocks.texts.HUE,
+      "colour": Blockly.Msg.TEXTS_HUE,
       "tooltip": Blockly.Msg.TEXT_COUNT_TOOLTIP,
       "helpUrl": Blockly.Msg.TEXT_COUNT_HELPURL
     });
@@ -533,7 +530,7 @@ Blockly.Blocks['text_replace'] = {
       ],
       "output": "String",
       "inputsInline": true,
-      "colour": Blockly.Blocks.texts.HUE,
+      "colour": Blockly.Msg.TEXTS_HUE,
       "tooltip": Blockly.Msg.TEXT_REPLACE_TOOLTIP,
       "helpUrl": Blockly.Msg.TEXT_REPLACE_HELPURL
     });
@@ -557,7 +554,7 @@ Blockly.Blocks['text_reverse'] = {
       ],
       "output": "String",
       "inputsInline": true,
-      "colour": Blockly.Blocks.texts.HUE,
+      "colour": Blockly.Msg.TEXTS_HUE,
       "tooltip": Blockly.Msg.TEXT_REVERSE_TOOLTIP,
       "helpUrl": Blockly.Msg.TEXT_REVERSE_HELPURL
     });

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -33,7 +33,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.TEXTS_HUE.
+ * @deprecated Use Blockly.Msg.TEXTS_HUE. (2018 April 5)
  */
 Blockly.Constants.Text.HUE = 160;
 

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -37,13 +37,10 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.VARIABLES_HUE.
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.VARIABLES_HUE.
  */
 Blockly.Constants.Variables.HUE = 330;
-/** @deprecated Use Blockly.Constants.Variables.HUE */
-Blockly.Blocks.variables.HUE = Blockly.Constants.Variables.HUE;
 
 Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   // Block for variable getter.

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -38,7 +38,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.VARIABLES_HUE.
+ * @deprecated Use Blockly.Msg.VARIABLES_HUE. (2018 April 5)
  */
 Blockly.Constants.Variables.HUE = 330;
 

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -37,7 +37,7 @@ goog.require('Blockly');
 
 /**
  * Unused constant for the common HSV hue for all blocks in this category.
- * @deprecated Use Blockly.Msg.VARIABLES_DYNAMIC_HUE.
+ * @deprecated Use Blockly.Msg.VARIABLES_DYNAMIC_HUE. (2018 April 5)
  */
 Blockly.Constants.VariablesDynamic.HUE = 310;
 

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -36,9 +36,8 @@ goog.require('Blockly');
 
 
 /**
- * Common HSV hue for all blocks in this category.
- * Should be the same as Blockly.Msg.VARIABLES_DYNAMIC_HUE.
- * @readonly
+ * Unused constant for the common HSV hue for all blocks in this category.
+ * @deprecated Use Blockly.Msg.VARIABLES_DYNAMIC_HUE.
  */
 Blockly.Constants.VariablesDynamic.HUE = 310;
 

--- a/core/block.js
+++ b/core/block.js
@@ -662,14 +662,14 @@ Blockly.Block.prototype.getHue = function() {
  */
 Blockly.Block.prototype.setColour = function(colour) {
   var dereferenced = goog.isString(colour) ?
-          Blockly.utils.replaceMessageReferences(colour) : colour;
+      Blockly.utils.replaceMessageReferences(colour) : colour;
 
   var hue = Number(dereferenced);
   if (!isNaN(hue) && 0 <= hue && hue <= 360) {
     this.hue_ = hue;
     this.colour_ = Blockly.hueToRgb(hue);
   } else if (goog.isString(dereferenced) &&
-        /^#[0-9a-fA-F]{6}$/.test(dereferenced)) {
+      /^#[0-9a-fA-F]{6}$/.test(dereferenced)) {
     this.colour_ = dereferenced;
     // Only store hue if colour is set as a hue.
     this.hue_ = null;

--- a/core/block.js
+++ b/core/block.js
@@ -657,19 +657,28 @@ Blockly.Block.prototype.getHue = function() {
 
 /**
  * Change the colour of a block.
- * @param {number|string} colour HSV hue value, or #RRGGBB string.
+ * @param {number|string} colour HSV hue value (0 to 360), #RRGGBB string,
+ *     or a message reference string pointing to one of those two values.
  */
 Blockly.Block.prototype.setColour = function(colour) {
-  var hue = Number(colour);
+  var dereferenced = goog.isString(colour) ?
+          Blockly.utils.replaceMessageReferences(colour) : colour;
+
+  var hue = Number(dereferenced);
   if (!isNaN(hue) && 0 <= hue && hue <= 360) {
     this.hue_ = hue;
     this.colour_ = Blockly.hueToRgb(hue);
-  } else if (goog.isString(colour) && /^#[0-9a-fA-F]{6}$/.test(colour)) {
-    this.colour_ = colour;
+  } else if (goog.isString(dereferenced) &&
+        /^#[0-9a-fA-F]{6}$/.test(dereferenced)) {
+    this.colour_ = dereferenced;
     // Only store hue if colour is set as a hue.
     this.hue_ = null;
   } else {
-    throw 'Invalid colour: ' + colour;
+    var errorMsg = 'Invalid colour: "' + dereferenced + '"';
+    if (colour != dereferenced) {
+      errorMsg += ' (from "' + colour + '")';
+    }
+    throw errorMsg;
   }
 };
 
@@ -1067,9 +1076,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
   if (json['colour'] !== undefined) {
     var rawValue = json['colour'];
     try {
-      var colour = goog.isString(rawValue) ?
-          Blockly.utils.replaceMessageReferences(rawValue) : rawValue;
-      this.setColour(colour);
+      this.setColour(rawValue);
     } catch (colorError) {
       console.warn(
           'Block "' + blockTypeName + '": Illegal color value: ', rawValue);

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -609,12 +609,13 @@ Blockly.checkBlockColourConstants_ = function() {
  * not extist (if flagged as removed) or has the same value as the Msg
  * constant. Prints a warning if this is not true.
  * @param {string} msgName The Msg constant identifier.
- * @param {Array<string>} The name parts of the tested constant.
- * @param {boolean} Whether the constant was already removed and should
+ * @param {Array<string>} blocklyNamePath The name parts of the tested
+ *     constant.
+ * @param {boolean} removed Whether the constant was already removed and should
  *     evaluate to undefined.
  */
-Blockly.checkBlockColourConstant_ =
-    function(msgName, blocklyNamePath, removed) {
+Blockly.checkBlockColourConstant_ = function(
+    msgName, blocklyNamePath, removed) {
   var namePath = 'Blockly';
   var value = Blockly;
   for (var i =0; i < blocklyNamePath.length; ++i) {
@@ -633,7 +634,7 @@ Blockly.checkBlockColourConstant_ =
     var warning = warningPattern.replace('%1', namePath).replace('%2', msgName);
     console.warn(warning);
   }
-}
+};
 
 // IE9 does not have a console.  Create a stub to stop errors.
 if (!goog.global['console']) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -562,6 +562,79 @@ Blockly.isNumber = function(str) {
   return /^\s*-?\d+(\.\d+)?\s*$/.test(str);
 };
 
+/**
+ * Checks old colour constants are not overwritten by the host application.
+ * If a constant is overwritten, it prints a console warning directing the
+ * developer to use the equivalent Msg constant.
+ */
+Blockly.checkBlockColourConstants_ = function() {
+  Blockly.checkBlockColourConstant_(
+      'LOGIC_HUE', ['Blocks', 'logic', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'LOGIC_HUE', ['Constants', 'Logic', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'LOOPS_HUE', ['Blocks', 'loops', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'LOOPS_HUE', ['Constants', 'Loops', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'MATH_HUE', ['Blocks', 'math', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'MATH_HUE', ['Constants', 'Math', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'TEXTS_HUE', ['Blocks', 'texts', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'TEXTS_HUE', ['Constants', 'Text', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'LISTS_HUE', ['Blocks', 'lists', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'LISTS_HUE', ['Constants', 'Lists', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'COLOUR_HUE', ['Blocks', 'colour', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'COLOUR_HUE', ['Constants', 'Colour', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'VARIABLES_HUE', ['Blocks', 'variables', 'HUE'], /* removed */ true);
+  Blockly.checkBlockColourConstant_(
+      'VARIABLES_HUE', ['Constants', 'Variables', 'HUE'], /* removed */ false);
+  // Blockly.Blocks.variables_dynamic.HUE never existed.
+  Blockly.checkBlockColourConstant_(
+      'VARIABLES_DYNAMIC_HUE', ['Constants', 'VariablesDynamic', 'HUE'], /* removed */ false);
+  Blockly.checkBlockColourConstant_(
+      'PROCEDURES_HUE', ['Blocks', 'procedures', 'HUE'], /* removed */ true);
+  // Blockly.Constants.Procedures.HUE never existed.
+};
+
+/**
+ * Checks for a constant in the Blockly namespace, verifying it either does
+ * not extist (if flagged as removed) or has the same value as the Msg
+ * constant. Prints a warning if this is not true.
+ * @param {string} msgName The Msg constant identifier.
+ * @param {Array<string>} The name parts of the tested constant.
+ * @param {boolean} Whether the constant was already removed and should
+ *     evaluate to undefined.
+ */
+Blockly.checkBlockColourConstant_ =
+    function(msgName, blocklyNamePath, removed) {
+  var namePath = 'Blockly';
+  var value = Blockly;
+  for (var i =0; i < blocklyNamePath.length; ++i) {
+    namePath += '.' + blocklyNamePath[i];
+    if (value) {
+      value = value[blocklyNamePath[i]];
+    }
+  }
+  var isExpectedValue = removed ?
+      value === undefined :
+      value == Blockly.Msg[msgName]; // Intentionally coercing the value.
+  if (!isExpectedValue) {
+    var warningPattern = removed ?
+        '%1 is unused and has been removed. Override Blockly.Msg.%2.' :
+        '%1 is deprecated and unused. Override Blockly.Msg.%2.';
+    var warning = warningPattern.replace('%1', namePath).replace('%2', msgName);
+    console.warn(warning);
+  }
+}
+
 // IE9 does not have a console.  Create a stub to stop errors.
 if (!goog.global['console']) {
   goog.global['console'] = {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -566,8 +566,9 @@ Blockly.isNumber = function(str) {
  * Checks old colour constants are not overwritten by the host application.
  * If a constant is overwritten, it prints a console warning directing the
  * developer to use the equivalent Msg constant.
+ * @package
  */
-Blockly.checkBlockColourConstants_ = function() {
+Blockly.checkBlockColourConstants = function() {
   Blockly.checkBlockColourConstant_(
       'LOGIC_HUE', ['Blocks', 'logic', 'HUE'], /* removed */ true);
   Blockly.checkBlockColourConstant_(
@@ -606,13 +607,14 @@ Blockly.checkBlockColourConstants_ = function() {
 
 /**
  * Checks for a constant in the Blockly namespace, verifying it either does
- * not extist (if flagged as removed) or has the same value as the Msg
+ * not exist (if flagged as removed) or has the same value as the Msg
  * constant. Prints a warning if this is not true.
  * @param {string} msgName The Msg constant identifier.
  * @param {Array<string>} blocklyNamePath The name parts of the tested
  *     constant.
  * @param {boolean} removed Whether the constant was already removed and should
  *     evaluate to undefined.
+ * @private
  */
 Blockly.checkBlockColourConstant_ = function(
     msgName, blocklyNamePath, removed) {

--- a/core/inject.js
+++ b/core/inject.js
@@ -45,6 +45,8 @@ goog.require('goog.userAgent');
  * @return {!Blockly.Workspace} Newly created main workspace.
  */
 Blockly.inject = function(container, opt_options) {
+  Blockly.checkBlockColourConstants_();
+
   if (goog.isString(container)) {
     container = document.getElementById(container) ||
         document.querySelector(container);

--- a/core/inject.js
+++ b/core/inject.js
@@ -45,7 +45,7 @@ goog.require('goog.userAgent');
  * @return {!Blockly.Workspace} Newly created main workspace.
  */
 Blockly.inject = function(container, opt_options) {
-  Blockly.checkBlockColourConstants_();
+  Blockly.checkBlockColourConstants();
 
   if (goog.isString(container)) {
     container = document.getElementById(container) ||


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1648 

### Proposed Changes

Making all blocks use the MSG colour values.

 * Deprecating Blockly.Constants.Lists.HUE and similar constants.
 * Removing deprecated Blockly.Blocks.lists.HUE constants.
 * Allowing message references in the Block.setColour() parameter.

### Reason for Changes

Since the conversion from JavaScript to JSON block definitions was never completed, several blocks used the old colour constants, while JSON use MSG constants. This made it difficult to change the colors on Blockly's predefined blocks.

### Test Coverage

I added the following lines to `playground.html` and then loaded all blocks in all categories, including the dynamic variables category.

```js
Blockly.Msg.LOGIC_HUE = '#193863';  // dark blue
Blockly.Msg.LOOPS_HUE = '#193863';
Blockly.Msg.MATH_HUE = '#193863';
Blockly.Msg.TEXTS_HUE = '#193863';
Blockly.Msg.LISTS_HUE = '#193863';
Blockly.Msg.COLOUR_HUE = '#193863';
Blockly.Msg.VARIABLES_HUE = '#193863';
Blockly.Msg.VARIABLES_DYNAMIC_HUE = '#193863';
Blockly.Msg.PROCEDURES_HUE = '#193863';
```

Additionally, I instantiated all blocks that have mutators and opened the mutator windows, checking the color of the configuration blocks.

Finally, I added varying combinations of the following lines to test for the console warnings:

```js
Blockly.Blocks.logic.HUE = "#193863"; // dark blue
Blockly.Constants.Logic.HUE = "#193863";
Blockly.Blocks.loops.HUE = "#193863";
Blockly.Constants.Loops.HUE = "#193863";
Blockly.Blocks.colour.HUE = "#193863";
Blockly.Constants.Colour.HUE = "#193863";
Blockly.Blocks.math.HUE = "#193863";
Blockly.Constants.Math.HUE = "#193863";
Blockly.Blocks.texts.HUE = "#193863";
Blockly.Constants.Text.HUE = "#193863";
Blockly.Blocks.lists.HUE = "#193863";
Blockly.Constants.Lists.HUE = "#193863";
Blockly.Blocks.variables.HUE = "#193863";
Blockly.Constants.Variables.HUE = "#193863";
Blockly.Constants.VariablesDynamic.HUE = "#193863";
Blockly.Blocks.procedures.HUE = "#193863";
```

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
