### PR TITLE
Added Scroll deltaMode Multiplier Constants

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -26,6 +26,17 @@
 
 goog.provide('Blockly.constants');
 
+/**
+ * The multiplier for scroll wheel deltas using the line delta mode.
+ * @type {number}
+ */
+Blockly.LINE_MODE_MULTIPLIER = 40;
+
+/**
+ * The multiplier for scroll wheel deltas using the page delta mode.
+ * @type {number}
+ */
+Blockly.PAGE_MODE_MULTIPLIER = 125;
 
 /**
  * Number of pixels the mouse must move before a drag starts.

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -217,14 +217,10 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
  * @private
  */
 Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
-  var delta = e.deltaX || e.deltaY;
+  var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
+  var delta = scrollDelta.x || scrollDelta.y;
 
   if (delta) {
-    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
-    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
-    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
-      delta *= 10;
-    }
     var metrics = this.getMetrics_();
     var pos = metrics.viewLeft + delta;
     var limit = metrics.contentWidth - metrics.viewWidth;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -207,16 +207,11 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
  * @private
  */
 Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
-  var delta = e.deltaY;
+  var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
 
-  if (delta) {
-    // Firefox's mouse wheel deltas are a tenth that of Chrome/Safari.
-    // DeltaMode is 1 for a mouse wheel, but not for a trackpad scroll event
-    if (goog.userAgent.GECKO && (e.deltaMode === 1)) {
-      delta *= 10;
-    }
+  if (scrollDelta.y) {
     var metrics = this.getMetrics_();
-    var pos = (metrics.viewTop - metrics.contentTop) + delta;
+    var pos = (metrics.viewTop - metrics.contentTop) + scrollDelta.y;
     var limit = metrics.contentHeight - metrics.viewHeight;
     pos = Math.min(pos, limit);
     pos = Math.max(pos, 0);

--- a/core/utils.js
+++ b/core/utils.js
@@ -305,6 +305,32 @@ Blockly.utils.mouseToSvg = function(e, svg, matrix) {
 };
 
 /**
+ * Get the scroll delta of a mouse event in pixel units.
+ * @param {!Event} e Mouse event.
+ * @return {{x: number, y: number}} Scroll delta object with .x and .y
+ *    properties.
+ */
+Blockly.utils.getScrollDeltaPixels = function(e) {
+  switch (e.deltaMode) {
+    case 0x00:  // Pixel mode.
+      return {
+        x: e.deltaX,
+        y: e.deltaY
+      };
+    case 0x01:  // Line mode.
+      return {
+        x: e.deltaX * Blockly.LINE_MODE_MULTIPLIER,
+        y: e.deltaY * Blockly.LINE_MODE_MULTIPLIER
+      };
+    case 0x02:  // Page mode.
+      return {
+        x: e.deltaX * Blockly.PAGE_MODE_MULTIPLIER,
+        y: e.deltaY * Blockly.PAGE_MODE_MULTIPLIER
+      };
+  }
+};
+
+/**
  * Given an array of strings, return the length of the shortest one.
  * @param {!Array.<string>} array Array of strings.
  * @return {number} Length of shortest string.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1316,27 +1316,24 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
     this.currentGesture_.cancel();
   }
 
-  // TODO (#2301): Change '10' from magic number to constant variable. Also
-  //  change in flyout_vertical.js and flyout_horizontal.js.
-  // Multiplier variable, so that non-pixel-deltaModes are supported.
-  var multiplier = e.deltaMode === 0x1 ? 10 : 1;
 
+  var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
   if (canWheelZoom && (e.ctrlKey || !canWheelMove)) {
     // The vertical scroll distance that corresponds to a click of a zoom button.
     var PIXELS_PER_ZOOM_STEP = 50;
-    var delta = -e.deltaY / PIXELS_PER_ZOOM_STEP * multiplier;
+    var delta = -scrollDelta.y / PIXELS_PER_ZOOM_STEP;
     var position = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
         this.getInverseScreenCTM());
     this.zoom(position.x, position.y, delta);
   } else {
-    var x = this.scrollX - e.deltaX * multiplier;
-    var y = this.scrollY - e.deltaY * multiplier;
+    var x = this.scrollX - scrollDelta.x;
+    var y = this.scrollY - scrollDelta.y;
 
-    if (e.shiftKey && e.deltaX === 0) {
+    if (e.shiftKey && !scrollDelta.x) {
       // Scroll horizontally (based on vertical scroll delta)
       // This is needed as for some browser/system combinations which do not
       // set deltaX.
-      x = this.scrollX - e.deltaY * multiplier;
+      x = this.scrollX - scrollDelta.y;
       y = this.scrollY; // Don't scroll vertically
     }
     this.scroll(x, y);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2301 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that scrolling with line or page delta modes isn't incredibly slow.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Slow is bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1 . Set mouse mode to line (windows settings).
2 . Scrolled vertically with mouse on all browsers. Observed how the scrolling looked the same on all browsers. (pass)
3 . Pressed shift and scrolled vertically with mouse on all browsers (shift causes horizontal scrolling). Observed how the scrolling looked the same on all browsers (pass)
4 . Scrolled vertically with touchpad on all browsers. Observed how the scrolling looked the same on all browsers. (pass)
5 . Scrolled horizontally with touchpad on all browsers. Observed how the scrolling looked the same on all browsers except IE 11 (apparently IE 11 doesn't let you scroll horizontally with touchpads). (pass)

1 . Set the mouse mode to page (windows settings).
2 . Scrolled vertically with mouse on all browsers. Observed how the scrolling looked the same (125 px) on Chrome and Firefox. IE 11 and Edge both convert it to pixels for you (568.75 and 830 px respectively) so there's nothing we can do about that. (pass)
3 . Pressed shift and scrolled vertically with mouse on all browsers. Observed the same Chrome/Firefox vs IE/Edge behavior. (pass)
4 . Scrolled vertically with touchpad on all browsers. Observed how the scrolling looked the same on all browsers. (pass)
5 . Scrolled horizontally with touchpad on all browsers. Observed how it looked basically the same on all browsers, except IE 11 doesn't let you scroll horizontally with the touchpad. (pass)

Tested on:
* Desktop Chrome, Windows 10
* Desktop Firefox, Windows 10
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11, Windows 10
* Windows Edge, Windows 10

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

The pixels per line values for different browsers are as follows:
Firefox: N/A they give you line values.
Chrome: ~41.6 px/ln
IE: ~35.7 px/ln
Edge: ~47.5 px/ln

So that's why the line multiplier is 40.

The pixels per page are much larger, but scrolling 700px isn't very good behavior for blockly, because you could lose blocks easily. So I decided 125 px is a good number (equivalent to 3lns in chrome).
