### PR TITLE
Add eslintrc to mocha directory

### DIFF
--- a/tests/mocha/.eslintrc
+++ b/tests/mocha/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "env": {
+        "browser": true,
+        "mocha": true
+    },
+    "globals": {
+        "chai": false,
+        "sinon": false,
+        "assertNull": true,
+        "assertNotNull": true,
+        "assertEquals": true,
+        "assertTrue": true,
+        "assertFalse": true,
+        "isEqualArrays": true,
+        "assertUndefined": true,
+        "assertNotUndefined": true
+
+    },
+    "extends": "eslint:recommended"
+}

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1,10 +1,4 @@
 
-// Declare some globals to make eslint happier.
-// TODO: make an eslint config that applies to this directory and put this
-// configuration in that file, instead of inline.
-/* global suite, test, setup, teardown */
-
-/* global assertNull, assertEquals */
 
 suite('Blocks', function() {
 

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -1,12 +1,4 @@
 
-// Declare some globals to make eslint happier.
-// TODO: make an eslint config that applies to this directory and put this
-// configuration in that file, instead of inline.
-/* global suite, test, setup, teardown */
-/* global sinon */
-
-/* global assertNotNull, assertNotUndefined, assertNull, assertEquals,
-   isEqualArrays, assertUndefined */
 suite('Events', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
@@ -39,7 +31,8 @@ suite('Events', function() {
 
   function checkExactEventValues(event, values) {
     var keys = Object.keys(values);
-    for (var i = 0, field; field = keys[i]; i++) {
+    for (var i = 0; i < keys.length; i++) {
+      var field = keys[i]
       assertEquals(values[field], event[field]);
     }
   }

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -1,11 +1,4 @@
 
-// Declare some globals to make eslint happier.
-// TODO: make an eslint config that applies to this directory and put this
-// configuration in that file, instead of inline.
-/* global suite, test, chai, setup, teardown */
-
-/* global assertNull, assertEquals, isEqualArrays */
-
 suite('Variable Fields', function() {
   function getMockBlock(workspace) {
     return {

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -1,4 +1,3 @@
-/* global chai */
 /* exported assertEquals, assertTrue, assertFalse, assertNull, assertNotNull,
    isEqualArrays, assertUndefined, assertNotUndefined */
 function _argumentsIncludeComments(expectedNumberOfNonCommentArgs, args) {

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -1,9 +1,4 @@
 
-// Declare some globals to make eslint happier.
-// TODO: make an eslint config that applies to this directory and put this
-// configuration in that file, instead of inline.
-/* global suite, test, chai, assertFalse, assertTrue, assertEquals */
-
 suite('Utils', function() {
   test('genUid', function() {
     var uuids = {};


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Add a `.eslintrc` file to the tests/mocha directory, and move inline eslint comments into the eslintrc.

### Reason for Changes

Consistent linting/the other way was just a hack to get going.
