### PR TITLE
Scroll very long context menus

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -584,6 +584,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyContextMenu {',
     'border-radius: 4px;',
+    'max-height: 100%;',
   '}',
 
   '.blocklyDropdownMenu {',

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -186,7 +186,12 @@ Blockly.WidgetDiv.positionWithAnchor = function(viewportBBox, anchorBBox,
   var x = Blockly.WidgetDiv.calculateX_(viewportBBox, anchorBBox, widgetSize,
       rtl);
 
-  Blockly.WidgetDiv.positionInternal_(x, y, widgetSize.height);
+  if (y < 0) {
+    Blockly.WidgetDiv.positionInternal_(x, 0, widgetSize.height + y);
+  }
+  else {
+    Blockly.WidgetDiv.positionInternal_(x, y, widgetSize.height);
+  }
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
Duplicate of this PR from scratch: https://github.com/LLK/scratch-blocks/pull/1821

Lets long context menus scroll.
