### PR TITLE
Reconnects child blocks when an undo is done on an else block

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -424,7 +424,6 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   },
   /**
    * Reconstructs the block with all child blocks attached.
-   * Fixes issue #2037.
    */
   rebuildShape_: function() {
     var valueConnections = [null];

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -331,7 +331,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   domToMutation: function(xmlElement) {
     this.elseifCount_ = parseInt(xmlElement.getAttribute('elseif'), 10) || 0;
     this.elseCount_ = parseInt(xmlElement.getAttribute('else'), 10) || 0;
-    this.updateShape_();
+    this.rebuildShape_();
   },
   /**
    * Populate the mutator's dialog with this block's components.
@@ -388,11 +388,8 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
     }
     this.updateShape_();
     // Reconnect any child blocks.
-    for (var i = 1; i <= this.elseifCount_; i++) {
-      Blockly.Mutator.reconnect(valueConnections[i], this, 'IF' + i);
-      Blockly.Mutator.reconnect(statementConnections[i], this, 'DO' + i);
-    }
-    Blockly.Mutator.reconnect(elseStatementConnection, this, 'ELSE');
+    this.reconnectChildBlocks_(valueConnections, statementConnections,
+        elseStatementConnection);
   },
   /**
    * Store pointers to any connected child blocks.
@@ -426,6 +423,30 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
     }
   },
   /**
+   * Reconstructs the block with all child blocks attached.
+   * Fixes issue #2037.
+   */
+  rebuildShape_: function() {
+    var valueConnections = [null];
+    var statementConnections = [null];
+    var elseStatementConnection = null;
+
+    if (this.getInput('ELSE')) {
+      elseStatementConnection = this.getInput('ELSE').connection.targetConnection;
+    }
+    var i = 1;
+    while (this.getInput('IF' + i)) {
+      var inputIf = this.getInput('IF' + i);
+      var inputDo = this.getInput('DO' + i);
+      valueConnections.push(inputIf.connection.targetConnection);
+      statementConnections.push(inputDo.connection.targetConnection);
+      i++;
+    }
+    this.updateShape_();
+    this.reconnectChildBlocks_(valueConnections, statementConnections,
+        elseStatementConnection);
+  },
+  /**
    * Modify this block to have the correct number of inputs.
    * @this Blockly.Block
    * @private
@@ -453,6 +474,23 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
       this.appendStatementInput('ELSE')
           .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE']);
     }
+  },
+  /**
+   * Reconnects child blocks.
+   * @param {!Array<?Blockly.RenderedConnection>} valueConnections List of value
+   * connectsions for if input.
+   * @param {!Array<?Blockly.RenderedConnection>} statementConnections List of
+   * statement connections for do input.
+   * @param {?Blockly.RenderedConnection} elseStatementConnection Statement
+   * connection for else input.
+   */
+  reconnectChildBlocks_: function(valueConnections, statementConnections,
+      elseStatementConnection) {
+    for (var i = 1; i <= this.elseifCount_; i++) {
+      Blockly.Mutator.reconnect(valueConnections[i], this, 'IF' + i);
+      Blockly.Mutator.reconnect(statementConnections[i], this, 'DO' + i);
+    }
+    Blockly.Mutator.reconnect(elseStatementConnection, this, 'ELSE');
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Resolves
#2037 

### Proposed Changes
Reconnects the children of an if/else block after an undo is made.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
![screen shot 2018-12-13 at 9 16 25 am](https://user-images.githubusercontent.com/23059043/49955513-cf963c80-feb7-11e8-968c-0d9e020f2583.png)
Before Undo

![screen shot 2018-12-13 at 9 16 31 am](https://user-images.githubusercontent.com/23059043/49955516-d329c380-feb7-11e8-9f3e-e8ce166bc10a.png)
After Undo 

When a user tries to undo adding an else block it rebuilds the if/else block by removing all inputs and reconstructing with the appropriate number of elseif and else  inputs. When removing the inputs it disconnects any statements attached to the inputs.

### Test Coverage

Tested on:
Desktop Chrome 
Desktop Firefox
Desktop Opera

### Additional Information
