### PR TITLE
Don't build upon npm install.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('build', gulp.shell.task([
 // and JavaScript code generation.  If you need another localization or
 // generator language, just copy and edit the srcs. Only one localization
 // language can be included.
-gulp.task('blockly_javascript_en', ['build'], function() {
+gulp.task('blockly_javascript_en', function() {
   var srcs = [
     'blockly_compressed.js',
     'blocks_compressed.js',
@@ -99,4 +99,4 @@ gulp.task('watch', buildWatchTaskFn('blockly_javascript_en'));
 
 // The default task concatenates files for Node.js, using English language
 // blocks and the JavaScript generator.
-gulp.task('default', ['blockly_javascript_en']);
+gulp.task('default', ['build', 'blockly_javascript_en']);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "name": "Neil Fraser"
   },
   "scripts": {
-    "prepare": "gulp default",
+    "prepare": "gulp blockly_javascript_en",
     "lint": "eslint .",
     "pretest": "tests/scripts/test_setup.sh",
     "test": "node tests/test_runner.js"
@@ -27,6 +27,7 @@
   "private": true,
   "devDependencies": {
     "eslint": "^4.16",
+    "google-closure-library": "^20180506.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-insert": "^0.5.0",
@@ -48,8 +49,5 @@
     "sub": true,
     "undef": true,
     "unused": true
-  },
-  "dependencies": {
-    "google-closure-library": "^20180506.0.0"
   }
 }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Don't run `build.py` upon `npm install`.
Moving `google-closure-library` dependency to `devDependencies` (which was supposed to be in the previous commit).

### Reason for Changes

Build depends upon ../closure-library, which is outside the usual
npm process. And since the library ships pre-built, just concatenate
the built files to make the node-ready version.

### Test Coverage

Created a clean copy (`git archive | tar -x`) in a directory without a sibling `../closure-library` and ran `npm install`. Verified build did not run but `blockly_node_javascript_en.js` was created (triggering errors related to #1812).

Tested on:
 * Node.js