### PR TITLE
Added FinishedLoading Event

### DIFF
--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -111,6 +111,7 @@ goog.addDependency("../../../" + dir + "/core/workspace_comment_render_svg.js", 
 goog.addDependency("../../../" + dir + "/core/workspace_comment_svg.js", ['Blockly.WorkspaceCommentSvg'], ['Blockly.Events.CommentCreate', 'Blockly.Events.CommentDelete', 'Blockly.Events.CommentMove', 'Blockly.utils', 'Blockly.WorkspaceComment', 'goog.math.Coordinate']);
 goog.addDependency("../../../" + dir + "/core/workspace_drag_surface_svg.js", ['Blockly.WorkspaceDragSurfaceSvg'], ['Blockly.utils']);
 goog.addDependency("../../../" + dir + "/core/workspace_dragger.js", ['Blockly.WorkspaceDragger'], ['goog.math.Coordinate']);
+goog.addDependency("../../../" + dir + "/core/workspace_events.js", ['Blockly.Events.FinishedLoading'], ['Blockly.Events', 'Blockly.Events.Abstract']);
 goog.addDependency("../../../" + dir + "/core/workspace_svg.js", ['Blockly.WorkspaceSvg'], ['Blockly.ConnectionDB', 'Blockly.constants', 'Blockly.Events.BlockCreate', 'Blockly.Gesture', 'Blockly.Grid', 'Blockly.Options', 'Blockly.ScrollbarPair', 'Blockly.Touch', 'Blockly.TouchGesture', 'Blockly.Trashcan', 'Blockly.utils', 'Blockly.VariablesDynamic', 'Blockly.Workspace', 'Blockly.WorkspaceAudio', 'Blockly.WorkspaceComment', 'Blockly.WorkspaceCommentSvg', 'Blockly.WorkspaceCommentSvg.render', 'Blockly.WorkspaceDragSurfaceSvg', 'Blockly.Xml', 'Blockly.ZoomControls', 'goog.dom', 'goog.math.Coordinate']);
 goog.addDependency("../../../" + dir + "/core/ws_comment_events.js", ['Blockly.Events.CommentBase', 'Blockly.Events.CommentChange', 'Blockly.Events.CommentCreate', 'Blockly.Events.CommentDelete', 'Blockly.Events.CommentMove'], ['Blockly.Events', 'Blockly.Events.Abstract', 'Blockly.Xml', 'Blockly.Xml.utils', 'goog.math.Coordinate']);
 goog.addDependency("../../../" + dir + "/core/xml.js", ['Blockly.Xml'], ['Blockly.Events.BlockCreate', 'Blockly.Events.VarCreate', 'Blockly.Xml.utils']);
@@ -1764,6 +1765,7 @@ goog.require('Blockly.Events.CommentDelete');
 goog.require('Blockly.Events.CommentMove');
 goog.require('Blockly.Events.Create');
 goog.require('Blockly.Events.Delete');
+goog.require('Blockly.Events.FinishedLoading');
 goog.require('Blockly.Events.Move');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Events.VarBase');

--- a/core/events.js
+++ b/core/events.js
@@ -150,6 +150,11 @@ Blockly.Events.COMMENT_CHANGE = 'comment_change';
 Blockly.Events.COMMENT_MOVE = 'comment_move';
 
 /**
+ * Name of event that records a workspace load.
+ */
+Blockly.Events.FINISHED_LOADING = 'finished_loading';
+
+/**
  * List of events queued for firing.
  * @private
  */

--- a/core/workspace_events.js
+++ b/core/workspace_events.js
@@ -2,8 +2,7 @@
  * @license
  * Visual Blocks Editor
  *
- * TODO: 2019 instead of 2018???
- * Copyright 2018 Google Inc.
+ * Copyright 2019 Google Inc.
  * https://developers.google.com/blockly/
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/workspace_events.js
+++ b/core/workspace_events.js
@@ -68,7 +68,7 @@ Blockly.Events.FinishedLoading.prototype.type = Blockly.Events.FINISHED_LOADING;
  * Encode the event as JSON.
  * @return {!Object} JSON representation.
  */
-Blockly.Events.Ui.prototype.toJson = function() {
+Blockly.Events.FinishedLoading.prototype.toJson = function() {
   var json = {
     'type': this.type,
   };
@@ -85,7 +85,7 @@ Blockly.Events.Ui.prototype.toJson = function() {
  * Decode the JSON event.
  * @param {!Object} json JSON representation.
  */
-Blockly.Events.Ui.prototype.fromJson = function(json) {
+Blockly.Events.FinishedLoading.prototype.fromJson = function(json) {
   this.workspaceId = json['workspaceId'];
   this.group = json['group'];
 };

--- a/core/workspace_events.js
+++ b/core/workspace_events.js
@@ -25,7 +25,7 @@
  */
 'use strict';
 
-goog.provide(Blockly.Events.FinishedLoading);
+goog.provide('Blockly.Events.FinishedLoading');
 
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Abstract');

--- a/core/workspace_events.js
+++ b/core/workspace_events.js
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * TODO: 2019 instead of 2018???
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class for a finished loading workspace event.
+ * @author BeksOmega
+ */
+'use strict';
+
+goog.provide(Blockly.Events.FinishedLoading);
+
+goog.require('Blockly.Events');
+goog.require('Blockly.Events.Abstract');
+
+/**
+ * Class for a finished loading event.
+ * Used to notify the developer when the workspace has finished loading (i.e
+ * domToWorkspace).
+ * Finished loading events do not record undo or redo.
+ * @param {!Blockly.Workspace} workspace The workspace that has finished
+ *    loading.
+ * @constructor
+ */
+Blockly.Events.FinishedLoading = function(workspace) {
+  /**
+   * The workspace identifier for this event.
+   * @type {string}
+   */
+  this.workspaceId = workspace.id;
+
+  /**
+   * The event group id for the group this event belongs to. Groups define
+   * events that should be treated as an single action from the user's
+   * perspective, and should be undone together.
+   * @type {string}
+   */
+  this.group = Blockly.Events.group_;
+
+  // Workspace events do not undo or redo.
+  this.recordUndo = false;
+};
+goog.inherits(Blockly.Events.FinishedLoading, Blockly.Events.Abstract);
+
+/**
+ * Type of this event.
+ * @type {string}
+ */
+Blockly.Events.FinishedLoading.prototype.type = Blockly.Events.FINISHED_LOADING;
+
+/**
+ * Encode the event as JSON.
+ * @return {!Object} JSON representation.
+ */
+Blockly.Events.Ui.prototype.toJson = function() {
+  var json = {
+    'type': this.type,
+  };
+  if (this.group) {
+    json['group'] = this.group;
+  }
+  if (this.workspaceId) {
+    json['workspaceId'] = this.workspaceId;
+  }
+  return json;
+};
+
+/**
+ * Decode the JSON event.
+ * @param {!Object} json JSON representation.
+ */
+Blockly.Events.Ui.prototype.fromJson = function(json) {
+  this.workspaceId = json['workspaceId'];
+  this.group = json['group'];
+};

--- a/core/xml.js
+++ b/core/xml.js
@@ -31,9 +31,9 @@
 goog.provide('Blockly.Xml');
 
 goog.require('Blockly.Events.BlockCreate');
+goog.require('Blockly.Events.FinishedLoading');
 goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.Xml.utils');
-goog.require('Blockly.Events.FinishedLoading');
 
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -33,6 +33,7 @@ goog.provide('Blockly.Xml');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.Xml.utils');
+goog.require('Blockly.Events.FinishedLoading');
 
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -467,6 +467,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   if (workspace.setResizesEnabled) {
     workspace.setResizesEnabled(true);
   }
+  Blockly.Events.fire(new Blockly.Events.FinishedLoading(workspace));
   return newBlockIds;
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
#2142 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Quote from Issue:
> Developers sometimes want to run some actions after a workspace finishes loading. There is no event to indicate this right now.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1 . Turned on "Log events" in the playground.
2 . Hit the "Spaghetti" button.
3 . Observed how a FinishedLoading event was correctly fired. (pass)

1 . Changed the following code ~ln 251 in playground:
```
  console.time('Spaghetti domToWorkspace');
  Blockly.Xml.domToWorkspace(dom, workspace);
  console.timeEnd('Spaghetti domToWorkspace');
```
To:
 ```
  console.time('Spaghetti domToWorkspace');
  Blockly.Events.setGroup(true);
  console.log(Blockly.Events.group_);
  Blockly.Xml.domToWorkspace(dom, workspace);
  Blockly.Events.setGroup(false);
  console.timeEnd('Spaghetti domToWorkspace');
```
2 . Hit the "Spaghetti" button.
3 . Observed how a FinishedLoading event (with the correct group) was fired. (pass)

1 . Added the following code at ~ln 256 in playground (at the top of the spaghettiXml var):
`'  <shadow type="controsl_if"></shadow>',`
2 . Hit the "Spaghetti" button.
3 . Observed how the FinishedLoading event was not fired, because an error was thrown. (pass)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
I'm not sure the FinishedLoading event needed to be in a new file, but I couldn't decide where else to put it. If it does need to be in a new file, I'm not sure if the copyright should be updated to 2019 or not.