### PR TITLE
Fix colour generator tests

### DIFF
--- a/tests/generators/colour.xml
+++ b/tests/generators/colour.xml
@@ -104,8 +104,18 @@
             <next>
               <block type="unittest_assertequals" inline="false">
                 <value name="MESSAGE">
-                  <block type="text">
-                    <field name="TEXT">test name</field>
+                  <block type="text_join">
+                    <mutation items="2"></mutation>
+                    <value name="ADD0">
+                      <block type="text">
+                        <field name="TEXT">length of random colour string: </field>
+                      </block>
+                    </value>
+                    <value name="ADD1">
+                      <block type="variables_get">
+                        <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
+                      </block>
+                    </value>
                   </block>
                 </value>
                 <value name="ACTUAL">
@@ -125,8 +135,18 @@
                 <next>
                   <block type="unittest_assertequals" inline="false">
                     <value name="MESSAGE">
-                      <block type="text">
-                        <field name="TEXT">test name</field>
+                      <block type="text_join">
+                        <mutation items="2"></mutation>
+                        <value name="ADD0">
+                          <block type="text">
+                            <field name="TEXT">format of random colour string: </field>
+                          </block>
+                        </value>
+                        <value name="ADD1">
+                          <block type="variables_get">
+                            <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
+                          </block>
+                        </value>
                       </block>
                     </value>
                     <value name="ACTUAL">
@@ -162,8 +182,32 @@
                           <block type="unittest_assertvalue" inline="false">
                             <field name="EXPECTED">TRUE</field>
                             <value name="MESSAGE">
-                              <block type="text">
-                                <field name="TEXT">test name</field>
+                              <block type="text_join">
+                                <mutation items="4"></mutation>
+                                <value name="ADD0">
+                                  <block type="text">
+                                    <field name="TEXT">contents of random colour string: </field>
+                                  </block>
+                                </value>
+                                <value name="ADD1">
+                                  <block type="variables_get">
+                                    <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
+                                  </block>
+                                </value>
+                                <value name="ADD2">
+                                  <block type="text">
+                                    <field name="TEXT"> at index: </field>
+                                  </block>
+                                </value>
+                                <value name="ADD3">
+                                  <block type="unittest_adjustindex">
+                                    <value name="INDEX">
+                                      <block type="variables_get">
+                                        <field name="VAR" id="Y^.=S=NGMAu`73E}(x;A" variabletype="">i</field>
+                                      </block>
+                                    </value>
+                                  </block>
+                                </value>
                               </block>
                             </value>
                             <value name="ACTUAL">
@@ -223,7 +267,7 @@
       </block>
     </statement>
   </block>
-  <block type="procedures_defnoreturn" x="520" y="205">
+  <block type="procedures_defnoreturn" x="638" y="213">
     <field name="NAME">test blend</field>
     <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">

--- a/tests/generators/colour.xml
+++ b/tests/generators/colour.xml
@@ -1,13 +1,18 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id=".BC!Zr?d!(!/,oU[FR=N">item</variable>
+    <variable type="" id="Y^.=S=NGMAu`73E}(x;A">i</variable>
+  </variables>
   <block type="procedures_defnoreturn" x="260" y="14">
     <field name="NAME">test colour picker</field>
+    <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">
       <block type="unittest_assertequals" inline="false">
         <value name="MESSAGE">
-           <block type="text">
-             <field name="TEXT">static colour</field>
-           </block>
-         </value>
+          <block type="text">
+            <field name="TEXT">static colour</field>
+          </block>
+        </value>
         <value name="ACTUAL">
           <block type="colour_picker">
             <field name="COLOUR">#ff6600</field>
@@ -23,13 +28,14 @@
   </block>
   <block type="procedures_defnoreturn" x="630" y="13">
     <field name="NAME">test rgb</field>
+    <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">
       <block type="unittest_assertequals" inline="false">
         <value name="MESSAGE">
-           <block type="text">
-             <field name="TEXT">from rgb</field>
-           </block>
-         </value>
+          <block type="text">
+            <field name="TEXT">from rgb</field>
+          </block>
+        </value>
         <value name="ACTUAL">
           <block type="colour_rgb" inline="false">
             <value name="RED">
@@ -81,6 +87,7 @@
   </block>
   <block type="procedures_defnoreturn" x="-7" y="223">
     <field name="NAME">test colour random</field>
+    <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">
       <block type="controls_repeat_ext" inline="true">
         <value name="TIMES">
@@ -90,22 +97,22 @@
         </value>
         <statement name="DO">
           <block type="variables_set" inline="false">
-            <field name="VAR">item</field>
+            <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
             <value name="VALUE">
               <block type="colour_random"></block>
             </value>
             <next>
               <block type="unittest_assertequals" inline="false">
                 <value name="MESSAGE">
