### PR TITLE
Keyboard nav ast node

### DIFF
--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -344,10 +344,9 @@ Blockly.ASTNode.prototype.findPrevForField_ = function(location, parentInput) {
   var block = location.sourceBlock_;
   var inputs = block.inputList;
   var curIdx = inputs.indexOf(parentInput);
-  var prevLocation = this.findPreviousEditableField_(location, parentInput);
-  var newAstNode;
+  var newAstNode = this.findPreviousEditableField_(location, parentInput);
 
-  if (!prevLocation && curIdx - 1 >= 0) {
+  if (!newAstNode && curIdx - 1 >= 0) {
     newAstNode = Blockly.ASTNode.createInputNode(inputs[curIdx - 1]);
   }
   return newAstNode;

--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -190,7 +190,7 @@ Blockly.ASTNode.prototype.getLocation = function() {
  * The type of the current location.
  * @return {String} The type of the location.
  */
-Blockly.ASTNode.prototype.getLocationType = function() {
+Blockly.ASTNode.prototype.getType = function() {
   return this.type_;
 };
 
@@ -516,7 +516,7 @@ Blockly.ASTNode.prototype.in = function() {
         if (fieldNode) {
           newAstNode = fieldNode;
         } else {
-          newAstNode = newParentInput.connection;
+          newAstNode = Blockly.ASTNode.createInputNode(newParentInput);
         }
       }
       break;

--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -1,0 +1,625 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview The class representing an ast node.
+ * Used to traverse the blockly ast.
+ */
+'use strict';
+
+goog.provide('Blockly.ASTNode');
+
+/**
+ * Class for an ASTNode.
+ * @constructor
+ * @param{String} type This is the type of what is being passed in. Either
+ * block, field, nextConnection...
+ * @param{Blockly.Block}
+ * @param{String} The name of the connection or field.
+ */
+Blockly.ASTNode = function(type, location, params) {
+
+  /*
+   * The type of the location.
+   * @type String
+   * @private
+   */
+  this.type_ = type;
+
+  /*
+   * In the case of a connection or field this is the block that the
+   * connection or field is on. In the case of a block this is just holds
+   * the block object.
+   * @private
+   */
+  this.location_ = location;
+
+  this.processParams(params);
+
+};
+
+/**
+ * Object holding different types for a cursor.
+ */
+Blockly.ASTNode.types = {
+  FIELD: 'field',
+  BLOCK: 'block',
+  INPUT: 'input',
+  OUTPUT: 'output',
+  NEXT: 'next',
+  PREVIOUS: 'previous',
+  STACK: 'stack',
+  WORKSPACE: 'workspace'
+};
+
+Blockly.ASTNode.prototype.processParams = function(params){
+  if (!params) {return;}
+  if (params['position']) {
+    this.position_ = params['position'];
+  }
+
+  if (params['block']) {
+    this.block_ = params['block'];
+  }
+
+  if (params['name']) {
+    this.name_ = params['name'];
+  }
+};
+
+/**
+ * Gets the current location of the cursor.
+ * @return {Blockly.Field|Blockly.Connection|Blockly.Block} The current field,
+ * connection, or block the cursor is on.
+ */
+Blockly.ASTNode.prototype.getLocation = function() {
+  return this.location_;
+};
+
+/**
+ * The type of the current location.
+ * @return {String} The type of the location.
+ */
+Blockly.ASTNode.prototype.getLocationType = function() {
+  return this.type_;
+};
+
+
+/**
+ * Set the type for the current position of the cursor.
+ * @private
+ */
+Blockly.ASTNode.prototype.setType_ = function() {
+  var location = this.location_;
+  var hasParent = this.parentInput_;
+  if (this.isStack_) {
+    this.type_ = this.types.STACK;
+  } else if (location.type === Blockly.OUTPUT_VALUE) {
+    this.type_ = this.types.OUTPUT;
+  } else if (location instanceof Blockly.Field) {
+    this.type_ = this.types.FIELD;
+  } else if (location.type === Blockly.INPUT_VALUE || hasParent) {
+    this.type_ = this.types.INPUT;
+  } else if (location instanceof Blockly.Block) {
+    this.type_ = this.types.BLOCK;
+  } else if (location.type === Blockly.PREVIOUS_STATEMENT) {
+    this.type_ = this.types.PREVIOUS;
+  } else if (location.type === Blockly.NEXT_STATEMENT) {
+    this.type_ = this.types.NEXT;
+  } else if (location instanceof Blockly.Workspace) {
+    this.type_ = this.types.WORKSPACE;
+  }
+};
+
+/**
+ * Get the parent input of the current location of the cursor.
+ * @return {Blockly.Input} The input that the connection belongs to.
+ * @private
+ */
+Blockly.ASTNode.prototype.findParentInput_ = function() {
+  var parentInput = null;
+  var location = this.getLocation();
+
+  if (location instanceof Blockly.Field
+    || location instanceof Blockly.Connection) {
+    parentInput = location.getParentInput();
+  }
+  return parentInput;
+};
+
+/**
+ * Get either the next editable field, or the first field for the given input.
+ * @param {!Blockly.Field} location The current location of the cursor.
+ * @param {!Blockly.Input} parentInput The parentInput of the field.
+ * @param {?Boolean} opt_first If true find the first editable field otherwise get
+ * the next field.
+ * @return {Blockly.Field} The next field or null if no next field exists.
+ * @private
+ */
+Blockly.ASTNode.prototype.findNextEditableField_ = function(location,
+    parentInput, opt_first) {
+  var fieldRow = parentInput.fieldRow;
+  var fieldIdx = fieldRow.indexOf(location);
+  var nextField = null;
+  var startIdx = opt_first ? 0 : fieldIdx + 1;
+  var astNode;
+  for (var i = startIdx; i < fieldRow.length; i++) {
+    var field = fieldRow[i];
+    if (field.isCurrentlyEditable()) {
+      nextField = field;
+      astNode = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD,
+          nextField.sourceBlock_, nextField.name);
+      break;
+    }
+  }
+  return astNode;
+};
+
+/**
+ * Get either the previous editable field, or get the first field for the given
+ * input.
+ * @param {!Blockly.Field} location The current location of the cursor.
+ * @param {!Blockly.Input} parentInput The parentInput of the field.
+ * @param {?Boolean} opt_last If true find the last editable field otherwise get
+ * the previous field.
+ * @return {Blockly.Field} The previous or last field or null if no next field
+ * exists.
+ * @private
+ */
+Blockly.ASTNode.prototype.findPreviousEditableField_ = function(location,
+    parentInput, opt_last) {
+  var fieldRow = parentInput.fieldRow;
+  var fieldIdx = fieldRow.indexOf(location);
+  var previousField = null;
+  var startIdx = opt_last ? fieldRow.length - 1 : fieldIdx - 1;
+  for (var i = startIdx; i >= 0; i--) {
+    var field = fieldRow[i];
+    if (field.isCurrentlyEditable()) {
+      previousField = field;
+      break;
+    }
+  }
+  return new Blockly.ASTNode(Blockly.ASTNode.types.FIELD,
+      previousField.sourceBlock_, previousField.name);
+};
+
+
+/**
+ * Get the first field or connection that is either editable or has connection
+ * value of not null.
+ * @param {!Blockly.Connection} location Current place of cursor.
+ * @param {!Blockly.Input} parentInput The parent input of the field or connection.
+ * @return {Blockly.Connection|Blockly.Field} The next field or connection.
+ * @private
+ */
+Blockly.ASTNode.prototype.findNextForInput_ = function(location, parentInput){
+  var inputs = location.sourceBlock_.inputList;
+  var curIdx = inputs.indexOf(parentInput);
+  if (curIdx <= -1) {return;}
+  var nxtIdx = curIdx + 1;
+  var nextLocation = null;
+
+  for (var i = nxtIdx; i < inputs.length; i++) {
+    var newInput = inputs[i];
+    var field = this.findNextEditableField_(location, newInput, true);
+    if (field) {
+      nextLocation = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+      break;
+    } else if (newInput.connection) {
+      var connection = newInput.connection;
+      nextLocation = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, connection);
+      break;
+    }
+  }
+  return nextLocation;
+};
+
+/**
+ * Find the next input or field given a field location.
+ * @param {!Blockly.Field} location The current location of the cursor.
+ * @param {!Blockly.Input} parentInput The parent input of the field.
+ * @return {Blockly.Field|Blockly.Connection} The next location.
+ * @private
+ */
+Blockly.ASTNode.prototype.findNextForField_ = function(location, parentInput) {
+  var nextLocation = this.findNextEditableField_(location, parentInput);
+
+  if (!nextLocation) {
+    nextLocation = parentInput.connection;
+    nextLocation = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, parentInput.connection);
+  }
+  return nextLocation;
+};
+
+
+/**
+ * Given the current selected field or connection find the previous connection
+ * or field.
+ * @param {!Blockly.Connection} location The current location of
+ * the cursor.
+ * @param {!Blockly.Input} parentInput Parent input of the connection or field.
+ * @return {Array<Blockly.Field|Blockly.Connection, Blockly.Input>} The first
+ * value is the next field or connection and the second value is the parent input.
+ * @private
+ */
+Blockly.ASTNode.prototype.findPrevForInput_ = function(location, parentInput){
+  var block = location.sourceBlock_;
+  var inputs = block.inputList;
+  var curIdx = inputs.indexOf(parentInput);
+  var prevLocation = null;
+
+  for (var i = curIdx; i >= 0; i--) {
+    var newInput = inputs[i];
+    var field = this.findPreviousEditableField_(location, newInput, true);
+    if (newInput.connection && newInput.connection !== parentInput.connection) {
+      var connection = newInput.connection;
+      prevLocation = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, newInput.connection);
+      this.parentInput_ = newInput;
+      break;
+    } else if (field && field !== location) {
+      prevLocation = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field.getLocation());
+      this.parentInput_ = newInput;
+      break;
+    }
+  }
+  return prevLocation;
+};
+
+/**
+ * Find the previous input or field given a field location.
+ * @param {!Blockly.Field} location The current location of the cursor.
+ * @param {!Blockly.Input} parentInput The parent input of the field.
+ * @return {Blockly.Field|Blockly.Connection} The previous location.
+ * @private
+ */
+Blockly.ASTNode.prototype.findPrevForField_ = function(location, parentInput) {
+  var block = location.sourceBlock_;
+  var inputs = block.inputList;
+  var curIdx = inputs.indexOf(parentInput);
+  var prevLocation = this.findPreviousEditableField_(location, parentInput);
+  var astNode;
+
+  if (!prevLocation && curIdx - 1 >= 0) {
+    prevLocation = inputs[curIdx - 1].connection;
+    astNode = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, prevLocation);
+    this.parentInput_ = inputs[curIdx - 1];
+  }
+  return astNode;
+};
+
+/**
+ * Walk from the given block back up through the stack of blocks to find the top
+ * block. If we are nested in a statement input only find the top most nested
+ * block. Do not go all the way to the top of the stack.
+ * @param {!Blockly.Block} sourceBlock A block in the stack.
+ * @return {Blockly.Block} The top block in a stack
+ * @private
+ */
+Blockly.ASTNode.prototype.findTop_ = function(sourceBlock) {
+  var topBlock = sourceBlock;
+  var targetConnection = sourceBlock.previousConnection.targetConnection;
+  //while the target is not an input and it is connected to another block
+  while (targetConnection && !targetConnection.getParentInput() && topBlock
+    && topBlock.previousConnection
+    && topBlock.previousConnection.targetBlock()) {
+    topBlock = topBlock.previousConnection.targetBlock();
+    targetConnection = topBlock.previousConnection.targetConnection;
+  }
+  return topBlock;
+};
+
+/**
+ * Navigate between stacks of blocks on the workspace.
+ * @param {?Boolean} forward True to go forward. False to go backwards.
+ * @return {Blockly.BlockSvg} The first block of the next stack.
+ * @private
+ */
+Blockly.ASTNode.prototype.navigateBetweenStacks_ = function(forward) {
+  var curLocation = this.getLocation();
+  if (!(curLocation instanceof Blockly.Block)) {
+    curLocation = curLocation.sourceBlock_;
+  }
+  if (!curLocation) {
+    return null;
+  }
+  var curRoot = curLocation.getRootBlock();
+  var topBlocks = curRoot.workspace.getTopBlocks();
+  for (var i = 0; i < topBlocks.length; i++) {
+    var topBlock = topBlocks[i];
+    if (curRoot.id == topBlock.id) {
+      var offset = forward ? 1 : -1;
+      var resultIndex = i + offset;
+      if (resultIndex == -1) {
+        resultIndex = topBlocks.length - 1;
+      } else if (resultIndex == topBlocks.length) {
+        resultIndex = 0;
+      }
+      return topBlocks[resultIndex];
+    }
+  }
+  throw Error('Couldn\'t find ' + (forward ? 'next' : 'previous') +
+      ' stack?!?!?!');
+};
+
+/**
+ * Find the first connection on a given block.
+ * We are defining first connection as the highest connection point on a given
+ * block. Therefore previous connection comes before output connection.
+ * @param {!Blockly.Field|Blockly.Block|Blockly.Connection} location The location
+ * of the cursor.
+ * @return {Blockly.Connection} The first connection.
+ * @private
+ */
+Blockly.ASTNode.prototype.findTopConnection_ = function(location) {
+  var previousConnection = location.previousConnection;
+  var outputConnection = location.outputConnection;
+  return previousConnection ? previousConnection : outputConnection;
+};
+
+Blockly.ASTNode.prototype.findTopASTConnection = function(block) {
+  var previousConnection = block.previousConnection;
+  var outputConnection = block.outputConnection;
+  var astNode;
+  if (previousConnection) {
+    astNode = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, previousConnection);
+  } else if (outputConnection) {
+    astNode = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, outputConnection);
+  }
+  return astNode;
+};
+
+
+/**
+ * Given a location in a stack of blocks find the next out connection. If the
+ * location is nested the next out location should be the connected input.
+ * @param {!Blockly.Block} location The source block for the current location.
+ * @return {Blockly.Connection|Blockly.Block} The next out connection or block.
+ * @private
+ */
+Blockly.ASTNode.prototype.findOutLocationForStack_ = function(location) {
+  var newLocation;
+  var topBlock = this.findTop_(location);
+  var astNode;
+  newLocation = topBlock.previousConnection.targetConnection;
+  astNode = Blockly.ASTNode(Blockly.ASTNode.types.NEXT, newLocation);
+  if (!newLocation) {
+    newLocation = topBlock.previousConnection;
+    astNode = Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, newLocation);
+    this.isStack_ = true;
+    this.stackBlock_ = topBlock;
+  }
+  return newLocation;
+};
+
+/**
+ * Find the next connection, field, or block.
+ * @return {Blockly.Field|Blockly.Block|Blockly.Connection} The next element.
+ */
+Blockly.ASTNode.prototype.next = function() {
+  var location = this.getLocation();
+  if (!location) {return null;}
+  var newAstNode;
+  var parentInput = this.findParentInput_();
+
+  switch (this.type_) {
+    case Blockly.ASTNode.types.STACK:
+      var nextTopBlock = this.navigateBetweenStacks_(true);
+      newAstNode = this.findTopASTConnection(nextTopBlock);
+      isStack = true;
+      break;
+
+    case Blockly.ASTNode.types.OUTPUT:
+      newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
+          location.sourceBlock_);
+      break;
+
+    case Blockly.ASTNode.types.FIELD:
+      newAstNode = this.findNextForField_(location, parentInput);
+      break;
+
+    case Blockly.ASTNode.types.INPUT:
+      newAstNode = this.findNextForInput_(location, parentInput);
+      break;
+
+    case Blockly.ASTNode.types.BLOCK:
+      newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, location.nextConnection);
+      break;
+
+    case Blockly.ASTNode.types.PREVIOUS:
+      var output = location.outputConnection;
+      if (output) {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT,
+            output);
+      } else {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
+            location.sourceBlock_);
+      }
+      break;
+
+    case Blockly.ASTNode.types.NEXT:
+      if (location.targetBlock()) {
+        newAstNode = this.findTopASTConnection(location.targetBlock());
+      }
+      break;
+  }
+
+  return newAstNode;
+};
+
+/**
+ * Find the next in connection or field.
+ * @return {Blockly.Field|Blockly.Block|Blockly.Connection} The next element.
+ */
+Blockly.ASTNode.prototype.in = function() {
+  var location = this.getLocation();
+  if (!location) {return null;}
+  var newLocation = null;
+  var newParentInput;
+
+  switch (this.type_) {
+    case Blockly.ASTNode.types.STACK:
+      this.isStack_ = false;
+      this.setType_();
+      break;
+    case Blockly.ASTNode.types.BLOCK:
+      var inputs = location.inputList;
+      if (inputs && inputs.length > 0) {
+        newParentInput = inputs[0];
+        var field = this.findNextEditableField_(location, newParentInput, true);
+        if (field) {
+          newLocation = field;
+        } else {
+          newLocation = newParentInput.connection;
+        }
+      }
+      break;
+
+    case Blockly.ASTNode.types.INPUT:
+      if (location.targetBlock()) {
+        newLocation = this.findTopConnection_(location.targetBlock());
+      }
+      break;
+  }
+
+  return newLocation;
+};
+
+/**
+ * Find the previous connection, field, or block.
+ * @return {Blockly.Field|Blockly.Block|Blockly.Connection} The next element.
+ */
+Blockly.ASTNode.prototype.prev = function() {
+  var location = this.getLocation();
+  if (!location) {return null;}
+  var newLocation;
+  var parentInput = this.findParentInput_();
+  var isStack = false;
+  var newAstNode;
+
+  switch (this.type_) {
+    case Blockly.ASTNode.types.STACK:
+      var nextTopBlock = this.navigateBetweenStacks_(true);
+      newLocation = this.findTopConnection_(nextTopBlock);
+      isStack = true;
+      break;
+
+    case Blockly.ASTNode.types.OUTPUT:
+      if (location.sourceBlock_ && location.sourceBlock_.previousConnection) {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS,
+            location.sourceBlock_.previousConnection);
+      }
+      break;
+
+    case Blockly.ASTNode.types.FIELD:
+      newAstNode = this.findPrevForField_(location, parentInput);
+      break;
+
+    case Blockly.ASTNode.types.INPUT:
+      newAstNode = this.findPrevForInput_(location, parentInput);
+      break;
+
+    case Blockly.ASTNode.types.BLOCK:
+      var output = location.outputConnection;
+      if (output) {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT,
+            output);
+      } else {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS,
+            location.previousConnection);
+      }
+      break;
+
+    case Blockly.ASTNode.types.PREVIOUS:
+      var prevBlock = location.targetBlock();
+      if (prevBlock) {
+        newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT,
+            prevBlock.nextConnection);
+      }
+      break;
+
+    case Blockly.ASTNode.types.NEXT:
+      newLocation = location.sourceBlock_;
+      newAstNode = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
+          location.sourceBlock_);
+      break;
+  }
+
+  return newAstNode;
+};
+
+/**
+ * Find the next out connection, field, or block.
+ * @return {Blockly.Field|Blockly.Block|Blockly.Connection} The next element.
+ */
+Blockly.ASTNode.prototype.out = function() {
+  var location = this.getLocation();
+  if (!location) {return null;}
+  var newLocation;
+  var isStack = false;
+
+  switch (this.type_) {
+    case Blockly.ASTNode.types.STACK:
+      break;
+
+    case Blockly.ASTNode.types.OUTPUT:
+      newLocation = location.targetConnection;
+      if (!newLocation) {
+        isStack = true;
+        this.stackBlock_ = location.sourceBlock_;
+        this.setType_();
+      }
+      break;
+
+    case Blockly.ASTNode.types.FIELD:
+      newLocation = location.sourceBlock_;
+      break;
+
+    case Blockly.ASTNode.types.INPUT:
+      newLocation = location.sourceBlock_;
+      break;
+
+    case Blockly.ASTNode.types.BLOCK:
+      var outputConnection = location.outputConnection;
+      if (outputConnection && outputConnection.targetConnection) {
+        newLocation = outputConnection.targetConnection;
+      } else if (outputConnection) {
+        newLocation = outputConnection;
+      } else {
+        //This is the case where we are on a block that is nested inside a
+        //statement input and we need to get the input that connects to the
+        //top block
+        newLocation = this.findOutLocationForStack_(location);
+        isStack = this.isStack_;
+      }
+      break;
+
+    case Blockly.ASTNode.types.PREVIOUS:
+      newLocation = this.findOutLocationForStack_(location.sourceBlock_);
+      isStack = this.isStack_;
+      break;
+
+    case Blockly.ASTNode.types.NEXT:
+      newLocation = this.findOutLocationForStack_(location.sourceBlock_);
+      isStack = this.isStack_;
+      break;
+  }
+
+  return newLocation;
+};

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -66,6 +66,9 @@ suite('ASTNode', function() {
       D: blockD,
       E: blockE
     };
+    Blockly.getMainWorkspace = function() {
+      return new Blockly.Workspace();
+    };
   });
   teardown(function() {
     delete Blockly.Blocks['input_statement'];
@@ -75,17 +78,6 @@ suite('ASTNode', function() {
   });
 
   suite('HelperFunctions', function() {
-    // test('setLocationForStackNotAtTop', function() {
-    //     var input = this.blocks.A.inputList[0];
-    //     this.cursor.setLocation(input, true, false);
-    //     assertEquals(this.cursor.isStack_, false)
-    //   });
-    // test('setLocationForStackAtTopBlock', function() {
-    //     var input = this.blocks.A.previousConnection;
-    //     this.cursor.setLocation(input, true, false);
-    //     assertEquals(this.cursor.isStack_, true)
-    //   });
-
       test('findNextEditableField_', function() {
         var input = this.blocks.A.inputList[0];
         var field = input.fieldRow[0];
@@ -103,284 +95,303 @@ suite('ASTNode', function() {
         assertEquals(editableField.getLocation(), input.fieldRow[0]);
       });
 
-      // test('findPreviousEditableField_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var field = input.fieldRow[1];
-      //   var prevField = input.fieldRow[0];
-      //   var editableField = this.cursor.findPreviousEditableField_(field, input);
-      //   assertEquals(editableField, prevField);
-      // });
+      test('findPreviousEditableField_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = input.fieldRow[1];
+        var prevField = input.fieldRow[0];
+        var node = new Blockly.ASTNode();
+        var editableField = node.findPreviousEditableField_(field, input);
+        assertEquals(editableField.getLocation(), prevField);
+      });
 
-      // test('findPreviousEditableFieldLast_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var field = input.fieldRow[0];
-      //   var editableField = this.cursor.findPreviousEditableField_(field, input, true);
-      //   assertEquals(editableField, input.fieldRow[1]);
-      // });
+      test('findPreviousEditableFieldLast_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = input.fieldRow[0];
+        var node = new Blockly.ASTNode();
+        var editableField = node.findPreviousEditableField_(field, input, true);
+        assertEquals(editableField.getLocation(), input.fieldRow[1]);
+      });
 
-      // test('findNextForInput_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var input2 = this.blocks.A.inputList[1];
-      //   var connection = input.connection;
-      //   var nextLocation = this.cursor.findNextForInput_(connection, input);
-      //   assertEquals(nextLocation, input2.connection);
-      //   assertEquals(input2, this.cursor.parentInput_);
-      // });
+      test('findNextForInput_', function() {
+        var input = this.blocks.A.inputList[0];
+        var input2 = this.blocks.A.inputList[1];
+        var connection = input.connection;
+        var node = new Blockly.ASTNode();
+        var nextLocation = node.findNextForInput_(connection, input);
+        assertEquals(nextLocation.getLocation(), input2.connection);
+      });
 
-      // test('findPrevForInput_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var input2 = this.blocks.A.inputList[1];
-      //   var connection = input2.connection;
-      //   var nextLocation = this.cursor.findPrevForInput_(connection, input2);
-      //   assertEquals(nextLocation, input.connection);
-      //   assertEquals(input, this.cursor.parentInput_);
-      // });
+      test('findPrevForInput_', function() {
+        var input = this.blocks.A.inputList[0];
+        var input2 = this.blocks.A.inputList[1];
+        var connection = input2.connection;
+        var node = new Blockly.ASTNode();
+        var nextLocation = node.findPrevForInput_(connection, input2);
+        assertEquals(nextLocation.getLocation(), input);
+      });
 
-      // test('findNextForField_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var field = this.blocks.A.inputList[0].fieldRow[0];
-      //   var field2 = this.blocks.A.inputList[0].fieldRow[1];
-      //   var nextLocation = this.cursor.findNextForField_(field, input);
-      //   assertEquals(nextLocation, field2);
-      // });
+      test('findNextForField_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field2 = this.blocks.A.inputList[0].fieldRow[1];
+        var node = new Blockly.ASTNode();
+        var nextLocation = node.findNextForField_(field, input);
+        assertEquals(nextLocation.getLocation(), field2);
+      });
 
-      // test('findPrevForField_', function() {
-      //   var input = this.blocks.A.inputList[0];
-      //   var field = this.blocks.A.inputList[0].fieldRow[0];
-      //   var field2 = this.blocks.A.inputList[0].fieldRow[1];
-      //   var nextLocation = this.cursor.findPrevForField_(field2, input);
-      //   assertEquals(nextLocation, field);
-      // });
+      test('findPrevForField_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field2 = this.blocks.A.inputList[0].fieldRow[1];
+        var nextLocation = this.cursor.findPrevForField_(field2, input);
+        assertEquals(nextLocation, field);
+      });
 
-      // test('findTop_', function() {
-      //   var topBlock = this.cursor.findTop_(this.blocks.C);
-      //   assertEquals(topBlock, this.blocks.C);
-      // });
+      test('navigateBetweenStacksForward', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
+        var nextStack = node.navigateBetweenStacks_(true);
+        assertEquals(nextStack, this.blocks.D);
+      });
 
-      // test('navigateBetweenStacksForward', function() {
-      //   this.cursor.setLocation(this.blocks.A.nextConnection);
-      //   var nextStack = this.cursor.navigateBetweenStacks_(true);
-      //   assertEquals(nextStack, this.blocks.D);
-      // });
-
-      // test('navigateBetweenStacksBackward', function() {
-      //   this.cursor.setLocation(this.blocks.D);
-      //   var nextStack = this.cursor.navigateBetweenStacks_(false);
-      //   assertEquals(nextStack, this.blocks.A);
-      // });
-
-      // test('checkIfStackFalse', function() {
-      //   this.cursor.setLocation(this.blocks.B);
-      //   var isStack = this.cursor.checkIfStack_();
-      //   assertEquals(isStack, false);
-      // });
-
-      // test('checkIfStackTrue', function() {
-      //   this.cursor.setLocation(this.blocks.A.previousConnection);
-      //   var isStack = this.cursor.checkIfStack_();
-      //   assertEquals(isStack, true);
-      // });
-
-      // test('findTopConnection', function() {
-      //   var topConnection = this.cursor.findTopConnection_(this.blocks.A);
-      //   assertEquals(topConnection, this.blocks.A.previousConnection);
-      // });
+      test('navigateBetweenStacksBackward', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
+        var nextStack = node.navigateBetweenStacks_(false);
+        assertEquals(nextStack, this.blocks.A);
+      });
     });
 
   suite('NavigationFunctions', function() {
     suite('Next', function() {
       test('previousConnection', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS,
-            this.blocks.A.previousConnection);
+        var node = Blockly.ASTNode.createConnectionNode(this.blocks.A.previousConnection);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.A);
       });
       test('block', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
-            this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.A.nextConnection);
       });
       test('nextConnection', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT,
-            this.blocks.A.nextConnection);
+        var node = Blockly.ASTNode.createConnectionNode(this.blocks.A.nextConnection);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.B.previousConnection);
       });
       test('input', function() {
         var input = this.blocks.A.inputList[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
-
+        var node = Blockly.ASTNode.createInputNode(input);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.A.inputList[1].connection);
       });
       test('output', function() {
         var output = this.blocks.E.outputConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var node = Blockly.ASTNode.createConnectionNode(output);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.E);
       });
       test('field', function() {
         var field = this.blocks.A.inputList[0].fieldRow[1];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var node = Blockly.ASTNode.createFieldNode(field);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.A.inputList[0].connection);
       });
       test('isStack', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, this.blocks.A.previousConnection);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.A);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.D.previousConnection);
