### PR TITLE
Fixed undoing events deleting/moving undeletable/unmovable blocks.

### DIFF
--- a/core/block_events.js
+++ b/core/block_events.js
@@ -279,7 +279,7 @@ Blockly.Events.Create.prototype.run = function(forward) {
   } else {
     for (var i = 0, id; id = this.ids[i]; i++) {
       var block = workspace.getBlockById(id);
-      if (block) {
+      if (block && block.isDeletable()) {
         block.dispose(false, false);
       } else if (id == this.blockId) {
         // Only complain about root-level block.
@@ -485,7 +485,7 @@ Blockly.Events.Move.prototype.isNull = function() {
 Blockly.Events.Move.prototype.run = function(forward) {
   var workspace = this.getEventWorkspace_();
   var block = workspace.getBlockById(this.blockId);
-  if (!block) {
+  if (!block || !block.isMovable()) {
     console.warn("Can't move non-existent block: " + this.blockId);
     return;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2191
As well as the moving unmovable blocks issue that arises when you fix the above.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that undoing delete/move events doesn't create/move undeletable/unmovable blocks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
At the moment users could accidentally delete undeletable blocks, or (if that issue is fixed) cause all of the unmoveable blocks to be stacked ontop of eachother (if they were created through .domToWorkspace).

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Added below code at ~ln 124 in playground:
```
var workspaceBlocks = document.getElementById("workspaceBlocks");
Blockly.Xml.domToWorkspace(workspaceBlocks, workspace);
```
2. Added below code at ~ln 366 in playground:
```
<xml xmlns="http://www.w3.org/1999/xhtml" id="workspaceBlocks" style="display:none">
    <block type="controls_if" deletable="false" movable="false" id="1" x="12" y="13"></block>
    <block type="controls_if" deletable="false" movable="false" id="1" x="12" y="100"></block>
    <block type="controls_if" deletable="false" movable="false" id="1" x="12" y="200"></block>
</xml>
```
3. Loaded the playground & observed how 3 'controls_if' blocks appeared.
4. Pressed ctrl/cmd z & observed how nothing changed.

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
