### PR TITLE
Kb exit toolbox

### DIFF
--- a/core/navigation.js
+++ b/core/navigation.js
@@ -81,7 +81,7 @@ Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_WS;
  * category.
  */
 Blockly.Navigation.focusToolbox = function() {
-  Blockly.Navigation.resetFlyout();
+  Blockly.Navigation.resetFlyout(false /* shouldHide */);
   Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_TOOLBOX;
   var workspace = Blockly.getMainWorkspace();
   var toolbox = workspace.getToolbox();
@@ -276,12 +276,16 @@ Blockly.Navigation.insertFromFlyout = function() {
 };
 
 /**
- * Reset flyout information.
+ * Reset flyout information, and optionally close the flyout.
+ * @param {boolean} shouldHide True if the flyout should be hidden.
  */
-Blockly.Navigation.resetFlyout = function() {
+Blockly.Navigation.resetFlyout = function(shouldHide) {
   var cursor = Blockly.Navigation.cursor_;
   Blockly.Navigation.flyoutBlock_ = null;
   cursor.hide();
+  if (shouldHide) {
+    cursor.workspace_.getFlyout_().hide();
+  }
 };
 
 /************/
@@ -361,10 +365,11 @@ Blockly.Navigation.insertBlockFromWs = function() {
 /**
  * Sets the cursor to the previous or output connection of the selected block
  * on the workspace.
+ * If no block is selected, places the cursor at a fixed point on the workspace.
  */
 Blockly.Navigation.focusWorkspace = function() {
   var cursor = Blockly.Navigation.cursor_;
-  Blockly.Navigation.resetFlyout();
+  Blockly.Navigation.resetFlyout(true /* shouldHide */);
   Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_WS;
   Blockly.keyboardAccessibilityMode_ = true;
   if (Blockly.selected) {
@@ -375,6 +380,12 @@ Blockly.Navigation.focusWorkspace = function() {
     var connection = previousConnection ? previousConnection : outputConnection;
     var newAstNode = Blockly.ASTNode.createConnectionNode(connection);
     cursor.setLocation(newAstNode);
+  } else {
+    var ws = cursor.workspace_;
+    // TODO: Find the center of the visible workspace.
+    var wsCoord = new goog.math.Coordinate(100, 100);
+    var wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);
+    cursor.setLocation(wsNode);
   }
 };
 
@@ -499,6 +510,10 @@ Blockly.Navigation.flyoutKeyHandler = function(e) {
     Blockly.Navigation.insertFromFlyout();
     keyHandled = true;
     console.log('Enter: Flyout : Select');
+  } else if (e.keyCode === goog.events.KeyCodes.E) {
+    console.log('E: Flyout: Exit');
+    Blockly.Navigation.focusWorkspace();
+    keyHandled = true;
   }
   return keyHandled;
 };
@@ -529,6 +544,10 @@ Blockly.Navigation.toolboxKeyHandler = function(e) {
   } else if (e.keyCode === goog.events.KeyCodes.ENTER) {
     keyHandled = true;
     //TODO: focus on flyout OR open if the category is nested
+  } else if (e.keyCode === goog.events.KeyCodes.E) {
+    console.log('E: Toolbox: Exit');
+    Blockly.Navigation.focusWorkspace();
+    keyHandled = true;
   }
   return keyHandled;
 };

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -81,9 +81,7 @@ suite('ASTNode', function() {
       E: blockE,
       F: blockF
     };
-    Blockly.getMainWorkspace = function() {
-      return new Blockly.Workspace();
-    };
+    sinon.stub(Blockly, "getMainWorkspace").returns(new Blockly.Workspace());
   });
   teardown(function() {
     delete Blockly.Blocks['input_statement'];
@@ -91,6 +89,7 @@ suite('ASTNode', function() {
     delete Blockly.Blocks['value_input'];
 
     this.workspace.dispose();
+    sinon.restore();
   });
 
   suite('HelperFunctions', function() {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -25,6 +25,12 @@
     <script src="event_test.js"></script>
     <script src="field_variable_test.js"></script>
     <script src="utils_test.js"></script>
+    <script src="navigation_test.js"></script>
+
+    <div id="blocklyDiv"></div>
+    <xml id="toolbox-minimal" style="display: none">
+      <block type="basic_block"></block>
+    </xml>
 
     <script>
       mocha.run();

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -1,0 +1,41 @@
+
+
+suite('Navigation', function() {
+
+  suite('Handles keys', function() {
+    setup(function() {
+      Blockly.defineBlocksWithJsonArray([{
+        "type": "basic_block",
+        "message0": ""
+      }]);
+
+      var toolbox = document.getElementById('toolbox-minimal');
+      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    });
+
+    test('Focuses workspace from flyout', function() {
+      Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_FLYOUT;
+      var mockEvent = {
+        keyCode: goog.events.KeyCodes.E
+      };
+      chai.assert.isTrue(Blockly.Navigation.navigate(mockEvent));
+      chai.assert.equal(Blockly.Navigation.currentState_,
+          Blockly.Navigation.STATE_WS);
+    });
+
+    test('Focuses workspace from toolbox', function() {
+      Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_TOOLBOX;
+      var mockEvent = {
+        keyCode: goog.events.KeyCodes.E
+      };
+      chai.assert.isTrue(Blockly.Navigation.navigate(mockEvent));
+      chai.assert.equal(Blockly.Navigation.currentState_,
+          Blockly.Navigation.STATE_WS);
+    });
+
+    teardown(function() {
+      delete Blockly.Blocks['basic_block'];
+      this.workspace.dispose();
+    });
+  });
+});


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Desired functionality for keyboard navigation.

### Proposed Changes

Move cursor to workspace when E pressed in toolbox or flyout.
Add `shouldHide` param to `Blockly.Navigation.resetFlyout`.

If there was a selected block on the workspace the cursor goes to that block.  Otherwise it goes to a fixed location on the workspace.

Add a test file for navigation, and a basic test.

Stub `getMainWorkspace` for AST Node tests, and restore it at the end of the tests.

### Reason for Changes

We needed a way to exit the flyout/toolbox without inserting a block.

### Test Coverage
Added mocha test.