### PR TITLE
Fixing JSDoc for the return type of Blockly.WorkspaceComment.parseAttributes

### DIFF
--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -331,7 +331,8 @@ Blockly.WorkspaceComment.fromXml = function(xmlComment, workspace) {
 /**
  * Decode an XML comment tag and return the results in an object.
  * @param {!Element} xml XML comment element.
- * @return {!Object} An object containing the information about the comment.
+ * @return {{w: number, h: number, x: number, y: number, content: string}} An
+ *     object containing the id, size, position, and comment string.
  * @package
  */
 Blockly.WorkspaceComment.parseAttributes = function(xml) {
@@ -339,31 +340,23 @@ Blockly.WorkspaceComment.parseAttributes = function(xml) {
   var xmlW = xml.getAttribute('w');
 
   return {
-    /* @type {string} */
+    // @type {string}
     id: xml.getAttribute('id'),
-    /**
-     * The height of the comment in workspace units, or 100 if not specified.
-     * @type {number}
-     */
+    // The height of the comment in workspace units, or 100 if not specified.
+    // @type {number}
     h: xmlH ? parseInt(xmlH, 10) : 100,
-    /**
-     * The width of the comment in workspace units, or 100 if not specified.
-     * @type {number}
-     */
+    // The width of the comment in workspace units, or 100 if not specified.
+    // @type {number}
     w: xmlW ? parseInt(xmlW, 10) : 100,
-    /**
-     * The x position of the comment in workspace coordinates, or NaN if not
-     * specified in the XML.
-     * @type {number}
-     */
+    // The x position of the comment in workspace coordinates, or NaN if not
+    // specified in the XML.
+    // @type {number}
     x: parseInt(xml.getAttribute('x'), 10),
-    /**
-     * The y position of the comment in workspace coordinates, or NaN if not
-     * specified in the XML.
-     * @type {number}
-     */
+    // The y position of the comment in workspace coordinates, or NaN if not
+    // specified in the XML.
+    // @type {number}
     y: parseInt(xml.getAttribute('y'), 10),
-    /* @type {string} */
+    // @type {string}
     content: xml.textContent
   };
 };


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Adjusting annotations of the return object properties of Blockly.WorkspaceComment.parseAttributes

### Reason for Changes

Previous form treated JSDoc `@return` object properties as globals.

### Test Coverage

Rebuilt JSDoc with this change.