### PR TITLE
Tweak insertion marker snap radii

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -42,20 +42,20 @@ Blockly.FLYOUT_DRAG_RADIUS = 10;
 /**
  * Maximum misalignment between connections for them to snap together.
  */
-Blockly.SNAP_RADIUS = 36;
+Blockly.SNAP_RADIUS = 28;
 
 /**
  * Maximum misalignment between connections for them to snap together,
  * when a connection is already highlighted.
  */
-Blockly.CONNECTING_SNAP_RADIUS = 48;
+Blockly.CONNECTING_SNAP_RADIUS = Blockly.SNAP_RADIUS;
 
 /**
  * How much to prefer staying connected to the current connection over moving to
  * a new connection.  The current previewed connection is considered to be this
  * much closer to the matching connection on the block than it actually is.
  */
-Blockly.CURRENT_CONNECTION_PREFERENCE = 0;
+Blockly.CURRENT_CONNECTION_PREFERENCE = 8;
 
 /**
  * The main colour of insertion markers, in hex.  The block is rendered a


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Insertion markers were too sticky when dragging a block with a statement input down through a stack of blocks.

### Proposed Changes

Decrease the radius to search for good connections.  This makes sense--the old radius was from scratch blocks, and their blocks are taller.

Also increase the preference for the current connection.

### Reason for Changes

It was not possible to drag an if block down one block through a stack of statement blocks.

### Test Coverage
Tested on the playground

### Additional Information

We can continue to tweak this, but these numbers feel okay to me.