### PR TITLE
typo fix in line 134 of field.js documentation

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -131,7 +131,7 @@ Blockly.Field.prototype.maxDisplayLength = 50;
 Blockly.Field.prototype.text_ = '';
 
 /**
- * Block this field is attached to.  Starts as null, then in set in init.
+ * Block this field is attached to.  Starts as null, then set in init.
  * @type {Blockly.Block}
  * @protected
  */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. --> #2368

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes a small grammar issue in documentation in field.js

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The typo bugs me.

### Test Coverage
N/A?
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<Tested on:>
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information
N/A
<!-- Anything else we should know? -->
