### PR TITLE
Added basic up and down block navigation

### DIFF
--- a/core/navigation.js
+++ b/core/navigation.js
@@ -20,7 +20,7 @@
 
 goog.provide('Blockly.Navigation');
 
-var connection = null;
+Blockly.Navigation.connection = null;
 
 Blockly.Navigation.navigateBetweenStacks = function(forward) {
   var curBlock = Blockly.selected;
@@ -48,11 +48,11 @@ Blockly.Navigation.navigateBetweenStacks = function(forward) {
 };
 
 Blockly.Navigation.setConnection = function() {
-  connection = Blockly.selected.previousConnection;
+  Blockly.Navigation.connection = Blockly.selected.previousConnection;
 };
 
 Blockly.Navigation.keyboardNext = function() {
-  var curConnect = connection;
+  var curConnect = Blockly.Navigation.connection;
   var nextConnection;
   if (!curConnect) {
     return null;
@@ -65,12 +65,12 @@ Blockly.Navigation.keyboardNext = function() {
     nextConnection = curConnect.sourceBlock_.nextConnection;
   }
   //Set cursor here
-  connection = nextConnection;
+  Blockly.Navigation.connection = nextConnection;
   return nextConnection;
 };
 
 Blockly.Navigation.keyboardPrev = function() {
-  var curConnect = connection;
+  var curConnect = Blockly.Navigation.connection;
   var prevConnection;
   if (!curConnect) {
     return null;
@@ -83,6 +83,6 @@ Blockly.Navigation.keyboardPrev = function() {
     prevConnection = curConnect.sourceBlock_.previousConnection;
   }
   //Set cursor here
-  connection = prevConnection;
+  Blockly.Navigation.connection = prevConnection;
   return prevConnection;
 };

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -20,6 +20,8 @@
 
 goog.provide('Blockly.Navigation');
 
+var connection = null;
+
 Blockly.Navigation.navigateBetweenStacks = function(forward) {
   var curBlock = Blockly.selected;
   if (!curBlock) {
@@ -43,4 +45,44 @@ Blockly.Navigation.navigateBetweenStacks = function(forward) {
   }
   throw Error('Couldn\'t find ' + (forward ? 'next' : 'previous') +
       ' stack?!?!?!');
+};
+
+Blockly.Navigation.setConnection = function() {
+  connection = Blockly.selected.previousConnection;
+};
+
+Blockly.Navigation.keyboardNext = function() {
+  var curConnect = connection;
+  var nextConnection;
+  if (!curConnect) {
+    return null;
+  }
+  var nxtBlock = curConnect.sourceBlock_.getNextBlock();
+  if (nxtBlock){
+    nextConnection = nxtBlock.previousConnection;
+  }
+  else {
+    nextConnection = curConnect.sourceBlock_.nextConnection;
+  }
+  //Set cursor here
+  connection = nextConnection;
+  return nextConnection;
+};
+
+Blockly.Navigation.keyboardPrev = function() {
+  var curConnect = connection;
+  var prevConnection;
+  if (!curConnect) {
+    return null;
+  }
+  var prevBlock = curConnect.sourceBlock_.getParent();
+  if (prevBlock){
+    prevConnection = prevBlock.previousConnection;
+  }
+  else {
+    prevConnection = curConnect.sourceBlock_.previousConnection;
+  }
+  //Set cursor here
+  connection = prevConnection;
+  return prevConnection;
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Currently no way to navigate blocks by keyboard.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Given a certain connection adds basic functionality for finding next and previous connection.

### Reason for Changes
Trying to add keyboard functionality. 
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
