### PR TITLE
Implement indented value inputs

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -67,14 +67,21 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     if (this.hasStatements_ === hasStatements) {
       return;
     }
+    var returnInput = this.getInput('RETURN');
     if (hasStatements) {
       this.appendStatementInput('STACK')
           .appendField(Blockly.Msg['PROCEDURES_DEFNORETURN_DO']);
-      if (this.getInput('RETURN')) {
+      if (returnInput) {
         this.moveInputBefore('STACK', 'RETURN');
+        returnInput.subtype = undefined;
+        returnInput.align = Blockly.ALIGN_RIGHT;
       }
     } else {
       this.removeInput('STACK', true);
+      if (returnInput) {
+        returnInput.subtype = Blockly.INDENTED_INPUT_VALUE;
+        returnInput.align = Blockly.ALIGN_LEFT;
+      }
     }
     this.hasStatements_ = hasStatements;
   },

--- a/core/block.js
+++ b/core/block.js
@@ -1240,6 +1240,17 @@ Blockly.Block.prototype.appendStatementInput = function(name) {
 };
 
 /**
+ * Shortcut for appending an inline value input row.
+ * @param {string} name Language-neutral identifier which may used to find this
+ *     input again.  Should be unique to this block.
+ * @return {!Blockly.Input} The input object created.
+ */
+
+Blockly.Block.prototype.appendIndentedValueInput = function(name) {
+  return this.appendInput_(Blockly.INDENTED_INPUT_VALUE, name);
+};
+
+/**
  * Shortcut for appending a dummy input row.
  * @param {string=} opt_name Language-neutral identifier which may used to find
  *     this input again.  Should be unique to this block.
@@ -1490,8 +1501,8 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
 
 /**
  * Add a value input, statement input or local variable to this block.
- * @param {number} type Either Blockly.INPUT_VALUE or Blockly.NEXT_STATEMENT or
- *     Blockly.DUMMY_INPUT.
+ * @param {number} type Either Blockly.INPUT_VALUE, Blockly.NEXT_STATEMENT, Blockly.DUMMY_INPUT,
+ *     or subtypes Blockly.INDENTED_INPUT_VALUE.
  * @param {string} name Language-neutral identifier which may used to find this
  *     input again.  Should be unique to this block.
  * @return {!Blockly.Input} The input object created.
@@ -1499,7 +1510,8 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
  */
 Blockly.Block.prototype.appendInput_ = function(type, name) {
   var connection = null;
-  if (type == Blockly.INPUT_VALUE || type == Blockly.NEXT_STATEMENT) {
+  if (type == Blockly.INPUT_VALUE || type == Blockly.NEXT_STATEMENT ||
+      type == Blockly.INDENTED_INPUT_VALUE) {
     connection = this.makeConnection_(type);
   }
   var input = new Blockly.Input(type, name, this, connection);

--- a/core/connection.js
+++ b/core/connection.js
@@ -42,13 +42,19 @@ Blockly.Connection = function(source, type) {
    * @protected
    */
   this.sourceBlock_ = source;
-  /** @type {number} */
-  this.type = type;
+  if (type == Blockly.INDENTED_INPUT_VALUE) {
+    /** @type {number} */
+    this.type = Blockly.INPUT_VALUE;
+    /** @subtype {number} */
+    this.subtype = Blockly.INDENTED_INPUT_VALUE;
+  } else {
+    this.type = type;
+  }
   // Shortcut for the databases for this connection's workspace.
   if (source.workspace.connectionDBList) {
-    this.db_ = source.workspace.connectionDBList[type];
+    this.db_ = source.workspace.connectionDBList[this.type];
     this.dbOpposite_ =
-        source.workspace.connectionDBList[Blockly.OPPOSITE_TYPE[type]];
+        source.workspace.connectionDBList[Blockly.OPPOSITE_TYPE[this.type]];
     this.hidden_ = !this.db_;
   }
 };

--- a/core/constants.js
+++ b/core/constants.js
@@ -156,6 +156,12 @@ Blockly.PREVIOUS_STATEMENT = 4;
 Blockly.DUMMY_INPUT = 5;
 
 /**
+ * ENUM for an indented value input.
+ * @const
+ */
+Blockly.INDENTED_INPUT_VALUE = 6;
+
+/**
  * ENUM for left alignment.
  * @const
  */

--- a/core/input.js
+++ b/core/input.js
@@ -43,8 +43,14 @@ Blockly.Input = function(type, name, block, connection) {
   if (type != Blockly.DUMMY_INPUT && !name) {
     throw Error('Value inputs and statement inputs must have non-empty name.');
   }
-  /** @type {number} */
-  this.type = type;
+  if (type == Blockly.INDENTED_INPUT_VALUE) {
+    /** @type {number} */
+    this.type = Blockly.INPUT_VALUE;
+    /** @type {number} */
+    this.subtype = Blockly.INDENTED_INPUT_VALUE;
+  } else {
+    this.type = type;
+  }
   /** @type {string} */
   this.name = name;
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This PR backports the indented input feature from MIT App Inventor to Google Blockly.

### Proposed Changes

Add an indented value input option for blocks. It adjusts the procedures_defreturn block so that if it has no statements it looks the same as the App Inventor procedures_defreturn block. RTL is supported as well:

<img width="227" alt="procedure definition with indented input, left-to-right" src="https://user-images.githubusercontent.com/1331253/49259548-ce6d0600-f407-11e8-9fb7-d59fc69ace45.png">
<img width="224" alt="procedure definition with indented input, right-to-left" src="https://user-images.githubusercontent.com/1331253/49259546-ce6d0600-f407-11e8-965f-af6213cbdcf7.png">


### Reason for Changes

We are gearing up to do another update of Blockly in App Inventor. As part of this, we want to package up feature changes that we have made to core and push them upstream so that others have the option of using them and to reduce conflicts in future merges. This change encapsulates the indented value input feature of App Inventor that we use for representing local scopes for computations and for procedures that return values.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
We tested by visually confirming that the block updates its shape when the "Allow Statements" option is ticked/not ticked.

### Additional Information

Not at this time