### PR TITLE
Fix insertion marker flickering on value inputs

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -392,7 +392,9 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
     case Blockly.OUTPUT_VALUE: {
       // Don't offer to connect an already connected left (male) value plug to
       // an available right (female) value plug.
-      if (candidate.isConnected() || this.isConnected()) {
+      if ((candidate.isConnected() &&
+          !candidate.targetBlock().isInsertionMarker()) ||
+          this.isConnected()) {
         return false;
       }
       break;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #2255 

### Proposed Changes

isConnectionAllowed was returning false if the target was already connected to any block, including an insertion marker.  Now it returns false if the target is connected to a non-insertion marker block.

### Reason for Changes

Flickering

### Test Coverage
Tested in the playground (though this one can definitely also take an actual test).

### Additional Information

I'm also going to cherry-pick this into the february release.