### PR TITLE
Removing (most) Closure from BlockFactory

### DIFF
--- a/demos/blockfactory/analytics.js
+++ b/demos/blockfactory/analytics.js
@@ -22,7 +22,8 @@
  * @fileoverview Stubbed interface functions for analytics integration.
  */
 
-goog.provide('BlocklyDevTools.Analytics');
+var BlocklyDevTools = BlocklyDevTools || Object.create(null);
+BlocklyDevTools.Analytics = BlocklyDevTools.Analytics || Object.create(null);
 
 /**
  * Whether these stub methods should log analytics calls to the console.

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -28,7 +28,6 @@
 goog.provide('AppController');
 
 goog.require('BlockFactory');
-goog.require('BlocklyDevTools.Analytics');
 goog.require('FactoryUtils');
 goog.require('BlockLibraryController');
 goog.require('BlockExporterController');

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -27,7 +27,6 @@
  */
 goog.provide('AppController');
 
-goog.require('BlockFactory');
 goog.require('BlockLibraryController');
 goog.require('BlockExporterController');
 goog.require('goog.dom.classlist');

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -25,13 +25,8 @@
  *
  * @author quachtina96 (Tina Quach)
  */
-goog.provide('AppController');
 
-goog.require('goog.dom.classlist');
-goog.require('goog.dom.xml');
-goog.require('goog.ui.PopupColorPicker');
-goog.require('goog.ui.ColorPicker');
-
+goog.require('goog.dom.xml');  // Used to detect Closure
 
 /**
  * Controller for the Blockly Factory
@@ -157,9 +152,7 @@ AppController.prototype.exportBlockLibraryToFile = function() {
  */
 AppController.prototype.formatBlockLibraryForExport_ = function(blockXmlMap) {
   // Create DOM for XML.
-  var xmlDom = goog.dom.createDom('xml', {
-    'xmlns':"http://www.w3.org/1999/xhtml"
-  });
+  var xmlDom = document.createElementNS('http://www.w3.org/1999/xhtml', 'xml');
 
   // Append each block node to XML DOM.
   for (var blockType in blockXmlMap) {
@@ -180,29 +173,25 @@ AppController.prototype.formatBlockLibraryForExport_ = function(blockXmlMap) {
  * @private
  */
 AppController.prototype.formatBlockLibraryForImport_ = function(xmlText) {
-  var xmlDom = Blockly.Xml.textToDom(xmlText);
-
-  // Get array of XMLs. Use an asterisk (*) instead of a tag name for the XPath
-  // selector, to match all elements at that level and get all factory_base
-  // blocks.
-  var blockNodes = goog.dom.xml.selectNodes(xmlDom, '*');
+  var inputXml = Blockly.Xml.textToDom(xmlText);
+  // Convert the live HTMLCollection of child Elements into a static array,
+  // since the addition to editorWorkspaceXml below removes it from inputXml.
+  var inputChildren = Array.from(inputXml.children);
 
   // Create empty map. The line below creates a  truly empy object. It doesn't
   // have built-in attributes/functions such as length or toString.
   var blockXmlTextMap = Object.create(null);
 
   // Populate map.
-  for (var i = 0, blockNode; blockNode = blockNodes[i]; i++) {
-
+  for (var i = 0, blockNode; blockNode = inputChildren[i]; i++) {
     // Add outer XML tag to the block for proper injection in to the
     // main workspace.
     // Create DOM for XML.
-    var xmlDom = goog.dom.createDom('xml', {
-      'xmlns':"http://www.w3.org/1999/xhtml"
-    });
-    xmlDom.appendChild(blockNode);
+    var editorWorkspaceXml =
+        document.createElementNS('http://www.w3.org/1999/xhtml', 'xml');
+    editorWorkspaceXml.appendChild(blockNode);
 
-    xmlText = Blockly.Xml.domToText(xmlDom);
+    xmlText = Blockly.Xml.domToText(editorWorkspaceXml);
     // All block types should be lowercase.
     var blockType = this.getBlockTypeFromXml_(xmlText).toLowerCase();
     // Some names are invalid so fix them up.
@@ -372,9 +361,9 @@ AppController.prototype.onTab = function() {
 AppController.prototype.styleTabs_ = function() {
   for (var tabName in this.tabMap) {
     if (this.selectedTab == tabName) {
-      goog.dom.classlist.addRemove(this.tabMap[tabName], 'taboff', 'tabon');
+      this.tabMap[tabName].classList.replace('taboff', 'tabon');
     } else {
-      goog.dom.classlist.addRemove(this.tabMap[tabName], 'tabon', 'taboff');
+      this.tabMap[tabName].classList.replace('tabon', 'taboff');
     }
   }
 };

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -27,7 +27,6 @@
  */
 goog.provide('AppController');
 
-goog.require('BlockLibraryController');
 goog.require('BlockExporterController');
 goog.require('goog.dom.classlist');
 goog.require('goog.ui.PopupColorPicker');

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -28,7 +28,6 @@
 goog.provide('AppController');
 
 goog.require('BlockFactory');
-goog.require('FactoryUtils');
 goog.require('BlockLibraryController');
 goog.require('BlockExporterController');
 goog.require('goog.dom.classlist');

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -27,8 +27,8 @@
  */
 goog.provide('AppController');
 
-goog.require('BlockExporterController');
 goog.require('goog.dom.classlist');
+goog.require('goog.dom.xml');
 goog.require('goog.ui.PopupColorPicker');
 goog.require('goog.ui.ColorPicker');
 

--- a/demos/blockfactory/block_definition_extractor.js
+++ b/demos/blockfactory/block_definition_extractor.js
@@ -37,7 +37,7 @@ BlockDefinitionExtractor = BlockDefinitionExtractor || Object.create(null);
 
 /**
  * Builds a BlockFactory workspace that reflects the block structure of the
- * exmaple block.
+ * example block.
  *
  * @param {!Blockly.Block} block The reference block from which the definition
  *     will be extracted.
@@ -45,7 +45,7 @@ BlockDefinitionExtractor = BlockDefinitionExtractor || Object.create(null);
  *     workspace.
  */
 BlockDefinitionExtractor.buildBlockFactoryWorkspace = function(block) {
-  var workspaceXml = goog.dom.createDom('xml');
+  var workspaceXml = document.createElement('xml');
   workspaceXml.append(
       BlockDefinitionExtractor.factoryBase_(block, block.type));
 
@@ -64,7 +64,7 @@ BlockDefinitionExtractor.buildBlockFactoryWorkspace = function(block) {
  */
 BlockDefinitionExtractor.newDomElement_ = function(name, opt_attrs, opt_text) {
   // Avoid createDom(..)'s attributes argument for being too HTML specific.
-  var elem = goog.dom.createDom(name);
+  var elem = document.createElement(name);
   if (opt_attrs) {
     for (var key in opt_attrs) {
       elem.setAttribute(key, opt_attrs[key]);
@@ -164,16 +164,17 @@ BlockDefinitionExtractor.factoryBase_ = function(block, name) {
   factoryBaseEl.append(helpUrlValue);
 
   // Convert colour_ to hue value 0-360 degrees
-  // TODO(#1247): Solve off-by-one errors.
-  // TODO: Deal with colors that don't map to standard hues. (Needs improved
-  //     block definitions.)
-  var colour_hue = Math.floor(
-      goog.color.hexToHsv(block.colour_)[0]);  // Off by one... sometimes
-  var colourBlock = BlockDefinitionExtractor.colourBlockFromHue_(colour_hue);
-  var colourInputValue =
-      BlockDefinitionExtractor.newDomElement_('value', {name: 'COLOUR'});
-  colourInputValue.append(colourBlock);
-  factoryBaseEl.append(colourInputValue);
+  var colour_hue = block.getHue();  // May be null if not set via hue.
+  if (colour_hue) {
+    var colourBlock = BlockDefinitionExtractor.colourBlockFromHue_(colour_hue);
+    var colourInputValue =
+        BlockDefinitionExtractor.newDomElement_('value', {name: 'COLOUR'});
+    colourInputValue.append(colourBlock);
+    factoryBaseEl.append(colourInputValue);
+  } else {
+    // Editor will not have a colour block and preview will render black.
+    // TODO: Support RGB colours in the block editor.
+  }
   return factoryBaseEl;
 };
 
@@ -480,7 +481,7 @@ BlockDefinitionExtractor.buildFieldDropdown_ = function(dropdown) {
   var menuGenerator = dropdown.menuGenerator_;
   if (typeof menuGenerator === 'function') {
     var options = menuGenerator();
-  } else if (goog.isArray(menuGenerator)) {
+  } else if (Array.isArray(menuGenerator)) {
     var options = menuGenerator;
   } else {
     throw new Error('Unrecognized type of menuGenerator: ' + menuGenerator);

--- a/demos/blockfactory/block_definition_extractor.js
+++ b/demos/blockfactory/block_definition_extractor.js
@@ -23,17 +23,11 @@
 'use strict';
 
 /**
- * Namespace for BlockDefinitionExtractor.
- */
-goog.provide('BlockDefinitionExtractor');
-
-
-/**
- * Class to contain all functions needed to extract block definition from
+ * Namespace to contain all functions needed to extract block definition from
  * the block preview data structure.
  * @namespace
  */
-BlockDefinitionExtractor = BlockDefinitionExtractor || Object.create(null);
+var BlockDefinitionExtractor = BlockDefinitionExtractor || Object.create(null);
 
 /**
  * Builds a BlockFactory workspace that reflects the block structure of the

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -32,7 +32,6 @@
 goog.provide('BlockExporterController');
 
 goog.require('FactoryUtils');
-goog.require('StandardCategories');
 goog.require('BlockExporterView');
 goog.require('goog.dom.xml');
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -31,7 +31,6 @@
 
 goog.provide('BlockExporterController');
 
-goog.require('FactoryUtils');
 goog.require('BlockExporterView');
 goog.require('goog.dom.xml');
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -29,17 +29,12 @@
 
 'use strict';
 
-goog.provide('BlockExporterController');
-
-goog.require('goog.dom.xml');
-
-
 /**
  * BlockExporter Controller Class
  * @param {!BlockLibrary.Storage} blockLibStorage Block Library Storage.
  * @constructor
  */
-BlockExporterController = function(blockLibStorage) {
+function BlockExporterController(blockLibStorage) {
   // BlockLibrary.Storage object containing user's saved blocks.
   this.blockLibStorage = blockLibStorage;
   // Utils for generating code to export.

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -35,7 +35,6 @@ goog.require('BlocklyDevTools.Analytics');
 goog.require('FactoryUtils');
 goog.require('StandardCategories');
 goog.require('BlockExporterView');
-goog.require('BlockExporterTools');
 goog.require('goog.dom.xml');
 
 
@@ -132,11 +131,11 @@ BlockExporterController.prototype.export = function() {
       BlocklyDevTools.Analytics.onWarning(msg);
       alert(msg);
     } else {
-      
+
       // Get generator stub code in the selected language for the blocks.
       var genStubs = this.tools.getGeneratorCode(blockXmlMap,
           language);
-      
+
       // Download the file.
       FactoryUtils.createAndDownloadFile(
           genStubs, generatorStub_filename + '.js', 'javascript');

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -31,7 +31,6 @@
 
 goog.provide('BlockExporterController');
 
-goog.require('BlocklyDevTools.Analytics');
 goog.require('FactoryUtils');
 goog.require('StandardCategories');
 goog.require('BlockExporterView');

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -31,7 +31,6 @@
 
 goog.provide('BlockExporterController');
 
-goog.require('BlockExporterView');
 goog.require('goog.dom.xml');
 
 

--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -28,19 +28,11 @@
  */
 'use strict';
 
-goog.provide('BlockExporterTools');
-
-goog.require('FactoryUtils');
-goog.require('BlockOption');
-goog.require('goog.dom');
-goog.require('goog.dom.xml');
-
-
 /**
  * Block Exporter Tools Class
  * @constructor
  */
-BlockExporterTools = function() {
+function BlockExporterTools() {
   // Create container for hidden workspace.
   this.container = document.createElement('div');
   this.container.id = 'blockExporterTools_hiddenWorkspace';

--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -42,11 +42,9 @@ goog.require('goog.dom.xml');
  */
 BlockExporterTools = function() {
   // Create container for hidden workspace.
-  this.container = goog.dom.createDom('div', {
-    'id': 'blockExporterTools_hiddenWorkspace'
-  }, ''); // Empty quotes for empty div.
-  // Hide hidden workspace.
-  this.container.style.display = 'none';
+  this.container = document.createElement('div');
+  this.container.id = 'blockExporterTools_hiddenWorkspace';
+  this.container.style.display = 'none';  // Hide the hidden workspace.
   document.body.appendChild(this.container);
   /**
    * Hidden workspace for the Block Exporter that holds pieces that make
@@ -165,45 +163,6 @@ BlockExporterTools.prototype.getGeneratorCode =
 BlockExporterTools.prototype.addBlockDefinitions = function(blockXmlMap) {
   var blockDefs = this.getBlockDefinitions(blockXmlMap, 'JavaScript');
   eval(blockDefs);
-};
-
-/**
- * Pulls information about all blocks in the block library to generate XML
- * for the selector workpace's toolbox.
- * @param {!BlockLibraryStorage} blockLibStorage Block Library Storage object.
- * @return {!Element} XML representation of the toolbox.
- */
-BlockExporterTools.prototype.generateToolboxFromLibrary
-    = function(blockLibStorage) {
-  // Create DOM for XML.
-  var xmlDom = goog.dom.createDom('xml', {
-    'id' : 'blockExporterTools_toolbox',
-    'style' : 'display:none'
-  });
-
-  var allBlockTypes = blockLibStorage.getBlockTypes();
-  // Object mapping block type to XML.
-  var blockXmlMap = blockLibStorage.getBlockXmlMap(allBlockTypes);
-
-  // Define the custom blocks in order to be able to create instances of
-  // them in the exporter workspace.
-  this.addBlockDefinitions(blockXmlMap);
-
-  for (var blockType in blockXmlMap) {
-    // Get block.
-    var block = FactoryUtils.getDefinedBlock(blockType, this.hiddenWorkspace);
-    var category = FactoryUtils.generateCategoryXml([block], blockType);
-    xmlDom.appendChild(category);
-  }
-
-  // If there are no blocks in library and the map is empty, append dummy
-  // category.
-  if (Object.keys(blockXmlMap).length == 0) {
-    var category = goog.dom.createDom('category');
-    category.setAttribute('name','Next Saved Block');
-    xmlDom.appendChild(category);
-  }
-  return xmlDom;
 };
 
 /**

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -29,9 +29,6 @@
 
 goog.provide('BlockExporterView');
 
-goog.require('BlockOption');
-goog.require('goog.dom');
-
 
 /**
  * BlockExporter View Class

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -27,15 +27,12 @@
 
 'use strict';
 
-goog.provide('BlockExporterView');
-
-
 /**
  * BlockExporter View Class
  * @param {!Object} blockOptions Map of block types to BlockOption objects.
  * @constructor
  */
-BlockExporterView = function(blockOptions) {
+function BlockExporterView(blockOptions) {
   //  Map of block types to BlockOption objects to select from.
   this.blockOptions = blockOptions;
 };

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -29,7 +29,6 @@
 
 goog.provide('BlockExporterView');
 
-goog.require('BlockExporterTools');
 goog.require('BlockOption');
 goog.require('goog.dom');
 

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -36,7 +36,6 @@ goog.provide('BlockLibraryController');
 
 goog.require('BlockLibraryStorage');
 goog.require('BlockLibraryView');
-goog.require('BlockFactory');
 
 
 /**

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -32,9 +32,6 @@
  */
 'use strict';
 
-goog.provide('BlockLibraryController');
-
-
 /**
  * Block Library Controller Class
  * @param {string} blockLibraryName Desired name of Block Library, also used
@@ -43,7 +40,7 @@ goog.provide('BlockLibraryController');
  *    object that allows user to import a block library.
  * @constructor
  */
-BlockLibraryController = function(blockLibraryName, opt_blockLibraryStorage) {
+function BlockLibraryController(blockLibraryName, opt_blockLibraryStorage) {
   this.name = blockLibraryName;
   // Create a new, empty Block Library Storage object, or load existing one.
   this.storage = opt_blockLibraryStorage || new BlockLibraryStorage(this.name);
@@ -139,7 +136,7 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
   }
 
   // Create block XML.
-  var xmlElement = goog.dom.createDom('xml');
+  var xmlElement = document.createElement('xml');
   var block = FactoryUtils.getRootBlock(BlockFactory.mainWorkspace);
   xmlElement.appendChild(Blockly.Xml.blockToDomWithXY(block));
 

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -35,7 +35,6 @@
 goog.provide('BlockLibraryController');
 
 goog.require('BlockLibraryStorage');
-goog.require('BlockLibraryView');
 
 
 /**

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -34,7 +34,6 @@
 
 goog.provide('BlockLibraryController');
 
-goog.require('BlocklyDevTools.Analytics');
 goog.require('BlockLibraryStorage');
 goog.require('BlockLibraryView');
 goog.require('BlockFactory');

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -34,8 +34,6 @@
 
 goog.provide('BlockLibraryController');
 
-goog.require('BlockLibraryStorage');
-
 
 /**
  * Block Library Controller Class

--- a/demos/blockfactory/block_library_storage.js
+++ b/demos/blockfactory/block_library_storage.js
@@ -27,9 +27,6 @@
 
 'use strict';
 
-goog.provide('BlockLibraryStorage');
-
-
 /**
  * Represents a block library's storage.
  * @param {string} blockLibraryName Desired name of Block Library, also used
@@ -37,7 +34,7 @@ goog.provide('BlockLibraryStorage');
  * @param {Object} opt_blocks Object mapping block type to XML.
  * @constructor
  */
-BlockLibraryStorage = function(blockLibraryName, opt_blocks) {
+function BlockLibraryStorage(blockLibraryName, opt_blocks) {
   // Add prefix to this.name to avoid collisions in local storage.
   this.name = 'BlockLibraryStorage.' + blockLibraryName;
   if (!opt_blocks) {
@@ -60,9 +57,7 @@ BlockLibraryStorage = function(blockLibraryName, opt_blocks) {
  * Reads the named block library from local storage and saves it in this.blocks.
  */
 BlockLibraryStorage.prototype.loadFromLocalStorage = function() {
-  // goog.global is synonymous to window, and allows for flexibility
-  // between browsers.
-  var object = goog.global.localStorage[this.name];
+  var object = localStorage[this.name];
   this.blocks = object ? JSON.parse(object) : null;
 };
 
@@ -70,7 +65,7 @@ BlockLibraryStorage.prototype.loadFromLocalStorage = function() {
  * Writes the current block library (this.blocks) to local storage.
  */
 BlockLibraryStorage.prototype.saveToLocalStorage = function() {
-  goog.global.localStorage[this.name] = JSON.stringify(this.blocks);
+  localStorage[this.name] = JSON.stringify(this.blocks);
 };
 
 /**

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -27,9 +27,6 @@
 
 'use strict';
 
-goog.provide('BlockLibraryView');
-
-
 /**
  * BlockLibraryView Class
  * @constructor

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -56,7 +56,7 @@ BlockLibraryView.prototype.addOption = function(blockType, selected) {
   var option = document.createElement('a');
   option.id ='dropdown_' + blockType;
   option.classList.add('blockLibOpt');
-  option.innerHTML = blockType;
+  option.textContent = blockType;
 
   // Add option to dropdown.
   this.dropdown.appendChild(option);

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -29,9 +29,6 @@
 
 goog.provide('BlockLibraryView');
 
-goog.require('goog.dom');
-goog.require('goog.dom.classlist');
-
 
 /**
  * BlockLibraryView Class
@@ -59,10 +56,10 @@ var BlockLibraryView = function() {
  */
 BlockLibraryView.prototype.addOption = function(blockType, selected) {
   // Create option.
-  var option = goog.dom.createDom('a', {
-    'id': 'dropdown_' + blockType,
-    'class': 'blockLibOpt'
-  }, blockType);
+  var option = document.createElement('a');
+  option.id ='dropdown_' + blockType;
+  option.classList.add('blockLibOpt');
+  option.innerHTML = blockType;
 
   // Add option to dropdown.
   this.dropdown.appendChild(option);
@@ -99,7 +96,7 @@ BlockLibraryView.prototype.setSelectedBlockType = function(blockTypeToSelect) {
  * @private
  */
 BlockLibraryView.prototype.selectOption_ = function(option) {
-  goog.dom.classlist.add(option, 'dropdown-content-selected');
+  option.classList.add('dropdown-content-selected');
 };
 
 /**
@@ -109,7 +106,7 @@ BlockLibraryView.prototype.selectOption_ = function(option) {
  * @private
  */
 BlockLibraryView.prototype.deselectOption_ = function(option) {
-  goog.dom.classlist.remove(option, 'dropdown-content-selected');
+  option.classList.remove('dropdown-content-selected');
 };
 
 /**
@@ -150,13 +147,12 @@ BlockLibraryView.prototype.updateButtons =
       if (blockType == 'block_type') {
         buttonFormatClass = 'button_alert';
       }
-      goog.dom.classlist.add(this.saveButton, buttonFormatClass);
+      this.saveButton.classList.add(buttonFormatClass);
       this.saveButton.disabled = false;
 
     } else {
       // No changes to save.
-      var classesToRemove = ['button_alert', 'button_warn'];
-      goog.dom.classlist.removeAll(this.saveButton, classesToRemove);
+      this.saveButton.classList.remove('button_alert', 'button_warn');
       this.saveButton.disabled = true;
     }
 

--- a/demos/blockfactory/block_option.js
+++ b/demos/blockfactory/block_option.js
@@ -102,7 +102,7 @@ BlockOption.prototype.createDom = function() {
   // Create and append text node for the label.
   var labelText = document.createElement('p');
   labelText.id = this.blockType + '_text';
-  labelText.innerHTML = this.blockType;
+  labelText.textContent = this.blockType;
   labelContainer.appendChild(labelText);
 
   this.dom = blockOptContainer;

--- a/demos/blockfactory/block_option.js
+++ b/demos/blockfactory/block_option.js
@@ -28,9 +28,6 @@
  */
 'use strict';
 
-goog.provide('BlockOption');
-
-
  /**
  * BlockOption Class
  * A block option includes checkbox, label, and div element that shows a preview

--- a/demos/blockfactory/block_option.js
+++ b/demos/blockfactory/block_option.js
@@ -19,16 +19,16 @@
  */
 
 /**
- * @fileoverview Javascript for the BlockOption class, used to represent each of
- * the various blocks that you may select. Each block option has a checkbox,
- * a label, and a preview workspace through which to view the block.
+ * @fileoverview Javascript for the BlockOption class, used to represent each
+ * of the various blocks that you may select in the Block Selector. Each block
+ * option has a checkbox, a label, and a preview workspace through which to
+ * view the block.
  *
  * @author quachtina96 (Tina Quach)
  */
 'use strict';
 
 goog.provide('BlockOption');
-goog.require('goog.dom');
 
 
  /**
@@ -70,48 +70,42 @@ var BlockOption = function(blockSelector, blockType, previewBlockXml) {
  */
 BlockOption.prototype.createDom = function() {
   // Create the div for the block option.
-  var blockOptContainer = goog.dom.createDom('div', {
-    'id': this.blockType,
-    'class': 'blockOption'
-  }, ''); // Empty quotes for empty div.
+  var blockOptContainer = document.createElement('div');
+  blockOptContainer.id = this.blockType;
+  blockOptContainer.classList.add('blockOption');
 
   // Create and append div in which to inject the workspace for viewing the
   // block option.
-  var blockOptionPreview = goog.dom.createDom('div', {
-    'id' : this.blockType + '_workspace',
-    'class': 'blockOption_preview'
-  }, '');
+  var blockOptionPreview = document.createElement('div');
+  blockOptionPreview.id = this.blockType + '_workspace';
+  blockOptionPreview.classList.add('blockOption_preview');
   blockOptContainer.appendChild(blockOptionPreview);
 
   // Create and append container to hold checkbox and label.
-  var checkLabelContainer = goog.dom.createDom('div', {
-    'class': 'blockOption_checkLabel'
-  }, '');
+  var checkLabelContainer = document.createElement('div');
+  checkLabelContainer.classList.add('blockOption_checkLabel');
   blockOptContainer.appendChild(checkLabelContainer);
 
   // Create and append container for checkbox.
-  var checkContainer = goog.dom.createDom('div', {
-    'class': 'blockOption_check'
-  }, '');
+  var checkContainer = document.createElement('div');
+  checkContainer.classList.add('blockOption_check');
   checkLabelContainer.appendChild(checkContainer);
 
   // Create and append checkbox.
-  this.checkbox = goog.dom.createDom('input', {
-    'type': 'checkbox',
-    'id': this.blockType + '_check'
-  }, '');
+  this.checkbox = document.createElement('input');
+  this.checkbox.id = this.blockType + '_check';
+  this.checkbox.setAttribute('type', 'checkbox');
   checkContainer.appendChild(this.checkbox);
 
   // Create and append container for block label.
-  var labelContainer = goog.dom.createDom('div', {
-    'class': 'blockOption_label'
-  }, '');
+  var labelContainer = document.createElement('div');
+  labelContainer.classList.add('blockOption_label');
   checkLabelContainer.appendChild(labelContainer);
 
   // Create and append text node for the label.
-  var labelText = goog.dom.createDom('p', {
-    'id': this.blockType + '_text'
-  }, this.blockType);
+  var labelText = document.createElement('p');
+  labelText.id = this.blockType + '_text';
+  labelText.innerHTML = this.blockType;
   labelContainer.appendChild(labelText);
 
   this.dom = blockOptContainer;

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -32,8 +32,7 @@
 /**
  * Namespace for Block Factory.
  */
-goog.provide('BlockFactory');
-
+var BlockFactory = BlockFactory || Object.create(null);
 
 /**
  * Workspace for user to build block.

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -34,7 +34,6 @@
  */
 goog.provide('BlockFactory');
 
-goog.require('FactoryUtils');
 
 /**
  * Workspace for user to build block.

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -35,7 +35,6 @@
 goog.provide('BlockFactory');
 
 goog.require('FactoryUtils');
-goog.require('StandardCategories');
 
 /**
  * Workspace for user to build block.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -32,8 +32,7 @@
 /**
  * Namespace for FactoryUtils.
  */
-goog.provide('FactoryUtils');
-
+var FactoryUtils = FactoryUtils || Object.create(null);
 
 /**
  * Get block definition code for the current block.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -766,7 +766,7 @@ FactoryUtils.getBlockTypeFromJsDefinition = function(blockDef) {
  */
 FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
   // Create category DOM element.
-  var categoryElement = goog.dom.createDom('category');
+  var categoryElement = document.createElement('category');
   categoryElement.setAttribute('name', categoryName);
 
   // For each block, add block element to category.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -889,7 +889,7 @@ FactoryUtils.injectCode = function(code, id) {
   pre.textContent = code;
   code = pre.textContent;
   code = PR.prettyPrintOne(code, 'js');
-  pre.innerHTML = code;
+  pre.textContent = code;
 };
 
 /**

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -34,8 +34,6 @@
  */
 goog.provide('FactoryUtils');
 
-goog.require('BlockDefinitionExtractor');
-
 
 /**
  * Get block definition code for the current block.

--- a/demos/blockfactory/standard_categories.js
+++ b/demos/blockfactory/standard_categories.js
@@ -32,7 +32,7 @@
 /**
  * Namespace for StandardCategories
  */
-goog.provide('StandardCategories');
+var StandardCategories = StandardCategories || Object.create(null);
 
 
 // Map of standard category information necessary to add a standard category

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -34,9 +34,6 @@
  * @author Emma Dauterman (evd2014)
  */
 
-goog.require('FactoryUtils');
-
-
 /**
  * Class for a WorkspaceFactoryController
  * @param {string} toolboxName Name of workspace toolbox XML.

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -34,7 +34,6 @@
  * @author Emma Dauterman (evd2014)
  */
 
-goog.require('BlocklyDevTools.Analytics');
 goog.require('FactoryUtils');
 goog.require('StandardCategories');
 

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -35,7 +35,6 @@
  */
 
 goog.require('FactoryUtils');
-goog.require('StandardCategories');
 
 
 /**

--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -59,11 +59,10 @@ WorkspaceFactoryGenerator = function(model) {
  */
 WorkspaceFactoryGenerator.prototype.generateToolboxXml = function() {
   // Create DOM for XML.
-  var xmlDom = goog.dom.createDom('xml',
-      {
-        'id' : 'toolbox',
-        'style' : 'display:none'
-      });
+  var xmlDom = document.createElement('xml');
+  xmlDom.id = 'toolbox';
+  xmlDom.style.display = 'none';
+
   if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
     this.loadToHiddenWorkspace_(this.model.getSelectedXml());
@@ -86,10 +85,10 @@ WorkspaceFactoryGenerator.prototype.generateToolboxXml = function() {
       var element = toolboxList[i];
       if (element.type == ListElement.TYPE_SEPARATOR) {
         // If the next element is a separator.
-        var nextElement = goog.dom.createDom('sep');
+        var nextElement = document.createElement('sep');
       } else if (element.type == ListElement.TYPE_CATEGORY) {
         // If the next element is a category.
-        var nextElement = goog.dom.createDom('category');
+        var nextElement = document.createElement('category');
         nextElement.setAttribute('name', element.name);
         // Add a colour attribute if one exists.
         if (element.color != null) {

--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -28,8 +28,6 @@
  * @author Emma Dauterman (evd2014)
  */
 
-goog.require('FactoryUtils');
-
 
 /**
  * Class for a WorkspaceFactoryGenerator

--- a/demos/blockfactory/workspacefactory/wfactory_init.js
+++ b/demos/blockfactory/workspacefactory/wfactory_init.js
@@ -27,6 +27,8 @@
  * @author Emma Dauterman (evd2014)
  */
 
+goog.require('goog.ui.PopupColorPicker');
+goog.require('goog.ui.ColorPicker');
 
 /**
  * Namespace for workspace factory initialization methods.

--- a/demos/blockfactory/workspacefactory/wfactory_init.js
+++ b/demos/blockfactory/workspacefactory/wfactory_init.js
@@ -27,7 +27,6 @@
  * @author Emma Dauterman (evd2014)
  */
 
- goog.require('FactoryUtils');
 
 /**
  * Namespace for workspace factory initialization methods.

--- a/demos/blockfactory/workspacefactory/wfactory_view.js
+++ b/demos/blockfactory/workspacefactory/wfactory_view.js
@@ -28,7 +28,6 @@
  * @author Emma Dauterman (edauterman)
  */
 
-goog.require('FactoryUtils');
 
 /**
  * Class for a WorkspaceFactoryView


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#668 (partially)

### Proposed Changes

Replacing all Closure `goog.` library calls from BlockFactory, with the exception of the ColorPicker and the test for the warning about running without Closure. This includes (almost) all `goog.provide` and `goog.require` statements.

Final status:
```
$ grep -rF "goog." .
./index.html:      Add it only if you need it.  See also goog.require in blockly.js.
./app_controller.js:goog.require('goog.dom.xml');  // Used to detect Closure
./app_controller.js:  if (!window.goog.dom.xml) {
./workspacefactory/wfactory_init.js:goog.require('goog.ui.PopupColorPicker');
./workspacefactory/wfactory_init.js:goog.require('goog.ui.ColorPicker');
./workspacefactory/wfactory_init.js:  var colourPicker = new goog.ui.ColorPicker();
./workspacefactory/wfactory_init.js:  var popupPicker = new goog.ui.PopupColorPicker(null, colourPicker);
./workspacefactory/wfactory_init.js:  goog.events.listen(popupPicker, 'change', function(e) {
```

I'll remove the ColorPicker and warning in a follow-up PR.

### Reason for Changes

Recent changes in Closure have been breaking BlockFactory, which uses Closure libraries but was not compiled by the Closure Compiler. This also simplifies use for people host their own BlockFactory, or running the local file from the repo.

### Test Coverage

Every changed function and class was run at least once (manual testing), verifying I did not break its primary behavior. Most changes are trivial.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->