### PR TITLE
tests/compile/compile.sh improvements

### DIFF
--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -2,7 +2,7 @@
 echo "Executing compile.sh from $(pwd)"
 
 # Find the Blockly project root if pwd is the root
-# or the directory containing this script.
+# or if pwd is the directory containing this script.
 if [ -f ./main.js ] && [ -f ./compile.sh ]; then
   BLOCKLY_ROOT="../.."
 elif [ -f tests/compile/compile.sh ]; then
@@ -15,7 +15,8 @@ fi
 # Test for npm and node_modules directory.
 if command -v npm >/dev/null 2>&1; then
   NODE_MODULES=$(npm root)
-  # npm root will invent a location based on pwd if it can't find one.
+  # npm root will invent a location based on pwd if it can't find
+  # one, such as when the project has not been `npm install`ed.
   # Clear the variable if the directory doesn't already exist.
   [[ ! -d $NODE_MODULES ]] && NODE_MODULES=""
 fi

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -1,42 +1,98 @@
+#!/bin/bash
 echo "Executing compile.sh from $(pwd)"
 
-# TODO: Find relative path to Blockly root. For now, assume it is pwd.
-
-# Find the Closure Compiler.
-if [ -f "$(npm root)/google-closure-compiler/compiler.jar" ]; then
-  COMPILER="$(npm root)/google-closure-compiler/compiler.jar"
-elif [ -f tests/compile/*compiler*.jar ]; then
-  COMPILER="tests/compile/*compiler*.jar"
-  # TODO: Check whether multiple files were found.
+# Find the Blockly project root if pwd is the root
+# or the directory containing this script.
+if [ -f ./main.js ] && [ -f ./compile.sh ]; then
+  BLOCKLY_ROOT="../.."
+elif [ -f tests/compile/compile.sh ]; then
+  BLOCKLY_ROOT="."
 else
-  echo "ERROR: Closure Compiler not found."
-  echo "Download from this URL, and place jar file in current directory."
-  echo "https://dl.google.com/closure-compiler/compiler-latest.zip"
+  echo "ERROR: Cannot determine BLOCKLY_ROOT" 1>&2;
   exit 1
 fi
 
-echo Using $COMPILER as the compiler.
-rm tests/compile/main_compressed.js 2> /dev/null
-echo Compiling Blockly...
-COMPILATION_COMMAND="java -jar $COMPILER --js='tests/compile/main.js' \
-  --js='core/**.js' \
-  --js='blocks/**.js' \
-  --js='generators/**.js' \
-  --js='msg/js/**.js' \
-  --js='../closure-library/closure/goog/**.js' \
-  --js='../closure-library/third_party/closure/goog/**.js' \
+# Test for npm and node_modules directory.
+if command -v npm >/dev/null 2>&1; then
+  NODE_MODULES=$(npm root)
+  # npm root will invent a location based on pwd if it can't find one.
+  # Clear the variable if the directory doesn't already exist.
+  [[ ! -d $NODE_MODULES ]] && NODE_MODULES=""
+fi
+
+# Find the Closure Compiler.
+if [ -n $NODE_MODULES ] && \
+  [ -s $NODE_MODULES/google-closure-compiler/compiler.jar ]; then
+  COMPILER=$NODE_MODULES/google-closure-compiler/compiler.jar
+  echo "Found npm google-closure-compiler:"
+  echo "  $COMPILER"
+  npm list google-closure-compiler | grep google-closure-compiler
+else
+  COMPILER_JARS=$(find $BLOCKLY_ROOT/tests/compile/ -maxdepth 1 -name "*compiler*.jar")
+  if [ -n "$COMPILER_JARS" ]; then
+    if [ $(echo "$COMPILER_JARS" | wc -l) -ne 1 ]; then
+      echo "ERROR: Found too many Closure *compiler*.jar files:" 1>&2;
+      echo "$COMPILER_JARS" 1>&2;
+      exit 1
+    fi
+    # TODO: Check whether multiple files were found.
+    COMPILER=$COMPILER_JARS
+    echo "Found local Closure compiler .jar:"
+    echo "  $COMPILER"
+  else
+    echo "ERROR: Closure Compiler not found." 1>&2;
+    echo "Either npm install google-closure-compiler" 1>&2;
+    echo "Or download from this URL, and place jar file in current directory." 1>&2;
+    echo "https://dl.google.com/closure-compiler/compiler-latest.zip" 1>&2;
+    exit 1
+  fi
+fi
+
+# Find the Closure Library.
+if [ -n $NODE_MODULES ] && \
+  [ -d "$NODE_MODULES/google-closure-library" ]; then
+  CLOSURE_LIB_ROOT="$NODE_MODULES/google-closure-library"
+  echo "Found npm google-closure-library:"
+  echo "  $CLOSURE_LIB_ROOT"
+  npm list google-closure-library | grep google-closure-library
+elif [ -d "$BLOCKLY_ROOT/../closure-library" ]; then
+  CLOSURE_LIB_ROOT="$BLOCKLY_ROOT/../closure-library"
+  echo "Found local Closure library:"
+  echo "  $CLOSURE_LIB_ROOT"
+  cat $CLOSURE_LIB_ROOT/package.json | grep version
+else
+  echo "ERROR: Closure library not found." 1>&2;
+  echo "Either npm install google-closure-library" 1>&2;
+  echo "Or clone the repo from GitHub in a directory next to Blockly." 1>&2;
+  echo "cd $BLOCKLY_ROOT/..; git clone https://github.com/google/closure-library.git" 1>&2;
+  exit 1
+fi
+
+if [ -f "$BLOCKLY_ROOT/tests/compile/main_compressed.js" ]; then
+  echo "Removing previous output."
+  rm "$BLOCKLY_ROOT/tests/compile/main_compressed.js"
+fi
+
+echo "Compiling Blockly..."
+COMPILATION_COMMAND="java -jar $COMPILER --js='$BLOCKLY_ROOT/tests/compile/main.js' \
+  --js='$BLOCKLY_ROOT/core/**.js' \
+  --js='$BLOCKLY_ROOT/blocks/**.js' \
+  --js='$BLOCKLY_ROOT/generators/**.js' \
+  --js='$BLOCKLY_ROOT/msg/js/**.js' \
+  --js='$CLOSURE_LIB_ROOT/closure/goog/**.js' \
+  --js='$CLOSURE_LIB_ROOT/third_party/closure/goog/**.js' \
   --generate_exports \
-  --externs externs/svg-externs.js \
+  --externs $BLOCKLY_ROOT/externs/svg-externs.js \
   --compilation_level ADVANCED_OPTIMIZATIONS \
   --dependency_mode=STRICT --entry_point=Main \
-  --js_output_file tests/compile/main_compressed.js"
-echo $COMPILATION_COMMAND
+  --js_output_file $BLOCKLY_ROOT/tests/compile/main_compressed.js"
+echo "$COMPILATION_COMMAND"
 $COMPILATION_COMMAND
 EXIT_CODE=$?
 echo "Compiler exit code: $EXIT_CODE"
-if [ "$EXIT_CODE" -eq 0 ] && [ -s tests/compile/main_compressed.js ]; then
-  echo Compilation OK.
+if [ "$EXIT_CODE" -eq 0 ] && [ -s "$BLOCKLY_ROOT/tests/compile/main_compressed.js" ]; then
+  echo "Compilation SUCCESS."
 else
-  echo Compilation FAIL.
+  echo "Compilation FAIL."
   exit 1
 fi

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -36,7 +36,6 @@ else
       echo "$COMPILER_JARS" 1>&2;
       exit 1
     fi
-    # TODO: Check whether multiple files were found.
     COMPILER=$COMPILER_JARS
     echo "Found local Closure compiler .jar:"
     echo "  $COMPILER"


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1873 and numerous other minor issues.

### Proposed Changes

 * Allow running from either Blockly root or local dir.
 * Allow the use of npm google-closure-library.
 * Log compiler/library versions
 * Log full *compiler*.jar filename. Limit to one match.
 * Add npm instructions for both compiler and library.
 * Minor stylistic polish.

### Reason for Changes

Improvements since I'm familiar with the code from previous PR.

### Test Coverage

 * I built from blockly root and from `tests/compile`.
 * I built with `npm` packages installed, and with local compiler `.jar` downloaded (from both locations)
 * Verified the output reflected the expected configuration and passed.
 * I ran with multiple `*compiler*.jar` files and watched it fail, listing all matches found.
