### PR TITLE
Work around a problem with RTL mutators

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -160,8 +160,6 @@ Blockly.VerticalFlyout.prototype.position = function() {
     this.leftEdge_ = x;
   }
   this.positionAt_(this.width_, this.height_, x, y);
-
-
 };
 
 /**

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -155,7 +155,7 @@ Blockly.VerticalFlyout.prototype.position = function() {
   var x = targetWorkspaceMetrics.absoluteLeft;
   if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT) {
     x += (targetWorkspaceMetrics.viewWidth - this.width_);
-    // Save the location of the left edge of the flyout, for use when firefox
+    // Save the location of the left edge of the flyout, for use when Firefox
     // gets the bounding client rect wrong.
     this.leftEdge_ = x;
   }
@@ -323,15 +323,23 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1066435
     if (goog.userAgent.GECKO &&
         this.targetWorkspace_ && this.targetWorkspace_.isMutator) {
-      // If we're in a mutator, its scale is always 1, purely because of some
-      // oddities in our rendering optimizations.  The actual scale is the same
-      // as the scale on the parent workspace.
-      var scale = this.targetWorkspace_.options.parentWorkspace.scale;
-      var altX = x + this.leftEdge_ * scale;
-      // If the browser was obviously wrong, use the calculated value.  If the
-      // browser's value was plausible, trust it.
-      if (Math.abs(altX - x) > 10) {
-        x = altX;
+      // The position of the left side of the mutator workspace in pixels
+      // relative to the window origin.
+      var targetWsLeftPixels =
+          this.targetWorkspace_.svgGroup_.getBoundingClientRect().x;
+      // The client rect is in pixels relative to the window origin.  When the
+      // browser gets the wrong value it reports that the flyout left is the
+      // same as the mutator workspace left.
+      // We know that in a mutator workspace with the flyout on the right, the
+      // visible area of the workspace should be more than ten pixels wide.  If
+      // the browser reports that the flyout is within ten pixels of the left
+      // side of the workspace, ignore it and manually calculate the value.
+      if (Math.abs(targetWsLeftPixels - x) < 10) {
+        // If we're in a mutator, its scale is always 1, purely because of some
+        // oddities in our rendering optimizations.  The actual scale is the
+        // same as the scale on the parent workspace.
+        var scale = this.targetWorkspace_.options.parentWorkspace.scale;
+        x = x + this.leftEdge_ * scale;
       }
     }
     return new goog.math.Rect(x, -BIG_NUM, BIG_NUM + width, BIG_NUM * 2);

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -329,8 +329,12 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
       // oddities in our rendering optimizations.  The actual scale is the same
       // as the scale on the parent workspace.
       var scale = this.targetWorkspace_.options.parentWorkspace.scale;
-      x += this.leftEdge_ * scale;
-
+      var altX = x + this.leftEdge_ * scale;
+      // If the browser was obviously wrong, use the calculated value.  If the
+      // browser's value was plausible, trust it.
+      if (Math.abs(altX - x) > 10) {
+        x = altX;
+      }
     }
     return new goog.math.Rect(x, -BIG_NUM, BIG_NUM + width, BIG_NUM * 2);
   }


### PR DESCRIPTION


## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1425 
### Proposed Changes

Change the calculation of the delete area for flyouts in mutators in RTL in firefox.  Explicitly add an offset from the left side of the mutator.

### Reason for Changes

See #1425, but TLDR: Firefox is reporting the wrong value, and that bug has been around for years.  We surfaced it with a combination of changes to our DOM structure and changes to delete logic.

### Test Coverage

Tested in the playground in Firefox in RTL mode, with the if/else mutator.
Tested at a variety of scales.
Also tested in LTR mode to make sure there are no regressions.

Tested in Chrome to confirm no regressions.

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

As soon as we merge this they're going to fix Firefox and this will all break again :(

This should unblock the Blockly Games release.