### PR TITLE
Changed Warnings to Interact Properly with Collapsing/Expanding.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -147,7 +147,7 @@ Blockly.BlockSvg.INLINE = -1;
  * @type {string}
  * @const
  */
-Blockly.BlockSvg.COLLAPSED_WARNING = 'TEMP_COLLAPSED_WARNING_';
+Blockly.BlockSvg.COLLAPSED_WARNING_ID = 'TEMP_COLLAPSED_WARNING_';
 
 /**
  * Create and initialize the SVG representation of the block.
@@ -528,24 +528,17 @@ Blockly.BlockSvg.prototype.setCollapsed = function(collapsed) {
     }
     for (var i = 1, block; block = descendants[i]; i++) {
       if (block.warning) {
-        this.setWarningText(block.warning.getText(),
-            Blockly.BlockSvg.COLLAPSED_WARNING + i);
+        this.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
+            Blockly.BlockSvg.COLLAPSED_WARNING_ID);
+        break;
       }
     }
   } else {
     this.removeInput(COLLAPSED_INPUT_NAME);
     // Clear any warnings inherited from enclosed blocks.
     if (this.warning) {
-      var keys = Object.keys(this.warning.text_);
-      var warningsDeleted = 0;
-      for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        if (key.indexOf(Blockly.BlockSvg.COLLAPSED_WARNING) != -1) {
-          this.warning.setText('', key);
-          warningsDeleted++;
-        }
-      }
-      if (warningsDeleted == keys.length) {
+      this.warning.setText('', Blockly.BlockSvg.COLLAPSED_WARNING_ID);
+      if (!Object.keys(this.warning.text_).length) {
         this.setWarningText(null);
       }
     }
@@ -1071,8 +1064,8 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
     parent = parent.getSurroundParent();
   }
   if (collapsedParent) {
-    collapsedParent.setWarningText(text,
-        Blockly.BlockSvg.COLLAPSED_WARNING + this.id + ' ' + id);
+    collapsedParent.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
+        Blockly.BlockSvg.COLLAPSED_WARNING_ID);
   }
 
   var changedState = false;

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -141,9 +141,9 @@ Blockly.BlockSvg.prototype.warningTextDb_ = null;
 Blockly.BlockSvg.INLINE = -1;
 
 /**
- * Prefix to add to warnings that bubble up when the parent block is
- * collapse. Allows us to remove the inherited warnings without removing the
- * ones that belong to the block.
+ * ID to give the "collapsed warnings" warning. Allows us to remove the
+ * "collapsed warnings" warning without removing any warnings that belong to
+ * the block.
  * @type {string}
  * @const
  */

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -1206,3 +1206,8 @@ Blockly.Msg.PROCEDURES_IFRETURN_WARNING = 'Warning: This block may be used only 
 /// comment text - This text appears in a new workspace comment, to hint that
 /// the user can type here.
 Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = 'Say something...';
+
+/// warning - This appears if the user collapses a block, and blocks inside
+// that block have warnings attached to them. It should inform the user that the
+// block they collapsed contains blocks that have warnings.
+Blockly.Msg.COLLAPSED_WARNINGS_WARNING = 'Collapsed blocks contain warnings.';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2175 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1. Warnings stay attached to a block even if it is collapsed & expanded.
2. Warnings now "bubble up" from child blocks when the parent is collapsed.
3. Only the "bubbled up" warnings get removed from the parent block when it is expanded.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Warnings should inform the user of when there is an issue with there code. Collapsing a block should make the workspace less cluttered, without sacrificing important information (especially warnings!). 

These changes make it so collapsing a block doesn't hide important information from its child blocks, and makes it so that any warnings on a block stick around until they are properly dealt with.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Added the below code at ~ ln 124  in the playground:
`var workspaceBlocks = document.getElementById("workspaceBlocks");
Blockly.Xml.domToWorkspace(workspaceBlocks, workspace);
workspace.getBlockById('1').setWarningText('warning');
workspace.getBlockById('2').setWarningText('warning inner');
workspace.getBlockById('3').setWarningText('warning outer');
workspace.getBlockById('4').setWarningText('warning inner');
document.onkeyup = function(e) {
	if (e.keyCode == 32) {
	  workspace.getBlockById('6').setWarningText('bubble up');
	}
};`
2. Add the below code at ~ln 372 in the playground:
`<xml xmlns="http://www.w3.org/1999/xhtml" id="workspaceBlocks" style="display:none">
	<block type="controls_if" id="1" x="12" y="13"></block>
	<block type="controls_if" x="12" y="100">
	  <value name="DO0">
		<block type="controls_if" id="2"></block>
	  </value>
	</block>
	<block type="controls_if" id="3" x="12" y="250">
	  <value name="DO0">
		<block type="controls_if" id="4"></block>
	  </value>
	</block>
	<block type="controls_if" id="5" x="12" y="400">
	  <value name="DO0">
		<block type="controls_if" id="6"></block>
	  </value>
	</block>
</xml>`

![warn 1](https://user-images.githubusercontent.com/25440652/50048622-03bf5800-0086-11e9-87ed-46a6c4a2204a.jpg)

3. Collapse all of the blocks.
4. Observe how the top 3 collapsed blocks all have warnings, and the warnings for the second and third blocks have bubbled up from the children correctly.

![warn 2](https://user-images.githubusercontent.com/25440652/50048624-1043b080-0086-11e9-9a33-5064708219cc.jpg)

5. Press space.
6. Observe how the 4th block now has a warning that bubbled up from its child.

![warn 3](https://user-images.githubusercontent.com/25440652/50048626-15a0fb00-0086-11e9-9e3e-edee38976f0e.jpg)

7. Expand all of the blocks.
8. Observe how all of the blocks bubbled up warnings have now been removed from the parents (2, 3, & 4) But none of the original warnings have been removed (1 & 3).

![warn 4](https://user-images.githubusercontent.com/25440652/50048631-29e4f800-0086-11e9-8dff-45a63387921a.jpg)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
