### PR TITLE
Allow color constants in Blockly.Constants to be undefined.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -632,9 +632,9 @@ Blockly.checkBlockColourConstant_ = function(
       value = value[blocklyNamePath[i]];
     }
   }
-  var isExpectedValue = removed ?
-      value === undefined :
-      value == Blockly.Msg[msgName]; // Intentionally coercing the value.
+  // If the value is not removed, intentionally comparing coerced type (==).
+  var isExpectedValue =
+      (value === undefined) || (!removed && value == Blockly.Msg[msgName]);
   if (!isExpectedValue) {
     var warningPattern = removed ?
         '%1 is unused and has been removed. Override Blockly.Msg.%2.' :


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1792

### Proposed Changes

Do not warn if a deprecated constant is not defined.

### Reason for Changes

Warnings were emitted when a deprecated `Blockly.Constants` was not declared, usually because the `blocks/` file was not included in a app.

### Test Coverage

Tested (before and after change) by commenting out `Blockly.Constants.Colour.HUE` and reloading the playground.
Also re-tested the warnings when `Blockly.Constants.Colour.HUE` or `Blockly.blocks.colour.HUE` were overridden, and that no warnings were displayed in the console when loaded without edits.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