-        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
-      });
-      test('isStack', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, this.blocks.A.previousConnection);
-        var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.D.previousConnection);
+        assertEquals(nextNode.getLocation(), this.blocks.D);
         assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
+        var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation().x, 110);
+        assertEquals(nextNode.wsCoordinate_.x, 110);
+        assertEquals(nextNode.getLocation(), this.workspace);
         assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
       });
     });
+
     suite('Previous', function() {
       test('previousConnectionTopBlock', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.A.previousConnection);
+        var prevConnection = this.blocks.A.previousConnection;
+        var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('previousConnection', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.B.previousConnection);
+        var prevConnection = this.blocks.B.previousConnection;
+        var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), this.blocks.A.nextConnection);
       });
       test('block', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
       });
       test('nextConnection', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
+        var nextConnection = this.blocks.A.nextConnection;
+        var node = Blockly.ASTNode.createConnectionNode(nextConnection)
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), this.blocks.A);
       });
       test('input', function() {
         var input = this.blocks.A.inputList[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var node = Blockly.ASTNode.createInputNode(input);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), input.fieldRow[1]);
       });
       test('output', function() {
         var output = this.blocks.E.outputConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var node = Blockly.ASTNode.createConnectionNode(output);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('field', function() {
         var field = this.blocks.A.inputList[0].fieldRow[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var node = Blockly.ASTNode.createFieldNode(field);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('isStack', function() {
-        var prevConnection = this.blocks.D.previousConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, prevConnection);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
+        assertEquals(prevNode.getLocation(), this.blocks.A);
         assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
-        var prevNode = node.prev();
-        assertEquals(prevNode.getLocation().x, 90);
-        assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
+        var nextNode = node.prev();
+        assertEquals(nextNode.wsCoordinate_.x, 90);
+        assertEquals(nextNode.getLocation(), this.workspace);
+        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
       });
     });
+
     suite('In', function() {
       test('block', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), this.blocks.A.inputList[0].fieldRow[0]);
       });
       test('input', function() {
         var input = this.blocks.A.inputList[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var node = Blockly.ASTNode.createInputNode(input);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), this.blocks.E.outputConnection);
       });
       test('output', function() {
         var output = this.blocks.E.outputConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var node = Blockly.ASTNode.createConnectionNode(output);
         var inNode = node.in();
         assertEquals(inNode, null);
       });
       test('field', function() {
         var field = this.blocks.A.inputList[0].fieldRow[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var node = Blockly.ASTNode.createFieldNode(field);
         var inNode = node.in();
         assertEquals(inNode, null);
       });
       test('isStack', function() {
         var prevConnection = this.blocks.D.previousConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, prevConnection);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), prevConnection);
         assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
