### PR TITLE
Snap a single block from a stack (if meta key is pressed)

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -144,9 +144,10 @@ Blockly.BlockDragger.initIconData_ = function(block) {
  * Start dragging a block.  This includes moving it to the drag surface.
  * @param {!goog.math.Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at mouse down, in pixel units.
+ * @param {boolean} healStack whether or not to heal the stack after disconnecting
  * @package
  */
-Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
+Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY, healStack) {
   if (!Blockly.Events.getGroup()) {
     Blockly.Events.setGroup(true);
   }
@@ -154,8 +155,10 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY) {
   this.workspace_.setResizesEnabled(false);
   Blockly.BlockSvg.disconnectUiStop_();
 
-  if (this.draggingBlock_.getParent()) {
-    this.draggingBlock_.unplug();
+  if (this.draggingBlock_.getParent() ||
+      (healStack && this.draggingBlock_.nextConnection &&
+      this.draggingBlock_.nextConnection.targetBlock())) {
+    this.draggingBlock_.unplug(healStack);
     var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
     var newLoc = goog.math.Coordinate.sum(this.startXY_, delta);
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -225,6 +225,14 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * @private
    */
   this.isEnding_ = false;
+
+  /**
+   * Boolean used to indicate whether or not to heal the stack after
+   * disconnecting a block.
+   * @type {boolean}
+   * @private
+   */
+  this.healStack_ = !Blockly.DRAG_STACK;
 };
 
 /**
@@ -443,7 +451,7 @@ Blockly.Gesture.prototype.updateIsDragging_ = function() {
 Blockly.Gesture.prototype.startDraggingBlock_ = function() {
   this.blockDragger_ = new Blockly.BlockDragger(this.targetBlock_,
       this.startWorkspace_);
-  this.blockDragger_.startBlockDrag(this.currentDragDeltaXY_);
+  this.blockDragger_.startBlockDrag(this.currentDragDeltaXY_, this.healStack_);
   this.blockDragger_.dragBlock(this.mostRecentEvent_,
       this.currentDragDeltaXY_);
 };
@@ -503,6 +511,7 @@ Blockly.Gesture.prototype.doStart = function(e) {
   }
 
   this.mouseDownXY_ = new goog.math.Coordinate(e.clientX, e.clientY);
+  this.healStack_ = e.altKey || e.ctrlKey || e.metaKey;
 
   this.bindMouseEvents(e);
 };


### PR DESCRIPTION
Remove a single block from a stack of any of the meta keys are pressed. 

![metakeysplit](https://user-images.githubusercontent.com/16690124/38154723-7a3da9a8-3428-11e8-9fd6-c01ceff01a7b.gif)

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1485 

### Proposed Changes

When the gesture starts set a flag (healStack) whether any of the meta key was pressed during the start of the click. 
When we disconnect the block (unplug), we pass healStack to the unplug function to heal the stack. (All the healstack code was already there).

### Reason for Changes

Feature used to exist and is very handy for rearranging blocks. 

### Test Coverage

Tested on:
- Chrome Mac
- Firefox Mac
- Safari Mac

### Additional Information

