### PR TITLE
Fix issues related to Python 3 compatibility

### DIFF
--- a/build.py
+++ b/build.py
@@ -336,7 +336,9 @@ class Gen_compressed(threading.Thread):
     conn = httplib.HTTPSConnection("closure-compiler.appspot.com")
     conn.request("POST", "/compile", urlencode(params), headers)
     response = conn.getresponse()
-    json_str = response.read()
+
+    # Decode is necessary for Python 3.4 compatibility
+    json_str = response.read().decode("utf-8")
     conn.close()
 
     # Parse the JSON response.
@@ -456,7 +458,7 @@ class Gen_langfiles(threading.Thread):
           # If a destination file was missing, rebuild.
           return True
       else:
-        print("Error checking file creation times: " + e)
+        print("Error checking file creation times: " + str(e))
 
   def run(self):
     # The files msg/json/{en,qqq,synonyms}.json depend on msg/messages.js.

--- a/i18n/create_messages.py
+++ b/i18n/create_messages.py
@@ -87,7 +87,7 @@ def main():
   # Read in synonyms file, which must be output in every language.
   synonym_defs = read_json_file(os.path.join(
       os.curdir, args.source_synonym_file))
-  
+
   # synonym_defs is also being sorted to ensure the same order is kept
   synonym_text = '\n'.join([u'Blockly.Msg["{0}"] = Blockly.Msg["{1}"];'
       .format(key, synonym_defs[key]) for key in sorted(synonym_defs)])

--- a/i18n/dedup_json.py
+++ b/i18n/dedup_json.py
@@ -51,9 +51,9 @@ def main():
     try:
       with codecs.open(filename, 'r', 'utf-8') as infile:
         j = json.load(infile)
-    except ValueError, e:
+    except ValueError as e:
       print('Error reading ' + filename)
-      raise InputError(file, str(e))
+      raise InputError(filename, str(e))
 
     # Built up output strings as an array to make output of delimiters easier.
     output = []

--- a/i18n/json_to_js.py
+++ b/i18n/json_to_js.py
@@ -100,7 +100,7 @@ def _process_file(path_to_json, target_lang, key_dict):
         if key != '@metadata':
             try:
                 identifier = key_dict[key]
-            except KeyError, e:
+            except KeyError as e:
                 print('Key "%s" is in %s but not in %s' %
                       (key, keyfile, args.key_file))
                 raise e

--- a/i18n/tests.py
+++ b/i18n/tests.py
@@ -37,7 +37,7 @@ class TestSequenceFunctions(unittest.TestCase):
                  u'block of actions.']
     for sentence in sentences:
       output = common.insert_breaks(sentence, 30, 50)
-      self.assert_(contains_all_chars(sentence, output),
+      self.assertTrue(contains_all_chars(sentence, output),
                    u'Mismatch between:\n{0}\n{1}'.format(
                        re.sub(spaces, '', sentence),
                        re.sub(spaces, '', output)))

--- a/i18n/xliff_to_json.py
+++ b/i18n/xliff_to_json.py
@@ -65,7 +65,7 @@ def _parse_trans_unit(trans_unit):
     try:
         result['source'] = get_value('source')
         result['target'] = get_value('target')
-    except InputError, e:
+    except InputError as e:
         raise InputError(key, e.msg)
 
     # Get notes, using the from value as key and the data as value.
@@ -112,8 +112,8 @@ def _process_file(filename):
         except IOError:
             # Don't get caught by below handler
             raise
-        except Exception, e:
-            print
+        except Exception as e:
+            print()
             raise InputError(filename, str(e))
 
         # Make sure needed fields are present and non-empty.
@@ -146,8 +146,8 @@ def _process_file(filename):
               results.append(unit)
 
         return results
-    except IOError, e:
-        print 'Error with file {0}: {1}'.format(filename, e.strerror)
+    except IOError as e:
+        print('Error with file {0}: {1}'.format(filename, e.strerror))
         sys.exit(1)
 
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
Most changes are for except usages and paranthesis around print. 
decode had to be added for Python 3.4 compatibility, in build.py#341, because of changes in return type of response.read() and supported argument types for json.loads between 2.7, 3.4 and 3.6

### Resolves
Further updates following up https://github.com/google/blockly/issues/2112

### Proposed Changes

### Reason for Changes
Making remaining python files compatible with Python 2 and 3 versions. 
This patch also covers Python 3.4 compatibility for build.py

### Test Coverage
All files are inspected by PyCharm

build.py and dedup_json.py is tested on Ubuntu 16.04 by comparing generated files using:

- original code with Python 2.7
- patched code with Python 2.7
- patched code with Python 3.4
- patched code with Python 3.6

json_to_js and create_messages are indirectly used by build. 

xliff_to_json.py is not tested but changes are not important to affect the code flow. 

### Additional Information

tests.py does not seem to be testing an existing function, so it might need to be removed or updated. 

Using "." for relative imports are encouraged (like "from .common import InputError" ) but it makes scripts trickier to run so they are not changed. 
