### PR TITLE
Correct block color reference in demos/graph

### DIFF
--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -192,42 +192,34 @@ if (typeof google == 'object') {
 }
 
 // Define the custom blocks and their JS generators.
-Blockly.Blocks['graph_get_x'] = {
-  // x variable getter.
-  init: function() {
-    this.jsonInit({
-      "message0": "x",
-      "output": "Number",
-      "colour": Blockly.Msg.VARIABLES_HUE,
-      "tooltip": Blockly.Msg.VARIABLES_GET_TOOLTIP,
-      "helpUrl": Blockly.Msg.VARIABLES_GET_HELPURL
-    });
-  }
-};
+Blockly.defineBlocksWithJsonArray([{
+  "type": "graph_get_x",
+  "message0": "x",
+  "output": "Number",
+  "colour": Blockly.Msg.VARIABLES_HUE,
+  "tooltip": Blockly.Msg.VARIABLES_GET_TOOLTIP,
+  "helpUrl": Blockly.Msg.VARIABLES_GET_HELPURL
+}]);
 
 Blockly.JavaScript['graph_get_x'] = function(block) {
   // x variable getter.
   return ['x', Blockly.JavaScript.ORDER_ATOMIC];
 };
 
-Blockly.Blocks['graph_set_y'] = {
-  // y variable setter.
-  init: function() {
-    this.jsonInit({
-      "message0": "y = %1",
-      "args0": [
-        {
-          "type": "input_value",
-          "name": "VALUE",
-          "check": "Number"
-        }
-      ],
-      "colour": Blockly.Msg.VARIABLES_HUE,
-      "tooltip": Blockly.Msg.VARIABLES_SET_TOOLTIP,
-      "helpUrl": Blockly.Msg.VARIABLES_SET_HELPURL
-    });
-  }
-};
+Blockly.defineBlocksWithJsonArray([{
+  "type": "graph_set_y",
+  "message0": "y = %1",
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "VALUE",
+      "check": "Number"
+    }
+  ],
+  "colour": Blockly.Msg.VARIABLES_HUE,
+  "tooltip": Blockly.Msg.VARIABLES_SET_TOOLTIP,
+  "helpUrl": Blockly.Msg.VARIABLES_SET_HELPURL
+}]);
 
 Blockly.JavaScript['graph_set_y'] = function(block) {
   // y variable setter.

--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -198,7 +198,7 @@ Blockly.Blocks['graph_get_x'] = {
     this.jsonInit({
       "message0": "x",
       "output": "Number",
-      "colour": Blockly.Blocks.variables.HUE,
+      "colour": Blockly.Msg.VARIABLES_HUE,
       "tooltip": Blockly.Msg.VARIABLES_GET_TOOLTIP,
       "helpUrl": Blockly.Msg.VARIABLES_GET_HELPURL
     });
@@ -222,7 +222,7 @@ Blockly.Blocks['graph_set_y'] = {
           "check": "Number"
         }
       ],
-      "colour": Blockly.Blocks.variables.HUE,
+      "colour": Blockly.Msg.VARIABLES_HUE,
       "tooltip": Blockly.Msg.VARIABLES_SET_TOOLTIP,
       "helpUrl": Blockly.Msg.VARIABLES_SET_HELPURL
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1790

### Proposed Changes

Use color constant from the Msg table, not the deprecated and removed value.

### Reason for Changes

The old constant was removed, rendering the block black.

### Test Coverage

Ran the graph demo. Looked at both custom variable blocks.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
