### PR TITLE
Renaming injectionDiv as blocklyInjectionDiv, for namespace consistency

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -126,7 +126,7 @@ Blockly.Css.CONTENT = [
     'z-index: 99999;', /* big value for bootstrap3 compatibility */
   '}',
 
-  '.injectionDiv {',
+  '.blocklyInjectionDiv {',
     'height: 100%;',
     'position: relative;',
     'overflow: hidden;', /* So blocks in drag surface disappear at edges */

--- a/core/inject.js
+++ b/core/inject.js
@@ -56,7 +56,7 @@ Blockly.inject = function(container, opt_options) {
     throw 'Error: container is not in current document.';
   }
   var options = new Blockly.Options(opt_options || {});
-  var subContainer = goog.dom.createDom(goog.dom.TagName.DIV, 'injectionDiv');
+  var subContainer = goog.dom.createDom(goog.dom.TagName.DIV, 'blocklyInjectionDiv');
   container.appendChild(subContainer);
   var svg = Blockly.createDom_(subContainer, options);
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -200,7 +200,7 @@ Blockly.utils.getInjectionDivXY_ = function(element) {
     x = x + xy.x;
     y = y + xy.y;
     var classes = element.getAttribute('class') || '';
-    if ((' ' + classes + ' ').indexOf(' injectionDiv ') != -1) {
+    if ((' ' + classes + ' ').indexOf(' blocklyInjectionDiv ') != -1) {
       break;
     }
     element = element.parentNode;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -247,8 +247,8 @@ Blockly.WorkspaceSvg.prototype.useWorkspaceDragSurface_ = false;
 Blockly.WorkspaceSvg.prototype.isDragSurfaceActive_ = false;
 
 /**
- * The first parent div with 'injectionDiv' in the name, or null if not set.
- * Access this with getInjectionDiv.
+ * The first parent div with 'blocklyInjectionDiv' in the class attribute, or
+ * null if not set. Access this with getInjectionDiv.
  * @type {!Element}
  * @private
  */
@@ -381,7 +381,8 @@ Blockly.WorkspaceSvg.prototype.getOriginOffsetInPixels = function() {
 /**
  * Return the injection div that is a parent of this workspace.
  * Walks the DOM the first time it's called, then returns a cached value.
- * @return {!Element} The first parent div with 'injectionDiv' in the name.
+ * @return {!Element} The first parent div with 'blocklyInjectionDiv' in the
+ *     class attribute.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.getInjectionDiv = function() {
@@ -391,7 +392,7 @@ Blockly.WorkspaceSvg.prototype.getInjectionDiv = function() {
     var element = this.svgGroup_;
     while (element) {
       var classes = element.getAttribute('class') || '';
-      if ((' ' + classes + ' ').indexOf(' injectionDiv ') != -1) {
+      if ((' ' + classes + ' ').indexOf(' blocklyInjectionDiv ') != -1) {
         this.injectionDiv_ = element;
         break;
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1258

### Proposed Changes

Renames the class "injectionDiv" as "blocklyInjectionDiv".

**Note:** This is technically a breaking change of a class name that has existed for many years. However, it is hard to imagine a app developer addressing this div specifically, instead of the parent div (the one the app developer named and passed into `Blockly.inject(...)`, and the one this `<div>` is sized to match).

If we choose not to accept this change, we should label #1258 with "wontfix".

### Reason for Changes

 * Consistency in the use of the "blockly" prefix in class names.
 * Reduce the change of class name collision with other CSS rules.

### Test Coverage

 * Opened the playground to verify it lays out correctly. Verified blocks on the workspace and during drag continue to clip at the workspace edges (an injection div CSS rule). Verified resizing the window continues to resize the workspace.
 * Rebuilt the code and tested the same on the fixed and resizable injection demos.
 * Ran jsunit tests.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
