### PR TITLE
Add support for handling window.prompt(..) etc in iOS mobile demo

### DIFF
--- a/demos/mobile/ios/Blockly WebView.xcodeproj/xcuserdata/marshalla.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/demos/mobile/ios/Blockly WebView.xcodeproj/xcuserdata/marshalla.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,6 +9,11 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
+		<key>Blockly WebView.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/demos/mobile/ios/Blockly WebView/ViewController.swift
+++ b/demos/mobile/ios/Blockly WebView/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import WebKit
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, WKUIDelegate {
     /// The name used to reference this iOS object when executing callbacks from the JS code.
     /// If this value is changed, it should also be changed in the `CODE_GENERATOR_BRIDGE_JS` file.
     fileprivate static let HOST_HTML = "Blockly/webview.html"
@@ -18,21 +18,60 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        webView.uiDelegate = self
         // Do any additional setup after loading the view, typically from a nib.
-        loadWebView()
+        loadWebContent()
     }
     
-    func loadWebView() {
+    func loadWebContent() {
         if let htmlUrl = Bundle.main.url(forResource: "webview", withExtension: "html", subdirectory: "Blockly") {
             webView.load(URLRequest.init(url: htmlUrl))
         }
     }
 
+    func webView(_ webView: WKWebView,
+                 runJavaScriptAlertPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping () -> Void) {
+        
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let title = NSLocalizedString("OK", comment: "OK Button")
+        let ok = UIAlertAction(title: title, style: .default) { (action: UIAlertAction) -> Void in
+            alert.dismiss(animated: true, completion: nil)
+        }
+        alert.addAction(ok)
+        present(alert, animated: true)
+        completionHandler()
+    }
+    
+    func webView(_ webView: WKWebView,
+                 runJavaScriptConfirmPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping (Bool) -> Void) {
+        
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let closeAndHandle = { (okayed: Bool) in
+            alert.dismiss(animated: true, completion: nil)
+            completionHandler(okayed)
+        }
+        
+        let okTitle = NSLocalizedString("OK", comment: "OK button title")
+        let ok = UIAlertAction(title: okTitle, style: .default) { (action: UIAlertAction) -> Void in
+            closeAndHandle(true)
+        }
+        alert.addAction(ok)
+        
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
+        let cancel = UIAlertAction(title: cancelTitle, style: .default) { (action: UIAlertAction) -> Void in
+            closeAndHandle(false)
+        }
+        alert.addAction(cancel)
+        present(alert, animated: true)
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
-
 }
 

--- a/demos/mobile/ios/Blockly WebView/ViewController.swift
+++ b/demos/mobile/ios/Blockly WebView/ViewController.swift
@@ -69,6 +69,34 @@ class ViewController: UIViewController, WKUIDelegate {
         present(alert, animated: true)
     }
     
+    func webView(_ webView: WKWebView,
+                 runJavaScriptTextInputPanelWithPrompt prompt: String,
+                 defaultText: String?,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping (String?) -> Void) {
+        
+        let alert = UIAlertController(title: prompt, message: nil, preferredStyle: .alert)
+        
+        alert.addTextField { (textField) in
+            textField.text = defaultText
+        }
+        
+        let okTitle = NSLocalizedString("OK", comment: "OK button title")
+        let okAction = UIAlertAction(title: okTitle, style: .default) { (_) in
+            let textInput = alert.textFields![0] as UITextField
+            completionHandler(textInput.text)
+        }
+        alert.addAction(okAction)
+        
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { (_) in
+            completionHandler(nil)
+        }
+        alert.addAction(cancelAction)
+        
+        present(alert, animated: true)
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.

--- a/demos/mobile/ios/Blockly WebView/ViewController.swift
+++ b/demos/mobile/ios/Blockly WebView/ViewController.swift
@@ -1,6 +1,5 @@
-//
 //  ViewController.swift
-//  Blockly WebView
+//  Blockly WebView UI controller.
 //
 //  Created by Andrew Marshall on 8/7/18.
 //  Copyright © 2018 Google. All rights reserved.
@@ -9,13 +8,17 @@
 import UIKit
 import WebKit
 
+
+/// A basic ViewController for a WebView.
+/// It handles the initial page load, and functions like window.prompt().
 class ViewController: UIViewController, WKUIDelegate {
     /// The name used to reference this iOS object when executing callbacks from the JS code.
     /// If this value is changed, it should also be changed in the `CODE_GENERATOR_BRIDGE_JS` file.
     fileprivate static let HOST_HTML = "Blockly/webview.html"
     
     @IBOutlet weak var webView: WKWebView!
-    
+ 
+    /// Additional setup after loading the UI NIB.
     override func viewDidLoad() {
         super.viewDidLoad()
         webView.uiDelegate = self
@@ -23,12 +26,17 @@ class ViewController: UIViewController, WKUIDelegate {
         loadWebContent()
     }
     
+    /// Load the root HTML page into the webview.
     func loadWebContent() {
-        if let htmlUrl = Bundle.main.url(forResource: "webview", withExtension: "html", subdirectory: "Blockly") {
+        if let htmlUrl = Bundle.main.url(forResource: "webview", withExtension: "html",
+                                         subdirectory: "Blockly") {
             webView.load(URLRequest.init(url: htmlUrl))
+        } else {
+            NSLog("Failed to load HTML. Could not find resource.")
         }
     }
 
+    /// Handle window.alert() with a native dialog.
     func webView(_ webView: WKWebView,
                  runJavaScriptAlertPanelWithMessage message: String,
                  initiatedByFrame frame: WKFrameInfo,
@@ -44,6 +52,7 @@ class ViewController: UIViewController, WKUIDelegate {
         completionHandler()
     }
     
+    /// Handle window.confirm() with a native dialog.
     func webView(_ webView: WKWebView,
                  runJavaScriptConfirmPanelWithMessage message: String,
                  initiatedByFrame frame: WKFrameInfo,
@@ -62,13 +71,15 @@ class ViewController: UIViewController, WKUIDelegate {
         alert.addAction(ok)
         
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
-        let cancel = UIAlertAction(title: cancelTitle, style: .default) { (action: UIAlertAction) -> Void in
+        let cancel = UIAlertAction(title: cancelTitle, style: .default) {
+            (action: UIAlertAction) -> Void in
             closeAndHandle(false)
         }
         alert.addAction(cancel)
         present(alert, animated: true)
     }
     
+    /// Handle window.prompt() with a native dialog.
     func webView(_ webView: WKWebView,
                  runJavaScriptTextInputPanelWithPrompt prompt: String,
                  defaultText: String?,
@@ -95,11 +106,6 @@ class ViewController: UIViewController, WKUIDelegate {
         alert.addAction(cancelAction)
         
         present(alert, animated: true)
-    }
-    
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
     }
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#2076

### Proposed Changes

In iOS ViewController, handle `alert(..)`, `confirm(..)`, and `prompt(..)` with native dialogs. These come up when confirming whether blocks can be deleted and alerting when blocks cannot be deleted. They are also supposed to come up when editing text and number fields on a phone... but don't, thanks to https://github.com/google/closure-library/issues/941.

I also added missing doc comments and corrected the Swift code style.

### Reason for Changes

Add UI where UI was previous missing.

### Test Coverage

Tested all three functions in a simulator window, both by calling them at the console and (with the exception of `prompt`) via interacting through Blockly.