### PR TITLE
Honour reductions to MAX_UNDO

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -523,7 +523,7 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
   if (event.recordUndo) {
     this.undoStack_.push(event);
     this.redoStack_.length = 0;
-    if (this.undoStack_.length > this.MAX_UNDO) {
+    while (this.undoStack_.length > this.MAX_UNDO) {
       this.undoStack_.unshift();
     }
   }

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -524,7 +524,7 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
     this.undoStack_.push(event);
     this.redoStack_.length = 0;
     while (this.undoStack_.length > this.MAX_UNDO) {
-      this.undoStack_.unshift();
+      this.undoStack_.shift();
     }
   }
   for (var i = 0, func; func = this.listeners_[i]; i++) {

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -523,7 +523,7 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
   if (event.recordUndo) {
     this.undoStack_.push(event);
     this.redoStack_.length = 0;
-    while (this.undoStack_.length > this.MAX_UNDO) {
+    while (this.undoStack_.length > this.MAX_UNDO && this.MAX_UNDO >= 0) {
       this.undoStack_.shift();
     }
   }


### PR DESCRIPTION
If workspace.MAX_UNDO is reduced, we now throw away the extra records in the stack, as opposed to just not growing it anymore.