### PR TITLE
Fix undoing a drag to connect

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -224,9 +224,9 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
     // These are expensive and don't need to be done if we're deleting.
     this.draggingBlock_.moveConnections_(delta.x, delta.y);
     this.draggingBlock_.setDragging(false);
+    this.fireMoveEvent_();
     this.draggedConnectionManager_.applyConnections();
     this.draggingBlock_.render();
-    this.fireMoveEvent_();
     this.draggingBlock_.scheduleSnapAndBump();
   }
   this.workspace_.setResizesEnabled(true);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -279,12 +279,8 @@ Blockly.BlockSvg.prototype.setParent = function(newParent) {
   // If we are losing a parent, we want to move our DOM element to the
   // root of the workspace.
   else if (oldParent) {
-    // Avoid moving a block up the DOM if it's currently selected/dragging,
-    // so as to avoid taking things off the drag surface.
-    if (Blockly.selected != this) {
-      this.workspace.getCanvas().appendChild(svgRoot);
-      this.translate(oldXY.x, oldXY.y);
-    }
+    this.workspace.getCanvas().appendChild(svgRoot);
+    this.translate(oldXY.x, oldXY.y);
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1780 

### Proposed Changes

Fire the move event at the end of a drag before firing the connect event.  This means that the events combine correctly.

Get rid of a check for `Blockly.selected` in `block.setParent`.

### Reason for Changes

For the change in block_dragger.js, see the [explanation](https://github.com/google/blockly/issues/1780#issuecomment-385087792) by @jlaurens in #1780.

The change in block_svg.js gets rid of a check against `Blockly.selected` that was causing problems if the block was actually selected.  I added that check as part of https://github.com/google/blockly/commit/df7f534ad6ed287ecc8d13c4e159138b71ed1e88.  It came in from scratch-blocks; I had noted that it was an odd check there, but didn't investigate further yet.  It appears to cause real problems here.

### Test Coverage
I imported two blocks (a math_number block and an addition block with no shadows).  I placed them in known locations, dragged to connect, and then used ctrl-z to undo.  I tested with the block selected and deselected.

This was all in the playground.  This would be a good candidate for testing with an event replay framework.
