### PR TITLE
Adding support for multi-line labels in the toolbox

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -383,7 +383,7 @@ Blockly.Field.prototype.updateWidth = function() {
 
 /**
  * Gets the width of a text element, caching it in the process.
- * @param {!Element} textElement An SVG 'text' element.
+ * @param {!Element} textElement An SVG 'text' or 'tspan' element.
  * @return {number} Width of element.
  */
 Blockly.Field.getCachedWidth = function(textElement) {
@@ -400,13 +400,14 @@ Blockly.Field.getCachedWidth = function(textElement) {
 
   // Attempt to compute fetch the width of the SVG text element.
   try {
-    if (goog.userAgent.IE || goog.userAgent.EDGE) {
+    // In IE 'tspan' elements don't have a getBBox so check for getBBox.
+    if ((goog.userAgent.IE || goog.userAgent.EDGE) && textElement.getBBox) {
       width = textElement.getBBox().width;
     } else {
       width = textElement.getComputedTextLength();
     }
   } catch (e) {
-    // In other cases where we fail to geth the computed text. Instead, use an
+    // In other cases where we fail to get the computed text. Instead, use an
     // approximation and do not cache the result. At some later point in time
     // when the block is inserted into the visible DOM, this method will be
     // called again and, at that point in time, will not throw an exception.

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -161,10 +161,42 @@ Blockly.FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-  svgText.textContent = this.text_;
 
-  this.width = Blockly.Field.getCachedWidth(svgText);
-  this.height = 20;  // Can't compute it :(
+  if (this.isLabel_) {
+    // Deal with multi-line labels.
+    var lines = this.text_.split('\n');
+
+    var tspans = lines.map(function(textLine, i) {
+      var tspanArgs = {
+        'class': 'blocklyFlyoutLabelTextLine',
+        'x': 0,
+        'dy': 20, // Can't compute it :(
+        'text-anchor': 'start'
+      }
+      if (i === 0) {
+        tspanArgs.y = 0;
+      }
+      var svgTSpan = Blockly.utils.createSvgElement('tspan', tspanArgs);
+      svgTSpan.textContent = textLine;
+      return svgTSpan;
+    });
+
+    tspans.forEach(function(tspan) { svgText.appendChild(tspan); })
+    
+    var maxLineLength = tspans
+      .map(function(tspan) { return Blockly.Field.getCachedWidth(tspan); })
+      .reduce(function(maxLength, length) {
+        return Math.max(maxLength, length);
+      });
+
+    this.width = maxLineLength;
+    this.height = 20 * lines.length; // Can't compute it :(
+  } else {
+    svgText.textContent = this.text_;
+
+    this.width = Blockly.Field.getCachedWidth(svgText);
+    this.height = 20 // Can't compute it :(
+  }
 
   if (!this.isLabel_) {
     this.width += 2 * Blockly.FlyoutButton.MARGIN;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Not linked to an issue

### Proposed Changes

Adds support for multi-line labels in the toolbox. 
![image](https://user-images.githubusercontent.com/4340831/38168676-fa3d2312-354b-11e8-9e7d-8ddf1f00912d.png)
![image](https://user-images.githubusercontent.com/4340831/38168679-0fc4e3fa-354c-11e8-91dd-1e32bc711617.png)
![image](https://user-images.githubusercontent.com/4340831/38168667-4ed53aa0-354b-11e8-9bd6-749e6c3b8dfc.png)

### Reason for Changes

Allows a summary description to be added to the top of a flyout. It can be used to provide general information about what the blocks in that group do.

### Test Coverage

Manually tested, as far as I am aware flyout_button is not tested in the unit tests.

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
* Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
