### PR TITLE
Adds check for a targetConnection

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -397,8 +397,12 @@ Blockly.Block.prototype.unplugFromRow_ = function(opt_healStack) {
 };
 
 /**
- * Returns the connection on the only value input on the block, or null if the
- * number of value inputs is not one.
+ * Returns the connection on the value input that is connected to another block.
+ * When an insertion marker is connected to a connection with a block already
+ * attached, the connected block is attached to the insertion marker.
+ * Since only one block can be displaced and attached to the insertion marker
+ * this should only ever return one connection.
+ *
  * @return {Blockly.Connection} The connection on the value input, or null.
  * @private
  */
@@ -406,7 +410,8 @@ Blockly.Block.prototype.getOnlyValueConnection_ = function() {
   var connection = null;
   for (var i = 0; i < this.inputList.length; i++) {
     var thisConnection = this.inputList[i].connection;
-    if (thisConnection && thisConnection.type == Blockly.INPUT_VALUE) {
+    if (thisConnection && thisConnection.type == Blockly.INPUT_VALUE
+        && thisConnection.targetConnection) {
       if (connection) {
         return null; // More than one value input found.
       }

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -238,7 +238,7 @@ function test_block_row_unplug_multi_inputs_middle() {
 
     // Middle block has multiple inputs.
     blocks.B.unplug(true);
-    assertUnpluggedNoheal(blocks);
+    assertUnpluggedHealed(blocks);
   } finally {
     blockTest_tearDown();
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2336 

### Proposed Changes
Currently, we are looking at all value inputs on a block. If there is more than one value input then we return null which means that we don't have a connection to reattach to the parent block. The proposed fix is to only look for value inputs that have something connected. In the case that something is connected we want to return that connection so that we can reattach this block to the parent. 

### Reason for Changes
When there was a block with more than one value input the block that was connected to the insertion marker would not get reattached to the parent. Therefore when we hid the insertion marker the block would disappear with it. 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
