### PR TITLE
Ignore insertion markers when checking remaining capacity

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -513,7 +513,18 @@ Blockly.Workspace.prototype.remainingCapacity = function() {
   if (isNaN(this.options.maxBlocks)) {
     return Infinity;
   }
-  return this.options.maxBlocks - this.getAllBlocks().length;
+
+  // Insertion markers exist on the workspace for rendering reasons, but should
+  // be ignored in capacity calculation because they dissolve at the end of a
+  // drag.
+  var allBlocks = this.getAllBlocks();
+  var allBlocksCount = allBlocks.length;
+  for (var i = 0; i < allBlocks.length; i++) {
+    if (allBlocks[i].isInsertionMarker()) {
+      allBlocksCount--;
+    }
+  }
+  return this.options.maxBlocks - allBlocksCount;
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2216 

### Proposed Changes

Subtract insertion marker blocks from the count of blocks on the workspace when checking remaining capacity.

### Reason for Changes

See #2216 

