### PR TITLE
Reorganize conditionals for block context menu

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -647,53 +647,58 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var block = this;
   var menuOptions = [];
 
-  if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
-    menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
-    if (this.isEditable() && !this.collapsed_ &&
-        this.workspace.options.comments) {
+  if (!this.isInFlyout) {
+    if (this.isDeletable() && this.isMovable()) {
+      menuOptions.push(Blockly.ContextMenu.blockDuplicateOption(block));
+    }
+
+    if (this.workspace.options.comments && !this.collapsed_ &&
+        this.isEditable()) {
       menuOptions.push(Blockly.ContextMenu.blockCommentOption(block));
     }
 
-    // Option to make block inline.
-    if (!this.collapsed_) {
-      for (var i = 1; i < this.inputList.length; i++) {
-        if (this.inputList[i - 1].type != Blockly.NEXT_STATEMENT &&
-            this.inputList[i].type != Blockly.NEXT_STATEMENT) {
-          // Only display this option if there are two value or dummy inputs
-          // next to each other.
-          var inlineOption = {enabled: true};
-          var isInline = this.getInputsInline();
-          inlineOption.text = isInline ?
-              Blockly.Msg['EXTERNAL_INPUTS'] : Blockly.Msg['INLINE_INPUTS'];
-          inlineOption.callback = function() {
-            block.setInputsInline(!isInline);
+    if (this.isMovable()) {
+      if (!this.collapsed_) {
+        // Option to make block inline.
+        for (var i = 1; i < this.inputList.length; i++) {
+          if (this.inputList[i - 1].type != Blockly.NEXT_STATEMENT &&
+              this.inputList[i].type != Blockly.NEXT_STATEMENT) {
+            // Only display this option if there are two value or dummy inputs
+            // next to each other.
+            var inlineOption = {enabled: true};
+            var isInline = this.getInputsInline();
+            inlineOption.text = isInline ?
+                Blockly.Msg['EXTERNAL_INPUTS'] : Blockly.Msg['INLINE_INPUTS'];
+            inlineOption.callback = function() {
+              block.setInputsInline(!isInline);
+            };
+            menuOptions.push(inlineOption);
+            break;
+          }
+        }
+        // Option to collapse block
+        if (this.workspace.options.collapse) {
+          var collapseOption = {enabled: true};
+          collapseOption.text = Blockly.Msg['COLLAPSE_BLOCK'];
+          collapseOption.callback = function() {
+            block.setCollapsed(true);
           };
-          menuOptions.push(inlineOption);
-          break;
+          menuOptions.push(collapseOption);
+        }
+      } else {
+        // Option to expand block.
+        if (this.workspace.options.collapse) {
+          var expandOption = {enabled: true};
+          expandOption.text = Blockly.Msg['EXPAND_BLOCK'];
+          expandOption.callback = function() {
+            block.setCollapsed(false);
+          };
+          menuOptions.push(expandOption);
         }
       }
     }
 
-    if (this.workspace.options.collapse) {
-      // Option to collapse/expand block.
-      if (this.collapsed_) {
-        var expandOption = {enabled: true};
-        expandOption.text = Blockly.Msg['EXPAND_BLOCK'];
-        expandOption.callback = function() {
-          block.setCollapsed(false);
-        };
-        menuOptions.push(expandOption);
-      } else {
-        var collapseOption = {enabled: true};
-        collapseOption.text = Blockly.Msg['COLLAPSE_BLOCK'];
-        collapseOption.callback = function() {
-          block.setCollapsed(true);
-        };
-        menuOptions.push(collapseOption);
-      }
-    }
-
-    if (this.workspace.options.disable) {
+    if (this.workspace.options.disable && this.isEditable()) {
       // Option to disable/enable block.
       var disableOption = {
         text: this.disabled ?
@@ -713,7 +718,9 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
       menuOptions.push(disableOption);
     }
 
-    menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
+    if (this.isDeletable()) {
+      menuOptions.push(Blockly.ContextMenu.blockDeleteOption(block));
+    }
   }
 
   menuOptions.push(Blockly.ContextMenu.blockHelpOption(block));

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -718,6 +718,8 @@ AppController.prototype.init = function() {
   BlockFactory.mainWorkspace = Blockly.inject('blockly',
       {collapse: false,
        toolbox: toolbox,
+       comments: false,
+       disable: false,
        media: '../../media/'});
 
   // Add tab handlers for switching between Block Factory and Block Exporter.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
[Issue #2388](https://github.com/google/blockly/issues/2388) - Comments should be allowed on non-movable/deletable blocks

### Proposed Changes

Regardless of deletable state:
* Add the "Add Comment"/"Remove Comment" menu items whenever the block is editable and not collapsed.
* Add the "Expand Block"/"Collapse Block" menu items whenever the block is movable.
* Add the "Inline Inputs"/"External Inputs" menu items whenever the block is movable and not collapsed.
* Add the "Disable Block"/"Enable Block" menu items whenever the block is editable.

Block Factory:
* Turned off comments and block disabling in the Blockly.inject() call.

### Reason for Changes

Previously, most of the context menu entries required that the block must be movable and deletable in addition to being editable. However, there's no compelling reason for these strict requirements: a block that can be edited should still be able to have a comment even if it can't be moved or deleted.

While making this change, I noticed that the other menu items could have their restrictions similarly loosened. Changing the visual organization of a block's inputs can be considered a "move" operation, so the inline/external toggle and the collapse/expand toggle don't need to be blocked by the deletable or editable flags. Similarly, changing the enabled/disabled state of a block can be considered an "edit" operation and it doesn't need to be blocked by the deletable or movable flags.

With the more permissive flags, existing code such as blockfactory have menu items appear that don't make sense in context. Since blockfactory is used for more than just a demo, I made sure to update the configuration.

### Test Coverage

Playground testing:
* Tested combinations of settings in personal project
* Tested combinations of settings in blockfactory demo

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
