### PR TITLE
Delay getting inverse screen CTM until needed

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -272,9 +272,3 @@ Blockly.RENAME_VARIABLE_ID = 'RENAME_VARIABLE_ID';
  * @const {string}
  */
 Blockly.DELETE_VARIABLE_ID = 'DELETE_VARIABLE_ID';
-
-/**
- * A constant value that we can use to mark calculated properties as dirty.
- * @const {string}
- */
-Blockly.DIRTY = 'dirty';

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -298,7 +298,14 @@ Blockly.WorkspaceSvg.prototype.targetWorkspace = null;
  * @type {SVGMatrix}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = Blockly.DIRTY;
+Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = null;
+
+/**
+ * Inverted screen CTM is dirty, recalculate it.
+ * @type {Boolean}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.inverseScreenCTMDirty_ = true;
 
 /**
  * Getter for the inverted screen CTM.
@@ -308,13 +315,11 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
 
   // Defer getting the screen CTM until we actually need it, this should
   // avoid forced reflows from any calls to updateInverseScreenCTM.
-  if (this.inverseScreenCTM_ == Blockly.DIRTY) {
+  if (this.inverseScreenCTMDirty_) {
     var ctm = this.getParentSvg().getScreenCTM();
     if (ctm) {
       this.inverseScreenCTM_ = ctm.inverse();
-    } else {
-      // When dirty, and we can't get a CTM, set it to null.
-      this.inverseScreenCTM_ = null;
+      this.inverseScreenCTMDirty_ = false;
     }
   }
 
@@ -325,7 +330,7 @@ Blockly.WorkspaceSvg.prototype.getInverseScreenCTM = function() {
  * Mark the inverse screen CTM as dirty.
  */
 Blockly.WorkspaceSvg.prototype.updateInverseScreenCTM = function() {
-  this.inverseScreenCTM_ = Blockly.DIRTY;
+  this.inverseScreenCTMDirty_ = true;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

* Wait until we are asked for this inverse screen CTM instead of immediately requesting the CTM from the browser right after we've mutated it, causing a forced layout / recalc styles.

### Reason for Changes

* to quote Chrome Debugger - "Forced reflow is a likely performance bottleneck"
* This forced reflow happens 2-3x per workspace update
* Nothing seems to read this value until drag events/other events are processed

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
