### PR TITLE
Allow statement connections to connect around block stacks during drags

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -355,29 +355,19 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
     return false;
   }
 
-  var firstStatementConnection =
-      this.sourceBlock_.getFirstStatementConnection();
-  var isFirstStatementConnection = this == firstStatementConnection;
-  var isNextConnection = this == this.sourceBlock_.nextConnection;
-
-  if (isNextConnection || isFirstStatementConnection) {
-    // If the candidate is the first connection in a stack, we can connect.
-    if (!candidate.targetConnection) {
-      return true;
-    }
-
-    var targetBlock = candidate.targetBlock();
-    // If it is connected to a real block, game over.
-    if (!targetBlock.isInsertionMarker()) {
-      return false;
-    }
-    // If it's connected to an insertion marker but that insertion marker
-    // is the first block in a stack, it's still fine.  If that insertion
-    // marker is in the middle of a stack, it won't work.
-    return !targetBlock.getPreviousBlock();
+  if (!candidate.targetConnection) {
+    return true;
   }
-  console.warn('Returning false by default from canConnectToPrevious_.');
-  return false;
+
+  var targetBlock = candidate.targetBlock();
+  // If it is connected to a real block, game over.
+  if (!targetBlock.isInsertionMarker()) {
+    return false;
+  }
+  // If it's connected to an insertion marker but that insertion marker
+  // is the first block in a stack, it's still fine.  If that insertion
+  // marker is in the middle of a stack, it won't work.
+  return !targetBlock.getPreviousBlock();
 };
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -360,12 +360,7 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
   var isFirstStatementConnection = this == firstStatementConnection;
   var isNextConnection = this == this.sourceBlock_.nextConnection;
 
-  // Complex blocks with no previous connection will not be allowed to connect
-  // mid-stack.
-  var sourceHasPreviousConn = this.sourceBlock_.previousConnection != null;
-
-  if (isNextConnection ||
-      (isFirstStatementConnection && !sourceHasPreviousConn)) {
+  if (isNextConnection || isFirstStatementConnection) {
     // If the candidate is the first connection in a stack, we can connect.
     if (!candidate.targetConnection) {
       return true;

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -335,7 +335,8 @@ Blockly.InsertionMarkerManager.prototype.shouldUpdatePreviews_ = function(
     // Decide whether the new connection has higher priority.
     if (this.localConnection_ && this.closestConnection_) {
       // The connection was the same as the current connection.
-      if (this.closestConnection_ == candidateClosest) {
+      if (this.closestConnection_ == candidateClosest &&
+          this.localConnection_ == candidateLocal) {
         return false;
       }
       var xDiff = this.localConnection_.x_ + dxy.x - this.closestConnection_.x_;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2131 

### Proposed Changes

Allow statement inputs to connect around block stacks during drags.
Remove distinction between first statement connection and other statement connections.

### Reason for Changes

See #2131
### Test Coverage

Tested with the example in #2131, and with an if-else block to test the case with more than one statement input.

### Additional Information

This makes it possible to connect on a statement input, but it's still not a great experience--the insertion marker is a little too stubborn about sticking around, so you have to drag away from the target and then back to switch which of the statement inputs you're connecting to.