### PR TITLE
Removing comment around <meta>

### DIFF
--- a/demos/mobile/html/index.html
+++ b/demos/mobile/html/index.html
@@ -2,7 +2,7 @@
 <!-- HTML file to host Blockly in a mobile WebView. -->
 <html>
 <head>
-  <!--<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">-->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <style type="text/css">
     html, body, #blocklyDiv {
       border: 0;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#2119

### Proposed change

Remove comment around <meta>.

### Reason for Changes

The <meta> tag fixes the page scale, and prevents the page from zooming.  This keeps the toolbox on screen (can't pan the page if the workspace absorbs the scroll action) and keeps the touch points at reasonable scale.

### Test Coverage

Rebuilt mobile demos and tested zoom behavior. The page scale starts correctly, and the page no longer zooms.

Tested on:
 * iOS simulator
 * Chrome mobile preview