### PR TITLE
Groups events fired during field input change

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -281,6 +281,10 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
   var text = htmlInput.value;
   if (text !== htmlInput.oldValue_) {
     htmlInput.oldValue_ = text;
+
+    // TODO(#2169): Once issue is fixed the setGroup functionality could be
+    //              moved up to the Field setValue method. This would create a
+    //              broader fix for all field types.
     Blockly.Events.setGroup(true);
     this.setValue(text);
     Blockly.Events.setGroup(false);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -281,7 +281,9 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
   var text = htmlInput.value;
   if (text !== htmlInput.oldValue_) {
     htmlInput.oldValue_ = text;
+    Blockly.Events.setGroup(true);
     this.setValue(text);
+    Blockly.Events.setGroup(false);
     this.validate_();
   } else if (goog.userAgent.WEBKIT) {
     // Cursor key.  Render the source block to show the caret moving.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#1508

### Proposed Changes
Adds setGroup(true) above where the BlockChange events get fired for renaming the procedure and renaming its callers.  

### Reason for Changes
When trying to undo renaming a procedure with multiple callers it would create an extra undo for every block that was renamed.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
