### PR TITLE
#172, Fixed [Edge, IE] Zoom control mouseover is not clipped

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -531,15 +531,15 @@ Blockly.Css.CONTENT = [
     'fill: #bbb;',
   '}',
 
-  '.blocklyZoom>image {',
+  '.blocklyZoom>image, .blocklyZoom>svg>image {',
     'opacity: .4;',
   '}',
 
-  '.blocklyZoom>image:hover {',
+  '.blocklyZoom>image:hover, .blocklyZoom>svg>image:hover {',
     'opacity: .6;',
   '}',
 
-  '.blocklyZoom>image:active {',
+  '.blocklyZoom>image:active, .blocklyZoom>svg>image:active {',
     'opacity: .8;',
   '}',
 

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -241,7 +241,7 @@ Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
   var ws = this.workspace_;
   var svgHolder = Blockly.utils.createSvgElement('svg',
       {
-        'y': 0
+        "id": "svg" + rnd
       },
       this.svgGroup_);
   var clip = Blockly.utils.createSvgElement('clipPath',

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -171,18 +171,27 @@ Blockly.ZoomControls.prototype.position = function() {
  */
 Blockly.ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
   /* This markup will be generated and added to the "blocklyZoom" group:
-  <clippath id="blocklyZoomoutClipPath837493">
-    <rect width="32" height="32" y="77"></rect>
-  </clippath>
-  <image width="96" height="124" x="-64" y="-15" xlink:href="media/sprites.png"
-      clip-path="url(#blocklyZoomoutClipPath837493)"></image>
+  <svg id="svg837493">
+    <clippath id="blocklyZoomoutClipPath837493">
+      <rect width="32" height="32" y="77"></rect>
+    </clippath>
+    <image width="96" height="124" x="-64" y="-15" xlink:href="media/sprites.png"
+        clip-path="url(#blocklyZoomoutClipPath837493)"></image>
+  </svg>
   */
   var ws = this.workspace_;
+
+  var svgHolder = Blockly.utils.createSvgElement('svg',
+      {
+        "id": "svg" + rnd
+      },
+      this.svgGroup_);
+
   var clip = Blockly.utils.createSvgElement('clipPath',
       {
         'id': 'blocklyZoomoutClipPath' + rnd
       },
-      this.svgGroup_);
+      svgHolder);
   Blockly.utils.createSvgElement('rect',
       {
         'width': 32,
@@ -197,7 +206,7 @@ Blockly.ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
         'y': -15,
         'clip-path': 'url(#blocklyZoomoutClipPath' + rnd + ')'
       },
-      this.svgGroup_);
+      svgHolder);
   zoomoutSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       ws.options.pathToMedia + Blockly.SPRITE.url);
 
@@ -220,18 +229,26 @@ Blockly.ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
  */
 Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
   /* This markup will be generated and added to the "blocklyZoom" group:
-  <clippath id="blocklyZoominClipPath837493">
-    <rect width="32" height="32" y="43"></rect>
-  </clippath>
-  <image width="96" height="124" x="-32" y="-49" xlink:href="media/sprites.png"
-      clip-path="url(#blocklyZoominClipPath837493)"></image>
+  <svg id="svg837493">
+    <clippath id="blocklyZoominClipPath837493">
+      <rect width="32" height="32" y="43"></rect>
+    </clippath>
+    <image width="96" height="124" x="-32" y="-49" xlink:href="media/sprites.png"
+        clip-path="url(#blocklyZoominClipPath837493)"></image>
+  </svg>
   */
+ 
   var ws = this.workspace_;
+  var svgHolder = Blockly.utils.createSvgElement('svg',
+      {
+        'y': 0
+      },
+      this.svgGroup_);
   var clip = Blockly.utils.createSvgElement('clipPath',
       {
         'id': 'blocklyZoominClipPath' + rnd
       },
-      this.svgGroup_);
+      svgHolder);
   Blockly.utils.createSvgElement('rect',
       {
         'width': 32,
@@ -247,7 +264,7 @@ Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
         'y': -49,
         'clip-path': 'url(#blocklyZoominClipPath' + rnd + ')'
       },
-      this.svgGroup_);
+      svgHolder);
   zoominSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       ws.options.pathToMedia + Blockly.SPRITE.url);
 
@@ -270,18 +287,25 @@ Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
  */
 Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
   /* This markup will be generated and added to the "blocklyZoom" group:
-  <clippath id="blocklyZoomresetClipPath837493">
-    <rect width="32" height="32"></rect>
-  </clippath>
-  <image width="96" height="124" y="-92" xlink:href="media/sprites.png"
-      clip-path="url(#blocklyZoomresetClipPath837493)"></image>
+  <svg id="svg837493">
+    <clippath id="blocklyZoomresetClipPath837493">
+      <rect width="32" height="32"></rect>
+    </clippath>
+    <image width="96" height="124" y="-92" xlink:href="media/sprites.png"
+        clip-path="url(#blocklyZoomresetClipPath837493)"></image>
+  </svg>
   */
   var ws = this.workspace_;
+  var svgHolder = Blockly.utils.createSvgElement('svg',
+      {
+        "id": "svg" + rnd
+      },
+      this.svgGroup_);
   var clip = Blockly.utils.createSvgElement('clipPath',
       {
         'id': 'blocklyZoomresetClipPath' + rnd
       },
-      this.svgGroup_);
+      svgHolder);
   Blockly.utils.createSvgElement('rect',
       {
         'width': 32,
@@ -294,7 +318,7 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
         'height': Blockly.SPRITE.height, 'y': -92,
         'clip-path': 'url(#blocklyZoomresetClipPath' + rnd + ')'
       },
-      this.svgGroup_);
+      svgHolder);
   zoomresetSvg.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
       ws.options.pathToMedia + Blockly.SPRITE.url);
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/172

### Proposed Changes

Fixed IE, Edge bug on rendering svg image, clipPath element and added svg element as holder of image element.

### Reason for Changes

These changes helped to solving #172 issue

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
* Windows Internet Explorer 10
* Windows Internet Explorer 11
* Windows Edge
