### PR TITLE
Add support for transitioning the workspace block and bubble canvas. 

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -165,7 +165,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
-    ' .blocklyBubbleCanvas.blocklyCanvasTransitioning {',
+  '.blocklyBubbleCanvas.blocklyCanvasTransitioning {',
     'transition: transform 0.5s;',
   '}',
 

--- a/core/css.js
+++ b/core/css.js
@@ -164,6 +164,11 @@ Blockly.Css.CONTENT = [
     'z-index: 50;', /* Display below toolbox, but above everything else. */
   '}',
 
+  '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
+    ' .blocklyBubbleCanvas.blocklyCanvasTransitioning {',
+    'transition: transform 0.5s;',
+  '}',
+
   '.blocklyTooltipDiv {',
     'background-color: #ffffc7;',
     'border: 1px solid #ddc;',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1481,6 +1481,27 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 };
 
 /**
+ * Add a transition class to the block and bubble canvas, to animate any
+ * transform changes.
+ */
+Blockly.WorkspaceSvg.prototype.beginCanvasTransition = function() {
+  Blockly.utils.addClass(
+      /** @type {!SVGElement} */ this.svgBlockCanvas_, 'blocklyCanvasTransitioning');
+  Blockly.utils.addClass(
+      /** @type {!SVGElement} */ this.svgBubbleCanvas_, 'blocklyCanvasTransitioning');
+};
+
+/**
+ * Remove transition class from the block and bubble canvas.
+ */
+Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
+  Blockly.utils.removeClass(
+      /** @type {!SVGElement} */ this.svgBlockCanvas_, 'blocklyCanvasTransitioning');
+  Blockly.utils.removeClass(
+      /** @type {!SVGElement} */ this.svgBubbleCanvas_, 'blocklyCanvasTransitioning');
+};
+
+/**
  * Center the workspace.
  */
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -173,7 +173,11 @@ Blockly.ZoomControls.prototype.createDom = function() {
   Blockly.bindEventWithChecks_(zoomresetSvg, 'mousedown', null, function(e) {
     workspace.markFocused();
     workspace.setScale(workspace.options.zoomOptions.startScale);
-    workspace.scrollCenter();
+    workspace.beginCanvasTransition();
+    workspace.scrollCenter(true);
+    setTimeout(function() {
+      workspace.endCanvasTransition();
+    }, 500);
     Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
     e.stopPropagation();  // Don't start a workspace scroll.
     e.preventDefault();  // Stop double-clicking from selecting text.


### PR DESCRIPTION
Add support for transitioning the workspace block and bubble canvas. 
Enable for scrollCenter.

It turns out only Chrome supports CSS transitions on SVG elements, so feel free not to pull in this change. Cool demo though!

![transitioncanvas](https://user-images.githubusercontent.com/16690124/38157580-2de3593a-343d-11e8-8469-5ee8a54b5d24.gif)

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No current issue open. 

### Proposed Changes

Animate the workspace move when scrolling. Support for developers to begin and end the transition property on the block and bubble canvas.

### Reason for Changes

Animations are great!

### Test Coverage


Tested on:
Only works on Chrome

### Additional Information
