### PR TITLE
Calls to getAllBlocks should pass a value for _ordered_

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -338,7 +338,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     this.updateParams_();
     // Update the mutator's variables if the mutator is open.
     if (this.mutator.isVisible()) {
-      var blocks = this.mutator.workspace_.getAllBlocks();
+      var blocks = this.mutator.workspace_.getAllBlocks(false);
       for (var i = 0, block; block = blocks[i]; i++) {
         if (block.type == 'procedures_mutatorarg' &&
             Blockly.Names.equals(oldName, block.getFieldValue('NAME'))) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -391,7 +391,6 @@ Blockly.prompt = function(message, defaultValue, callback) {
  * @private
  */
 Blockly.jsonInitFactory_ = function(jsonDef) {
-  /** @this Blockly.Block */
   return function() {
     this.jsonInit(jsonDef);
   };

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -56,7 +56,7 @@ Blockly.Procedures.NAME_TYPE = Blockly.PROCEDURE_CATEGORY_NAME;
  *     list, and return value boolean.
  */
 Blockly.Procedures.allProcedures = function(root) {
-  var blocks = root.getAllBlocks();
+  var blocks = root.getAllBlocks(false);
   var proceduresReturn = [];
   var proceduresNoReturn = [];
   for (var i = 0; i < blocks.length; i++) {
@@ -134,7 +134,7 @@ Blockly.Procedures.isLegalName_ = function(name, workspace, opt_exclude) {
  * @return {boolean} True if the name is used, otherwise return false.
  */
 Blockly.Procedures.isNameUsed = function(name, workspace, opt_exclude) {
-  var blocks = workspace.getAllBlocks();
+  var blocks = workspace.getAllBlocks(false);
   // Iterate through every block and check the name.
   for (var i = 0; i < blocks.length; i++) {
     if (blocks[i] == opt_exclude) {
@@ -165,7 +165,7 @@ Blockly.Procedures.rename = function(name) {
   var oldName = this.text_;
   if (oldName != name && oldName != legalName) {
     // Rename any callers.
-    var blocks = this.sourceBlock_.workspace.getAllBlocks();
+    var blocks = this.sourceBlock_.workspace.getAllBlocks(false);
     for (var i = 0; i < blocks.length; i++) {
       if (blocks[i].renameProcedure) {
         blocks[i].renameProcedure(oldName, legalName);
@@ -258,7 +258,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
  */
 Blockly.Procedures.getCallers = function(name, workspace) {
   var callers = [];
-  var blocks = workspace.getAllBlocks();
+  var blocks = workspace.getAllBlocks(false);
   // Iterate through every block and check the name.
   for (var i = 0; i < blocks.length; i++) {
     if (blocks[i].getProcedureCall) {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -73,7 +73,7 @@ Blockly.VariableMap.prototype.clear = function() {
 Blockly.VariableMap.prototype.renameVariable = function(variable, newName) {
   var type = variable.type;
   var conflictVar = this.getVariable(newName, type);
-  var blocks = this.workspace.getAllBlocks();
+  var blocks = this.workspace.getAllBlocks(false);
   Blockly.Events.setGroup(true);
   try {
     // The IDs may match if the rename is a simple case change (name1 -> Name1).
@@ -384,7 +384,7 @@ Blockly.VariableMap.prototype.getAllVariables = function() {
  */
 Blockly.VariableMap.prototype.getVariableUsesById = function(id) {
   var uses = [];
-  var blocks = this.workspace.getAllBlocks();
+  var blocks = this.workspace.getAllBlocks(false);
   // Iterate through every block and check the name.
   for (var i = 0; i < blocks.length; i++) {
     var blockVariables = blocks[i].getVarModels();

--- a/core/variables.js
+++ b/core/variables.js
@@ -55,7 +55,7 @@ Blockly.Variables.NAME_TYPE = Blockly.VARIABLE_CATEGORY_NAME;
  * @return {!Array.<!Blockly.VariableModel>} Array of variable models.
  */
 Blockly.Variables.allUsedVarModels = function(ws) {
-  var blocks = ws.getAllBlocks();
+  var blocks = ws.getAllBlocks(false);
   var variableHash = Object.create(null);
   // Iterate through every block and add each variable to the hash.
   for (var x = 0; x < blocks.length; x++) {
@@ -108,7 +108,7 @@ Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
  * @return {!Array.<string>} A list of non-duplicated variable names.
  */
 Blockly.Variables.allDeveloperVariables = function(workspace) {
-  var blocks = workspace.getAllBlocks();
+  var blocks = workspace.getAllBlocks(false);
   var hash = {};
   for (var i = 0; i < blocks.length; i++) {
     var block = blocks[i];

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -907,7 +907,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
  */
 Blockly.WorkspaceSvg.prototype.render = function() {
   // Generate list of all blocks.
-  var blocks = this.getAllBlocks();
+  var blocks = this.getAllBlocks(false);
   // Render each block.
   for (var i = blocks.length - 1; i >= 0; i--) {
     blocks[i].render(false);
@@ -993,7 +993,7 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
       // distance with neighbouring blocks.
       do {
         var collide = false;
-        var allBlocks = this.getAllBlocks();
+        var allBlocks = this.getAllBlocks(false);
         for (var i = 0, otherBlock; otherBlock = allBlocks[i]; i++) {
           var otherXY = otherBlock.getRelativeToSurfaceXY();
           if (Math.abs(blockX - otherXY.x) <= 1 &&

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -866,7 +866,7 @@ function fieldNameCheck(referenceBlock) {
   }
   var name = referenceBlock.getFieldValue('FIELDNAME').toLowerCase();
   var count = 0;
-  var blocks = referenceBlock.workspace.getAllBlocks();
+  var blocks = referenceBlock.workspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     var otherName = block.getFieldValue('FIELDNAME');
     if (!block.disabled && !block.getInheritedDisabled() &&
@@ -891,7 +891,7 @@ function inputNameCheck(referenceBlock) {
   }
   var name = referenceBlock.getFieldValue('INPUTNAME').toLowerCase();
   var count = 0;
-  var blocks = referenceBlock.workspace.getAllBlocks();
+  var blocks = referenceBlock.workspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     var otherName = block.getFieldValue('INPUTNAME');
     if (!block.disabled && !block.getInheritedDisabled() &&

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -167,7 +167,7 @@ WorkspaceFactoryController.prototype.transferFlyoutBlocksToCategory =
   // Saves the user's blocks from the flyout in a category if there is no
   // toolbox and the user has dragged in blocks.
   if (!this.model.hasElements() &&
-        this.toolboxWorkspace.getAllBlocks().length > 0) {
+        this.toolboxWorkspace.getAllBlocks(false).length > 0) {
     // Create the new category.
     this.createCategory('Category 1', true);
     // Set the new category as selected.
@@ -743,7 +743,7 @@ WorkspaceFactoryController.prototype.importFile = function(file, importMode) {
 
         // Confirm that the user wants to override their current toolbox.
         var hasToolboxElements = controller.model.hasElements() ||
-            controller.toolboxWorkspace.getAllBlocks().length > 0;
+            controller.toolboxWorkspace.getAllBlocks(false).length > 0;
         if (hasToolboxElements) {
             var msg = 'Are you sure you want to import? You will lose your ' +
                 'current toolbox.';
@@ -762,7 +762,7 @@ WorkspaceFactoryController.prototype.importFile = function(file, importMode) {
         controller.setMode(WorkspaceFactoryController.MODE_PRELOAD);
 
         // Confirm that the user wants to override their current blocks.
-        if (controller.toolboxWorkspace.getAllBlocks().length > 0) {
+        if (controller.toolboxWorkspace.getAllBlocks(false).length > 0) {
           var msg = 'Are you sure you want to import? You will lose your ' +
             'current workspace blocks.';
           var continueAnyway = confirm(msg);
@@ -1022,7 +1022,7 @@ WorkspaceFactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * shadow blocks in the view but are still editable and movable.
  */
 WorkspaceFactoryController.prototype.convertShadowBlocks = function() {
-  var blocks = this.toolboxWorkspace.getAllBlocks();
+  var blocks = this.toolboxWorkspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     if (block.isShadow()) {
       block.setShadow(false);
@@ -1096,7 +1096,7 @@ WorkspaceFactoryController.prototype.clearAndLoadXml_ = function(xml) {
   this.toolboxWorkspace.clearUndo();
   Blockly.Xml.domToWorkspace(xml, this.toolboxWorkspace);
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
-      (this.toolboxWorkspace.getAllBlocks()));
+      (this.toolboxWorkspace.getAllBlocks(false)));
   this.warnForUndefinedBlocks_();
 };
 
@@ -1334,7 +1334,7 @@ WorkspaceFactoryController.prototype.isDefinedBlock = function(block) {
  * @private
  */
 WorkspaceFactoryController.prototype.warnForUndefinedBlocks_ = function() {
-  var blocks = this.toolboxWorkspace.getAllBlocks();
+  var blocks = this.toolboxWorkspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     if (!this.isDefinedBlock(block)) {
       block.setWarningText(block.type + ' is not defined (it is not a standard '

--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -215,7 +215,7 @@ WorkspaceFactoryGenerator.prototype.appendHiddenWorkspaceToDom_ =
  */
 WorkspaceFactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ =
     function() {
-  var blocks = this.hiddenWorkspace.getAllBlocks();
+  var blocks = this.hiddenWorkspace.getAllBlocks(false);
   for (var i = 0; i < blocks.length; i++) {
     if (this.model.isShadowBlock(blocks[i].id)) {
       blocks[i].setShadow(true);

--- a/demos/blockfactory_old/blocks.js
+++ b/demos/blockfactory_old/blocks.js
@@ -47,7 +47,7 @@ Blockly.Blocks['factory_base'] = {
         ['↓ bottom connection', 'BOTTOM']],
         function(option) {
           this.sourceBlock_.updateShape_(option);
-          // Connect a shadow block to this new input. 
+          // Connect a shadow block to this new input.
           this.sourceBlock_.spawnOutputShadow_(option);
         });
     this.appendDummyInput()
@@ -787,7 +787,7 @@ function fieldNameCheck(referenceBlock) {
   }
   var name = referenceBlock.getFieldValue('FIELDNAME').toLowerCase();
   var count = 0;
-  var blocks = referenceBlock.workspace.getAllBlocks();
+  var blocks = referenceBlock.workspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     var otherName = block.getFieldValue('FIELDNAME');
     if (!block.disabled && !block.getInheritedDisabled() &&
@@ -812,7 +812,7 @@ function inputNameCheck(referenceBlock) {
   }
   var name = referenceBlock.getFieldValue('INPUTNAME').toLowerCase();
   var count = 0;
-  var blocks = referenceBlock.workspace.getAllBlocks();
+  var blocks = referenceBlock.workspace.getAllBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     var otherName = block.getFieldValue('INPUTNAME');
     if (!block.disabled && !block.getInheritedDisabled() &&

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -341,7 +341,7 @@ Code.attemptCodeGeneration = function(generator, prettyPrintType) {
  * @param generator {!Blockly.Generator} The generator to use.
  */
 Code.checkAllGeneratorFunctionsDefined = function(generator) {
-  var blocks = Code.workspace.getAllBlocks();
+  var blocks = Code.workspace.getAllBlocks(false);
   var missingBlockGenerators = [];
   for (var i = 0; i < blocks.length; i++) {
     var blockType = blocks[i].type;
@@ -536,7 +536,7 @@ Code.runJS = function() {
  * Discard all blocks from the workspace.
  */
 Code.discard = function() {
-  var count = Code.workspace.getAllBlocks().length;
+  var count = Code.workspace.getAllBlocks(false).length;
   if (count < 2 ||
       window.confirm(Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1', count))) {
     Code.workspace.clear();

--- a/demos/plane/plane.js
+++ b/demos/plane/plane.js
@@ -360,8 +360,8 @@ Plane.recalculate = function() {
       block.customUpdate && block.customUpdate();
     }
   }
-  updateBlocks(Plane.workspace.getAllBlocks());
-  updateBlocks(Plane.workspace.flyout_.workspace_.getAllBlocks());
+  updateBlocks(Plane.workspace.getAllBlocks(false));
+  updateBlocks(Plane.workspace.flyout_.workspace_.getAllBlocks(false));
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None.  Gets rid of some compiler warnings.

### Proposed Changes

All calls to `workspace.getAllBlocks` now pass `false` for `ordered`.  

### Reason for Changes

Cleanup related to https://github.com/google/blockly/commit/662d79443f4e9a59334e19e2802399e6f427812c

There's nw an option to get blocks in order (slow) or out of order (faster).  These calls were missed in the original PR.

### Test Coverage
No change in executed code (undefined is falsy).