### PR TITLE
Do not escape % in python strings.

### DIFF
--- a/generators/python.js
+++ b/generators/python.js
@@ -224,8 +224,7 @@ Blockly.Python.scrubNakedValue = function(line) {
 Blockly.Python.quote_ = function(string) {
   // Can't use goog.string.quote since % must also be escaped.
   string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/\%/g, '\\%');
+                 .replace(/\n/g, '\\\n');
 
   // Follow the CPython behaviour of repr() for a non-byte string.
   var quote = '\'';


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Remove escaping code for `%` in python strings.

### Reason for Changes

`%` is not a special character in a python string.

### Test Coverage

### Additional Information

Rebase of #1890, commit 793055… from Ellipsis753:patch-1

