### PR TITLE
workspace comments: promote comment when selected

### DIFF
--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -173,6 +173,20 @@ Blockly.WorkspaceCommentSvg.prototype.showContextMenu_ = function(e) {
 };
 
 /**
+ * Move this workspace comment to the top of the stack.
+ * @return {!boolean} Whether or not the comment has been moved.
+ * @private
+ */
+Blockly.WorkspaceCommentSvg.prototype.promote_ = function() {
+  var svgGroup = this.svgGroup_.parentNode;
+  if (svgGroup.lastChild !== this.svgGroup_) {
+    svgGroup.appendChild(this.svgGroup_);
+    return true;
+  }
+  return false;
+};
+
+/**
  * Select this comment.  Highlight it visually.
  * @package
  */
@@ -195,6 +209,7 @@ Blockly.WorkspaceCommentSvg.prototype.select = function() {
   event.workspaceId = this.workspace.id;
   Blockly.Events.fire(event);
   Blockly.selected = this;
+  this.promote_();
   this.addSelect();
 };
 


### PR DESCRIPTION
Promote the workspace comment to the top of the stack when selected. 

![ws_promote](https://user-images.githubusercontent.com/16690124/38155201-33acee38-342b-11e8-96bd-40e4319ea747.gif)

