### PR TITLE
Added maxTrashcanContents Property to Workspace Options

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -54,6 +54,14 @@ Blockly.Options = function(options) {
     if (hasTrashcan === undefined) {
       hasTrashcan = hasCategories;
     }
+    var maxTrashcanContents = options['maxTrashcanContents'];
+    if (hasTrashcan) {
+      if (maxTrashcanContents === undefined) {
+        maxTrashcanContents = Infinity;
+      }
+    } else {
+      maxTrashcanContents = 0;
+    }
     var hasCollapse = options['collapse'];
     if (hasCollapse === undefined) {
       hasCollapse = hasCategories;
@@ -124,6 +132,7 @@ Blockly.Options = function(options) {
   this.hasCategories = hasCategories;
   this.hasScrollbars = hasScrollbars;
   this.hasTrashcan = hasTrashcan;
+  this.maxTrashcanContents = maxTrashcanContents;
   this.hasSounds = hasSounds;
   this.hasCss = hasCss;
   this.horizontalLayout = horizontalLayout;

--- a/core/options.js
+++ b/core/options.js
@@ -57,7 +57,7 @@ Blockly.Options = function(options) {
     var maxTrashcanContents = options['maxTrashcanContents'];
     if (hasTrashcan) {
       if (maxTrashcanContents === undefined) {
-        maxTrashcanContents = Infinity;
+        maxTrashcanContents = 32;
       }
     } else {
       maxTrashcanContents = 0;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -38,6 +38,10 @@ goog.require('goog.math.Rect');
  */
 Blockly.Trashcan = function(workspace) {
   this.workspace_ = workspace;
+  if (this.workspace_.options.maxTrashcanContents <= 0) {
+    return;
+  }
+
   var flyoutWorkspaceOptions = {
     scrollbars: true,
     disabledPatternId: this.workspace_.options.disabledPatternId,
@@ -116,14 +120,6 @@ Blockly.Trashcan.prototype.SPRITE_TOP_ = 32;
  * @private
  */
 Blockly.Trashcan.prototype.HAS_BLOCKS_LID_ANGLE = 0.1;
-
-/**
- * The maximum number of blocks that can go in the trashcan's flyout. '0' turns
- * turns off trashcan contents, 'Infinity' sets it to unlimited.
- * @type {number}
- * @private
- */
-Blockly.Trashcan.prototype.MAX_CONTENTS = 32;
 
 /**
  * Current open/close state of the lid.
@@ -273,9 +269,11 @@ Blockly.Trashcan.prototype.createDom = function() {
  * @return {number} Distance from workspace bottom to the top of trashcan.
  */
 Blockly.Trashcan.prototype.init = function(bottom) {
-  Blockly.utils.insertAfter(this.flyout_.createDom('svg'),
-      this.workspace_.getParentSvg());
-  this.flyout_.init(this.workspace_);
+  if (this.workspace_.options.maxTrashcanContents > 0) {
+    Blockly.utils.insertAfter(this.flyout_.createDom('svg'),
+        this.workspace_.getParentSvg());
+    this.flyout_.init(this.workspace_);
+  }
 
   this.bottom_ = this.MARGIN_BOTTOM_ + bottom;
   this.setOpen_(false);
@@ -448,7 +446,7 @@ Blockly.Trashcan.prototype.mouseOut_ = function() {
 Blockly.Trashcan.prototype.onDelete_ = function() {
   var trashcan = this;
   return function(event) {
-    if (!trashcan.MAX_CONTENTS) {
+    if (trashcan.workspace_.options.maxTrashcanContents <= 0) {
       return;
     }
     if (event.type == Blockly.Events.BLOCK_DELETE) {
@@ -457,9 +455,12 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
         return;
       }
       trashcan.contents_.unshift(cleanedXML);
-      if (trashcan.contents_.length > trashcan.MAX_CONTENTS) {
-        trashcan.contents_.splice(trashcan.MAX_CONTENTS,
-            trashcan.contents_.length - trashcan.MAX_CONTENTS);
+      if (trashcan.contents_.length >
+          trashcan.workspace_.options.maxTrashcanContents) {
+        trashcan.contents_.splice(
+            trashcan.workspace_.options.maxTrashcanContents,
+            trashcan.contents_.length -
+            trashcan.workspace_.options.maxTrashcanContents);
       }
 
       trashcan.hasBlocks_ = true;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2165 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Allows you to set the maximum number of blocks allowed in the trashcan flyout through the workspace options struct.

* The flyout is not created if the maxTrashcanContents is <= 0.
* maxTrashcanContents is Infinity by default if the workspace has a trashcan.
* maxTrashcanContents is 0 by default if the workspace does not have a trashcan.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Allows developers to modify this option without changing the core.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Flyout Created/Not Created
1. Set the maxTrashcanContents option to Infinity.
2. Inspected the playground and observed how a trashcan flyout was created. (pass)
3. Set the maxTrashcanContents option to 0.
4. Inspected the playground and observed how a trashcan flyout was not created. (pass)

Default Values
1. Added below code at ln 143 in options:
`console.log(this.maxTrashcanContents);`
2. Opened playground in categories mode (hasTrashcan true) w/ maxTrashcanContents option undefined.
3. Observed how the maxTrashcanContents is Inifinity by default. (pass)
4. Opened the playground in simple mode (hasTrashcan false) w/ maxTrashcanContents option undefined.
5. Observed how the maxTrashcanContents is 0 by default. (pass)

Other Values
1. Set the maxTrashcanContents option to 2.
2. Deleted 3 block stacks.
3. Observed how only two block stacks appeared in the trashcan flyout. (pass)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
