### PR TITLE
Setting the value of math_numnber toolbox blocks to 123.

### DIFF
--- a/demos/accessible/index.html
+++ b/demos/accessible/index.html
@@ -109,7 +109,9 @@
       <block type="controls_flow_statements"></block>
     </category>
     <category name="Math" colour="230">
-      <block type="math_number" gap="32"></block>
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <block type="math_number">

--- a/demos/code/index.html
+++ b/demos/code/index.html
@@ -113,7 +113,9 @@
       <block type="controls_flow_statements"></block>
     </category>
     <category name="%{BKY_CATMATH}" colour="%{BKY_MATH_HUE}">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <shadow type="math_number">

--- a/demos/custom-dialogs/index.html
+++ b/demos/custom-dialogs/index.html
@@ -34,7 +34,9 @@
 
   <xml id="toolbox" style="display: none">
     <category name="Inputs" colour="230">
-      <block type="math_number" gap="32"></block>
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
       <block type="text"></block>
       <block type="text_prompt_ext">
         <value name="TEXT">

--- a/demos/fixed/index.html
+++ b/demos/fixed/index.html
@@ -31,7 +31,9 @@
     <block type="controls_if"></block>
     <block type="logic_compare"></block>
     <block type="controls_repeat_ext"></block>
-    <block type="math_number"></block>
+    <block type="math_number">
+      <field name="NUM">123</field>
+    </block>
     <block type="math_arithmetic"></block>
     <block type="text"></block>
     <block type="text_print"></block>

--- a/demos/generator/index.html
+++ b/demos/generator/index.html
@@ -52,7 +52,9 @@
       <block type="controls_whileUntil"></block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
     </category>

--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -59,7 +59,9 @@
 
   <xml id="toolbox" style="display: none">
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <shadow type="math_number">

--- a/demos/interpreter/async-execution.html
+++ b/demos/interpreter/async-execution.html
@@ -59,7 +59,9 @@
       <block type="controls_whileUntil"></block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
     </category>

--- a/demos/interpreter/step-execution.html
+++ b/demos/interpreter/step-execution.html
@@ -66,7 +66,9 @@
       <block type="controls_whileUntil"></block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
     </category>

--- a/demos/maxBlocks/index.html
+++ b/demos/maxBlocks/index.html
@@ -68,7 +68,9 @@
       </block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
     </category>

--- a/demos/minimap/index.html
+++ b/demos/minimap/index.html
@@ -39,7 +39,9 @@
     <block type="controls_if"></block>
     <block type="logic_compare"></block>
     <block type="controls_repeat_ext"></block>
-    <block type="math_number"></block>
+    <block type="math_number">
+      <field name="NUM">123</field>
+    </block>
     <block type="math_arithmetic"></block>
     <block type="text"></block>
     <block type="text_print"></block>

--- a/demos/mirror/index.html
+++ b/demos/mirror/index.html
@@ -41,7 +41,9 @@
     <block type="controls_if"></block>
     <block type="logic_compare"></block>
     <block type="controls_repeat_ext"></block>
-    <block type="math_number"></block>
+    <block type="math_number">
+      <field name="NUM">123</field>
+    </block>
     <block type="math_arithmetic"></block>
     <block type="text"></block>
     <block type="text_print"></block>

--- a/demos/resizable/overlay.html
+++ b/demos/resizable/overlay.html
@@ -57,7 +57,9 @@
     <block type="controls_if"></block>
     <block type="logic_compare"></block>
     <block type="controls_repeat_ext"></block>
-    <block type="math_number"></block>
+    <block type="math_number">
+      <field name="NUM">123</field>
+    </block>
     <block type="math_arithmetic"></block>
     <block type="text"></block>
     <block type="text_print"></block>

--- a/demos/rtl/index.html
+++ b/demos/rtl/index.html
@@ -81,7 +81,9 @@
       <block type="controls_flow_statements"></block>
     </category>
     <category name="رياضيات">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
       <block type="math_trig"></block>

--- a/demos/storage/index.html
+++ b/demos/storage/index.html
@@ -68,7 +68,9 @@
       <block type="controls_whileUntil"></block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
     </category>

--- a/demos/toolbox/index.html
+++ b/demos/toolbox/index.html
@@ -78,7 +78,9 @@
       <block type="controls_flow_statements"></block>
     </category>
     <category name="Math">
-      <block type="math_number"></block>
+      <block type="math_number">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic"></block>
       <block type="math_single"></block>
       <block type="math_trig"></block>

--- a/tests/multi_playground.html
+++ b/tests/multi_playground.html
@@ -202,7 +202,9 @@ h1 {
       <block type="controls_flow_statements"></block>
     </category>
     <category name="Math" colour="230">
-      <block type="math_number" gap="32"></block>
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <shadow type="math_number">

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -441,7 +441,9 @@ h1 {
       <block type="controls_flow_statements"></block>
     </category>
     <category name="Math" colour="230">
-      <block type="math_number" gap="32"></block>
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <shadow type="math_number">
@@ -768,7 +770,9 @@ h1 {
       <block type="controls_flow_statements"></block>
     </category>
     <category name="Math" colour="230">
-      <block type="math_number" gap="32"></block>
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
       <block type="math_arithmetic">
         <value name="A">
           <shadow type="math_number">


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1659

### Proposed Changes

Setting the value of `math_numnber` toolbox blocks to 123.

<img width="411" alt="screen shot 2018-04-11 at 4 02 30 pm" src="https://user-images.githubusercontent.com/9916202/38647589-e34b48ba-3da1-11e8-9982-e12d310a4caf.png">

### Reason for Changes

Using 123 as a better indicator to the user this block can represent any number, and the user should replace this value with the desired number.

Admittedly, the basis of this assumption is not grounded in experimental evidence. App developers are encouraged to choose the right decision for their own apps.

### Test Coverage

Opened the Math toolbox category of every demo and playground.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
