### PR TITLE
Fixes Block Input Sticking to the Screen When Navigated Away

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -437,7 +437,10 @@ Blockly.init_ = function(mainWorkspace) {
  */
 Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
-    Blockly.bindEventWithChecks_(document, 'mousedown', null, Blockly.hideChaff);
+    Blockly.bindEventWithChecks_(document, 'mousedown', null, function() {
+      Blockly.hideChaff();
+      Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+    });
     Blockly.bindEventWithChecks_(document, 'scroll', null,
         Blockly.mainWorkspace.updateInverseScreenCTM
             .bind(Blockly.mainWorkspace));

--- a/core/inject.js
+++ b/core/inject.js
@@ -437,6 +437,7 @@ Blockly.init_ = function(mainWorkspace) {
  */
 Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
+    Blockly.bindEventWithChecks_(document, 'mousedown', null, Blockly.hideChaff);
     Blockly.bindEventWithChecks_(document, 'scroll', null,
         Blockly.mainWorkspace.updateInverseScreenCTM
             .bind(Blockly.mainWorkspace));

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -160,18 +160,6 @@ Blockly.Toolbox.prototype.init = function() {
   this.HtmlDiv.setAttribute('dir', workspace.RTL ? 'RTL' : 'LTR');
   svg.parentNode.insertBefore(this.HtmlDiv, svg);
 
-  // Clicking on toolbox closes popups.
-  Blockly.bindEventWithChecks_(this.HtmlDiv, 'mousedown', this,
-      function(e) {
-        if (Blockly.utils.isRightButton(e) || e.target == this.HtmlDiv) {
-          // Close flyout.
-          Blockly.hideChaff(false);
-        } else {
-          // Just close popups.
-          Blockly.hideChaff(true);
-        }
-        Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
-      }, /*opt_noCaptureIdentifier*/ false, /*opt_noPreventDefault*/ true);
   var workspaceOptions = {
     disabledPatternId: workspace.options.disabledPatternId,
     parentWorkspace: workspace,

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -160,6 +160,19 @@ Blockly.Toolbox.prototype.init = function() {
   this.HtmlDiv.setAttribute('dir', workspace.RTL ? 'RTL' : 'LTR');
   svg.parentNode.insertBefore(this.HtmlDiv, svg);
 
+  // Clicking on toolbox closes popups.
+  Blockly.bindEventWithChecks_(this.HtmlDiv, 'mousedown', this,
+      function(e) {
+        if (Blockly.utils.isRightButton(e) || e.target == this.HtmlDiv) {
+          // Close flyout.
+          Blockly.hideChaff(false);
+        } else {
+          // Just close popups.
+          Blockly.hideChaff(true);
+        }
+        Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+        e.stopPropagation();  // Don't let the document handle this event.
+      }, /*opt_noCaptureIdentifier*/ false, /*opt_noPreventDefault*/ true);
   var workspaceOptions = {
     disabledPatternId: workspace.options.disabledPatternId,
     parentWorkspace: workspace,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2066 and half of #2267 (I wasn't able to reproduce the sticking-on-scroll behavior)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Calls hideChaff when the document is clicked. Also removes the hideChaff call from the toolbox, since that is now handled by the document listener.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bug fixes are good.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1 . Created a block with a text/number input field.
2 . Selected said field.
3 . Clicked the surface of the document. Observed how the field lost focus. (pass)
4 . Selected the field once again.
5 . Clicked on a category. Observed how the field lost focus. (pass)
6 . Selected the field once again.
7 . Click on a non-category part of the toolbox. Observed how the field lost focus (pass)
8 . Selected the field once again..
9 . Clicked the workspace. Observed how the field lost focus. (pass)

1 . Switched the toolbox view to simple.
2 . Created a block with a text/number input field.
3 . Selected said field.
4 . Clicked the flyout toolbox. Observed how the field lost focus. (pass)

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
* Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
