### PR TITLE
Initial cursor rendering, supports coordinate positioning only

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -587,6 +587,11 @@ Blockly.Css.CONTENT = [
     'max-height: 100%;',
   '}',
 
+  '.blocklyCursor {',
+    'border-radius: 4px;',
+    'max-height: 100%;',
+  '}',
+
   '.blocklyDropdownMenu {',
     'padding: 0 !important;',
   '}',

--- a/core/css.js
+++ b/core/css.js
@@ -587,11 +587,6 @@ Blockly.Css.CONTENT = [
     'max-height: 100%;',
   '}',
 
-  '.blocklyCursor {',
-    'border-radius: 4px;',
-    'max-height: 100%;',
-  '}',
-
   '.blocklyDropdownMenu {',
     'padding: 0 !important;',
   '}',

--- a/core/cursor.js
+++ b/core/cursor.js
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2012 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Methods for graphically rendering a cursor as SVG.
+ * @author samelh@microsoft.com (Sam El-Husseini)
+ */
+'use strict';
+
+goog.provide('Blockly.Cursor');
+
+
+/**
+ * Class for a cursor.
+ * @param {!Blockly.Workspace} workspace The workspace to sit in.
+ * @constructor
+ */
+Blockly.Cursor = function(workspace) {
+  this.workspace_ = workspace;
+};
+
+/**
+ * Height of the horizontal cursor.
+ * @type {number}
+ * @const
+ */
+Blockly.Cursor.CURSOR_HEIGHT = 5;
+
+/**
+ * Width of the horizontal cursor.
+ * @type {number}
+ * @const
+ */
+Blockly.Cursor.CURSOR_WIDTH = 100;
+
+/**
+ * Cursor color.
+ * @type {number}
+ * @const
+ */
+Blockly.Cursor.CURSOR_COLOR = '#FFCC33';
+
+/**
+ * A reference to the current object that the cursor is associated with
+ * @type {goog.math.Coordinate|Blockly.Connection|Blockly.Field}
+ */
+Blockly.Cursor.CURSOR_REFERENCE = null;
+
+/**
+ * Create the zoom controls.
+ * @return {!Element} The zoom controls SVG group.
+ */
+Blockly.Cursor.prototype.createDom = function() {
+  this.svgGroup_ =
+      Blockly.utils.createSvgElement('g', {
+        'class': 'blocklyCursor',
+        'style': 'display: none'
+      }, null);
+
+  this.createCursorSvg_();
+  return this.svgGroup_;
+};
+
+/**
+ * Show the cursor on the workspace, use the event to determine it's positioning
+ * @param {!Event} e Mouse event for the shift click that is making the cursor appear.
+ * @param {boolean} rtl True if RTL, false if LTR.
+ * @package
+ */
+Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
+  var ws = this.workspace_;
+  var injectionDiv = ws.getInjectionDiv();
+  // Bounding rect coordinates are in client coordinates, meaning that they
+  // are in pixels relative to the upper left corner of the visible browser
+  // window.  These coordinates change when you scroll the browser window.
+  var boundingRect = injectionDiv.getBoundingClientRect();
+
+  // The client coordinates offset by the injection div's upper left corner.
+  var clientOffsetPixels = new goog.math.Coordinate(
+      e.clientX - boundingRect.left, e.clientY - boundingRect.top);
+
+  // The offset in pixels between the main workspace's origin and the upper
+  // left corner of the injection div.
+  var mainOffsetPixels = ws.getOriginOffsetInPixels();
+
+  // The position of the new comment in pixels relative to the origin of the
+  // main workspace.
+  var finalOffsetPixels = goog.math.Coordinate.difference(clientOffsetPixels,
+      mainOffsetPixels);
+
+  // The position of the new comment in main workspace coordinates.
+  var finalOffsetMainWs = finalOffsetPixels.scale(1 / ws.scale);
+
+  var cursorSize = new goog.math.Size(Blockly.Cursor.CURSOR_WIDTH, Blockly.Cursor.CURSOR_HEIGHT);
+
+  var x = finalOffsetMainWs.x + (rtl ? -cursorSize.width : cursorSize.width);
+  var y = finalOffsetMainWs.y;
+  this.showWithCoordinates_(x, y);
+};
+
+/**
+ * Show the cursor using coordinates
+ * @param {number} x The new x position to move the cursor to.
+ * @param {number} y The new y position to move the cursor to.
+ */
+Blockly.Cursor.prototype.showWithCoordinates_ = function(x, y) {
+  this.CURSOR_REFERENCE = new goog.math.Coordinate(x, y);
+  
+  this.cursorSvgRect_.setAttribute('x', x);
+  this.cursorSvgRect_.setAttribute('y', y);
+
+  this.show();
+};
+
+/**
+ * Show the cursor
+ */
+Blockly.Cursor.prototype.show = function() {
+  this.svgGroup_.style.display = '';
+};
+
+/**
+ * Hide the cursor.
+ */
+Blockly.Cursor.prototype.hide = function() {
+  this.svgGroup_.style.display = 'none';
+};
+
+/**
+ * Create the cursor svg.
+ * @return {Element} The SVG node created.
+ * @private
+ */
+Blockly.Cursor.prototype.createCursorSvg_ = function() {
+  /* This markup will be generated and added to the .svgGroup_:
+  <g>
+    <rect width="100" height="5">
+      <animate attributeType="XML" attributeName="fill" dur="1s"
+        values="transparent;transparent;#fff;transparent" repeatCount="indefinite" />
+    </rect>
+  </g>
+  */
+  this.cursorSvg_ = Blockly.utils.createSvgElement('g',
+      {
+        'width': Blockly.Cursor.CURSOR_WIDTH,
+        'height': Blockly.Cursor.CURSOR_HEIGHT
+      }, this.svgGroup_);
+  this.cursorSvgRect_ = Blockly.utils.createSvgElement('rect',
+      {
+        'x': '0',
+        'y': '0',
+        'fill': Blockly.Cursor.CURSOR_COLOR,
+        'width': Blockly.Cursor.CURSOR_WIDTH,
+        'height': Blockly.Cursor.CURSOR_HEIGHT
+      },
+      this.cursorSvg_);
+  Blockly.utils.createSvgElement('animate',
+      {
+        'attributeType': 'XML',
+        'attributeName': 'fill',
+        'dur': '1s',
+        'values': Blockly.Cursor.CURSOR_COLOR + ';transparent;transparent;',
+        'repeatCount': 'indefinite'
+      },
+      this.cursorSvgRect_);
+  return this.cursorSvg_;
+};

--- a/core/cursor.js
+++ b/core/cursor.js
@@ -112,7 +112,7 @@ Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
 
   var x = finalOffsetMainWs.x + (rtl ? -cursorSize.width : cursorSize.width);
   var y = finalOffsetMainWs.y;
-  this.showWithCoordinates_(x, y);
+  this.showWithCoordinates(x, y);
 };
 
 /**
@@ -120,12 +120,24 @@ Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
  * @param {number} x The new x position to move the cursor to.
  * @param {number} y The new y position to move the cursor to.
  */
