### PR TITLE
Fix setting tooltips in field init for label fields

### DIFF
--- a/core/field_label.js
+++ b/core/field_label.js
@@ -44,6 +44,7 @@ Blockly.FieldLabel = function(text, opt_class) {
   this.size_ = new goog.math.Size(0, 17.5);
   this.class_ = opt_class;
   this.setValue(text);
+  this.tooltip_ = '';
 };
 goog.inherits(Blockly.FieldLabel, Blockly.Field);
 
@@ -76,6 +77,12 @@ Blockly.FieldLabel.prototype.init = function() {
   // Build the DOM.
   this.textElement_ = Blockly.utils.createSvgElement('text',
       {'class': 'blocklyText', 'y': this.size_.height - 5}, null);
+  if (this.tooltip_) {
+    this.textElement_.tooltip = this.tooltip_;
+  } else {
+    // Configure the field to be transparent with respect to tooltips.
+    this.textElement_.tooltip = this.sourceBlock_;
+  }
   if (this.class_) {
     Blockly.utils.addClass(this.textElement_, this.class_);
   }
@@ -84,8 +91,6 @@ Blockly.FieldLabel.prototype.init = function() {
   }
   this.sourceBlock_.getSvgRoot().appendChild(this.textElement_);
 
-  // Configure the field to be transparent with respect to tooltips.
-  this.textElement_.tooltip = this.sourceBlock_;
   Blockly.Tooltip.bindMouseEvents(this.textElement_);
   // Force a render.
   this.render_();
@@ -116,7 +121,10 @@ Blockly.FieldLabel.prototype.getSvgRoot = function() {
  *     link to for its tooltip.
  */
 Blockly.FieldLabel.prototype.setTooltip = function(newTip) {
-  this.textElement_.tooltip = newTip;
+  this.tooltip_ = newTip;
+  if (this.textElement_) {
+    this.textElement_.tooltip = newTip;
+  }
 };
 
 Blockly.Field.register('field_label', Blockly.FieldLabel);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -110,8 +110,12 @@ Blockly.FieldTextInput.prototype.setValue = function(newValue) {
     if (this.sourceBlock_) {
       var validated = this.callValidator(newValue);
       // If the new value is invalid, validation returns null.
-      // In this case we still want to display the illegal result.
-      if (validated !== null) {
+      if (validated === null) {
+        return;
+      }
+      // If the validator returned undefined, it didn't have an
+      // opinion.  If it cared, use the new value.
+      if (typeof validated != 'undefined') {
         newValue = validated;
       }
     }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #2030 
### Proposed Changes

Saves the tooltip value and sets it when initializing the field's svg.
### Reason for Changes

Previous code failed if the function was called too early.

### Test Coverage

Testing in chrome by running this snippet and then hovering over the resulting field:

```
Blockly.Blocks['test_1'] = {
    init: function() {
    this.appendDummyInput('in1');
    var in1 = this.getInput('in1');
    var field = new Blockly.FieldLabel('Test');
    field.setTooltip('Test tooltip');
    in1.appendField(field);
    }
};

bl = Blockly.getMainWorkspace().newBlock('test_1')
bl.initSvg()
bl.render();
```

### Additional Information

I still need to fix field_image