### PR TITLE
Add Block.setEnabled

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -328,12 +328,12 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
     if (legal) {
       this.setWarningText(null);
       if (!this.isInFlyout) {
-        this.setDisabled(false);
+        this.setEnabled(true);
       }
     } else {
       this.setWarningText(Blockly.Msg['CONTROLS_FLOW_STATEMENTS_WARNING']);
       if (!this.isInFlyout && !this.getInheritedDisabled()) {
-        this.setDisabled(true);
+        this.setEnabled(false);
       }
     }
   }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -639,7 +639,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     this.argumentVarModels_ = [];
     this.quarkConnections_ = {};
     this.quarkIds_ = null;
-    this.previousDisabledState_ = false;
+    this.previousEnabledState_ = true;
   },
 
   /**
@@ -985,7 +985,7 @@ Blockly.Blocks['procedures_callreturn'] = {
     this.arguments_ = [];
     this.quarkConnections_ = {};
     this.quarkIds_ = null;
-    this.previousDisabledState_ = false;
+    this.previousEnabledState_ = true;
   },
 
   getProcedureCall: Blockly.Blocks['procedures_callnoreturn'].getProcedureCall,

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -933,10 +933,10 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         }
         Blockly.Events.setGroup(event.group);
         if (event.newValue) {
-          this.previousDisabledState_ = this.disabled;
+          this.previousEnabledState_ = this.isEnabled();
           this.setEnabled(false);
         } else {
-          this.setEnabled(!this.previousDisabledState_);
+          this.setEnabled(this.previousEnabledState_);
         }
         Blockly.Events.setGroup(oldGroup);
       }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -934,9 +934,9 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         Blockly.Events.setGroup(event.group);
         if (event.newValue) {
           this.previousDisabledState_ = this.disabled;
-          this.setDisabled(true);
+          this.setEnabled(false);
         } else {
-          this.setDisabled(this.previousDisabledState_);
+          this.setEnabled(!this.previousDisabledState_);
         }
         Blockly.Events.setGroup(oldGroup);
       }
@@ -1081,12 +1081,12 @@ Blockly.Blocks['procedures_ifreturn'] = {
       }
       this.setWarningText(null);
       if (!this.isInFlyout) {
-        this.setDisabled(false);
+        this.setEnabled(true);
       }
     } else {
       this.setWarningText(Blockly.Msg['PROCEDURES_IFRETURN_WARNING']);
       if (!this.isInFlyout && !this.getInheritedDisabled()) {
-        this.setDisabled(true);
+        this.setEnabled(false);
       }
     }
   },

--- a/core/block.js
+++ b/core/block.js
@@ -1217,12 +1217,27 @@ Blockly.Block.prototype.getInputsInline = function() {
 /**
  * Set whether the block is disabled or not.
  * @param {boolean} disabled True if disabled.
+ * @deprecated April 2018
  */
 Blockly.Block.prototype.setDisabled = function(disabled) {
+  console.warn('Deprecated call to Blockly.Block.prototype.setDisabled, ' +
+               'use Blockly.Block.prototype.setEnabled instead.');
   if (this.disabled != disabled) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
         this, 'disabled', null, this.disabled, disabled));
     this.disabled = disabled;
+  }
+};
+
+/**
+ * Set whether the block is enabled or not.
+ * @param {boolean} enabled True if enabled.
+ */
+Blockly.Block.prototype.setEnabled = function(enabled) {
+  if (this.disabled == enabled) {
+    Blockly.Events.fire(new Blockly.Events.BlockChange(
+        this, 'disabled', null, this.disabled, !enabled));
+    this.disabled = !enabled;
   }
 };
 

--- a/core/block.js
+++ b/core/block.js
@@ -75,8 +75,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.inputList = [];
   /** @type {boolean|undefined} */
   this.inputsInline = undefined;
-  /** 
-   * @type {boolean} 
+  /**
+   * @type {boolean}
    * @private
    */
   this.disabled = false;
