### PR TITLE
Access colours using bracket notation

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -929,11 +929,11 @@ Blockly.Block.prototype.setStyle = function(blockStyleName) {
   this.styleName_ = blockStyleName;
 
   if (blockStyle) {
-    this.secondaryColour_ = blockStyle.secondaryColour;
-    this.tertiaryColour_ = blockStyle.tertiaryColour;
+    this.secondaryColour_ = blockStyle['secondaryColour'];
+    this.tertiaryColour_ = blockStyle['tertiaryColour'];
     this.hat = blockStyle.hat;
     // Set colour will trigger an updateColour() on a block_svg
-    this.setColour(blockStyle.primaryColour);
+    this.setColour(blockStyle['primaryColour']);
   }
   else {
     throw Error('Invalid style name: ' + blockStyleName);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Resolves #2215

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Use ['primaryColour'] instead of .primaryColour because strings do not get changed during compilation unlike .primaryColour.

### Reason for Changes
.primaryColour was getting changed to a different variable name and the value name on the style was not. 

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
