### PR TITLE
Fix context menus on blocks with variables

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -261,13 +261,13 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
     if (this.isInFlyout){
       return;
     }
-    var varName = this.getFieldValue('VAR');
+    var variable = this.getField('VAR').getVariable();
+    var varName = variable.name;
     if (!this.isCollapsed() && varName != null) {
       var option = {enabled: true};
       option.text =
-        Blockly.Msg.VARIABLES_SET_CREATE_GET.replace('%1', varName);
-      var xmlField = goog.dom.createDom('field', null, varName);
-      xmlField.setAttribute('name', 'VAR');
+          Blockly.Msg.VARIABLES_SET_CREATE_GET.replace('%1', varName);
+      var xmlField = Blockly.Variables.generateVariableFieldDom(variable);
       var xmlBlock = goog.dom.createDom('block', null, xmlField);
       xmlBlock.setAttribute('type', 'variables_get');
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -371,12 +371,13 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 
     // Add options to create getters for each parameter.
     if (!this.isCollapsed()) {
-      for (var i = 0; i < this.arguments_.length; i++) {
+      for (var i = 0; i < this.argumentVarModels_.length; i++) {
         var option = {enabled: true};
-        var name = this.arguments_[i];
+        var argVar = this.argumentVarModels_[i];
+        var name = argVar.name;
         option.text = Blockly.Msg.VARIABLES_SET_CREATE_GET.replace('%1', name);
-        var xmlField = goog.dom.createDom('field', null, name);
-        xmlField.setAttribute('name', 'VAR');
+
+        var xmlField = Blockly.Variables.generateVariableFieldDom(argVar);
         var xmlBlock = goog.dom.createDom('block', null, xmlField);
         xmlBlock.setAttribute('type', 'variables_get');
         option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -113,7 +113,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
     }
 
     var option = {enabled: this.workspace.remainingCapacity() > 0};
-    var name = this.getFieldValue('VAR');
+    var name = this.getField('VAR').getText();
     option.text = contextMenuMsg.replace('%1', name);
     var xmlField = goog.dom.createDom('field', null, name);
     xmlField.setAttribute('name', 'VAR');

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -110,13 +110,11 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       contextMenuMsg = Blockly.Msg.VARIABLES_SET_CREATE_GET;
     }
 
-    var option = { enabled: this.workspace.remainingCapacity() > 0 };
-    var name = this.getFieldValue('VAR');
+    var option = {enabled: this.workspace.remainingCapacity() > 0};
+    var name = this.getField('VAR').getText();
     option.text = contextMenuMsg.replace('%1', name);
     var xmlField = goog.dom.createDom('field', null, name);
     xmlField.setAttribute('name', 'VAR');
-    var variableModel = this.workspace.getVariable(name);
-    xmlField.setAttribute('variabletype', variableModel.type);
     var xmlBlock = goog.dom.createDom('block', null, xmlField);
     xmlBlock.setAttribute('type', opposite_type);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);

--- a/core/variables.js
+++ b/core/variables.js
@@ -456,7 +456,8 @@ Blockly.Variables.generateVariableFieldXmlString = function(variableModel) {
 
 /**
  * Generate DOM objects representing a variable field.
- * @param {!Blockly.VariableModel} variableModel The variable model represent.
+ * @param {!Blockly.VariableModel} variableModel The variable model to
+ *     represent.
  * @return {Element} The generated DOM.
  * @package
  */

--- a/core/variables.js
+++ b/core/variables.js
@@ -159,7 +159,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       var gap = Blockly.Blocks['math_change'] ? 8 : 24;
       var blockText = '<xml>' +
             '<block type="variables_set" gap="' + gap + '">' +
-            Blockly.Variables.generateVariableFieldXml_(firstVariable) +
+            Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
             '</block>' +
             '</xml>';
       var block = Blockly.Xml.textToDom(blockText).firstChild;
@@ -169,7 +169,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       var gap = Blockly.Blocks['variables_get'] ? 20 : 8;
       var blockText = '<xml>' +
           '<block type="math_change" gap="' + gap + '">' +
-          Blockly.Variables.generateVariableFieldXml_(firstVariable) +
+          Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +
@@ -185,7 +185,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       if (Blockly.Blocks['variables_get']) {
         var blockText = '<xml>' +
             '<block type="variables_get" gap="8">' +
-            Blockly.Variables.generateVariableFieldXml_(variable) +
+            Blockly.Variables.generateVariableFieldXmlString(variable) +
             '</block>' +
             '</xml>';
         var block = Blockly.Xml.textToDom(blockText).firstChild;
@@ -439,9 +439,9 @@ Blockly.Variables.nameUsedWithAnyType_ = function(name, workspace) {
  * @param {!Blockly.VariableModel} variableModel The variable model to generate
  *     an XML string from.
  * @return {string} The generated XML.
- * @private
+ * @package
  */
-Blockly.Variables.generateVariableFieldXml_ = function(variableModel) {
+Blockly.Variables.generateVariableFieldXmlString = function(variableModel) {
   // The variable name may be user input, so it may contain characters that need
   // to be escaped to create valid XML.
   var typeString = variableModel.type;
@@ -449,9 +449,24 @@ Blockly.Variables.generateVariableFieldXml_ = function(variableModel) {
     typeString = '\'\'';
   }
   var text = '<field name="VAR" id="' + variableModel.getId() +
-    '" variabletype="' + goog.string.htmlEscape(typeString) +
-    '">' + goog.string.htmlEscape(variableModel.name) + '</field>';
+      '" variabletype="' + goog.string.htmlEscape(typeString) +
+      '">' + goog.string.htmlEscape(variableModel.name) + '</field>';
   return text;
+};
+
+/**
+ * Generate DOM objects representing a variable field.
+ * @param {!Blockly.VariableModel} variableModel The variable model represent.
+ * @return {Element} The generated DOM.
+ * @package
+ */
+Blockly.Variables.generateVariableFieldDom = function(variableModel) {
+  var xmlFieldString =
+      Blockly.Variables.generateVariableFieldXmlString(variableModel);
+  var text = '<xml>' + xmlFieldString + '</xml>';
+  var dom = Blockly.Xml.textToDom(text);
+  var fieldDom = dom.firstChild;
+  return fieldDom;
 };
 
 /**

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -94,7 +94,7 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
       var gap = 24;
       var blockText = '<xml>' +
           '<block type="variables_set_dynamic" gap="' + gap + '">' +
-          Blockly.Variables.generateVariableFieldXml_(firstVariable) +
+          Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
           '</block>' +
           '</xml>';
       var block = Blockly.Xml.textToDom(blockText).firstChild;
@@ -104,7 +104,7 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
       for (var i = 0, variable; variable = variableModelList[i]; i++) {
         var blockText = '<xml>' +
             '<block type="variables_get_dynamic" gap="8">' +
-            Blockly.Variables.generateVariableFieldXml_(variable) +
+            Blockly.Variables.generateVariableFieldXmlString(variable) +
             '</block>' +
             '</xml>';
         var block = Blockly.Xml.textToDom(blockText).firstChild;

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -392,7 +392,7 @@ function test_variableFieldXml_caseSensitive() {
   };
 
   var generatedXml =
-    Blockly.Variables.generateVariableFieldXml_(mockVariableModel);
+    Blockly.Variables.generateVariableFieldXmlString(mockVariableModel);
   var goldenXml =
       '<field name="VAR"' +
       ' id="' + id + '"' +


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1658 

### Proposed Changes

Update the text of the custom context menu options to refer to the variable by name, not ID.
Update the generated XML to create a block that refers to the correct variable.

### Reason for Changes

The previous implementation worked when variable field values gave the name of the variable rather than ID.  I missed this when testing variable by ID changes.

### Test Coverage

Unit tests pass.
I loaded all blocks that have this type of context menu option (XML is in a comment on #1658) and checked that the right-click menu said the right thing and generated the right block when clicked.

