### PR TITLE
Added randomness to bumping per Issue #2011

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -69,6 +69,11 @@ Blockly.INSERTION_MARKER_COLOUR = '#000000';
 Blockly.BUMP_DELAY = 250;
 
 /**
+ * Maximum randomness in workspace units for bumping a block.
+ */
+Blockly.BUMP_RANDOMNESS = 10;
+
+/**
  * Number of characters to truncate a collapsed block to.
  */
 Blockly.COLLAPSE_CHARS = 30;

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -97,8 +97,10 @@ Blockly.RenderedConnection.prototype.bumpAwayFrom_ = function(staticConnection) 
   // Raise it to the top for extra visibility.
   var selected = Blockly.selected == rootBlock;
   selected || rootBlock.addSelect();
-  var dx = (staticConnection.x_ + Blockly.SNAP_RADIUS) - this.x_;
-  var dy = (staticConnection.y_ + Blockly.SNAP_RADIUS) - this.y_;
+  var dx = (staticConnection.x_ + Blockly.SNAP_RADIUS +
+      Math.floor(Math.random() * Blockly.BUMP_RANDOMNESS)) - this.x_;
+  var dy = (staticConnection.y_ + Blockly.SNAP_RADIUS +
+      Math.floor(Math.random() * Blockly.BUMP_RANDOMNESS)) - this.y_;
   if (reverse) {
     // When reversing a bump due to an uneditable block, bump up.
     dy = -dy;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Add randomness to bump distances[ #2011](https://github.com/google/blockly/issues/2011)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds 0 to 10 workspace units to the dx & dy when bumping a block.

![bumping blocks](https://user-images.githubusercontent.com/25440652/49344776-909ef600-f630-11e8-9fda-e4ce5aeee90b.gif)


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Improves Readability.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested using method seen above.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

N/A
