### PR TITLE
Rewrote LOGIC_COMPARE_ONCHANGE_MIXIN to fix #1408.

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -520,8 +520,6 @@ Blockly.Constants.Logic.fixLogicCompareRtlOpLabels =
  * @readonly
  */
 Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
-  prevBlocks_: [null, null],
-
   /**
    * Called whenever anything on the workspace changes.
    * Prevent mismatched types from being compared.
@@ -529,25 +527,37 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
    * @this Blockly.Block
    */
   onchange: function(e) {
+    if (!this.prevBlocks_) {
+      this.prevBlocks_ = [null, null];
+    }
+
     var blockA = this.getInputTargetBlock('A');
     var blockB = this.getInputTargetBlock('B');
     // Disconnect blocks that existed prior to this change if they don't match.
     if (blockA && blockB &&
         !blockA.outputConnection.checkType_(blockB.outputConnection)) {
-      // Mismatch between two inputs.  Disconnect previous and bump it away.
-      // Ensure that any disconnections are grouped with the causing event.
+      // Mismatch between two inputs.  Revert the block connections,
+      // bumping away the newly connected block(s).
       Blockly.Events.setGroup(e.group);
-      for (var i = 0; i < this.prevBlocks_.length; i++) {
-        var block = this.prevBlocks_[i];
-        if (block === blockA || block === blockB) {
-          block.unplug();
-          block.bumpNeighbours_();
+      var prevA = this.prevBlocks_[0];
+      if (prevA !== blockA) {
+        blockA.unplug();
+        if (prevA) {
+          this.getInput('A').connection.connect(prevA.outputConnection);
         }
       }
+      var prevB = this.prevBlocks_[1];
+      if (prevB !== blockB) {
+        blockB.unplug();
+        if (prevB) {
+          this.getInput('B').connection.connect(prevB.outputConnection);
+        }
+      }
+      this.bumpNeighbours_();
       Blockly.Events.setGroup(false);
     }
-    this.prevBlocks_[0] = blockA;
-    this.prevBlocks_[1] = blockB;
+    this.prevBlocks_[0] = this.getInputTargetBlock('A');
+    this.prevBlocks_[1] = this.getInputTargetBlock('B');
   }
 };
 

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -542,14 +542,16 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
       var prevA = this.prevBlocks_[0];
       if (prevA !== blockA) {
         blockA.unplug();
-        if (prevA) {
+        if (prevA && !prevA.isShadow()) {
+          // The shadow block is automatically replaced during unplug().
           this.getInput('A').connection.connect(prevA.outputConnection);
         }
       }
       var prevB = this.prevBlocks_[1];
       if (prevB !== blockB) {
         blockB.unplug();
-        if (prevB) {
+        if (prevB && !prevB.isShadow()) {
+          // The shadow block is automatically replaced during unplug().
           this.getInput('B').connection.connect(prevB.outputConnection);
         }
       }

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1143,6 +1143,33 @@ h1 {
       <block type="example_angle"></block>
       <block type="example_date"></block>
     </category>
+    <category name="Mutators">
+      <label text="logic_compare"></label>
+      <block type="logic_compare">
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+      <block type="logic_compare">
+        <value name="A">
+          <block type="math_number">
+            <field name="NUM">10</field>
+          </block>
+        </value>
+        <value name="B">
+          <block type="math_number">
+            <field name="NUM">10</field>
+          </block>
+        </value>
+      </block>
+    </category>
     <category name="Style">
       <label text="Hats"></label>
       <block type="styled_event_cap"></block>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1408

### Proposed Changes

 * Create prevBlock_ upon first call to onchange.
 * Revert state upon an incompatible combination, bumping the new incompatible
   block, instead of the old block. Thus, the shadow is never the bumped block.

Bug:
 * The undo stack get caught in a loop, and will never undo back to a state
   equivalent to the previous action.

### Reason for Changes

Prevent the creation of orphan shadow blocks on the workspace.

### Test Coverage

Added a pair of `logic_compare` test blocks to the Playground "Test Blocks" toolbox.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