+        var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
         var inNode = node.in();
-        assertEquals(inNode.getLocation(), null);
-        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(inNode.getLocation(), this.workspace.getTopBlocks()[0].previousConnection);
+        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.STACK);
+
       });
     });
 
     suite('Out', function() {
       test('topBlock', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
         var outNode = node.out();
-        assertEquals(outNode.getLocation(), this.blocks.A.previousConnection);
+        assertEquals(outNode.getLocation(), this.blocks.A);
       });
       test('nestedBlock', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.C);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.C);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.B.inputList[1].connection);
       });
       test('input', function() {
         var input = this.blocks.A.inputList[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var node = Blockly.ASTNode.createInputNode(input);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.A);
       });
       test('output', function() {
         var output = this.blocks.E.outputConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var node = Blockly.ASTNode.createConnectionNode(output);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.A.inputList[0].connection);
       });
       test('field', function() {
         var field = this.blocks.A.inputList[0].fieldRow[0];
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var node = Blockly.ASTNode.createFieldNode(field);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.A);
       });
       test('insideStatement', function() {
         var nextConnection = this.blocks.C.nextConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, nextConnection);
+        var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.B.inputList[1].connection);
       });
       test('stack', function() {
         var prevConnection = this.blocks.D.previousConnection;
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, prevConnection);
+        var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var outNode = node.out();
-        assertEquals(outNode.getLocation(), prevConnection);
+        assertEquals(outNode.getLocation(), this.blocks.D);
         assertEquals(outNode.getLocationType(), Blockly.ASTNode.types.STACK);
+      });
+      test('workspace', function() {
+        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
+        var outNode = node.out();
+        assertEquals(outNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(outNode.wsCoordinate_.x, 100);
+        assertEquals(outNode.wsCoordinate_.y, 100);
+      });
+    });
+
+    suite('createFunctions', function() {
+      test('createFieldNode', function() {
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var node = Blockly.ASTNode.createFieldNode(field);
+        assertEquals(node.getLocation(), field);
+        assertEquals(node.getLocationType(), Blockly.ASTNode.types.FIELD);
+      });
+      test('createConnectionNode', function() {
+        var prevConnection = this.blocks.D.previousConnection;
+        var node = Blockly.ASTNode.createConnectionNode(prevConnection);
+        assertEquals(node.getLocation(), prevConnection);
+        assertEquals(node.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
+      });
+      test('createInputNode', function() {
+        var input = this.blocks.A.inputList[0];
+        var node = Blockly.ASTNode.createInputNode(input);
+        assertEquals(node.getLocation(), input);
+        assertEquals(node.getLocationType(), Blockly.ASTNode.types.INPUT);
+      });
+      test('createWorkspaceNode', function() {
+        var coordinate = new goog.math.Coordinate(100,100);
+        var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
+        assertEquals(node.getLocation(), this.workspace);
+        assertEquals(node.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(node.getWsCoordinate(), coordinate);
+      });
+      test('createStatementConnectionNode', function() {
+        var nextConnection = this.blocks.A.inputList[1].connection;
+        var node = Blockly.ASTNode.createConnectionNode(nextConnection);
+        assertEquals(node.getLocation(), nextConnection);
+        assertEquals(node.getLocationType(), Blockly.ASTNode.types.INPUT);
       });
     });
   });

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -232,6 +232,19 @@ suite('ASTNode', function() {
         assertEquals(nextNode.getLocation(), this.blocks.D.previousConnection);
         assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
       });
