### PR TITLE
Generator test improvements

### DIFF
--- a/tests/generators/colour.xml
+++ b/tests/generators/colour.xml
@@ -60,6 +60,7 @@
     </statement>
   </block>
   <block type="unittest_main" x="-5" y="49">
+    <field name="SUITE_NAME">Colour</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test colour picker"></mutation>

--- a/tests/generators/functions.xml
+++ b/tests/generators/functions.xml
@@ -1,6 +1,7 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <!-- Do not include <variables> here to test backward compatibility. -->
   <block type="unittest_main" x="0" y="1">
+    <field name="SUITE_NAME">Functions</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test procedure"></mutation>

--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -91,7 +91,7 @@ function start() {
 }
 
 /*
- * Run this test to load all of the test files in all_test_names.  The contents
+ * Run this test to load all of the tests in the selected suites.  The contents
  * will be loaded into the workspace in order.  To test the generators:
  * - select your language from the buttons above the text area
  * - copy all of the generated code
@@ -101,20 +101,26 @@ function start() {
  * If some tests are failing, load test suites individually to continue
  * debugging.
  */
-function loadAll() {
+function loadSelected() {
   var output = document.getElementById('importExport');
   output.style.background = 'gray';
 
   var loadingElem = document.getElementById('loading');
   loadingElem.textContent = 'loading...';
 
-  var options = document.getElementById('testUrl').options;
-  for (var i = 0; i < options.length; i++) {
-    var testUrl = options[i].value;
-    if (testUrl) {
-      var xmlText = fetchFile(testUrl);
-      if (xmlText !== null) {
-        fromXml(testUrl, xmlText, /* opt_append */ true);
+  // Clear before adding all of the blocks.
+  demoWorkspace.clear();
+
+  var boxList = document.getElementById('checkboxes');
+  var inputChildren = boxList.getElementsByTagName('input');
+  for (var i = 0; i < inputChildren.length; i++) {
+    if (inputChildren[i].checked) {
+      var testUrl = inputChildren[i].value;
+      if (testUrl) {
+        var xmlText = fetchFile(testUrl);
+        if (xmlText !== null) {
+          fromXml(testUrl, xmlText, /* opt_append */ true);
+        }
       }
     }
   }
@@ -122,14 +128,13 @@ function loadAll() {
   loadingElem.textContent = 'done';
 }
 
-function loadXml() {
-  var dropdown = document.getElementById('testUrl');
-  var url = dropdown.options[dropdown.selectedIndex].value;
+/**
+ * Ask the user for a file name, then load that file's contents.
+ */
+function loadOther() {
+  var url = window.prompt('Enter URL of test file.');
   if (!url) {
-    url = window.prompt('Enter URL of test file.');
-    if (!url) {
-      return;
-    }
+    return;
   }
   var xmlText = fetchFile(url);
   if (xmlText !== null) {
@@ -186,6 +191,22 @@ function fromXml(filename, xmlText, opt_append) {
     console.error(e.stack ? e : msg);
     alert(msg);
     return;
+  }
+}
+
+function checkAll() {
+  var boxList = document.getElementById('checkboxes');
+  var inputChildren = boxList.getElementsByTagName('input');
+  for (var i = 0; i < inputChildren.length; i++) {
+    inputChildren[i].checked = true;
+  }
+}
+
+function uncheckAll() {
+  var boxList = document.getElementById('checkboxes');
+  var inputChildren = boxList.getElementsByTagName('input');
+  for (var i = 0; i < inputChildren.length; i++) {
+    inputChildren[i].checked = false;
   }
 }
 
@@ -369,26 +390,28 @@ h1 {
 
     <p><a href="https://developers.google.com/blockly/guides/modify/web/unit-testing">See the docs</a> for details on running the tests.
 
-    <p>
-      <select id="testUrl">
-        <option value="logic.xml">Logic</option>
-        <option value="loops1.xml">Loops 1 (repeat, while, foreach)</option>
-        <option value="loops2.xml">Loops 2 (count)</option>
-        <option value="loops3.xml">Loops 3 (continue, break)</option>
-        <option value="math.xml">Math</option>
-        <option value="text.xml">Text</option>
-        <option value="lists.xml">Lists</option>
-        <option value="colour.xml">Colour</option>
-        <option value="variables.xml">Variables</option>
-        <option value="functions.xml">Functions</option>
-        <option value="">Other...</option>
-      </select>
-      <input type="button" value="Load" onclick="loadXml()">
-    </p>
+
+    <div id="checkboxes">
+      <input type="button" value="Check all" onclick="checkAll()">
+      <input type="button" value="Uncheck all" onclick="uncheckAll()"><br/>
+      <input type="checkbox" value="logic.xml">Logic</input><br/>
+      <input type="checkbox" value="loops1.xml">Loops 1 (repeat, while, foreach)</input><br/>
+      <input type="checkbox" value="loops2.xml">Loops 2 (count)</input><br/>
+      <input type="checkbox" value="loops3.xml">Loops 3 (continue, break)</input><br/>
+      <input type="checkbox" value="math.xml">Math</input><br/>
+      <input type="checkbox" value="text.xml">Text</input><br/>
+      <input type="checkbox" value="lists.xml">Lists</input><br/>
+      <input type="checkbox" value="colour.xml">Colour</input><br/>
+      <input type="checkbox" value="variables.xml">Variables</input><br/>
+      <input type="checkbox" value="functions.xml">Functions</input><br/>
+    </div>
 
     <p>
-      <input type="button" value="Load all" id="loadAllBtn" onclick="loadAll()">
-      <label for="loadAllBtn" id="loading"></label>
+      <input type="button" value="Load selected" id="loadSelectedBtn" onclick="loadSelected()">
+      <label for="loadSelectedBtn" id="loading"></label>
+    </p>
+    <p>
+      <input type="button" value="Load by file name" onclick="loadOther()">
     </p>
 
     <p>

--- a/tests/generators/lists.xml
+++ b/tests/generators/lists.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="13" y="13">
+    <field name="SUITE_NAME">Lists</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test create"></mutation>

--- a/tests/generators/logic.xml
+++ b/tests/generators/logic.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="-13" y="-13">
+    <field name="SUITE_NAME">Logic</field>
     <statement name="DO">
       <block type="unittest_assertvalue" inline="false">
         <field name="EXPECTED">TRUE</field>

--- a/tests/generators/loops1.xml
+++ b/tests/generators/loops1.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="33" y="140">
+    <field name="SUITE_NAME">Loops 1</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test repeat"></mutation>

--- a/tests/generators/loops2.xml
+++ b/tests/generators/loops2.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="66" y="-2">
+    <field name="SUITE_NAME">Loops 2</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test count"></mutation>

--- a/tests/generators/loops3.xml
+++ b/tests/generators/loops3.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="19" y="106">
+    <field name="SUITE_NAME">Loops 3</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test break"></mutation>

--- a/tests/generators/math.xml
+++ b/tests/generators/math.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="13" y="13">
+    <field name="SUITE_NAME">Math</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test arithmetic"></mutation>

--- a/tests/generators/text.xml
+++ b/tests/generators/text.xml
@@ -1,5 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="unittest_main" x="13" y="-63">
+    <field name="SUITE_NAME">Text</field>
     <statement name="DO">
       <block type="procedures_callnoreturn">
         <mutation name="test length"></mutation>

--- a/tests/generators/unittest.js
+++ b/tests/generators/unittest.js
@@ -29,7 +29,8 @@ Blockly.Blocks['unittest_main'] = {
   init: function() {
     this.setColour(65);
     this.appendDummyInput()
-        .appendField('run tests');
+        .appendField('run test suite')
+        .appendField(new Blockly.FieldTextInput(''), 'SUITE_NAME');
     this.appendStatementInput('DO');
     this.setTooltip('Executes the enclosed unit tests,\n' +
                     'then prints a summary.');

--- a/tests/generators/unittest_dart.js
+++ b/tests/generators/unittest_dart.js
@@ -59,6 +59,11 @@ Blockly.Dart['unittest_main'] = function(block) {
         '}']);
   // Setup global to hold test results.
   var code = resultsVar + ' = [];\n';
+  // Say which test suite this is.
+  code += 'print(\'\\n====================\\n\\n' +
+      'Running suite: ' +
+      block.getFieldValue('SUITE_NAME') +
+       '\');\n';
   // Run tests (unindented).
   code += Blockly.Dart.statementToCode(block, 'DO')
       .replace(/^  /, '').replace(/\n  /g, '\n');

--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -60,6 +60,11 @@ Blockly.JavaScript['unittest_main'] = function(block) {
         '}']);
   // Setup global to hold test results.
   var code = resultsVar + ' = [];\n';
+  // Say which test suite this is.
+  code += 'console.log(\'\\n====================\\n\\n' +
+      'Running suite: ' +
+      block.getFieldValue('SUITE_NAME') +
+       '\')\n';
   // Run tests (unindented).
   code += Blockly.JavaScript.statementToCode(block, 'DO')
       .replace(/^  /, '').replace(/\n  /g, '\n');

--- a/tests/generators/unittest_lua.js
+++ b/tests/generators/unittest_lua.js
@@ -58,6 +58,11 @@ Blockly.Lua['unittest_main'] = function(block) {
        'end']);
   // Setup global to hold test results.
   var code = resultsVar + ' = {}\n';
+  // Say which test suite this is.
+  code += 'print(\'\\n====================\\n\\n' +
+      'Running suite: ' +
+      block.getFieldValue('SUITE_NAME') +
+       '\')\n';
   // Run tests (unindented).
   code += Blockly.Lua.statementToCode(block, 'DO')
       .replace(/^  /, '').replace(/\n  /g, '\n');

--- a/tests/generators/unittest_php.js
+++ b/tests/generators/unittest_php.js
@@ -52,7 +52,7 @@ Blockly.PHP['unittest_main'] = function(block) {
           '  array_push($report, "Number of tests run: " . count(' + resultsVar + '));',
           '  array_push($report, "");',
           '  if ($fails) {',
-          '    array_push($report, "FAILED (failures=" . $fails + ")");',
+          '    array_push($report, "FAILED (failures=" . $fails . ")");',
           '  } else {',
           '    array_push($report, "OK");',
           '  }',
@@ -60,6 +60,11 @@ Blockly.PHP['unittest_main'] = function(block) {
           '}']);
   // Setup global to hold test results.
   var code = resultsVar + ' = array();\n';
+  // Say which test suite this is.
+  code += 'print("\\n====================\\n\\n' +
+      'Running suite: ' +
+      block.getFieldValue('SUITE_NAME') +
+       '\\n");\n';
   // Run tests (unindented).
   code += Blockly.PHP.statementToCode(block, 'DO')
       .replace(/^  /, '').replace(/\n  /g, '\n');

--- a/tests/generators/unittest_python.js
+++ b/tests/generators/unittest_python.js
@@ -56,6 +56,11 @@ Blockly.Python['unittest_main'] = function(block) {
 
   // Setup global to hold test results.
   var code = resultsVar + ' = []\n';
+  // Say which test suite this is.
+  code += 'print(\'\\n====================\\n\\n' +
+      'Running suite: ' +
+      block.getFieldValue('SUITE_NAME') +
+       '\')\n';
   // Run tests (unindented).
   code += Blockly.Python.statementToCode(block, 'DO')
       .replace(/^  /, '').replace(/\n  /g, '\n');

--- a/tests/generators/variables.xml
+++ b/tests/generators/variables.xml
@@ -1,6 +1,7 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <!-- Do not include <variables> here to test backward compatibility. -->
   <block type="unittest_main" x="0" y="0">
+    <field name="SUITE_NAME">Variables</field>
     <statement name="DO">
       <block type="variables_set" inline="false">
         <field name="VAR">item</field>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Pick which generator tests to run with checkboxes instead of a dropdown.
Add a suite name field to the unittest_main block, update all tests to have the correct value in that field, and update generators to print that value.
### Reason for Changes

I don't enjoy running generator tests.

This makes it possible to run a subset of the tests to find which ones are failing, without needing to go immediately to running only one suite at a time.

Having the suite name makes it possible to see what test suite failed and isolate it more quickly.