### PR TITLE
Remove unneeded String() and str() calls.

### DIFF
--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -252,11 +252,11 @@ Blockly.JavaScript['lists_setIndex'] = function(block) {
 
 /**
  * Returns an expression calculating the index into a list.
- * @private
  * @param {string} listName Name of the list, used to calculate length.
  * @param {string} where The method of indexing, selected by dropdown in Blockly
  * @param {string=} opt_at The optional offset when indexing from start/end.
  * @return {string} Index expression.
+ * @private
  */
 Blockly.JavaScript.lists.getIndex_ = function(listName, where, opt_at) {
   if (where == 'FIRST') {

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -35,6 +35,25 @@ Blockly.JavaScript['text'] = function(block) {
   return [code, Blockly.JavaScript.ORDER_ATOMIC];
 };
 
+/**
+ * Enclose the provided value in 'String(...)' function.
+ * Leave string literals alone.
+ * @param {string} value Code evaluating to a value.
+ * @return {string} Code evaluating to a string.
+ * @private
+ */
+Blockly.JavaScript.text.forceString_ = function(value) {
+  if (Blockly.JavaScript.text.forceString_.strRegExp.test(value)) {
+    return value;
+  }
+  return 'String(' + value + ')';
+};
+
+/**
+ * Regular expression to detect a single-quoted string literal.
+ */
+Blockly.JavaScript.text.forceString_.strRegExp = /^\s*'([^']|\\')*'\s*$/;
+
 Blockly.JavaScript['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   switch (block.itemCount_) {
@@ -43,14 +62,15 @@ Blockly.JavaScript['text_join'] = function(block) {
     case 1:
       var element = Blockly.JavaScript.valueToCode(block, 'ADD0',
           Blockly.JavaScript.ORDER_NONE) || '\'\'';
-      var code = 'String(' + element + ')';
+      var code = Blockly.JavaScript.text.forceString_(element);
       return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
     case 2:
       var element0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
           Blockly.JavaScript.ORDER_NONE) || '\'\'';
       var element1 = Blockly.JavaScript.valueToCode(block, 'ADD1',
           Blockly.JavaScript.ORDER_NONE) || '\'\'';
-      var code = 'String(' + element0 + ') + String(' + element1 + ')';
+      var code = Blockly.JavaScript.text.forceString_(element0) + ' + ' +
+          Blockly.JavaScript.text.forceString_(element1);
       return [code, Blockly.JavaScript.ORDER_ADDITION];
     default:
       var elements = new Array(block.itemCount_);
@@ -69,7 +89,7 @@ Blockly.JavaScript['text_append'] = function(block) {
       block.getFieldValue('VAR'), Blockly.Variables.NAME_TYPE);
   var value = Blockly.JavaScript.valueToCode(block, 'TEXT',
       Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  return varName + ' = String(' + varName + ') + String(' + value + ');\n';
+  return varName + ' += ' + Blockly.JavaScript.text.forceString_(value) + ';\n';
 };
 
 Blockly.JavaScript['text_length'] = function(block) {
@@ -142,11 +162,11 @@ Blockly.JavaScript['text_charAt'] = function(block) {
 
 /**
  * Returns an expression calculating the index into a string.
- * @private
  * @param {string} stringName Name of the string, used to calculate length.
  * @param {string} where The method of indexing, selected by dropdown in Blockly
  * @param {string=} opt_at The optional offset when indexing from start/end.
  * @return {string} Index expression.
+ * @private
  */
 Blockly.JavaScript.text.getIndex_ = function(stringName, where, opt_at) {
   if (where == 'FIRST') {

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -114,11 +114,11 @@ Blockly.Lua['lists_indexOf'] = function(block) {
 
 /**
  * Returns an expression calculating the index into a list.
- * @private
  * @param {string} listName Name of the list, used to calculate length.
  * @param {string} where The method of indexing, selected by dropdown in Blockly
  * @param {string=} opt_at The optional offset when indexing from start/end.
  * @return {string} Index expression.
+ * @private
  */
 Blockly.Lua.lists.getIndex_ = function(listName, where, opt_at) {
   if (where == 'FIRST') {

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -35,6 +35,25 @@ Blockly.Python['text'] = function(block) {
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
+/**
+ * Enclose the provided value in 'str(...)' function.
+ * Leave string literals alone.
+ * @param {string} value Code evaluating to a value.
+ * @return {string} Code evaluating to a string.
+ * @private
+ */
+Blockly.Python.text.forceString_ = function(value) {
+  if (Blockly.Python.text.forceString_.strRegExp.test(value)) {
+    return value;
+  }
+  return 'str(' + value + ')';
+};
+
+/**
+ * Regular expression to detect a single-quoted string literal.
+ */
+Blockly.Python.text.forceString_.strRegExp = /^\s*'([^']|\\')*'\s*$/;
+
 Blockly.Python['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   //Should we allow joining by '-' or ',' or any other characters?
@@ -45,15 +64,16 @@ Blockly.Python['text_join'] = function(block) {
     case 1:
       var element = Blockly.Python.valueToCode(block, 'ADD0',
               Blockly.Python.ORDER_NONE) || '\'\'';
-      var code = 'str(' + element + ')';
+      var code = Blockly.Python.text.forceString_(element);
       return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       break;
     case 2:
       var element0 = Blockly.Python.valueToCode(block, 'ADD0',
-              Blockly.Python.ORDER_NONE) || '\'\'';
+          Blockly.Python.ORDER_NONE) || '\'\'';
       var element1 = Blockly.Python.valueToCode(block, 'ADD1',
-              Blockly.Python.ORDER_NONE) || '\'\'';
-      var code = 'str(' + element0 + ') + str(' + element1 + ')';
+          Blockly.Python.ORDER_NONE) || '\'\'';
+      var code = Blockly.Python.text.forceString_(element0) + ' + ' +
+          Blockly.Python.text.forceString_(element1);
       return [code, Blockly.Python.ORDER_ADDITIVE];
       break;
     default:
@@ -76,7 +96,8 @@ Blockly.Python['text_append'] = function(block) {
       Blockly.Variables.NAME_TYPE);
   var value = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  return varName + ' = str(' + varName + ') + str(' + value + ')\n';
+  return varName + ' = str(' + varName + ') + ' +
+      Blockly.Python.text.forceString_(value) + '\n';
 };
 
 Blockly.Python['text_length'] = function(block) {


### PR DESCRIPTION
String literals in JS and Python don’t need to be coerced to strings.

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Makes generated JS and Python code cleaner.

### Proposed Changes

Previously, generated code for string concatenation looked like this:

JS: String('hello') + String('world');
Py: str('hello') + str('world');

Now string literals are detected and the unneeded string functions are dropped:

JS: 'hello' + 'world'
Py: 'hello' + 'world'

By the same token, string append looked like this:

JS: x = String(x) + String('foo');
Py: x = str(x) + str('foo');

Now append looks like this:

JS: x += 'foo';
Py: x = str(x) + 'foo';

(Python can't use += because x might not be a string and unlike JS, Python won't quietly cast x.)

In all cases, if an element isn't a string literal, the String() or str() functions are retained.

### Reason for Changes

Procrastinating from real work.

### Test Coverage

Ran existing unit tests for strings.

Tested on:
* Desktop Chrome