### PR TITLE
Add test for replacing a rendered shadow block

### DIFF
--- a/tests/workspace_svg/workspace_svg_test.js
+++ b/tests/workspace_svg/workspace_svg_test.js
@@ -19,6 +19,42 @@
  */
 'use strict';
 
+function helper_setUpMockBlocks() {
+  // TODO: Replace with defineGetVarBlock();
+  Blockly.defineBlocksWithJsonArray([{
+    'type': 'field_variable_test_block',
+    'message0': '%1',
+    'args0': [
+      {
+        'type': 'field_variable',
+        'name': 'VAR',
+        'variable': 'item'
+      }
+    ],
+  },
+  {
+    'type': 'simple_test_block',
+    'message0': 'simple test block',
+    'output': null
+  },
+  {
+    'type': 'test_val_in',
+    'message0': 'test in %1',
+    'args0': [
+      {
+        'type': 'input_value',
+        'name': 'NAME'
+      }
+    ]
+  }]);
+}
+
+function helper_tearDownMockBlocks() {
+  delete Blockly.Blocks['field_variable_test_block'];
+  delete Blockly.Blocks['simple_test_block'];
+  delete Blockly.Blocks['test_val_in'];
+}
+
 function helper_createWorkspaceWithToolbox() {
   var toolbox = document.getElementById('toolbox-categories');
   return Blockly.inject('blocklyDiv', {toolbox: toolbox});
@@ -102,5 +138,33 @@ function test_appendDomToWorkspace() {
     assertEquals('Block 2 position y',23 + blocks[0].getHeightWidth().height + Blockly.BlockSvg.SEP_SPACE_Y,blocks[1].getRelativeToSurfaceXY().y);
   } finally {
     workspace.dispose();
+  }
+}
+
+function test_svgDisposeWithShadow() {
+  helper_setUpMockBlocks();
+  var workspace = helper_createWorkspaceWithToolbox();
+  var blockNew;
+  try {
+    var dom = Blockly.Xml.textToDom(
+      '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+        '<block type="test_val_in">' +
+          '<value name="NAME">' +
+            '<shadow type="simple_test_block"></shadow>' +
+          '</value>' +
+        '</block>' +
+      '</xml>');
+
+    Blockly.Xml.appendDomToWorkspace(dom, workspace);
+    assertEquals('Block count', 2, workspace.getAllBlocks().length);
+    var inputConnection = workspace.getTopBlocks()[0].getInput('NAME').connection;
+
+    blockNew = helper_createNewBlock(workspace, 'simple_test_block');
+    inputConnection.connect(blockNew.outputConnection);
+
+  } finally {
+    workspace.dispose();
+    blockNew && blockNew.dispose();
+    helper_tearDownMockBlocks();
   }
 }


### PR DESCRIPTION
PR #1970 created a bug that only occurred when replacing a rendered
shadow block. Add a test for this case to prevent breaking it again.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1981)
<!-- Reviewable:end -->
