### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
-    "eslint": "^5.10.0",
-    "google-closure-compiler": "^20181210.0.0",
-    "google-closure-library": "^20180910.0.0",
+    "eslint": "^5.13.0",
+    "google-closure-compiler": "^20190121.0.0",
+    "google-closure-library": "^20190121.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-insert": "^0.5.0",
     "gulp-series": "^1.0.2",
     "gulp-shell": "^0.6.5",
-    "jshint": "^2.9.7",
+    "jshint": "^2.10.1",
     "webdriverio": "^4.14.1"
   },
   "jshintConfig": {
@@ -51,6 +51,6 @@
     "unused": true
   },
   "dependencies": {
-    "jsdom": "^13.0.0"
+    "jsdom": "^13.2.0"
   }
 }


### PR DESCRIPTION
Update dependencies for February release.

This does not update webdriverio.  See #2283.