### PR TITLE
Fix setting tooltips in field init for fields

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -52,6 +52,7 @@ Blockly.FieldImage = function(src, width, height, opt_alt, opt_onClick) {
   this.size_ = new goog.math.Size(this.width_,
       this.height_ + 2 * Blockly.BlockSvg.INLINE_PADDING_Y);
   this.text_ = opt_alt || '';
+  this.tooltip_ = '';
   this.setValue(src);
 
   if (typeof opt_onClick == 'function') {
@@ -108,8 +109,12 @@ Blockly.FieldImage.prototype.init = function() {
   this.setValue(this.src_);
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
 
-  // Configure the field to be transparent with respect to tooltips.
-  this.setTooltip(this.sourceBlock_);
+  if (this.tooltip_) {
+    this.imageElement_.tooltip = this.tooltip_;
+  } else {
+    // Configure the field to be transparent with respect to tooltips.
+    this.setTooltip(this.sourceBlock_);
+  }
   Blockly.Tooltip.bindMouseEvents(this.imageElement_);
 
   this.maybeAddClickHandler_();
@@ -145,7 +150,10 @@ Blockly.FieldImage.prototype.maybeAddClickHandler_ = function() {
  *     link to for its tooltip.
  */
 Blockly.FieldImage.prototype.setTooltip = function(newTip) {
-  this.imageElement_.tooltip = newTip;
+  this.tooltip_ = newTip;
+  if (this.imageElement_) {
+    this.imageElement_.tooltip = newTip;
+  }
 };
 
 /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -44,6 +44,7 @@ Blockly.FieldLabel = function(text, opt_class) {
   this.size_ = new goog.math.Size(0, 17.5);
   this.class_ = opt_class;
   this.setValue(text);
+  this.tooltip_ = '';
 };
 goog.inherits(Blockly.FieldLabel, Blockly.Field);
 
@@ -84,8 +85,12 @@ Blockly.FieldLabel.prototype.init = function() {
   }
   this.sourceBlock_.getSvgRoot().appendChild(this.textElement_);
 
-  // Configure the field to be transparent with respect to tooltips.
-  this.textElement_.tooltip = this.sourceBlock_;
+  if (this.tooltip_) {
+    this.textElement_.tooltip = this.tooltip_;
+  } else {
+    // Configure the field to be transparent with respect to tooltips.
+    this.textElement_.tooltip = this.sourceBlock_;
+  }
   Blockly.Tooltip.bindMouseEvents(this.textElement_);
   // Force a render.
   this.render_();
@@ -116,7 +121,10 @@ Blockly.FieldLabel.prototype.getSvgRoot = function() {
  *     link to for its tooltip.
  */
 Blockly.FieldLabel.prototype.setTooltip = function(newTip) {
-  this.textElement_.tooltip = newTip;
+  this.tooltip_ = newTip;
+  if (this.textElement_) {
+    this.textElement_.tooltip = newTip;
+  }
 };
 
 Blockly.Field.register('field_label', Blockly.FieldLabel);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#2030
### Proposed Changes

Saves the tooltip value and sets it when initializing the field's svg.
### Reason for Changes

Previous code failed if the function was called too early.


### Test Coverage
Tested in Chrome by running these two snippets and hovering over the resulting blocks

```
Blockly.Blocks['test_1'] = {
    init: function() {
    this.appendDummyInput('in1');
    var in1 = this.getInput('in1');
    var field = new Blockly.FieldLabel('Test');
    field.setTooltip('Test tooltip');
    in1.appendField(field);
    }
};

bl = Blockly.getMainWorkspace().newBlock('test_1')
bl.initSvg()
bl.render();
```

And
```
Blockly.Blocks['test_1'] = {
    init: function() {
    this.appendDummyInput('in1');
    var in1 = this.getInput('in1');
    var field = new Blockly.FieldImage('https://www.gstatic.com/codesite/ph/images/star_on.gif', 15, 15);
    field.setTooltip('Test tooltip');
    in1.appendField(field);
    }
};

bl = Blockly.getMainWorkspace().newBlock('test_1')
bl.initSvg()
bl.render();
```