### PR TITLE
Removed setVisible (fields, inputs) from the Public API

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -172,7 +172,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       containerBlock.setFieldValue(
           this.hasStatements_ ? 'TRUE' : 'FALSE', 'STATEMENTS');
     } else {
-      containerBlock.getInput('STATEMENT_INPUT').setVisible(false);
+      containerBlock.removeInput('STATEMENT_INPUT');
     }
 
     // Parameter list.

--- a/core/field.js
+++ b/core/field.js
@@ -319,8 +319,10 @@ Blockly.Field.prototype.isVisible = function() {
 };
 
 /**
- * Sets whether this editable field is visible or not.
+ * Sets whether this editable field is visible or not. Should only be called
+ * by input.setVisible.
  * @param {boolean} visible True if visible.
+ * @package
  */
 Blockly.Field.prototype.setVisible = function(visible) {
   if (this.visible_ == visible) {
@@ -330,7 +332,7 @@ Blockly.Field.prototype.setVisible = function(visible) {
   var root = this.getSvgRoot();
   if (root) {
     root.style.display = visible ? 'block' : 'none';
-    this.render_();
+    this.size_.width = 0;
   }
 };
 
@@ -411,11 +413,6 @@ Blockly.Field.prototype.getSvgRoot = function() {
  * @protected
  */
 Blockly.Field.prototype.render_ = function() {
-  if (!this.visible_) {
-    this.size_.width = 0;
-    return;
-  }
-
   // Replace the text.
   this.textElement_.textContent = this.getDisplayText_();
   this.updateWidth();

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -126,11 +126,6 @@ Blockly.FieldAngle.RADIUS = Blockly.FieldAngle.HALF - 1;
  * @private
  */
 Blockly.FieldAngle.prototype.render_ = function() {
-  if (!this.visible_) {
-    this.size_.width = 0;
-    return;
-  }
-
   // Update textElement.
   this.textElement_.textContent = this.getDisplayText_();
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -437,10 +437,6 @@ Blockly.FieldDropdown.prototype.setValue = function(newValue) {
  * @private
  */
 Blockly.FieldDropdown.prototype.render_ = function() {
-  if (!this.visible_) {
-    this.size_.width = 0;
-    return;
-  }
   if (this.sourceBlock_ && this.arrow_) {
     // Update arrow's colour.
     this.arrow_.style.fill = this.sourceBlock_.getColour();

--- a/core/input.js
+++ b/core/input.js
@@ -163,9 +163,10 @@ Blockly.Input.prototype.isVisible = function() {
 
 /**
  * Sets whether this input is visible or not.
- * Used to collapse/uncollapse a block.
+ * Should only be used to collapse/uncollapse a block.
  * @param {boolean} visible True if visible.
  * @return {!Array.<!Blockly.Block>} List of blocks to render.
+ * @package
  */
 Blockly.Input.prototype.setVisible = function(visible) {
   var renderList = [];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2381 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes setVisible from the public API. This change applies to inputs and fields but not from icons (comments, mutators, warnings, etc), scrollbars, flyouts, or workspaces.

In doing so this removes a [setVisible call from the procedures_defnoreturn](https://github.com/google/blockly/blob/9c4f9d6c1693c3c25160f008d3eaa2539127c9e8/blocks/procedures.js#L175) block.

Also cleans up setVisible within fields. Some of the setVisible logic was leaking into the render() function because of the old way of re-rendering fields (setting their width to zero) it has now been moved back to the setVisible function.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Set visible should not be used to hide fields or inputs, it should only be used when collapsing a block.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested collapsing blocks:
![SetVisible_Collapsing](https://user-images.githubusercontent.com/25440652/56697500-9eb6e700-66a3-11e9-888e-c4f0ee11dce4.jpg)

Tested the procedure block mutator:
On Develop:
![SetVisible_Procedure_Develop](https://user-images.githubusercontent.com/25440652/56698010-4aad0200-66a5-11e9-852f-440d56fdb2b8.jpg)

On This Branch:
![SetVisible_Procedure_Branch](https://user-images.githubusercontent.com/25440652/56698019-539dd380-66a5-11e9-8cf6-71756d6cbded.jpg)

Tested on:
 * Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
 * Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A