### PR TITLE
Immovable blocks should not move when workspace is cleaned

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1285,6 +1285,9 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function() {
   var topBlocks = this.getTopBlocks(true);
   var cursorY = 0;
   for (var i = 0, block; block = topBlocks[i]; i++) {
+    if (!block.isMovable()) {
+      continue;
+    }
     var xy = block.getRelativeToSurfaceXY();
     block.moveBy(-xy.x, cursorY - xy.y);
     block.snapToGrid();


### PR DESCRIPTION
To recreate the issue reported by James Ma, go to the playground, and import this XML:
```
<xml xmlns="http://www.w3.org/1999/xhtml">
  <block type="controls_whileUntil" x="13" y="13"></block>
  <block movable="false" type="logic_negate" x="188" y="88"></block>
</xml>
```
Then right-click on workspace and cleanup blocks.  The 'not' block is immovable yet moves to a new location.

With this PR, the 'not' block does not move.