### PR TITLE
Fixed Filter Capacity not Considering Child Blocks.

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -725,13 +725,11 @@ Blockly.Flyout.prototype.moveRectToBlock_ = function(rect, block) {
  * @private
  */
 Blockly.Flyout.prototype.filterForCapacity_ = function() {
-  var remainingCapacity = this.targetWorkspace_.remainingCapacity();
   var blocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     if (this.permanentlyDisabled_.indexOf(block) == -1) {
-      var allBlocks = block.getDescendants(false);
-      block.setDisabled(allBlocks.length > remainingCapacity ||
-          this.targetWorkspace_.remainingCapacityOfType(block.type) <= 0);
+      block.setDisabled(!this.targetWorkspace_
+          .isCapacityAvailable(Blockly.utils.getBlockTypeCounts(block)));
     }
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2154 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Correctly disables blocks in the flyout if there is not capacity available for them.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Users should not be able to create blocks that put the workspace over its capacity limits.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Added below code at ~ln 1084 in playground.
`<block type="limit_instances">
        <value name="STATEMENT">
          <block type="limit_instances">
          </block>
        </value>
      </block>`
2. Set maxBlocks to 4.
2. Opened the test block's toolbox in the playground, and then the basic category.
3. Dragged the last block out into the workspace, and reopened the basic category. Last block is disabled (pass)
![filtercapacity1](https://user-images.githubusercontent.com/25440652/49597506-6fd8e800-f931-11e8-86c9-c753328dffd7.jpg)

4. Dragged the second to last block out into the workspace, and reopened the basic category. Two last blocks are disabled (pass)
![filtercapacity2](https://user-images.githubusercontent.com/25440652/49597526-77988c80-f931-11e8-9314-0a0bc3cc3d32.jpg)

5. Dragged the third to last block out inot the workspace, and reopened the basic category. All blocks are disabled, because of maxBlocks (pass).
![filtercapacity3](https://user-images.githubusercontent.com/25440652/49597537-7c5d4080-f931-11e8-8e9b-6e5743990e63.jpg)


Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
