### PR TITLE
Fixed Being Unable to Register Button Callbacks in Category-less Toolbox

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -75,21 +75,11 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
   this.isLabel_ = isLabel;
 
   /**
-   * Function to call when this button is clicked.
-   * @type {function(!Blockly.FlyoutButton)}
+   * The key to the function called when this button is clicked.
+   * @type {string}
    * @private
    */
-  this.callback_ = null;
-
-  var callbackKey = xml.getAttribute('callbackKey');
-  if (this.isLabel_ && callbackKey) {
-    console.warn('Labels should not have callbacks. Label text: ' + this.text_);
-  } else if (!this.isLabel_ &&
-      !(callbackKey && targetWorkspace.getButtonCallback(callbackKey))) {
-    console.warn('Buttons should have callbacks. Button text: ' + this.text_);
-  } else {
-    this.callback_ = targetWorkspace.getButtonCallback(callbackKey);
-  }
+  this.callbackKey_ = xml.getAttribute('callbackKey');
 
   /**
    * If specified, a CSS class to add to this button.
@@ -257,8 +247,12 @@ Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
     gesture.cancel();
   }
 
-  // Call the callback registered to this button.
-  if (this.callback_) {
-    this.callback_(this);
+  if (this.isLabel_ && this.callbackKey_) {
+    console.warn('Labels should not have callbacks. Label text: ' + this.text_);
+  } else if (!this.isLabel_ && !(this.callbackKey_ &&
+      this.targetWorkspace_.getButtonCallback(this.callbackKey_))) {
+    console.warn('Buttons should have callbacks. Button text: ' + this.text_);
+  } else if (!this.isLabel_) {
+    this.targetWorkspace_.getButtonCallback(this.callbackKey_)(this);
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1146

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes the callback to be looked up dynamically whenever the button is clicked instead of being associated with the flyout button on instantiation.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This allows button callbacks to be added to category-less toolboxes.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Added below code at ~ln 124 in playground.
```
 workspace.registerButtonCallback('CALLBACKLABEL', function(button) {
    console.log("Label Callback!");
  });
  workspace.registerButtonCallback('CALLBACKBUTTON', function(button) {
    console.log("Button Callback!");
  });
```
2. Added below code at ~ln 367 in playground.
```
    <label text="label without callback"></label>
    <label text="label with callback" callbackKey="CALLBACKLABEL"></label>
    <button text="button without callback"></button>
    <button text="button with callback" callbackKey="CALLBACKBUTTON"></button>
```
3. Set the playground toolbox to "Simple".
4. Clicked the first label, observed how nothing happend. (pass)
5. Clicked the second label, observed how I got a "Labels should not have callbacks" warning. (pass)
6. Clicked the first button, observed how I got a "Buttons should have callbacks" warning. (pass)
7. Clicked the second button, observed how I got a "Button Callback!" log statement. (pass)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
