### PR TITLE
 Position correctly when inserting before another block (from the flyout)

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -1167,31 +1167,6 @@ Blockly.BlockSvg.prototype.renderStatementInput_ = function(pathObject, row,
 };
 
 /**
- * Position an new block correctly, so that it doesn't move the existing block
- * when connected to it.
- * @param {!Blockly.Block} newBlock The block to position - either the first
- *     block in a dragged stack or an insertion marker.
- * @param {!Blockly.Connection} newConnection The connection on the new block's
- *     stack - either a connection on newBlock, or the last NEXT_STATEMENT
- *     connection on the stack if the stack's being dropped before another
- *     block.
- * @param {!Blockly.Connection} existingConnection The connection on the
- *     existing block, which newBlock should line up with.
- */
-Blockly.BlockSvg.prototype.positionNewBlock = function(newBlock, newConnection,
-    existingConnection) {
-  // We only need to position the new block if it's before the existing one,
-  // otherwise its position is set by the previous block.
-  if (newConnection.type == Blockly.NEXT_STATEMENT ||
-      newConnection.type == Blockly.INPUT_VALUE) {
-    var dx = existingConnection.x_ - newConnection.x_;
-    var dy = existingConnection.y_ - newConnection.y_;
-
-    newBlock.moveBy(dx, dy);
-  }
-};
-
-/**
  * Visual effect to show that if the dragging block is dropped, this block will
  * be replaced.  If a shadow block, it will disappear.  Otherwise it will bump.
  * @param {boolean} add True if highlighting should be added.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1502,3 +1502,25 @@ Blockly.BlockSvg.prototype.scheduleSnapAndBump = function() {
     Blockly.Events.setGroup(false);
   }, Blockly.BUMP_DELAY);
 };
+
+/**
+ * Position a block so that it doesn't move the target block when connected.
+ * The block to position is usually either the first block in a dragged stack or
+ * an insertion marker.
+ * @param {!Blockly.Connection} sourceConnection The connection on the moving
+ *     block's stack.
+ * @param {!Blockly.Connection} targetConnection The connection that should stay
+ *     stationary as this block is positioned.
+ */
+Blockly.BlockSvg.prototype.positionNearConnection = function(sourceConnection,
+    targetConnection) {
+  // We only need to position the new block if it's before the existing one,
+  // otherwise its position is set by the previous block.
+  if (sourceConnection.type == Blockly.NEXT_STATEMENT ||
+      sourceConnection.type == Blockly.INPUT_VALUE) {
+    var dx = targetConnection.x_ - sourceConnection.x_;
+    var dy = targetConnection.y_ - sourceConnection.y_;
+
+    this.moveBy(dx, dy);
+  }
+};

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -689,7 +689,7 @@ Blockly.InsertionMarkerManager.prototype.connectMarker_ = function() {
   imBlock.getSvgRoot().setAttribute('visibility', 'visible');
 
   // Position based on the calculated connection locations.
-  imBlock.positionNewBlock(imBlock, imConn, closest);
+  imBlock.positionNearConnection(imConn, closest);
 
   // Connect() also renders the insertion marker.
   imConn.connect(closest);

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -93,88 +93,88 @@ suite('ASTNode', function() {
   });
 
   suite('HelperFunctions', function() {
-      test('findNextEditableField_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = input.fieldRow[0];
-        var nextField = input.fieldRow[1];
-        var node = Blockly.ASTNode.createFieldNode(field);
-        var editableField = node.findNextEditableField_(field, input);
-        assertEquals(editableField.getLocation(), nextField);
-      });
-
-      test('findNextEditableFieldFirst_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = input.fieldRow[1];
-        var node = Blockly.ASTNode.createFieldNode(field);
-        var editableField = node.findNextEditableField_(field, input, true);
-        assertEquals(editableField.getLocation(), input.fieldRow[0]);
-      });
-
-      test('findPreviousEditableField_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = input.fieldRow[1];
-        var prevField = input.fieldRow[0];
-        var node = Blockly.ASTNode.createFieldNode(prevField);
-        var editableField = node.findPreviousEditableField_(field, input);
-        assertEquals(editableField.getLocation(), prevField);
-      });
-
-      test('findPreviousEditableFieldLast_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = input.fieldRow[0];
-        var node = Blockly.ASTNode.createFieldNode(field);
-        var editableField = node.findPreviousEditableField_(field, input, true);
-        assertEquals(editableField.getLocation(), input.fieldRow[1]);
-      });
-
-      test('findNextForInput_', function() {
-        var input = this.blocks.A.inputList[0];
-        var input2 = this.blocks.A.inputList[1];
-        var connection = input.connection;
-        var node = Blockly.ASTNode.createConnectionNode(connection);
-        var newASTNode = node.findNextForInput_(connection, input);
-        assertEquals(newASTNode.getLocation(), input2.connection);
-      });
-
-      test('findPrevForInput_', function() {
-        var input = this.blocks.A.inputList[0];
-        var input2 = this.blocks.A.inputList[1];
-        var connection = input2.connection;
-        var node = Blockly.ASTNode.createConnectionNode(connection);
-        var newASTNode = node.findPrevForInput_(connection, input2);
-        assertEquals(newASTNode.getLocation(), input.connection);
-      });
-
-      test('findNextForField_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = this.blocks.A.inputList[0].fieldRow[0];
-        var field2 = this.blocks.A.inputList[0].fieldRow[1];
-        var node = Blockly.ASTNode.createFieldNode(field2);
-        var newASTNode = node.findNextForField_(field, input);
-        assertEquals(newASTNode.getLocation(), field2);
-      });
-
-      test('findPrevForField_', function() {
-        var input = this.blocks.A.inputList[0];
-        var field = this.blocks.A.inputList[0].fieldRow[0];
-        var field2 = this.blocks.A.inputList[0].fieldRow[1];
-        var node = Blockly.ASTNode.createFieldNode(field2);
-        var newASTNode = node.findPrevForField_(field2, input);
-        assertEquals(newASTNode.getLocation(), field);
-      });
-
-      test('navigateBetweenStacksForward', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
-        var newASTNode = node.navigateBetweenStacks_(true);
-        assertEquals(newASTNode.getLocation(), this.blocks.D);
-      });
-
-      test('navigateBetweenStacksBackward', function() {
-        var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
-        var newASTNode = node.navigateBetweenStacks_(false);
-        assertEquals(newASTNode.getLocation(), this.blocks.A);
-      });
+    test('findNextEditableField_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = input.fieldRow[0];
+      var nextField = input.fieldRow[1];
+      var node = Blockly.ASTNode.createFieldNode(field);
+      var editableField = node.findNextEditableField_(field, input);
+      assertEquals(editableField.getLocation(), nextField);
     });
