### PR TITLE
Fix error by init of dropdown in case the value is ""

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -392,8 +392,8 @@ Blockly.FieldDropdown.prototype.getValue = function() {
  * @param {string} newValue New value to set.
  */
 Blockly.FieldDropdown.prototype.setValue = function(newValue) {
-  if (newValue === null || newValue === this.value_) {
-    return;  // No change if null.
+  if (newValue === null || (newValue === this.value_ && this.text_)) {
+    return;  // No change if null and text_ was initialized.
   }
   if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->



## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
I have following dropdown options

```
[
    ["no matter", ""]
    ["Update", "true"]
    ["Command", "false"]
]
```
In case my value is "" the text is not filled with "no matter" by the initial draw and the empty selector is shown. I expect the text "no matter"

This PR fixes that


### Proposed Changes

Just check if the text_ was initialized and if not => do it.

### Reason for Changes

Invalid drawing if value is ""

### Test Coverage

the change is so tiny.

### Additional Information

<!-- Anything else we should know? -->
