### PR TITLE
Add a referencesVariables function to field

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -751,7 +751,7 @@ Blockly.Block.prototype.getVars = function() {
   var vars = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable) {
+      if (field.referencesVariables()) {
         vars.push(field.getValue());
       }
     }
@@ -768,7 +768,7 @@ Blockly.Block.prototype.getVarModels = function() {
   var vars = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable) {
+      if (field.referencesVariables()) {
         var model = this.workspace.getVariableById(field.getValue());
         // Check if the variable actually exists (and isn't just a potential
         // variable).
@@ -790,7 +790,7 @@ Blockly.Block.prototype.getVarModels = function() {
 Blockly.Block.prototype.updateVarName = function(variable) {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable &&
+      if (field.referencesVariables() &&
           variable.getId() == field.getValue()) {
         field.setText(variable.name);
       }
@@ -808,7 +808,7 @@ Blockly.Block.prototype.updateVarName = function(variable) {
 Blockly.Block.prototype.renameVarById = function(oldId, newId) {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldVariable &&
+      if (field.referencesVariables() &&
           oldId == field.getValue()) {
         field.setValue(newId);
       }

--- a/core/field.js
+++ b/core/field.js
@@ -604,3 +604,14 @@ Blockly.Field.prototype.setTooltip = function(_newTip) {
 Blockly.Field.prototype.getAbsoluteXY_ = function() {
   return goog.style.getPageOffset(this.borderRect_);
 };
+
+/**
+ * Whether this field references any Blockly variables.  If true it may need to
+ * be handled differently during serialization and deserialization.  Subclasses
+ * may override this.
+ * @return {boolean} True if this field has any variable references.
+ * @package
+ */
+Blockly.Field.prototype.referencesVariables = function() {
+  return false;
+};

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -354,11 +354,10 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
 };
 
 /**
- * Whether this field references any Blockly variables.  If true it may need to
- * be handled differently during serialization and deserialization.  Subclasses
- * may override this.
- * @return {boolean} True if this field has any variable references.
+ * Overrides referencesVariables(), indicating this field refers to a variable.
+ * @return {boolean} True.
  * @package
+ * @override
  */
 Blockly.FieldVariable.prototype.referencesVariables = function() {
   return true;

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -353,4 +353,15 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   this.setValue(id);
 };
 
+/**
+ * Whether this field references any Blockly variables.  If true it may need to
+ * be handled differently during serialization and deserialization.  Subclasses
+ * may override this.
+ * @return {boolean} True if this field has any variable references.
+ * @package
+ */
+Blockly.FieldVariable.prototype.referencesVariables = function() {
+  return true;
+};
+
 Blockly.Field.register('field_variable', Blockly.FieldVariable);

--- a/core/xml.js
+++ b/core/xml.js
@@ -136,7 +136,7 @@ Blockly.Xml.fieldToDomVariable_ = function(field) {
  */
 Blockly.Xml.fieldToDom_ = function(field) {
   if (field.name && field.EDITABLE) {
-    if (field instanceof Blockly.FieldVariable) {
+    if (field.referencesVariables()) {
       return Blockly.Xml.fieldToDomVariable_(field);
     } else {
       var container = goog.dom.createDom('field', null, field.getValue());
@@ -796,7 +796,7 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
 
   var workspace = block.workspace;
   var text = xml.textContent;
-  if (field instanceof Blockly.FieldVariable) {
+  if (field.referencesVariables()) {
     Blockly.Xml.domToFieldVariable_(workspace, xml, text, field);
   } else {
     field.setValue(text);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Merge issues with scratch-blocks.

### Proposed Changes

Add a `referencesVariables` function to field, and use it insteand of `field instanceof Blockly.FieldVariable`.

### Reason for Changes

Scratch blocks has more types of fields that references variables, and we have merge conflicts every place where we do one instanceof check and they do two.  

### Test Coverage
Played around with the playground, and all tests pass.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
