### PR TITLE
Fix advanced compilation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,9 @@ matrix:
       node_js: stable
       osx_image: xcode8.3
 
-before_install:
-- npm install google-closure-library
-- npm install google-closure-compiler
-- npm install webdriverio
-# Symlink closure library
-- ln -s $(npm root)/google-closure-library ../closure-library
-
 before_script:
+  # Symlink closure library
+  - ln -s $(npm root)/google-closure-library ../closure-library
   - export DISPLAY=:99.0
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then ( tests/scripts/setup_linux_env.sh ) fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ( tests/scripts/setup_osx_env.sh ) fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       osx_image: xcode8.3
 
 before_script:
+  # Symlink closure library used by test/jsunit
+  - ln -s $(npm root)/google-closure-library ../closure-library
   - export DISPLAY=:99.0
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then ( tests/scripts/setup_linux_env.sh ) fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ( tests/scripts/setup_osx_env.sh ) fi
@@ -23,4 +25,5 @@ script:
   - set -x
   - npm run lint
   - npm test
+  - tests/compile/compile.sh
   - cd tests/compile; compile.sh; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       osx_image: xcode8.3
 
 before_script:
-  # Symlink closure library
-  - ln -s $(npm root)/google-closure-library ../closure-library
   - export DISPLAY=:99.0
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then ( tests/scripts/setup_linux_env.sh ) fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ( tests/scripts/setup_osx_env.sh ) fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ script:
   - npm run lint
   - npm test
   - tests/compile/compile.sh
