### PR TITLE
Removing Blockly.utils.getScale_() and usage.

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -210,9 +210,8 @@ Blockly.utils.getInjectionDivXY_ = function(element) {
   var y = 0;
   while (element) {
     var xy = Blockly.utils.getRelativeXY(element);
-    var scale = Blockly.utils.getScale_(element);
-    x = (x * scale) + xy.x;
-    y = (y * scale) + xy.y;
+    x = x + xy.x;
+    y = y + xy.y;
     var classes = element.getAttribute('class') || '';
     if ((' ' + classes + ' ').indexOf(' injectionDiv ') != -1) {
       break;
@@ -220,25 +219,6 @@ Blockly.utils.getInjectionDivXY_ = function(element) {
     element = element.parentNode;
   }
   return new goog.math.Coordinate(x, y);
-};
-
-/**
- * Return the scale of this element.
- * @param {!Element} element  The element to find the coordinates of.
- * @return {!number} number represending the scale applied to the element.
- * @private
- */
-Blockly.utils.getScale_ = function(element) {
-  var scale = 1;
-  var transform = element.getAttribute('transform');
-  if (transform) {
-    var transformComponents =
-        transform.match(Blockly.utils.getScale_.REGEXP_);
-    if (transformComponents && transformComponents[0]) {
-      scale = parseFloat(transformComponents[0]);
-    }
-  }
-  return scale;
 };
 
 /**
@@ -252,15 +232,6 @@ Blockly.utils.getScale_ = function(element) {
  */
 Blockly.utils.getRelativeXY.XY_REGEX_ =
     /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*\))?/;
-
-
-/**
- * Static regex to pull the scale values out of a transform style property.
- * Accounts for same exceptions as XY_REGEXP_.
- * @type {!RegExp}
- * @private
- */
-Blockly.utils.getScale_REGEXP_ = /scale\(\s*([-+\d.e]+)\s*\)/;
 
 /**
  * Static regex to pull the x,y,z values out of a translate3d() style property.


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1702

### Proposed Changes

Removing Blockly.utils.getScale_() and usage.

### Reason for Changes

The function only returns 1 for the two cases it was used on, making the scale multiplication a no-op.

### Test Coverage

Ran inside the playground, performing the two types of actions that trigger `getInjectionDivXY_(..)`: clicking in the scroll bar area to page one "page" (workspace width/height) at a time; clicking/dragging blocks out of the toolbox at various page & workspace zoom levels, including mutator workspaces.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
