### PR TITLE
Add a playgound for debugging SVG paths

### DIFF
--- a/tests/rendering/svg_paths.html
+++ b/tests/rendering/svg_paths.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SVG Path Playground</title>
+  <script src="../../blockly_uncompressed.js"></script>
+
+  <style>
+    html, body {
+      height: 100%;
+    }
+    body {
+      background-color: #fff;
+      font-family: sans-serif;
+      overflow: hidden;
+    }
+    .pathDebugClass {
+      stroke-width: 1px;
+      stroke: black;
+      fill: none;
+    }
+    .lineStartMarker {
+      fill: blue;
+    }
+  </style>
+
+<script>
+'use strict';
+var svgSpace;
+
+function addPathAt(path, x, y) {
+  var group = Blockly.utils.createSvgElement('g', {}, svgSpace);
+  Blockly.utils.createSvgElement('path', {
+    'd': 'm ' + (x + 50) + ',' + y + ' ' + path,
+    'marker-start': 'url(#startDot)',
+    'marker-end': 'url(#endDot)',
+    'class': 'pathDebugClass'
+  },
+  group);
+
+
+  return group;
+}
+
+function start() {
+  svgSpace = document.getElementById('workspace');
+  addPathAt(Blockly.BlockSvg.TAB_PATH_DOWN, 0, 0);
+  addPathAt(Blockly.BlockSvg.START_HAT_PATH, 0, 40);
+  addPathAt(Blockly.BlockSvg.NOTCH_PATH_LEFT, 0, 60);
+  addPathAt(Blockly.BlockSvg.NOTCH_PATH_RIGHT, 0, 70);
+  addPathAt(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER, 0, 90);
+}
+</script>
+
+</head>
+
+<body onload="start()">
+
+  <svg xmlns="http://www.w4.org/2000/svg" version="1.1" width="1000px" height="1000px" viewBox="0 0 200 200" id="workspace">
+
+    <defs>
+      <!-- Background grid -->
+      <pattern id="grid" patternUnits="userSpaceOnUse" width="10" height="10">
+        <line stroke="#ccc" stroke-width="2" x1="0" y1="1" x2="2" y2="1"></line>
+      </pattern>
+      <!-- simple dot marker definitions -->
+      <marker id="startDot" viewBox="0 0 10 10" refX="5" refY="5"
+          markerWidth="5" markerHeight="5">
+        <circle cx="5" cy="5" r="2" fill="red" />
+      </marker>
+      <marker id="endDot" viewBox="0 0 10 10" refX="5" refY="5"
+          markerWidth="5" markerHeight="5">
+        <circle cx="5" cy="5" r="2" fill="blue" />
+      </marker>
+    </defs>
+    <rect x="0" y="0" width="1000" height="1000" style="fill:url(#grid);"></rect>
+  </svg>
+</body>

--- a/tests/rendering/svg_paths.html
+++ b/tests/rendering/svg_paths.html
@@ -1,4 +1,23 @@
 <!DOCTYPE html>
+<!--
+@license
+Blockly Tests
+
+Copyright 2019 Google Inc.
+https://developers.google.com/blockly/
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <html>
 <head>
   <meta charset="utf-8">
@@ -29,9 +48,12 @@
 var svgSpace;
 
 function addPathAt(path, x, y) {
-  var group = Blockly.utils.createSvgElement('g', {}, svgSpace);
+  var group = Blockly.utils.createSvgElement('g',
+      {
+        'transform': 'translate(' + (x + 50) + ', ' + y + ')'
+      }, svgSpace);
   Blockly.utils.createSvgElement('path', {
-    'd': 'm ' + (x + 50) + ',' + y + ' ' + path,
+    'd': 'M 0,0 ' + path,
     'marker-start': 'url(#startDot)',
     'marker-end': 'url(#endDot)',
     'class': 'pathDebugClass'


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Makes debugging block paths less painful.

### Proposed Changes

Creates a page with a grid that makes it easy to draw paths defined in Blockly core.  It looks like this:
![image](https://user-images.githubusercontent.com/13686399/54400686-48589080-4681-11e9-89e0-2379e789f7a2.png)

You can add a path:
```
  addPathAt(Blockly.BlockSvg.TAB_PATH_DOWN, 0, 0);
  addPathAt(Blockly.BlockSvg.START_HAT_PATH, 0, 40);
  addPathAt(Blockly.BlockSvg.NOTCH_PATH_LEFT, 0, 60);
  addPathAt(Blockly.BlockSvg.NOTCH_PATH_RIGHT, 0, 70);
  addPathAt(Blockly.BlockSvg.INNER_TOP_LEFT_CORNER, 0, 90);
```

The path renders with a red dot at the beginning and a blue dot at the end (helpful for working with paths that run LTR or RTL).

### Reason for Changes

We consistently hear people asking if they can tweak the block connections.  It is much easier to do this when you can see what the different parts of the path evaluate to.

Also, I'm working on rendering again and I needed this.
