### PR TITLE
Revert changes to i18n/js_to_json.py from 4cb4b42

### DIFF
--- a/i18n/js_to_json.py
+++ b/i18n/js_to_json.py
@@ -48,10 +48,10 @@ import re
 from common import write_files
 
 
-_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg\[(\w*)\]\s*=\s*'(.*)';?\r?$""")
+_INPUT_DEF_PATTERN = re.compile("""Blockly.Msg.(\w*)\s*=\s*'(.*)';?\r?$""")
 
 _INPUT_SYN_PATTERN = re.compile(
-    """Blockly.Msg\[(\w*)\]\s*=\s*Blockly.Msg\[(\w*)\];""")
+    """Blockly.Msg.(\w*)\s*=\s*Blockly.Msg.(\w*);""")
 
 _CONSTANT_DESCRIPTION_PATTERN = re.compile(
     """{{Notranslate}}""", re.IGNORECASE)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1934

### Proposed Changes

`messages.js` does not use array notation. Match on original dot notation.

### Reason for Changes

Message building broke, but only noticed when the message files were out of date.

Future: Need to update Travis to test compilation with `msg/js` files removed (and maybe other files).

### Test Coverage

Removed `msg/js/en.js` and rebuilt