### PR TITLE
Fixed Comments Not Being Recorded in Delete Event

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -893,16 +893,28 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     this.warningTextDb_ = null;
   }
 
+  // If the block is rendered we need to record the event before disposing of
+  // the icons to prevent losing information.
+  // TODO (#1969): Remove event generation/firing once comments are fixed.
+  this.unplug(healStack);
+  var deleteEvent;
+  if (Blockly.Events.isEnabled()) {
+    deleteEvent = new Blockly.Events.BlockDelete(this);
+  }
   Blockly.Events.disable();
   try {
     var icons = this.getIcons();
     for (var i = 0; i < icons.length; i++) {
       icons[i].dispose();
     }
+    // TODO (#1969): Move out of disable block once comments are fixed.
+    Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
   } finally {
     Blockly.Events.enable();
   }
-  Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
+  if (Blockly.Events.isEnabled() && deleteEvent) {
+    Blockly.Events.fire(deleteEvent);
+  }
 
   Blockly.utils.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1960

### Proposed Changes

Quote from #1970 

> For now, have block_svg handle firing the event so it can capture all the info correctly.
#1969 documents future work to not have the rendered icon own the comment.

This PR also calls this.unplug(healstack) before creating the delete event, so we don't see the error reported in #1972.

### Reason for Changes

Quote from #1970 

> The icons in rendered Blockly currently own the comment text. When a block was deleted the icons were being disposed of before the block info was recorded in the event, which meant the comment was lost. This adds some additional logic to block_svg to make sure the event is captured before the icons are removed.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Opened playground, turned on event logging, opened console.
2. Created a block.
3. Added a comment to the block.
4. Observed how a Change event was correctly fire.
5. Deleted the block.
6. Observed how a delete event (with the proper XML) was correctly fired. (pass)
7. Un-Deleted the block.
8. Observed how the un-deleted block had a comment containing the correct text. (pass)

Also tested for #1972 
1. Created a square root block.
2. Attached a number block to it. (pass)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
