### PR TITLE
Warn if jsonInit() receives a colour attribute without a value.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1086,15 +1086,15 @@ Blockly.Block.prototype.appendDummyInput = function(opt_name) {
  * @param {!Object} json Structured data describing the block.
  */
 Blockly.Block.prototype.jsonInit = function(json) {
-  var blockTypeName = json['type'];
+  var warningPrefix = json['type'] ? 'Block "' + json['type'] + '": ' : '';
 
   // Validate inputs.
   goog.asserts.assert(
       json['output'] == undefined || json['previousStatement'] == undefined,
-      'Must not have both an output and a previousStatement.');
+      warningPrefix + 'Must not have both an output and a previousStatement.');
 
   // Set basic properties of block.
-  this.jsonInitColour_(json);
+  this.jsonInitColour_(json, warningPrefix);
 
   // Interpolate the message blocks.
   var i = 0;
@@ -1132,8 +1132,10 @@ Blockly.Block.prototype.jsonInit = function(json) {
     this.setHelpUrl(localizedValue);
   }
   if (goog.isString(json['extensions'])) {
-    console.warn('JSON attribute \'extensions\' should be an array of ' +
-      'strings. Found raw string in JSON for \'' + json['type'] + '\' block.');
+    console.warn(
+        warningPrefix + 'JSON attribute \'extensions\' should be an array of' +
+        ' strings. Found raw string in JSON for \'' + json['type'] +
+        '\' block.');
     json['extensions'] = [json['extensions']];  // Correct and continue.
   }
 
@@ -1154,19 +1156,19 @@ Blockly.Block.prototype.jsonInit = function(json) {
 /**
  * Initialize the colour of this block from the JSON description.
  * @param {!Object} json Structured data describing the block.
+ * @param {string} warningPrefix Warning prefix string identifying block.
  * @private
  */
-Blockly.Block.prototype.jsonInitColour_ = function(json) {
+Blockly.Block.prototype.jsonInitColour_ = function(json, warningPrefix) {
   if ('colour' in json) {
     if (json['colour'] === undefined) {
-      console.warn('Block "' + blockTypeName + '": Undefined color value.');
+      console.warn(warningPrefix + 'Undefined color value.');
     } else {
       var rawValue = json['colour'];
       try {
         this.setColour(rawValue);
       } catch (colorError) {
-        console.warn(
-            'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
+        console.warn(warningPrefix + 'Illegal color value: ', rawValue);
       }
     }
   }

--- a/core/block.js
+++ b/core/block.js
@@ -1094,13 +1094,17 @@ Blockly.Block.prototype.jsonInit = function(json) {
       'Must not have both an output and a previousStatement.');
 
   // Set basic properties of block.
-  if (json['colour'] !== undefined) {
-    var rawValue = json['colour'];
-    try {
-      this.setColour(rawValue);
-    } catch (colorError) {
-      console.warn(
-          'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
+  if ('colour' in json) {
+    if (json['colour'] === undefined) {
+      console.warn('Block "' + blockTypeName + '": Undefined color value.');
+    } else {
+      var rawValue = json['colour'];
+      try {
+        this.setColour(rawValue);
+      } catch (colorError) {
+        console.warn(
+            'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
+      }
     }
   }
 

--- a/core/block.js
+++ b/core/block.js
@@ -1094,19 +1094,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
       'Must not have both an output and a previousStatement.');
 
   // Set basic properties of block.
-  if ('colour' in json) {
-    if (json['colour'] === undefined) {
-      console.warn('Block "' + blockTypeName + '": Undefined color value.');
-    } else {
-      var rawValue = json['colour'];
-      try {
-        this.setColour(rawValue);
-      } catch (colorError) {
-        console.warn(
-            'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
-      }
-    }
-  }
+  this.jsonInitColour_(json);
 
   // Interpolate the message blocks.
   var i = 0;
@@ -1159,6 +1147,27 @@ Blockly.Block.prototype.jsonInit = function(json) {
     for (var i = 0; i < extensionNames.length; ++i) {
       var extensionName = extensionNames[i];
       Blockly.Extensions.apply(extensionName, this, false);
+    }
+  }
+};
+
+/**
+ * Initialize the colour of this block from the JSON description.
+ * @param {!Object} json Structured data describing the block.
+ * @private
+ */
+Blockly.Block.prototype.jsonInitColour_ = function(json) {
+  if ('colour' in json) {
+    if (json['colour'] === undefined) {
+      console.warn('Block "' + blockTypeName + '": Undefined color value.');
+    } else {
+      var rawValue = json['colour'];
+      try {
+        this.setColour(rawValue);
+      } catch (colorError) {
+        console.warn(
+            'Block "' + blockTypeName + '": Illegal color value: ', rawValue);
+      }
     }
   }
 };


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #1790.

### Proposed Changes

In `jsonInit()`, if the JSON object has a `colour` attribute, but not a value, emit a warning.

For simplicity, this will occur on every block initialization of the given block type.

### Reason for Changes

Warn developers that their blocks may be referencing a removed colour constant, or similar error.

### Test Coverage

Ran the graph demo that was using the old constants.  Saw the new warning.
After rebasing, tested against a `logic_boolean` with an explicit `colour: undefined`.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
