### PR TITLE
Show the cursor with attached to a statement connection

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -80,6 +80,19 @@ Blockly.mainWorkspace = null;
 Blockly.selected = null;
 
 /**
+ * Current cursor.
+ * @type {Blockly.Cursor}
+ */
+Blockly.cursor = null;
+
+/**
+ * Whether or not we're currently in keyboard accessibility mode.
+ * @type {Boolean}
+ * @private
+ */
+Blockly.keyboardAccessibilityMode_ = false;
+
+/**
  * All of the connections on blocks that are currently being dragged.
  * @type {!Array.<!Blockly.Connection>}
  * @private
@@ -261,6 +274,12 @@ Blockly.onKeyDown_ = function(e) {
       Blockly.hideChaff();
       workspace.undo(e.shiftKey);
     }
+  } else if (Blockly.keyboardAccessibilityMode_
+      && (e.keyCode === goog.events.KeyCodes.UP
+        || e.keyCode === goog.events.KeyCodes.DOWN)) {
+    Blockly.Navigation.navigate(e);
+  } else if (Blockly.keyboardAccessibilityMode_ && e.keyCode === goog.events.KeyCodes.SPACE) {
+    Blockly.Navigation.setConnection();
   }
   // Common code for delete and cut.
   // Don't delete in the flyout.

--- a/core/cursor.js
+++ b/core/cursor.js
@@ -51,6 +51,13 @@ Blockly.Cursor.CURSOR_HEIGHT = 5;
 Blockly.Cursor.CURSOR_WIDTH = 100;
 
 /**
+ * The start length of the notch.
+ * @type {number}
+ * @const
+ */
+Blockly.Cursor.NOTCH_START_LENGTH = 24;
+
+/**
  * Cursor color.
  * @type {number}
  * @const
@@ -84,7 +91,7 @@ Blockly.Cursor.prototype.createDom = function() {
  * @param {boolean} rtl True if RTL, false if LTR.
  * @package
  */
-Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
+Blockly.Cursor.prototype.workspaceShow = function(e) {
   var ws = this.workspace_;
   var injectionDiv = ws.getInjectionDiv();
   // Bounding rect coordinates are in client coordinates, meaning that they
@@ -108,9 +115,7 @@ Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
   // The position of the new comment in main workspace coordinates.
   var finalOffsetMainWs = finalOffsetPixels.scale(1 / ws.scale);
 
-  var cursorSize = new goog.math.Size(Blockly.Cursor.CURSOR_WIDTH, Blockly.Cursor.CURSOR_HEIGHT);
-
-  var x = finalOffsetMainWs.x + (rtl ? -cursorSize.width : cursorSize.width);
+  var x = finalOffsetMainWs.x;
   var y = finalOffsetMainWs.y;
   this.showWithCoordinates(x, y);
 };
