### PR TITLE
Converting bad block warning into an error.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -53,14 +53,13 @@ goog.require('goog.math.Coordinate');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @constructor
+ * @throw When block is not valid or block name is not allowed.
  */
 Blockly.Block = function(workspace, prototypeName, opt_id) {
   if (typeof Blockly.Generator.prototype[prototypeName] !== 'undefined') {
-    console.warn('FUTURE ERROR: Block prototypeName "' + prototypeName +
-        '" conflicts with Blockly.Generator members. Registering Generators ' +
-        'for this block type will incur errors.' +
-        '\nThis name will be DISALLOWED (throwing an error) in future ' +
-        'versions of Blockly.');
+    // Occluding Generator class members is not allowed.
+    throw Error('Block prototypeName "' + prototypeName +
+        '" conflicts with Blockly.Generator members.');
   }
 
   /** @type {string} */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#1558.

### Proposed Changes

Make previously added warning an official breaking error.

### Reason for Changes

Occluding Generator members is *bad*.
