### PR TITLE
Added updateColour to Field

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -41,6 +41,7 @@ goog.require('Blockly.Warning');
 goog.require('Blockly.Workspace');
 
 goog.require('goog.math.Coordinate');
+goog.require('goog.color');
 
 
 /**
@@ -879,6 +880,46 @@ Blockly.Block.prototype.getColourSecondary = function() {
  */
 Blockly.Block.prototype.getColourTertiary = function() {
   return this.colourTertiary_;
+};
+
+/**
+ * Get the shadow colour of a block.
+ * @return {?string} #RRGGBB string.
+ */
+Blockly.Block.prototype.getColourShadow = function() {
+  var colourSecondary = this.getColourSecondary();
+  if (colourSecondary) {
+    return colourSecondary;
+  }
+  var rgb = goog.color.hexToRgb(this.getColour());
+  rgb = goog.color.lighten(rgb, 0.6);
+  return goog.color.rgbArrayToHex(rgb);
+};
+
+/**
+ * Get the border colour(s) of a block.
+ * @return {{colourDark, colourLight, colourBorder}} An object containing
+ *     colour values for the border(s) of the block. If the block is using a
+ *     style the colourBorder will be defined and equal to the tertiary colour
+ *     of the style (#RRGGBB string). Otherwise the colourDark and colourLight
+ *     attributes will be defined (#RRGGBB strings).
+ * @package
+ */
+Blockly.Block.prototype.getColourBorder = function() {
+  var colourTertiary = this.getColourTertiary();
+  if (colourTertiary) {
+    return {
+      colourBorder: colourTertiary,
+      colourLight: null,
+      colourDark: null
+    };
+  }
+  var rgb = goog.color.hexToRgb(this.getColour());
+  return {
+    colourBorder: null,
+    colourLight: goog.color.rgbArrayToHex(goog.color.lighten(rgb, 0.3)),
+    colourDark: goog.color.rgbArrayToHex(goog.color.darken(rgb, 0.2))
+  };
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -941,74 +941,59 @@ Blockly.BlockSvg.prototype.updateColour = function() {
     // Disabled blocks don't have colour.
     return;
   }
-  var hexColour = this.getColour();
-  var colourSecondary = this.getColourSecondary();
-  var colourTertiary = this.getColourTertiary();
-  var rgb = goog.color.hexToRgb(hexColour);
 
   if (this.isShadow()) {
-    hexColour = this.setShadowColour_(rgb, colourSecondary);
+    this.setShadowColour_();
   } else {
-    this.setBorderColour_(rgb, colourTertiary);
+    this.setBorderColour_();
+    this.svgPath_.setAttribute('fill', this.getColour());
   }
-  this.svgPath_.setAttribute('fill', hexColour);
 
   var icons = this.getIcons();
   for (var i = 0; i < icons.length; i++) {
     icons[i].updateColour();
   }
 
-  // Bump every dropdown to change its colour.
-  // TODO (#1456)
   for (var x = 0, input; input = this.inputList[x]; x++) {
     for (var y = 0, field; field = input.fieldRow[y]; y++) {
-      field.forceRerender();
+      field.updateColour();
     }
   }
 };
 
 /**
  * Sets the colour of the border.
- * Removes the light and dark paths if a tertiary colour is defined.
- * @param {!string} rgb Colour of the block.
- * @param {?string} colourTertiary Colour of the border.
+ * Removes the light and dark paths if a border colour is defined.
  */
