### PR TITLE
Require goog.userAgent in the correct files.

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -29,8 +29,6 @@ goog.provide('Blockly.BlockSvg.render');
 
 goog.require('Blockly.BlockSvg');
 
-goog.require('goog.userAgent');
-
 
 // UI constants for rendering blocks.
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -39,7 +39,6 @@ goog.require('goog.Timer');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
-goog.require('goog.userAgent');
 
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -55,7 +55,6 @@ goog.require('Blockly.inject');
 goog.require('Blockly.utils');
 
 goog.require('goog.color');
-goog.require('goog.userAgent');
 
 
 // Turn off debugging when compiled.

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -39,6 +39,7 @@ goog.require('goog.events');
 goog.require('goog.style');
 goog.require('goog.ui.Menu');
 goog.require('goog.ui.MenuItem');
+goog.require('goog.userAgent');
 
 
 /**

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -29,7 +29,6 @@ goog.provide('Blockly.FieldImage');
 goog.require('Blockly.Field');
 goog.require('goog.dom');
 goog.require('goog.math.Size');
-goog.require('goog.userAgent');
 
 
 /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -37,7 +37,6 @@ goog.require('Blockly.WorkspaceSvg');
 goog.require('goog.dom');
 goog.require('goog.events');
 goog.require('goog.math.Rect');
-goog.require('goog.userAgent');
 
 
 /**

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -27,6 +27,8 @@
 
 goog.provide('Blockly.WorkspaceAudio');
 
+goog.require('goog.userAgent');
+
 
 /**
  * Class for loading, storing, and playing audio for a workspace.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -48,7 +48,6 @@ goog.require('Blockly.ZoomControls');
 goog.require('goog.array');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
-goog.require('goog.userAgent');
 
 
 /**


### PR DESCRIPTION
Removes requires in files that don't actually use it, and add requires in files that do use it.