### PR TITLE
Delete variable

### DIFF
--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -48,6 +48,10 @@ Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
   Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       null, 'Colour');
 };
+Blockly.VariablesDynamic.onDeleteVariableButtonClick = function(button) {
+  Blockly.Variables.deleteVariableButtonHandler(button.getTargetWorkspace());
+};
+
 /**
  * Construct the elements (blocks and button) required by the flyout for the
  * variable category.
@@ -56,18 +60,18 @@ Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
  */
 Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
   var xmlList = [];
-  var button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_STRING_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_STRING');
-  xmlList.push(button);
-  button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_NUMBER_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_NUMBER');
-  xmlList.push(button);
-  button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_COLOUR_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_COLOUR');
-  xmlList.push(button);
+
+  xmlList.push(Blockly.Variables.createButton_(
+      '%{BKY_NEW_STRING_VARIABLE}', 'CREATE_VARIABLE_STRING'));
+
+  xmlList.push(Blockly.Variables.createButton_(
+      '%{BKY_NEW_NUMBER_VARIABLE}', 'CREATE_VARIABLE_NUMBER'));
+
+  xmlList.push(Blockly.Variables.createButton_(
+      '%{BKY_NEW_COLOUR_VARIABLE}', 'CREATE_VARIABLE_COLOUR'));
+
+  xmlList.push(Blockly.Variables.createButton_(
+      '%{BKY_DELETE_VARIABLE_BUTTON_TITLE}', 'DELETE_VARIABLE'));
 
   workspace.registerButtonCallback('CREATE_VARIABLE_STRING',
       Blockly.VariablesDynamic.onCreateVariableButtonClick_String);
@@ -75,6 +79,9 @@ Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
       Blockly.VariablesDynamic.onCreateVariableButtonClick_Number);
   workspace.registerButtonCallback('CREATE_VARIABLE_COLOUR',
       Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour);
+  workspace.registerButtonCallback('DELETE_VARIABLE',
+      Blockly.VariablesDynamic.onDeleteVariableButtonClick);
+
 
 
   var blockList = Blockly.VariablesDynamic.flyoutCategoryBlocks(workspace);

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -34,7 +34,7 @@
 
 goog.provide('Blockly.Msg.en');
 
-goog.require('Blockly.Msg')
+goog.require('Blockly.Msg');
 
 
 /**

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -34,7 +34,7 @@
 
 goog.provide('Blockly.Msg.en');
 
-goog.require('Blockly.Msg');
+goog.require('Blockly.Msg')
 
 
 /**
@@ -147,6 +147,13 @@ Blockly.Msg.DELETE_VARIABLE_CONFIRMATION = 'Delete %1 uses of the "%2" variable?
 Blockly.Msg.CANNOT_DELETE_VARIABLE_PROCEDURE = 'Can\'t delete the variable "%1" because it\'s part of the definition of the function "%2"';
 /// dropdown choice - Delete the currently selected variable.
 Blockly.Msg.DELETE_VARIABLE = 'Delete the "%1" variable';
+/// alert - Tells the user that the variable name does not exist.
+Blockly.Msg.VARIABLE_DOES_NOT_EXIST = 'A variable named "%1" does not exist.';
+/// alert - Text on the button used to launch the delete variable dialogue.
+Blockly.Msg.DELETE_VARIABLE_BUTTON_TITLE = 'Delete variable...';
+/// alert - Prompts the user to enter the name of an exisiting variable in order to delete it. See [https://github.com/google/blockly/wiki/Variables#dropdown-menu https://github.com/google/blockly/wiki/Variables#dropdown-menu]
+Blockly.Msg.DELETE_VARIABLE_PROMPT = 'Delete variable with name:';
+
 
 // Colour Blocks.
 /// {{Optional}} url - Information about colour.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/1105 

### Proposed Changes
Adds a delete button to the default variables toolbox category.
<img width="156" alt="screen shot 2018-11-28 at 2 51 34 pm" src="https://user-images.githubusercontent.com/23059043/49187677-22e78700-f31d-11e8-837f-e640d85a7d7f.png">

### Reason for Changes

There was no way before to delete a variable without dragging it into the workspace.

### Test Coverage

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
