### PR TITLE
local_build: Add build for local_blocks_compressed.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ npm-debug.log
 tests/compile/main_compressed.js
 tests/compile/*compiler*.jar
 local_build/*compiler*.jar
-local_build/local_blockly_compressed.js
+local_build/local_*_compressed.js

--- a/local_build/local_build.sh
+++ b/local_build/local_build.sh
@@ -86,7 +86,13 @@ fi
 
 rm local_blocks_compressed.js 2> /dev/null
 echo Compiling Blockly blocks...
+
+# Add Blockly and Blockly.Blocks to be compatible with the compiler.
 echo -e "'use strict';\ngoog.provide('Blockly');goog.provide('Blockly.Blocks');" > temp.js
+
+# Concatenate all blocks/*.js into the first file, as the compiler will otherwise
+# remove them as not needed.
+# Also remove 'use strict' to avoid unnecessary warnings
 cat ../blocks/*.js| grep -v "^'use strict';" >> temp.js
 java -jar $COMPILER \
   --js='temp.js' \
@@ -101,6 +107,7 @@ java -jar $COMPILER \
 rm temp.js 2> /dev/null
 if [ -s local_blocks_compressed.js ]; then
        echo Compilation OK
+       # Remove Blockly initialization line. This is present in local_blockly_compressed.
        sed -i 's/var Blockly={Blocks:{}};//g' local_blocks_compressed.js
 else
        echo Compilation FAIL.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2099

### Proposed Changes

This change modifies local_build.sh to generate local_blocks_compressed.js

### Reason for Changes

local build only supports generating local_blockly_compressed.js.

### Test Coverage

Tested on my local system

Tested on:
Desktop Chrome

### Additional Information

<!-- Anything else we should know? -->
