### PR TITLE
Fix #1380

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -180,16 +180,14 @@ Blockly.RenderedConnection.prototype.tighten_ = function() {
  * Find the closest compatible connection to this connection.
  * All parameters are in workspace units.
  * @param {number} maxLimit The maximum radius to another connection.
- * @param {number} dx Horizontal offset between this connection's location
- *     in the database and the current location (as a result of dragging).
- * @param {number} dy Vertical offset between this connection's location
+ * @param {!goog.math.Coordinate} dxy Offset between this connection's location
  *     in the database and the current location (as a result of dragging).
  * @return {!{connection: ?Blockly.Connection, radius: number}} Contains two
  *     properties: 'connection' which is either another connection or null,
  *     and 'radius' which is the distance.
  */
-Blockly.RenderedConnection.prototype.closest = function(maxLimit, dx, dy) {
-  return this.dbOpposite_.searchForClosest(this, maxLimit, dx, dy);
+Blockly.RenderedConnection.prototype.closest = function(maxLimit, dxy) {
+  return this.dbOpposite_.searchForClosest(this, maxLimit, dxy);
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix #1380 
Fix #1849 

### Proposed Changes

Change the signature of `Blockly.RenderedConnection.prototype.closest` to match how it's actually used.

### Reason for Changes

The declaration and usage were mismatched.

### Additional Information

Reduces compiler warnings by 4.