### PR TITLE
Move workspace context menu options into contextmenu.js

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -294,20 +294,14 @@ Blockly.ContextMenu.blockDuplicateOption = function(block) {
  */
 Blockly.ContextMenu.blockCommentOption = function(block) {
   // If there's already a comment, add an option to delete it.
-  if (block.comment) {
-    var text = Blockly.Msg['REMOVE_COMMENT'];
-    var callback = function() {
-      block.setCommentText(null);
-    };
-  } else {
-    // If there's no comment, add an option to create a comment.
-    var text = Blockly.Msg['ADD_COMMENT'];
-    var callback = function() {
-      block.setCommentText('');
-    };
-  }
+  // If there's no comment, add an option to create a comment.
+  var msgIdentifier = block.comment ? 'REMOVE_COMMENT' : 'ADD_COMMENT';
+  var callback = function() {
+    block.setCommentText(block.comment ? null : '');
+  };
 
-  return Blockly.ContextMenu.createOption(text, !goog.userAgent.IE, callback);
+  return Blockly.ContextMenu.createOption(
+      Blockly.Msg[msgIdentifier], !goog.userAgent.IE, callback);
 };
 
 /**

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -302,6 +302,116 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
 };
 
 /**
+ * Make a context menu option for undoing the most recent action on the
+ * workspace.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsUndoOption = function(ws) {
+  return {
+    text: Blockly.Msg['UNDO'],
+    enabled: ws.hasUndoStack(),
+    callback: ws.undo.bind(ws, false)
+  };
+};
+
+/**
+ * Make a context menu option for redoing the most recent action on the
+ * workspace.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsRedoOption = function(ws) {
+  return {
+    text: Blockly.Msg['REDO'],
+    enabled: ws.hasRedoStack(),
+    callback: ws.undo.bind(ws, true)
+  };
+};
+
+/**
+ * Make a context menu option for cleaning up blocks on the workspace, by
+ * aligning them vertically.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
+ *     originated.
+ * @param {number} numTopBlocks The number of top blocks on the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsCleanupOption = function(ws, numTopBlocks) {
+  return {
+    text: Blockly.Msg['CLEAN_UP'],
+    enabled: numTopBlocks > 1,
+    callback: ws.cleanUp.bind(ws, true)
+  };
+};
+
+/**
+ * Helper function for toggling delete state on blocks on the workspace, to be
+ * called from a right-click menu.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @param {boolean} shouldCollapse True if the blocks should be collapsed, false
+ *     if they should be expanded.
+ * @private
+ */
+Blockly.ContextMenu.toggleCollapseFn_ = function(topBlocks, shouldCollapse) {
+  // Add a little animation to collapsing and expanding.
+  var DELAY = 10;
+  var ms = 0;
+  for (var i = 0; i < topBlocks.length; i++) {
+    var block = topBlocks[i];
+    while (block) {
+      setTimeout(block.setCollapsed.bind(block, shouldCollapse), ms);
+      block = block.getNextBlock();
+      ms += DELAY;
+    }
+  }
+};
+
+/**
+ * Make a context menu option for collapsing all block stacks on the workspace.
+ * @param {boolean} hasExpandedBlocks Whether there are any non-collapsed blocks
+ *     on the workspace.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsCollapseOption = function(hasExpandedBlocks, topBlocks) {
+  return {
+    enabled: hasExpandedBlocks,
+    text: Blockly.Msg['COLLAPSE_ALL'],
+    callback: function() {
+      Blockly.ContextMenu.toggleCollapseFn_(topBlocks, true);
+    }
+  };
+};
+
+/**
+ * Make a context menu option for expanding all block stacks on the workspace.
+ * @param {boolean} hasCollapsedBlocks Whether there are any collapsed blocks
+ *     on the workspace.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     the workspace.
+ * @return {!Object} A menu option, containing text, enabled, and a callback.
+ * @package
+ */
+Blockly.ContextMenu.wsExpandOption = function(hasCollapsedBlocks, topBlocks) {
+  return {
+    enabled: hasCollapsedBlocks,
+    text: Blockly.Msg['EXPAND_ALL'],
+    callback: function() {
+      Blockly.ContextMenu.toggleCollapseFn_(topBlocks, false);
+    }
+  };
+};
+
+/**
  * Make a context menu option for deleting the current workspace comment.
  * @param {!Blockly.WorkspaceCommentSvg} comment The workspace comment where the
  *     right-click originated.

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -311,46 +311,6 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
 };
 
 /**
- * Add a context menu option for undoing the most recent action on the
- * workspace.
- * @param {!Array.<!Object>} optionsArr Array of menu options to add to.
- * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
- *     originated.
- * @package
- */
-Blockly.ContextMenu.addWsUndoOption = function(optionsArr, ws) {
-  optionsArr.push(Blockly.ContextMenu.createOption(
-      Blockly.Msg['UNDO'], ws.hasUndoStack(), ws.undo.bind(ws, false)));
-};
-
-/**
- * Add a context menu option for redoing the most recent action on the
- * workspace.
- * @param {!Array.<!Object>} optionsArr Array of menu options to add to.
- * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
- *     originated.
- * @package
- */
-Blockly.ContextMenu.wsRedoOption = function(optionsArr, ws) {
-  optionsArr.push(Blockly.ContextMenu.createOption(
-      Blockly.Msg['REDO'], ws.hasRedoStack(), ws.undo.bind(ws, true)));
-};
-
-/**
- * Make a context menu option for cleaning up blocks on the workspace, by
- * aligning them vertically.
- * @param {!Blockly.WorkspaceSvg} ws The workspace where the right-click
- *     originated.
- * @param {number} numTopBlocks The number of top blocks on the workspace.
- * @return {!Object} A menu option, containing text, enabled, and a callback.
- * @package
- */
-Blockly.ContextMenu.wsCleanupOption = function(ws, numTopBlocks) {
-  return Blockly.ContextMenu.createOption(
-      Blockly.Msg['CLEAN_UP'], numTopBlocks > 1, ws.cleanUp.bind(ws, true));
-};
-
-/**
  * Helper function for toggling delete state on blocks on the workspace, to be
  * called from a right-click menu.
  * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -483,6 +483,22 @@ Blockly.Workspace.prototype.clearUndo = function() {
 };
 
 /**
+ * @return {boolean} whether there are any events in the redo stack.
+ * @package
+ */
+Blockly.Workspace.prototype.hasRedoStack = function() {
+  return this.redoStack_.length != 0;
+};
+
+/**
+ * @return {boolean} whether there are any events in the undo stack.
+ * @package
+ */
+Blockly.Workspace.prototype.hasUndoStack = function() {
+  return this.undoStack_.length != 0;
+};
+
+/**
  * When something in this workspace changes, call a function.
  * @param {!Function} func Function to call.
  * @return {!Function} Function that can be passed to

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -483,22 +483,6 @@ Blockly.Workspace.prototype.clearUndo = function() {
 };
 
 /**
- * @return {boolean} whether there are any events in the redo stack.
- * @package
- */
-Blockly.Workspace.prototype.hasRedoStack = function() {
-  return this.redoStack_.length != 0;
-};
-
-/**
- * @return {boolean} whether there are any events in the undo stack.
- * @package
- */
-Blockly.Workspace.prototype.hasUndoStack = function() {
-  return this.undoStack_.length != 0;
-};
-
-/**
  * When something in this workspace changes, call a function.
  * @param {!Function} func Function to call.
  * @return {!Function} Function that can be passed to

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1270,13 +1270,15 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   var ws = this;
 
   // Options to undo/redo previous action.
-  Blockly.ContextMenu.addWsUndoOption(menuOptions, this);
-  Blockly.ContextMenu.wsRedoOption(menuOptions, this);
+  menuOptions.push(Blockly.ContextMenu.createOption(Blockly.Msg['UNDO'],
+      this.undoStack_.length != 0, this.undo.bind(this, false)));
+  menuOptions.push(Blockly.ContextMenu.createOption(Blockly.Msg['REDO'],
+      this.redoStack_.length != 0, this.undo.bind(this, true)));
 
   // Option to clean up blocks.
   if (this.scrollbar) {
-    menuOptions.push(
-        Blockly.ContextMenu.wsCleanupOption(this, topBlocks.length));
+    menuOptions.push(Blockly.ContextMenu.createOption(Blockly.Msg['CLEAN_UP'],
+        topBlocks.length > 1, this.cleanUp.bind(this, true)));
   }
 
   if (this.options.collapse) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1270,8 +1270,8 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   var ws = this;
 
   // Options to undo/redo previous action.
-  menuOptions.push(Blockly.ContextMenu.wsUndoOption(this));
-  menuOptions.push(Blockly.ContextMenu.wsRedoOption(this));
+  Blockly.ContextMenu.addWsUndoOption(menuOptions, this);
+  Blockly.ContextMenu.wsRedoOption(menuOptions, this);
 
   // Option to clean up blocks.
   if (this.scrollbar) {
@@ -1301,6 +1301,10 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
         topBlocks));
   }
 
+  // Option to add a workspace comment.
+  if (this.options.comments) {
+    menuOptions.push(Blockly.ContextMenu.workspaceCommentOption(ws, e));
+  }
   // Option to delete all blocks.
   // Count the number of blocks that are deletable.
   var deleteList = Blockly.WorkspaceSvg.buildDeleteList_(topBlocks);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1303,10 +1303,6 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
         topBlocks));
   }
 
-  // Option to add a workspace comment.
-  if (this.options.comments) {
-    menuOptions.push(Blockly.ContextMenu.workspaceCommentOption(ws, e));
-  }
   // Option to delete all blocks.
   // Count the number of blocks that are deletable.
   var deleteList = Blockly.WorkspaceSvg.buildDeleteList_(topBlocks);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1270,28 +1270,15 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   var ws = this;
 
   // Options to undo/redo previous action.
-  var undoOption = {};
-  undoOption.text = Blockly.Msg['UNDO'];
-  undoOption.enabled = this.undoStack_.length > 0;
-  undoOption.callback = this.undo.bind(this, false);
-  menuOptions.push(undoOption);
-  var redoOption = {};
-  redoOption.text = Blockly.Msg['REDO'];
-  redoOption.enabled = this.redoStack_.length > 0;
-  redoOption.callback = this.undo.bind(this, true);
-  menuOptions.push(redoOption);
+  menuOptions.push(Blockly.ContextMenu.wsUndoOption(this));
+  menuOptions.push(Blockly.ContextMenu.wsRedoOption(this));
 
   // Option to clean up blocks.
   if (this.scrollbar) {
-    var cleanOption = {};
-    cleanOption.text = Blockly.Msg['CLEAN_UP'];
-    cleanOption.enabled = topBlocks.length > 1;
-    cleanOption.callback = this.cleanUp.bind(this);
-    menuOptions.push(cleanOption);
+    menuOptions.push(
+        Blockly.ContextMenu.wsCleanupOption(this, topBlocks.length));
   }
 
-  // Add a little animation to collapsing and expanding.
-  var DELAY = 10;
   if (this.options.collapse) {
     var hasCollapsedBlocks = false;
     var hasExpandedBlocks = false;
@@ -1307,57 +1294,18 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
       }
     }
 
-    /**
-     * Option to collapse or expand top blocks.
-     * @param {boolean} shouldCollapse Whether a block should collapse.
-     * @private
-     */
-    var toggleOption = function(shouldCollapse) {
-      var ms = 0;
-      for (var i = 0; i < topBlocks.length; i++) {
-        var block = topBlocks[i];
-        while (block) {
-          setTimeout(block.setCollapsed.bind(block, shouldCollapse), ms);
-          block = block.getNextBlock();
-          ms += DELAY;
-        }
-      }
-    };
+    menuOptions.push(Blockly.ContextMenu.wsCollapseOption(hasExpandedBlocks,
+        topBlocks));
 
-    // Option to collapse top blocks.
-    var collapseOption = {enabled: hasExpandedBlocks};
-    collapseOption.text = Blockly.Msg['COLLAPSE_ALL'];
-    collapseOption.callback = function() {
-      toggleOption(true);
-    };
-    menuOptions.push(collapseOption);
-
-    // Option to expand top blocks.
-    var expandOption = {enabled: hasCollapsedBlocks};
-    expandOption.text = Blockly.Msg['EXPAND_ALL'];
-    expandOption.callback = function() {
-      toggleOption(false);
-    };
-    menuOptions.push(expandOption);
+    menuOptions.push(Blockly.ContextMenu.wsExpandOption(hasCollapsedBlocks,
+        topBlocks));
   }
 
   // Option to delete all blocks.
   // Count the number of blocks that are deletable.
