### PR TITLE
Button to load all XML files for testing

### DIFF
--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -70,6 +70,7 @@
 <script src="../../blocks/colour.js"></script>
 <script src="../../blocks/variables.js"></script>
 <script src="../../blocks/procedures.js"></script>
+
 <script>
 'use strict';
 
@@ -87,6 +88,49 @@ function start() {
        zoom: {controls: true, wheel: true}
        });
   changeIndex();
+}
+
+var all_test_names = [
+  'logic',
+  'loops1',
+  'loops2',
+  'loops3',
+  'math',
+  'text',
+  'lists',
+  'colour',
+  'variables',
+  'functions'
+];
+
+/*
+ * Run this test to load all of the test files in all_test_names.  The contents
+ * will be loaded into the workspace in order.  To test the generators:
+ * - select your language from the buttons above the text area
+ * - copy all of the generated code
+ * - run it in an interpreter of your choice
+ * - scan all of the results for "FAIL".  All test suites are running in order,
+ *      and each will report OK or FAIL based only on the tests in that suite.
+ * If some tests are failing, load test suites individually to continue
+ * debugging.
+ */
+function loadAll() {
+  var output = document.getElementById('importExport');
+  output.style.background = 'gray';
+
+  var loadingElem = document.getElementById('loading');
+  loadingElem.textContent = 'loading...';
+  for (var i = 0; i < all_test_names.length; i++) {
+    var testName = all_test_names[i];
+    var url = testName + '.xml';
+
+    var xmlText = fetchFile(url);
+    if (xmlText !== null) {
+      fromXml(url, xmlText, /* opt_append */ true);
+    }
+  }
+  output.style.background = '';
+  loadingElem.textContent = 'done';
 }
 
 function loadXml() {
@@ -127,16 +171,24 @@ function fetchFile(xmlUrl) {
 /**
  * @param {string} filename The URL (or other name) of the XML, for reporting.
  * @param {string} xmlText The actual XML text.
+ * @param {boolean=} opt_append True if the XML should be appended to the
+ *     workspace.  Otherwise the workspace is cleared and the new XML is loaded.
  */
-function fromXml(filename, xmlText) {
+function fromXml(filename, xmlText, opt_append) {
   var output = document.getElementById('importExport');
   output.value = xmlText;
   output.scrollTop = 0;
   output.scrollLeft = 0;
-  demoWorkspace.clear();
+  if (!opt_append) {
+    demoWorkspace.clear();
+  }
   try {
     var xmlDoc = Blockly.Xml.textToDom(xmlText);
-    Blockly.Xml.domToWorkspace(xmlDoc, demoWorkspace);
+    if (opt_append) {
+      Blockly.Xml.appendDomToWorkspace(xmlDoc, demoWorkspace);
+    } else {
+      Blockly.Xml.domToWorkspace(xmlDoc, demoWorkspace);
+    }
   } catch (e) {
     var msg = 'Error parsing XML: ' + filename + '\n\n\t' + e;
     if (e.stack) {
@@ -219,6 +271,9 @@ h1 {
 #importExport {
   height: 100%;
   width: 100%;
+}
+#loading {
+  color: red;
 }
 </style>
 </head>
@@ -339,6 +394,11 @@ h1 {
         <option value="">Other...</option>
       </select>
       <input type="button" value="Load" onclick="loadXml()">
+    </p>
+
+    <p>
+      <input type="button" value="Load all" id="loadAllBtn" onclick="loadAll()">
+      <label for="loadAllBtn" id="loading"></label>
     </p>
 
     <p>

--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -90,19 +90,6 @@ function start() {
   changeIndex();
 }
 
-var all_test_names = [
-  'logic',
-  'loops1',
-  'loops2',
-  'loops3',
-  'math',
-  'text',
-  'lists',
-  'colour',
-  'variables',
-  'functions'
-];
-
 /*
  * Run this test to load all of the test files in all_test_names.  The contents
  * will be loaded into the workspace in order.  To test the generators:
@@ -120,13 +107,15 @@ function loadAll() {
 
   var loadingElem = document.getElementById('loading');
   loadingElem.textContent = 'loading...';
-  for (var i = 0; i < all_test_names.length; i++) {
-    var testName = all_test_names[i];
-    var url = testName + '.xml';
 
-    var xmlText = fetchFile(url);
-    if (xmlText !== null) {
-      fromXml(url, xmlText, /* opt_append */ true);
+  var options = document.getElementById('testUrl').options;
+  for (var i = 0; i < options.length; i++) {
+    var testUrl = options[i].value;
+    if (testUrl) {
+      var xmlText = fetchFile(testUrl);
+      if (xmlText !== null) {
+        fromXml(testUrl, xmlText, /* opt_append */ true);
+      }
     }
   }
   output.style.background = '';


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Makes it easier and faster to run all of the generator tests for a single language at once.

### Proposed Changes

Add a button that loads all of the test suites into the workspace in order, using appendDomToWorkspace.

### Reason for Changes

A lot of the time required for generator testing is in the repeated clicks to load and generate for each file.  This reduces that time in the case that everything works.

### Test Coverage
I loaded everything, then ran the tests in various languages.  PHP still fails with the known bug in the list generators; everything else works.

Tested on
* Desktop Firefox

### Additional Information

We still need to find a way to fully automate generating and running code, so that we can add it to travis.