### PR TITLE
Add some workspace comment tests

### DIFF
--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -80,7 +80,79 @@ function test_disposeWsCommentTwice() {
     comment.dispose();
     // Nothing should go wrong the second time dispose is called.
     comment.dispose();
-  }finally {
+  } finally {
     workspaceCommentTest_tearDown();
+  }
+}
+
+function test_wsCommentHeightWidth() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    assertEquals('Initial width', 20, comment.getWidth());
+    assertEquals('Initial height', 10, comment.getHeight());
+
+    comment.setWidth(30);
+    assertEquals('New width should be different', 30, comment.getWidth());
+    assertEquals('New height should not be different', 10, comment.getHeight());
+
+    comment.setHeight(40);
+    assertEquals('New width should not be different', 30, comment.getWidth());
+    assertEquals('New height should be different', 40, comment.getHeight());
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_wsCommentXY() {
+  workspaceCommentTest_setUp();
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    var xy = comment.getXY();
+    assertEquals('Initial X position', 0, xy.x);
+    assertEquals('Initial Y position', 0, xy.y);
+
+    comment.moveBy(10, 100);
+    xy = comment.getXY();
+    assertEquals('New X position', 10, xy.x);
+    assertEquals('New Y position', 100, xy.y);
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+  }
+}
+
+function test_wsCommentContent() {
+  workspaceCommentTest_setUp();
+
+  Blockly.Events.fire = temporary_fireEvent;
+  temporary_fireEvent.firedEvents_ = [];
+  try {
+    var comment =
+        new Blockly.WorkspaceComment(workspace, 'comment text', 10, 20, 'comment id');
+    assertEquals(
+        'Check comment text', 'comment text', comment.getContent());
+    assertEquals(
+        'Workspace undo stack has one event', 1, workspace.undoStack_.length);
+
+    comment.setContent('comment text');
+    assertEquals(
+        'Comment text has not changed', 'comment text', comment.getContent());
+    // Setting the text to the old value does not fire an event.
+    assertEquals(
+        'Workspace undo stack has one event', 1, workspace.undoStack_.length);
+
+    comment.setContent('new comment text');
+    assertEquals(
+        'Comment text has changed', 'new comment text', comment.getContent());
+    assertEquals(
+        'Workspace undo stack has two events', 2, workspace.undoStack_.length);
+    comment.dispose();
+  } finally {
+    workspaceCommentTest_tearDown();
+    Blockly.Events.fire = savedFireFunc;
   }
 }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

General testing.
### Proposed Changes

Tests for XY, content, and HW getters and setters for headless workspace comments.

### Reason for Changes

Continuing work on comments in scratch-blocks means that we may have compatibility problems as constructors and events change.  These tests can help us verify that we're not breaking anything in headless mode.  Scratch-blocks doesn't really run headless, but scratch blocks and blockly should behave the same with respect to these comments.

### Test Coverage
New JSunit tests.

### Additional Information

This also need to land in scratch blocks.  https://github.com/LLK/scratch-blocks/issues/1563