### PR TITLE
#1871 Create a common helper function for Comment[Create|Delete]

### DIFF
--- a/core/ws_comment_events.js
+++ b/core/ws_comment_events.js
@@ -215,8 +215,16 @@ Blockly.Events.CommentCreate.prototype.fromJson = function(json) {
  * @param {boolean} forward True if run forward, false if run backward (undo).
  */
 Blockly.Events.CommentCreate.prototype.run = function(forward) {
+  Blockly.Events.CommentCreateDeleteHelper(forward);
+};
+
+/**
+ * Helper function for Comment[Create|Delete]
+ * @param {boolean} create if True then Create, if False then Delete
+ */
+Blockly.Events.CommentCreateDeleteHelper = function(create) {
   var workspace = this.getEventWorkspace_();
-  if (forward) {
+  if (create) {
     var xml = goog.dom.createDom('xml');
     xml.appendChild(this.xml);
     Blockly.Xml.domToWorkspace(xml, workspace);
@@ -230,7 +238,6 @@ Blockly.Events.CommentCreate.prototype.run = function(forward) {
     }
   }
 };
-
 /**
  * Class for a comment deletion event.
  * @param {Blockly.WorkspaceComment} comment The deleted comment.
@@ -277,20 +284,7 @@ Blockly.Events.CommentDelete.prototype.fromJson = function(json) {
  * @param {boolean} forward True if run forward, false if run backward (undo).
  */
 Blockly.Events.CommentDelete.prototype.run = function(forward) {
-  var workspace = this.getEventWorkspace_();
-  if (forward) {
-    var comment = workspace.getCommentById(this.commentId);
-    if (comment) {
-      comment.dispose(false, false);
-    } else {
-      // Only complain about root-level block.
-      console.warn("Can't uncreate non-existent comment: " + this.commentId);
-    }
-  } else {
-    var xml = goog.dom.createDom('xml');
-    xml.appendChild(this.xml);
-    Blockly.Xml.domToWorkspace(xml, workspace);
-  }
+  Blockly.Events.CommentCreateDeleteHelper(!forward);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [ x] I branched from develop
- [x ] My pull request is against develop
- [ x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1871

### Proposed Changes

This PR will create a common Helper function within lockly.Events.CommentCreateDeleteHelper. It will be called by Blockly.Events.CommentCreate.prototype and Blockly.Events.CommentDelete.prototype

### Reason for Changes
Cleanup of code base. Reduce redundant code

### Test Coverage

I havent added new test cases. I would expect existing ones to pass successfully 

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
