### PR TITLE
Deprecate Blockly.Constants.Colour and .Lists

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -30,7 +30,7 @@
 'use strict';
 
 goog.provide('Blockly.Blocks.colour');  // Deprecated
-goog.provide('Blockly.Constants.Colour');
+goog.provide('Blockly.Constants.Colour');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -30,7 +30,7 @@
 'use strict';
 
 goog.provide('Blockly.Blocks.lists');  // Deprecated
-goog.provide('Blockly.Constants.Lists');
+goog.provide('Blockly.Constants.Lists');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly');


### PR DESCRIPTION
Both namespaces are only used by the deprecated `HUE` constant.

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No issue. The constants were marked deprecated in a recent PR, which means the namespaces might be removed in the (far) future. The deprecation notice gives developers early warning on such removal.

### Proposed Changes

Adding comments to mark namespaces as deprecated.
Backdating the deprecation to the date the `HUE` constants were deprecated.

### Test Coverage

None. Only added comments.
