### PR TITLE
Fix a problem with scrolling on firefox

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -212,8 +212,9 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
   var delta = e.deltaY;
 
   if (delta) {
-    if (goog.userAgent.GECKO) {
-      // Firefox's deltas are a tenth that of Chrome/Safari.
+    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
+    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
+    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
       delta *= 10;
     }
     var metrics = this.getMetrics_();


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Fix pulled over from Scratch-blocks that uses the correct multiplier for a trackpad scroll event.
### Reason for Changes

Scrolling was weird on ff.
