### PR TITLE
Add a function to scroll the workspace to center on a given block

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -860,7 +860,10 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     var workspace = this.workspace;
     option.callback = function() {
       var def = Blockly.Procedures.getDefinition(name, workspace);
-      def && def.select();
+      if (def) {
+        workspace.centerOnBlock(def.id);
+        def.select();
+      }
     };
     options.push(option);
   },

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1486,6 +1486,7 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
   if (!this.scrollbar) {
     // Can't center a non-scrolling workspace.
+    console.warn('Tried to scroll a non-scrollable workspace.');
     return;
   }
   var metrics = this.getMetrics();
@@ -1636,6 +1637,56 @@ Blockly.WorkspaceSvg.getContentDimensionsBounded_ = function(ws, svgSize) {
   };
   return dimensions;
 };
+
+/**
+ * Scroll the workspace to center on the given block.
+ * @param {?string} id ID of block center on.
+ * @public
+ */
+Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
+  if (!this.scrollbar) {
+    console.warn('Tried to scroll a non-scrollable workspace.');
+    return;
+  }
+  var block = this.getBlockById(id);
+  if (block) {
+    // XY is in workspace coordinates.
+    var xy = block.getRelativeToSurfaceXY();
+    // Height/width is in workspace units.
+    var heightWidth = block.getHeightWidth();
+
+    // Center in workspace units.
+    var blockCenterX = xy.x + heightWidth.width / 2;
+    var blockCenterY = xy.y + heightWidth.height / 2;
+
+    // Workspace scale, used to convert from workspace coordinates to pixels.
+    var scale = this.scale;
+
+    // Center in pixels.  0, 0 is at the workspace origin.  These numbers may
+    // be negative.
+    var pixelX = blockCenterX * scale;
+    var pixelY = blockCenterY * scale;
+
+    var metrics = this.getMetrics();
+
+    // Scrolling to here would put the block in the top-left corner of the
+    // visible workspace.
+    var scrollToBlockX = pixelX - metrics.contentLeft;
+    var scrollToBlockY = pixelY - metrics.contentTop;
+
+    // viewHeight and viewWidth are in pixels.
+    var halfViewWidth = metrics.viewWidth / 2;
+    var halfViewHeight = metrics.viewHeight / 2;
+
+    // Put the block in the center of the visible workspace instead.
+    var scrollToCenterX = scrollToBlockX - halfViewWidth;
+    var scrollToCenterY = scrollToBlockY - halfViewHeight;
+
+    Blockly.WidgetDiv.hide(true);
+    this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+  }
+};
+
 
 /**
  * Return an object with all the metrics required to size scrollbars for a

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1508,46 +1508,49 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
     console.warn('Tried to scroll a non-scrollable workspace.');
     return;
   }
+
   var block = this.getBlockById(id);
-  if (block) {
-    // XY is in workspace coordinates.
-    var xy = block.getRelativeToSurfaceXY();
-    // Height/width is in workspace units.
-    var heightWidth = block.getHeightWidth();
-
-    // Find the enter of the block in workspace units.
-    var blockCenterY = xy.y + heightWidth.height / 2;
-
-    // In RTL the block's position is the top right of the block, not top left.
-    var multiplier = this.RTL ? -1 : 1;
-    var blockCenterX = xy.x + (multiplier * heightWidth.width / 2);
-
-    // Workspace scale, used to convert from workspace coordinates to pixels.
-    var scale = this.scale;
-
-    // Center in pixels.  0, 0 is at the workspace origin.  These numbers may
-    // be negative.
-    var pixelX = blockCenterX * scale;
-    var pixelY = blockCenterY * scale;
-
-    var metrics = this.getMetrics();
-
-    // Scrolling to here would put the block in the top-left corner of the
-    // visible workspace.
-    var scrollToBlockX = pixelX - metrics.contentLeft;
-    var scrollToBlockY = pixelY - metrics.contentTop;
-
-    // viewHeight and viewWidth are in pixels.
-    var halfViewWidth = metrics.viewWidth / 2;
-    var halfViewHeight = metrics.viewHeight / 2;
-
-    // Put the block in the center of the visible workspace instead.
-    var scrollToCenterX = scrollToBlockX - halfViewWidth;
-    var scrollToCenterY = scrollToBlockY - halfViewHeight;
-
-    Blockly.hideChaff();
-    this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+  if (!block) {
+    return;
   }
+
+  // XY is in workspace coordinates.
+  var xy = block.getRelativeToSurfaceXY();
+  // Height/width is in workspace units.
+  var heightWidth = block.getHeightWidth();
+
+  // Find the enter of the block in workspace units.
+  var blockCenterY = xy.y + heightWidth.height / 2;
+
+  // In RTL the block's position is the top right of the block, not top left.
+  var multiplier = this.RTL ? -1 : 1;
+  var blockCenterX = xy.x + (multiplier * heightWidth.width / 2);
+
+  // Workspace scale, used to convert from workspace coordinates to pixels.
+  var scale = this.scale;
+
+  // Center in pixels.  0, 0 is at the workspace origin.  These numbers may
+  // be negative.
+  var pixelX = blockCenterX * scale;
+  var pixelY = blockCenterY * scale;
+
+  var metrics = this.getMetrics();
+
+  // Scrolling to here would put the block in the top-left corner of the
+  // visible workspace.
+  var scrollToBlockX = pixelX - metrics.contentLeft;
+  var scrollToBlockY = pixelY - metrics.contentTop;
+
+  // viewHeight and viewWidth are in pixels.
+  var halfViewWidth = metrics.viewWidth / 2;
+  var halfViewHeight = metrics.viewHeight / 2;
+
+  // Put the block in the center of the visible workspace instead.
+  var scrollToCenterX = scrollToBlockX - halfViewWidth;
+  var scrollToCenterY = scrollToBlockY - halfViewHeight;
+
+  Blockly.hideChaff();
+  this.scrollbar.set(scrollToCenterX, scrollToCenterY);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1515,9 +1515,12 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
     // Height/width is in workspace units.
     var heightWidth = block.getHeightWidth();
 
-    // Center in workspace units.
-    var blockCenterX = xy.x + heightWidth.width / 2;
+    // Find the enter of the block in workspace units.
     var blockCenterY = xy.y + heightWidth.height / 2;
+
+    // In RTL the block's position is the top right of the block, not top left.
+    var multiplier = this.RTL ? -1 : 1;
+    var blockCenterX = xy.x + (multiplier * heightWidth.width / 2);
 
     // Workspace scale, used to convert from workspace coordinates to pixels.
     var scale = this.scale;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1499,6 +1499,55 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
 };
 
 /**
+ * Scroll the workspace to center on the given block.
+ * @param {?string} id ID of block center on.
+ * @public
+ */
+Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
+  if (!this.scrollbar) {
+    console.warn('Tried to scroll a non-scrollable workspace.');
+    return;
+  }
+  var block = this.getBlockById(id);
+  if (block) {
+    // XY is in workspace coordinates.
+    var xy = block.getRelativeToSurfaceXY();
+    // Height/width is in workspace units.
+    var heightWidth = block.getHeightWidth();
+
+    // Center in workspace units.
+    var blockCenterX = xy.x + heightWidth.width / 2;
+    var blockCenterY = xy.y + heightWidth.height / 2;
+
+    // Workspace scale, used to convert from workspace coordinates to pixels.
+    var scale = this.scale;
+
+    // Center in pixels.  0, 0 is at the workspace origin.  These numbers may
+    // be negative.
+    var pixelX = blockCenterX * scale;
+    var pixelY = blockCenterY * scale;
+
+    var metrics = this.getMetrics();
+
+    // Scrolling to here would put the block in the top-left corner of the
+    // visible workspace.
+    var scrollToBlockX = pixelX - metrics.contentLeft;
+    var scrollToBlockY = pixelY - metrics.contentTop;
+
+    // viewHeight and viewWidth are in pixels.
+    var halfViewWidth = metrics.viewWidth / 2;
+    var halfViewHeight = metrics.viewHeight / 2;
+
+    // Put the block in the center of the visible workspace instead.
+    var scrollToCenterX = scrollToBlockX - halfViewWidth;
+    var scrollToCenterY = scrollToBlockY - halfViewHeight;
+
+    Blockly.hideChaff();
+    this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+  }
+};
+
+/**
  * Set the workspace's zoom factor.
  * @param {number} newScale Zoom factor.
  */
