### PR TITLE
Added flyout to trashcan to "get back" deleted blocks.`

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -326,8 +326,14 @@ Blockly.onContextMenu_ = function(e) {
 Blockly.hideChaff = function(opt_allowToolbox) {
   Blockly.Tooltip.hide();
   Blockly.WidgetDiv.hide();
+  // For now the trashcan flyout always autocloses because it overlays the
+  // trashcan UI (no trashcan to click to close it)
+  var workspace = Blockly.getMainWorkspace();
+  if (workspace.trashcan &&
+      workspace.trashcan.flyout_) {
+    workspace.trashcan.flyout_.hide();
+  }
   if (!opt_allowToolbox) {
-    var workspace = Blockly.getMainWorkspace();
     if (workspace.toolbox_ &&
         workspace.toolbox_.flyout_ &&
         workspace.toolbox_.flyout_.autoClose) {

--- a/core/inject.js
+++ b/core/inject.js
@@ -219,10 +219,10 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     Blockly.utils.insertAfter(flyout, svg);
   }
   if (options.hasTrashcan) {
-    mainWorkspace.addTrashcan_();
+    mainWorkspace.addTrashcan();
   }
   if (options.zoomOptions && options.zoomOptions.controls) {
-    mainWorkspace.addZoomControls_();
+    mainWorkspace.addZoomControls();
   }
 
   // A null translation will also apply the correct initial scale.

--- a/core/inject.js
+++ b/core/inject.js
@@ -218,6 +218,12 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     var flyout = mainWorkspace.addFlyout_('svg');
     Blockly.utils.insertAfter(flyout, svg);
   }
+  if (options.hasTrashcan) {
+    mainWorkspace.addTrashcan_();
+  }
+  if (options.zoomOptions && options.zoomOptions.controls) {
+    mainWorkspace.addZoomControls_();
+  }
 
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);
@@ -320,6 +326,14 @@ Blockly.init_ = function(mainWorkspace) {
       }
       mainWorkspace.translate(mainWorkspace.scrollX, 0);
     }
+  }
+
+  var bottom = Blockly.Scrollbar.scrollbarThickness;
+  if (options.hasTrashcan) {
+    bottom = mainWorkspace.trashcan.init(bottom);
+  }
+  if (options.zoomOptions && options.zoomOptions.controls) {
+    mainWorkspace.zoomControls_.init(bottom);
   }
 
   if (options.hasScrollbars) {

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -147,7 +147,7 @@ Blockly.Trashcan.prototype.minOpenness_ = 0;
 Blockly.Trashcan.prototype.hasBlocks_ = false;
 
 /**
- * A list of Xml representing blocks "inside" the trashcan.
+ * A list of Xml (stored as strings) representing blocks "inside" the trashcan.
  * @type {Array}
  * @private
  */
@@ -411,7 +411,11 @@ Blockly.Trashcan.prototype.click = function() {
     return;
   }
 
-  this.flyout_.show(this.contents_);
+  var xml = [];
+  for (var i = 0, text; text = this.contents_[i]; i++) {
+    xml[i] = Blockly.Xml.textToDom(text).firstChild;
+  }
+  this.flyout_.show(xml);
 };
 
 /**
@@ -449,14 +453,10 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
     }
     if (event.type == Blockly.Events.BLOCK_DELETE) {
       var cleanedXML = trashcan.cleanBlockXML_(event.oldXml);
-      console.log('cleaned XML:');
-      console.log(cleanedXML);
       if (trashcan.contents_.indexOf(cleanedXML) != -1) {
         return;
       }
       trashcan.contents_.unshift(cleanedXML);
-      console.log('added to contents: ');
-      console.log(trashcan.contents_);
       if (trashcan.contents_.length > trashcan.MAX_CONTENTS) {
         trashcan.contents_.splice(trashcan.MAX_CONTENTS,
             trashcan.contents_.length - trashcan.MAX_CONTENTS);
@@ -474,7 +474,8 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
  *    content array.
  * @param {!Element} xml An XML tree defining the block and any
  *    connected child blocks.
- * @returns {!Element} The XML tree cleaned of all unnecessary attributes.
+ * @returns {!string} Text representing the XML tree, cleaned of all unnecessary
+ * attributes.
  * @private
  */
 Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
@@ -508,5 +509,5 @@ Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
     }
     node = nextNode;
   }
-  return xmlBlock;
+  return '<xml>' + Blockly.Xml.domToText(xmlBlock) + '</xml>';
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -479,34 +479,34 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
  */
 Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
   var xmlBlock = xml.cloneNode(true);
-  var block = xmlBlock;
-  while (block) {
+  var node = xmlBlock;
+  while (node) {
     // Things like text inside tags are still treated as nodes, but they
     // don't have attributes (or the removeAttribute function) so we can
     // skip removing attributes from them.
-    if (block.removeAttribute) {
-      block.removeAttribute('x');
-      block.removeAttribute('y');
-      block.removeAttribute('id');
+    if (node.removeAttribute) {
+      node.removeAttribute('x');
+      node.removeAttribute('y');
+      node.removeAttribute('id');
     }
 
-    // Try to traverse down the tree
-    var nextBlock = block.firstChild || block.nextSibling;
-    // If we can't go down, try to traverse back up the tree.
-    if (!nextBlock) {
-      nextBlock = block.parentNode;
-      while (nextBlock) {
+    // Try to go down the tree
+    var nextNode = node.firstChild || node.nextSibling;
+    // If we can't go down, try to go back up the tree.
+    if (!nextNode) {
+      nextNode = node.parentNode;
+      while (nextNode) {
         // We are valid again!
-        if (nextBlock.nextSibling) {
-          nextBlock = nextBlock.nextSibling;
+        if (nextNode.nextSibling) {
+          nextNode = nextNode.nextSibling;
           break;
         }
         // Try going up again. If parentNode is null that means we have
         // reached the top, and we will break out of both loops.
-        nextBlock = nextBlock.parentNode;
+        nextNode = nextNode.parentNode;
       }
     }
-    block = nextBlock;
+    node = nextNode;
   }
   return xmlBlock;
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -459,7 +459,7 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
 
       trashcan.hasBlocks = true;
       trashcan.minOpenness_ = trashcan.HAS_BLOCKS_LID_ANGLE;
-      trashcan.setLidAngle_(trashcan.minOpenness_);
+      trashcan.setLidAngle_(trashcan.minOpenness_ * 45);
     }
   };
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -575,20 +575,20 @@ Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
 
 /**
  * Add a trashcan.
- * @private
+ * @package
  */
-Blockly.WorkspaceSvg.prototype.addTrashcan_ = function() {
+Blockly.WorkspaceSvg.prototype.addTrashcan = function() {
   /** @type {Blockly.Trashcan} */
   this.trashcan = new Blockly.Trashcan(this);
   var svgTrashcan = this.trashcan.createDom();
-  this.svgGroup_.insertBefore(svgTrashcan, this.svgBlockCanvas_).nextSibling;
+  this.svgGroup_.insertBefore(svgTrashcan, this.svgBlockCanvas_);
 };
 
 /**
  * Add zoom controls.
- * @private
+ * @package
  */
-Blockly.WorkspaceSvg.prototype.addZoomControls_ = function() {
+Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
   /** @type {Blockly.ZoomControls} */
   this.zoomControls_ = new Blockly.ZoomControls(this);
   var svgZoomControls = this.zoomControls_.createDom();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -466,13 +466,6 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   /** @type {SVGElement} */
   this.svgBubbleCanvas_ = Blockly.utils.createSvgElement('g',
       {'class': 'blocklyBubbleCanvas'}, this.svgGroup_);
-  var bottom = Blockly.Scrollbar.scrollbarThickness;
-  if (this.options.hasTrashcan) {
-    bottom = this.addTrashcan_(bottom);
-  }
-  if (this.options.zoomOptions && this.options.zoomOptions.controls) {
-    this.addZoomControls_(bottom);
-  }
 
   if (!this.isFlyout) {
     Blockly.bindEventWithChecks_(this.svgGroup_, 'mousedown', this,
@@ -582,30 +575,24 @@ Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
 
 /**
  * Add a trashcan.
- * @param {number} bottom Distance from workspace bottom to bottom of trashcan.
- * @return {number} Distance from workspace bottom to the top of trashcan.
  * @private
  */
-Blockly.WorkspaceSvg.prototype.addTrashcan_ = function(bottom) {
+Blockly.WorkspaceSvg.prototype.addTrashcan_ = function() {
   /** @type {Blockly.Trashcan} */
   this.trashcan = new Blockly.Trashcan(this);
   var svgTrashcan = this.trashcan.createDom();
-  this.svgGroup_.insertBefore(svgTrashcan, this.svgBlockCanvas_);
-  return this.trashcan.init(bottom);
+  this.svgGroup_.insertBefore(svgTrashcan, this.svgBlockCanvas_).nextSibling;
 };
 
 /**
  * Add zoom controls.
- * @param {number} bottom Distance from workspace bottom to bottom of controls.
- * @return {number} Distance from workspace bottom to the top of controls.
  * @private
  */
-Blockly.WorkspaceSvg.prototype.addZoomControls_ = function(bottom) {
+Blockly.WorkspaceSvg.prototype.addZoomControls_ = function() {
   /** @type {Blockly.ZoomControls} */
   this.zoomControls_ = new Blockly.ZoomControls(this);
   var svgZoomControls = this.zoomControls_.createDom();
   this.svgGroup_.appendChild(svgZoomControls);
-  return this.zoomControls_.init(bottom);
 };
 
 /**

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -132,6 +132,9 @@ Blockly.ZoomControls.prototype.dispose = function() {
  * Move the zoom controls to the bottom-right corner.
  */
 Blockly.ZoomControls.prototype.position = function() {
+  if (!this.bottom_) {
+    return;
+  }
   var metrics = this.workspace_.getMetrics();
   if (!metrics) {
     // There are no metrics available (workspace is probably not visible).

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -132,6 +132,7 @@ Blockly.ZoomControls.prototype.dispose = function() {
  * Move the zoom controls to the bottom-right corner.
  */
 Blockly.ZoomControls.prototype.position = function() {
+  // Not yet initialized.
   if (!this.bottom_) {
     return;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2136

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a flyout that appears ontop of the trashcan (and zoom controls) when the trashcan is clicked. You can then drag deleted blocks out of the trashcan.

Requirements:
1.There should be indication that the trashcan has blocks: When the trashcan has contents the lid is tilted & animates on hover.
2.Deleted blocks should render in an intuitive order: Newest at the top.
3.Deleted blocks should be easy to get: 1 click and 1 drag to retrieve, and the flyout always renders ontop of the trashcan.
4.The flyout should not be cluttered: Only 1 instances of every block (or group of blocks) is added to the flyout. A MAX_CONTENTS property limits the number of blocks (or groups of blocks).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Using keyboard controls (ctrl z) could be unintuitive for young users. This creates a way that they can get back their accidentally deleted blocks purely through UI.

### Test Coverage

Requirement 1:
1. Dragged a 'controls_if' block into the trashcan. Did steps 2-5. (pass)
2. Observed how the lid is now tilted.
3. Hovered over the trashcan.
4. Observed how the lid animates (only animates when over the 'body' of the trashcan to avoid jitter).
5. Refreshed page.
6. Dragged a 'controls_if' block onto the workspace and pressed the delete key. Repeated 2-5. (pass)
7. Dragged a 'controls_if' block onto the workspace and deleted through the right-click context menu. Repeated 2-4. (pass)

Requirement 2:
1. Dragged a 'controls_if' block into the trashcan.
2. Dragged a 'logic_compare' block into the trashcan.
3. Clicked the trashcan to open the flyout.
4. Observed how the 'logic_compare' block was above the 'controls_if' block. (pass)

Requirement 3:
1. Added a block to the trashcan.
2. Clicked the trashcan.
3. Observed how the flyout opened over the trashcan, and that blocks could be dragged out of it.
4. Repeated for all combinations of RTL/LTR and Start/End. (pass)

Requirement 4:
1. Set the trashcan's MAX_CONTENTS var to 1.
1. Dragged 2 'controls_if' blocks to the trashcan.
2. Clicked the trashcan.
3. Observed how there was only 1 'control_if' block in the trashcan. (pass)
4. Dragged a 'logic_compare' block into the trashcan.
5. Clicked the trashcan.
6. Observed how there was no 'controls_if' block in the flyout, only a 'logic_compare' block. (pass)

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Note: Blocks Never get Removed From Trashcan (at least atm)

When you drag things out of the trashcan you'd think they should be removed from the trashcan's flyout. The problem is that (atm) there's no way to tell what flyout you grabbed the block from, or if it was un-deleted through events (as far as I know). If you do remove the blocks from the flyout whenever you receive a 'BLOCK_CREATED' event you end up in a situtation like this:

![removecontents](https://user-images.githubusercontent.com/25440652/49666597-68870c80-fa0d-11e8-845a-7e318da4aab8.gif)

Where you didn't drag the block out of the trashcan's flyout, (you created it from the toolbox) but it still gets removed.

A couple solutions I came up with (and why they suck):
1. Override a method on the flyout (possibly the .blockMouseDown_ method) and have it notify the trashcan when a block is created. This is not maintainable.
2. Don't allow 'primitive' (existing in the toolbox) blocks to be added to the flyout. A) I couldn't get workspace.options.languageTree.contains(myXML) to work when I tried it. B) A bit unintuitive.
3. Add an observer pattern to the flyout so it can notify you when a block is created. This is really only useful for the trashcan so it seems like overkill.

Erik's suggestion about looking through the undo stack for BLOCK_DELETE events would have worked, until you drag a block out of the trashcan's flyout which adds a create event to the undo stack. Then you're back to comparing creates vs deletes, which is the original problem.

So that's the thought proccess behind not removing blocks from the trashcan. If anyone has a better idea, or sees where my logic has gaps I would still love to add this feature!

### Note on Reviewing this PR:

I had to move around where some things like the trashcan, and zoom controls get created & initialized so that the trashcan's flyout could be initialized properly. So please double check that to make sure I didn't break anything.
<!-- Anything else we should know? -->

### Additional Info
Hoping to work on #2035 and getting the contents flyout to work horizontally next.