-                   <block type="text">
-                     <field name="TEXT">test name</field>
-                   </block>
-                 </value>
+                  <block type="text">
+                    <field name="TEXT">test name</field>
+                  </block>
+                </value>
                 <value name="ACTUAL">
                   <block type="text_length" inline="false">
                     <value name="VALUE">
                       <block type="variables_get">
-                        <field name="VAR">item</field>
+                        <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
                       </block>
                     </value>
                   </block>
@@ -118,17 +125,17 @@
                 <next>
                   <block type="unittest_assertequals" inline="false">
                     <value name="MESSAGE">
-                       <block type="text">
-                         <field name="TEXT">test name</field>
-                       </block>
-                     </value>
+                      <block type="text">
+                        <field name="TEXT">test name</field>
+                      </block>
+                    </value>
                     <value name="ACTUAL">
                       <block type="text_charAt">
                         <mutation at="false"></mutation>
                         <field name="WHERE">FIRST</field>
                         <value name="VALUE">
                           <block type="variables_get">
-                            <field name="VAR">item</field>
+                            <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
                           </block>
                         </value>
                       </block>
@@ -140,31 +147,35 @@
                     </value>
                     <next>
                       <block type="controls_for">
-                        <field name="VAR">i</field>
+                        <field name="VAR" id="Y^.=S=NGMAu`73E}(x;A" variabletype="">i</field>
                         <value name="FROM">
                           <block type="math_number">
-                            <field name="NUM">2</field>
+                            <field name="NUM">1</field>
                           </block>
                         </value>
                         <value name="TO">
                           <block type="math_number">
-                            <field name="NUM">7</field>
+                            <field name="NUM">6</field>
                           </block>
                         </value>
                         <statement name="DO">
                           <block type="unittest_assertvalue" inline="false">
-                            <value name="MESSAGE">
-                               <block type="text">
-                                 <field name="TEXT">test name</field>
-                               </block>
-                             </value>
                             <field name="EXPECTED">TRUE</field>
+                            <value name="MESSAGE">
+                              <block type="text">
+                                <field name="TEXT">test name</field>
+                              </block>
+                            </value>
                             <value name="ACTUAL">
                               <block type="logic_compare">
                                 <field name="OP">NEQ</field>
                                 <value name="A">
-                                  <block type="math_number">
-                                    <field name="NUM">0</field>
+                                  <block type="unittest_adjustindex">
+                                    <value name="INDEX">
+                                      <block type="math_number">
+                                        <field name="NUM">-1</field>
+                                      </block>
+                                    </value>
                                   </block>
                                 </value>
                                 <value name="B">
@@ -181,12 +192,16 @@
                                         <field name="WHERE">FROM_START</field>
                                         <value name="VALUE">
                                           <block type="variables_get">
-                                            <field name="VAR">item</field>
+                                            <field name="VAR" id=".BC!Zr?d!(!/,oU[FR=N" variabletype="">item</field>
                                           </block>
                                         </value>
                                         <value name="AT">
-                                          <block type="variables_get">
-                                            <field name="VAR">i</field>
+                                          <block type="unittest_adjustindex">
+                                            <value name="INDEX">
+                                              <block type="variables_get">
+                                                <field name="VAR" id="Y^.=S=NGMAu`73E}(x;A" variabletype="">i</field>
+                                              </block>
+                                            </value>
                                           </block>
                                         </value>
                                       </block>
@@ -210,13 +225,14 @@
   </block>
   <block type="procedures_defnoreturn" x="520" y="205">
     <field name="NAME">test blend</field>
+    <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">
       <block type="unittest_assertequals" inline="false">
         <value name="MESSAGE">
-           <block type="text">
-             <field name="TEXT">blend</field>
-           </block>
-         </value>
+          <block type="text">
+            <field name="TEXT">blend</field>
+          </block>
+        </value>
         <value name="ACTUAL">
           <block type="colour_blend" inline="false">
             <value name="COLOUR1">


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No issue filed, but the random colour tests in the generator suite were failing when generated with zero-based-indexing because the tests were not correctly adjusting the index and return value.

### Proposed Changes

- Correctly use the "adjusted" block to take indexing into account.
- Add better messages to the asserts.

### Reason for Changes

Generator tests were failing.

### Test Coverage
I ran the generator tests in both indexing modes.

### Additional Information
Old "test colour random" function:
![image](https://user-images.githubusercontent.com/13686399/42001168-f9a5779a-7a17-11e8-8956-4ebc4c629543.png)

New "test colour random" function:
![image](https://user-images.githubusercontent.com/13686399/42001202-1bd59372-7a18-11e8-863a-a6cbc11b4c1a.png)
