### PR TITLE
Support %{..} in flyout_button (#1927)

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -161,7 +161,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-  svgText.textContent = this.text_;
+  svgText.textContent = Blockly.utils.replaceMessageReferences(this.text_);
 
   this.width = Blockly.Field.getCachedWidth(svgText);
   this.height = 20;  // Can't compute it :(

--- a/core/variables.js
+++ b/core/variables.js
@@ -129,7 +129,7 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
 Blockly.Variables.flyoutCategory = function(workspace) {
   var xmlList = [];
   var button = goog.dom.createDom('button');
-  button.setAttribute('text', Blockly.Msg['NEW_VARIABLE']);
+  button.setAttribute('text', '%{BKY_NEW_VARIABLE}');
   button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
   workspace.registerButtonCallback('CREATE_VARIABLE', function(button) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1927 

### Proposed Changes

Expand `%{..}` references in toolbox `<button>` and `<label>`

### Reason for Changes

Support i18n.

### Test Coverage

Changed the add variable category button to emit the message reference, and tested in Code demo.

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
