### PR TITLE
Addwarningfix/1831

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -334,15 +334,15 @@ Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
         // (eg. `%{BKY_MATH_HUE}`).
         var colour = Blockly.utils.replaceMessageReferences(
             childIn.getAttribute('colour'));
-        if (goog.isString(colour)) {
-          if (/^#[0-9a-fA-F]{6}$/.test(colour)) {
-            childOut.hexColour = colour;
-          } else {
-            childOut.hexColour = Blockly.hueToRgb(Number(colour));
-          }
+        if (/^#[0-9a-fA-F]{6}$/.test(colour)) {
+          childOut.hexColour = colour;
+          this.hasColours_ = true;
+        } else if (!isNaN(Number(colour))) {
+          childOut.hexColour = Blockly.hueToRgb(Number(colour));
           this.hasColours_ = true;
         } else {
           childOut.hexColour = '';
+          console.warn("Toolbox category \"" + categoryName + "\" has unrecognized colour attribute: " + colour);
         }
         if (childIn.getAttribute('expanded') == 'true') {
           if (childOut.blocks.length) {

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -342,7 +342,7 @@ Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
           this.hasColours_ = true;
         } else {
           childOut.hexColour = '';
-          console.warn("Toolbox category \"" + categoryName + "\" has unrecognized colour attribute: " + colour);
+          console.warn('Toolbox category "' + categoryName + '" has unrecognized colour attribute: ' + colour);
         }
         if (childIn.getAttribute('expanded') == 'true') {
           if (childOut.blocks.length) {


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1831.
### Proposed Changes

Adds a console warning when an unrecognized colour value is given for a toolbox and sets no colour.
(Previously unrecognized colour values were set to black)

### Reason for Changes

Gives more information to the developer.

### Test Coverage

Tested using playground.html.

Tested on:
Desktop Chrome
Desktop Firefox
Desktop Safari

### Additional Information

<!-- Anything else we should know? -->
