### PR TITLE
Changed how Bubbles Position Themselves

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -401,22 +401,121 @@ Blockly.Bubble.prototype.setAnchorLocation = function(xy) {
  * @private
  */
 Blockly.Bubble.prototype.layoutBubble_ = function() {
-  // Compute the preferred bubble location.
-  var relativeLeft = -this.width_ / 4;
-  var relativeTop = -this.height_ - Blockly.BlockSvg.MIN_BLOCK_Y;
-  // Prevent the bubble from being off-screen.
   var metrics = this.workspace_.getMetrics();
   metrics.viewWidth /= this.workspace_.scale;
   metrics.viewLeft /= this.workspace_.scale;
+  var optimalLeft = this.getOptimalRelativeLeft_(metrics);
+  var optimalTop = this.getOptimalRelativeTop_(metrics);
+  var bbox = this.shape_.getBBox();
+
+  var topPosition = {x: optimalLeft,
+    y: -this.height_ - Blockly.BlockSvg.MIN_BLOCK_Y};
+  var startPosition = {x: -this.width_ - 30, y: optimalTop};
+  var endPosition = {x: bbox.width, y: optimalTop};
+  var bottomPosition = {x: optimalLeft, y: bbox.height};
+
+  var closerPosition = bbox.width < bbox.height ? endPosition : bottomPosition;
+  var fartherPosition = bbox.width < bbox.height ? bottomPosition : endPosition;
+
+  var topPositionOverlap = this.getOverlap_(topPosition, metrics);
+  var startPositionOverlap = this.getOverlap_(startPosition, metrics);
+  var closerPositionOverlap = this.getOverlap_(closerPosition, metrics);
+  var fartherPositionOverlap = this.getOverlap_(fartherPosition, metrics);
+
+  // Set the position to whichever position shows the most of the bubble,
+  // with tiebreaks going in the order: top > start > close > far.
+  var mostOverlap = Math.max(topPositionOverlap, startPositionOverlap,
+      closerPositionOverlap, fartherPositionOverlap);
+  if (topPositionOverlap == mostOverlap) {
+    this.relativeLeft_ = topPosition.x;
+    this.relativeTop_ = topPosition.y;
+    return;
+  }
+  if (startPositionOverlap == mostOverlap) {
+    this.relativeLeft_ = startPosition.x;
+    this.relativeTop_ = startPosition.y;
+    return;
+  }
+  if (closerPositionOverlap == mostOverlap) {
+    this.relativeLeft_ = closerPosition.x;
+    this.relativeTop_ = closerPosition.y;
+    return;
+  }
+  this.relativeLeft_ = fartherPosition.x;
+  this.relativeTop_ = fartherPosition.y;
+};
+
+/**
+ * Calculate the what percentage of the bubble overlaps with the visible
+ * workspace (what percentage of the bubble is visible).
+ * @param {!Object} relativeMin The position of the top-left corner of the
+ *    bubble relative to the anchor point.
+ * @param {!number} relativeMin.x The x-position of the relativeMin.
+ * @param {!number} relativeMin.y The y-position of the relativeMin.
+ * @param {!Object} metrics The metrics of the workspace the bubble will
+ *    appear in.
+ * @returns {number} The percentage of the bubble that is visible.
+ * @private
+ */
+Blockly.Bubble.prototype.getOverlap_ = function(relativeMin, metrics) {
+  // The position of the top-start corner of the bubble in workspace units.
+  var bubbleMin = {
+    x: relativeMin.x + (this.workspace_.RTL ?
+        metrics.viewWidth - this.anchorXY_.x :
+        this.anchorXY_.x),
+    y: relativeMin.y + this.anchorXY_.y
+  };
+  // The position of the bottom-end corner of the bubble in workspace units.
+  var bubbleMax = {
+    x: bubbleMin.x + this.width_,
+    y: bubbleMin.y + this.height_
+  };
+  // The position of the top-start corner of the workspace.
+  var workspaceMin = {
+    x: metrics.viewLeft,
+    y: metrics.viewTop
+  };
+  // The position of the bottom-end corner of the workspace.
+  var workspaceMax = {
+    x: workspaceMin.x + metrics.viewWidth,
+    y: workspaceMin.y + metrics.viewHeight
+  };
+
+  var overlapWidth = Math.min(bubbleMax.x, workspaceMax.x) -
+      Math.max(bubbleMin.x, workspaceMin.x);
+  var overlapHeight = Math.min(bubbleMax.y, workspaceMax.y) -
+      Math.max(bubbleMin.y, workspaceMin.y);
+  return Math.max(0, Math.min(1,
+      (overlapWidth * overlapHeight) / (this.width_ * this.height_)));
+};
+
+/**
+ * Calculate what the optimal horizontal position of the top-left corner of the
+ * bubble is (relative to the anchor point) so that the most area of the
+ * bubble is shown.
+ * @param {!Object} metrics The metrics of the workspace the bubble will
+ *    appear in.
+ * @returns {number} The optimal horizontal position of the top-left corner
+ *    of the bubble.
+ * @private
+ */
+Blockly.Bubble.prototype.getOptimalRelativeLeft_ = function(metrics) {
+  var relativeLeft = -this.width_ / 4;
+
+  // No amount of sliding left or right will give us a better overlap.
+  if (this.width_ > metrics.viewWidth) {
+    return relativeLeft;
+  }
+
   var anchorX = this.anchorXY_.x;
   if (this.workspace_.RTL) {
     if (anchorX - metrics.viewLeft - relativeLeft - this.width_ <
         Blockly.Scrollbar.scrollbarThickness) {
       // Slide the bubble right until it is onscreen.
       relativeLeft = anchorX - metrics.viewLeft - this.width_ -
-        Blockly.Scrollbar.scrollbarThickness;
+          Blockly.Scrollbar.scrollbarThickness;
     } else if (anchorX - metrics.viewLeft - relativeLeft >
-               metrics.viewWidth) {
+        metrics.viewWidth) {
       // Slide the bubble left until it is onscreen.
       relativeLeft = anchorX - metrics.viewLeft - metrics.viewWidth;
     }
@@ -433,13 +532,42 @@ Blockly.Bubble.prototype.layoutBubble_ = function() {
           this.width_ - Blockly.Scrollbar.scrollbarThickness;
     }
   }
-  if (this.anchorXY_.y + relativeTop < metrics.viewTop) {
-    // Slide the bubble below the block.
-    var bBox = /** @type {SVGLocatable} */ (this.shape_).getBBox();
-    relativeTop = bBox.height;
+
+  return relativeLeft;
+};
+
+/**
+ * Calculate what the optimal vertical position of the top-left corner of
+ * the bubble is (relative to the anchor point) so that the most area of the
+ * bubble is shown.
+ * @param {!Object} metrics The metrics of the workspace the bubble will
+ *    appear in.
+ * @returns {number} The optimal vertical position of the top-left corner
+ *    of the bubble.
+ * @private
+ */
+Blockly.Bubble.prototype.getOptimalRelativeTop_ = function(metrics) {
+  var relativeTop = -this.height_ / 4;
+
+  // No amount of sliding up or down will give us a better overlap.
+  if (this.height_ > metrics.viewHeight) {
+    return relativeTop;
   }
-  this.relativeLeft_ = relativeLeft;
-  this.relativeTop_ = relativeTop;
+
+  var anchorY = this.anchorXY_.y;
+  if (anchorY + relativeTop < metrics.viewTop) {
+    // Slide the bubble down until it is onscreen.
+    relativeTop = metrics.viewTop - anchorY;
+  } else if (metrics.viewTop + metrics.viewHeight <
+      anchorY + relativeTop + this.height_ +
+      Blockly.BlockSvg.SEP_SPACE_Y +
+      Blockly.Scrollbar.scrollbarThickness) {
+    // Slide the bubble up until it is onscreen.
+    relativeTop = metrics.viewTop + metrics.viewHeight - anchorY -
+        this.height_ - Blockly.Scrollbar.scrollbarThickness;
+  }
+
+  return relativeTop;
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -472,7 +472,7 @@ Blockly.Bubble.prototype.getOverlap_ = function(relativeMin, metrics) {
   };
   // The position of the top-start corner of the workspace.
   var workspaceMin = {
-    x: metrics.viewLeft,
+    x: this.workspace_.RTL ? -metrics.viewLeft : metrics.viewLeft,
     y: metrics.viewTop
   };
   // The position of the bottom-end corner of the workspace.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1521 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The bubble now has 4 possible positions it could be in:
* Top shifted
* Start shifted
* End shifted
* Bottom shifted

Shifted meaning that it has been moved along it's "subaxis" (x-axis for top and bottom, y-axis for start and end) so that the maximum amount of the bubble will be shown for the given position. E.g. if the bubble is being positioned at the top, but it is being overlapped by the workspace on the left, it will be shifted to the right so that the maximum amount of the bubble will be shown.

For each of these positions the "overlap percentage" (meaning the percentage of the bubble's total area that is visible when in a given position) is calculated. The bubble is then placed at the position with the highest "overlap percentage" with tiebreaks going in the below order (which is basically just distance order).
1. Top
2. Start
3. Whichever is closer out of end & bottom.
4. Whichever is farther out of end & bottom.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This makes it so that bubbles are always located in the optimal position. Optimal meaning whichever location shows the maximum amount of the bubble, and secondarily whichever location is closest to the anchor position.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Added the below code at ~ln 429 in bubble (just to watch incase anything is buggy).
```
console.log('--- most ' + mostOverlap + ' ---');
console.log('top ' + topPositionOverlap);
console.log('start ' + startPositionOverlap);
console.log('close ' + closerPositionOverlap);
console.log('far ' + fartherPositionOverlap);
```
2. Did a lot of [this](https://youtu.be/JkVLbHiKtFk).



Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
Yeah... this might be a bit overengineered, but I was bored =)