### PR TITLE
Add argsIgnorePattern to the eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,16 @@
             }
         ],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],
-        "no-unused-vars": ["error", {"args": "after-used", "varsIgnorePattern": "^_"}],
+        "no-unused-vars": [
+            "error",
+            {
+                "args": "after-used",
+                # Ignore vars starting with an underscore.
+                "varsIgnorePattern": "^_",
+                # Ignore arguments starting with an underscore.
+                "argsIgnorePattern": "^_"
+            }
+        ],
         "no-use-before-define": ["error"],
         "quotes": ["off"], # Blockly uses single quotes except for JSON blobs, which must use double quotes.
         "semi": ["error", "always"],

--- a/core/block.js
+++ b/core/block.js
@@ -337,13 +337,11 @@ Blockly.Block.prototype.unplug = function(opt_healStack) {
 
 /**
  * Returns all connections originating from this block.
- * @param {boolean} all If true, return all connections even hidden ones.
+ * @param {boolean} _all If true, return all connections even hidden ones.
  * @return {!Array.<!Blockly.Connection>} Array of connections.
  * @private
  */
-Blockly.Block.prototype.getConnections_ = function(
-    /* eslint-disable no-unused-vars */ all
-    /* eslint-enable no-unused-vars */) {
+Blockly.Block.prototype.getConnections_ = function(_all) {
   var myConnections = [];
   if (this.outputConnection) {
     myConnections.push(this.outputConnection);
@@ -1432,23 +1430,20 @@ Blockly.Block.prototype.setCommentText = function(text) {
 
 /**
  * Set this block's warning text.
- * @param {?string} text The text, or null to delete.
- * @param {string=} opt_id An optional ID for the warning text to be able to
+ * @param {?string} _text The text, or null to delete.
+ * @param {string=} _opt_id An optional ID for the warning text to be able to
  *     maintain multiple warnings.
  */
-Blockly.Block.prototype.setWarningText = function(text,
-    /* eslint-disable no-unused-vars */ opt_id
-    /* eslint-enable no-unused-vars */) {
+Blockly.Block.prototype.setWarningText = function(_text, _opt_id) {
   // NOP.
 };
 
 /**
  * Give this block a mutator dialog.
- * @param {Blockly.Mutator} mutator A mutator dialog instance or null to remove.
+ * @param {Blockly.Mutator} _mutator A mutator dialog instance or null to
+ *     remove.
  */
-Blockly.Block.prototype.setMutator = function(
-    /* eslint-disable no-unused-vars */ mutator
-    /* eslint-enable no-unused-vars */) {
+Blockly.Block.prototype.setMutator = function(_mutator) {
   // NOP.
 };
 

--- a/core/comment.js
+++ b/core/comment.js
@@ -127,9 +127,7 @@ Blockly.Comment.prototype.createEditor_ = function() {
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     e.stopPropagation();
   });
-  Blockly.bindEventWithChecks_(textarea, 'change', this, function(
-      /* eslint-disable no-unused-vars */ e
-      /* eslint-enable no-unused-vars */) {
+  Blockly.bindEventWithChecks_(textarea, 'change', this, function(_e) {
     if (this.text_ != textarea.value) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
           this.block_, 'comment', null, this.text_, textarea.value));
@@ -218,11 +216,10 @@ Blockly.Comment.prototype.setVisible = function(visible) {
 
 /**
  * Bring the comment to the top of the stack when clicked on.
- * @param {!Event} e Mouse up event.
+ * @param {!Event} _e Mouse up event.
  * @private
  */
-Blockly.Comment.prototype.textareaFocus_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
+Blockly.Comment.prototype.textareaFocus_ = function(_e) {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.

--- a/core/events/abstract.js
+++ b/core/events/abstract.js
@@ -122,11 +122,9 @@ Blockly.Events.Abstract.prototype.isNull = function() {
 
 /**
  * Run an event.
- * @param {boolean} forward True if run forward, false if run backward (undo).
+ * @param {boolean} _forward True if run forward, false if run backward (undo).
  */
-Blockly.Events.Abstract.prototype.run = function(
-    /* eslint-disable no-unused-vars */ forward
-    /* eslint-enable no-unused-vars */) {
+Blockly.Events.Abstract.prototype.run = function(_forward) {
   // Defined by subclasses.
 };
 

--- a/core/field.js
+++ b/core/field.js
@@ -576,8 +576,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
  * @param {!Event} e Mouse down event.
  * @private
  */
-Blockly.Field.prototype.onMouseDown_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
+Blockly.Field.prototype.onMouseDown_ = function(e) {
   if (!this.sourceBlock_ || !this.sourceBlock_.workspace) {
     return;
   }
@@ -589,12 +588,10 @@ Blockly.Field.prototype.onMouseDown_ = function(
 
 /**
  * Change the tooltip text for this field.
- * @param {string|!Element} newTip Text for tooltip or a parent element to
+ * @param {string|!Element} _newTip Text for tooltip or a parent element to
  *     link to for its tooltip.
  */
-Blockly.Field.prototype.setTooltip = function(
-    /* eslint-disable no-unused-vars */ newTip
-    /* eslint-enable no-unused-vars */) {
+Blockly.Field.prototype.setTooltip = function(_newTip) {
   // Non-abstract sub-classes may wish to implement this.  See FieldLabel.
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -273,11 +273,10 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
 
 /**
  * Handle a change to the editor.
- * @param {!Event} e Keyboard event.
+ * @param {!Event} _e Keyboard event.
  * @private
  */
-Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
+Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
   var htmlInput = Blockly.FieldTextInput.htmlInput_;
   // Update source block.
   var text = htmlInput.value;

--- a/core/generator.js
+++ b/core/generator.js
@@ -378,11 +378,9 @@ Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
  * Hook for code to run before code generation starts.
  * Subclasses may override this, e.g. to initialise the database of variable
  * names.
- * @param {!Blockly.Workspace} workspace Workspace to generate code from.
+ * @param {!Blockly.Workspace} _workspace Workspace to generate code from.
  */
-Blockly.Generator.prototype.init = function(
-    /* eslint-disable no-unused-vars */ workspace
-    /* eslint-enable no-unused-vars */) {
+Blockly.Generator.prototype.init = function(_workspace) {
   // Optionally override
 };
 
@@ -392,14 +390,12 @@ Blockly.Generator.prototype.init = function(
  * Subclasses may override this, e.g. to generate code for statements following
  * the block, or to handle comments for the specified block and any connected
  * value blocks.
- * @param {!Blockly.Block} block The current block.
+ * @param {!Blockly.Block} _block The current block.
  * @param {string} code The JavaScript code created for this block.
  * @return {string} JavaScript code with comments and subsequent blocks added.
  * @private
  */
-Blockly.Generator.prototype.scrub_ = function(
-    /* eslint-disable no-unused-vars */ block, code
-    /* eslint-enable no-unused-vars */) {
+Blockly.Generator.prototype.scrub_ = function(_block, code) {
   // Optionally override
   return code;
 };
@@ -411,9 +407,7 @@ Blockly.Generator.prototype.scrub_ = function(
  * @param {string} code Generated code.
  * @return {string} Completed code.
  */
-Blockly.Generator.prototype.finish = function(
-    /* eslint-disable no-unused-vars */ code
-    /* eslint-enable no-unused-vars */) {
+Blockly.Generator.prototype.finish = function(code) {
   // Optionally override
   return code;
 };
@@ -426,9 +420,7 @@ Blockly.Generator.prototype.finish = function(
  * @param {string} line Line of generated code.
  * @return {string} Legal line of code.
  */
-Blockly.Generator.prototype.scrubNakedValue = function(
-    /* eslint-disable no-unused-vars */ line
-    /* eslint-enable no-unused-vars */) {
+Blockly.Generator.prototype.scrubNakedValue = function(line) {
   // Optionally override
   return line;
 };

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -629,11 +629,10 @@ Blockly.Toolbox.TreeNode.prototype.getExpandIconSafeHtml = function() {
 
 /**
  * Expand or collapse the node on mouse click.
- * @param {!goog.events.BrowserEvent} e The browser event.
+ * @param {!goog.events.BrowserEvent} _e The browser event.
  * @override
  */
-Blockly.Toolbox.TreeNode.prototype.onClick_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-disable no-unused-vars */) {
+Blockly.Toolbox.TreeNode.prototype.onClick_ = function(_e) {
   // Expand icon.
   if (this.hasChildren() && this.isUserCollapsible_) {
     this.toggle();
@@ -648,23 +647,21 @@ Blockly.Toolbox.TreeNode.prototype.onClick_ = function(
 
 /**
  * Suppress the inherited mouse down behaviour.
- * @param {!goog.events.BrowserEvent} e The browser event.
+ * @param {!goog.events.BrowserEvent} _e The browser event.
  * @override
  * @private
  */
-Blockly.Toolbox.TreeNode.prototype.onMouseDown = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-disable no-unused-vars */) {
+Blockly.Toolbox.TreeNode.prototype.onMouseDown = function(_e) {
   // NOPE.
 };
 
 /**
  * Suppress the inherited double-click behaviour.
- * @param {!goog.events.BrowserEvent} e The browser event.
+ * @param {!goog.events.BrowserEvent} _e The browser event.
  * @override
  * @private
  */
-Blockly.Toolbox.TreeNode.prototype.onDoubleClick_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-disable no-unused-vars */) {
+Blockly.Toolbox.TreeNode.prototype.onDoubleClick_ = function(_e) {
   // NOP.
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -181,11 +181,10 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
 
 /**
  * Hide the tooltip if the mouse leaves the object and enters the workspace.
- * @param {!Event} e Mouse event.
+ * @param {!Event} _e Mouse event.
  * @private
  */
-Blockly.Tooltip.onMouseOut_ = function(/* eslint-disable no-unused-vars */e
-    /* eslint-enable no-unused-vars */) {
+Blockly.Tooltip.onMouseOut_ = function(_e) {
   if (Blockly.Tooltip.blocked_) {
     // Someone doesn't want us to show tooltips.
     return;

--- a/core/warning.js
+++ b/core/warning.js
@@ -149,12 +149,11 @@ Blockly.Warning.prototype.setVisible = function(visible) {
 
 /**
  * Bring the warning to the top of the stack when clicked on.
- * @param {!Event} e Mouse up event.
+ * @param {!Event} _e Mouse up event.
  * @private
  */
 
-Blockly.Warning.prototype.bodyFocus_ = function(
-    /* eslint-disable no-unused-vars */ e /* eslint-enable no-unused-vars */) {
+Blockly.Warning.prototype.bodyFocus_ = function(_e) {
   this.bubble_.promote_();
 };
 

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -260,15 +260,13 @@ Blockly.Workspace.prototype.deleteVariableInternal_ = function(variable, uses) {
 /**
  * Check whether a variable exists with the given name.  The check is
  * case-insensitive.
- * @param {string} name The name to check for.
+ * @param {string} _name The name to check for.
  * @return {number} The index of the name in the variable list, or -1 if it is
  *     not present.
  * @deprecated April 2017
  */
 
-Blockly.Workspace.prototype.variableIndexOf = function(
-    /* eslint-disable no-unused-vars */ name
-    /* eslint-enable no-unused-vars */) {
+Blockly.Workspace.prototype.variableIndexOf = function(_name) {
   console.warn(
       'Deprecated call to Blockly.Workspace.prototype.variableIndexOf');
   return -1;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Configure eslint to ignore unused arguments that start with an underscore.

### Reason for Changes

Lets us get rid of some per-argument flags that we were using to ignore unused variables.  These are mostly in handlers and callback functions that might be overridden, where we still want to document that it will be called with an argument.

### Test Coverage
eslint passes

### Additional Information
This is a nifty flag that I just learned about, but it's been in eslint for a while.