-  var deleteList = [];
-  function addDeletableBlocks(block) {
-    if (block.isDeletable()) {
-      deleteList = deleteList.concat(block.getDescendants(false));
-    } else {
-      var children = block.getChildren(false);
-      for (var i = 0; i < children.length; i++) {
-        addDeletableBlocks(children[i]);
-      }
-    }
-  }
-  for (var i = 0; i < topBlocks.length; i++) {
-    addDeletableBlocks(topBlocks[i]);
-  }
+  var deleteList = Blockly.WorkspaceSvg.buildDeleteList_(topBlocks);
 
+  var DELAY = 10;
   function deleteNext() {
     Blockly.Events.setGroup(eventGroup);
     var block = deleteList.shift();
@@ -1372,19 +1320,20 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
     Blockly.Events.setGroup(false);
   }
 
+  var deleteCount = deleteList.length;
   var deleteOption = {
-    text: deleteList.length == 1 ? Blockly.Msg['DELETE_BLOCK'] :
-        Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(deleteList.length)),
-    enabled: deleteList.length > 0,
+    text: deleteCount == 1 ? Blockly.Msg['DELETE_BLOCK'] :
+        Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(deleteCount)),
+    enabled: deleteCount > 0,
     callback: function() {
       if (ws.currentGesture_) {
         ws.currentGesture_.cancel();
       }
-      if (deleteList.length < 2 ) {
+      if (deleteCount < 2 ) {
         deleteNext();
       } else {
         Blockly.confirm(
-            Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1', deleteList.length),
+            Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1', deleteCount),
             function(ok) {
               if (ok) {
                 deleteNext();
@@ -1401,6 +1350,33 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   }
 
   Blockly.ContextMenu.show(e, menuOptions, this.RTL);
+};
+
+/**
+ * Build a list of all deletable blocks that are reachable from the given
+ * list of top blocks.
+ * @param {!Array.<!Blockly.BlockSvg>} topBlocks The list of top blocks on the
+ *     workspace.
+ * @return {!Array.<!Blockly.BlockSvg>} A list of deletable blocks on the
+ *     workspace.
+ * @private
+ */
+Blockly.WorkspaceSvg.buildDeleteList_ = function(topBlocks) {
+  var deleteList = [];
+  function addDeletableBlocks(block) {
+    if (block.isDeletable()) {
+      deleteList = deleteList.concat(block.getDescendants(false));
+    } else {
+      var children = block.getChildren(false);
+      for (var i = 0; i < children.length; i++) {
+        addDeletableBlocks(children[i]);
+      }
+    }
+  }
+  for (var i = 0; i < topBlocks.length; i++) {
+    addDeletableBlocks(topBlocks[i]);
+  }
+  return deleteList;
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Decompose pieces of the showContextMenu function on the workspace.

### Reason for Changes

Mergeability with Scratch Blocks, readability.

### Test Coverage

I checked that the playground still opens and runs.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
