### PR TITLE
Fixed Image Dropdowns on Disabled Blocks not Rendering Correctly.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -204,8 +204,6 @@ Blockly.Field.prototype.init = function() {
   this.mouseDownWrapper_ =
       Blockly.bindEventWithChecks_(
           this.fieldGroup_, 'mousedown', this, this.onMouseDown_);
-  // Force a render.
-  this.render_();
 };
 
 /**
@@ -375,7 +373,7 @@ Blockly.Field.prototype.render_ = function() {
 };
 
 /**
- * Updates thw width of the field. This calls getCachedWidth which won't cache
+ * Updates the width of the field. This calls getCachedWidth which won't cache
  * the approximated width on IE/Edge when `getComputedTextLength` fails. Once
  * it eventually does succeed, the result will be cached.
  */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2238 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
So the problem is that the first time FieldDropdown.renderSelectedImage_ is called the dropdown arrow is not yet rendered, which causes the FieldDropdown to calculate its size incorrectly. By happy accident, if the block is enabled the field is forced to rerender because of updateColor(), but when the block is disabled this does not happen, so it is stuck with the incorrect size.

The incorrect first size calculation is triggered as follows: (function names link to the function, arrows link to the call)
[xml.domToBlock](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/xml.js#L535) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/xml.js#L555)
[block.initSvg](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_svg.js#L147) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_svg.js#L152)
[Input.init](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/input.js#L230) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/input.js#L235)
[Field.init](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field.js#L179) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field.js#L208)
[FieldDropdown.render_](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field_dropdown.js#L431) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field_dropdown.js#L450)
[FieldDropdown.renderSelectedImage_](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field_dropdown.js#L463)

#### I believe this can be corrected by removing the call to FieldDropdown.render_ in Field.init.

If block.render() is always called after Field.init / Input.init we can safely remove the render_ call in Field.init because block.render() triggers the following:
[block.render](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_render_svg.js#L318) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_render_svg.js#L336)
[block.renderCompute_](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_render_svg.js#L404) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_render_svg.js#L480)
[field.getSize](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field.js#L456) [>](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field.js#L458)
[FieldDropdown.render_](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/field_dropdown.js#L431)

Field.init is called in three places (as far as I can tell): 1) [block_svg.setCollapsed()](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_svg.js#L511) 2)[ input.insertFieldAt()](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/input.js#L111) 3) [input.init()](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/input.js#L235).

After block_svg.setCollapsed() calls Field.init() it calls block.render() [here](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/block_svg.js#L525). So if we remove the FieldDropdown.render_() call it will not cause problems here.

After input.insertFieldAt() calls Field.init() it calls block.render() [here](https://github.com/google/blockly/blob/3342a375ff0cee0be42062765d24922be2917170/core/input.js#L128). So if we remove the FieldDropdown.render_() call it will not cause problems here.

After input.init() calls Field.init it does not call block.render(), but luckily the only place input.init() gets called (again as far as I can tell) is from BlockSvg.initSvg(), and anytime BlockSvg.initSvg() is called block.render() is also called. So if we remove the FieldDropdown.render_() call it will not cause problems here either.

#### TL:DR (or another way of thinking about it)
It does not make sense for render_ to be called inside Field.init because the calculations aren't ready to be performed. If they were ready to be performed we wouldn't have the problem of the width being incorrectly calculated in the first place.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixes dropdowns being rendered incorrectly, also removes some extra calculations we don't need to do.

First 5 Spaghetti tests include the render_ call. Average time: 2856 ms
Last 5 Spaghetti tests do not include the render_ call. Average time: 2521 ms.
![spaghetti tests](https://user-images.githubusercontent.com/25440652/51949474-822b4b80-23e1-11e9-9731-e8fbcf08b0e8.jpg)


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1 . Opened up the playground.
2 . Clicked through all of the categories.
3 . Observed how everything was rendering correctly. (pass)

1 . Went to: tests/playground.html?toolbox=test-blocks
2 . From the 'Fields' category, created a block with the image dropdown.
3 . Right-clicked, disabled block.
4 . Right-clicked, duplicated block.
5 . Observed how the block was duplicated correctly. (pass)

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
I apologize for writing war and peace on your github.
