### PR TITLE
Fix #1893, null colour attribute for toolbox category

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -334,10 +334,14 @@ Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
         // (eg. `%{BKY_MATH_HUE}`).
         var colour = Blockly.utils.replaceMessageReferences(
             childIn.getAttribute('colour'));
-        if (/^#[0-9a-fA-F]{6}$/.test(colour)) {
+        if (colour === null || colour === '') {
+          // No attribute. No colour.
+          childOut.hexColour = '';
+        } else if (/^#[0-9a-fA-F]{6}$/.test(colour)) {
           childOut.hexColour = colour;
           this.hasColours_ = true;
-        } else if (!isNaN(Number(colour))) {
+        } else if (typeof colour === 'number'
+            || (typeof colour === 'string' && !isNaN(Number(colour)))) {
           childOut.hexColour = Blockly.hueToRgb(Number(colour));
           this.hasColours_ = true;
         } else {


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes regression in #1893. Patch on change in #1831.

### Proposed Changes

Verify typeof colour variable before passing through Number().

### Reason for Changes

Missing attributes return `null`, and `Number(null) === 0`, resulting in a red hues category color.

### Test Coverage

Opened the Playground test blocks, observing the (lack of) colour next to the category label.
Opened the console noting the lack of warning messages.

Locally added the following toolbox categories to the playground test blocks:

    <category name="No colour attr"></category>
    <category name="Empty colour attr" colour=""></category>
    <category name='"0" colour attr' colour="0"></category>
    <category name='"undefined" colour attr' colour="undefined"></category>
    <category name='"null" colour attr' colour="null"></category>
    <category name='"true" colour attr' colour="true"></category>
    <category name='"false" colour attr' colour="false"></category>
    <category name="Blue colour attr" colour="240"></category>

    <category name="Empty string ref colour attr" colour="%{BKY_EMPTY_STR}"></category>
    <category name="0 ref colour attr" colour="%{BKY_ZERO}"></category>
    <category name='Undefined ref colour attr' colour="%{BKY_UNDEFINED}"></category>
    <category name='null ref colour attr' colour="%{BKY_NULL}"></category>
    <category name='true ref colour attr' colour="%{BKY_TRUE}"></category>
    <category name='false ref colour attr' colour="%{BKY_FALSE}"></category>
    <category name="Blue ref colour attr" colour="%{BKY_BLUE}"></category>

verifying the following (almost) expected warnings in the console:

```
toolbox.js:349 Toolbox category ""Undefined" colour attr" has unrecognized colour attribute: toolbox.js:349 Toolbox category ""null" colour attr" has unrecognized colour attribute: null
toolbox.js:349 Toolbox category ""true" colour attr" has unrecognized colour attribute: true
toolbox.js:349 Toolbox category ""false" colour attr" has unrecognized colour attribute: false
toolbox.js:349 Toolbox category "Undefined ref colour attr" has unrecognized colour attribute: undefined
toolbox.js:349 Toolbox category "true ref colour attr" has unrecognized colour attribute: true
toolbox.js:349 Toolbox category "false ref colour attr" has unrecognized colour attribute: false
```

Note: the Blockly.Msg that referenced `null` did not produce a warning, but that is such an edge case, I'm ignoring it.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
