### PR TITLE
Moved RTL Demo Blocks so They Aren't Behind the Toolbox

### DIFF
--- a/demos/rtl/index.html
+++ b/demos/rtl/index.html
@@ -169,7 +169,7 @@
   </xml>
 
   <xml id="startBlocks" style="display: none">
-    <block type="controls_if" inline="false" x="-100" y="50">
+    <block type="controls_if" inline="false" x="50" y="50">
       <value name="IF0">
         <block type="logic_compare" inline="true">
           <field name="OP">LT</field>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2387 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the blocks are now positioned correctly in RTL.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Blocks being positioned behind the toolbox looks bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![RTLDemo](https://user-images.githubusercontent.com/25440652/56459410-130e2500-6348-11e9-9754-f47fd09aba59.jpg)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
