### PR TITLE
Update comment body size in resizeBubble

### DIFF
--- a/core/comment.js
+++ b/core/comment.js
@@ -123,6 +123,7 @@ Blockly.Comment.prototype.createEditor_ = function() {
   textarea.setAttribute('dir', this.block_.RTL ? 'RTL' : 'LTR');
   body.appendChild(textarea);
   this.textarea_ = textarea;
+  this.body_ = body;
   this.foreignObject_.appendChild(body);
   Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_,
       true, true);
@@ -168,6 +169,8 @@ Blockly.Comment.prototype.resizeBubble_ = function() {
     var doubleBorderWidth = 2 * Blockly.Bubble.BORDER_WIDTH;
     this.foreignObject_.setAttribute('width', size.width - doubleBorderWidth);
     this.foreignObject_.setAttribute('height', size.height - doubleBorderWidth);
+    this.body_.setAttribute('width', size.width - doubleBorderWidth);
+    this.body_.setAttribute('height', size.height - doubleBorderWidth);
     this.textarea_.style.width = (size.width - doubleBorderWidth - 4) + 'px';
     this.textarea_.style.height = (size.height - doubleBorderWidth - 4) + 'px';
   }


### PR DESCRIPTION
The size of HTML body in blockly comment will be affected by the outer CSS like bootstrap, update body size in resizeBubble will avoid this problem.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
