### PR TITLE
Movement Updates

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -946,6 +946,12 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
+    if (!this.workspace.isMovable_()) {
+      // If we center on the block and the workspace isn't movable we could
+      // loose blocks at the edges of the workspace.
+      return;
+    }
+
     var option = {enabled: true};
     option.text = Blockly.Msg['PROCEDURES_HIGHLIGHT_DEF'];
     var name = this.getProcedureCall();

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -946,7 +946,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * @this Blockly.Block
    */
   customContextMenu: function(options) {
-    if (!this.workspace.isMovable_()) {
+    if (!this.workspace.isMovable()) {
       // If we center on the block and the workspace isn't movable we could
       // loose blocks at the edges of the workspace.
       return;

--- a/core/events.js
+++ b/core/events.js
@@ -155,6 +155,21 @@ Blockly.Events.COMMENT_MOVE = 'comment_move';
 Blockly.Events.FINISHED_LOADING = 'finished_loading';
 
 /**
+ * List of events that cause objects to be bumped back into the visible
+ * portion of the workspace (only used for non-movable workspaces).
+ *
+ * Not to be confused with bumping so that disconnected connections to do
+ * not appear connected.
+ * @const
+ */
+Blockly.Events.BUMP_EVENTS = [
+  Blockly.Events.BLOCK_CREATE,
+  Blockly.Events.BLOCK_MOVE,
+  Blockly.Events.COMMENT_CREATE,
+  Blockly.Events.COMMENT_MOVE
+];
+
+/**
  * List of events queued for firing.
  * @private
  */

--- a/core/inject.js
+++ b/core/inject.js
@@ -288,10 +288,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // We always check isMovable_ again because the original
       // "not movable" state of isMovable_ could have been changed.
       if (!mainWorkspace.isDragging() && !mainWorkspace.isMovable() &&
-          (e.type == Blockly.Events.BLOCK_CREATE ||
-          e.type == Blockly.Events.BLOCK_MOVE ||
-          e.type == Blockly.Events.COMMENT_CREATE ||
-          e.type == Blockly.Events.COMMENT_MOVE)) {
+          (Blockly.Events.BUMP_EVENTS.indexOf(e.type) != -1)) {
         var metrics = getWorkspaceMetrics();
         if (metrics.contentTop < metrics.viewTop ||
             metrics.contentBottom > metrics.viewBottom ||
@@ -353,41 +350,6 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     };
     mainWorkspace.addChangeListener(bumpObjects);
   }
-
-  // A reminder for developers to add any events that have to do with
-  // objects on/in the workspace to the bumpObjects function. Useful when
-  // testing often happens on a bounded workspace.
-  var bumpObjectsEventChecker = function(e) {
-    switch (e.type) {
-      case Blockly.Events.BLOCK_CREATE:
-      case Blockly.Events.BLOCK_MOVE:
-      case Blockly.Events.COMMENT_CREATE:
-      case Blockly.Events.COMMENT_MOVE:
-        // bumpObjects activates on these events, they are a known factor.
-        // Nothing to worry about here.
-        break;
-      case Blockly.Events.BLOCK_CHANGE:
-      case Blockly.Events.BLOCK_DELETE:
-      case Blockly.Events.COMMENT_CHANGE:
-      case Blockly.Events.COMMENT_DELETE:
-      case Blockly.Events.VAR_CREATE:
-      case Blockly.Events.VAR_DELETE:
-      case Blockly.Events.VAR_RENAME:
-      case Blockly.Events.UI:
-      case Blockly.Events.FINISHED_LOADING:
-        // bumpObjects ignores these events, they are also a know factor.
-        // Nothing to worry about here.
-        break;
-      default:
-        // We found an event we don't know about. It may or may not need
-        // to activate bumpObjects, notify the developer.
-        // If your event has to do with objects on/in the workspace, add it to
-        // the bumpObjects function. Either way add a check to this function.
-        console.warn('Found an event that may need to be added to' +
-          ' bumpObjects. Please check before submitting a PR.');
-    }
-  };
-  mainWorkspace.addChangeListener(bumpObjectsEventChecker);
 
   // The SVG is now fully assembled.
   Blockly.svgResize(mainWorkspace);

--- a/core/inject.js
+++ b/core/inject.js
@@ -237,7 +237,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // If the event is of a type that does not affect block placement,
       // return. In this case it is better return-if rather than do-if so
       // that if events are added that should activate this function to work,
-      // people don't ned to remember to update it.
+      // people don't need to remember to update it.
       if (e.type == Blockly.Events.BLOCK_DELETE ||
           e.type == Blockly.Events.VAR_CREATE ||
           e.type == Blockly.Events.VAR_DELETE ||
@@ -326,7 +326,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
           }
           if (e) {
             if (!e.group && movedBlock) {
-              console.log('WARNING: Moved blocks in bounds but there was no event group.'
+              console.log('WARNING: Moved block in bounds but there was no event group.'
                         + ' This may break undo.');
             }
             Blockly.Events.setGroup(oldGroup);

--- a/core/inject.js
+++ b/core/inject.js
@@ -363,8 +363,8 @@ Blockly.init_ = function(mainWorkspace) {
     mainWorkspace.scrollbar.resize();
   } else {
     mainWorkspace.setMetrics({x: .5, y: .5});
-    // Makes it so zoom controls zoom correctly when the content is not
-    // bounded & the toolbox has categories.
+    // Makes it so metrics.viewLeft and metrics.viewTop are calculated
+    // correctly, as well as some other things (like zoom) that rely on scroll.
     var metrics = mainWorkspace.getMetrics();
     mainWorkspace.scrollX = metrics.absoluteLeft;
     mainWorkspace.scrollY = metrics.absoluteTop;

--- a/core/inject.js
+++ b/core/inject.js
@@ -232,7 +232,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   mainWorkspace.translate(0, 0);
   Blockly.mainWorkspace = mainWorkspace;
 
-  if (!options.readOnly && !mainWorkspace.isMovable_()) {
+  if (!options.readOnly && !mainWorkspace.isMovable()) {
     // Helper functions for the workspaceChanged callback.
     var getWorkspaceMetrics = function() {
       var workspaceMetrics = Object.create(null);
@@ -249,7 +249,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
       // Get the exact content metrics (in workspace units), even if the
       // content is bounded.
-      if (mainWorkspace.isContentBounded_()) {
+      if (mainWorkspace.isContentBounded()) {
         // Already in workspace units, no need to divide by scale.
         var blocksBoundingBox = mainWorkspace.getBlocksBoundingBox();
         workspaceMetrics.contentLeft = blocksBoundingBox.x;
@@ -287,7 +287,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     var bumpObjects = function(e) {
       // We always check isMovable_ again because the original
       // "not movable" state of isMovable_ could have been changed.
-      if (!mainWorkspace.isDragging() && !mainWorkspace.isMovable_() &&
+      if (!mainWorkspace.isDragging() && !mainWorkspace.isMovable() &&
           (e.type == Blockly.Events.BLOCK_CREATE ||
           e.type == Blockly.Events.BLOCK_MOVE ||
           e.type == Blockly.Events.COMMENT_CREATE ||

--- a/core/inject.js
+++ b/core/inject.js
@@ -269,20 +269,6 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
       return workspaceMetrics;
     };
-    var getWorkspaceObjectMetrics = function(object) {
-      var position = object.getRelativeToSurfaceXY();
-      var size = object.getHeightWidth();
-
-      return {
-        // In LTR the position is at the top-left of the block, and in RTL
-        // it is at the top-right of the block. We need to add the width
-        // accordingly.
-        left: position.x - (options.RTL ? size.width : 0),
-        right: position.x + (options.RTL ? 0 : size.width),
-        top: position.y,
-        bottom: position.y + size.height,
-      };
-    };
 
     var bumpObjects = function(e) {
       // We always check isMovable_ again because the original
@@ -312,28 +298,28 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
               var object = mainWorkspace.getCommentById(e.commentId);
               break;
           }
-          var objectMetrics = getWorkspaceObjectMetrics(object);
+          var objectMetrics = object.getBoundingRectangle();
 
           // Bump any object that's above the top back inside.
-          var overflowTop = metrics.viewTop - objectMetrics.top;
+          var overflowTop = metrics.viewTop - objectMetrics.topLeft.y;
           if (overflowTop > 0) {
             object.moveBy(0, overflowTop);
           }
 
           // Bump any object that's below the bottom back inside.
-          var overflowBottom = metrics.viewBottom - objectMetrics.bottom;
+          var overflowBottom = metrics.viewBottom - objectMetrics.bottomRight.y;
           if (overflowBottom < 0) {
             object.moveBy(0, overflowBottom);
           }
 
           // Bump any object that's off the left back inside.
-          var overflowLeft = metrics.viewLeft - objectMetrics.left;
+          var overflowLeft = metrics.viewLeft - objectMetrics.topLeft.x;
           if (overflowLeft > 0) {
             object.moveBy(overflowLeft, 0);
           }
 
           // Bump any object that's off the right back inside.
-          var overflowRight = metrics.viewRight - objectMetrics.right;
+          var overflowRight = metrics.viewRight - objectMetrics.bottomRight.x;
           if (overflowRight < 0) {
             object.moveBy(overflowRight, 0);
           }

--- a/core/inject.js
+++ b/core/inject.js
@@ -247,8 +247,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       workspaceMetrics.viewBottom =
           (defaultMetrics.viewTop + defaultMetrics.viewHeight) / scale;
 
-      // Get the exact content metrics in workspace units, even if the
-      // content is bound.
+      // Get the exact content metrics (in workspace units), even if the
+      // content is bounded.
       if (mainWorkspace.isContentBounded_()) {
         // Already in workspace units, not need to divide by scale.
         var blocksBoundingBox = mainWorkspace.getBlocksBoundingBox();
@@ -340,8 +340,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
           if (e) {
             if (!e.group) {
-              console.log('WARNING: Moved block in bounds but there was no event group.'
-                        + ' This may break undo.');
+              console.log('WARNING: Moved object in bounds but there was no' +
+                ' event group. This may break undo.');
             }
             Blockly.Events.setGroup(oldGroup);
           }

--- a/core/inject.js
+++ b/core/inject.js
@@ -281,7 +281,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       };
     };
 
-    var workspaceChanged = function(e) {
+    var bumpObjects = function(e) {
       // We always check isMovable_ again because the original
       // "not movable" state of isMovable_ could have been changed.
       if (!mainWorkspace.isDragging() && !mainWorkspace.isMovable_() &&
@@ -352,7 +352,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
         }
       }
     };
-    mainWorkspace.addChangeListener(workspaceChanged);
+    mainWorkspace.addChangeListener(bumpObjects);
   }
   // The SVG is now fully assembled.
   Blockly.svgResize(mainWorkspace);

--- a/core/inject.js
+++ b/core/inject.js
@@ -233,7 +233,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   Blockly.mainWorkspace = mainWorkspace;
 
   if (!options.readOnly && !mainWorkspace.isMovable()) {
-    // Helper functions for the workspaceChanged callback.
+    // Helper function for the workspaceChanged callback.
+    // TODO (#2300): Move metrics math back to the WorkspaceSvg.
     var getWorkspaceMetrics = function() {
       var workspaceMetrics = Object.create(null);
       var defaultMetrics = mainWorkspace.getMetrics();

--- a/core/inject.js
+++ b/core/inject.js
@@ -282,7 +282,6 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
             Blockly.Events.setGroup(e.group);
           }
 
-          var MARGIN = 25;
           var movedBlock = false;
           var block = mainWorkspace.getBlockById(e.blockId);
 
@@ -297,7 +296,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
           // Bump any block that's above the top back inside.
           var overflowTop =
-              metrics.viewTop + MARGIN - blockHW.height - blockXY.y;
+              metrics.viewTop - blockXY.y;
           if (overflowTop > 0) {
             // Convert to workspace units.
             overflowTop /= mainWorkspace.scale;
@@ -307,7 +306,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
           // Bump any block that's below the bottom back inside.
           var overflowBottom =
-            metrics.viewTop + metrics.viewHeight - MARGIN - blockXY.y;
+            metrics.viewTop + metrics.viewHeight - blockHW.height - blockXY.y;
           if (overflowBottom < 0) {
             // Convert to workspace units.
             overflowBottom /= mainWorkspace.scale;
@@ -316,8 +315,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
           }
 
           // Bump any block that's off the left back inside.
-          var overflowLeft = MARGIN + metrics.viewLeft -
-              blockXY.x - (options.RTL ? 0 : blockHW.width);
+          var overflowLeft = metrics.viewLeft -
+              blockXY.x + (options.RTL ? blockHW.width : 0);
           if (overflowLeft > 0) {
             // Convert to workspace units.
             overflowLeft /= mainWorkspace.scale;
@@ -326,8 +325,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
           }
 
           // Bump any block that's off the right back inside.
-          var overflowRight = metrics.viewLeft + metrics.viewWidth - MARGIN -
-              blockXY.x + (options.RTL ? blockHW.width : 0);
+          var overflowRight = metrics.viewLeft + metrics.viewWidth -
+              blockXY.x - (options.RTL ? 0 : blockHW.width);
           if (overflowRight < 0) {
             // Convert to workspace units.
             overflowRight /= mainWorkspace.scale;

--- a/core/inject.js
+++ b/core/inject.js
@@ -450,7 +450,7 @@ Blockly.init_ = function(mainWorkspace) {
   }
 
   if (mainWorkspace.flyout_) {
-    // Translate the workspace sideways to avoid the fixed flyout.
+    // Shift the workspace origin sideways to avoid the fixed flyout.
     switch (mainWorkspace.toolboxPosition) {
       case Blockly.TOOLBOX_AT_LEFT:
         mainWorkspace.scrollX =
@@ -466,7 +466,6 @@ Blockly.init_ = function(mainWorkspace) {
       // If the toolbox is at the top left (workspace origin) is untouched,
       // so no need to include it.
     }
-    mainWorkspace.translate(mainWorkspace.scrollX, mainWorkspace.scrollY);
   }
 
   // Load the sounds.

--- a/core/inject.js
+++ b/core/inject.js
@@ -275,7 +275,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
       return {
         // In LTR the position is at the top-left of the block, and in RTL
-        // it is at the top-right of the block, we need to add with accordingly.
+        // it is at the top-right of the block. We need to add the width
+        // accordingly.
         left: position.x - (options.RTL ? size.width : 0),
         right: position.x + (options.RTL ? 0 : size.width),
         top: position.y,
@@ -343,7 +344,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
           if (e) {
             if (!e.group) {
               console.log('WARNING: Moved object in bounds but there was no' +
-                ' event group. This may break undo.');
+                  ' event group. This may break undo.');
             }
             Blockly.Events.setGroup(oldGroup);
           }
@@ -380,7 +381,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       default:
         // We found an event we don't know about. It may or may not need
         // to activate bumpObjects, notify the developer.
-        // If your event has to with objects on/in the workspace, add it to
+        // If your event has to do with objects on/in the workspace, add it to
         // the bumpObjects function. Either way add a check to this function.
         console.warn('Found an event that may need to be added to' +
           ' bumpObjects. Please check before submitting a PR.');

--- a/core/inject.js
+++ b/core/inject.js
@@ -436,6 +436,9 @@ Blockly.init_ = function(mainWorkspace) {
  */
 Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
+    Blockly.bindEventWithChecks_(document, 'scroll', null,
+        Blockly.mainWorkspace.updateInverseScreenCTM
+            .bind(Blockly.mainWorkspace));
     Blockly.bindEventWithChecks_(document, 'keydown', null, Blockly.onKeyDown_);
     // longStop needs to run to stop the context menu from showing up.  It
     // should run regardless of what other touch event handlers have run.

--- a/core/inject.js
+++ b/core/inject.js
@@ -286,10 +286,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // "not movable" state of isMovable_ could have been changed.
       if (!mainWorkspace.isDragging() && !mainWorkspace.isMovable_() &&
           (e.type == Blockly.Events.BLOCK_CREATE ||
-          e.type == Blockly.Events.BLOCK_CHANGE ||
           e.type == Blockly.Events.BLOCK_MOVE ||
           e.type == Blockly.Events.COMMENT_CREATE ||
-          e.type == Blockly.Events.COMMENT_CHANGE ||
           e.type == Blockly.Events.COMMENT_MOVE)) {
         var metrics = getWorkspaceMetrics();
         if (metrics.contentTop < metrics.viewTop ||
@@ -306,12 +304,10 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
           switch (e.type) {
             case Blockly.Events.BLOCK_CREATE:
-            case Blockly.Events.BlockChange:
             case Blockly.Events.BLOCK_MOVE:
               var object = mainWorkspace.getBlockById(e.blockId);
               break;
             case Blockly.Events.COMMENT_CREATE:
-            case Blockly.Events.COMMENT_CHANGE:
             case Blockly.Events.COMMENT_MOVE:
               var object = mainWorkspace.getCommentById(e.commentId);
               break;
@@ -354,6 +350,42 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
     };
     mainWorkspace.addChangeListener(bumpObjects);
   }
+
+  // A reminder for developers to add any events that have to do with
+  // objects on/in the workspace to the bumpObjects function. Useful when
+  // testing often happens on a bounded workspace.
+  var bumpObjectsEventChecker = function(e) {
+    switch (e.type) {
+      case Blockly.Events.BLOCK_CREATE:
+      case Blockly.Events.BLOCK_MOVE:
+      case Blockly.Events.COMMENT_CREATE:
+      case Blockly.Events.COMMENT_MOVE:
+        // bumpObjects activates on these events, they are a known factor.
+        // Nothing to worry about here.
+        break;
+      case Blockly.Events.BLOCK_CHANGE:
+      case Blockly.Events.BLOCK_DELETE:
+      case Blockly.Events.COMMENT_CHANGE:
+      case Blockly.Events.COMMENT_DELETE:
+      case Blockly.Events.VAR_CREATE:
+      case Blockly.Events.VAR_DELETE:
+      case Blockly.Events.VAR_RENAME:
+      case Blockly.Events.UI:
+      case Blockly.Events.FINISHED_LOADING:
+        // bumpObjects ignores these events, they are also a know factor.
+        // Nothing to worry about here.
+        break;
+      default:
+        // We found an event we don't know about. It may or may not need
+        // to activate bumpObjects, notify the developer.
+        // If your event has to with objects on/in the workspace, add it to
+        // the bumpObjects function. Either way add a check to this function.
+        console.warn('Found an event that may need to be added to' +
+          ' bumpObjects. Please check before submitting a PR.');
+    }
+  };
+  mainWorkspace.addChangeListener(bumpObjectsEventChecker);
+
   // The SVG is now fully assembled.
   Blockly.svgResize(mainWorkspace);
   Blockly.WidgetDiv.createDom();

--- a/core/inject.js
+++ b/core/inject.js
@@ -431,12 +431,6 @@ Blockly.init_ = function(mainWorkspace) {
       mainWorkspace.flyout_.init(mainWorkspace);
       mainWorkspace.flyout_.show(options.languageTree.childNodes);
       mainWorkspace.flyout_.scrollToStart();
-      // Translate the workspace sideways to avoid the fixed flyout.
-      mainWorkspace.scrollX = mainWorkspace.flyout_.width_;
-      if (options.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-        mainWorkspace.scrollX *= -1;
-      }
-      mainWorkspace.translate(mainWorkspace.scrollX, 0);
     }
   }
 
@@ -453,6 +447,26 @@ Blockly.init_ = function(mainWorkspace) {
     mainWorkspace.scrollbar.resize();
   } else {
     mainWorkspace.setMetrics({x: .5, y: .5});
+  }
+
+  if (mainWorkspace.flyout_) {
+    // Translate the workspace sideways to avoid the fixed flyout.
+    switch (mainWorkspace.toolboxPosition) {
+      case Blockly.TOOLBOX_AT_LEFT:
+        mainWorkspace.scrollX =
+            mainWorkspace.RTL ?  0 : mainWorkspace.flyout_.width_;
+        break;
+      case Blockly.TOOLBOX_AT_RIGHT:
+        mainWorkspace.scrollX =
+            mainWorkspace.RTL ? -mainWorkspace.flyout_.width_ : 0;
+        break;
+      case Blockly.TOOLBOX_AT_TOP:
+        mainWorkspace.scrollY = mainWorkspace.flyout_.height_;
+        break;
+      // If the toolbox is at the top left (workspace origin) is untouched,
+      // so no need to include it.
+    }
+    mainWorkspace.translate(mainWorkspace.scrollX, mainWorkspace.scrollY);
   }
 
   // Load the sounds.

--- a/core/inject.js
+++ b/core/inject.js
@@ -238,7 +238,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // return. In this case it is better return-if rather than do-if so
       // that if events are added that should activate this function to work,
       // people don't ned to remember to update it.
-      if (e.type == Blockly.Events.VAR_CREATE ||
+      if (e.type == Blockly.Events.BLOCK_DELETE ||
+          e.type == Blockly.Events.VAR_CREATE ||
           e.type == Blockly.Events.VAR_DELETE ||
           e.type == Blockly.Events.VAR_RENAME ||
           e.type == Blockly.Events.UI) {

--- a/core/inject.js
+++ b/core/inject.js
@@ -238,13 +238,15 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // "not bounded" state of isContentBounded_ could have been changed.
       if (!mainWorkspace.isDragging() && !mainWorkspace.isContentBounded_()) {
         var metrics = mainWorkspace.getMetrics();
-        if (metrics.contentTop < metrics.viewTop ||
+        var edgeLeft = metrics.viewLeft + metrics.absoluteLeft;
+        var edgeTop = metrics.viewTop + metrics.absoluteTop;
+        if (metrics.contentTop < edgeTop ||
             metrics.contentTop + metrics.contentHeight >
-            metrics.viewHeight + metrics.viewTop ||
+            metrics.viewHeight + edgeTop ||
             metrics.contentLeft <
-                (options.RTL ? metrics.viewLeft : metrics.viewLeft) ||
+                (options.RTL ? metrics.viewLeft : edgeLeft) ||
             metrics.contentLeft + metrics.contentWidth > (options.RTL ?
-                metrics.viewWidth : metrics.viewWidth + metrics.viewLeft)) {
+                metrics.viewWidth : metrics.viewWidth + edgeLeft)) {
           // One or more blocks may be out of bounds.  Bump them back in.
           var MARGIN = 25;
           var blocks = mainWorkspace.getTopBlocks(false);
@@ -258,28 +260,27 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
             var blockXY = block.getRelativeToSurfaceXY();
             var blockHW = block.getHeightWidth();
             // Bump any block that's above the top back inside.
-            var overflowTop = metrics.viewTop + MARGIN
-                - blockHW.height - blockXY.y;
+            var overflowTop = edgeTop + MARGIN - blockHW.height - blockXY.y;
             if (overflowTop > 0) {
               block.moveBy(0, overflowTop);
               movedBlocks = true;
             }
             // Bump any block that's below the bottom back inside.
             var overflowBottom =
-                metrics.viewTop + metrics.viewHeight - MARGIN - blockXY.y;
+                edgeTop + metrics.viewHeight - MARGIN - blockXY.y;
             if (overflowBottom < 0) {
               block.moveBy(0, overflowBottom);
               movedBlocks = true;
             }
             // Bump any block that's off the left back inside.
-            var overflowLeft = MARGIN + metrics.viewLeft -
+            var overflowLeft = MARGIN + edgeLeft -
                 blockXY.x - (options.RTL ? 0 : blockHW.width);
             if (overflowLeft > 0) {
               block.moveBy(overflowLeft, 0);
               movedBlocks = true;
             }
             // Bump any block that's off the right back inside.
-            var overflowRight = metrics.viewLeft + metrics.viewWidth - MARGIN -
+            var overflowRight = edgeLeft + metrics.viewWidth - MARGIN -
                 blockXY.x + (options.RTL ? blockHW.width : 0);
             if (overflowRight < 0) {
               block.moveBy(overflowRight, 0);

--- a/core/inject.js
+++ b/core/inject.js
@@ -250,7 +250,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       // Get the exact content metrics (in workspace units), even if the
       // content is bounded.
       if (mainWorkspace.isContentBounded_()) {
-        // Already in workspace units, not need to divide by scale.
+        // Already in workspace units, no need to divide by scale.
         var blocksBoundingBox = mainWorkspace.getBlocksBoundingBox();
         workspaceMetrics.contentLeft = blocksBoundingBox.x;
         workspaceMetrics.contentTop = blocksBoundingBox.y;
@@ -274,6 +274,8 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       var size = object.getHeightWidth();
 
       return {
+        // In LTR the position is at the top-left of the block, and in RTL
+        // it is at the top-right of the block, we need to add with accordingly.
         left: position.x - (options.RTL ? size.width : 0),
         right: position.x + (options.RTL ? 0 : size.width),
         top: position.y,

--- a/core/inject.js
+++ b/core/inject.js
@@ -450,7 +450,7 @@ Blockly.init_ = function(mainWorkspace) {
   }
 
   if (mainWorkspace.flyout_) {
-    // Shift the workspace origin sideways to avoid the fixed flyout.
+    // Translate the workspace sideways to avoid the fixed flyout.
     switch (mainWorkspace.toolboxPosition) {
       case Blockly.TOOLBOX_AT_LEFT:
         mainWorkspace.scrollX =
@@ -466,6 +466,7 @@ Blockly.init_ = function(mainWorkspace) {
       // If the toolbox is at the top left (workspace origin) is untouched,
       // so no need to include it.
     }
+    mainWorkspace.translate(mainWorkspace.scrollX, mainWorkspace.scrollY);
   }
 
   // Load the sounds.

--- a/core/options.js
+++ b/core/options.js
@@ -100,10 +100,6 @@ Blockly.Options = function(options) {
         Blockly.TOOLBOX_AT_RIGHT : Blockly.TOOLBOX_AT_LEFT;
   }
 
-  var hasScrollbars = options['scrollbars'];
-  if (hasScrollbars === undefined) {
-    hasScrollbars = hasCategories;
-  }
   var hasCss = options['css'];
   if (hasCss === undefined) {
     hasCss = true;
@@ -135,7 +131,10 @@ Blockly.Options = function(options) {
   this.maxInstances = options['maxInstances'];
   this.pathToMedia = pathToMedia;
   this.hasCategories = hasCategories;
-  this.hasScrollbars = hasScrollbars;
+  this.moveOptions = Blockly.Options.parseMoveOptions(
+      options, hasCategories);
+  /** @deprecated  January 2019 */
+  this.hasScrollbars = this.moveOptions.scrollbars;
   this.hasTrashcan = hasTrashcan;
   this.maxTrashcanContents = maxTrashcanContents;
   this.hasSounds = hasSounds;
@@ -164,6 +163,40 @@ Blockly.Options.prototype.setMetrics = null;
  * @return {Object} Contains size and position metrics, or null.
  */
 Blockly.Options.prototype.getMetrics = null;
+
+/**
+ * Parse the user-specified zoom options, using reasonable defaults where
+ *    behavior is unspecified.
+ * @param {!Object} options Dictionary of options.
+ * @param {!boolean} hasCategories Whether the workspace has categories or not.
+ * @return {!Object} A dictionary of normalized options.
+ * @private
+ */
+Blockly.Options.parseMoveOptions = function(options, hasCategories) {
+  var move = options['move'] || {};
+  var moveOptions = {};
+  if (move['scrollbars'] === undefined
+      && options['scrollbars'] === undefined) {
+    moveOptions.scrollbars = hasCategories;
+  } else {
+    moveOptions.scrollbars = !!move['scrollbars'] || !!options['scrollbars'];
+  }
+  if (!moveOptions.scrollbars || move['wheel'] === undefined) {
+    // Defaults to false so that developers' settings don't appear to change.
+    moveOptions.wheel = false;
+  } else {
+    moveOptions.wheel = !!move['wheel'];
+  }
+  if (!moveOptions.scrollbars) {
+    moveOptions.drag = false;
+  } else if (move['drag'] === undefined) {
+    // Defaults to true if scrollbars is true.
+    moveOptions.drag = true;
+  } else {
+    moveOptions.drag = !!move['drag'];
+  }
+  return moveOptions;
+};
 
 /**
  * Parse the user-specified zoom options, using reasonable defaults where

--- a/core/options.js
+++ b/core/options.js
@@ -165,7 +165,7 @@ Blockly.Options.prototype.setMetrics = null;
 Blockly.Options.prototype.getMetrics = null;
 
 /**
- * Parse the user-specified zoom options, using reasonable defaults where
+ * Parse the user-specified move options, using reasonable defaults where
  *    behavior is unspecified.
  * @param {!Object} options Dictionary of options.
  * @param {!boolean} hasCategories Whether the workspace has categories or not.

--- a/core/options.js
+++ b/core/options.js
@@ -131,8 +131,7 @@ Blockly.Options = function(options) {
   this.maxInstances = options['maxInstances'];
   this.pathToMedia = pathToMedia;
   this.hasCategories = hasCategories;
-  this.moveOptions = Blockly.Options.parseMoveOptions(
-      options, hasCategories);
+  this.moveOptions = Blockly.Options.parseMoveOptions(options, hasCategories);
   /** @deprecated  January 2019 */
   this.hasScrollbars = this.moveOptions.scrollbars;
   this.hasTrashcan = hasTrashcan;

--- a/core/utils.js
+++ b/core/utils.js
@@ -295,8 +295,10 @@ Blockly.utils.isRightButton = function(e) {
  */
 Blockly.utils.mouseToSvg = function(e, svg, matrix) {
   var svgPoint = svg.createSVGPoint();
-  svgPoint.x = e.clientX;
-  svgPoint.y = e.clientY;
+  // We need this in page coordinates so it works even when the document is
+  // scrolled.
+  svgPoint.x = e.pageX;
+  svgPoint.y = e.pageY;
 
   if (!matrix) {
     matrix = svg.getScreenCTM().inverse();

--- a/core/utils.js
+++ b/core/utils.js
@@ -295,10 +295,8 @@ Blockly.utils.isRightButton = function(e) {
  */
 Blockly.utils.mouseToSvg = function(e, svg, matrix) {
   var svgPoint = svg.createSVGPoint();
-  // We need this in page coordinates so it works even when the document is
-  // scrolled.
-  svgPoint.x = e.pageX;
-  svgPoint.y = e.pageY;
+  svgPoint.x = e.clientX;
+  svgPoint.y = e.clientY;
 
   if (!matrix) {
     matrix = svg.getScreenCTM().inverse();

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -94,5 +94,5 @@ Blockly.WorkspaceDragger.prototype.endDrag = function(currentDragDeltaXY) {
  */
 Blockly.WorkspaceDragger.prototype.drag = function(currentDragDeltaXY) {
   var newXY = goog.math.Coordinate.sum(this.startScrollXY_, currentDragDeltaXY);
-  this.workspace_.scroll_(newXY.x, newXY.y);
+  this.workspace_.scroll(newXY.x, newXY.y);
 };

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -46,15 +46,6 @@ Blockly.WorkspaceDragger = function(workspace) {
   this.workspace_ = workspace;
 
   /**
-   * The workspace's metrics object at the beginning of the drag.  Contains size
-   * and position metrics of a workspace.
-   * Coordinate system: pixel coordinates.
-   * @type {!Object}
-   * @private
-   */
-  this.startDragMetrics_ = workspace.getMetrics();
-
-  /**
    * The scroll position of the workspace at the beginning of the drag.
    * Coordinate system: pixel coordinates.
    * @type {!goog.math.Coordinate}
@@ -102,30 +93,6 @@ Blockly.WorkspaceDragger.prototype.endDrag = function(currentDragDeltaXY) {
  * @package
  */
 Blockly.WorkspaceDragger.prototype.drag = function(currentDragDeltaXY) {
-  var metrics = this.startDragMetrics_;
   var newXY = goog.math.Coordinate.sum(this.startScrollXY_, currentDragDeltaXY);
-
-  // Bound the new XY based on workspace bounds.
-  var x = Math.min(newXY.x, -metrics.contentLeft);
-  var y = Math.min(newXY.y, -metrics.contentTop);
-  x = Math.max(x, metrics.viewWidth - metrics.contentLeft -
-               metrics.contentWidth);
-  y = Math.max(y, metrics.viewHeight - metrics.contentTop -
-               metrics.contentHeight);
-
-  x = -x - metrics.contentLeft;
-  y = -y - metrics.contentTop;
-
-  this.updateScroll_(x, y);
-};
-
-/**
- * Move the scrollbars to drag the workspace.
- * x and y are in pixels.
- * @param {number} x The new x position to move the scrollbar to.
- * @param {number} y The new y position to move the scrollbar to.
- * @private
- */
-Blockly.WorkspaceDragger.prototype.updateScroll_ = function(x, y) {
-  this.workspace_.scrollbar.set(x, y);
+  this.workspace_.scroll_(newXY.x, newXY.y);
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1793,8 +1793,8 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
 /**
  * Scroll the workspace by a specified amount (in pixels), keeping in the
  * bounds.
- * @param {number} x Target X to scroll to
- * @param {number} y Target Y to scroll to
+ * @param {number} x Target X to scroll to.
+ * @param {number} y Target Y to scroll to.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.scroll_ = function(x, y) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1219,8 +1219,7 @@ Blockly.WorkspaceSvg.prototype.isContentBounded_ = function() {
  * through zooming with the scroll wheel (since the zoom is centered on the
  * mouse position). This does not include zooming with the zoom controls
  * since the X Y coordinates are decided programmatically.
- * @returns {boolean} True if the workspace should be is movable, false
- *     otherwise.
+ * @returns {boolean} True if the workspace is movable, false otherwise.
  * @package
  */
 Blockly.WorkspaceSvg.prototype.isMovable_ = function() {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1666,7 +1666,7 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
     x -= this.flyout_.width_ / 2;
   }
   var y = (metrics.contentHeight - metrics.viewHeight) / 2;
-  this.scrollbar.set(x, y);
+  this.scroll_(x, y);
 };
 
 /**
@@ -1721,7 +1721,7 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
   var scrollToCenterY = scrollToBlockY - halfViewHeight;
 
   Blockly.hideChaff();
-  this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+  this.scroll_(scrollToCenterX, scrollToCenterY);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1653,7 +1653,7 @@ Blockly.WorkspaceSvg.prototype.zoom = function(x, y, amount) {
   y = center.y;
 
   // Find the new scrollX/scrollY so that the center remains in the same
-  // position (relative to the mouse) after we zoom.
+  // position (relative to the center) after we zoom.
   var matrix = matrix.translate(x * (1 - scaleChange), y * (1 - scaleChange))
       .scale(scaleChange);
   // newScale and matrix.a should be identical (within a rounding error).
@@ -1670,8 +1670,8 @@ Blockly.WorkspaceSvg.prototype.zoom = function(x, y, amount) {
  */
 Blockly.WorkspaceSvg.prototype.zoomCenter = function(type) {
   var metrics = this.getMetrics();
-  var x = metrics.viewWidth / 2;
-  var y = metrics.viewHeight / 2;
+  var x = (metrics.viewWidth / 2) + metrics.absoluteLeft;
+  var y = (metrics.viewHeight / 2) + metrics.absoluteTop;
   this.zoom(x, y, type);
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1630,7 +1630,11 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
   var workspaceWidth = metrics.viewWidth;
   var workspaceHeight = metrics.viewHeight;
   if (this.flyout_) {
-    workspaceWidth -= this.flyout_.width_;
+    if (this.horizontalLayout) {
+      workspaceHeight -= this.flyout_.height_;
+    } else {
+      workspaceWidth -= this.flyout_.width_;
+    }
   }
   var ratioX = workspaceWidth / blocksWidth;
   var ratioY = workspaceHeight / blocksHeight;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1309,8 +1309,8 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     this.currentGesture_.cancel();
   }
 
-  // TODO: Change '10' from magic number to constant variable. Also change in
-  // flyout_vertical.js and flyout_horizontal.js.
+  // TODO (#2301): Change '10' from magic number to constant variable. Also
+  //  change in flyout_vertical.js and flyout_horizontal.js.
   // Multiplier variable, so that non-pixel-deltaModes are supported.
   var multiplier = e.deltaMode === 0x1 ? 10 : 1;
 
@@ -1914,8 +1914,12 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
     // content's top-left. Then we negate this so we get the displacement from
     // the content's top-left to the view's top-left, matching the
     // directionality of the scrollbars.
-    this.scrollbar.hScroll.set(-(x + metrics.contentLeft));
-    this.scrollbar.vScroll.set(-(y + metrics.contentTop));
+
+    // TODO (#2299): Change these to not use the internal ratio_ property.
+    this.scrollbar.hScroll.setHandlePosition(-(x + metrics.contentLeft) *
+        this.scrollbar.hScroll.ratio_);
+    this.scrollbar.vScroll.setHandlePosition(-(y + metrics.contentTop) *
+        this.scrollbar.vScroll.ratio_);
   }
 
   // Hide the WidgetDiv without animation. This is to prevent a disposal

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -672,10 +672,9 @@ Blockly.WorkspaceSvg.prototype.resizeContents = function() {
     return;
   }
   if (this.scrollbar) {
-    // TODO(picklesrus): Once rachel-fenichel's scrollbar refactoring
-    // is complete, call the method that only resizes scrollbar
-    // based on contents.
-    this.scrollbar.resize();
+    var metrics = this.getMetrics();
+    this.scrollbar.hScroll.resizeContentHorizontal(metrics);
+    this.scrollbar.vScroll.resizeContentVertical(metrics);
   }
   this.updateInverseScreenCTM();
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1804,10 +1804,10 @@ Blockly.WorkspaceSvg.prototype.scroll_ = function(x, y) {
   // location.
   Blockly.WidgetDiv.hide(true);
 
-  this.scrollX = x;
-  this.scrollY = y;
   x += metrics.absoluteLeft;
   y += metrics.absoluteTop;
+  this.scrollX = x;
+  this.scrollY = y;
   this.translate(x, y);
   if (this.grid_) {
     this.grid_.moveTo(x, y);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1836,7 +1836,7 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
 
   // Convert from workspace directions to canvas directions.
   var x = -scrollToCenterX - metrics.contentLeft;
-  var y = -scrollToCenterY - metrics.contentLeft;
+  var y = -scrollToCenterY - metrics.contentTop;
 
   Blockly.hideChaff();
   this.scroll(x, y);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1201,7 +1201,7 @@ Blockly.WorkspaceSvg.prototype.isDraggable = function() {
  * workspace's content should be sized so that it can move (bounded) or not
  * (exact sizing).
  * @returns {boolean} True if the workspace should be bounded, false otherwise.
- * @private
+ * @package
  */
 Blockly.WorkspaceSvg.prototype.isContentBounded_ = function() {
   return (this.options.moveOptions && this.options.moveOptions.scrollbars)
@@ -1810,19 +1810,19 @@ Blockly.WorkspaceSvg.prototype.scroll_ = function(x, y) {
   // location.
   Blockly.WidgetDiv.hide(true);
 
-  x += metrics.absoluteLeft;
-  y += metrics.absoluteTop;
   this.scrollX = x;
   this.scrollY = y;
+  if (this.scrollbar) {
+    this.scrollbar.hScroll.setHandlePosition((-x - metrics.contentLeft)
+      * this.scrollbar.hScroll.ratio_);
+    this.scrollbar.vScroll.setHandlePosition((-y - metrics.contentTop)
+      * this.scrollbar.vScroll.ratio_);
+  }
+  x += metrics.absoluteLeft;
+  y += metrics.absoluteTop;
   this.translate(x, y);
   if (this.grid_) {
     this.grid_.moveTo(x, y);
-  }
-  if (this.scrollbar) {
-    this.scrollbar.hScroll.setHandlePosition((-x - metrics.contentLeft)
-        * this.scrollbar.hScroll.ratio_);
-    this.scrollbar.vScroll.setHandlePosition((-y - metrics.contentTop)
-      * this.scrollbar.vScroll.ratio_);
   }
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1619,6 +1619,12 @@ Blockly.WorkspaceSvg.prototype.zoomCenter = function(type) {
  * Zoom the blocks to fit in the workspace if possible.
  */
 Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
+  if (!this.isMovable_()) {
+    console.warn('Tried to move a non-movable workspace. This could result' +
+      ' in blocks becoming inaccessible.');
+    return;
+  }
+
   var metrics = this.getMetrics();
   var blocksBox = this.getBlocksBoundingBox();
   var blocksWidth = blocksBox.width;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1705,7 +1705,6 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
       blocksWidth += this.flyout_.width_ / this.scale;
     }
   }
-  console.log(blocksWidth + ' blocksWidth');
 
   var workspaceWidth = metrics.viewWidth;
   var workspaceHeight = metrics.viewHeight;
@@ -1902,7 +1901,7 @@ Blockly.WorkspaceSvg.prototype.scroll_ = function(x, y) {
     // The negative x/y values are our new viewLeft and viewTop values.
     // The view position (distance from the view's top-left to the origin)
     // minus the negative content position (distance from the content's
-    // top-left to the origin) is the distance the view's top-left is from the
+    // top-left to the origin) is the distance from the view's top-left to the
     // content's top-left.
     this.scrollbar.hScroll.setHandlePosition((-x - metrics.contentLeft)
       * this.scrollbar.hScroll.ratio_);
@@ -1910,7 +1909,7 @@ Blockly.WorkspaceSvg.prototype.scroll_ = function(x, y) {
       * this.scrollbar.vScroll.ratio_);
   }
   // We have to shift the translation so that when the canvas is at 0, 0 the
-  // workspace origin is not beneath the toolbox.
+  // workspace origin is not underneath the toolbox.
   x += metrics.absoluteLeft;
   y += metrics.absoluteTop;
   this.translate(x, y);
@@ -2120,7 +2119,7 @@ Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function() {
 };
 
 /**
- * Sets the X/Y translations of a top level workspace to match the scrollbars.
+ * Sets the X/Y translations of a top level workspace.
  * @param {!Object} xyRatio Contains an x and/or y property which is a float
  *     between 0 and 1 specifying the degree of scrolling.
  * @private
@@ -2134,8 +2133,11 @@ Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
   if (typeof xyRatio.y == 'number') {
     this.scrollY = -metrics.contentHeight * xyRatio.y - metrics.contentTop;
   }
+  // We have to shift the translation so that when the canvas is at 0, 0 the
+  // workspace origin is not underneath the toolbox.
   var x = this.scrollX + metrics.absoluteLeft;
   var y = this.scrollY + metrics.absoluteTop;
+  // We could call scroll_ here, but that has extra checks we don't need to do.
   this.translate(x, y);
   if (this.grid_) {
     this.grid_.moveTo(x, y);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1349,7 +1349,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
   menuOptions.push(redoOption);
 
   // Option to clean up blocks.
-  if (this.scrollbar) {
+  if (this.isContentBounded_()) {
     var cleanOption = {};
     cleanOption.text = Blockly.Msg['CLEAN_UP'];
     cleanOption.enabled = topBlocks.length > 1;
@@ -1613,7 +1613,7 @@ Blockly.WorkspaceSvg.prototype.zoomToFit = function() {
   if (this.flyout_) {
     workspaceWidth -= this.flyout_.width_;
   }
-  if (!this.scrollbar) {
+  if (!this.isContentBounded_()) {
     // Origin point of 0,0 is fixed, blocks will not scroll to center.
     blocksWidth += metrics.contentLeft;
     blocksHeight += metrics.contentTop;
@@ -1671,11 +1671,6 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
  * @public
  */
 Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
-  if (!this.scrollbar) {
-    console.warn('Tried to scroll a non-scrollable workspace.');
-    return;
-  }
-
   var block = this.getBlockById(id);
   if (!block) {
     return;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1620,11 +1620,16 @@ Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
 };
 
 /**
- * Zooming the blocks centered in (x, y) coordinate with zooming in or out.
- * @param {number} x X coordinate of center.
- * @param {number} y Y coordinate of center.
- * @param {number} amount Amount of zooming
- *                        (negative zooms out and positive zooms in).
+ * Zooms the workspace in or out relative to/centered on the given (x, y)
+ * coordinate.
+ * @param {number} x X coordinate of center, in pixel units relative to the
+ *     top-left corner of the parentSVG.
+ * @param {number} y Y coordinate of center, in pixel units relative to the
+ *     top-left corner of the parentSVG.
+ * @param {number} amount Amount of zooming. The formula for the new scale
+ *     is newScale = currentScale * (scaleSpeed^amount). scaleSpeed is set in
+ *     the workspace options. Negative amount values zoom out, and positive
+ *     amount values zoom in.
  */
 Blockly.WorkspaceSvg.prototype.zoom = function(x, y, amount) {
   // Scale factor.
@@ -1642,7 +1647,9 @@ Blockly.WorkspaceSvg.prototype.zoom = function(x, y, amount) {
     scaleChange = this.options.zoomOptions.minScale / this.scale;
   }
 
-  // Transform the x/y out of the canvas' space, so that they're usable.
+  // Transform the x/y coordinates from the parentSVG's space into the
+  // canvas' space, so that they are in workspace units relative to the top
+  // left of the visible portion of the workspace.
   var matrix = this.getCanvas().getCTM();
   var center = this.getParentSvg().createSVGPoint();
   center.x = x;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1672,6 +1672,12 @@ Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
  * Center the workspace.
  */
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
+  if (!this.isMovable_()) {
+    console.warn('Tried to move a non-movable workspace. This could result' +
+      ' in blocks becoming inaccessible.');
+    return;
+  }
+
   var metrics = this.getMetrics();
   var x = (metrics.contentWidth - metrics.viewWidth) / 2;
   var y = (metrics.contentHeight - metrics.viewHeight) / 2;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -814,8 +814,10 @@ Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
 
 /**
  * Translate this workspace to new coordinates.
- * @param {number} x Horizontal translation.
- * @param {number} y Vertical translation.
+ * @param {number} x Horizontal translation, in pixel units relative to the
+ *    top left of the blockly div.
+ * @param {number} y Vertical translation, in pixel units relative to the
+ *    top left of the blockly div.
  */
 Blockly.WorkspaceSvg.prototype.translate = function(x, y) {
   if (this.useWorkspaceDragSurface_ && this.isDragSurfaceActive_) {
@@ -829,6 +831,10 @@ Blockly.WorkspaceSvg.prototype.translate = function(x, y) {
   // Now update the block drag surface if we're using one.
   if (this.blockDragSurface_) {
     this.blockDragSurface_.translateAndScaleGroup(x, y, this.scale);
+  }
+  // And update the grid if we're using one.
+  if (this.grid_) {
+    this.grid_.moveTo(x, y);
   }
 };
 
@@ -1920,9 +1926,6 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
   x += metrics.absoluteLeft;
   y += metrics.absoluteTop;
   this.translate(x, y);
-  if (this.grid_) {
-    this.grid_.moveTo(x, y);
-  }
 };
 
 /**
@@ -2146,9 +2149,6 @@ Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_ = function(xyRatio) {
   var y = this.scrollY + metrics.absoluteTop;
   // We could call scroll here, but that has extra checks we don't need to do.
   this.translate(x, y);
-  if (this.grid_) {
-    this.grid_.moveTo(x, y);
-  }
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1310,7 +1310,6 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
   if ((this.options.zoomOptions && this.options.zoomOptions.wheel)
       && (!(this.options.moveOptions && this.options.moveOptions.wheel)
           || e.ctrlKey)) {
-    // TODO: Change '50' from magic number to constant variable.
     // The vertical scroll distance that corresponds to a click of a zoom button.
     var PIXELS_PER_ZOOM_STEP = 50;
     var delta = -e.deltaY / PIXELS_PER_ZOOM_STEP * multiplier;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1671,10 +1671,23 @@ Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
   var metrics = this.getMetrics();
   var x = (metrics.contentWidth - metrics.viewWidth) / 2;
-  if (this.flyout_) {
-    x -= this.flyout_.width_ / 2;
-  }
   var y = (metrics.contentHeight - metrics.viewHeight) / 2;
+  if (this.flyout_) {
+    switch (this.toolboxPosition) {
+      case Blockly.TOOLBOX_AT_LEFT:
+        x -= this.flyout_.width_ / 2;
+        break;
+      case Blockly.TOOLBOX_AT_RIGHT:
+        x += this.flyout_.width_ / 2;
+        break;
+      case Blockly.TOOLBOX_AT_TOP:
+        y -= this.flyout_.height_ / 2;
+        break;
+      case Blockly.TOOLBOX_AT_BOTTOM:
+        y += this.flyout_.height_ / 2;
+        break;
+    }
+  }
   x = -metrics.contentLeft - x;
   y = -metrics.contentTop - y;
   this.scroll_(x, y);
@@ -1687,7 +1700,8 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
  */
 Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
   if (!this.isMovable_()) {
-    console.warn('Tried to move a non-movable workspace.')
+    console.warn('Tried to move a non-movable workspace. This could result' +
+      ' in blocks becoming inaccessible.');
     return;
   }
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1650,22 +1650,19 @@ Blockly.WorkspaceSvg.prototype.endCanvasTransition = function() {
       /** @type {!SVGElement} */ (this.svgBubbleCanvas_),
       'blocklyCanvasTransitioning');
 };
+
 /**
  * Center the workspace.
  */
 Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
-  if (!this.scrollbar) {
-    // Can't center a non-scrolling workspace.
-    console.warn('Tried to scroll a non-scrollable workspace.');
-    return;
-  }
   var metrics = this.getMetrics();
   var x = (metrics.contentWidth - metrics.viewWidth) / 2;
   if (this.flyout_) {
     x -= this.flyout_.width_ / 2;
   }
   var y = (metrics.contentHeight - metrics.viewHeight) / 2;
-  this.scroll_(x, y);
+  this.scroll_((-metrics.contentLeft - x) - metrics.absoluteLeft,
+      (-metrics.contentTop - y) - metrics.absoluteTop);
 };
 
 /**
@@ -1720,7 +1717,8 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
   var scrollToCenterY = scrollToBlockY - halfViewHeight;
 
   Blockly.hideChaff();
-  this.scroll_(scrollToCenterX, scrollToCenterY);
+  this.scroll_((-metrics.contentLeft - scrollToCenterX) + metrics.absoluteLeft,
+      (-metrics.contentLeft - scrollToCenterY) + metrics.absoluteTop);
 };
 
 /**

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -102,7 +102,7 @@ Blockly.ZoomControls.prototype.createDom = function() {
   var rnd = String(Math.random()).substring(2);
   this.createZoomOutSvg_(rnd);
   this.createZoomInSvg_(rnd);
-  if (this.workspace_.isMovable_()) {
+  if (this.workspace_.isMovable()) {
     // If we zoom to the center and the workspace isn't movable we could
     // loose blocks at the edges of the workspace.
     this.createZoomResetSvg_(rnd);

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -162,7 +162,9 @@ Blockly.ZoomControls.prototype.position = function() {
   if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
     this.top_ = this.verticalSpacing_;
     this.zoomInGroup_.setAttribute('transform', 'translate(0, 34)');
-    this.zoomResetGroup_.setAttribute('transform', 'translate(0, 77)');
+    if (this.zoomResetGroup_) {
+      this.zoomResetGroup_.setAttribute('transform', 'translate(0, 77)');
+    }
   } else {
     this.top_ = metrics.viewHeight + metrics.absoluteTop -
         this.HEIGHT_ - this.verticalSpacing_;

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -103,6 +103,8 @@ Blockly.ZoomControls.prototype.createDom = function() {
   this.createZoomOutSvg_(rnd);
   this.createZoomInSvg_(rnd);
   if (this.workspace_.isMovable_()) {
+    // If we zoom to the center and the workspace isn't movable we could
+    // loose blocks at the edges of the workspace.
     this.createZoomResetSvg_(rnd);
   }
   return this.svgGroup_;

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -102,7 +102,9 @@ Blockly.ZoomControls.prototype.createDom = function() {
   var rnd = String(Math.random()).substring(2);
   this.createZoomOutSvg_(rnd);
   this.createZoomInSvg_(rnd);
-  this.createZoomResetSvg_(rnd);
+  if (this.workspace_.isMovable_()) {
+    this.createZoomResetSvg_(rnd);
+  }
   return this.svgGroup_;
 };
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -109,7 +109,11 @@ function start() {
         oneBasedIndex: true,
         readOnly: false,
         rtl: rtl,
-        scrollbars: true,
+        move: {
+          scrollbars: true,
+          drag: true,
+          wheel: false,
+        },
         toolbox: toolbox,
         toolboxPosition: side == 'top' || side == 'start' ? 'start' : 'end',
         zoom:


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2205 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Adds a new "move" object configuration option with the following properties:
* scrollbars: Determines if the workspace has scrollbars. Defaults to true if the workspace has categories.
* drag: Determines if the workspace can be dragged with the mouse. Always false if scrollbars is false (at least in options parsing). Defaults to true if scrollbars is true.
* wheel: Determines if the workspace can be scrolled with the mouse wheel. Always false if scrollbars is false (at least in options parsing). Defaults to false.

Parsing does not currently allow these options to be independent, but you can make them independent by overriding the drag & wheel options after the workspace has been injected. This behavior is supported.

Changes the zoom function so that the zoom is "anchored" to the mouse position, even without scrollbars.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
People have requested scroll on wheel. #110

Also I think it may be useful to start separating the movement functionality from scrollbars to work towards #2145

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
  
Independent-ness of Scrollbars/Drag/Scrollwheel
1. Set move > scrollbars option to true. Set move > drag option to false. Set move > wheel option to false.
2. Observed that scrollbars alone worked. (pass)
3. Set move > scrollbars option to false. Overwrote move > drag to be true. Set move > wheel option to false. 
4. Observed that the dragging alone worked. And that scrollbars were not created. (pass)
5. Set move > scrollbars option to false. Set move > drag option to false. Overwrote move > wheel to be true.
6. Placed a block so I could observe the scrolling.
7. Observed that the scrollwheel alone worked. And that scrollbars were not created. (pass)

Scrolling and Zooming Interaction
1. Set move > scrollbars option to true. Set move > wheel option to false. Set zoom > wheel option to true.
2. Scrolled the mouse wheel. Observed how the workspace zoomed. (pass)
3. Set move > scrollbars option to true. Set move > wheel option to true. Set zoom > wheel option to true.
4. Scrolled the mouse wheel. Observed how the workspace scrolled vertical. (pass)
5. Hit shift and scrolled the mouse wheel. Observed how the workspace scrolled horizontally. (pass)
6. Hit ctrl and scrolled the mouse wheel. Observed how the workspace zoomed. (pass)
7. Set move > scrollbars option to true. Set move > wheel option to true. Set zoom > wheel option to false.
8. Scrolled the mouse wheel. Observed how the workspace scrolled. (pass)
9. Hit shift and scrolled the mouse wheel. Observed how the workspace scrolled horizontally. (pass)

Zooming With and Without Scrollbars
1. Set scrollbars option to true. Set zoom > wheel option to true. Placed a block to visualize zooming.
2. Scrolled the mouse wheel. Observed how the zoom was anchored to the mouse. (pass)
3. Pressed the zoom in control. Observed how it zoomed towards the center. (pass)
4. Changed scrollbars option to false.
5. Scrolled the mouse wheel. Observed how the zoom was anchored to the mouse. (pass)
6. Pressed the zoom in control. Observed how it zoomed towards the center. (pass)
7. Changed the zoom > wheel option to false. 
8. Pressed the zoom in control. Observed how it zoomed towards the top left corner. (pass)

Note: Steps 7&8 of the above make it so the content is no longer bounded. If you were to, for example, override drag to make the content bounded it would zoom towards the center.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
All of this works, but there are still some things I want to do (like clean up calls to scrollbars.set) so I consider it a little bit WIP. I just wanted to post a PR before I went too crazy doing things, so I can still change stuff easily.