### PR TITLE
Changed Buttons and Labels to Respect <sep> Elements in Toolbox

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -447,11 +447,13 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   var contents = [];
   var gaps = [];
   this.permanentlyDisabled_.length = 0;
+  var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
   for (var i = 0, xml; xml = xmlList[i]; i++) {
-    if (xml.tagName) {
-      var tagName = xml.tagName.toUpperCase();
-      var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
-      if (tagName == 'BLOCK') {
+    if (!xml.tagName) {
+      continue;
+    }
+    switch (xml.tagName.toUpperCase()) {
+      case 'BLOCK':
         var curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
         if (curBlock.disabled) {
           // Record blocks that were initially disabled.
@@ -459,15 +461,16 @@ Blockly.Flyout.prototype.show = function(xmlList) {
           this.permanentlyDisabled_.push(curBlock);
         }
         contents.push({type: 'block', block: curBlock});
+        // This is a deprecated method for adding gap to a block.
+        // <block type="math_arithmetic" gap="8"></block>
         var gap = parseInt(xml.getAttribute('gap'), 10);
         gaps.push(isNaN(gap) ? default_gap : gap);
-      } else if (xml.tagName.toUpperCase() == 'SEP') {
-        // Change the gap between two blocks.
+        break;
+      case 'SEP':
+        // Change the gap between two toolbox elements.
         // <sep gap="36"></sep>
         // The default gap is 24, can be set larger or smaller.
-        // This overwrites the gap attribute on the previous block.
-        // Note that a deprecated method is to add a gap to a block.
-        // <block type="math_arithmetic" gap="8"></block>
+        // This overwrites the gap attribute on the previous element.
         var newGap = parseInt(xml.getAttribute('gap'), 10);
         // Ignore gaps before the first block.
         if (!isNaN(newGap) && gaps.length > 0) {
@@ -475,14 +478,17 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         } else {
           gaps.push(default_gap);
         }
-      } else if (tagName == 'BUTTON' || tagName == 'LABEL') {
+        break;
+      case 'LABEL':
         // Labels behave the same as buttons, but are styled differently.
-        var isLabel = tagName == 'LABEL';
+        var isLabel = true;
+        // Falls through.
+      case 'BUTTON':
         var curButton = new Blockly.FlyoutButton(this.workspace_,
             this.targetWorkspace_, xml, isLabel);
         contents.push({type: 'button', button: curButton});
         gaps.push(default_gap);
-      }
+        break;
     }
   }
 

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -359,25 +359,14 @@ Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
         lastElement = childIn;
         break;
       case 'SEP':
-        if (lastElement) {
-          if (lastElement.tagName.toUpperCase() == 'CATEGORY') {
-            // Separator between two categories.
-            // <sep></sep>
-            treeOut.add(new Blockly.Toolbox.TreeSeparator(
-                this.treeSeparatorConfig_));
-          } else {
-            // Change the gap between two blocks.
-            // <sep gap="36"></sep>
-            // The default gap is 24, can be set larger or smaller.
-            // Note that a deprecated method is to add a gap to a block.
-            // <block type="math_arithmetic" gap="8"></block>
-            var newGap = parseFloat(childIn.getAttribute('gap'));
-            if (!isNaN(newGap) && lastElement) {
-              lastElement.setAttribute('gap', newGap);
-            }
-          }
+        if (lastElement && lastElement.tagName.toUpperCase() == 'CATEGORY') {
+          // Separator between two categories.
+          // <sep></sep>
+          treeOut.add(new Blockly.Toolbox.TreeSeparator(
+              this.treeSeparatorConfig_));
+          break;
         }
-        break;
+        // Otherwise falls through.
       case 'BLOCK':
       case 'SHADOW':
       case 'LABEL':


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2396

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that button and label flyout elements obey sep elements.

I also changed flyout XML parsing so that it uses a switch statement so that it matches the toolbox XML parsing.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
If you have a lot of buttons stacked on top of eachother it can make your flyout look pretty cluttered. It would be nice to be able to set the gap between them to be smaller.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

XML for this testing: (default gap is 24)
```
  <category name="Separation">
      <block type="logic_compare"></block>
      <sep gap="32"></sep>
      <block type="logic_compare"></block>
      <sep gap="8"></sep>
      <block type="logic_compare"></block>
      <button text="button" callbackKey="logCallback"></button>
      <sep gap="32"></sep>
      <button text="button" callbackKey="logCallback"></button>
      <sep gap="8"></sep>
      <button text="button" callbackKey="logCallback"></button>
      <label text="label"></label>
      <sep gap="32"></sep>
      <label text="label"></label>
      <sep gap="8"></sep>
      <label text="label"></label>
    </category>
```

Old Separation Code:
![SeparationOld](https://user-images.githubusercontent.com/25440652/56458964-333ae580-6342-11e9-8a46-ea770c274067.jpg)
New Separation Code:
![SeparationNew](https://user-images.githubusercontent.com/25440652/56458966-37ff9980-6342-11e9-9a4d-c9fc46bcc299.jpg)

I also checked:
* Category Separators
* Simple Toolboxes
* Mutators (b/c mutators always break)
* LTR and RTL

they all look good!

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
