### PR TITLE
Strip coordinates from storage of single block stacks in demos.

### DIFF
--- a/appengine/storage.js
+++ b/appengine/storage.js
@@ -71,6 +71,15 @@ BlocklyStorage.restoreBlocks = function(opt_workspace) {
 BlocklyStorage.link = function(opt_workspace) {
   var workspace = opt_workspace || Blockly.getMainWorkspace();
   var xml = Blockly.Xml.workspaceToDom(workspace, true);
+  // Remove x/y coordinates from XML if there's only one block stack.
+  // There's no reason to store this, removing it helps with anonymity.
+  if (workspace.getTopBlocks(false).length == 1 && xml.querySelector) {
+    var block = xml.querySelector('block');
+    if (block) {
+      block.removeAttribute('x');
+      block.removeAttribute('y');
+    }
+  }
   var data = Blockly.Xml.domToText(xml);
   BlocklyStorage.makeRequest_('/storage', 'xml', data, workspace);
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -407,8 +407,10 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
         // to be moved to a nested destination in the next operation.
         var block = Blockly.Xml.domToBlock(xmlChild, workspace);
         newBlockIds.push(block.id);
-        var blockX = parseInt(xmlChild.getAttribute('x'), 10);
-        var blockY = parseInt(xmlChild.getAttribute('y'), 10);
+        var blockX = xmlChild.hasAttribute('x') ?
+            parseInt(xmlChild.getAttribute('x'), 10) : 10;
+        var blockY = xmlChild.hasAttribute('y') ?
+            parseInt(xmlChild.getAttribute('y'), 10) : 10;
         if (!isNaN(blockX) && !isNaN(blockY)) {
           block.moveBy(workspace.RTL ? width - blockX : blockX, blockY);
         }


### PR DESCRIPTION
When loading, place blocks with no coordinates at 10,10 instead of 0,0.