### PR TITLE
Fixed Visible Floating Point Errors in Number Fields.

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -79,6 +79,10 @@ Blockly.FieldNumber.fromJson = function(options) {
 Blockly.FieldNumber.prototype.setConstraints = function(min, max, precision) {
   precision = parseFloat(precision);
   this.precision_ = isNaN(precision) ? 0 : precision;
+  var precisionString = this.precision_.toString();
+  var decimalIndex = precisionString.indexOf('.');
+  this.fractionalDigits_ = (decimalIndex == -1) ? -1 :
+      precisionString.length - (decimalIndex + 1);
   min = parseFloat(min);
   this.min_ = isNaN(min) ? -Infinity : min;
   max = parseFloat(max);
@@ -106,13 +110,14 @@ Blockly.FieldNumber.prototype.classValidator = function(text) {
     // Invalid number.
     return null;
   }
+  // Get the value in range.
+  n = Math.min(Math.max(n, this.min_), this.max_);
   // Round to nearest multiple of precision.
   if (this.precision_ && isFinite(n)) {
     n = Math.round(n / this.precision_) * this.precision_;
   }
-  // Get the value in range.
-  n = Math.min(Math.max(n, this.min_), this.max_);
-  return String(n);
+  return (this.fractionalDigits_ == -1) ? String(n) :
+      n.toFixed(this.fractionalDigits_);
 };
 
 Blockly.Field.register('field_number', Blockly.FieldNumber);

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -207,8 +207,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "A number."
   },
   {
-    "type": "test_fields_integer",
-    "message0": "integer %1",
+    "type": "test_fields_number_whole",
+    "message0": "precision 1 %1",
     "args0": [
       {
         "type": "field_number",
@@ -219,11 +219,11 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     ],
     "style": "math_blocks",
     "output": "Number",
-    "tooltip": "An integer."
+    "tooltip": "The number should be rounded to multiples of 1"
   },
   {
     "type": "test_fields_number_hundredths",
-    "message0": "$ %1",
+    "message0": "precision 0.01 %1",
     "args0": [
       {
         "type": "field_number",
@@ -234,7 +234,37 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     ],
     "style": "math_blocks",
     "output": "Number",
-    "tooltip": "A dollar amount."
+    "tooltip": "The number should be rounded to multiples of 0.01"
+  },
+  {
+    "type": "test_fields_number_halves",
+    "message0": "precision 0.5 %1",
+    "args0": [
+      {
+        "type": "field_number",
+        "name": "NUM",
+        "precision": 0.5,
+        "text": "0"
+      }
+    ],
+    "style": "math_blocks",
+    "output": "Number",
+    "tooltip": "The number should be rounded to multiples of 0.5"
+  },
+  {
+    "type": "test_fields_number_three_halves",
+    "message0": "precision 1.5 %1",
+    "args0": [
+      {
+        "type": "field_number",
+        "name": "NUM",
+        "precision": 1.5,
+        "text": "0"
+      }
+    ],
+    "style": "math_blocks",
+    "output": "Number",
+    "tooltip": "The number should be rounded to multiples of 1.5"
   },
   {
     "type": "test_fields_integer_bounded",

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1197,10 +1197,16 @@ h1 {
       <block type="test_fields_number">
         <field name="NUM">123.456</field>
       </block>
-      <block type="test_fields_integer">
+      <block type="test_fields_number_hundredths">
         <field name="NUM">123.456</field>
       </block>
-      <block type="test_fields_number_hundredths">
+      <block type="test_fields_number_halves">
+        <field name="NUM">123.456</field>
+      </block>
+      <block type="test_fields_number_whole">
+        <field name="NUM">123.456</field>
+      </block>
+      <block type="test_fields_number_three_halves">
         <field name="NUM">123.456</field>
       </block>
       <block type="test_fields_integer_bounded">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#516 also #1945 which is a dupe.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so numbers are rounded to a fixed decimal place before being returned to eliminate visible floating point errors.

I also moved the clamp to be above the precision check, for reasons discussed in #516.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Floating point errors are confusing and ugly.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

The numbers section of the fields test blocks category now has some additional blocks. The integer block has also had its label changed to 'precision 1'.

Old Validator:
![NumbersValidator_Old](https://user-images.githubusercontent.com/25440652/56097883-db6a2d80-5eae-11e9-9570-2807c9717ef8.jpg)

New Validator:
![NumbersValidator_New](https://user-images.githubusercontent.com/25440652/56097886-defdb480-5eae-11e9-909a-68ff207acbf1.jpg)
**Note the extra .0 on the 'precision 1.5' block.** This may or may not be desirable, and I'm happy to change it.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
