### PR TITLE
Revert breaking changes to BlockFactory

### DIFF
--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -148,7 +148,7 @@ BlockFactory.updateLanguage = function() {
     if (!BlockFactory.updateBlocksFlagDelayed) {
       var languagePre = document.getElementById('languagePre');
       var languageTA = document.getElementById('languageTA');
-      code = languagePre.textContent.trim();
+      code = languagePre.innerText.trim();
       languageTA.value = code;
     }
   }

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -889,7 +889,7 @@ FactoryUtils.injectCode = function(code, id) {
   pre.textContent = code;
   code = pre.textContent;
   code = PR.prettyPrintOne(code, 'js');
-  pre.textContent = code;
+  pre.innerHTML = code;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

XML code the block definition `<pre>`, and missing preview:

![screen shot 2018-06-25 at 3 18 51 pm](https://user-images.githubusercontent.com/9916202/41878770-69d84292-788b-11e8-8d66-95523665c948.png)


### Proposed Changes

Correct the overcorrection, restoring use of `innerHTML`.

### Reason for Changes

Excessive removal of `innerHTML` reference broke code.

### Test Coverage

Opened BlockFactory to see it was correct and working.

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
