### PR TITLE
Adaptive popup size for FieldDropdowns

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -567,9 +567,6 @@ Blockly.Css.CONTENT = [
 
   '.blocklyDropdownMenu {',
     'padding: 0 !important;',
-    /* max-height value is same as the constant
-     * Blockly.FieldDropdown.MAX_MENU_HEIGHT defined in field_dropdown.js. */
-    'max-height: 300px !important;',
   '}',
 
   /* Override the default Closure URL. */

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -67,6 +67,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
 };
 goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 
+
 /**
  * Construct a FieldDropdown from a JSON arg object.
  * @param {!Object} options A JSON object with options (options).
@@ -84,10 +85,9 @@ Blockly.FieldDropdown.fromJson = function(options) {
 Blockly.FieldDropdown.CHECKMARK_OVERHANG = 25;
 
 /**
- * Maximum height of the dropdown menu,it's also referenced in css.js as
- * part of .blocklyDropdownMenu.
+ * Maximum height of the dropdown menu, as a percentage of the viewport height.
  */
-Blockly.FieldDropdown.MAX_MENU_HEIGHT = 300;
+Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH = 0.45;
 
 /**
  * Android can't (in 2014) display "▾", so use "▼" instead.
@@ -258,8 +258,12 @@ Blockly.FieldDropdown.prototype.positionMenu_ = function(menu) {
   this.createWidget_(menu);
   var menuSize = Blockly.utils.uiMenu.getSize(menu);
 
-  if (menuSize.height > Blockly.FieldDropdown.MAX_MENU_HEIGHT) {
-    menuSize.height = Blockly.FieldDropdown.MAX_MENU_HEIGHT;
+  console.log('document.documentElement.clientHeight =', document.documentElement.clientHeight);
+  var maxHeightVh = Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH
+      * document.documentElement.clientHeight;
+  console.log('maxHeightVh = ', maxHeightVh);
+  if (menuSize.height > maxHeightVh) {
+    menuSize.height = maxHeightVh;
   }
 
   if (this.sourceBlock_.RTL) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -257,10 +257,10 @@ Blockly.FieldDropdown.prototype.positionMenu_ = function(menu) {
   this.createWidget_(menu);
   var menuSize = Blockly.utils.uiMenu.getSize(menu);
 
-  var maxHeightVh = Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH
+  var menuMaxHeightPx = Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH
       * document.documentElement.clientHeight;
-  if (menuSize.height > maxHeightVh) {
-    menuSize.height = maxHeightVh;
+  if (menuSize.height > menuMaxHeightPx) {
+    menuSize.height = menuMaxHeightPx;
   }
 
   if (this.sourceBlock_.RTL) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -67,7 +67,6 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
 };
 goog.inherits(Blockly.FieldDropdown, Blockly.Field);
 
-
 /**
  * Construct a FieldDropdown from a JSON arg object.
  * @param {!Object} options A JSON object with options (options).
@@ -258,10 +257,8 @@ Blockly.FieldDropdown.prototype.positionMenu_ = function(menu) {
   this.createWidget_(menu);
   var menuSize = Blockly.utils.uiMenu.getSize(menu);
 
-  console.log('document.documentElement.clientHeight =', document.documentElement.clientHeight);
   var maxHeightVh = Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH
       * document.documentElement.clientHeight;
-  console.log('maxHeightVh = ', maxHeightVh);
   if (menuSize.height > maxHeightVh) {
     menuSize.height = maxHeightVh;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1364

### Proposed Changes

Limit height of the dropdown popup to 45% of the height of the viewport.
Removed hardcoded height limit. (Why was `max-height` previously `!important`?)

### Reason for Changes

Prevent the popup from exceeding the boundaries of the viewport.

### Test Coverage

Using `example_dropdown_long` in `test_blocks.js`, open the drop down when the block is visible near the top, near the bottom, slightly above the middle, slightly below the middle, and at various workspace zoom scales and page zoom scales. Make sure the contents can scroll in all cases.

Tested on:
 * Desktop Chrome 
 * Desktop Firefox
 * Desktop Safari
 * Windows Edge (Surface)
 * Android phone (O)
 * iOS iPad
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
