### PR TITLE
Changed Trashcan Lid Opening Direction

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -398,9 +398,11 @@ Blockly.Trashcan.prototype.animateLid_ = function() {
  * @private
  */
 Blockly.Trashcan.prototype.setLidAngle_ = function(lidAngle) {
+  var openAtRight = this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT
+    || (this.workspace_.horizontalLayout && this.workspace_.RTL);
   this.svgLid_.setAttribute('transform', 'rotate(' +
-    (this.workspace_.RTL ? -lidAngle : lidAngle) + ',' +
-    (this.workspace_.RTL ? 4 : this.WIDTH_ - 4) + ',' +
+    (openAtRight ? -lidAngle : lidAngle) + ',' +
+    (openAtRight ? 4 : this.WIDTH_ - 4) + ',' +
     (this.LID_HEIGHT_ - 2) + ')');
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
See Additional Information on #2240 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes the trashcan lid animation so that it always opens towards the workspace (i.e. the direction blocks will be comming from).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Feels better. ¯\\\_(ツ)_/¯ 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Opened the multiplayground.
2. Dragged a block towards the trashcan. Observed how it opened in the "correct" direction. (pass)
3. Repeated step 2 for every workspace.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
