### PR TITLE
Fixed updateToolbox Not Properly Updating Flyouts

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1574,8 +1574,10 @@ Blockly.WorkspaceSvg.prototype.updateToolbox = function(tree) {
       throw Error('Existing toolbox has no categories.  Can\'t change mode.');
     }
     this.options.languageTree = tree;
-    this.toolbox_.populate_(tree);
+    var openNode = this.toolbox_.populate_(tree);
     this.toolbox_.addColour_();
+    this.toolbox_.position();
+    this.toolbox_.tree_.setSelectedItem(openNode);
   } else {
     if (!this.flyout_) {
       throw Error('Existing toolbox has categories.  Can\'t change mode.');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2330 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so open flyouts are properly positioned & populated when updateToolbox is called on the workspace.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before the flyouts would not be modified at all, causing visual bugs.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Added the expanded="true" attribute to the Logic toolbox category in the "toolbox-categories" toolbox at ~ln 430 in playground.
2. Added the expanded="true" attribute to the Basic toolbox category in the "toolbox-test-blocks" toolbox at ~ln 1113 in playground. 
3. Added the below code at ~ ln 146 in playground:
```
function test() {
  var categoriesTB = document.getElementById('toolbox-categories');
  var testTB = document.getElementById('toolbox-test-blocks');
  Blockly.getMainWorkspace().updateToolbox(testTB);
}
```
4. Refreshed the playground in chrome:
![Categories](https://user-images.githubusercontent.com/25440652/54646644-fcc92c80-4a5c-11e9-9688-eecd999aa9b2.jpg)
and ran the test() command in console. Observed how it was rendered correctly. (pass)
![Basic_Expanded](https://user-images.githubusercontent.com/25440652/54646649-02267700-4a5d-11e9-9217-d13a8a1e681c.jpg)

5. Set the expanded attribute on the Basic toolbox category in the "toolbox-test-blocks" toolbox to false.
6. Refreshed the playground in chrome and ran the test() command in console. Observed how it was rendered correctly, meaning the flyout was closed. (pass)
![Basic_NotExpanded](https://user-images.githubusercontent.com/25440652/54646656-0783c180-4a5d-11e9-8f0a-60e979783699.jpg)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
