### PR TITLE
Fixes from scratch blocks

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -259,6 +259,10 @@ Blockly.Block.prototype.dispose = function(healStack) {
     // well as corruption of the connection database.  Therefore we must
     // methodically step through the blocks and carefully disassemble them.
 
+    if (Blockly.selected == this) {
+      Blockly.selected = null;
+    }
+
     // First, dispose of all my children.
     for (var i = this.childBlocks_.length - 1; i >= 0; i--) {
       this.childBlocks_[i].dispose(false);
@@ -365,7 +369,7 @@ Blockly.Block.prototype.getConnections_ = function(_all) {
  * @return {Blockly.Connection} The last next connection on the stack, or null.
  * @package
  */
-Blockly.Block.prototype.lastConnectionInStack_ = function() {
+Blockly.Block.prototype.lastConnectionInStack = function() {
   var nextConnection = this.nextConnection;
   while (nextConnection) {
     var nextBlock = nextConnection.targetBlock();
@@ -1282,7 +1286,6 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
             case 'input_dummy':
               input = this.appendDummyInput(element['name']);
               break;
-
             default:
               field = Blockly.Field.fromJson(element);
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -36,6 +36,7 @@ goog.require('Blockly.RenderedConnection');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
+
 goog.require('goog.Timer');
 goog.require('goog.asserts');
 goog.require('goog.dom');
@@ -320,13 +321,18 @@ Blockly.BlockSvg.prototype.getRelativeToSurfaceXY = function() {
  */
 Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
   goog.asserts.assert(!this.parentBlock_, 'Block has parent.');
-  var event = new Blockly.Events.BlockMove(this);
+  var eventsEnabled = Blockly.Events.isEnabled();
+  if (eventsEnabled) {
+    var event = new Blockly.Events.BlockMove(this);
+  }
   var xy = this.getRelativeToSurfaceXY();
   this.translate(xy.x + dx, xy.y + dy);
   this.moveConnections_(dx, dy);
-  event.recordNew();
+  if (eventsEnabled) {
+    event.recordNew();
+    Blockly.Events.fire(event);
+  }
   this.workspace.resizeContents();
-  Blockly.Events.fire(event);
 };
 
 /**
@@ -570,7 +576,7 @@ Blockly.BlockSvg.prototype.createTabList_ = function() {
  * @private
  */
 Blockly.BlockSvg.prototype.onMouseDown_ = function(e) {
-  var gesture = this.workspace.getGesture(e);
+  var gesture = this.workspace && this.workspace.getGesture(e);
   if (gesture) {
     gesture.handleBlockStart(e, this);
   }

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -215,7 +215,7 @@ Blockly.DraggedConnectionManager.prototype.addHighlighting_ = function() {
 Blockly.DraggedConnectionManager.prototype.initAvailableConnections_ = function() {
   var available = this.topBlock_.getConnections_(false);
   // Also check the last connection on this stack
-  var lastOnStack = this.topBlock_.lastConnectionInStack_();
+  var lastOnStack = this.topBlock_.lastConnectionInStack();
   if (lastOnStack && lastOnStack != this.topBlock_.nextConnection) {
     available.push(lastOnStack);
   }

--- a/core/field.js
+++ b/core/field.js
@@ -360,10 +360,7 @@ Blockly.Field.prototype.render_ = function() {
   }
 
   // Replace the text.
-  goog.dom.removeChildren(/** @type {!Element} */ (this.textElement_));
-  var textNode = document.createTextNode(this.getDisplayText_());
-  this.textElement_.appendChild(textNode);
-
+  this.textElement_.textContent = this.getDisplayText_();
   this.updateWidth();
 };
 

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -116,6 +116,13 @@ Blockly.Workspace = function(opt_options) {
 Blockly.Workspace.prototype.rendered = false;
 
 /**
+ * Returns `true` if the workspace is currently in the process of a bulk clear.
+ * @type {boolean}
+ * @package
+ */
+Blockly.Workspace.prototype.isClearing = false;
+
+/**
  * Maximum number of undo events in stack. `0` turns off undo, `Infinity` sets it to unlimited.
  * @type {number}
  */
@@ -264,22 +271,27 @@ Blockly.Workspace.prototype.getAllBlocks = function(ordered) {
  * Dispose of all blocks and comments in workspace.
  */
 Blockly.Workspace.prototype.clear = function() {
-  var existingGroup = Blockly.Events.getGroup();
-  if (!existingGroup) {
-    Blockly.Events.setGroup(true);
-  }
-  while (this.topBlocks_.length) {
-    this.topBlocks_[0].dispose();
-  }
-  while (this.topComments_.length) {
-    this.topComments_[this.topComments_.length - 1].dispose();
-  }
-  if (!existingGroup) {
-    Blockly.Events.setGroup(false);
-  }
-  this.variableMap_.clear();
-  if (this.potentialVariableMap_) {
-    this.potentialVariableMap_.clear();
+  this.isClearing = true;
+  try {
+    var existingGroup = Blockly.Events.getGroup();
+    if (!existingGroup) {
+      Blockly.Events.setGroup(true);
+    }
+    while (this.topBlocks_.length) {
+      this.topBlocks_[0].dispose();
+    }
+    while (this.topComments_.length) {
+      this.topComments_[this.topComments_.length - 1].dispose();
+    }
+    if (!existingGroup) {
+      Blockly.Events.setGroup(false);
+    }
+    this.variableMap_.clear();
+    if (this.potentialVariableMap_) {
+      this.potentialVariableMap_.clear();
+    }
+  } finally {
+    this.isClearing = false;
   }
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -365,6 +365,21 @@ Blockly.Xml.textToDom = function(text) {
 };
 
 /**
+ * Clear the given workspace then decode an XML DOM and
+ * create blocks on the workspace.
+ * @param {!Element} xml XML DOM.
+ * @param {!Blockly.Workspace} workspace The workspace.
+ * @return {Array.<string>} An array containing new block ids.
+ */
+Blockly.Xml.clearWorkspaceAndLoadFromXml = function(xml, workspace) {
+  workspace.setResizesEnabled(false);
+  workspace.clear();
+  var blockIds = Blockly.Xml.domToWorkspace(xml, workspace);
+  workspace.setResizesEnabled(true);
+  return blockIds;
+};
+
+/**
  * Decode an XML DOM and create blocks on the workspace.
  * @param {!Element} xml XML DOM.
  * @param {!Blockly.Workspace} workspace The workspace.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Various changes from scratch blocks, including
- Use .textContent setter instead of deleting and recreating nodes: https://github.com/LLK/scratch-blocks/pull/1438
- Add an XML utility to clear the workspace and then load a new one without refreshing:  https://github.com/LLK/scratch-blocks/pull/1178
- Optimize block.setParent while clearing the workspace: https://github.com/LLK/scratch-blocks/pull/1441

### Reason for Changes
Performance improvements, especially for repeatedly opening large workspaces.
