### PR TITLE
Rename getDeveloperVars() as getDeveloperVariables()

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -114,8 +114,8 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
     var block = blocks[i];
     var getDeveloperVariables = block.getDeveloperVariables;
     if (!getDeveloperVariables && block.getDeveloperVars) {
-      // getDeveloperVars was renamed getDeveloperVariables, already
-      // existing documentation.
+      // August 2018: getDeveloperVars() was deprecated and renamed
+      // getDeveloperVariables().
       getDeveloperVariables = block.getDeveloperVars;
       if (!Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_[
           block.type]) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -92,6 +92,12 @@ Blockly.Variables.allUsedVariables = function() {
 };
 
 /**
+ * @private
+ * @type {Object<string,boolean>}
+ */
+Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
+
+/**
  * Find all developer variables used by blocks in the workspace.
  * Developer variables are never shown to the user, but are declared as global
  * variables in the generated code.
@@ -106,7 +112,19 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
   var hash = {};
   for (var i = 0; i < blocks.length; i++) {
     var block = blocks[i];
-    var getDeveloperVariables = block.getDeveloperVariables || block.getDeveloperVars;
+    var getDeveloperVariables = block.getDeveloperVariables;
+    if (!getDeveloperVariables && block.getDeveloperVars) {
+      // getDeveloperVars was renamed getDeveloperVariables, already
+      // existing documentation.
+      getDeveloperVariables = block.getDeveloperVars;
+      if (!Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_[
+          block.type]) {
+        console.warn('Function getDeveloperVars() deprecated. Use ' +
+          'getDeveloperVariables() (block type \'' + block.type + '\')');
+        Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_[
+            block.type] = true;
+      }
+    }
     if (getDeveloperVariables) {
       var devVars = getDeveloperVariables();
       for (var j = 0; j < devVars.length; j++) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

The documentation for allDeveloperVariables in https://developers.google.com/blockly/reference/js/Blockly.Variables does not match the variable in code.

(Rebase of #1979, which was apparently abandoned.)

### Proposed Changes

Accept either old `getDeveloperVars()` or `getDeveloperVariables()` (as document).
Also emit on-shot warning when the old function name is detected, noting which block definition triggered the error.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Umm......