-  - cd tests/compile; compile.sh; cd ..

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "private": true,
   "devDependencies": {
     "eslint": "^4.16",
+    "google-closure-compiler": "^20180506.0.0",
     "google-closure-library": "^20180506.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -19,7 +19,7 @@ fi
 echo Using $COMPILER as the compiler.
 rm main_compressed.js 2> /dev/null
 echo Compiling Blockly...
-java -jar $COMPILER --js='tests/compile/main.js' \
+COMPILATION_COMMAND="java -jar $COMPILER --js='tests/compile/main.js' \
   --js='core/**.js' \
   --js='blocks/**.js' \
   --js='generators/**.js' \
@@ -30,7 +30,9 @@ java -jar $COMPILER --js='tests/compile/main.js' \
   --externs externs/svg-externs.js \
   --compilation_level ADVANCED_OPTIMIZATIONS \
   --dependency_mode=STRICT --entry_point=Main \
-  --js_output_file 'tests/compile/main_compressed.js'
+  --js_output_file 'tests/compile/main_compressed.js'"
+echo $COMPILATION_COMMAND
+$COMPILATION_COMMAND
 if [ -s main_compressed.js ]; then
   echo Compilation OK.
 else

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -13,21 +13,24 @@ else
   exit 1
 fi
 
+# TODO: Find relative path to Blockly root. For now, assume it is pwd.
+# TODO: Find relative path to closure, possibly in node_modules.
+
 echo Using $COMPILER as the compiler.
 rm main_compressed.js 2> /dev/null
 echo Compiling Blockly...
-java -jar $COMPILER --js='main.js' \
-  --js='../../core/**.js' \
-  --js='../../blocks/**.js' \
-  --js='../../generators/**.js' \
-  --js='../../msg/js/**.js' \
-  --js='../../../closure-library/closure/goog/**.js' \
-  --js='../../../closure-library/third_party/closure/goog/**.js' \
+java -jar $COMPILER --js='tests/compile/main.js' \
+  --js='core/**.js' \
+  --js='blocks/**.js' \
+  --js='generators/**.js' \
+  --js='msg/js/**.js' \
+  --js='../closure-library/closure/goog/**.js' \
+  --js='../closure-library/third_party/closure/goog/**.js' \
   --generate_exports \
-  --externs ../../externs/svg-externs.js \
+  --externs externs/svg-externs.js \
   --compilation_level ADVANCED_OPTIMIZATIONS \
   --dependency_mode=STRICT --entry_point=Main \
-  --js_output_file main_compressed.js
+  --js_output_file 'tests/compile/main_compressed.js'
 if [ -s main_compressed.js ]; then
   echo Compilation OK.
 else

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -1,10 +1,12 @@
 echo "Executing compile.sh from $(pwd)"
 
+# TODO: Find relative path to Blockly root. For now, assume it is pwd.
+
 # Find the Closure Compiler.
 if [ -f "$(npm root)/google-closure-compiler/compiler.jar" ]; then
   COMPILER="$(npm root)/google-closure-compiler/compiler.jar"
-elif [ -f *compiler*.jar ]; then
-  COMPILER="*compiler*.jar"
+elif [ -f tests/compile/*compiler*.jar ]; then
+  COMPILER="tests/compile/*compiler*.jar"
   # TODO: Check whether multiple files were found.
 else
   echo "ERROR: Closure Compiler not found."
@@ -13,11 +15,8 @@ else
   exit 1
 fi
 
-# TODO: Find relative path to Blockly root. For now, assume it is pwd.
-# TODO: Find relative path to closure, possibly in node_modules.
-
 echo Using $COMPILER as the compiler.
-rm main_compressed.js 2> /dev/null
+rm tests/compile/main_compressed.js 2> /dev/null
 echo Compiling Blockly...
 COMPILATION_COMMAND="java -jar $COMPILER --js='tests/compile/main.js' \
   --js='core/**.js' \
@@ -30,10 +29,12 @@ COMPILATION_COMMAND="java -jar $COMPILER --js='tests/compile/main.js' \
   --externs externs/svg-externs.js \
   --compilation_level ADVANCED_OPTIMIZATIONS \
   --dependency_mode=STRICT --entry_point=Main \
-  --js_output_file 'tests/compile/main_compressed.js'"
+  --js_output_file tests/compile/main_compressed.js"
 echo $COMPILATION_COMMAND
 $COMPILATION_COMMAND
-if [ -s main_compressed.js ]; then
+EXIT_CODE=$?
+echo "Compiler exit code: $EXIT_CODE"
+if [ "$EXIT_CODE" -eq 0 ] && [ -s tests/compile/main_compressed.js ]; then
   echo Compilation OK.
 else
   echo Compilation FAIL.

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -1,3 +1,5 @@
+echo "Executing compile.sh from $(pwd)"
+
 # Find the Closure Compiler.
 if [ -f "$(npm root)/google-closure-compiler/compiler.jar" ]; then
   COMPILER="$(npm root)/google-closure-compiler/compiler.jar"

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -8,6 +8,12 @@ goog.require('Blockly.Constants.Logic');
 goog.require('Blockly.Constants.Loops');
 goog.require('Blockly.Constants.Math');
 goog.require('Blockly.Constants.Text');
+// TODO: Add the following. Expecting additional warnings.
+//goog.require('Blockly.Constants.Lists');
+//goog.require('Blockly.Constants.Colour');
+//goog.require('Blockly.Constants.Variables');
+//goog.require('Blockly.Constants.VariablesDynamic');
+//goog.require('Blockly.Constants.procedures');
 
 Main.init = function() {
   Blockly.inject('blocklyDiv', {


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1824 

### Proposed Changes

 * Replace `cd tests/compile; compile.sh; cd ..` with a direct call `tests/compile/compile.sh` in `.travis.yml`.
 * Rewrote `compile.sh` to assume it is run from the project root.
 * Test the exit code of the compiler, not just the presence of the output file.

**TODO[#1872]:** Test compilation with the other blocks (variables, procedures, colours, and lists).
**TODO[#1873]:** Adaptively find the correct path.

### Reason for Changes

Travis was not running advanced compilation, like we thought.

### Test Coverage

 * Ran `tests/compile/compile.sh` locally and opened the matching `index.html` file.
 * Ensured Travis passed, checking logs to verify there were no compilation errors (and compilation warnings were logged).

Tested on:
 * Desktop Chrome