### PR TITLE
Call svgResize in the resize handler.

### DIFF
--- a/demos/resizable/overlay.html
+++ b/demos/resizable/overlay.html
@@ -86,6 +86,7 @@
       blocklyDiv.style.top = y + 'px';
       blocklyDiv.style.width = blocklyArea.offsetWidth + 'px';
       blocklyDiv.style.height = blocklyArea.offsetHeight + 'px';
+      Blockly.svgResize(demoWorkspace);
     };
     window.addEventListener('resize', onresize, false);
     onresize();


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves #2000

### Proposed Changes

Call `svgResize()` at the end of the window resize handler.

### Reason for Changes

Without the extra call, window maximize does not appear to trigger resizing behavior for Chrome, Firefox, and Safari.

### Test Coverage

Opened `demos/resizable/overlay.html` in a window, and then maximized and minimized the window, ensuring the workspace filled the screen.

Tested on:
 * Desktop Chrome 
 * Desktop Firefox
 * Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
