### PR TITLE
Added isDirty_ Property to Fields

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -280,8 +280,6 @@ Blockly.FieldAngle.prototype.setText = function(text) {
     return;
   }
   this.updateGraph_();
-  // Cached width is obsolete.  Clear it.
-  this.size_.width = 0;
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -120,9 +120,11 @@ Blockly.FieldColour.prototype.DROPDOWN_BACKGROUND_COLOUR = 'white';
  */
 Blockly.FieldColour.prototype.init = function() {
   Blockly.FieldColour.superClass_.init.call(this);
-  this.borderRect_.style['fillOpacity'] = 1;
   this.size_ = new goog.math.Size(Blockly.FieldColour.DEFAULT_WIDTH,
       Blockly.FieldColour.DEFAULT_HEIGHT);
+  this.borderRect_.style['fillOpacity'] = 1;
+  this.borderRect_.setAttribute('width',
+      this.size_.width + Blockly.BlockSvg.SEP_SPACE_X);
   this.setValue(this.getValue());
 };
 
@@ -140,36 +142,18 @@ Blockly.FieldColour.prototype.dispose = function() {
 };
 
 /**
+ * Colour fields are fixed with, no need to update.
+ */
+Blockly.FieldColour.prototype.updateWidth = function() {
+  // NOP
+};
+
+/**
  * Return the current colour.
  * @return {string} Current colour in '#rrggbb' format.
  */
 Blockly.FieldColour.prototype.getValue = function() {
   return this.colour_;
-};
-
-/**
- * Get the size, and rerender if necessary.
- * @return {!goog.math.Size} Height and width.
- */
-Blockly.FieldColour.prototype.getSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
-
-  return this.size_;
-};
-
-/**
- * Updates the width of the field.  Colour fields have a constant width, but
- * the width is sometimes reset to force a rerender.
- */
-Blockly.FieldColour.prototype.updateWidth = function() {
-  var width = Blockly.FieldColour.DEFAULT_WIDTH;
-  if (this.borderRect_) {
-    this.borderRect_.setAttribute('width',
-        width + Blockly.BlockSvg.SEP_SPACE_X);
-  }
-  this.size_.width = width;
 };
 
 /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -92,8 +92,6 @@ Blockly.FieldLabel.prototype.init = function() {
     this.textElement_.tooltip = this.sourceBlock_;
   }
   Blockly.Tooltip.bindMouseEvents(this.textElement_);
-  // Force a render.
-  this.render_();
 };
 
 /**

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -190,7 +190,64 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
             "text": "NO DATE FIELD"
           }
       }
-    ]
+    ],
+    "colour": 230
+  },
+  {
+    "type": "test_fields_text_input",
+    "message0": "text input %1",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "TEXT_INPUT",
+        "text": "default"
+      }
+    ],
+    "colour": 230,
+    "tooltip": "",
+    "helpUrl": ""
+  },
+  {
+    "type": "test_fields_checkbox",
+    "message0": "checkbox %1",
+    "args0": [
+      {
+        "type": "field_checkbox",
+        "name": "CHECKBOX",
+        "checked": true
+      }
+    ],
+    "colour": 230,
+    "tooltip": "",
+    "helpUrl": ""
+  },
+  {
+    "type": "test_fields_colour",
+    "message0": "colour %1",
+    "args0": [
+      {
+        "type": "field_colour",
+        "name": "COLOUR",
+        "colour": "#ff0000"
+      }
+    ],
+    "colour": 230,
+    "tooltip": "",
+    "helpUrl": ""
+  },
+  {
+    "type": "test_fields_variable",
+    "message0": "variable %1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VARIABLE",
+        "variable": "item"
+      }
+    ],
+    "colour": 230,
+    "tooltip": "",
+    "helpUrl": ""
   },
   {
     "type": "test_fields_number",

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1223,6 +1223,10 @@ h1 {
       <label text="Others"></label>
       <block type="test_fields_angle"></block>
       <block type="test_fields_date"></block>
+      <block type="test_fields_text_input"></block>
+      <block type="test_fields_checkbox"></block>
+      <block type="test_fields_colour"></block>
+      <block type="test_fields_variable"></block>
     </category>
     <category name="Mutators">
       <label text="logic_compare"></label>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #1623

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an isDirty_ property to a field to tell if the field needs to be rerendered.

Also does some cleanup on angle, colour, and label, which weren't conforming to standward.

#### Backwards Compatability

Checks the circumstance of: not dirty, visible, but width = 0, because this probably means someone is using the old rerender method. It then logs a warning, and does the render anyway.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before if you wanted to rerender a field you had to set its size_.width property to 0. This was inconvenient, and confusing because size_.width would also be zero when the field was not visible (unrelated to rerendering). 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I wasn't exactly sure how to test this since it isn't really a functional change just a structural one, so I just decided to create test blocks for all the fields that didn't have one yet. They are all rendered correctly when the flyout is opened.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

Some not-render-related things with size_ can still be cleaned up (looking at you label and dropdown fields!) but I didn't want to dig into that until getSize/getCorrectedSize has been decided.