+
+    test('findNextEditableFieldFirst_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = input.fieldRow[1];
+      var node = Blockly.ASTNode.createFieldNode(field);
+      var editableField = node.findNextEditableField_(field, input, true);
+      assertEquals(editableField.getLocation(), input.fieldRow[0]);
+    });
+
+    test('findPreviousEditableField_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = input.fieldRow[1];
+      var prevField = input.fieldRow[0];
+      var node = Blockly.ASTNode.createFieldNode(prevField);
+      var editableField = node.findPreviousEditableField_(field, input);
+      assertEquals(editableField.getLocation(), prevField);
+    });
+
+    test('findPreviousEditableFieldLast_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = input.fieldRow[0];
+      var node = Blockly.ASTNode.createFieldNode(field);
+      var editableField = node.findPreviousEditableField_(field, input, true);
+      assertEquals(editableField.getLocation(), input.fieldRow[1]);
+    });
+
+    test('findNextForInput_', function() {
+      var input = this.blocks.A.inputList[0];
+      var input2 = this.blocks.A.inputList[1];
+      var connection = input.connection;
+      var node = Blockly.ASTNode.createConnectionNode(connection);
+      var newASTNode = node.findNextForInput_(connection, input);
+      assertEquals(newASTNode.getLocation(), input2.connection);
+    });
+
+    test('findPrevForInput_', function() {
+      var input = this.blocks.A.inputList[0];
+      var input2 = this.blocks.A.inputList[1];
+      var connection = input2.connection;
+      var node = Blockly.ASTNode.createConnectionNode(connection);
+      var newASTNode = node.findPrevForInput_(connection, input2);
+      assertEquals(newASTNode.getLocation(), input.connection);
+    });
+
+    test('findNextForField_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = this.blocks.A.inputList[0].fieldRow[0];
+      var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      var node = Blockly.ASTNode.createFieldNode(field2);
+      var newASTNode = node.findNextForField_(field, input);
+      assertEquals(newASTNode.getLocation(), field2);
+    });
+
+    test('findPrevForField_', function() {
+      var input = this.blocks.A.inputList[0];
+      var field = this.blocks.A.inputList[0].fieldRow[0];
+      var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      var node = Blockly.ASTNode.createFieldNode(field2);
+      var newASTNode = node.findPrevForField_(field2, input);
+      assertEquals(newASTNode.getLocation(), field);
+    });
+
+    test('navigateBetweenStacksForward', function() {
+      var node = new Blockly.ASTNode(Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
+      var newASTNode = node.navigateBetweenStacks_(true);
+      assertEquals(newASTNode.getLocation(), this.blocks.D);
+    });
+
+    test('navigateBetweenStacksBackward', function() {
+      var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
+      var newASTNode = node.navigateBetweenStacks_(false);
+      assertEquals(newASTNode.getLocation(), this.blocks.A);
+    });
+  });
 
   suite('NavigationFunctions', function() {
     suite('Next', function() {
@@ -247,7 +247,7 @@ suite('ASTNode', function() {
       });
       test('nextConnection', function() {
         var nextConnection = this.blocks.A.nextConnection;
-        var node = Blockly.ASTNode.createConnectionNode(nextConnection)
+        var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), this.blocks.A);
       });


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Previously the block stack would move to 100, 100 on the workspace if the new block was being inserted at the start.

### Proposed Changes

Use the same code that we use to solve this problem for insertion markers.
I moved the helper function and changed its signature because it had an unnecessary param before.  That's the first commit.  The second commit uses it.
Remove extra `connect` calls in `insertBlock`--`connect` moves the `orphanBlock` around internally.

### Reason for Changes

Blocks need to stay in the same place as new blocks are connected.

### Test Coverage

Tested in the playground.

### Additional information
I had to add a call to `render` so that the new block's connection positions are correct internally.  That I expected.  I also had to explicitly set the connections to not be hidden, which I didn't expect.  The connections are hidden in `domToBlock` and unhidden in a timeout, for speed when creating large block stacks.  But if the connections are still hidden when I move the block, Erik's new code in #2003 makes the child block disappear.