@@ -1241,7 +1241,7 @@ Blockly.Block.prototype.isEnabled = function() {
  * @param {boolean} enabled True if enabled.
  */
 Blockly.Block.prototype.setEnabled = function(enabled) {
-  if (this.isEnabled != enabled) {
+  if (this.isEnabled() != enabled) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
         this, 'disabled', null, this.disabled, !enabled));
     this.disabled = !enabled;

--- a/core/block.js
+++ b/core/block.js
@@ -75,7 +75,10 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.inputList = [];
   /** @type {boolean|undefined} */
   this.inputsInline = undefined;
-  /** @type {boolean} */
+  /** 
+   * @type {boolean} 
+   * @private
+   */
   this.disabled = false;
   /** @type {string|!Function} */
   this.tooltip = '';
@@ -1217,16 +1220,20 @@ Blockly.Block.prototype.getInputsInline = function() {
 /**
  * Set whether the block is disabled or not.
  * @param {boolean} disabled True if disabled.
- * @deprecated April 2018
+ * @deprecated May 2019
  */
 Blockly.Block.prototype.setDisabled = function(disabled) {
   console.warn('Deprecated call to Blockly.Block.prototype.setDisabled, ' +
                'use Blockly.Block.prototype.setEnabled instead.');
-  if (this.disabled != disabled) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this, 'disabled', null, this.disabled, disabled));
-    this.disabled = disabled;
-  }
+  this.setEnabled(!disabled);
+};
+
+/**
+ * Get whether this block is enabled or not.
+ * @return {boolean} True if enabled.
+ */
+Blockly.Block.prototype.isEnabled = function() {
+  return !this.disabled;
 };
 
 /**
@@ -1234,7 +1241,7 @@ Blockly.Block.prototype.setDisabled = function(disabled) {
  * @param {boolean} enabled True if enabled.
  */
 Blockly.Block.prototype.setEnabled = function(enabled) {
-  if (this.disabled == enabled) {
+  if (this.isEnabled != enabled) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
         this, 'disabled', null, this.disabled, !enabled));
     this.disabled = !enabled;

