### PR TITLE
Restructure isConnectionAllowed to match scratch blocks

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -345,35 +345,45 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
     return false;
   }
 
-  // Don't offer to connect an already connected left (male) value plug to
-  // an available right (female) value plug.  Don't offer to connect the
-  // bottom of a statement block to one that's already connected.
-  if (candidate.type == Blockly.OUTPUT_VALUE ||
-      candidate.type == Blockly.PREVIOUS_STATEMENT) {
-    if (candidate.isConnected() || this.isConnected()) {
-      return false;
-    }
-  }
-
-  // Offering to connect the left (male) of a value block to an already
-  // connected value pair is ok, we'll splice it in.
-  // However, don't offer to splice into an immovable block.
-  if (candidate.type == Blockly.INPUT_VALUE && candidate.isConnected() &&
-      !candidate.targetBlock().isMovable() &&
-      !candidate.targetBlock().isShadow()) {
-    return false;
-  }
-
-  // Don't let a block with no next connection bump other blocks out of the
-  // stack.  But covering up a shadow block or stack of shadow blocks is fine.
-  // Similarly, replacing a terminal statement with another terminal statement
-  // is allowed.
-  if (this.type == Blockly.PREVIOUS_STATEMENT &&
-      candidate.isConnected() &&
-      !this.sourceBlock_.nextConnection &&
-      !candidate.targetBlock().isShadow() &&
-      candidate.targetBlock().nextConnection) {
-    return false;
+  switch (candidate.type) {
+    case Blockly.PREVIOUS_STATEMENT:
+      // Don't offer to connect the bottom of a statement block to one that's
+      // already connected.
+      if (candidate.isConnected() || this.isConnected()) {
+        return false;
+      }
+      break;
+    case Blockly.OUTPUT_VALUE:
+      // Don't offer to connect an already connected left (male) value plug to
+      // an available right (female) value plug.
+      if (candidate.isConnected() || this.isConnected()) {
+        return false;
+      }
+      break;
+    case Blockly.INPUT_VALUE:
+      // Offering to connect the left (male) of a value block to an already
+      // connected value pair is ok, we'll splice it in.
+      // However, don't offer to splice into an unmovable block.
+      if (candidate.targetConnection &&
+          !candidate.targetBlock().isMovable() &&
+          !candidate.targetBlock().isShadow()) {
+        return false;
+      }
+      break;
+    case Blockly.NEXT_STATEMENT:
+      // Don't let a block with no next connection bump other blocks out of the
+      // stack.  But covering up a shadow block or stack of shadow blocks is
+      // fine.  Similarly, replacing a terminal statement with another terminal
+      // statement is allowed.
+      if (candidate.isConnected() &&
+          !this.sourceBlock_.nextConnection &&
+          !candidate.targetBlock().isShadow() &&
+          candidate.targetBlock().nextConnection) {
+        return false;
+      }
+      break;
+    default:
+      throw Error('Unknown connection type in isConnectionAllowed');
   }
 
   // Don't let blocks try to connect to themselves or ones they nest.


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of adding insertion markers.
### Proposed Changes

Restructure isConnectionAllowed to match scratch blocks.

### Reason for Changes

Much of the detail work for insertion markers happens in isConnectionAllowed.  I've been struggling to see what needs to be changed because it's written differently in the two repos.  I'm matching the structure that the functional code has to make my diffs a bit easier to parse.

### Test Coverage
Tested with airstrike + dragging in the playground.