-Blockly.BlockSvg.prototype.setBorderColour_ = function(rgb, colourTertiary) {
-  if (colourTertiary) {
-    this.svgPathLight_.setAttribute('stroke', 'none');
-    this.svgPathDark_.setAttribute('fill', 'none');
-    this.svgPath_.setAttribute('stroke', colourTertiary);
+Blockly.BlockSvg.prototype.setBorderColour_ = function() {
+  var borderColours = this.getColourBorder();
+  if (borderColours.colourBorder) {
+    this.svgPathLight_.style.display = 'none';
+    this.svgPathDark_.style.display = 'none';
+
+    this.svgPath_.setAttribute('stroke', borderColours.colourBorder);
   } else {
     this.svgPathLight_.style.display = '';
-    var hexLight = goog.color.rgbArrayToHex(goog.color.lighten(rgb, 0.3));
-    var hexDark = goog.color.rgbArrayToHex(goog.color.darken(rgb, 0.2));
-    this.svgPathLight_.setAttribute('stroke', hexLight);
-    this.svgPathDark_.setAttribute('fill', hexDark);
+    this.svgPathDark_.style.display = '';
     this.svgPath_.setAttribute('stroke', 'none');
 
+    this.svgPathLight_.setAttribute('stroke', borderColours.colourLight);
+    this.svgPathDark_.setAttribute('fill', borderColours.colourDark);
   }
 };
 
 /**
  * Sets the colour of shadow blocks.
- * @param {!string} rgb Primary colour of the block.
- * @param {?string} colourSecondary Colour for shadow block.
- * @return {!string} The background colour of the block.
+ * @return {?string} The background colour of the block.
  */
-Blockly.BlockSvg.prototype.setShadowColour_ = function(rgb, colourSecondary) {
-  var hexColour;
-  if (colourSecondary) {
-    this.svgPathLight_.style.display = 'none';
-    this.svgPathDark_.style.display = 'none';
-    this.svgPath_.setAttribute('fill', colourSecondary);
-    hexColour = colourSecondary;
-  } else {
-    rgb = goog.color.lighten(rgb, 0.6);
-    hexColour = goog.color.rgbArrayToHex(rgb);
-    this.svgPathLight_.style.display = 'none';
-    this.svgPathDark_.setAttribute('fill', hexColour);
-  }
-  return hexColour;
+Blockly.BlockSvg.prototype.setShadowColour_ = function() {
+  this.svgPathLight_.style.display = 'none';
+  this.svgPathDark_.style.display = 'none';
+  this.svgPath_.setAttribute('stroke', 'none');
+
+  var shadowColour = this.getColourShadow();
+  this.svgPath_.setAttribute('fill', shadowColour);
+  return shadowColour;
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -432,6 +432,15 @@ Blockly.Field.prototype.getSvgRoot = function() {
 };
 
 /**
+ * Updates the field to match the colour/style of the block. Should only be
+ * called by BlockSvg.updateColour().
+ * @package
+ */
+Blockly.Field.prototype.updateColour = function() {
+  // Non-abstract sub-classes may wish to implement this. See FieldDropdown.
+};
+
+/**
  * Draws the border with the correct width.
  * Saves the computed width in a property.
  * @protected

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -433,14 +433,25 @@ Blockly.FieldDropdown.prototype.setValue = function(newValue) {
 };
 
 /**
+ * Updates the dropdown arrow to match the colour/style of the block.
+ * @package
+ */
+Blockly.FieldDropdown.prototype.updateColour = function() {
+  // Update arrow's colour.
+  if (this.sourceBlock_ && this.arrow_) {
+    if (this.sourceBlock_.isShadow()) {
+      this.arrow_.style.fill = this.sourceBlock_.getColourShadow();
+    } else {
+      this.arrow_.style.fill = this.sourceBlock_.getColour();
+    }
+  }
+};
+
+/**
  * Draws the border with the correct width.
  * @private
  */
 Blockly.FieldDropdown.prototype.render_ = function() {
-  if (this.sourceBlock_ && this.arrow_) {
-    // Update arrow's colour.
-    this.arrow_.style.fill = this.sourceBlock_.getColour();
-  }
   var child;
   while ((child = this.textElement_.firstChild)) {
     this.textElement_.removeChild(child);

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -174,7 +174,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           }
       }
     ],
-    "colour": "230"
+    "style": "math_blocks",
   },
   {
     "type": "test_fields_date",
@@ -191,7 +191,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           }
       }
     ],
-    "colour": 230
+    "style": "math_blocks",
   },
   {
     "type": "test_fields_text_input",
@@ -203,7 +203,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "text": "default"
       }
     ],
-    "colour": 230,
+    "style": "math_blocks",
     "tooltip": "",
     "helpUrl": ""
   },
@@ -217,7 +217,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "checked": true
       }
     ],
-    "colour": 230,
+    "style": "math_blocks",
     "tooltip": "",
     "helpUrl": ""
   },
@@ -231,7 +231,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "colour": "#ff0000"
       }
     ],
-    "colour": 230,
+    "style": "math_blocks",
     "tooltip": "",
     "helpUrl": ""
   },
@@ -245,7 +245,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "variable": "item"
       }
     ],
-    "colour": 230,
+    "style": "math_blocks",
     "tooltip": "",
     "helpUrl": ""
   },
@@ -259,7 +259,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "text": "default"
       }
     ],