--- a/core/block_events.js
+++ b/core/block_events.js
@@ -186,7 +186,7 @@ Blockly.Events.Change.prototype.run = function(forward) {
       block.setCollapsed(value);
       break;
     case 'disabled':
-      block.setDisabled(value);
+      block.setEnabled(!value);
       break;
     case 'inline':
       block.setInputsInline(value);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -704,7 +704,7 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
           if (!group) {
             Blockly.Events.setGroup(true);
           }
-          block.setEnabled(block.disabled);
+          block.setEnabled(!block.isEnabled());
           if (!group) {
             Blockly.Events.setGroup(false);
           }
@@ -1180,7 +1180,7 @@ Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
  * @param {boolean} enabled True if enabled.
  */
 Blockly.BlockSvg.prototype.setEnabled = function(enabled) {
-  if (this.isEnabled != enabled) {
+  if (this.isEnabled() != enabled) {
     Blockly.BlockSvg.superClass_.setEnabled.call(this, enabled);
     if (this.rendered) {
       this.updateDisabled();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -704,7 +704,7 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
           if (!group) {
             Blockly.Events.setGroup(true);
           }
-          block.setDisabled(!block.disabled);
+          block.setEnabled(block.disabled);
           if (!group) {
             Blockly.Events.setGroup(false);
           }
@@ -1167,10 +1167,26 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
 /**
  * Set whether the block is disabled or not.
  * @param {boolean} disabled True if disabled.
+ * @deprecated April 2018
  */
 Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
+  console.warn('Deprecated call to Blockly.BlockSvg.prototype.setDisabled, ' +
+  'use Blockly.BlockSvg.prototype.setEnabled instead.');
   if (this.disabled != disabled) {
     Blockly.BlockSvg.superClass_.setDisabled.call(this, disabled);
+    if (this.rendered) {
+      this.updateDisabled();
+    }
+  }
+};
+
+/**
+ * Set whether the block is enabled or not.
+ * @param {boolean} enabled True if enabled.
+ */
+Blockly.BlockSvg.prototype.setEnabled = function(enabled) {
+  if (this.disabled == enabled) {
+    Blockly.BlockSvg.superClass_.setEnabled.call(this, enabled);
     if (this.rendered) {
       this.updateDisabled();
     }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1167,17 +1167,12 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
 /**
  * Set whether the block is disabled or not.
  * @param {boolean} disabled True if disabled.
- * @deprecated April 2018
+ * @deprecated May 2019
  */
 Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
   console.warn('Deprecated call to Blockly.BlockSvg.prototype.setDisabled, ' +
   'use Blockly.BlockSvg.prototype.setEnabled instead.');
-  if (this.disabled != disabled) {
-    Blockly.BlockSvg.superClass_.setDisabled.call(this, disabled);
-    if (this.rendered) {
-      this.updateDisabled();
-    }
-  }
+  this.setEnabled(!disabled);
 };
 
 /**
@@ -1185,7 +1180,7 @@ Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
  * @param {boolean} enabled True if enabled.
  */
 Blockly.BlockSvg.prototype.setEnabled = function(enabled) {
-  if (this.disabled == enabled) {
+  if (this.isEnabled != enabled) {
     Blockly.BlockSvg.superClass_.setEnabled.call(this, enabled);
     if (this.rendered) {
       this.updateDisabled();

--- a/core/events.js
+++ b/core/events.js
@@ -414,12 +414,12 @@ Blockly.Events.disableOrphans = function(event) {
       if (block.getParent() && !block.getParent().disabled) {
         var children = block.getDescendants(false);
         for (var i = 0, child; child = children[i]; i++) {
-          child.setDisabled(false);
+          child.setEnabled(true);
         }
       } else if ((block.outputConnection || block.previousConnection) &&
                  !workspace.isDragging()) {
         do {
-          block.setDisabled(true);
+          block.setEnabled(false);
           block = block.getNextBlock();
         } while (block);
       }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -744,10 +744,10 @@ Blockly.Flyout.prototype.filterForCapacity_ = function() {
   var blocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {
     if (this.permanentlyDisabled_.indexOf(block) == -1) {
-      var disable = !this.targetWorkspace_
+      var enable = this.targetWorkspace_
           .isCapacityAvailable(Blockly.utils.getBlockTypeCounts(block));
       while (block) {
-        block.setDisabled(disable);
+        block.setEnabled(enable);
         block = block.getNextBlock();
       }
     }

--- a/core/xml.js
+++ b/core/xml.js
@@ -754,7 +754,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   }
   var disabled = xmlBlock.getAttribute('disabled');
   if (disabled) {
-    block.setDisabled(disabled == 'true' || disabled == 'disabled');
+    block.setEnabled(disabled != 'true' && disabled != 'disabled');
   }
   var deletable = xmlBlock.getAttribute('deletable');
   if (deletable) {

--- a/tests/workspace_svg/procedure_svg_test.js
+++ b/tests/workspace_svg/procedure_svg_test.js
@@ -66,7 +66,7 @@ function test_procedureReturnSetDisabledUpdatesCallers() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g1');
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are disabled when their definition is disabled.',
@@ -82,7 +82,7 @@ function test_procedureReturnSetDisabledUpdatesCallers() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g2');
-    barDef.setDisabled(false);
+    barDef.setEnabled(true);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are enabled when their definition is enabled.',
@@ -125,10 +125,10 @@ function test_procedureReturnEnablingRemembersOldCallerState() {
     var barDef = workspace.getBlockById('bar-def');
     var barCalls = [workspace.getBlockById('bar-c1'), workspace.getBlockById('bar-c2')];
 
-    barCalls[0].setDisabled(true);
+    barCalls[0].setEnabled(false);
     workspace.clearUndo();
     Blockly.Events.setGroup('g1');
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are disabled when their definition is disabled.',
@@ -143,7 +143,7 @@ function test_procedureReturnEnablingRemembersOldCallerState() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g2');
-    barDef.setDisabled(false);
+    barDef.setEnabled(true);
     Blockly.Events.setGroup(false);
 
 
@@ -184,7 +184,7 @@ function test_procedureNoReturnSetDisabledUpdatesCallers() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g1');
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are disabled when their definition is disabled.',
@@ -200,7 +200,7 @@ function test_procedureNoReturnSetDisabledUpdatesCallers() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g2');
-    barDef.setDisabled(false);
+    barDef.setEnabled(true);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are enabled when their definition is enabled.',
@@ -241,10 +241,10 @@ function test_procedureNoReturnEnablingRemembersOldCallerState() {
     var barDef = workspace.getBlockById('bar-def');
     var barCalls = [workspace.getBlockById('bar-c1'), workspace.getBlockById('bar-c2')];
 
-    barCalls[0].setDisabled(true);
+    barCalls[0].setEnabled(false);
     workspace.clearUndo();
     Blockly.Events.setGroup('g1');
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
     Blockly.Events.setGroup(false);
 
     assertTrue('Callers are disabled when their definition is disabled.',
@@ -259,7 +259,7 @@ function test_procedureNoReturnEnablingRemembersOldCallerState() {
 
     workspace.clearUndo();
     Blockly.Events.setGroup('g2');
-    barDef.setDisabled(false);
+    barDef.setEnabled(true);
     Blockly.Events.setGroup(false);
 
 
@@ -329,19 +329,19 @@ function test_procedureEnableDisableInteractions() {
     var fooCalls = [workspace.getBlockById('foo-c1'), workspace.getBlockById('foo-c2')];
     var bazCall = workspace.getBlockById('baz-c1');
 
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
 
     assertTrue('Callers are disabled when their definition is disabled.',
         barCalls[0].disabled && barCalls[1].disabled);
     assertTrue('Callers in definitions are disabled by inheritence.',
         !fooCalls[0].disabled && fooCalls[0].getInheritedDisabled());
 
-    fooDef.setDisabled(true);
+    fooDef.setEnabled(false);
 
     assertTrue('Callers are disabled when their definition is disabled',
         fooCalls[0].disabled && fooCalls[1].disabled);
 
-    barDef.setDisabled(false);
+    barDef.setEnabled(true);
 
     assertTrue('Callers are reenabled with their definition',
         !barCalls[0].disabled && !barCalls[0].disabled);
@@ -349,7 +349,7 @@ function test_procedureEnableDisableInteractions() {
     assertTrue('Nested disabled callers remain disabled, not by inheritence.',
         fooCalls[0].disabled && !fooCalls[0].getInheritedDisabled());
 
-    bazDef.setDisabled(true);
+    bazDef.setEnabled(false);
 
     assertTrue('Caller is disabled with its definition',
         bazCall.disabled);
@@ -357,11 +357,11 @@ function test_procedureEnableDisableInteractions() {
     assertTrue('Caller in the return is disabled by inheritence.',
         !barCalls[1].disabled && barCalls[1].getInheritedDisabled());
 
-    barDef.setDisabled(true);
+    barDef.setEnabled(false);
     assertTrue('Callers are disabled when their definition is disabled.',
         barCalls[0].disabled && barCalls[1].disabled);
 
-    bazDef.setDisabled(false);
+    bazDef.setEnabled(true);
 
     assertTrue('Caller in the return remains disabled, not by inheritence.',
         barCalls[1].disabled && !barCalls[1].getInheritedDisabled());


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
[Issue #1593](https://github.com/google/blockly/issues/1593)

### Proposed Changes
From [Issue #1593](https://github.com/google/blockly/issues/1593), provides the negated version of `setDisabled` with `setEnabled`. 

`setDisabled` is deprecated in Block.prototype, and BlockSvg.prototype.
Calls to `setDisabled` have been updated to use `setEnabled`.

### Reason for Changes

From [Issue #1593](https://github.com/google/blockly/issues/1593), removes double-negation in this instance.

### Test Coverage
**Blockly Tests**
PASSED JSUnit test
PASSED Workspace_SVG test
**Playground Testing**
Playground Test:
Disabled Blocks still enable/disable fine.
Loading disabled/enabled blocks though XML is fine.

Tested on:
Browsers:
- Desktop Chrome v73
- Desktop Firefox v66

Device: Windows Laptop
OS: Windows 10 v1803

### Additional Information
`setDisabled` has only been deprecated. The original function has only been modified for deprecated warnings.