@@ -1637,56 +1686,6 @@ Blockly.WorkspaceSvg.getContentDimensionsBounded_ = function(ws, svgSize) {
   };
   return dimensions;
 };
-
-/**
- * Scroll the workspace to center on the given block.
- * @param {?string} id ID of block center on.
- * @public
- */
-Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
-  if (!this.scrollbar) {
-    console.warn('Tried to scroll a non-scrollable workspace.');
-    return;
-  }
-  var block = this.getBlockById(id);
-  if (block) {
-    // XY is in workspace coordinates.
-    var xy = block.getRelativeToSurfaceXY();
-    // Height/width is in workspace units.
-    var heightWidth = block.getHeightWidth();
-
-    // Center in workspace units.
-    var blockCenterX = xy.x + heightWidth.width / 2;
-    var blockCenterY = xy.y + heightWidth.height / 2;
-
-    // Workspace scale, used to convert from workspace coordinates to pixels.
-    var scale = this.scale;
-
-    // Center in pixels.  0, 0 is at the workspace origin.  These numbers may
-    // be negative.
-    var pixelX = blockCenterX * scale;
-    var pixelY = blockCenterY * scale;
-
-    var metrics = this.getMetrics();
-
-    // Scrolling to here would put the block in the top-left corner of the
-    // visible workspace.
-    var scrollToBlockX = pixelX - metrics.contentLeft;
-    var scrollToBlockY = pixelY - metrics.contentTop;
-
-    // viewHeight and viewWidth are in pixels.
-    var halfViewWidth = metrics.viewWidth / 2;
-    var halfViewHeight = metrics.viewHeight / 2;
-
-    // Put the block in the center of the visible workspace instead.
-    var scrollToCenterX = scrollToBlockX - halfViewWidth;
-    var scrollToCenterY = scrollToBlockY - halfViewHeight;
-
-    Blockly.WidgetDiv.hide(true);
-    this.scrollbar.set(scrollToCenterX, scrollToCenterY);
-  }
-};
-
 
 /**
  * Return an object with all the metrics required to size scrollbars for a


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

### Additional Information

This allows us to go to a block with a warning, or go to the definition of a user-defined function!