-    "colour": 230,
+    "style": "math_blocks",
     "tooltip": "",
     "helpUrl": ""
   },

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -156,9 +156,36 @@ function addToolboxButtonCallbacks() {
       block.setFieldValue(text, 'LABEL');
     }
   };
+  var setRandomStyle = function(button) {
+    var blocks = button.workspace_.getAllBlocks();
+    var styles = Object.keys(Blockly.getTheme().getAllBlockStyles());
+    styles.splice(styles.indexOf(blocks[0].getStyleName()), 1);
+    var style = styles[Math.floor(Math.random() * styles.length)];
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setStyle(style);
+    }
+  };
+  var toggleEnabled = function(button) {
+    var blocks = button.workspace_.getAllBlocks();
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setEnabled(!block.isEnabled());
+    }
+  };
+  var toggleShadow = function(button) {
+    var blocks = button.workspace_.getAllBlocks();
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setShadow(!block.isShadow());
+    }
+  };
 
   workspace.registerButtonCallback(
-    'randomizeLabelText', randomizeLabelText);
+      'setRandomStyle', setRandomStyle);
+  workspace.registerButtonCallback(
+      'toggleEnabled', toggleEnabled);
+  workspace.registerButtonCallback(
+      'toggleShadow', toggleShadow);
+  workspace.registerButtonCallback(
+      'randomizeLabelText', randomizeLabelText);
   workspace.registerButtonCallback(
       'addDynamicOption', Blockly.TestBlocks.addDynamicDropdownOption_);
   workspace.registerButtonCallback(
@@ -1209,6 +1236,11 @@ h1 {
     </category>
     <category name="Fields" expanded="true">
       <category name="Defaults">
+        <button text="set random style" callbackKey="setRandomStyle"></button>
+        <sep gap="8"></sep>
+        <button text="toggle enabled" callbackKey="toggleEnabled"></button>
+        <sep gap="8"></sep>
+        <button text="toggle shadow" callbackKey="toggleShadow"></button>
         <block type="test_fields_angle"></block>
         <block type="test_fields_date"></block>
         <block type="test_fields_checkbox"></block>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #1623 and sorta #1456

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a function so fields can be coloured based on the colour of their block.

Also creates dedicated functions for getting a blocks shadow and border colours. This way if more things in the future need access to this logic it's all in one place.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
More efficient than rerendering every field when the colour updates & separates responsibilities.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I added buttons to the default fields category so styles, enabling/disabling, and shadowing/unshadowing could be tested.

Classic:
![Classic](https://user-images.githubusercontent.com/25440652/56834766-2da03c80-6827-11e9-8c90-bf6092e1054b.jpg)

Classic, style randomized:
![Classic_StyleRandomized](https://user-images.githubusercontent.com/25440652/56834775-3133c380-6827-11e9-8921-608d73105b9b.jpg)

Classic, shadow true:
![Classic_ShadowTrue](https://user-images.githubusercontent.com/25440652/56834780-33961d80-6827-11e9-94f3-ef1ae1bb144c.jpg)

Classic, shadow false (everything renables correctly):
![Classic_ShadowFalse](https://user-images.githubusercontent.com/25440652/56834784-35f87780-6827-11e9-8972-cca4bae7afb8.jpg)

Modern:
![Modern](https://user-images.githubusercontent.com/25440652/56834786-38f36800-6827-11e9-9d19-a13e7407b985.jpg)

Modern, style randomized:
![Modern_StyleRandomized](https://user-images.githubusercontent.com/25440652/56834788-3bee5880-6827-11e9-825c-122d050b62f0.jpg)

Modern, shadow true:
![Modern_ShadowTrue](https://user-images.githubusercontent.com/25440652/56834792-3ee94900-6827-11e9-9f8a-f0a94a2d2c55.jpg)

Modern, shadow false (everything renables correctly):
![Modern_ShadowFalse](https://user-images.githubusercontent.com/25440652/56834797-414ba300-6827-11e9-8730-a9d8922d98e3.jpg)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
Currently fields do not react to their block being enabled/disabled, which includes not getting colour updates.

(The following are the same as on develop/master)
Classic Disabled:
![Classic_Disabled](https://user-images.githubusercontent.com/25440652/56834800-44df2a00-6827-11e9-8676-e773c6b00eb7.jpg)

Modern Disabled:
![Modern_Disabled](https://user-images.githubusercontent.com/25440652/56834804-47da1a80-6827-11e9-8e99-57074e09b36c.jpg)

