### PR TITLE
Removing goog.* uses from blocks/*.js files

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -268,8 +268,9 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
       option.text =
           Blockly.Msg['VARIABLES_SET_CREATE_GET'].replace('%1', varName);
       var xmlField = Blockly.Variables.generateVariableFieldDom(variable);
-      var xmlBlock = goog.dom.createDom('block', null, xmlField);
+      var xmlBlock = document.createElement('block');
       xmlBlock.setAttribute('type', 'variables_get');
+      xmlBlock.appendChild(xmlField);
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);
     }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -621,7 +621,9 @@ Blockly.Blocks['procedures_callnoreturn'] = {
       // Reset the quarks (a mutator is about to open).
       return;
     }
-    if (goog.array.equals(this.arguments_, paramNames)) {
+    // Test arguments (arrays of strings) for changes. '\n' is not a valid
+    // argument name character, so it is a valid delimiter here.
+    if (paramNames.join('\n') == this.arguments_.join('\n')) {
       // No change.
       this.quarkIds_ = paramIds;
       return;
@@ -633,13 +635,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     if (!this.quarkIds_) {
       // Initialize tracking for this block.
       this.quarkConnections_ = {};
-      if (paramNames.join('\n') == this.arguments_.join('\n')) {
-        // No change to the parameters, allow quarkConnections_ to be
-        // populated with the existing connections.
-        this.quarkIds_ = paramIds;
-      } else {
-        this.quarkIds_ = [];
-      }
+      this.quarkIds_ = [];
     }
     // Switch off rendering while the block is rebuilt.
     var savedRendered = this.rendered;

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -357,15 +357,16 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     var option = {enabled: true};
     var name = this.getFieldValue('NAME');
     option.text = Blockly.Msg['PROCEDURES_CREATE_DO'].replace('%1', name);
-    var xmlMutation = goog.dom.createDom('mutation');
+    var xmlMutation = document.createElement('mutation');
     xmlMutation.setAttribute('name', name);
     for (var i = 0; i < this.arguments_.length; i++) {
-      var xmlArg = goog.dom.createDom('arg');
+      var xmlArg = document.createElement('arg');
       xmlArg.setAttribute('name', this.arguments_[i]);
       xmlMutation.appendChild(xmlArg);
     }
-    var xmlBlock = goog.dom.createDom('block', null, xmlMutation);
+    var xmlBlock = document.createElement('block');
     xmlBlock.setAttribute('type', this.callType_);
+    xmlBlock.appendChild(xmlMutation);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
     options.push(option);
 
@@ -378,8 +379,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
         option.text = Blockly.Msg['VARIABLES_SET_CREATE_GET'].replace('%1', name);
 
         var xmlField = Blockly.Variables.generateVariableFieldDom(argVar);
-        var xmlBlock = goog.dom.createDom('block', null, xmlField);
+        var xmlBlock = document.createElement('block');
         xmlBlock.setAttribute('type', 'variables_get');
+        xmlBlock.appendChild(xmlField);
         option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
         options.push(option);
       }
@@ -809,8 +811,8 @@ Blockly.Blocks['procedures_callnoreturn'] = {
          *   </block>
          * </xml>
          */
-        var xml = goog.dom.createDom('xml');
-        var block = goog.dom.createDom('block');
+        var xml = document.createElement('xml');
+        var block = document.createElement('block');
         block.setAttribute('type', this.defType_);
         var xy = this.getRelativeToSurfaceXY();
         var x = xy.x + Blockly.SNAP_RADIUS * (this.RTL ? -1 : 1);
@@ -819,7 +821,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         block.setAttribute('y', y);
         var mutation = this.mutationToDom();
         block.appendChild(mutation);
-        var field = goog.dom.createDom('field');
+        var field = document.createElement('field');
         field.setAttribute('name', 'NAME');
         field.appendChild(document.createTextNode(this.getProcedureCall()));
         block.appendChild(field);

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -115,10 +115,12 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
     var option = {enabled: this.workspace.remainingCapacity() > 0};
     var name = this.getField('VAR').getText();
     option.text = contextMenuMsg.replace('%1', name);
-    var xmlField = goog.dom.createDom('field', null, name);
+    var xmlField = document.createElement('field');
     xmlField.setAttribute('name', 'VAR');
-    var xmlBlock = goog.dom.createDom('block', null, xmlField);
+    xmlField.appendChild(document.createTextNode(name));
+    var xmlBlock = document.createElement('block');
     xmlBlock.setAttribute('type', opposite_type);
+    xmlBlock.appendChild(xmlField);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
     options.push(option);
   }

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -113,10 +113,12 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     var option = {enabled: this.workspace.remainingCapacity() > 0};
     var name = this.getField('VAR').getText();
     option.text = contextMenuMsg.replace('%1', name);
-    var xmlField = goog.dom.createDom('field', null, name);
+    var xmlField = document.createElement('field');
     xmlField.setAttribute('name', 'VAR');
-    var xmlBlock = goog.dom.createDom('block', null, xmlField);
+    xmlField.appendChild(document.createTextNode(name));
+    var xmlBlock = document.createElement('block');
     xmlBlock.setAttribute('type', opposite_type);
+    xmlBlock.appendChild(xmlField);
     option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
     options.push(option);
   },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1971

### Proposed Changes

Replace all uses of `goog.*` library calls, other than `goog.provide(..)` and `goog.require(..)`. Specifically, `goog.dom.createDom(..)` and one use of `goog.array.equals(..)`.

### Reason for Changes

`blocks/` files may not be compiled with the Closure compiler and should never use `goog.*` library calls.

This happened to work in the past because these functions happened to be called by `core/` files. However, as we are distancing ourselves from Closure library, the calls in `core/` were removed and now causes the crash identified in #1971

### Test Coverage

Performed actions in the playground that triggered each of the modified methods:
 * Performed numerous various procedure mutator interactions/modiciations.
 * Used variable block shortcuts in context menus.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
