### PR TITLE
Adding Blockly.utils.removeNode(..)

### DIFF
--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -81,7 +81,7 @@ Blockly.BlockAnimations.disposeUiStep_ = function(clone, rtl, start,
   var ms = new Date - start;
   var percent = ms / 150;
   if (percent > 1) {
-    clone.parentNode.removeChild(clone);
+    Blockly.utils.removeNode(clone);
   } else {
     var x = clone.translateX_ +
         (rtl ? -1 : 1) * clone.bBox_.width * workspaceScale / 2 * percent;
@@ -141,7 +141,7 @@ Blockly.BlockAnimations.connectionUiStep_ = function(ripple, start, scale) {
   var ms = new Date - start;
   var percent = ms / 150;
   if (percent > 1) {
-    ripple.parentNode.removeChild(ripple);
+    Blockly.utils.removeNode(ripple);
   } else {
     ripple.setAttribute('r', percent * 25 * scale);
     ripple.style.opacity = 1 - percent;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -855,7 +855,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   }
   Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
 
-  this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+  Blockly.utils.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -604,7 +604,7 @@ Blockly.Bubble.prototype.setColour = function(hexColour) {
 Blockly.Bubble.prototype.dispose = function() {
   Blockly.Bubble.unbindDragEvents_();
   // Dispose of and unlink the bubble.
-  this.bubbleGroup_.parentNode.removeChild(this.bubbleGroup_);
+  Blockly.utils.removeNode(this.bubbleGroup_);
   this.bubbleGroup_ = null;
   this.bubbleArrow_ = null;
   this.bubbleBack_ = null;

--- a/core/field.js
+++ b/core/field.js
@@ -226,7 +226,7 @@ Blockly.Field.prototype.dispose = function() {
   }
   this.sourceBlock_ = null;
   if (this.fieldGroup_) {
-    this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
+    Blockly.utils.removeNode(this.fieldGroup_);
     this.fieldGroup_ = null;
   }
   this.textElement_ = null;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -441,7 +441,7 @@ Blockly.FieldDropdown.prototype.render_ = function() {
     this.textElement_.removeChild(child);
   }
   if (this.imageElement_) {
-    this.imageElement_.parentNode.removeChild(this.imageElement_);
+    Blockly.utils.removeNode(this.imageElement_);
     this.imageElement_ = null;
   }
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -120,7 +120,7 @@ Blockly.FieldImage.prototype.init = function() {
  */
 Blockly.FieldImage.prototype.dispose = function() {
   if (this.fieldGroup_) {
-    this.fieldGroup_.parentNode.removeChild(this.fieldGroup_);
+    Blockly.utils.removeNode(this.fieldGroup_);
     this.fieldGroup_ = null;
   }
   this.imageElement_ = null;

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -96,7 +96,7 @@ Blockly.FieldLabel.prototype.init = function() {
  */
 Blockly.FieldLabel.prototype.dispose = function() {
   if (this.textElement_) {
-    this.textElement_.parentNode.removeChild(this.textElement_);
+    Blockly.utils.removeNode(this.textElement_);
     this.textElement_ = null;
   }
 };

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -276,7 +276,7 @@ Blockly.Flyout.prototype.dispose = function() {
     this.workspace_ = null;
   }
   if (this.svgGroup_) {
-    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+    Blockly.utils.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.svgBackground_ = null;
@@ -526,7 +526,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   for (var j = 0; j < this.mats_.length; j++) {
     var rect = this.mats_[j];
     if (rect) {
-      rect.parentNode.removeChild(rect);
+      Blockly.utils.removeNode(rect);
     }
   }
   this.mats_.length = 0;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -239,7 +239,7 @@ Blockly.FlyoutButton.prototype.dispose = function() {
     Blockly.unbindEvent_(this.onMouseUpWrapper_);
   }
   if (this.svgGroup_) {
-    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+    Blockly.utils.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.workspace_ = null;

--- a/core/icon.js
+++ b/core/icon.js
@@ -96,7 +96,7 @@ Blockly.Icon.prototype.createIcon = function() {
  */
 Blockly.Icon.prototype.dispose = function() {
   // Dispose of and unlink the icon.
-  this.iconGroup_.parentNode.removeChild(this.iconGroup_);
+  Blockly.utils.removeNode(this.iconGroup_);
   this.iconGroup_ = null;
   // Dispose of and unlink the bubble.
   this.setVisible(false);

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -262,7 +262,7 @@ Blockly.RenderedConnection.prototype.unhideAll = function() {
  * Remove the highlighting around this connection.
  */
 Blockly.RenderedConnection.prototype.unhighlight = function() {
-  Blockly.Connection.highlightedPath_.parentNode.removeChild(Blockly.Connection.highlightedPath_);
+  Blockly.utils.removeNode(Blockly.Connection.highlightedPath_);
   delete Blockly.Connection.highlightedPath_;
 };
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -72,7 +72,7 @@ Blockly.ScrollbarPair.prototype.oldHostMetrics_ = null;
  * Unlink from all DOM elements to prevent memory leaks.
  */
 Blockly.ScrollbarPair.prototype.dispose = function() {
-  this.corner_.parentNode.removeChild(this.corner_);
+  Blockly.utils.removeNode(this.corner_);
   this.corner_ = null;
   this.workspace_ = null;
   this.oldHostMetrics_ = null;
@@ -347,7 +347,7 @@ Blockly.Scrollbar.prototype.dispose = function() {
   Blockly.unbindEvent_(this.onMouseDownHandleWrapper_);
   this.onMouseDownHandleWrapper_ = null;
 
-  this.outerSvg_.parentNode.removeChild(this.outerSvg_);
+  Blockly.utils.removeNode(this.outerSvg_);
   this.outerSvg_ = null;
   this.svgGroup_ = null;
   this.svgBackground_ = null;

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -219,7 +219,7 @@ Blockly.Toolbox.prototype.init = function() {
 Blockly.Toolbox.prototype.dispose = function() {
   this.flyout_.dispose();
   this.tree_.dispose();
-  this.HtmlDiv.parentNode.removeChild(this.HtmlDiv);
+  Blockly.utils.removeNode(this.HtmlDiv);
   this.workspace_ = null;
   this.lastCategory_ = null;
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -228,7 +228,7 @@ Blockly.Trashcan.prototype.init = function(bottom) {
  */
 Blockly.Trashcan.prototype.dispose = function() {
   if (this.svgGroup_) {
-    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+    Blockly.utils.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.svgLid_ = null;

--- a/core/utils.js
+++ b/core/utils.js
@@ -115,6 +115,16 @@ Blockly.utils.hasClass = function(element, className) {
 };
 
 /**
+ * Removes a node from its parent. No-op if not attached to a parent.
+ * @param {Node} node The node to remove.
+ * @return {Node} The node removed if removed; else, null.
+ */
+// Copied from Closure goog.dom.removeNode
+Blockly.utils.removeNode = function(node) {
+  return node && node.parentNode ? node.parentNode.removeChild(node) : null;
+};
+
+/**
  * Don't do anything for this event, just halt propagation.
  * @param {!Event} e An event.
  */

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -117,7 +117,7 @@ Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
     Blockly.Events.fire(new Blockly.Events.CommentDelete(this));
   }
 
-  this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+  Blockly.utils.removeNode(this.svgGroup_);
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;
   this.svgRect_ = null;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -511,7 +511,7 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
   }
   Blockly.WorkspaceSvg.superClass_.dispose.call(this);
   if (this.svgGroup_) {
-    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+    Blockly.utils.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.svgBlockCanvas_ = null;
@@ -558,7 +558,7 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
     // SVG is injected into (i.e. injectionDiv).
     var div = this.getParentSvg().parentNode;
     if (div) {
-      div.parentNode.removeChild(div);
+      Blockly.utils.removeNode(div);
     }
   }
   if (this.resizeHandlerWrapper_) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -289,7 +289,7 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
         if (textNode.nodeType == 3 && textNode.data.trim() == '' &&
             node.firstChild != textNode) {
           // Prune whitespace after a tag.
-          textNode.parentNode.removeChild(textNode);
+          Blockly.utils.removeNode(textNode);
         }
       }
       if (node) {
@@ -297,7 +297,7 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
         node = node.nextSibling;
         if (textNode.nodeType == 3 && textNode.data.trim() == '') {
           // Prune whitespace before a tag.
-          textNode.parentNode.removeChild(textNode);
+          Blockly.utils.removeNode(textNode);
         }
       }
     }

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -122,7 +122,7 @@ Blockly.ZoomControls.prototype.init = function(bottom) {
  */
 Blockly.ZoomControls.prototype.dispose = function() {
   if (this.svgGroup_) {
-    this.svgGroup_.parentNode.removeChild(this.svgGroup_);
+    Blockly.utils.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
   }
   this.workspace_ = null;


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#2040

### Proposed Changes

Duplicate older removeNode behavior by copying `goog.dom.removeNode(..)` into the Blockly codebase. Replaced all original locations of `goog.dom.removeNode(..)`, not just the case for the existing error.

### Reason for Changes

The null check appears necessary, though the whole error case is not fully understood.

### Test Coverage

I opened the BlockFactory locally, which crashed before making these changes.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