+      test('isStack', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, this.blocks.A.previousConnection);
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.D.previousConnection);
+        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
+      });
+      test('workspace', function() {
+        var coordinate = new goog.math.Coordinate(100,100);
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation().x, 110);
+        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+      });
     });
     suite('Previous', function() {
       test('previousConnectionTopBlock', function() {
@@ -279,6 +292,13 @@ suite('ASTNode', function() {
         assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
         assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.STACK);
       });
+      test('workspace', function() {
+        var coordinate = new goog.math.Coordinate(100,100);
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation().x, 90);
+        assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+      });
     });
     suite('In', function() {
       test('block', function() {
@@ -310,6 +330,13 @@ suite('ASTNode', function() {
         var inNode = node.in();
         assertEquals(inNode.getLocation(), prevConnection);
         assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
+      });
+      test('workspace', function() {
+        var coordinate = new goog.math.Coordinate(100,100);
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.WORKSPACE, coordinate);
+        var inNode = node.in();
+        assertEquals(inNode.getLocation(), null);
+        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
       });
     });
 

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -74,116 +74,118 @@ suite('ASTNode', function() {
     this.workspace.dispose();
   });
 
-  // suite('HelperFunctions', function() {
-  //   test('setLocationForStackNotAtTop', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       this.cursor.setLocation(input, true, false);
-  //       assertEquals(this.cursor.isStack_, false)
-  //     });
-  //   test('setLocationForStackAtTopBlock', function() {
-  //       var input = this.blocks.A.previousConnection;
-  //       this.cursor.setLocation(input, true, false);
-  //       assertEquals(this.cursor.isStack_, true)
-  //     });
+  suite('HelperFunctions', function() {
+    // test('setLocationForStackNotAtTop', function() {
+    //     var input = this.blocks.A.inputList[0];
+    //     this.cursor.setLocation(input, true, false);
+    //     assertEquals(this.cursor.isStack_, false)
+    //   });
+    // test('setLocationForStackAtTopBlock', function() {
+    //     var input = this.blocks.A.previousConnection;
+    //     this.cursor.setLocation(input, true, false);
+    //     assertEquals(this.cursor.isStack_, true)
+    //   });
 
-  //     test('findNextEditableField_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = input.fieldRow[0];
-  //       var nextField = input.fieldRow[1];
-  //       var editableField = this.cursor.findNextEditableField_(field, input);
-  //       assertEquals(editableField, nextField);
-  //     });
+      test('findNextEditableField_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = input.fieldRow[0];
+        var nextField = input.fieldRow[1];
+        var node = new Blockly.ASTNode();
+        var editableField = node.findNextEditableField_(field, input);
+        assertEquals(editableField.getLocation(), nextField);
+      });
 
-  //     test('findNextEditableFieldFirst_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = input.fieldRow[1];
-  //       var editableField = this.cursor.findNextEditableField_(field, input, true);
-  //       assertEquals(editableField, input.fieldRow[0]);
-  //     });
+      test('findNextEditableFieldFirst_', function() {
+        var input = this.blocks.A.inputList[0];
+        var field = input.fieldRow[1];
+        var node = new Blockly.ASTNode();
+        var editableField = node.findNextEditableField_(field, input, true);
+        assertEquals(editableField.getLocation(), input.fieldRow[0]);
+      });
 
-  //     test('findPreviousEditableField_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = input.fieldRow[1];
-  //       var prevField = input.fieldRow[0];
-  //       var editableField = this.cursor.findPreviousEditableField_(field, input);
-  //       assertEquals(editableField, prevField);
-  //     });
+      // test('findPreviousEditableField_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var field = input.fieldRow[1];
+      //   var prevField = input.fieldRow[0];
+      //   var editableField = this.cursor.findPreviousEditableField_(field, input);
+      //   assertEquals(editableField, prevField);
+      // });
 
-  //     test('findPreviousEditableFieldLast_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = input.fieldRow[0];
-  //       var editableField = this.cursor.findPreviousEditableField_(field, input, true);
-  //       assertEquals(editableField, input.fieldRow[1]);
-  //     });
+      // test('findPreviousEditableFieldLast_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var field = input.fieldRow[0];
+      //   var editableField = this.cursor.findPreviousEditableField_(field, input, true);
+      //   assertEquals(editableField, input.fieldRow[1]);
+      // });
 
-  //     test('findNextForInput_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var input2 = this.blocks.A.inputList[1];
-  //       var connection = input.connection;
-  //       var nextLocation = this.cursor.findNextForInput_(connection, input);
-  //       assertEquals(nextLocation, input2.connection);
-  //       assertEquals(input2, this.cursor.parentInput_);
-  //     });
+      // test('findNextForInput_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var input2 = this.blocks.A.inputList[1];
+      //   var connection = input.connection;
+      //   var nextLocation = this.cursor.findNextForInput_(connection, input);
+      //   assertEquals(nextLocation, input2.connection);
+      //   assertEquals(input2, this.cursor.parentInput_);
+      // });
 
-  //     test('findPrevForInput_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var input2 = this.blocks.A.inputList[1];
-  //       var connection = input2.connection;
-  //       var nextLocation = this.cursor.findPrevForInput_(connection, input2);
-  //       assertEquals(nextLocation, input.connection);
-  //       assertEquals(input, this.cursor.parentInput_);
-  //     });
+      // test('findPrevForInput_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var input2 = this.blocks.A.inputList[1];
+      //   var connection = input2.connection;
+      //   var nextLocation = this.cursor.findPrevForInput_(connection, input2);
+      //   assertEquals(nextLocation, input.connection);
+      //   assertEquals(input, this.cursor.parentInput_);
+      // });
 
-  //     test('findNextForField_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = this.blocks.A.inputList[0].fieldRow[0];
-  //       var field2 = this.blocks.A.inputList[0].fieldRow[1];
-  //       var nextLocation = this.cursor.findNextForField_(field, input);
-  //       assertEquals(nextLocation, field2);
-  //     });
+      // test('findNextForField_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var field = this.blocks.A.inputList[0].fieldRow[0];
+      //   var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      //   var nextLocation = this.cursor.findNextForField_(field, input);
+      //   assertEquals(nextLocation, field2);
+      // });
 
-  //     test('findPrevForField_', function() {
-  //       var input = this.blocks.A.inputList[0];
-  //       var field = this.blocks.A.inputList[0].fieldRow[0];
-  //       var field2 = this.blocks.A.inputList[0].fieldRow[1];
-  //       var nextLocation = this.cursor.findPrevForField_(field2, input);
-  //       assertEquals(nextLocation, field);
-  //     });
+      // test('findPrevForField_', function() {
+      //   var input = this.blocks.A.inputList[0];
+      //   var field = this.blocks.A.inputList[0].fieldRow[0];
+      //   var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      //   var nextLocation = this.cursor.findPrevForField_(field2, input);
+      //   assertEquals(nextLocation, field);
+      // });
 
-  //     test('findTop_', function() {
-  //       var topBlock = this.cursor.findTop_(this.blocks.C);
-  //       assertEquals(topBlock, this.blocks.C);
-  //     });
+      // test('findTop_', function() {
+      //   var topBlock = this.cursor.findTop_(this.blocks.C);
+      //   assertEquals(topBlock, this.blocks.C);
+      // });
 
-  //     test('navigateBetweenStacksForward', function() {
-  //       this.cursor.setLocation(this.blocks.A.nextConnection);
-  //       var nextStack = this.cursor.navigateBetweenStacks_(true);
-  //       assertEquals(nextStack, this.blocks.D);
-  //     });
+      // test('navigateBetweenStacksForward', function() {
+      //   this.cursor.setLocation(this.blocks.A.nextConnection);
+      //   var nextStack = this.cursor.navigateBetweenStacks_(true);
+      //   assertEquals(nextStack, this.blocks.D);
+      // });
 
-  //     test('navigateBetweenStacksBackward', function() {
-  //       this.cursor.setLocation(this.blocks.D);
-  //       var nextStack = this.cursor.navigateBetweenStacks_(false);
-  //       assertEquals(nextStack, this.blocks.A);
-  //     });
+      // test('navigateBetweenStacksBackward', function() {
+      //   this.cursor.setLocation(this.blocks.D);
+      //   var nextStack = this.cursor.navigateBetweenStacks_(false);
+      //   assertEquals(nextStack, this.blocks.A);
+      // });
 
-  //     test('checkIfStackFalse', function() {
-  //       this.cursor.setLocation(this.blocks.B);
-  //       var isStack = this.cursor.checkIfStack_();
-  //       assertEquals(isStack, false);
-  //     });
+      // test('checkIfStackFalse', function() {
+      //   this.cursor.setLocation(this.blocks.B);
+      //   var isStack = this.cursor.checkIfStack_();
+      //   assertEquals(isStack, false);
+      // });
 
-  //     test('checkIfStackTrue', function() {
-  //       this.cursor.setLocation(this.blocks.A.previousConnection);
-  //       var isStack = this.cursor.checkIfStack_();
-  //       assertEquals(isStack, true);
-  //     });
+      // test('checkIfStackTrue', function() {
+      //   this.cursor.setLocation(this.blocks.A.previousConnection);
+      //   var isStack = this.cursor.checkIfStack_();
+      //   assertEquals(isStack, true);
+      // });
 
-  //     test('findTopConnection', function() {
-  //       var topConnection = this.cursor.findTopConnection_(this.blocks.A);
-  //       assertEquals(topConnection, this.blocks.A.previousConnection);
-  //     });
-  //   });
+      // test('findTopConnection', function() {
+      //   var topConnection = this.cursor.findTopConnection_(this.blocks.A);
+      //   assertEquals(topConnection, this.blocks.A.previousConnection);
+      // });
+    });
 
   suite('NavigationFunctions', function() {
     suite('Next', function() {
@@ -197,14 +199,12 @@ suite('ASTNode', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
             this.blocks.A);
         var nextNode = node.next();
-
         assertEquals(nextNode.getLocation(), this.blocks.A.nextConnection);
       });
       test('nextConnection', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT,
             this.blocks.A.nextConnection);
         var nextNode = node.next();
-
         assertEquals(nextNode.getLocation(), this.blocks.B.previousConnection);
       });
       test('input', function() {
@@ -217,40 +217,32 @@ suite('ASTNode', function() {
       test('output', function() {
         var output = this.blocks.E.outputConnection;
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
-
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.E);
       });
       test('field', function() {
         var field = this.blocks.A.inputList[0].fieldRow[1];
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
-
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.A.inputList[0].connection);
       });
-      // test('isStack', function() {
-      //   var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, field);
-
-      //   this.cursor.setLocation(this.blocks.A.previousConnection, true);
-      //   this.cursor.next();
-      //   assertEquals(this.cursor.getLocation(), this.blocks.D.previousConnection);
-      //   assertEquals(this.cursor.isStack_, true);
-      // });
+      test('isStack', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, this.blocks.A.previousConnection);
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.D.previousConnection);
+        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
+      });
     });
     suite('Previous', function() {
-      // test('previousConnectionTopBlock', function() {
-      //   var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.A.previousConnection);
-
-      //   var prevNode = node.prev();
-      //   assertEquals(prevNode.getLocation(), this.blocks.A.inputList[0].connection);
-
-      // });
+      test('previousConnectionTopBlock', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.A.previousConnection);
+        var prevNode = node.prev();
+        assertEquals(prevNode, null);
+      });
       test('previousConnection', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.B.previousConnection);
