### PR TITLE
Pulls from MakeCode fork the ability to rename and delete variables i…

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -100,30 +100,75 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if (this.isInFlyout){
-      return;
-    }
-    // Getter blocks have the option to create a setter block, and vice versa.
-    if (this.type == 'variables_get') {
-      var opposite_type = 'variables_set';
-      var contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
-    } else {
-      var opposite_type = 'variables_get';
-      var contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
-    }
+    if (!this.isInFlyout){
+      // Getter blocks have the option to create a setter block, and vice versa.
+      if (this.type == 'variables_get') {
+        var opposite_type = 'variables_set';
+        var contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
+      } else {
+        var opposite_type = 'variables_get';
+        var contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
+      }
 
-    var option = {enabled: this.workspace.remainingCapacity() > 0};
-    var name = this.getField('VAR').getText();
-    option.text = contextMenuMsg.replace('%1', name);
-    var xmlField = document.createElement('field');
-    xmlField.setAttribute('name', 'VAR');
-    xmlField.appendChild(document.createTextNode(name));
-    var xmlBlock = document.createElement('block');
-    xmlBlock.setAttribute('type', opposite_type);
-    xmlBlock.appendChild(xmlField);
-    option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
-    options.push(option);
+      var option = {enabled: this.workspace.remainingCapacity() > 0};
+      var name = this.getField('VAR').getText();
+      option.text = contextMenuMsg.replace('%1', name);
+      var xmlField = document.createElement('field');
+      xmlField.setAttribute('name', 'VAR');
+      xmlField.appendChild(document.createTextNode(name));
+      var xmlBlock = document.createElement('block');
+      xmlBlock.setAttribute('type', opposite_type);
+      xmlBlock.appendChild(xmlField);
+      option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
+      options.push(option);
+      // Getter blocks have the option to rename or delete that variable.
+    } else {
+      if (this.type == 'variables_get' || this.type == 'variables_get_reporter'){
+        var renameOption = {
+          text: Blockly.Msg.RENAME_VARIABLE,
+          enabled: true,
+          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
+        };
+        var name = this.getField('VAR').getText();
+        var deleteOption = {
+          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          enabled: true,
+          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
+        };
+        options.unshift(renameOption);
+        options.unshift(deleteOption);
+      }
+    }
   }
+};
+
+/**
+  * Callback for rename variable dropdown menu option associated with a
+  * variable getter block.
+  * @param {!Blockly.Block} block The block with the variable to rename.
+  * @return {!function()} A function that renames the variable.
+  */
+Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    Blockly.Variables.renameVariable(workspace, variable);
+  };
+};
+
+/**
+ * Callback for delete variable dropdown menu option associated with a
+ * variable getter block.
+ * @param {!Blockly.Block} block The block with the variable to delete.
+ * @return {!function()} A function that deletes the variable.
+ */
+Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    workspace.deleteVariableById(variable.getId());
+    workspace.refreshToolboxSelection();
+  };
 };
 
 Blockly.Extensions.registerMixin('contextMenu_variableSetterGetter',

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -97,34 +97,50 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
    */
   customContextMenu: function(options) {
     // Getter blocks have the option to create a setter block, and vice versa.
-    if (this.isInFlyout) {
-      return;
-    }
-    var opposite_type;
-    var contextMenuMsg;
-    var id = this.getFieldValue('VAR');
-    var variableModel = this.workspace.getVariableById(id);
-    var varType = variableModel.type;
-    if (this.type == 'variables_get_dynamic') {
-      opposite_type = 'variables_set_dynamic';
-      contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
-    } else {
-      opposite_type = 'variables_get_dynamic';
-      contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
-    }
+    if (!this.isInFlyout) {
+      var opposite_type;
+      var contextMenuMsg;
+      var id = this.getFieldValue('VAR');
+      var variableModel = this.workspace.getVariableById(id);
+      var varType = variableModel.type;
+      if (this.type == 'variables_get_dynamic') {
+        opposite_type = 'variables_set_dynamic';
+        contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
+      } else {
+        opposite_type = 'variables_get_dynamic';
+        contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
+      }
 
-    var option = {enabled: this.workspace.remainingCapacity() > 0};
-    var name = this.getField('VAR').getText();
-    option.text = contextMenuMsg.replace('%1', name);
-    var xmlField = document.createElement('field');
-    xmlField.setAttribute('name', 'VAR');
-    xmlField.setAttribute('variabletype', varType);
-    xmlField.appendChild(document.createTextNode(name));
-    var xmlBlock = document.createElement('block');
-    xmlBlock.setAttribute('type', opposite_type);
-    xmlBlock.appendChild(xmlField);
-    option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
-    options.push(option);
+      var option = {enabled: this.workspace.remainingCapacity() > 0};
+      var name = this.getField('VAR').getText();
+      option.text = contextMenuMsg.replace('%1', name);
+      var xmlField = document.createElement('field');
+      xmlField.setAttribute('name', 'VAR');
+      xmlField.setAttribute('variabletype', varType);
+      xmlField.appendChild(document.createTextNode(name));
+      var xmlBlock = document.createElement('block');
+      xmlBlock.setAttribute('type', opposite_type);
+      xmlBlock.appendChild(xmlField);
+      option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
+      options.push(option);
+    } else {
+      if (this.type == 'variables_get_dynamic' ||
+       this.type == 'variables_get_reporter_dynamic') {
+        var renameOption = {
+          text: Blockly.Msg.RENAME_VARIABLE,
+          enabled: true,
+          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
+        };
+        var name = this.getField('VAR').getText();
+        var deleteOption = {
+          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          enabled: true,
+          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
+        };
+        options.unshift(renameOption);
+        options.unshift(deleteOption);
+      }
+    }
   },
   onchange: function() {
     var id = this.getFieldValue('VAR');
@@ -135,6 +151,35 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       this.getInput('VALUE').connection.setCheck(variableModel.type);
     }
   }
+};
+
+/**
+  * Callback for rename variable dropdown menu option associated with a
+  * variable getter block.
+  * @param {!Blockly.Block} block The block with the variable to rename.
+  * @return {!function()} A function that renames the variable.
+  */
+Blockly.Constants.VariablesDynamic.RENAME_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    Blockly.Variables.renameVariable(workspace, variable);
+  };
+};
+
+/**
+ * Callback for delete variable dropdown menu option associated with a
+ * variable getter block.
+ * @param {!Blockly.Block} block The block with the variable to delete.
+ * @return {!function()} A function that deletes the variable.
+ */
+Blockly.Constants.VariablesDynamic.DELETE_OPTION_CALLBACK_FACTORY = function(block) {
+  return function() {
+    var workspace = block.workspace;
+    var variable = block.getField('VAR').getVariable();
+    workspace.deleteVariableById(variable.getId());
+    workspace.refreshToolboxSelection();
+  };
 };
 
 Blockly.Extensions.registerMixin('contextMenu_variableDynamicSetterGetter',


### PR DESCRIPTION
…n flyout

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#1105

### Proposed Changes
Adds ability to rename and delete a variable through the context menu in the variable flyout. Discussed here: #2143
<img width="286" alt="screen shot 2018-11-29 at 2 29 02 pm" src="https://user-images.githubusercontent.com/23059043/49256238-2f361780-f3e3-11e8-91de-0d33be1cc90a.png">
.

### Reason for Changes
So that users can delete or rename a variable without first having to drag it into the workspace. 

### Test Coverage

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
This code is pulled from the MakeCode fork found here: https://github.com/Microsoft/pxt-blockly/pull/159/commits/2537e077113adb6e328bb5db3166a5e7e8af2c22