### PR TITLE
Fixes bumping too much when in RTL

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -106,7 +106,8 @@ Blockly.RenderedConnection.prototype.bumpAwayFrom_ = function(staticConnection) 
     dy = -dy;
   }
   if (rootBlock.RTL) {
-    dx = -dx;
+    dx = (staticConnection.x_ - Blockly.SNAP_RADIUS -
+      Math.floor(Math.random() * Blockly.BUMP_RANDOMNESS)) - this.x_;
   }
   rootBlock.moveBy(dx, dy);
   selected || rootBlock.removeSelect();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2290 
### Proposed Changes
Previously we were just taking the negative value of dx when in RTL. As far as I can tell this only works the first time that we bump a block. The next times that we bump a block the x value of the output connection is farther to the left(because of the previous bump) while the place that we want to get to (staticConnection.x_ + snap_radius + random number) is moving farther to the right. So when we take the different between the two it is getting larger and larger creating the unnecessarily large bump.

The proposed fix is to change subtract the snap_radius and random number instead of adding them. This way our target is in the same direction as the block is moving. Which will create a smaller bump.

### Reason for Changes
Some blocks in RTL were getting bumped too far.

### Test Coverage
Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
