### PR TITLE
Make event filtering stricter for move events

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -225,8 +225,12 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
     this.draggingBlock_.moveConnections_(delta.x, delta.y);
     this.draggingBlock_.setDragging(false);
     this.fireMoveEvent_();
-    this.draggedConnectionManager_.applyConnections();
-    this.draggingBlock_.render();
+    if (this.draggedConnectionManager_.wouldConnectBlock()) {
+      // Applying connections also rerenders the relevant blocks.
+      this.draggedConnectionManager_.applyConnections();
+    } else {
+      this.draggingBlock_.render();
+    }
     this.draggingBlock_.scheduleSnapAndBump();
   }
   this.workspace_.setResizesEnabled(true);

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -126,6 +126,16 @@ Blockly.DraggedConnectionManager.prototype.wouldDeleteBlock = function() {
 };
 
 /**
+ * Return whether the block would be deleted if dropped immediately, based on
+ * information from the most recent move event.
+ * @return {boolean} true if the block would be deleted if dropped immediately.
+ * @package
+ */
+Blockly.DraggedConnectionManager.prototype.wouldConnectBlock = function() {
+  return !!this.closestConnection_;
+};
+
+/**
  * Connect to the closest connection and render the results.
  * This should be called at the end of a drag.
  * @package

--- a/core/dragged_connection_manager.js
+++ b/core/dragged_connection_manager.js
@@ -126,9 +126,9 @@ Blockly.DraggedConnectionManager.prototype.wouldDeleteBlock = function() {
 };
 
 /**
- * Return whether the block would be deleted if dropped immediately, based on
+ * Return whether the block would be connected if dropped immediately, based on
  * information from the most recent move event.
- * @return {boolean} true if the block would be deleted if dropped immediately.
+ * @return {boolean} true if the block would be connected if dropped immediately.
  * @package
  */
 Blockly.DraggedConnectionManager.prototype.wouldConnectBlock = function() {

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -790,3 +790,30 @@ function test_events_newblock_newvar_xml() {
     Blockly.Events.fire = savedFireFunc;
   }
 }
+
+function test_events_filter_nomerge_move() {
+  // Move events should only merge if they refer to the same block and are
+  // consecutive.
+  eventTest_setUpWithMockBlocks();
+  try {
+    var block1 = createSimpleTestBlock(workspace);
+    var block2 = createSimpleTestBlock(workspace);
+
+    var events = [];
+    helper_addMoveEvent(events, block1, 1, 1);
+    helper_addMoveEvent(events, block2, 1, 1);
+    events.push(new Blockly.Events.BlockDelete(block2));
+    helper_addMoveEvent(events, block1, 2, 2);
+
+    var filteredEvents = Blockly.Events.filter(events, true);
+    // Nothing should have merged.
+    assertEquals(4, filteredEvents.length);
+    // test that the order hasn't changed
+    assertTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
+    assertTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+    assertTrue(filteredEvents[2] instanceof Blockly.Events.BlockDelete);
+    assertTrue(filteredEvents[3] instanceof Blockly.Events.BlockMove);
+  } finally {
+    eventTest_tearDownWithMockBlocks();
+  }
+}

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -794,6 +794,9 @@ function test_events_newblock_newvar_xml() {
 function test_events_filter_nomerge_move() {
   // Move events should only merge if they refer to the same block and are
   // consecutive.
+  // See github.com/google/blockly/pull/1892 for a worked example showing
+  // how merging non-consecutive events can fail when replacing a shadow
+  // block.
   eventTest_setUpWithMockBlocks();
   try {
     var block1 = createSimpleTestBlock(workspace);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The rest of https://github.com/google/blockly/issues/1780

### Proposed Changes

Make the filter function only merge consecutive move events on the same blocks.

### Reason for Changes

The fix in #1889 exposed a new problem, which was that events were getting merged in the wrong way.  The example is:

![image](https://user-images.githubusercontent.com/13686399/40519733-144733a2-5f76-11e8-9d72-5fdcec2c2ace.png)

Dragging the "123" block to the addition block leads to four events:
- move "123" to an x,y position near the addition block
- move the shadow block from the parent block to the main workspace
- delete the shadow block
- move "123" to connect to the addition block

The middle two events are a result of calling `unplug` on the shadow block.

The previous merge algorithm then merged the first and 4th event, giving:
- move "123" to connect to the addition block
- move the shadow block from the parent block to the main workspace
- delete the shadow block

This worked fine, but undoing it tries to undelete and move a shadow block that doesn't exist.  That's because the first event actually caused the second and third events.

### Test Coverage
I added a new jsunit test to check exactly this case.  The other tests still pass.

In the playground, I dragged to connect a bunch of combinations of blocks (connect over a shadow, connect an input to an output, connect to a statement input, etc).  For each one I did the drag, then undid it, then redid it.  Everything ended up in the right place.  Again, this is a good candidate for the event replay framework.

### Additional Information

This issue affects scratch blocks as well, so they'll need the same fix.

This also led to #1891, which is a bigger question about event filtering in general.
