### PR TITLE
Revert "Fix #1960 by collecting block info before icons are destroyed"

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -837,27 +837,16 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     this.warningTextDb_ = null;
   }
 
-  // If the block is rendered we need to record the event before disposing of
-  // the icons to prevent losing information.
-  // TODO (#1969): Remove event generation/firing once comments are fixed.
-  var deleteEvent;
-  if (Blockly.Events.isEnabled()) {
-    deleteEvent = new Blockly.Events.BlockDelete(this);
-  }
   Blockly.Events.disable();
   try {
     var icons = this.getIcons();
     for (var i = 0; i < icons.length; i++) {
       icons[i].dispose();
     }
-    // TODO (#1969): Move out of disable block once comments are fixed.
-    Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
   } finally {
     Blockly.Events.enable();
   }
-  if (Blockly.Events.isEnabled() && deleteEvent) {
-    Blockly.Events.fire(deleteEvent);
-  }
+  Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
 
   this.svgGroup_.parentNode.removeChild(this.svgGroup_);
   blockWorkspace.resizeContents();


### PR DESCRIPTION
Reverts google/blockly#1970

Causes a crash when replacing a shadow block. Should just do the full fix to decouple icons from the comment instead of patching around it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1973)
<!-- Reviewable:end -->
