### PR TITLE
Fix #1632: Added alt attribute to the field image.

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -53,7 +53,7 @@ Blockly.FieldImage = function(src, width, height, opt_alt, opt_onClick) {
       this.height_ + 2 * Blockly.BlockSvg.INLINE_PADDING_Y);
   this.tooltip_ = '';
   this.setValue(src);
-  this.setText(opt_alt)
+  this.setText(opt_alt);
 
   if (typeof opt_onClick == 'function') {
     this.clickHandler_ = opt_onClick;

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -51,9 +51,9 @@ Blockly.FieldImage = function(src, width, height, opt_alt, opt_onClick) {
   this.width_ = Number(width);
   this.size_ = new goog.math.Size(this.width_,
       this.height_ + 2 * Blockly.BlockSvg.INLINE_PADDING_Y);
-  this.text_ = opt_alt || '';
   this.tooltip_ = '';
   this.setValue(src);
+  this.setText(opt_alt)
 
   if (typeof opt_onClick == 'function') {
     this.clickHandler_ = opt_onClick;
@@ -107,6 +107,7 @@ Blockly.FieldImage.prototype.init = function() {
       },
       this.fieldGroup_);
   this.setValue(this.src_);
+  this.setText(this.text_);
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
 
   if (this.tooltip_) {
@@ -193,6 +194,9 @@ Blockly.FieldImage.prototype.setText = function(alt) {
     return;
   }
   this.text_ = alt;
+  if (this.imageElement_) {
+    this.imageElement_.setAttribute('alt', alt || '');
+  }
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #1632 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
This PR adds `alt` attribute to the imageElement of fieldImage.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
This changes will add alt value to the image in the block.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
**Steps to test changes**:
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
- Created one block factor with the image field.
- Added it to the workspace and inspect the image element.
- Found `alt` attribute:
![image](https://user-images.githubusercontent.com/16653571/50073955-60468280-0200-11e9-8200-1d8549cb171b.png)
- Found tootip with text tag in svg:
![image](https://user-images.githubusercontent.com/16653571/50074882-465a6f00-0203-11e9-8b8d-1477074cb9d7.png)



Tested on:
- Desktop Chrome
- Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->