### PR TITLE
Ignore insertion markers in getAllBlocks; add accessors for insertion markers

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -351,3 +351,19 @@ Blockly.BlockDragger.prototype.dragIcons_ = function(dxy) {
     data.icon.setIconLocation(goog.math.Coordinate.sum(data.location, dxy));
   }
 };
+
+/**
+ * Get a list of the insertion markers that currently exist.  Drags have 0, 1,
+ * or 2 insertion markers.
+ * @return {!Array.<!Blockly.BlockSvg>} A possibly empty list of insertion
+ *     marker blocks.
+ * @package
+ */
+Blockly.BlockDragger.prototype.getInsertionMarkers = function() {
+  // No insertion markers with the old style of dragged connection managers.
+  if (this.draggedConnectionManager_ &&
+      this.draggedConnectionManager_.getInsertionMarkers) {
+    return this.draggedConnectionManager_.getInsertionMarkers();
+  }
+  return [];
+};

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -940,3 +940,17 @@ Blockly.Gesture.prototype.isDragging = function() {
 Blockly.Gesture.prototype.hasStarted = function() {
   return this.hasStarted_;
 };
+
+/**
+ * Get a list of the insertion markers that currently exist.  Block drags have
+ * 0, 1, or 2 insertion markers.
+ * @return {!Array.<!Blockly.BlockSvg>} A possibly empty list of insertion
+ *     marker blocks.
+ * @package
+ */
+Blockly.Gesture.prototype.getInsertionMarkers = function() {
+  if (this.blockDragger_) {
+    return this.blockDragger_.getInsertionMarkers();
+  }
+  return [];
+};

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -696,3 +696,21 @@ Blockly.InsertionMarkerManager.prototype.connectMarker_ = function() {
 };
 
 /**** End insertion marker display functions ****/
+
+/**
+ * Get a list of the insertion markers that currently exist.  Drags have 0, 1,
+ * or 2 insertion markers.
+ * @return {!Array.<!Blockly.BlockSvg>} A possibly empty list of insertion
+ *     marker blocks.
+ * @package
+ */
+Blockly.InsertionMarkerManager.prototype.getInsertionMarkers = function() {
+  var result = [];
+  if (this.firstMarker_) {
+    result.push(this.firstMarker_);
+  }
+  if (this.lastMarker_) {
+    result.push(this.lastMarker_);
+  }
+  return result;
+};

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -328,7 +328,14 @@ Blockly.Workspace.prototype.getAllBlocks = function(ordered) {
       blocks.push.apply(blocks, blocks[i].getChildren(false));
     }
   }
-  return blocks;
+
+  // Insertion markers exist on the workspace for rendering reasons, but aren't
+  // "real" blocks from a developer perspective.
+  var filtered = blocks.filter(function(block) {
+    return !block.isInsertionMarker();
+  });
+
+  return filtered;
 };
 
 /**
@@ -514,17 +521,7 @@ Blockly.Workspace.prototype.remainingCapacity = function() {
     return Infinity;
   }
 
-  // Insertion markers exist on the workspace for rendering reasons, but should
-  // be ignored in capacity calculation because they dissolve at the end of a
-  // drag.
-  var allBlocks = this.getAllBlocks();
-  var allBlocksCount = allBlocks.length;
-  for (var i = 0; i < allBlocks.length; i++) {
-    if (allBlocks[i].isInsertionMarker()) {
-      allBlocksCount--;
-    }
-  }
-  return this.options.maxBlocks - allBlocksCount;
+  return this.options.maxBlocks - this.getAllBlocks().length;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -900,6 +900,13 @@ Blockly.WorkspaceSvg.prototype.render = function() {
   for (var i = blocks.length - 1; i >= 0; i--) {
     blocks[i].render(false);
   }
+
+  if (this.currentGesture_) {
+    var imList = this.currentGesture_.getInsertionMarkers();
+    for (var i = 0; i < imList.length; i++) {
+      imList[i].render(false);
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2236

### Proposed Changes

Stop counting insertion markers in the results of getAllBlocks.  Add an accessor for getting the current live insertion markers from a gesture.

It also would have worked to have an optional parameter to getAllBlocks, but I decided to leave its signature alone and do something a little more complicated but only in internal code.  This way we don't add yet another thing to the external API.

### Reason for Changes

See #2236 
### Test Coverage
Tested in the max blocks demo with uncompressed blockly.

### Additional Information

This might also apply to `workspace.getBlocksByType`, `getTopBlocks`, etc.  It's kind of unfortunate: there are good reasons for the blocks to be in the top blocks list, mostly related to behaving like perfectly normal blocks for connection and disconnection purposes, but in all other cases they're unwanted.