### PR TITLE
Removing namespace declarations for deprecated and unused namespaces.

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.colour');  // Deprecated
 goog.provide('Blockly.Constants.Colour');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.lists');  // Deprecated
 goog.provide('Blockly.Constants.Lists');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.logic');  // Deprecated
 goog.provide('Blockly.Constants.Logic');
 
 goog.require('Blockly.Blocks');

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.loops');  // Deprecated
 goog.provide('Blockly.Constants.Loops');
 
 goog.require('Blockly.Blocks');

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.math');  // Deprecated
 goog.provide('Blockly.Constants.Math');
 
 goog.require('Blockly.Blocks');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -24,8 +24,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.procedures');
-
 goog.require('Blockly.Blocks');
 goog.require('Blockly');
 

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -24,7 +24,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.texts');  // Deprecated
 goog.provide('Blockly.Constants.Text');
 
 goog.require('Blockly.Blocks');

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -29,7 +29,6 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.variables');  // Deprecated.
 goog.provide('Blockly.Constants.Variables');
 
 goog.require('Blockly.Blocks');


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No reported issue.

### Proposed Changes

Removing the empty namespace objects that use to contain the original block colour constants.

### Reason for Changes

These namespaces use to contain the original block hue constants, but were deprecated (via comment, except for procedures) over a year ago. With the removal of those constants, the declarations were creating empty, unused objects.

References to old block constants were failing silently because the empty object existed.

### Test Coverage

Rebuilt compressed files and ran graph demo, which referred to the old constants (#1790).

With this change, the demo now throws:
```
index.html:225 Uncaught TypeError: Cannot read property 'HUE' of undefined
    at Blockly.BlockSvg.init (index.html:225)
    at Blockly.BlockSvg.Blockly.Block (blockly_compressed.js:1324)
    at new Blockly.BlockSvg (blockly_compressed.js:1377)
    at Blockly.WorkspaceSvg.newBlock (blockly_compressed.js:1231)
    at Object.Blockly.Xml.domToBlockHeadless_ (blockly_compressed.js:1202)
    at Object.Blockly.Xml.domToBlock (blockly_compressed.js:1199)
    at Object.Blockly.Xml.domToWorkspace (blockly_compressed.js:1195)
    at Graph.init (index.html:345)
```

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
