### PR TITLE
Fix lint errors in field_textinput

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -106,18 +106,17 @@ Blockly.FieldTextInput.prototype.dispose = function() {
  * @override
  */
 Blockly.FieldTextInput.prototype.setValue = function(newValue) {
-  if (newValue === null) {
-    return;  // No change if null.
-  }
-  if (this.sourceBlock_) {
-    var validated = this.callValidator(newValue);
-    // If the new value is invalid, validation returns null.
-    // In this case we still want to display the illegal result.
-    if (validated !== null) {
-      newValue = validated;
+  if (newValue !== null) { // No change if null.
+    if (this.sourceBlock_) {
+      var validated = this.callValidator(newValue);
+      // If the new value is invalid, validation returns null.
+      // In this case we still want to display the illegal result.
+      if (validated !== null) {
+        newValue = validated;
+      }
     }
+    Blockly.Field.prototype.setValue.call(this, newValue);
   }
-  Blockly.Field.prototype.setValue.call(this, newValue);
 };
 
 /**
@@ -369,6 +368,11 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
   };
 };
 
+/**
+ * Attempt to save the text field changes when the user input loses focus.
+ * If the value is not valid, revert to the default value.
+ * @private
+ */
 Blockly.FieldTextInput.prototype.maybeSaveEdit_ = function() {
   var htmlInput = Blockly.FieldTextInput.htmlInput_;
   // Save the edit (if it validates).


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes the following lint errors:
```
/.../Blockly/web/previous-attempt-at-1958/field_textinput.js
  119:12  error  Expected space(s) after "if"  keyword-spacing
  121:7   error  'setText' is not defined      no-undef
  396:1   error  Missing JSDoc return type     valid-jsdoc

✖ 3 problems (3 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

FAILED: eslint
```

### Test Coverage

Ran `npm test playground.html` successfully.