### PR TITLE
Playground upgrades

### DIFF
--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -26,6 +26,25 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": []
   },
   {
+    "type": "value_to_stack",
+    "message0": "value to stack",
+    "nextStatement": null,
+    "output": null,
+    "colour": 230,
+  },
+  {
+    "type": "value_to_statement",
+    "message0": "value to statement %1",
+    "args0": [
+      {
+        "type": "input_statement",
+        "name": "STATEMENT"
+      }
+    ],
+    "output": null,
+    "colour": 230,
+  },
+  {
     "type": "example_dropdown_long",
     "message0": "long: %1",
     "args0": [

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -30,7 +30,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "message0": "value to stack",
     "nextStatement": null,
     "output": null,
-    "colour": 230,
+    "colour": 230
   },
   {
     "type": "value_to_statement",
@@ -42,7 +42,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       }
     ],
     "output": null,
-    "colour": 230,
+    "colour": 230
   },
   {
     "type": "example_dropdown_long",

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -70,7 +70,7 @@
 var workspace = null;
 
 function start() {
-  setBackgroundColor();
+  setBackgroundColour();
 
   // Parse the URL arguments.
   var match = location.search.match(/dir=([^&]+)/);
@@ -110,7 +110,7 @@ function start() {
             wheel: true,
             startScale: 1.0,
             maxScale: 4,
-            minScale: .25,
+            minScale: 0.25,
             scaleSpeed: 1.1
           }
       });
@@ -130,13 +130,10 @@ function start() {
   taChange();
 }
 
-function setBackgroundColor() {
-  var lilac = '#d6d6ff';
-
-  var currentPage = window.location.href;
-  var regexFile = /^file[\S]*$/;
-
-  if (regexFile.test(currentPage)) {
+function setBackgroundColour() {
+  // Set background colour to differentiate server vs local copy.
+  if (location.protocol == 'file:') {
+    var lilac = '#d6d6ff';
     document.getElementsByTagName('body')[0].style.backgroundColor = lilac;
   }
 }

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -77,8 +77,14 @@ function start() {
   var rtl = match && match[1] == 'rtl';
   document.forms.options.elements.dir.selectedIndex = Number(rtl);
   var toolbox = getToolboxElement();
+  var toolboxNames = [
+      'toolbox-categories',
+      'toolbox-categories-typed-variables',
+      'toolbox-simple',
+      'toolbox-test-blocks'
+  ];
   document.forms.options.elements.toolbox.selectedIndex =
-      getToolboxFormIndex(toolbox.id);
+      toolboxNames.indexOf(toolbox.id);
   match = location.search.match(/side=([^&]+)/);
   var side = match ? match[1] : 'start';
   document.forms.options.elements.side.value = side;
@@ -146,18 +152,6 @@ function getToolboxElement() {
   // The three possible values are: "simple", "categories",
   // "categories-typed-variables".
   return document.getElementById('toolbox-' + toolboxSuffix);
-}
-
-function getToolboxFormIndex(id) {
-  if (id == 'toolbox-categories') {
-    return 0;
-  } else if (id == 'toolbox-categories-typed-variables') {
-    return 1;
-  } else if (id == 'toolbox-simple') {
-    return 2;
-  }
-  // Didn't recognize it.
-  return 0;
 }
 
 function toXml() {
@@ -1060,6 +1054,8 @@ h1 {
     <category name="Basic">
       <block type="empty_block"></block>
       <block type="empty_block_with_mutator"></block>
+      <block type="value_to_stack"></block>
+      <block type="value_to_statement"></block>
     </category>
     <category name="Drag">
       <label text="Drag each to the workspace"></label>

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -140,7 +140,7 @@ function setBackgroundColour() {
   // Set background colour to differentiate server vs local copy.
   if (location.protocol == 'file:') {
     var lilac = '#d6d6ff';
-    document.getElementsByTagName('body')[0].style.backgroundColor = lilac;
+    document.body.style.backgroundColor = lilac;
   }
 }
 


### PR DESCRIPTION
Adds two new blocks to the playground's test blocks:
<img width="346" alt="screen shot 2018-09-22 at 05 56 54" src="https://user-images.githubusercontent.com/250480/45917455-707ed980-be2c-11e8-8ff1-feec6b737f2e.png">

Fixes dropdown which previously could not be set to 'Test Blocks' due to missing condition.

Simplifies detection of file:// url.