### PR TITLE
Fixed Mutator Flyout Being Positioned Incorrectly RTL

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -155,7 +155,7 @@ Blockly.HorizontalFlyout.prototype.position = function() {
   // X is always 0 since this is a horizontal flyout.
   var x = 0;
   // If this flyout is the toolbox flyout.
-  if (targetWorkspaceMetrics.toolboxPosition == this.toolboxPosition_) {
+  if (this.targetWorkspace_.toolboxPosition == this.toolboxPosition_) {
     // If there is a toolbox.
     if (targetWorkspaceMetrics.toolboxHeight) {
       if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -152,7 +152,7 @@ Blockly.VerticalFlyout.prototype.position = function() {
   // Y is always 0 since this is a vertical flyout.
   var y = 0;
   // If this flyout is the toolbox flyout.
-  if (targetWorkspaceMetrics.toolboxPosition == this.toolboxPosition_) {
+  if (this.targetWorkspace_.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
     if (targetWorkspaceMetrics.toolboxWidth) {
       if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -397,8 +397,7 @@ Blockly.Mutator.prototype.getFlyoutMetrics_ = function() {
     viewWidth: this.workspaceWidth_ - this.workspace_.getFlyout().getWidth(),
     absoluteTop: 0,
     absoluteLeft: this.workspace_.RTL ? 0 :
-        this.workspace_.getFlyout().getWidth(),
-    toolboxPosition: this.workspace_.toolboxPosition
+        this.workspace_.getFlyout().getWidth()
   };
 };
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -397,7 +397,8 @@ Blockly.Mutator.prototype.getFlyoutMetrics_ = function() {
     viewWidth: this.workspaceWidth_ - this.workspace_.getFlyout().getWidth(),
     absoluteTop: 0,
     absoluteLeft: this.workspace_.RTL ? 0 :
-        this.workspace_.getFlyout().getWidth()
+        this.workspace_.getFlyout().getWidth(),
+    toolboxPosition: this.workspace_.toolboxPosition
   };
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2377 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the mutator is positioned correctly in RTL once again.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before it overlapped the workspace blocks and other bad things.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![Mutator_Categories_1](https://user-images.githubusercontent.com/25440652/56060637-4fc09780-5d1c-11e9-9fa7-04051073161b.jpg)
![Mutator_Categories_2](https://user-images.githubusercontent.com/25440652/56060640-518a5b00-5d1c-11e9-9520-fffbc3417efc.jpg)
![Mutator_Simple_1](https://user-images.githubusercontent.com/25440652/56060644-53541e80-5d1c-11e9-9414-6cdd845597fc.jpg)
![Mutator_Simple_2](https://user-images.githubusercontent.com/25440652/56060649-54854b80-5d1c-11e9-931b-afdf748ed553.jpg)


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
PR #2349 (which fixed the trashcan flyout positioning) added a check to see if the flyout's toolbox positioned match its target workspace's toolbox position (that is, if it was the toobox flyout). The problem was the mutators weren't returning what their toolbox position was, so the flyout was assuming it wasn't the toolbox flyout, causing it to position itself incorrectly.
