### PR TITLE
Added fromXml and toXml to Fields

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -244,6 +244,30 @@ Blockly.Field.prototype.initModel = function() {
 };
 
 /**
+ * Sets the field's value based on the given XML element. Should only be
+ * called by Blockly.Xml.
+ * @param {!Element} fieldElement The element containing info about the
+ *    field's state.
+ * @package
+ */
+Blockly.Field.prototype.fromXml = function(fieldElement) {
+  this.setValue(fieldElement.textContent);
+};
+
+/**
+ * Serializes this field's value to XML. Should only be called by Blockly.Xml.
+ * @param {!Element} fieldElement The element to populate with info about the
+ *    field's state.
+ * @return {!Element} The element containing info about the field's state.
+ * @package
+ */
+Blockly.Field.prototype.toXml = function(fieldElement) {
+  fieldElement.setAttribute('name', this.name);
+  fieldElement.textContent = this.getValue();
+  return fieldElement;
+};
+
+/**
  * Dispose of all DOM objects belonging to this editable field.
  */
 Blockly.Field.prototype.dispose = function() {

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -126,6 +126,37 @@ Blockly.FieldVariable.prototype.initModel = function() {
   }
 };
 
+Blockly.FieldVariable.prototype.fromXml = function(fieldElement) {
+  var id = fieldElement.getAttribute('id');
+  var variableName = fieldElement.textContent;
+  var variableType = fieldElement.getAttribute('variabletype') || '';
+
+  var variable = Blockly.Variables.getOrCreateVariablePackage(
+      this.workspace_ || this.sourceBlock_.workspace, id,
+      variableName, variableType);
+
+  // This should never happen :)
+  if (variableType != null && variableType !== variable.type) {
+    throw Error('Serialized variable type with id \'' +
+      variable.getId() + '\' had type ' + variable.type + ', and ' +
+      'does not match variable field that references it: ' +
+      Blockly.Xml.domToText(fieldElement) + '.');
+  }
+
+  this.setValue(variable.getId());
+};
+
+Blockly.FieldVariable.prototype.toXml = function(fieldElement) {
+  // Make sure the variable is initialized.
+  this.initModel();
+
+  fieldElement.setAttribute('name', this.name);
+  fieldElement.setAttribute('id', this.variable_.getId());
+  fieldElement.textContent = this.variable_.name;
+  fieldElement.setAttribute('variableType', this.variable_.type);
+  return fieldElement;
+};
+
 /**
  * Dispose of this field.
  * @public


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1627 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds fromXml and toXml methods to fields that Blockly.Xml.domToField_ and fieldToDom_ can call.

Also changes the playground over to the new value-attribute rather than textContent based xml because... I thought it would be nice I guess ¯\\\_(ツ)_/¯

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Some fields (e.g. variable fields) need more information to be serialized to xml than just the field name and value. This adds functions that custom fields can override so people can impliment more advanced fields without having to change the core.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added backwards compatibility mocha tests:
![FromXMLToXML_Mocha](https://user-images.githubusercontent.com/25440652/56701271-058fcc80-66b3-11e9-8092-2144f2aee128.jpg)

Also here's a gif of some things serializing and deserializing:
![Serialization](https://user-images.githubusercontent.com/25440652/56701286-17716f80-66b3-11e9-8a9e-12dbfbacd07a.gif)
That generated this XML:
```
<xml xmlns="http://www.w3.org/1999/xhtml">
  <variables>
    <variable type="" id="4=m(NP7VfKepgVGbq99y">am i item?</variable>
  </variables>
  <block type="test_fields_angle" id="pcasU-Ep,|#V,:HX]wN~" x="13" y="12">
    <field name="FIELDNAME" value="88"></field>
  </block>
  <block type="test_fields_date" id="wIadJFYd:h^^;oE1=XK}" x="13" y="62">
    <field name="FIELDNAME" value="2019-04-24"></field>
  </block>
  <block type="test_fields_checkbox" id="]b#S7?J!hd9]dLeUm_70" x="13" y="113">
    <field name="CHECKBOX" value="FALSE"></field>
  </block>
  <block type="test_fields_colour" id="~?Dg`]Hj=9Y_qjg?88*Z" x="13" y="163">
    <field name="COLOUR" value="#ffff00"></field>
  </block>
  <block type="test_fields_text_input" id="~(^KZ}SBbC?+Z0-0a/K6" x="13" y="213">
    <field name="TEXT_INPUT" value="am i default?"></field>
  </block>
  <block type="test_fields_variable" id="QEy@*.M-w4:^{(Y),k$%" x="12" y="262">
    <field name="VARIABLE" id="4=m(NP7VfKepgVGbq99y" variablename="am i item?" variabletype=""></field>
  </block>
  <block type="test_fields_label_serializable" id="A5)khRy04vFL~CPD*A`T" x="13" y="313">
    <field name="LABEL" value="BAAA"></field>
  </block>
</xml>
```

Switching the playground over also allowed me to test that the deserialization was working.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
It may be better to call the 'variablename' attribute 'value' (even though it's more confusing) because I think having them be different is more prone to errors (i.e. when I was switching the playground over I messed it up a bunch).

Also I'm cool with removing the value  attribute stuff all together, that was just in the original solution proposal so I went with it.