-
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), this.blocks.A.nextConnection);
-
       });
       test('block', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
@@ -267,34 +259,102 @@ suite('ASTNode', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), input.fieldRow[1]);
-
       });
-      // test('output', function() {
-      //   var output = this.blocks.E.outputConnection;
-      //   this.cursor.setLocation(output);
-      //   //cursor.prev should return null but cursor should stay on same location
-      //   assertEquals(this.cursor.prev(), null);
-      //   assertEquals(this.cursor.getLocation(), output);
-      // });
-      // test('field', function() {
-      //   var field = this.blocks.A.inputList[0].fieldRow[0];
-      //   this.cursor.setLocation(field, this.blocks.A.inputList[0]);
-      //   assertEquals(this.cursor.prev(), null);
-      //   assertEquals(this.cursor.getLocation(), field);
-      // });
-      // test('isStack', function() {
-      //   this.cursor.setLocation(this.blocks.D.previousConnection, true);
-      //   this.cursor.prev();
-      //   assertEquals(this.cursor.getLocation(), this.blocks.A.previousConnection);
-      //   assertEquals(this.cursor.isStack_, true);
-      // });
-      // test('hasParentInput', function() {
-      //   var input = this.blocks.B.inputList[1];
-      //   this.cursor.setLocation(input.connection, input);
-      //   this.cursor.prev();
-      //   assertEquals(this.cursor.getLocation(), this.blocks.B.inputList[0].connection);
-      //   assertEquals(this.cursor.parentInput_, this.blocks.B.inputList[0]);
-      // });
+      test('output', function() {
+        var output = this.blocks.E.outputConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var prevNode = node.prev();
+        assertEquals(prevNode, null);
+      });
+      test('field', function() {
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var prevNode = node.prev();
+        assertEquals(prevNode, null);
+      });
+      test('isStack', function() {
+        var prevConnection = this.blocks.D.previousConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, prevConnection);
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
+        assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.STACK);
+      });
+    });
+    suite('In', function() {
+      test('block', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var inNode = node.in();
+        assertEquals(inNode.getLocation(), this.blocks.A.inputList[0].fieldRow[0]);
+      });
+      test('input', function() {
+        var input = this.blocks.A.inputList[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var inNode = node.in();
+        assertEquals(inNode.getLocation(), this.blocks.E.outputConnection);
+      });
+      test('output', function() {
+        var output = this.blocks.E.outputConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var inNode = node.in();
+        assertEquals(inNode, null);
+      });
+      test('field', function() {
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var inNode = node.in();
+        assertEquals(inNode, null);
+      });
+      test('isStack', function() {
+        var prevConnection = this.blocks.D.previousConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, prevConnection);
+        var inNode = node.in();
+        assertEquals(inNode.getLocation(), prevConnection);
+        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
+      });
+    });
+
+    suite('Out', function() {
+      test('topBlock', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.A.previousConnection);
+      });
+      test('nestedBlock', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.C);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.B.inputList[1].connection);
+      });
+      test('input', function() {
+        var input = this.blocks.A.inputList[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.A);
+      });
+      test('output', function() {
+        var output = this.blocks.E.outputConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.A.inputList[0].connection);
+      });
+      test('field', function() {
+        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.A);
+      });
+      test('insideStatement', function() {
+        var nextConnection = this.blocks.C.nextConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, nextConnection);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), this.blocks.B.inputList[1].connection);
+      });
+      test('stack', function() {
+        var prevConnection = this.blocks.D.previousConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, prevConnection);
+        var outNode = node.out();
+        assertEquals(outNode.getLocation(), prevConnection);
+        assertEquals(outNode.getLocationType(), Blockly.ASTNode.types.STACK);
+      });
     });
   });
 });

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -32,6 +32,19 @@ suite('ASTNode', function() {
       "helpUrl": ""
     },
     {
+      "type": "value_input",
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "NAME"
+        }
+      ],
+      "colour": 230,
+      "tooltip": "",
+      "helpUrl": ""
+    },
+    {
       "type": "field_input",
       "message0": "%1",
       "args0": [
@@ -54,6 +67,7 @@ suite('ASTNode', function() {
     var blockC = this.workspace.newBlock('input_statement');
     var blockD = this.workspace.newBlock('input_statement');
     var blockE = this.workspace.newBlock('field_input');
+    var blockF = this.workspace.newBlock('value_input');
 
     blockA.nextConnection.connect(blockB.previousConnection);
     blockA.inputList[0].connection.connect(blockE.outputConnection);
@@ -64,7 +78,8 @@ suite('ASTNode', function() {
       B: blockB,
       C: blockC,
       D: blockD,
-      E: blockE
+      E: blockE,
+      F: blockF
     };
     Blockly.getMainWorkspace = function() {
       return new Blockly.Workspace();
@@ -73,6 +88,7 @@ suite('ASTNode', function() {
   teardown(function() {
     delete Blockly.Blocks['input_statement'];
     delete Blockly.Blocks['field_input'];
+    delete Blockly.Blocks['value_input'];
 
     this.workspace.dispose();
   });
@@ -199,7 +215,7 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createStackNode(this.blocks.A);
         var nextNode = node.next();
         assertEquals(nextNode.getLocation(), this.blocks.D);
-        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.STACK);
+        assertEquals(nextNode.getType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
@@ -207,7 +223,7 @@ suite('ASTNode', function() {
         var nextNode = node.next();
         assertEquals(nextNode.wsCoordinate_.x, 110);
         assertEquals(nextNode.getLocation(), this.workspace);
-        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(nextNode.getType(), Blockly.ASTNode.types.WORKSPACE);
       });
     });
 
@@ -256,8 +272,8 @@ suite('ASTNode', function() {
       test('isStack', function() {
         var node = Blockly.ASTNode.createStackNode(this.blocks.D);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A);
-        assertEquals(prevNode.getLocationType(), Blockly.ASTNode.types.STACK);
+        assertEquals(prevNode.getLocation(), this.blocks.F);
+        assertEquals(prevNode.getType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
@@ -265,7 +281,7 @@ suite('ASTNode', function() {
         var nextNode = node.prev();
         assertEquals(nextNode.wsCoordinate_.x, 90);
         assertEquals(nextNode.getLocation(), this.workspace);
-        assertEquals(nextNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(nextNode.getType(), Blockly.ASTNode.types.WORKSPACE);
       });
     });
 
@@ -280,6 +296,12 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createInputNode(input);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), this.blocks.E.outputConnection);
+      });
+      test('blockToInput', function() {
+        var input = this.blocks.F.inputList[0];
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.F);
+        var inNode = node.in();
+        assertEquals(inNode.getLocation(), input);
       });
       test('output', function() {
         var output = this.blocks.E.outputConnection;
@@ -298,14 +320,14 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createStackNode(this.blocks.D);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), prevConnection);
-        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
+        assertEquals(inNode.getType(), Blockly.ASTNode.types.PREVIOUS);
       });
       test('workspace', function() {
         var coordinate = new goog.math.Coordinate(100,100);
         var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), this.workspace.getTopBlocks()[0].previousConnection);
-        assertEquals(inNode.getLocationType(), Blockly.ASTNode.types.STACK);
+        assertEquals(inNode.getType(), Blockly.ASTNode.types.STACK);
 
       });
     });
