### PR TITLE
Another attempt at testing for PointerEvent.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -464,8 +464,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
   };
 
   var bindData = [];
-  var window = goog.global['window'];
-  if (window && window.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
+  if (goog.global.PointerEvent && (name in Blockly.Touch.TOUCH_MAP)) {
     for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
       node.addEventListener(type, wrapFunc, false);
       bindData.push([node, type, wrapFunc]);

--- a/core/touch.js
+++ b/core/touch.js
@@ -48,8 +48,7 @@ Blockly.Touch.touchIdentifier_ = null;
  * @type {Object}
  */
 Blockly.Touch.TOUCH_MAP = {};
-var window = goog.global['window'];
-if (window && window.PointerEvent) {
+if (goog.global.PointerEvent) {
   Blockly.Touch.TOUCH_MAP = {
     'mousedown': ['pointerdown'],
     'mouseenter': ['pointerenter'],


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Advanced compilation error introduced in #1856. Now bypassing `window` altogether.

### Proposed Changes

Test `goog.global.PointerEvent` directly.

### Reason for Changes

Duplicate var `window` in the previous version.

### Test Coverage

 * Opened playground and tested pinch zoom.
 * Rebuilt with gulp and tested `require('.')`.
 * Executed `tests/compile/compile.sh` with errors (lots of warnings).

Tested on:
 * Desktop Chrome
 * Node.js