### PR TITLE
Allow block xml disable tag to be more accepting

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -713,7 +713,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   }
   var disabled = xmlBlock.getAttribute('disabled');
   if (disabled) {
-    block.setDisabled(disabled == 'true');
+    block.setDisabled(disabled == 'true' || disabled == 'disabled');
   }
   var deletable = xmlBlock.getAttribute('deletable');
   if (deletable) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

This reapplies the change from #229 on the 'develop' branch. Please look there for all details.

@rachel-fenichel , I wasn't sure if I could just change the base of my previous PR so I cherry-picked the change to `develop` and created this new PR.

