### PR TITLE
fix bug.when create get/set dynamic variable block from set/get , lost the type.

### DIFF
--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -102,14 +102,14 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     }
     var opposite_type;
     var contextMenuMsg;
-    var varType;
+    var id = this.getFieldValue('VAR');
+    var variableModel = this.workspace.getVariableById(id);
+    var varType = variableModel.type
     if (this.type == 'variables_get_dynamic') {
       opposite_type = 'variables_set_dynamic';
-      varType = this.outputConnection.check_ ? this.outputConnection.check_[0] : "";
       contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
     } else {
       opposite_type = 'variables_get_dynamic';
-      varType = this.inputList[0].connection.check_ ? this.inputList[0].connection.check_[0] : "";
       contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
     }
 

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -104,7 +104,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     var contextMenuMsg;
     var id = this.getFieldValue('VAR');
     var variableModel = this.workspace.getVariableById(id);
-    var varType = variableModel.type
+    var varType = variableModel.type;
     if (this.type == 'variables_get_dynamic') {
       opposite_type = 'variables_set_dynamic';
       contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -102,11 +102,14 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     }
     var opposite_type;
     var contextMenuMsg;
+    var varType;
     if (this.type == 'variables_get_dynamic') {
       opposite_type = 'variables_set_dynamic';
+      varType = this.outputConnection.check_ ? this.outputConnection.check_[0] : "";
       contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
     } else {
       opposite_type = 'variables_get_dynamic';
+      varType = this.inputList[0].connection.check_ ? this.inputList[0].connection.check_[0] : "";
       contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
     }
 
@@ -115,6 +118,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     option.text = contextMenuMsg.replace('%1', name);
     var xmlField = document.createElement('field');
     xmlField.setAttribute('name', 'VAR');
+    xmlField.setAttribute('variabletype', varType);
     xmlField.appendChild(document.createTextNode(name));
     var xmlBlock = document.createElement('block');
     xmlBlock.setAttribute('type', opposite_type);


### PR DESCRIPTION
when create get/set dynamic variable block from set/get ,
lost the type.


## The basics

- [x ] I branched from develop
- [x ] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
