### PR TITLE
Revert #1796, restoring block file provide statements.

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.colour');  // Deprecated
 goog.provide('Blockly.Constants.Colour');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.lists');  // Deprecated
 goog.provide('Blockly.Constants.Lists');  // deprecated, 2018 April 5
 
 goog.require('Blockly.Blocks');

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.logic');  // Deprecated
 goog.provide('Blockly.Constants.Logic');
 
 goog.require('Blockly.Blocks');

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.loops');  // Deprecated
 goog.provide('Blockly.Constants.Loops');
 
 goog.require('Blockly.Blocks');

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.math');  // Deprecated
 goog.provide('Blockly.Constants.Math');
 
 goog.require('Blockly.Blocks');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -24,6 +24,8 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.procedures');
+
 goog.require('Blockly.Blocks');
 goog.require('Blockly');
 

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -24,6 +24,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.texts');  // Deprecated
 goog.provide('Blockly.Constants.Text');
 
 goog.require('Blockly.Blocks');

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -29,6 +29,7 @@
  */
 'use strict';
 
+goog.provide('Blockly.Blocks.variables');  // Deprecated.
 goog.provide('Blockly.Constants.Variables');
 
 goog.require('Blockly.Blocks');


### PR DESCRIPTION
This reverts commit 75459abfddda176a0c779ec555154d9563a2d67e, PR #1796.


## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly-games/issues/79

### Proposed Changes

Restores deprecated `goog.provides(..)` statements in block files.

### Reason for Changes

These were used to load the block files in projects that use Closure for full-project compilation.

### Test Coverage

None. Restoring old code. No additional changes.
