### PR TITLE
Replace call once with set timeout

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -267,7 +267,7 @@ Blockly.BlockDragger.prototype.maybeDeleteBlock_ = function() {
 
   if (this.wouldDeleteBlock_) {
     if (trashcan) {
-      goog.Timer.callOnce(trashcan.close, 100, trashcan);
+      setTimeout(trashcan.close, 100, trashcan);
     }
     // Fire a move event, so we know where to go back to for an undo.
     this.fireMoveEvent_();

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -319,7 +319,7 @@ Blockly.Trashcan.prototype.animateLid_ = function() {
   var opacity = goog.math.lerp(0.4, 0.8, this.lidOpen_);
   this.svgGroup_.style.opacity = opacity;
   if (this.lidOpen_ > 0 && this.lidOpen_ < 1) {
-    this.lidTask_ = goog.Timer.callOnce(this.animateLid_, 20, this);
+    this.lidTask_ = setTimeout(this.animateLid_, 20, this);
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Issue #1905 

### Proposed Changes
This change is to replace the `goog.Timer.callOnce` function with the `setTimeout` function since the `callOnce` function wasn't working as expected. 

### Reason for Changes

In the issue linked above and the related issues such as #1901 and https://github.com/google/closure-library/issues/903, there has been numerous issues with the `callOnce` function. Therefore the proposed change was to remove the usage of it and replace with the `setTimeout` function.

### Test Coverage
Windows 7, Google Chrome.


### Additional Information

<!-- Anything else we should know? -->
