### PR TITLE
Correcting annotations of procedure block mixin functions

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -282,6 +282,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @param {string} newId ID of new variable.  May be the same as oldId, but
    *     with an updated name.  Guaranteed to be the same type as the old
    *     variable.
+   * @override
    * @this Blockly.Block
    */
   renameVarById: function(oldId, newId) {
@@ -310,6 +311,8 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * variable is in use on this block, rerender to show the new name.
    * @param {!Blockly.VariableModel} variable The variable being renamed.
    * @package
+   * @override
+   * @this Blockly.Block
    */
   updateVarName: function(variable) {
     var newName = variable.name;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Missing annotations on procedure functions.

### Proposed Changes

Adding `@override` and `@this`
