### PR TITLE
Make ui events work when block is null; test

### DIFF
--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -34,6 +34,10 @@ goog.require('goog.math.Coordinate');
 
 /**
  * Class for a UI event.
+ * UI events are events that don't need to be sent over the wire for multi-user
+ * editing to work (e.g. scrolling the workspace, zooming, opening toolbox
+ * categories).
+ * UI events do not undo or redo.
  * @param {Blockly.Block} block The affected block.
  * @param {string} element One of 'selected', 'comment', 'mutator', etc.
  * @param {*} oldValue Previous value of element.
@@ -42,16 +46,13 @@ goog.require('goog.math.Coordinate');
  * @constructor
  */
 Blockly.Events.Ui = function(block, element, oldValue, newValue) {
-  if (!block) {
-    return;  // Blank event to be populated by fromJson.
-  }
-
   Blockly.Events.Ui.superClass_.constructor.call(this);
-  this.blockId = block.id;
-  this.workspaceId = block.workspace.id;
+  this.blockId = block ? block.id : null;
+  this.workspaceId = block? block.workspace.id : null;
   this.element = element;
   this.oldValue = oldValue;
   this.newValue = newValue;
+  // UI events do not undo or redo.
   this.recordUndo = false;
 };
 goog.inherits(Blockly.Events.Ui, Blockly.Events.Abstract);

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -312,6 +312,52 @@ function test_blockMove_constructoroldParentId() {
   }
 }
 
+function test_uiEvent_constructor_null() {
+  try {
+    Blockly.Events.setGroup('testGroup');
+    var event = new Blockly.Events.Ui(null, 'foo', 'bar', 'baz');
+    checkExactEventValues(event,
+        {
+          'blockId': null,
+          'workspaceId': null,
+          'type': 'ui',
+          'oldValue': 'bar',
+          'newValue': 'baz',
+          'element': 'foo',
+          'recordUndo': false,
+          'group': 'testGroup'
+        }
+    );
+  } finally {
+    Blockly.Events.setGroup(false);
+  }
+}
+
+function test_uiEvent_constructor_block() {
+  eventTest_setUpWithMockBlocks();
+  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  try {
+    var block1 = createSimpleTestBlock(workspace);
+    Blockly.Events.setGroup('testGroup');
+    var event = new Blockly.Events.Ui(block1, 'foo', 'bar', 'baz');
+    checkExactEventValues(event,
+        {
+          'blockId': '1',
+          'workspaceId': workspace.id,
+          'type': 'ui',
+          'oldValue': 'bar',
+          'newValue': 'baz',
+          'element': 'foo',
+          'recordUndo': false,
+          'group': 'testGroup'
+        }
+    );
+  } finally {
+    Blockly.Events.setGroup(false);
+    eventTest_tearDownWithMockBlocks();
+  }
+}
+
 function test_varCreate_constructor() {
   eventTest_setUp();
   try {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1810, I think.

### Proposed Changes

Don't cancel out of UI event creation if the block is null.  The block is essentially optional for UI events.
Add tests

### Reason for Changes

Fix bug #1810 

### Test Coverage
Tested in playground: opening one toolbox category and then another gives these events:

![image](https://user-images.githubusercontent.com/13686399/39608804-f40609ca-4ef8-11e8-8d0f-66d5b1745b1f.png)

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
