### PR TITLE
Adding gulpfile to build Node.js compatible library.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,10 @@
 *_compressed*.js
 *_uncompressed*.js
+blockly_node_javascript_en.js
+gulpfile.js
 /msg/*
 /core/css.js
+/core/node_lib_suffix.js
 /tests/blocks/*
 /tests/compile/*
 /tests/jsunit/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,6 @@ blockly_node_javascript_en.js
 gulpfile.js
 /msg/*
 /core/css.js
-/core/node_lib_suffix.js
 /tests/blocks/*
 /tests/compile/*
 /tests/jsunit/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+blockly_node_javascript_en.js
 node_modules
 npm-debug.log
 .DS_Store

--- a/core/node_lib_suffix.js
+++ b/core/node_lib_suffix.js
@@ -1,7 +1,0 @@
-// Expose Blockly global.
-if (typeof module === 'object') {
-  module.exports = Blockly;
-}
-if (typeof window === 'object') {
-  window.Blockly === Blockly;
-}

--- a/core/node_lib_suffix.js
+++ b/core/node_lib_suffix.js
@@ -1,0 +1,7 @@
+// Expose Blockly global.
+if (typeof module === 'object') {
+  module.exports = Blockly;
+}
+if (typeof window === 'object') {
+  window.Blockly === Blockly;
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,8 +59,8 @@ gulp.task('blockly_javascript_en', ['build'], function() {
   return gulp.src(srcs)
       .pipe(gulp.concat('blockly_node_javascript_en.js'))
       .pipe(insert.append(`
-if (typeof module === 'object') module.exports = Blockly;
-if (typeof window === 'object') window.Blockly = Blockly;\n`))
+if (typeof module === 'object') { module.exports = Blockly; }
+if (typeof window === 'object') { window.Blockly = Blockly; }\n`))
       .pipe(gulp.dest(''));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,7 @@
 var gulp = require('gulp');
 gulp.shell = require('gulp-shell');
 gulp.concat = require('gulp-concat');
+var insert = require('gulp-insert');
 
 // Rebuilds Blockly, including the following:
 //  - blockly_compressed.js
@@ -52,11 +53,14 @@ gulp.task('blockly_javascript_en', ['build'], function() {
     'blockly_compressed.js',
     'blocks_compressed.js',
     'javascript_compressed.js',
-    'msg/js/en.js',
-    'core/node_lib_suffix.js'
+    'msg/js/en.js'
   ];
+  // Concatenate the sources, appending the module export at the bottom.
   return gulp.src(srcs)
       .pipe(gulp.concat('blockly_node_javascript_en.js'))
+      .pipe(insert.append(`
+if (typeof module === 'object') module.exports = Blockly;
+if (typeof window === 'object') window.Blockly = Blockly;\n`))
       .pipe(gulp.dest(''));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Gulp script to build Blockly for Node & NPM.
+ * Run this script by calling "npm install" in this directory.
+ */
+
+var gulp = require('gulp');
+gulp.shell = require('gulp-shell');
+gulp.concat = require('gulp-concat');
+
+// Rebuilds Blockly, including the following:
+//  - blockly_compressed.js
+//  - blocks_compressed.js
+//  - Localization string tables in msg/js/*.js
+//  - Generators in generators/*.js
+// These files are already up-to-date in the master branch.
+gulp.task('build', gulp.shell.task([
+  'python build.py'
+]));
+
+// Concatenates the necessary files to load Blockly in a Node.js VM.  Blockly's
+// inidividual libraries target use in a browser, where globals (via the window
+// objects) are used to share state and APIs.  By concatenating all the
+// necessary components into a single file, Blockly can be loaded as a Node.js
+// module.
+//
+// This task builds Node with the assumption that the app needs English blocks
+// and JavaScript code generation.  If you need another localization or
+// generator language, just copy and edit the srcs. Only one localization
+// language can be included.
+gulp.task('blockly_javascript_en', ['build'], function() {
+  var srcs = [
+    'blockly_compressed.js',
+    'blocks_compressed.js',
+    'javascript_compressed.js',
+    'msg/js/en.js',
+    'core/node_lib_suffix.js'
+  ];
+  return gulp.src(srcs)
+      .pipe(gulp.concat('blockly_node_javascript_en.js'))
+      .pipe(gulp.dest(''));
+});
+
+/**
+ * Task-builder for the watch function. Currently any change invokes the whole
+ * build script. Invoke with "gulp watch".
+ *
+ * @param {?string=} concatTask Name of the concatenating task for node usage.
+ */
+// TODO: Only run the necessary phases of the build script for a given change.
+function buildWatchTaskFn(concatTask) {
+  return function() {
+    // Tasks to trigger.
+    var tasks = ['build'];
+    if (concatTask) {
+      tasks.push(concatTask);
+    }
+
+    // Currently any changes invokes the whole build script. (To fix.)
+    var srcs = [
+      'core/**/*.js',                      // Blockly core code
+      'blocks/*.js',                       // Block definitions
+      'generators/**/*.js',                // Code generation
+      'msg/messages.js', 'msg/json/*.json' // Localization data
+    ];
+    var options = {
+      debounceDelay: 2000   // Milliseconds to delay rebuild.
+    };
+    gulp.watch(srcs, options, tasks);
+  };
+}
+
+// Watch Blockly files for changes and trigger automatic rebuilds, including
+// the Node-ready blockly_node_javascript_en.js file.
+gulp.task('watch', buildWatchTaskFn('blockly_javascript_en'));
+
+// The default task concatenates files for Node.js, using English language
+// blocks and the JavaScript generator.
+gulp.task('default', ['blockly_javascript_en']);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "eslint": "^4.16",
     "gulp-concat": "^2.6.1",
+    "gulp-insert": "^0.5.0",
     "gulp-series": "^1.0.2",
     "gulp-shell": "^0.6.5",
     "jshint": "^2.9.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "blockly",
-  "version": "1.0.0",
+  "version": "1.20180420.0-develop",
   "description": "Blockly is a library for building visual programming editors.",
+  "main": "blockly_node_javascript_en.js",
   "keywords": [
     "blockly"
   ],
@@ -17,6 +18,7 @@
     "name": "Neil Fraser"
   },
   "scripts": {
+    "prepare": "gulp default",
     "lint": "eslint .",
     "pretest": "tests/scripts/test_setup.sh",
     "test": "node tests/test_runner.js"
@@ -24,8 +26,11 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
-    "jshint": "latest",
-    "eslint": "^4.16"
+    "eslint": "^4.16",
+    "gulp-concat": "^2.6.1",
+    "gulp-series": "^1.0.2",
+    "gulp-shell": "^0.6.5",
+    "jshint": "^2.9.5"
   },
   "jshintConfig": {
     "globalstrict": true,
@@ -43,6 +48,7 @@
   },
   "dependencies": {
     "google-closure-library": "^20180204.0.0",
+    "gulp": "^3.9.1",
     "install": "^0.8.8",
     "npm": "^4.4.4",
     "webdriverio": "^4.6.2"


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Importing Blockly into a Node.js project, which is important for headless testing.

### Proposed Changes

The gulp file is derived from work in PR #887, with numerous
refinements and clarifying comments.

Also updating the version number in package.json, including the
'develop' prerelease tag for the develop branch.

### Reason for Changes

This is a long requested feature, and one important for testing our headless infrastructure.

### Test Coverage

I built using `npm install`, and then successfully ran `var Blockly = require('./blockly');` inside Node, check for the presence of expected Blockly API and block definitions.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
 * Node!!! (v8.11.1)

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