-Blockly.Cursor.prototype.showWithCoordinates_ = function(x, y) {
+Blockly.Cursor.prototype.showWithCoordinates = function(x, y) {
   this.CURSOR_REFERENCE = new goog.math.Coordinate(x, y);
   
   this.cursorSvgRect_.setAttribute('x', x);
   this.cursorSvgRect_.setAttribute('y', y);
 
+  this.show();
+};
+
+/**
+ * Show the cursor using a connection
+ * @param {Blockly.Connection} connection The connection to position the cursor to
+ */
+Blockly.Cursor.prototype.showWithConnection = function(connection) {
+  this.CURSOR_REFERENCE = connection;
+
+  // TODO: position to connection
+  
   this.show();
 };
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -587,7 +587,7 @@ Blockly.Gesture.prototype.handleUp = function(e) {
   } else if (this.isBlockClick_()) {
     this.doBlockClick_();
   } else if (this.isWorkspaceClick_()) {
-    this.doWorkspaceClick_();
+    this.doWorkspaceClick_(e);
   }
 
   e.preventDefault();
@@ -753,10 +753,15 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
 
 /**
  * Execute a workspace click.
+ * @param {!Event} e A mouse up or touch end event.
  * @private
  */
-Blockly.Gesture.prototype.doWorkspaceClick_ = function() {
-  if (Blockly.selected) {
+Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
+  this.startWorkspace_.cursor_.hide();
+  if (e.shiftKey) {
+    // Show the cursor at the specified position
+    this.startWorkspace_.cursor_.workspaceShow(e, this.startWorkspace_.RTL);
+  } else if (Blockly.selected) {
     Blockly.selected.unselect();
   }
 };

--- a/core/inject.js
+++ b/core/inject.js
@@ -228,6 +228,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     mainWorkspace.addZoomControls();
   }
 
+  mainWorkspace.addCursor();
+
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);
   Blockly.mainWorkspace = mainWorkspace;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -48,6 +48,7 @@ goog.require('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.Xml');
 goog.require('Blockly.ZoomControls');
+goog.require('Blockly.Cursor');
 
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
@@ -531,6 +532,11 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
     this.zoomControls_ = null;
   }
 
+  if (this.cursor_) {
+    this.cursor_.dispose();
+    this.cursor_ = null;
+  }
+
   if (this.audioManager_) {
     this.audioManager_.dispose();
     this.audioManager_ = null;
@@ -593,6 +599,17 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
   this.zoomControls_ = new Blockly.ZoomControls(this);
   var svgZoomControls = this.zoomControls_.createDom();
   this.svgGroup_.appendChild(svgZoomControls);
+};
+
+/**
+ * Add zoom controls.
+ * @package
+ */
+Blockly.WorkspaceSvg.prototype.addCursor = function() {
+  /** @type {Blockly.Cursor} */
+  this.cursor_ = new Blockly.Cursor(this);
+  var svgCursor = this.cursor_.createDom();
+  this.svgGroup_.appendChild(svgCursor);
 };
 
 /**


### PR DESCRIPTION
Creates the Cursor class that is in charge of showing, positioning and rendering the cursor SVG into the workspace. 

Show the cursor using a mouse click when the shift key is down on the workspace at the position of the click.

The cursor currently animates using SVG SMIL but that's not supported on IE and Edge, I didn't want to spend too much time on rendering just yet, but we can animate with JS instead.
