### PR TITLE
#1848 Fixed throw console warning when deleting workspace comments

### DIFF
--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -425,6 +425,7 @@ Blockly.WorkspaceCommentSvg.prototype.disposeInternal_ = function() {
   this.foreignObject_ = null;
   this.svgRectTarget_ = null;
   this.svgHandleTarget_ = null;
+  this.disposed_ = true;
 };
 
 /**
@@ -436,6 +437,8 @@ Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
   this.focused_ = true;
   // Defer CSS changes.
   setTimeout(function() {
+    if(comment.disposed_)
+      return;
     comment.textarea_.focus();
     comment.addFocus();
     Blockly.utils.addClass(
@@ -454,6 +457,8 @@ Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
   this.focused_ = false;
   // Defer CSS changes.
   setTimeout(function() {
+    if(comment.disposed_)
+      return;
     comment.textarea_.blur();
     comment.removeFocus();
     Blockly.utils.removeClass(

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -437,8 +437,9 @@ Blockly.WorkspaceCommentSvg.prototype.setFocus = function() {
   this.focused_ = true;
   // Defer CSS changes.
   setTimeout(function() {
-    if(comment.disposed_)
+    if (comment.disposed_) {
       return;
+    }
     comment.textarea_.focus();
     comment.addFocus();
     Blockly.utils.addClass(
@@ -457,8 +458,10 @@ Blockly.WorkspaceCommentSvg.prototype.blurFocus = function() {
   this.focused_ = false;
   // Defer CSS changes.
   setTimeout(function() {
-    if(comment.disposed_)
+    if (comment.disposed_) {
       return;
+    }
+
     comment.textarea_.blur();
     comment.removeFocus();
     Blockly.utils.removeClass(


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1848

### Proposed Changes

I added disposed state for svg component, so we could check it before blur or focus

### Reason for Changes

These changes helped to solving #1848 issue

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
