### PR TITLE
Add support for transitioning the workspace block and bubble canvases on scrollCenter

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -166,7 +166,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
   '.blocklyBubbleCanvas.blocklyCanvasTransitioning {',
-    'transition: transform 0.5s;',
+    'transition: transform .5s;',
   '}',
 
   '.blocklyTooltipDiv {',

--- a/core/css.js
+++ b/core/css.js
@@ -164,6 +164,11 @@ Blockly.Css.CONTENT = [
     'z-index: 50;', /* Display below toolbox, but above everything else. */
   '}',
 
+  '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
+  '.blocklyBubbleCanvas.blocklyCanvasTransitioning {',
+    'transition: transform 0.5s;',
+  '}',
+
   '.blocklyTooltipDiv {',
     'background-color: #ffffc7;',
     'border: 1px solid #ddc;',

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1596,6 +1596,32 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 };
 
 /**
+ * Add a transition class to the block and bubble canvas, to animate any
+ * transform changes.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.beginCanvasTransition = function() {
+  Blockly.utils.addClass(
+      /** @type {!SVGElement} */ this.svgBlockCanvas_,
+      'blocklyCanvasTransitioning');
+  Blockly.utils.addClass(
+      /** @type {!SVGElement} */ this.svgBubbleCanvas_,
+      'blocklyCanvasTransitioning');
+};
+
+/**
+ * Remove transition class from the block and bubble canvas.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
+  Blockly.utils.removeClass(
+      /** @type {!SVGElement} */ this.svgBlockCanvas_,
+      'blocklyCanvasTransitioning');
+  Blockly.utils.removeClass(
+      /** @type {!SVGElement} */ this.svgBubbleCanvas_,
+      'blocklyCanvasTransitioning');
+};
+/**
  * Center the workspace.
  */
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -302,7 +302,11 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
   Blockly.bindEventWithChecks_(zoomresetSvg, 'mousedown', null, function(e) {
     ws.markFocused();
     ws.setScale(ws.options.zoomOptions.startScale);
+    ws.beginCanvasTransition();
     ws.scrollCenter();
+    setTimeout(function() {
+      ws.endCanvasTransition();
+    }, 500);
     Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
     e.stopPropagation();  // Don't start a workspace scroll.
     e.preventDefault();  // Stop double-clicking from selecting text.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

This is just a new version of #1754.  From that description:

> Animate the workspace move when scrolling. Support for developers to begin and end the transition property on the block and bubble canvas.

>Add support for transitioning the workspace block and bubble canvas.
>
> Enable for scrollCenter.
> 
> It turns out only Chrome supports CSS transitions on SVG elements, so feel free not to pull in this change. Cool demo though!

### Reason for Changes

> Animations are great!

### Test Coverage
Only works on chrome.

### Additional Information
I tested what happens if you pick up a block during this transition, and it can be significantly offset from the mouse (tested by setting the transition to 5 seconds).  However, with a .5s transition it's hard to make that happen, and the offset is only during that one drag--the blocks don't end up in an overall bad state.  I think we should take this change, since it makes things just a bit nicer on chrome.