### PR TITLE
Remove custom touch handling code for dropdown fields

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -144,19 +144,8 @@ Blockly.FieldDropdown.prototype.init = function() {
 Blockly.FieldDropdown.prototype.showEditor_ = function() {
   Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, null);
   var menu = this.createMenu_();
-  this.addEventListeners_(menu);
-  this.positionMenu_(menu);
-};
-
-/**
- * Add event listeners for actions on the items in the dropdown menu.
- * @param {!goog.ui.Menu} menu The menu to add listeners to.
- * @private
- */
-Blockly.FieldDropdown.prototype.addEventListeners_ = function(menu) {
   this.addActionListener_(menu);
-  this.addTouchStartListener_(menu);
-  this.addTouchEndListener_(menu);
+  this.positionMenu_(menu);
 };
 
 /**
@@ -178,38 +167,6 @@ Blockly.FieldDropdown.prototype.addActionListener_ = function(menu) {
   }
   // Listen for mouse/keyboard events.
   goog.events.listen(menu, goog.ui.Component.EventType.ACTION, callback);
-};
-
-/**
- * Add a listener for touch start events on menu items.
- * @param {!goog.ui.Menu} menu The menu to add the listener to.
- * @private
- */
-Blockly.FieldDropdown.prototype.addTouchStartListener_ = function(menu) {
-  // Listen for touch events (why doesn't Closure handle this already?).
-  function callback(e) {
-    var control = this.getOwnerControl(/** @type {Node} */ (e.target));
-    // Highlight the menu item.
-    control.handleMouseDown(e);
-  }
-  menu.getHandler().listen(
-      menu.getElement(), goog.events.EventType.TOUCHSTART, callback);
-};
-
-/**
- * Add a listener for touch end events on menu items.
- * @param {!goog.ui.Menu} menu The menu to add the listener to.
- * @private
- */
-Blockly.FieldDropdown.prototype.addTouchEndListener_ = function(menu) {
-  // Listen for touch events (why doesn't Closure handle this already?).
-  function callbackTouchEnd(e) {
-    var control = this.getOwnerControl(/** @type {Node} */ (e.target));
-    // Activate the menu item.
-    control.performActionInternal(e);
-  }
-  menu.getHandler().listen(
-      menu.getElement(), goog.events.EventType.TOUCHEND, callbackTouchEnd);
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1804
### Proposed Changes

Get rid of custom touch handling code for dropdown fields.
### Reason for Changes

The touch handler was selecting on touch up, which meant that you couldn't scroll a long dropdown--releasing the scroll would select an item.
### Test Coverage
Tested with the long dropdown field in the test blocks on the playground, in chrome in mobile mode.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

I tried to get confirmation that the closure dropdown now works correctly in touch, but I have not heard any response.  From experimentation it seems to do the right thing; I'm a bit concerned about Edge/pointer events.