### PR TITLE
Pan the workspace by x,y CSS units

### DIFF
--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -173,6 +173,24 @@ Blockly.ScrollbarPair.prototype.set = function(x, y) {
 };
 
 /**
+ * Pan the handles of both scrollbars to be at a certain position in CSS pixels
+ * relative to their parents.
+ * @param {number} x Horizontal scroll value.
+ * @param {number} y Vertical scroll value.
+ */
+Blockly.ScrollbarPair.prototype.panBy = function(x, y) {
+  // Find the current x,y position
+
+  var hNewHandlePosition = x * this.hScroll.ratio_;
+  var vNewHandlePosition = y * this.vScroll.ratio_;
+
+  var hHandlePosition = this.hScroll.handlePosition_ + hNewHandlePosition;
+  var vHandlePosition = this.vScroll.handlePosition_ + vNewHandlePosition;
+
+  this.set(hHandlePosition / this.hScroll.ratio_, vHandlePosition / this.hScroll.ratio_);
+};
+
+/**
  * Helper to calculate the ratio of handle position to scrollbar view size.
  * @param {number} handlePosition The value of the handle.
  * @param {number} viewSize The total size of the scrollbar's view.

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -173,24 +173,6 @@ Blockly.ScrollbarPair.prototype.set = function(x, y) {
 };
 
 /**
- * Pan the handles of both scrollbars to be at a certain position in CSS pixels
- * relative to their parents.
- * @param {number} x Horizontal scroll value.
- * @param {number} y Vertical scroll value.
- */
-Blockly.ScrollbarPair.prototype.panBy = function(x, y) {
-  // Find the current x,y position
-
-  var hNewHandlePosition = x * this.hScroll.ratio_;
-  var vNewHandlePosition = y * this.vScroll.ratio_;
-
-  var hHandlePosition = this.hScroll.handlePosition_ + hNewHandlePosition;
-  var vHandlePosition = this.vScroll.handlePosition_ + vNewHandlePosition;
-
-  this.set(hHandlePosition / this.hScroll.ratio_, vHandlePosition / this.hScroll.ratio_);
-};
-
-/**
  * Helper to calculate the ratio of handle position to scrollbar view size.
  * @param {number} handlePosition The value of the handle.
  * @param {number} viewSize The total size of the scrollbar's view.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1589,8 +1589,8 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 
 /**
  * Pan the workspace by a specified amount, keeping in the bounds.
- * @param {number} x Target X to scroll to
- * @param {number} y Target Y to scroll to
+ * @param {number} x Offset X to scroll by
+ * @param {number} y Offset Y to scroll by
  */
 Blockly.WorkspaceSvg.prototype.panByOffset = function(x, y) {
   var x = this.scrollX - x;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1589,8 +1589,8 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 
 /**
  * Pan the workspace by a specified amount, keeping in the bounds.
- * @param {number} x Offset X to scroll by
- * @param {number} y Offset Y to scroll by
+ * @param {number} x Offset X to scroll by in pixels.
+ * @param {number} y Offset Y to scroll by in pixels.
  */
 Blockly.WorkspaceSvg.prototype.panByOffset = function(x, y) {
   var x = this.scrollX - x;
@@ -1600,8 +1600,9 @@ Blockly.WorkspaceSvg.prototype.panByOffset = function(x, y) {
 
 /**
  * Scroll the workspace by a specified amount, keeping in the bounds.
- * @param {number} x Target X to scroll to
- * @param {number} y Target Y to scroll to
+ * TODO: Unit annotations
+ * @param {number} x Target X to scroll to.
+ * @param {number} y Target Y to scroll to.
  */
 Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
   var metrics = this.getMetrics();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1588,6 +1588,37 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
 };
 
 /**
+ * Pan the workspace by a specified amount, keeping in the bounds.
+ * @param {number} x Target X to scroll to
+ * @param {number} y Target Y to scroll to
+ */
+Blockly.WorkspaceSvg.prototype.panByOffset = function(x, y) {
+  var x = this.scrollX - x;
+  var y = this.scrollY - y;
+  this.scroll(x, y);
+};
+
+/**
+ * Scroll the workspace by a specified amount, keeping in the bounds.
+ * @param {number} x Target X to scroll to
+ * @param {number} y Target Y to scroll to
+ */
+Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
+  var metrics = this.getMetrics();
+  x = Math.min(x, -metrics.contentLeft);
+  y = Math.min(y, -metrics.contentTop);
+  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
+               metrics.contentWidth);
+  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
+               metrics.contentHeight);
+  // When the workspace starts scrolling, hide the WidgetDiv without animation.
+  // This is to prevent a dispoal animation from happening in the wrong location.
+  Blockly.WidgetDiv.hide(true);
+  // Move the scrollbars and the page will scroll automatically.
+  this.scrollbar.set(-x - metrics.contentLeft, -y - metrics.contentTop);
+};
+
+/**
  * Add a transition class to the block and bubble canvas, to animate any
  * transform changes.
  * @package


### PR DESCRIPTION
For keyboard accessibility, the PR supports the ability to programmatically pan the workspace by x and y in CSS units.

To test, drag a block to the workspace and call: 
``Blockly.mainWorkspace.panByOffset(50,50)``

I've split up the scroll function as it can be used by https://github.com/google/blockly/issues/2205#issuecomment-454534679 to scroll using the scrollbar as well.