### PR TITLE
Add curly and space-infix-ops rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
     "rules": {
-        "curly": ["error", "multi-line"],
+        "curly": ["error"],
         "eol-last": ["error"],
         "indent": [
             "error", 2,  # Blockly/Google use 2-space indents
@@ -50,6 +50,7 @@
         "quotes": ["off"], # Blockly uses single quotes except for JSON blobs, which must use double quotes.
         "semi": ["error", "always"],
         "space-before-function-paren": ["error", "never"], # Blockly doesn't have space before function paren
+        "space-infix-ops": ["error"],
         "strict": ["off"], # Blockly uses 'use strict' in files
         "no-cond-assign": ["off"], # Blockly often uses cond-assignment in loops
         "no-redeclare": ["off"], # Closure style allows redeclarations

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -626,7 +626,7 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
    * @this Blockly.Block
    */
   newQuote_: function(open) {
-    var isLeft = this.RTL? !open : open;
+    var isLeft = this.RTL ? !open : open;
     var dataUri = isLeft ?
       this.QUOTE_IMAGE_LEFT_DATAURI :
       this.QUOTE_IMAGE_RIGHT_DATAURI;

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -135,7 +135,7 @@ Blockly.BlockDragSurfaceSvg.prototype.translateAndScaleGroup = function(x, y, sc
   var fixedX = x.toFixed(0);
   var fixedY = y.toFixed(0);
   this.dragGroup_.setAttribute('transform',
-      'translate('+ fixedX + ','+ fixedY + ') scale(' + scale + ')');
+      'translate(' + fixedX + ',' + fixedY + ') scale(' + scale + ')');
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -632,7 +632,7 @@ Blockly.checkBlockColourConstant_ = function(
     msgName, blocklyNamePath, expectedValue) {
   var namePath = 'Blockly';
   var value = Blockly;
-  for (var i =0; i < blocklyNamePath.length; ++i) {
+  for (var i = 0; i < blocklyNamePath.length; ++i) {
     namePath += '.' + blocklyNamePath[i];
     if (value) {
       value = value[blocklyNamePath[i]];

--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -48,7 +48,7 @@ goog.require('goog.math.Coordinate');
 Blockly.Events.Ui = function(block, element, oldValue, newValue) {
   Blockly.Events.Ui.superClass_.constructor.call(this);
   this.blockId = block ? block.id : null;
-  this.workspaceId = block? block.workspace.id : null;
+  this.workspaceId = block ? block.workspace.id : null;
   this.element = element;
   this.oldValue = oldValue;
   this.newValue = newValue;


### PR DESCRIPTION
Make curly stricter.

Require spaces around infix ops.