### PR TITLE
Fix RTL mutators in Edge and IE

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -371,8 +371,15 @@ Blockly.Flyout.prototype.updateDisplay_ = function() {
 Blockly.Flyout.prototype.positionAt_ = function(width, height, x, y) {
   this.svgGroup_.setAttribute("width", width);
   this.svgGroup_.setAttribute("height", height);
-  var transform = 'translate(' + x + 'px,' + y + 'px)';
-  Blockly.utils.setCssTransform(this.svgGroup_, transform);
+  if (this.svgGroup_.tagName == 'svg') {
+    var transform = 'translate(' + x + 'px,' + y + 'px)';
+    Blockly.utils.setCssTransform(this.svgGroup_, transform);
+  } else {
+    // IE and Edge don't support CSS transforms on SVG elements so
+    // it's important to set the transform on the SVG element itself
+    var transform = 'translate(' + x + ',' + y + ')';
+    this.svgGroup_.setAttribute("transform", transform);
+  }
 
   // Update the scrollbar (if one exists).
   if (this.scrollbar_) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1806

### Proposed Changes

CSS transforms on SVG (inner) elements are not supported in IE and Edge.

I've scanned the codebase and https://github.com/google/blockly/blob/master/core/flyout_base.js#L375 (when the tagname is a `<g>`) is the only instance where Blockly.utils.setCssTransform is used on an SVG (inner) element. All other instances apply this on the SVG `<svg>` element and that's okay.

### Reason for Changes

RTL mutators were broken on IE and Edge. The transform wasn't getting applied and so both the flyout and the workspace were left aligned (on top of each other)

### Test Coverage

Tested on: 
- Desktop Mac Chrome
- IE 11
- Edge 16

### Additional Information

Not sure how to avoid something like this in the future @rachel-fenichel any thoughts?