### PR TITLE
Added Displaying Trashcan Flyout Horizontally When Layout is Horizontal

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -41,19 +41,25 @@ Blockly.Trashcan = function(workspace) {
   if (this.workspace_.options.maxTrashcanContents <= 0) {
     return;
   }
-
+  // Create flyout options.
   var flyoutWorkspaceOptions = {
     scrollbars: true,
     disabledPatternId: this.workspace_.options.disabledPatternId,
     parentWorkspace: this.workspace_,
     RTL: this.workspace_.RTL,
-    oneBasedIndex: workspace.options.oneBasedIndex,
-    // TODO: Add horizontal.
-    /*horizontalLayout: this.workspace_.horizontalLayout,*/
-    toolboxPosition: this.workspace_.RTL ? Blockly.TOOLBOX_AT_LEFT :
-        Blockly.TOOLBOX_AT_RIGHT
+    oneBasedIndex: this.workspace_.options.oneBasedIndex,
   };
-  this.flyout_ = new Blockly.VerticalFlyout(flyoutWorkspaceOptions);
+  // Create vertical or horizontal flyout.
+  if (this.workspace_.horizontalLayout) {
+    flyoutWorkspaceOptions.toolboxPosition =
+        this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_TOP ?
+        Blockly.TOOLBOX_AT_BOTTOM : Blockly.TOOLBOX_AT_TOP;
+    this.flyout_ = new Blockly.HorizontalFlyout(flyoutWorkspaceOptions);
+  } else {
+    flyoutWorkspaceOptions.toolboxPosition = this.workspace_.RTL ?
+        Blockly.TOOLBOX_AT_LEFT : Blockly.TOOLBOX_AT_RIGHT;
+    this.flyout_ = new Blockly.VerticalFlyout(flyoutWorkspaceOptions);
+  }
   this.workspace_.addChangeListener(this.onDelete_());
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2166 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Displays the trashcan flyout horizontally when the layout is horizontally.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
The flyout always appears "ontop" of the trashcan.
![flyoutposition1](https://user-images.githubusercontent.com/25440652/50997977-e772d780-14da-11e9-8a1c-7460d411c84b.jpg)
![flyoutposition2](https://user-images.githubusercontent.com/25440652/50997982-ea6dc800-14da-11e9-87eb-d7e95512101c.jpg)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