@@ -350,12 +372,12 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var outNode = node.out();
         assertEquals(outNode.getLocation(), this.blocks.D);
-        assertEquals(outNode.getLocationType(), Blockly.ASTNode.types.STACK);
+        assertEquals(outNode.getType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
         var node = Blockly.ASTNode.createStackNode(this.blocks.D);
         var outNode = node.out();
-        assertEquals(outNode.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(outNode.getType(), Blockly.ASTNode.types.WORKSPACE);
         assertEquals(outNode.wsCoordinate_.x, 100);
         assertEquals(outNode.wsCoordinate_.y, 100);
       });
@@ -366,32 +388,32 @@ suite('ASTNode', function() {
         var field = this.blocks.A.inputList[0].fieldRow[0];
         var node = Blockly.ASTNode.createFieldNode(field);
         assertEquals(node.getLocation(), field);
-        assertEquals(node.getLocationType(), Blockly.ASTNode.types.FIELD);
+        assertEquals(node.getType(), Blockly.ASTNode.types.FIELD);
       });
       test('createConnectionNode', function() {
         var prevConnection = this.blocks.D.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         assertEquals(node.getLocation(), prevConnection);
-        assertEquals(node.getLocationType(), Blockly.ASTNode.types.PREVIOUS);
+        assertEquals(node.getType(), Blockly.ASTNode.types.PREVIOUS);
       });
       test('createInputNode', function() {
         var input = this.blocks.A.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         assertEquals(node.getLocation(), input);
-        assertEquals(node.getLocationType(), Blockly.ASTNode.types.INPUT);
+        assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
       });
       test('createWorkspaceNode', function() {
         var coordinate = new goog.math.Coordinate(100,100);
         var node = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
         assertEquals(node.getLocation(), this.workspace);
-        assertEquals(node.getLocationType(), Blockly.ASTNode.types.WORKSPACE);
+        assertEquals(node.getType(), Blockly.ASTNode.types.WORKSPACE);
         assertEquals(node.getWsCoordinate(), coordinate);
       });
       test('createStatementConnectionNode', function() {
         var nextConnection = this.blocks.A.inputList[1].connection;
         var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         assertEquals(node.getLocation(), nextConnection);
-        assertEquals(node.getLocationType(), Blockly.ASTNode.types.INPUT);
+        assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
       });
     });
   });

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -1,0 +1,300 @@
+
+
+suite('ASTNode', function() {
+  setup(function() {
+    Blockly.defineBlocksWithJsonArray([{
+      "type": "input_statement",
+      "message0": "%1 %2 %3 %4",
+      "args0": [
+        {
+          "type": "field_input",
+          "name": "NAME",
+          "text": "default"
+        },
+        {
+          "type": "field_input",
+          "name": "NAME",
+          "text": "default"
+        },
+        {
+          "type": "input_value",
+          "name": "NAME"
+        },
+        {
+          "type": "input_statement",
+          "name": "NAME"
+        }
+      ],
+      "previousStatement": null,
+      "nextStatement": null,
+      "colour": 230,
+      "tooltip": "",
+      "helpUrl": ""
+    },
+    {
+      "type": "field_input",
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_input",
+          "name": "NAME",
+          "text": "default"
+        }
+      ],
+      "output": null,
+      "colour": 230,
+      "tooltip": "",
+      "helpUrl": ""
+    }
+    ]);
+    this.workspace = new Blockly.Workspace();
+    this.cursor = this.workspace.cursor;
+    var blockA = this.workspace.newBlock('input_statement');
+    var blockB = this.workspace.newBlock('input_statement');
+    var blockC = this.workspace.newBlock('input_statement');
+    var blockD = this.workspace.newBlock('input_statement');
+    var blockE = this.workspace.newBlock('field_input');
+
+    blockA.nextConnection.connect(blockB.previousConnection);
+    blockA.inputList[0].connection.connect(blockE.outputConnection);
+    blockB.inputList[1].connection.connect(blockC.previousConnection);
+
+    this.blocks = {
+      A: blockA,
+      B: blockB,
+      C: blockC,
+      D: blockD,
+      E: blockE
+    };
+  });
+  teardown(function() {
+    delete Blockly.Blocks['input_statement'];
+    delete Blockly.Blocks['field_input'];
+
+    this.workspace.dispose();
+  });
+
+  // suite('HelperFunctions', function() {
+  //   test('setLocationForStackNotAtTop', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       this.cursor.setLocation(input, true, false);
+  //       assertEquals(this.cursor.isStack_, false)
+  //     });
+  //   test('setLocationForStackAtTopBlock', function() {
+  //       var input = this.blocks.A.previousConnection;
+  //       this.cursor.setLocation(input, true, false);
+  //       assertEquals(this.cursor.isStack_, true)
+  //     });
+
+  //     test('findNextEditableField_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = input.fieldRow[0];
+  //       var nextField = input.fieldRow[1];
+  //       var editableField = this.cursor.findNextEditableField_(field, input);
+  //       assertEquals(editableField, nextField);
+  //     });
+
+  //     test('findNextEditableFieldFirst_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = input.fieldRow[1];
+  //       var editableField = this.cursor.findNextEditableField_(field, input, true);
+  //       assertEquals(editableField, input.fieldRow[0]);
+  //     });
+
+  //     test('findPreviousEditableField_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = input.fieldRow[1];
+  //       var prevField = input.fieldRow[0];
+  //       var editableField = this.cursor.findPreviousEditableField_(field, input);
+  //       assertEquals(editableField, prevField);
+  //     });
+
+  //     test('findPreviousEditableFieldLast_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = input.fieldRow[0];
+  //       var editableField = this.cursor.findPreviousEditableField_(field, input, true);
+  //       assertEquals(editableField, input.fieldRow[1]);
+  //     });
+
+  //     test('findNextForInput_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var input2 = this.blocks.A.inputList[1];
+  //       var connection = input.connection;
+  //       var nextLocation = this.cursor.findNextForInput_(connection, input);
+  //       assertEquals(nextLocation, input2.connection);
+  //       assertEquals(input2, this.cursor.parentInput_);
+  //     });
+
+  //     test('findPrevForInput_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var input2 = this.blocks.A.inputList[1];
+  //       var connection = input2.connection;
+  //       var nextLocation = this.cursor.findPrevForInput_(connection, input2);
+  //       assertEquals(nextLocation, input.connection);
+  //       assertEquals(input, this.cursor.parentInput_);
+  //     });
+
+  //     test('findNextForField_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = this.blocks.A.inputList[0].fieldRow[0];
+  //       var field2 = this.blocks.A.inputList[0].fieldRow[1];
+  //       var nextLocation = this.cursor.findNextForField_(field, input);
+  //       assertEquals(nextLocation, field2);
+  //     });
+
+  //     test('findPrevForField_', function() {
+  //       var input = this.blocks.A.inputList[0];
+  //       var field = this.blocks.A.inputList[0].fieldRow[0];
+  //       var field2 = this.blocks.A.inputList[0].fieldRow[1];
+  //       var nextLocation = this.cursor.findPrevForField_(field2, input);
+  //       assertEquals(nextLocation, field);
+  //     });
+
+  //     test('findTop_', function() {
+  //       var topBlock = this.cursor.findTop_(this.blocks.C);
+  //       assertEquals(topBlock, this.blocks.C);
+  //     });
+
+  //     test('navigateBetweenStacksForward', function() {
+  //       this.cursor.setLocation(this.blocks.A.nextConnection);
+  //       var nextStack = this.cursor.navigateBetweenStacks_(true);
+  //       assertEquals(nextStack, this.blocks.D);
+  //     });
+
+  //     test('navigateBetweenStacksBackward', function() {
+  //       this.cursor.setLocation(this.blocks.D);
+  //       var nextStack = this.cursor.navigateBetweenStacks_(false);
+  //       assertEquals(nextStack, this.blocks.A);
+  //     });
+
+  //     test('checkIfStackFalse', function() {
+  //       this.cursor.setLocation(this.blocks.B);
+  //       var isStack = this.cursor.checkIfStack_();
+  //       assertEquals(isStack, false);
+  //     });
+
+  //     test('checkIfStackTrue', function() {
+  //       this.cursor.setLocation(this.blocks.A.previousConnection);
+  //       var isStack = this.cursor.checkIfStack_();
+  //       assertEquals(isStack, true);
+  //     });
+
+  //     test('findTopConnection', function() {
+  //       var topConnection = this.cursor.findTopConnection_(this.blocks.A);
+  //       assertEquals(topConnection, this.blocks.A.previousConnection);
+  //     });
+  //   });
+
+  suite('NavigationFunctions', function() {
+    suite('Next', function() {
+      test('previousConnection', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS,
+            this.blocks.A.previousConnection);
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.A);
+      });
+      test('block', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK,
+            this.blocks.A);
+        var nextNode = node.next();
+
+        assertEquals(nextNode.getLocation(), this.blocks.A.nextConnection);
+      });
+      test('nextConnection', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT,
+            this.blocks.A.nextConnection);
+        var nextNode = node.next();
+
+        assertEquals(nextNode.getLocation(), this.blocks.B.previousConnection);
+      });
+      test('input', function() {
+        var input = this.blocks.A.inputList[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.A.inputList[1].connection);
+      });
+      test('output', function() {
+        var output = this.blocks.E.outputConnection;
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.OUTPUT, output);
+
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.E);
+      });
+      test('field', function() {
+        var field = this.blocks.A.inputList[0].fieldRow[1];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.FIELD, field);
+
+        var nextNode = node.next();
+        assertEquals(nextNode.getLocation(), this.blocks.A.inputList[0].connection);
+      });
+      // test('isStack', function() {
+      //   var node = new Blockly.ASTNode(Blockly.ASTNode.types.STACK, field);
+
+      //   this.cursor.setLocation(this.blocks.A.previousConnection, true);
+      //   this.cursor.next();
+      //   assertEquals(this.cursor.getLocation(), this.blocks.D.previousConnection);
+      //   assertEquals(this.cursor.isStack_, true);
+      // });
+    });
+    suite('Previous', function() {
+      // test('previousConnectionTopBlock', function() {
+      //   var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.A.previousConnection);
+
+      //   var prevNode = node.prev();
+      //   assertEquals(prevNode.getLocation(), this.blocks.A.inputList[0].connection);
+
+      // });
+      test('previousConnection', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.PREVIOUS, this.blocks.B.previousConnection);
+
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation(), this.blocks.A.nextConnection);
+
+      });
+      test('block', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.A);
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
+      });
+      test('nextConnection', function() {
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation(), this.blocks.A);
+      });
+      test('input', function() {
+        var input = this.blocks.A.inputList[0];
+        var node = new Blockly.ASTNode(Blockly.ASTNode.types.INPUT, input.connection);
+        var prevNode = node.prev();
+        assertEquals(prevNode.getLocation(), input.fieldRow[1]);
+
+      });
+      // test('output', function() {
+      //   var output = this.blocks.E.outputConnection;
+      //   this.cursor.setLocation(output);
+      //   //cursor.prev should return null but cursor should stay on same location
+      //   assertEquals(this.cursor.prev(), null);
+      //   assertEquals(this.cursor.getLocation(), output);
+      // });
+      // test('field', function() {
+      //   var field = this.blocks.A.inputList[0].fieldRow[0];
+      //   this.cursor.setLocation(field, this.blocks.A.inputList[0]);
+      //   assertEquals(this.cursor.prev(), null);
+      //   assertEquals(this.cursor.getLocation(), field);
+      // });
+      // test('isStack', function() {
+      //   this.cursor.setLocation(this.blocks.D.previousConnection, true);
+      //   this.cursor.prev();
+      //   assertEquals(this.cursor.getLocation(), this.blocks.A.previousConnection);
+      //   assertEquals(this.cursor.isStack_, true);
+      // });
+      // test('hasParentInput', function() {
+      //   var input = this.blocks.B.inputList[1];
+      //   this.cursor.setLocation(input.connection, input);
+      //   this.cursor.prev();
+      //   assertEquals(this.cursor.getLocation(), this.blocks.B.inputList[0].connection);
+      //   assertEquals(this.cursor.parentInput_, this.blocks.B.inputList[0]);
+      // });
+    });
+  });
+});

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -133,8 +133,8 @@ suite('ASTNode', function() {
         var input2 = this.blocks.A.inputList[1];
         var connection = input.connection;
         var node = new Blockly.ASTNode();
-        var nextLocation = node.findNextForInput_(connection, input);
-        assertEquals(nextLocation.getLocation(), input2.connection);
+        var newASTNode = node.findNextForInput_(connection, input);
+        assertEquals(newASTNode.getLocation(), input2.connection);
       });
 
       test('findPrevForInput_', function() {
@@ -142,8 +142,8 @@ suite('ASTNode', function() {
         var input2 = this.blocks.A.inputList[1];
         var connection = input2.connection;
         var node = new Blockly.ASTNode();
-        var nextLocation = node.findPrevForInput_(connection, input2);
-        assertEquals(nextLocation.getLocation(), input);
+        var newASTNode = node.findPrevForInput_(connection, input2);
+        assertEquals(newASTNode.getLocation(), input);
       });
 
       test('findNextForField_', function() {
@@ -151,28 +151,29 @@ suite('ASTNode', function() {
         var field = this.blocks.A.inputList[0].fieldRow[0];
         var field2 = this.blocks.A.inputList[0].fieldRow[1];
         var node = new Blockly.ASTNode();
-        var nextLocation = node.findNextForField_(field, input);
-        assertEquals(nextLocation.getLocation(), field2);
+        var newASTNode = node.findNextForField_(field, input);
+        assertEquals(newASTNode.getLocation(), field2);
       });
 
       test('findPrevForField_', function() {
         var input = this.blocks.A.inputList[0];
         var field = this.blocks.A.inputList[0].fieldRow[0];
         var field2 = this.blocks.A.inputList[0].fieldRow[1];
-        var nextLocation = this.cursor.findPrevForField_(field2, input);
-        assertEquals(nextLocation, field);
+        var node = new Blockly.ASTNode();
+        var newASTNode = node.findPrevForField_(field2, input);
+        assertEquals(newASTNode.getLocation(), field);
       });
 
       test('navigateBetweenStacksForward', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
-        var nextStack = node.navigateBetweenStacks_(true);
-        assertEquals(nextStack, this.blocks.D);
+        var nextTopBlock = node.navigateBetweenStacks_(true);
+        assertEquals(nextTopBlock, this.blocks.D);
       });
 
       test('navigateBetweenStacksBackward', function() {
         var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
-        var nextStack = node.navigateBetweenStacks_(false);
-        assertEquals(nextStack, this.blocks.A);
+        var nextTopBlock = node.navigateBetweenStacks_(false);
+        assertEquals(nextTopBlock, this.blocks.A);
       });
     });
 

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -20,6 +20,7 @@
     </script>
     <script src="test_helpers.js"></script>
     <script src="block_test.js"></script>
+    <script src="astnode_test.js"></script>
     <script src="cursor_test.js"></script>
     <script src="event_test.js"></script>
     <script src="field_variable_test.js"></script>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [] I branched from develop
- [] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes
Adds an AST Node for keyboard navigation. An AST Node will be able to find the next, prev, in, or out node from its current location. 

### Reason for Changes
To create a better keyboard navigation api.

### Test Coverage
Tests are written in mocha.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
