### PR TITLE
Hides chaff on document mouseup

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -420,6 +420,11 @@ Blockly.init_ = function(mainWorkspace) {
  */
 Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
+    document.addEventListener('mouseup', function() {
+      Blockly.hideChaff();
+      Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
+    }, false);
+
     Blockly.bindEventWithChecks_(document, 'scroll', null, function() {
       var workspaces = Blockly.Workspace.getAll();
       for (var i = 0, workspace; workspace = workspaces[i]; i++) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2066 & #2312

### Proposed Changes
Previously this was fixed in #2286, however it was breaking context menus. Clicks on context menus were not being processed because the document mousedown function was calling Blockly.hideChaff() before the context menu mouse up event could process the user’s click. The closure context menus use 'mouseup' to process the user's click. We therefore need to use mouseup so that the click on the context menu can be processed before we call Blockly.hideChaff() in the document mouseup event handler. 

We can’t use the Blockly.bindEvent functions because it changes mouseup to be pointerup which we can't use because the closure menus use mouseup. If we used pointerup then the context menu click would not be guaranteed to execute first and we would have the same problem with context menus not working. 

### Reason for Changes

### Test Coverage
Tested on ios device to make sure using mouseup instead of pointer up didn't break things. From what I can tell contextMenus still work and we don't need hideChaff to be called because we use popups when clicking on fields. The only exception to this seems to be the angel picker. However, this might need to be fixed see #2316.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
