### PR TITLE
Disable ws comments in IE

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -388,7 +388,11 @@ Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
     }
   };
 
-  var wsCommentOption = {enabled: true};
+  var wsCommentOption = {
+    // Foreign objects don't work in IE.  Don't let the user create comments
+    // that they won't be able to edit.
+    enabled: !goog.userAgent.IE
+  };
   wsCommentOption.text = Blockly.Msg.ADD_COMMENT;
   wsCommentOption.callback = function() {
     addWsComment();


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Related to #230 

### Proposed Changes

Makes the "Add Comment" option in the workspace context menu gray out in Internet Explorer.

### Reason for Changes

IE doesn't support foreign objects, so comments aren't editable.  We decided we're okay with that as long as we don't make it possible to create a comment that can't be edited.
