### PR TITLE
Add some functions for insertion markers

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -795,6 +795,24 @@ Blockly.BlockSvg.prototype.setShadow = function(shadow) {
 };
 
 /**
+ * Set whether this block is an insertion marker block or not.
+ * Once set this cannot be unset.
+ * @param {boolean} insertionMarker True if an insertion marker.
+ * @package
+ */
+Blockly.BlockSvg.prototype.setInsertionMarker = function(insertionMarker) {
+  if (this.isInsertionMarker_ == insertionMarker) {
+    return;  // No change.
+  }
+  this.isInsertionMarker_ = insertionMarker;
+  if (this.isInsertionMarker_) {
+    this.setColour(Blockly.INSERTION_MARKER_COLOUR);
+    Blockly.utils.addClass(/** @type {!Element} */ (this.svgGroup_),
+        'blocklyInsertionMarker');
+  }
+};
+
+/**
  * Return the root node of the SVG or null if none exists.
  * @return {Element} The root SVG node (probably a group).
  */


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Progress on insertion markers

### Proposed Changes

Add some of the functions that insertion markers will need, without changing any of the actual rendering logic.

The added functions are 
- `isInsertionMarker`
- `setInsertionMarker`
- `getPreviousBlock`
- `getFirstStatementConnection`
- `getMatchingConnection`

I also added the `isInsertionMarker_` property to block.js

### Reason for Changes

I'll need these for insertion markers.

These are the pieces of https://github.com/google/blockly/pull/1987/files that can come out into a separate PR while I debug the rest of it.

### Test Coverage
No changes to the code that's actually running until I land the insertionMarkerManager.
