### PR TITLE
Fixed Trashcan Flyout Positioning

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -154,18 +154,32 @@ Blockly.HorizontalFlyout.prototype.position = function() {
 
   // X is always 0 since this is a horizontal flyout.
   var x = 0;
-  // If there is a toolbox.
-  if (targetWorkspaceMetrics.toolboxHeight) {
-    if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
-      var y = targetWorkspaceMetrics.toolboxHeight;
+  // If this flyout is the toolbox flyout.
+  if (targetWorkspaceMetrics.toolboxPosition == this.toolboxPosition_) {
+    // If there is a toolbox.
+    if (targetWorkspaceMetrics.toolboxHeight) {
+      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+        var y = targetWorkspaceMetrics.toolboxHeight;
+      } else {
+        var y = targetWorkspaceMetrics.viewHeight - this.height_;
+      }
     } else {
-      var y = targetWorkspaceMetrics.viewHeight - this.height_;
+      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+        var y = 0;
+      } else {
+        var y = targetWorkspaceMetrics.viewHeight;
+      }
     }
   } else {
     if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
       var y = 0;
     } else {
-      var y = targetWorkspaceMetrics.viewHeight;
+      // Because the anchor point of the flyout is on the top, but we want
+      // to align the bottom edge of the flyout with the bottom edge of the
+      // blocklyDiv, we calculate the full height of the div minus the height
+      // of the flyout.
+      var y = targetWorkspaceMetrics.viewHeight
+        + targetWorkspaceMetrics.absoluteTop - this.height_;
     }
   }
   this.positionAt_(this.width_, this.height_, x, y);

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -151,18 +151,32 @@ Blockly.VerticalFlyout.prototype.position = function() {
 
   // Y is always 0 since this is a vertical flyout.
   var y = 0;
-  // If there is a toolbox.
-  if (targetWorkspaceMetrics.toolboxWidth) {
-    if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
-      var x = targetWorkspaceMetrics.toolboxWidth;
+  // If this flyout is the toolbox flyout.
+  if (targetWorkspaceMetrics.toolboxPosition == this.toolboxPosition_) {
+    // If there is a category toolbox.
+    if (targetWorkspaceMetrics.toolboxWidth) {
+      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+        var x = targetWorkspaceMetrics.toolboxWidth;
+      } else {
+        var x = targetWorkspaceMetrics.viewWidth - this.width_;
+      }
     } else {
-      var x = targetWorkspaceMetrics.viewWidth - this.width_;
+      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+        var x = 0;
+      } else {
+        var x = targetWorkspaceMetrics.viewWidth;
+      }
     }
   } else {
     if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
       var x = 0;
     } else {
-      var x = targetWorkspaceMetrics.viewWidth;
+      // Because the anchor point of the flyout is on the left, but we want
+      // to align the right edge of the flyout with the right edge of the
+      // blocklyDiv, we calculate the full width of the div minus the width
+      // of the flyout.
+      var x = targetWorkspaceMetrics.viewWidth
+          + targetWorkspaceMetrics.absoluteLeft - this.width_;
     }
   }
   this.positionAt_(this.width_, this.height_, x, y);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2345 <- Best issue number evaaar.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the trashcan flyout is positioned correctly (aligned with the edge of the blocklyDiv)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
It looks ugly otherwise.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Categories, Small Flyout
![Trashcan_Categories_Small_Vert](https://user-images.githubusercontent.com/25440652/55243656-e3fb0c80-51fc-11e9-9c68-105c22fa3578.jpg)
![Trashcan_Categories_Small_Horiz](https://user-images.githubusercontent.com/25440652/55243660-e65d6680-51fc-11e9-8cda-cb00933d7017.jpg)

Categories, Big Flyout
![Trashcan_Categories_Big_Vert](https://user-images.githubusercontent.com/25440652/55243661-e8272a00-51fc-11e9-90ce-57236886167a.jpg)
![Trashcan_Categories_Big_Horiz](https://user-images.githubusercontent.com/25440652/55243666-e9f0ed80-51fc-11e9-9535-68f86f7ea1b4.jpg)

Simple, Small Flyout
![Trashcan_Simple_Small_Vert](https://user-images.githubusercontent.com/25440652/55243673-ed847480-51fc-11e9-9adb-0057f9f02088.jpg)
![Trashcan_Simple_Small_Horiz](https://user-images.githubusercontent.com/25440652/55243676-ef4e3800-51fc-11e9-8d3d-ec474183923d.jpg)

Simple, Big FLyout
![Trashcan_Simple_Big_Vert](https://user-images.githubusercontent.com/25440652/55243678-f07f6500-51fc-11e9-895b-e46f291398aa.jpg)
![Trashcan_Simple_Big_Horiz](https://user-images.githubusercontent.com/25440652/55243685-f1b09200-51fc-11e9-84bd-ca6ae09cff42.jpg)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
