### PR TITLE
Mark some field properties protected

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -127,28 +127,28 @@ Blockly.Field.prototype.maxDisplayLength = 50;
 /**
  * Visible text to display.
  * @type {string}
- * @private
+ * @protected
  */
 Blockly.Field.prototype.text_ = '';
 
 /**
  * Block this field is attached to.  Starts as null, then in set in init.
  * @type {Blockly.Block}
- * @private
+ * @protected
  */
 Blockly.Field.prototype.sourceBlock_ = null;
 
 /**
  * Is the field visible, or hidden due to the block being collapsed?
  * @type {boolean}
- * @private
+ * @protected
  */
 Blockly.Field.prototype.visible_ = true;
 
 /**
  * Validation function called when user edits an editable field.
  * @type {Function}
- * @private
+ * @protected
  */
 Blockly.Field.prototype.validator_ = null;
 
@@ -362,7 +362,7 @@ Blockly.Field.prototype.getSvgRoot = function() {
 /**
  * Draws the border with the correct width.
  * Saves the computed width in a property.
- * @private
+ * @protected
  */
 Blockly.Field.prototype.render_ = function() {
   if (!this.visible_) {
@@ -466,7 +466,7 @@ Blockly.Field.prototype.getSize = function() {
  * scaling.
  * @return {!Object} An object with top, bottom, left, and right in pixels
  *     relative to the top left corner of the page (window coordinates).
- * @private
+ * @protected
  */
 Blockly.Field.prototype.getScaledBBox_ = function() {
   var bBox = this.borderRect_.getBBox();
@@ -485,7 +485,7 @@ Blockly.Field.prototype.getScaledBBox_ = function() {
  * Get the text from this field as displayed on screen.  May differ from getText
  * due to ellipsis, and other formatting.
  * @return {string} Currently displayed text.
- * @private
+ * @protected
  */
 Blockly.Field.prototype.getDisplayText_ = function() {
   var text = this.text_;
@@ -582,7 +582,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
 /**
  * Handle a mouse down event on a field.
  * @param {!Event} e Mouse down event.
- * @private
+ * @protected
  */
 Blockly.Field.prototype.onMouseDown_ = function(e) {
   if (!this.sourceBlock_ || !this.sourceBlock_.workspace) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -99,7 +99,7 @@ Blockly.FieldDropdown.prototype.CURSOR = 'default';
 /**
  * Language-neutral currently selected string or image object.
  * @type {string|!Object}
- * @private
+ * @protected
  */
 Blockly.FieldDropdown.prototype.value_ = '';
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -77,7 +77,7 @@ Blockly.FieldTextInput.FONTSIZE = 11;
  * The HTML input element for the user to type, or null if no FieldTextInput
  * editor is currently open.
  * @type {HTMLInputElement}
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.htmlInput_ = null;
 
@@ -152,7 +152,7 @@ Blockly.FieldTextInput.prototype.setSpellcheck = function(check) {
  * Show the inline free-text editor on top of the text.
  * @param {boolean=} opt_quietInput True if editor should be created without
  *     focus.  Defaults to false.
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
   this.workspace_ = this.sourceBlock_.workspace;
@@ -295,7 +295,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
 /**
  * Check to see if the contents of the editor validates.
  * Style the editor accordingly.
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.prototype.validate_ = function() {
   var valid = true;
@@ -315,7 +315,7 @@ Blockly.FieldTextInput.prototype.validate_ = function() {
 
 /**
  * Resize the editor and the underlying block to fit the text.
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   var div = Blockly.WidgetDiv.DIV;

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -110,7 +110,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * workspaces on a page; this is more accurate than using
    * Blockly.getMainWorkspace().
    * @type {Blockly.WorkspaceSvg}
-   * @private
+   * @protected
    */
   this.startWorkspace_ = null;
 
@@ -165,7 +165,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * A handle to use to unbind a mouse move listener at the end of a drag.
    * Opaque data returned from Blockly.bindEventWithChecks_.
    * @type {Array.<!Array>}
-   * @private
+   * @protected
    */
   this.onMoveWrapper_ = null;
 
@@ -173,7 +173,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * A handle to use to unbind a mouse up listener at the end of a drag.
    * Opaque data returned from Blockly.bindEventWithChecks_.
    * @type {Array.<!Array>}
-   * @private
+   * @protected
    */
   this.onUpWrapper_ = null;
 
@@ -223,7 +223,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
   /**
    * Boolean used internally to break a cycle in disposal.
    * @type {boolean}
-   * @private
+   * @protected
    */
   this.isEnding_ = false;
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -311,7 +311,7 @@ Blockly.WorkspaceSvg.prototype.inverseScreenCTM_ = null;
 
 /**
  * Inverted screen CTM is dirty, recalculate it.
- * @type {Boolean}
+ * @type {boolean}
  * @private
  */
 Blockly.WorkspaceSvg.prototype.inverseScreenCTMDirty_ = true;
@@ -1602,10 +1602,10 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
  */
 Blockly.WorkspaceSvg.prototype.beginCanvasTransition = function() {
   Blockly.utils.addClass(
-      /** @type {!SVGElement} */ this.svgBlockCanvas_,
+      /** @type {!SVGElement} */ (this.svgBlockCanvas_),
       'blocklyCanvasTransitioning');
   Blockly.utils.addClass(
-      /** @type {!SVGElement} */ this.svgBubbleCanvas_,
+      /** @type {!SVGElement} */ (this.svgBubbleCanvas_),
       'blocklyCanvasTransitioning');
 };
 
@@ -1615,10 +1615,10 @@ Blockly.WorkspaceSvg.prototype.beginCanvasTransition = function() {
  */
 Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
   Blockly.utils.removeClass(
-      /** @type {!SVGElement} */ this.svgBlockCanvas_,
+      /** @type {!SVGElement} */ (this.svgBlockCanvas_),
       'blocklyCanvasTransitioning');
   Blockly.utils.removeClass(
-      /** @type {!SVGElement} */ this.svgBubbleCanvas_,
+      /** @type {!SVGElement} */ (this.svgBubbleCanvas_),
       'blocklyCanvasTransitioning');
 };
 /**

--- a/core/ws_comment_events.js
+++ b/core/ws_comment_events.js
@@ -215,26 +215,28 @@ Blockly.Events.CommentCreate.prototype.fromJson = function(json) {
  * @param {boolean} forward True if run forward, false if run backward (undo).
  */
 Blockly.Events.CommentCreate.prototype.run = function(forward) {
-  Blockly.Events.CommentCreateDeleteHelper(forward);
+  Blockly.Events.CommentCreateDeleteHelper(this, forward);
 };
 
 /**
  * Helper function for Comment[Create|Delete]
+ * @param {!Blockly.Events.CommentCreate|!Blockly.Events.CommentDelete} event
+ *     The event to run.
  * @param {boolean} create if True then Create, if False then Delete
  */
-Blockly.Events.CommentCreateDeleteHelper = function(create) {
-  var workspace = this.getEventWorkspace_();
+Blockly.Events.CommentCreateDeleteHelper = function(event, create) {
+  var workspace = event.getEventWorkspace_();
   if (create) {
     var xml = goog.dom.createDom('xml');
-    xml.appendChild(this.xml);
+    xml.appendChild(event.xml);
     Blockly.Xml.domToWorkspace(xml, workspace);
   } else {
-    var comment = workspace.getCommentById(this.commentId);
+    var comment = workspace.getCommentById(event.commentId);
     if (comment) {
       comment.dispose(false, false);
     } else {
       // Only complain about root-level block.
-      console.warn("Can't uncreate non-existent comment: " + this.commentId);
+      console.warn("Can't uncreate non-existent comment: " + event.commentId);
     }
   }
 };
@@ -284,7 +286,7 @@ Blockly.Events.CommentDelete.prototype.fromJson = function(json) {
  * @param {boolean} forward True if run forward, false if run backward (undo).
  */
 Blockly.Events.CommentDelete.prototype.run = function(forward) {
-  Blockly.Events.CommentCreateDeleteHelper(!forward);
+  Blockly.Events.CommentCreateDeleteHelper(this, !forward);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -133,7 +133,6 @@ Blockly.Xml.fieldToDomVariable_ = function(field) {
 /**
  * Encode a field as XML.
  * @param {!Blockly.Field} field The field to encode.
- * @param {!Blockly.Workspace} workspace The workspace that the field is in.
  * @return {?Element} XML element, or null if the field did not need to be
  *     serialized.
  * @private


### PR DESCRIPTION
These are all properties that are being used by other field types that extend the base type.  Removes ~80 build warnings.