### PR TITLE
Revised references to window to solve Node issues.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -464,8 +464,8 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
   };
 
   var bindData = [];
-  if (goog.global.window && goog.global.window.PointerEvent &&
-      (name in Blockly.Touch.TOUCH_MAP)) {
+  var window = goog.global['window'];
+  if (window && window.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
     for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
       node.addEventListener(type, wrapFunc, false);
       bindData.push([node, type, wrapFunc]);
@@ -517,8 +517,8 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
   };
 
   var bindData = [];
-  if (goog.global.window && goog.global.window.PointerEvent &&
-      (name in Blockly.Touch.TOUCH_MAP)) {
+  var window = goog.global['window'];
+  if (window && window.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
     for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
       node.addEventListener(type, wrapFunc, false);
       bindData.push([node, type, wrapFunc]);

--- a/core/touch.js
+++ b/core/touch.js
@@ -48,7 +48,8 @@ Blockly.Touch.touchIdentifier_ = null;
  * @type {Object}
  */
 Blockly.Touch.TOUCH_MAP = {};
-if (goog.global.window && goog.global.window.PointerEvent) {
+var window = goog.global['window'];
+if (window && window.PointerEvent) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['pointerdown'],
     'mouseenter': ['pointerenter'],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1812 regression

### Proposed Changes

Replacing `goog.global.window` with `goog.global['window']`, which seems to get past the compiler and loads into Node again.

### Reason for Changes

Sometime in the last three weeks (since #1818), closure compiler started unwrapping `goog.global.window` references, breaking Node usage again.

### Test Coverage

Rebuilt via gulp after change, and tested `var Blockly = require('.');` in node, in effect loading a rebuilt the `blockly_node_javascript_en.js`. This command was failing prior to this change.

Tested on:
 * Node.js