### PR TITLE
Fixed Trashcan Hotspot & Changed Positioning

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -366,8 +366,6 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
     }
     // Record the height for .getMetrics_ and .position.
     this.height_ = flyoutHeight;
-    // Call this since it is possible the trash and zoom buttons need
-    // to move. e.g. on a bottom positioned flyout when zoom is clicked.
-    this.targetWorkspace_.resize();
+    this.position();
   }
 };

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -392,8 +392,6 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
     }
     // Record the width for .getMetrics_ and .position.
     this.width_ = flyoutWidth;
-    // Call this since it is possible the trash and zoom buttons need
-    // to move. e.g. on a bottom positioned flyout when zoom is clicked.
-    this.targetWorkspace_.resize();
+    this.position();
   }
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -56,7 +56,8 @@ Blockly.Trashcan = function(workspace) {
         Blockly.TOOLBOX_AT_BOTTOM : Blockly.TOOLBOX_AT_TOP;
     this.flyout_ = new Blockly.HorizontalFlyout(flyoutWorkspaceOptions);
   } else {
-    flyoutWorkspaceOptions.toolboxPosition = this.workspace_.RTL ?
+    flyoutWorkspaceOptions.toolboxPosition =
+      this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT ?
         Blockly.TOOLBOX_AT_LEFT : Blockly.TOOLBOX_AT_RIGHT;
     this.flyout_ = new Blockly.VerticalFlyout(flyoutWorkspaceOptions);
   }
@@ -304,9 +305,8 @@ Blockly.Trashcan.prototype.dispose = function() {
 
 /**
  * Position the trashcan.
- * It is positioned in the upper corner when the toolbox is on bottom, and the
- * bottom corner for all other toolbox positions. It is on the right in LTR,
- * and left in RTL.
+ * It is positioned in the opposite corner to the corner the
+ * categories/toolbox starts at.
  */
 Blockly.Trashcan.prototype.position = function() {
   // Not yet initialized.
@@ -318,21 +318,14 @@ Blockly.Trashcan.prototype.position = function() {
     // There are no metrics available (workspace is probably not visible).
     return;
   }
-  if (this.workspace_.RTL) {
-    this.left_ = this.MARGIN_SIDE_ + Blockly.Scrollbar.scrollbarThickness;
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
-      this.left_ += metrics.flyoutWidth;
-      if (this.workspace_.toolbox_) {
-        this.left_ += metrics.absoluteLeft;
-      }
-    }
-  } else {
+  if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_LEFT
+    || (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
+    // Toolbox starts in the left corner.
     this.left_ = metrics.viewWidth + metrics.absoluteLeft -
-        this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
-
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-      this.left_ -= metrics.flyoutWidth;
-    }
+      this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
+  } else {
+    // Toolbox starts in the right corner.
+    this.left_ = this.MARGIN_SIDE_ + Blockly.Scrollbar.scrollbarThickness;
   }
 
   if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -131,7 +131,9 @@ Blockly.ZoomControls.prototype.dispose = function() {
 };
 
 /**
- * Move the zoom controls to the bottom-right corner.
+ * Position the zoom controls.
+ * It is positioned in the opposite corner to the corner the
+ * categories/toolbox starts at.
  */
 Blockly.ZoomControls.prototype.position = function() {
   // Not yet initialized.
@@ -143,21 +145,14 @@ Blockly.ZoomControls.prototype.position = function() {
     // There are no metrics available (workspace is probably not visible).
     return;
   }
-  if (this.workspace_.RTL) {
-    this.left_ = this.MARGIN_SIDE_ + Blockly.Scrollbar.scrollbarThickness;
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
-      this.left_ += metrics.flyoutWidth;
-      if (this.workspace_.toolbox_) {
-        this.left_ += metrics.absoluteLeft;
-      }
-    }
-  } else {
+  if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_LEFT
+    || (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
+    // Toolbox starts in the left corner.
     this.left_ = metrics.viewWidth + metrics.absoluteLeft -
-        this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
-
-    if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-      this.left_ -= metrics.flyoutWidth;
-    }
+      this.WIDTH_ - this.MARGIN_SIDE_ - Blockly.Scrollbar.scrollbarThickness;
+  } else {
+    // Toolbox starts in the right corner.
+    this.left_ = this.MARGIN_SIDE_ + Blockly.Scrollbar.scrollbarThickness;
   }
 
   if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2237 also similar to #2035 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The trashcan and zoom controls are now positioned in the corner opposite the toolbox. (This just changes LTR, Vertical, End & RTL, Vertical, End)
![toolboxesvertical](https://user-images.githubusercontent.com/25440652/51873335-a0c21180-2311-11e9-99ea-c41be326d3a9.jpg)
![toolboxeshorizontal](https://user-images.githubusercontent.com/25440652/51873337-a28bd500-2311-11e9-8129-be97810aa7c7.jpg)

Also replaces a call to workspace.resize() with a call to flyout.position() which corrects the trashcan hotspot bug.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) Removes the "chasing" of zoom controls that would occure when resizing the LTR, Vertical, End & RTL, Vertical, End workspaces when they had simple toolboxes.
2) Allows us to replace the workspace.resize() call with a call to flyout.position(), because the reason resize was called was specifically to move the trashcan (bad behavior stop it!). Replacing this call fixes the hotspot problem.

Plus the multiplayground looks very nice now =D

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Opened the multiplayground, and set the toolbox mode to simple.
2. Observed how all of the trashcans & zoom controls were positioned correctly (pass).
3. Pressed the + & - zoom controls. Observed that the flyouts were being resized, but the trashcan & zoom controls were not moving. (pass)
4. Dragged a block from the flyout into the trashcan. Observed how the hotspot was correct. (pass)
5. Clicked the trashcan. Observed how the flyout was created in the correct location, over the trashcan. (pass)
6. Dragged a block out of the trashcan flyout back into the trashcan. Observed how the hotspot was still correct (pass)
7. Repeated steps 3-6 for every workspace on the multiplayground.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
Possible follow-up PR:
The trashcan lid opens on the left in LTR mode and on the right in RTL mode. This now feels weird for the Vertical, End workspaces because they open in the opposite direction you generally drag blocks into them from.
![trashcanliddirection](https://user-images.githubusercontent.com/25440652/51874088-68700280-2314-11e9-8e89-ce734e3d9931.gif)
Is this something you peoples would like changed?