### PR TITLE
Fixed Buttons Being Rendered as Labels if They Come After a Label

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -480,10 +480,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
         }
         break;
       case 'LABEL':
-        // Labels behave the same as buttons, but are styled differently.
-        var isLabel = true;
-        // Falls through.
       case 'BUTTON':
+        var isLabel = xml.tagName.toUpperCase() == 'LABEL';
         var curButton = new Blockly.FlyoutButton(this.workspace_,
             this.targetWorkspace_, xml, isLabel);
         contents.push({type: 'button', button: curButton});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so buttons that come after labels in a flyout are correctly rendered as buttons and not labels.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before (meaning after I changed flyout parsing to a switch statement, but before this change) the flyout would be rendered like this:
![Sep_Bad](https://user-images.githubusercontent.com/25440652/56770787-b8226680-6769-11e9-9a33-acc00cb3f3d2.jpg)

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![Sep_Good](https://user-images.githubusercontent.com/25440652/56770793-bc4e8400-6769-11e9-81fc-eb0325623a3e.jpg)


Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
