### PR TITLE
Fixed multiple trashcans on the same page leaking state.

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -37,7 +37,28 @@ goog.require('goog.math.Rect');
  * @constructor
  */
 Blockly.Trashcan = function(workspace) {
+  /**
+   * The workspace the trashcan sits in.
+   * @type {!Blockly.Workspace}
+   * @private
+   */
   this.workspace_ = workspace;
+
+  /**
+   * True if the trashcan contains blocks, otherwise false.
+   * @type {boolean}
+   * @private
+   */
+  this.hasBlocks_ = false;
+
+  /**
+   * A list of Xml (stored as strings) representing blocks "inside" the trashcan.
+   * @type {Array}
+   * @private
+   */
+  this.contents_ = [];
+
+
   if (this.workspace_.options.maxTrashcanContents <= 0) {
     return;
   }
@@ -141,20 +162,6 @@ Blockly.Trashcan.prototype.isOpen = false;
  * @private
  */
 Blockly.Trashcan.prototype.minOpenness_ = 0;
-
-/**
- * True if the trashcan contains blocks, otherwise false.
- * @type {boolean}
- * @private
- */
-Blockly.Trashcan.prototype.hasBlocks_ = false;
-
-/**
- * A list of Xml (stored as strings) representing blocks "inside" the trashcan.
- * @type {Array}
- * @private
- */
-Blockly.Trashcan.prototype.contents_ = [];
 
 /**
  * The SVG group containing the trash can.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2291 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves contents_ and hasBlocks_ to be declared on the instances rather than the prototype.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
contents_ had to be moved because it was only being *modified* by the instances rather than *set*. This means that each instances was modifying the prototype array, rather than its own personal array.

hasBlocks_ was moved because I thought it made more sense that way.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1. Opened multi playground.
2. Deleted a 'controls_if' block from one workspace.
3. Deleted a 'controls_if' block from another workspace. Observed how the trashcan's lid opened slightly (pass)
4. Opened the first workspace's trashcan.
5. Removed the 'controls_if' block. Observed how there was no error. (pass)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
I fixed the big problem (declaring contents on the instance rather than the prototype), but I wasn't sure how you would want it organized, so I just did what I thought looked best.
