### PR TITLE
Stop handling keypresses when the workspace is hidden.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -173,9 +173,12 @@ Blockly.svgResize = function(workspace) {
  * @private
  */
 Blockly.onKeyDown_ = function(e) {
-  if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)) {
+  if (Blockly.mainWorkspace.options.readOnly || Blockly.utils.isTargetInput(e)
+      || (Blockly.mainWorkspace.rendered && !Blockly.mainWorkspace.isVisible)) {
     // No key actions on readonly workspaces.
     // When focused on an HTML text input widget, don't trap any keys.
+    // Ignore keypresses on rendered workspaces that have been explicitly
+    // hidden.
     return;
   }
   var deleteBlock = false;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -128,11 +128,19 @@ Blockly.WorkspaceSvg.prototype.resizeHandlerWrapper_ = null;
 
 /**
  * The render status of an SVG workspace.
- * Returns `true` for visible workspaces and `false` for non-visible,
- * or headless, workspaces.
+ * Returns `false` for headless workspaces and true for instances of
+ * `Blockly.WorkspaceSvg`.
  * @type {boolean}
  */
 Blockly.WorkspaceSvg.prototype.rendered = true;
+
+/**
+ * Whether the workspace is visible.  False if the workspace has been hidden
+ * by calling `setVisisble(false)`.
+ * @type {boolean}
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.isVisible = true;
 
 /**
  * Is this workspace the surface for a flyout?
@@ -830,6 +838,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
   } else {
     Blockly.hideChaff(true);
   }
+  this.isVisible = isVisible;
 };
 
 /**


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/LLK/scratch-blocks/issues/1019
### Proposed Changes

Add an `isVisible` property on `WorkspaceSvg`.
Make `rendered` specifically refer to whether a workspace is a `Workspace` or `WorkspaceSvg`.
Set `isVisible` when updating the visibility of a rendered workspace.
Check for `isVisible` when handling kepresses.

### Reason for Changes

Blockly shouldn't eat keyboard events when hidden.
Particularly annoying when trying to undo changes in the paint editor in scratch blocks accidentally deletes blocks instead.

### Test Coverage

Tested on my local playground and the hosted playground to make sure the behaviour has actually changed.

Added some blocks to the workspace.
Clicked "Hide"
Hit Ctrl-Z a few times
Clicked "Show"
Confirmed that all of the blocks are still there.

On the hosted playground I confirmed that some of the blocks had disappeared while hidden.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
