### PR TITLE
Add test for deleting a rendered block with a comment

### DIFF
--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -191,6 +191,7 @@ function test_blockDelete_constructor() {
   setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
   try {
     var block = createSimpleTestBlock(workspace);
+    block.setCommentText('test comment');
     var event = new Blockly.Events.BlockDelete(block);
     checkDeleteEventValues(event, block, ['1'], 'delete');
   } finally {

--- a/tests/workspace_svg/event_svg_test.js
+++ b/tests/workspace_svg/event_svg_test.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+goog.require('goog.testing');
+goog.require('goog.testing.MockControl');
+
+function eventSvg_setUpMockBlocks() {
+  // TODO: Replace with defineGetVarBlock();
+  Blockly.defineBlocksWithJsonArray([{
+    'type': 'field_variable_test_block',
+    'message0': '%1',
+    'args0': [
+      {
+        'type': 'field_variable',
+        'name': 'VAR',
+        'variable': 'item'
+      }
+    ],
+  },
+  {
+    'type': 'simple_test_block',
+    'message0': 'simple test block',
+    'output': null
+  },
+  {
+    'type': 'test_val_in',
+    'message0': 'test in %1',
+    'args0': [
+      {
+        'type': 'input_value',
+        'name': 'NAME'
+      }
+    ]
+  }]);
+}
+
+function eventSvg_tearDownMockBlocks() {
+  delete Blockly.Blocks['field_variable_test_block'];
+  delete Blockly.Blocks['simple_test_block'];
+  delete Blockly.Blocks['test_val_in'];
+}
+
+function eventSvg_createWorkspaceWithToolbox() {
+  var toolbox = document.getElementById('toolbox-categories');
+  return Blockly.inject('blocklyDiv', {toolbox: toolbox});
+}
+
+function eventSvg_createNewBlock(workspace, type) {
+  var block = workspace.newBlock(type);
+  block.initSvg();
+  return block;
+}
+
+function test_blockDelete_svgDispose() {
+  eventSvg_setUpMockBlocks();
+  var workspace = eventSvg_createWorkspaceWithToolbox();
+  Blockly.Events.fire = temporary_fireEvent;
+  temporary_fireEvent.firedEvents_ = [];
+  try {
+    var block = eventSvg_createNewBlock(workspace);
+    block.setCommentText('test comment');
+    var event = new Blockly.Events.BlockDelete(block);
+    workspace.clearUndo();
+    block.dispose();
+    var firedEvents = workspace.undoStack_;
+    assertEquals('Delete event created by dispose matches constructed delete event',
+      Blockly.Xml.domToText(event.oldXml), Blockly.Xml.domToText(firedEvents[0].oldXml));
+  } finally {
+    eventSvg_tearDownMockBlocks();
+    workspace.dispose();
+  }
+}

--- a/tests/workspace_svg/index.html
+++ b/tests/workspace_svg/index.html
@@ -51,7 +51,10 @@ h1 {
   <div id="blocklyDiv"></div>
 
   <h1>Blockly Workspace testing</h1>
+  <script src="../jsunit/test_utilities.js"></script>
   <script src="workspace_svg_test.js"></script>
+  <!-- TODO (#1960): Uncomment once comment deletion is fixed. -->
+  <!--<script src="event_svg_test.js"></script>-->
 
   <xml id="toolbox-simple" style="display: none">
     <block type="controls_ifelse"></block>


### PR DESCRIPTION
Disabled for now as it fails due to #1960.

I also added a comment to the block being used in the delete event test so if they start getting lost in headless too we'll notice.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

SVG tests aren't being run by travis, but I disabled so it won't start failing when they do get run.

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/1984)
<!-- Reviewable:end -->