@@ -122,11 +127,8 @@ Blockly.Cursor.prototype.workspaceShow = function(e, rtl) {
  */
 Blockly.Cursor.prototype.showWithCoordinates = function(x, y) {
   this.CURSOR_REFERENCE = new goog.math.Coordinate(x, y);
-  
-  this.cursorSvgRect_.setAttribute('x', x);
-  this.cursorSvgRect_.setAttribute('y', y);
 
-  this.show();
+  this.show(x, y, Blockly.Cursor.CURSOR_WIDTH);
 };
 
 /**
@@ -134,17 +136,30 @@ Blockly.Cursor.prototype.showWithCoordinates = function(x, y) {
  * @param {Blockly.Connection} connection The connection to position the cursor to
  */
 Blockly.Cursor.prototype.showWithConnection = function(connection) {
+  if (!connection) {
+    return;
+  }
   this.CURSOR_REFERENCE = connection;
 
-  // TODO: position to connection
-  
-  this.show();
+  var targetBlock = connection.sourceBlock_;
+  var xy = targetBlock.getRelativeToSurfaceXY();
+  this.show(xy.x + connection.offsetInBlock_.x - Blockly.Cursor.NOTCH_START_LENGTH,
+      xy.y + connection.offsetInBlock_.y, targetBlock.getHeightWidth().width);
 };
 
 /**
- * Show the cursor
+ * Move and show the cursor at the specified coordinate in workspace units.
+ * @param {number} x The new x, in workspace units.
+ * @param {number} y The new y, in workspace units.
+ * @param {number} width The new width, in workspace units.
  */
-Blockly.Cursor.prototype.show = function() {
+Blockly.Cursor.prototype.show = function(x, y, width) {
+  var cursorSize = new goog.math.Size(Blockly.Cursor.CURSOR_WIDTH, Blockly.Cursor.CURSOR_HEIGHT);
+
+  this.cursorSvgRect_.setAttribute('x', x + (this.workspace_.RTL ? -cursorSize.width : cursorSize.width));
+  this.cursorSvgRect_.setAttribute('y', y);
+  this.cursorSvgRect_.setAttribute('width', width);
+  
   this.svgGroup_.style.display = '';
 };
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -757,10 +757,12 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
  * @private
  */
 Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
-  this.startWorkspace_.cursor_.hide();
+  Blockly.keyboardAccessibilityMode_ = false;
+  Blockly.cursor.hide();
   if (e.shiftKey) {
     // Show the cursor at the specified position
-    this.startWorkspace_.cursor_.workspaceShow(e, this.startWorkspace_.RTL);
+    Blockly.cursor.workspaceShow(e);
+    Blockly.keyboardAccessibilityMode_ = true;
   } else if (Blockly.selected) {
     Blockly.selected.unselect();
   }

--- a/core/inject.js
+++ b/core/inject.js
@@ -228,7 +228,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     mainWorkspace.addZoomControls();
   }
 
-  mainWorkspace.addCursor();
+  Blockly.cursor = mainWorkspace.addCursor();
 
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -49,6 +49,7 @@ Blockly.Navigation.navigateBetweenStacks = function(forward) {
 
 Blockly.Navigation.setConnection = function() {
   Blockly.Navigation.connection = Blockly.selected.previousConnection;
+  Blockly.cursor.showWithConnection(Blockly.selected.previousConnection);
 };
 
 Blockly.Navigation.keyboardNext = function() {
@@ -65,6 +66,7 @@ Blockly.Navigation.keyboardNext = function() {
     nextConnection = curConnect.sourceBlock_.nextConnection;
   }
   //Set cursor here
+  Blockly.cursor.showWithConnection(nextConnection);
   Blockly.Navigation.connection = nextConnection;
   return nextConnection;
 };
@@ -83,6 +85,23 @@ Blockly.Navigation.keyboardPrev = function() {
     prevConnection = curConnect.sourceBlock_.previousConnection;
   }
   //Set cursor here
+  Blockly.cursor.showWithConnection(prevConnection);
   Blockly.Navigation.connection = prevConnection;
   return prevConnection;
+};
+
+Blockly.Navigation.navigate = function(e) {
+  if (e.keyCode === goog.events.KeyCodes.UP) {
+    Blockly.Navigation.keyboardPrev();
+  } else if (e.keyCode === goog.events.KeyCodes.DOWN) {
+    Blockly.Navigation.keyboardNext();
+  }
+};
+
+Blockly.Navigation.enableKeyboardAccessibility = function() {
+  Blockly.keyboardAccessibilityMode_ = true;
+};
+
+Blockly.Navigation.disableKeyboardAccessibility = function() {
+  Blockly.keyboardAccessibilityMode_ = false;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -604,12 +604,14 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
 /**
  * Add zoom controls.
  * @package
+ * @return {Blockly.Cursor} return the created cursor
  */
 Blockly.WorkspaceSvg.prototype.addCursor = function() {
   /** @type {Blockly.Cursor} */
   this.cursor_ = new Blockly.Cursor(this);
   var svgCursor = this.cursor_.createDom();
   this.svgGroup_.appendChild(svgCursor);
+  return this.cursor_;
 };
 
 /**


### PR DESCRIPTION
Support showing a cursor that's associated with a PREV/NEXT connection. Input/Output still to come.

Renders the cursor on the workspace, and moves it to the prev/next connection coordinates taking into account the offset.

Helper methods for enabling / disabling keyboard accessibility mode. 
For testing: Use space to set the cursor at the previous connection of a selected block.
