### PR TITLE
Added Event Filtering to workspaceChanged in Mutator

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -141,6 +141,9 @@ Blockly.Mutator.prototype.createEditor_ = function() {
     var quarkXml = null;
   }
   var workspaceOptions = {
+    // If you want to enable disabling, also remove the
+    // event filter from workspaceChanged_ .
+    disable: false,
     disabledPatternId: this.block_.workspace.options.disabledPatternId,
     languageTree: quarkXml,
     parentWorkspace: this.block_.workspace,
@@ -315,9 +318,15 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
  * Update the source block when the mutator's blocks are changed.
  * Bump down any block that's too high.
  * Fired whenever a change is made to the mutator's workspace.
+ * @param {!Blockly.Events.Abstract} e Custom data for event.
  * @private
  */
-Blockly.Mutator.prototype.workspaceChanged_ = function() {
+Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
+  if (e.type == Blockly.Events.UI ||
+      (e.type == Blockly.Events.CHANGE && e.element == 'disabled')) {
+    return;
+  }
+
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a little bit of optimization to the workspaceChanged function by having it return on events that don't actually change anything.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Eliminating extra operations is good.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

workspaceChanged is called for two purposes A) Rerendering the source block (the one being mutated) and B) Resizing the bubble.

[UI events](https://developers.google.com/blockly/guides/configure/web/events#blocklyeventsui) do not affect the composition of the workspace. They also do not affect the size of the workspace. This means the A & B are not neccessary.

[Disable events](https://developers.google.com/blockly/guides/configure/web/events#blocklyeventsblock_change) do affect the composition of the workspace, but by default disabling is not available for workspaces (because they have simple toolboxes, and now an explicit flag), the event is only fired because of the disableOrphans callback. This means that disable events effectively do not affect the composition of the workspace. They also do not affect the size of the workspace. This means that A & B are not neccessary.

There's the basic explanation, but if there's anything specific you'd like me to test I'm all for it.

Tested on:

N/A
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
