### PR TITLE
Correct require goog.Timer statements.

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -32,6 +32,7 @@ goog.require('Blockly.Events.BlockMove');
 
 goog.require('goog.math.Coordinate');
 goog.require('goog.asserts');
+goog.require('goog.Timer');
 
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -37,7 +37,6 @@ goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
 
-goog.require('goog.Timer');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -32,6 +32,7 @@ goog.require('Blockly.WorkspaceCommentSvg');
 
 goog.require('goog.math.Coordinate');
 goog.require('goog.asserts');
+goog.require('goog.Timer');
 
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -32,7 +32,6 @@ goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Icon');
 goog.require('Blockly.WorkspaceSvg');
-goog.require('goog.Timer');
 goog.require('goog.dom');
 
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Correcting `goog.require('goog.Timer')` calls only exist in files that actually use `goog.Timer`.

Also confirmed successful compilation using `tests/compile/compile.sh`.

### Test Coverage

Rebuilt (with workspace comments enabled) and tested various trashcan animations (the only use of `Timer`) in `demos/code/index.html` (compiled/compressed blockly).

Tested on:
  * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

