### PR TITLE
Fix #1959 by calling bring to front when a block drag starts inside a…

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -152,6 +152,13 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY, hea
     Blockly.Events.setGroup(true);
   }
 
+  // Mutators don't have the same type of z-ordering as the normal workspace during a drag.
+  // They have to rely on the order of the blocks in the svg. For performance reasons that
+  // usually happens at the end of a drag, but do it at the beginning for mutators.
+  if (this.workspace_.isMutator) {
+    this.draggingBlock_.bringToFront();
+  }
+
   this.workspace_.setResizesEnabled(false);
   Blockly.BlockAnimations.disconnectUiStop();
 


### PR DESCRIPTION
… mutator.


## The basics

- [ x] I branched from develop
- [x ] My pull request is against develop
- [x ] My code follows the [style guide] I'm relying on travis to run lint for me on this one...

## The details
### Resolves

#1959 


### Reason for Changes
See #1959 
### Test Coverage

Tested on:
 * Desktop Chrome 

