### PR TITLE
Changed New Variable to Default Setter to That Variable

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -171,18 +171,20 @@ Blockly.Variables.flyoutCategory = function(workspace) {
  */
 Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
   var variableModelList = workspace.getVariablesOfType('');
-  variableModelList.sort(Blockly.VariableModel.compareByName);
 
   var xmlList = [];
   if (variableModelList.length > 0) {
-    var firstVariable = variableModelList[0];
+    // New variables are added to the end of the variableModelList.
+    var mostRecentVariableFieldXmlString =
+      Blockly.Variables.generateVariableFieldXmlString(
+          variableModelList[variableModelList.length - 1]);
     if (Blockly.Blocks['variables_set']) {
       var gap = Blockly.Blocks['math_change'] ? 8 : 24;
       var blockText = '<xml>' +
-            '<block type="variables_set" gap="' + gap + '">' +
-            Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
-            '</block>' +
-            '</xml>';
+          '<block type="variables_set" gap="' + gap + '">' +
+          mostRecentVariableFieldXmlString +
+          '</block>' +
+          '</xml>';
       var block = Blockly.Xml.textToDom(blockText).firstChild;
       xmlList.push(block);
     }
@@ -190,7 +192,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       var gap = Blockly.Blocks['variables_get'] ? 20 : 8;
       var blockText = '<xml>' +
           '<block type="math_change" gap="' + gap + '">' +
-          Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
+          mostRecentVariableFieldXmlString +
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +
@@ -202,8 +204,9 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       xmlList.push(block);
     }
 
-    for (var i = 0, variable; variable = variableModelList[i]; i++) {
-      if (Blockly.Blocks['variables_get']) {
+    if (Blockly.Blocks['variables_get']) {
+      variableModelList.sort(Blockly.VariableModel.compareByName);
+      for (var i = 0, variable; variable = variableModelList[i]; i++) {
         var blockText = '<xml>' +
             '<block type="variables_get" gap="8">' +
             Blockly.Variables.generateVariableFieldXmlString(variable) +

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -89,12 +89,11 @@ Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
  */
 Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
   var variableModelList = workspace.getAllVariables();
-  variableModelList.sort(Blockly.VariableModel.compareByName);
 
   var xmlList = [];
   if (variableModelList.length > 0) {
     if (Blockly.Blocks['variables_set_dynamic']) {
-      var firstVariable = variableModelList[0];
+      var firstVariable = variableModelList[variableModelList.length - 1];
       var gap = 24;
       var blockText = '<xml>' +
           '<block type="variables_set_dynamic" gap="' + gap + '">' +
@@ -105,6 +104,7 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
       xmlList.push(block);
     }
     if (Blockly.Blocks['variables_get_dynamic']) {
+      variableModelList.sort(Blockly.VariableModel.compareByName);
       for (var i = 0, variable; variable = variableModelList[i]; i++) {
         var blockText = '<xml>' +
             '<block type="variables_get_dynamic" gap="8">' +


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2050 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the most recently created variable is the one selected in the setter/change blocks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
When you create a new variable, often you want to set that variable immediately. This makes it more convenient. Previously the selected variable would be the first one alphabetically.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Created a 'z' variable. Observed how it was selected in the set/change blocks. (pass)
2. Created an 'a' variable. Observed how it was selected in the set/change blocks. (pass)
3. Created a 'b' variable. Observed how it was selected in the set/change blocks. (pass)

Before on step 3, the 'a' variable would have still been selected.

1. Switched the workspace toolbox to dynamic variables.
2. Created an 'a' string variable. Observed how it was selected in the set block. (pass)
3. Created a 'b' number variable. Observed how it was selected in the set block. (pass)
4. Created a 'c' colour variable. Observed how it was selected in the set block. (pass)


Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
1. Most developers probably won't notice this change, but some of the bigger users (e.g. Scratch, MakeCode) may want a heads-up about this.

2. I wrote this up because I thought it would be fun to dig into (and it was), but I also know this is a feature request with no discussion attached, so if you guys don't actually want it that's cool =) 
