### PR TITLE
Add a marker that shows where the user has marked on the workspace

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -357,6 +357,28 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
 };
 
 /**
+ * Move a block to a position.
+ * @param {goog.math.Coordinate} xy The position to move to in workspace units.
+ */
+Blockly.BlockSvg.prototype.moveTo = function(xy) {
+  if (this.parentBlock_) {
+    throw Error('Block has parent.');
+  }
+  var eventsEnabled = Blockly.Events.isEnabled();
+  if (eventsEnabled) {
+    var event = new Blockly.Events.BlockMove(this);
+  }
+  var curXY = this.getRelativeToSurfaceXY();
+  this.translate(xy.x, xy.y);
+  this.moveConnections_(xy.x - curXY.x, xy.y - curXY.y);
+  if (eventsEnabled) {
+    event.recordNew();
+    Blockly.Events.fire(event);
+  }
+  this.workspace.resizeContents();
+};
+
+/**
  * Transforms a block by setting the translation on the transform attribute
  * of the block's SVG.
  * @param {number} x The x coordinate of the translation in workspace units.

--- a/core/cursor.js
+++ b/core/cursor.js
@@ -98,7 +98,7 @@ Blockly.Cursor.prototype.next = function() {
 
 /**
  * Find the in connection or field.
- * @return {Blockly.ASTNode} The next element, or null if the current node is
+ * @return {Blockly.ASTNode} The in element, or null if the current node is
  *     not set or there is no in value.
  */
 Blockly.Cursor.prototype.in = function() {
@@ -115,8 +115,8 @@ Blockly.Cursor.prototype.in = function() {
 
 /**
  * Find the previous connection, field, or block.
- * @return {Blockly.ASTNode} The next element, or null if the current node is
- *     not set or there is no previous value.
+ * @return {Blockly.ASTNode} The previous element, or null if the current node
+ *     is not set or there is no previous value.
  */
 Blockly.Cursor.prototype.prev = function() {
   var curNode = this.getCurNode();
@@ -132,7 +132,7 @@ Blockly.Cursor.prototype.prev = function() {
 
 /**
  * Find the out connection, field, or block.
- * @return {Blockly.ASTNode} The next element, or null if the current node is
+ * @return {Blockly.ASTNode} The out element, or null if the current node is
  *     not set or there is no out value.
  */
 Blockly.Cursor.prototype.out = function() {

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -32,11 +32,15 @@ goog.require('Blockly.Cursor');
 /**
  * Class for a cursor.
  * @param {!Blockly.Workspace} workspace The workspace to sit in.
+ * @param {?boolean} opt_isImmovable True if the cursor cannot be moved with
+ *     calls to prev/next/in/out.  This is called a marker.
  * @extends {Blockly.Cursor}
  * @constructor
  */
-Blockly.CursorSvg = function(workspace) {
+Blockly.CursorSvg = function(workspace, opt_isImmovable) {
+  Blockly.CursorSvg.superClass_.constructor.call(this);
   this.workspace_ = workspace;
+  this.isMarker_ = opt_isImmovable || false;
 };
 goog.inherits(Blockly.CursorSvg, Blockly.Cursor);
 
@@ -74,6 +78,13 @@ Blockly.CursorSvg.VERTICAL_PADDING = 5;
  * @const
  */
 Blockly.CursorSvg.CURSOR_COLOR = '#cc0a0a';
+
+/**
+ * Immovable marker color.
+ * @type {string}
+ * @const
+ */
+Blockly.CursorSvg.MARKER_COLOR = '#4286f4';
 
 /**
  * A reference to the current object that the cursor is associated with
@@ -342,6 +353,9 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
     </rect>
   </g>
   */
+
+  var colour = this.isMarker_ ? Blockly.CursorSvg.MARKER_COLOR :
+      Blockly.CursorSvg.CURSOR_COLOR;
   this.cursorSvg_ = Blockly.utils.createSvgElement('g',
       {
         'width': Blockly.CursorSvg.CURSOR_WIDTH,
@@ -352,7 +366,7 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
       {
         'x': '0',
         'y': '0',
-        'fill': Blockly.CursorSvg.CURSOR_COLOR,
+        'fill': colour,
         'width': Blockly.CursorSvg.CURSOR_WIDTH,
         'height': Blockly.CursorSvg.CURSOR_HEIGHT,
         'style': 'display: none;'
@@ -380,25 +394,80 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
       },
       this.cursorSvg_);
 
-  Blockly.utils.createSvgElement('animate',
-      {
-        'attributeType': 'XML',
-        'attributeName': 'fill',
-        'dur': '1s',
-        'values': Blockly.CursorSvg.CURSOR_COLOR + ';transparent;transparent;',
-        'repeatCount': 'indefinite'
-      },
-      this.cursorSvgLine_);
+  // Markers don't blink.
+  if (!this.isMarker_) {
+    Blockly.utils.createSvgElement('animate',
+        {
+          'attributeType': 'XML',
+          'attributeName': 'fill',
+          'dur': '1s',
+          'values': Blockly.CursorSvg.CURSOR_COLOR + ';transparent;transparent;',
+          'repeatCount': 'indefinite'
+        },
+        this.cursorSvgLine_);
 
-  Blockly.utils.createSvgElement('animate',
-      {
-        'attributeType': 'XML',
-        'attributeName': 'fill',
-        'dur': '1s',
-        'values': Blockly.CursorSvg.CURSOR_COLOR + ';transparent;transparent;',
-        'repeatCount': 'indefinite'
-      },
-      this.cursorInputOutput_);
+    Blockly.utils.createSvgElement('animate',
+        {
+          'attributeType': 'XML',
+          'attributeName': 'fill',
+          'dur': '1s',
+          'values': Blockly.CursorSvg.CURSOR_COLOR + ';transparent;transparent;',
+          'repeatCount': 'indefinite'
+        },
+        this.cursorInputOutput_);
+  }
 
   return this.cursorSvg_;
+};
+
+/**
+ * Find the next connection, field, or block.
+ * Does nothing if this cursor is an immovable marker.
+ * @return {Blockly.ASTNode} The next element, or null if the current node is
+ *     not set or there is no next value.
+ */
+Blockly.CursorSvg.prototype.next = function() {
+  if (this.isMarker_) {
+    return null;
+  }
+  return Blockly.CursorSvg.superClass_.next.call(this);
+};
+
+/**
+ * Find the in connection or field.
+ * Does nothing if this cursor is an immovable marker.
+ * @return {Blockly.ASTNode} The in element, or null if the current node is
+ *     not set or there is no in value.
+ */
+Blockly.CursorSvg.prototype.in = function() {
+  if (this.isMarker_) {
+    return null;
+  }
+  return Blockly.CursorSvg.superClass_.in.call(this);
+};
+
+/**
+ * Find the previous connection, field, or block.
+ * Does nothing if this cursor is an immovable marker.
+ * @return {Blockly.ASTNode} The previous element, or null if the current node
+ *     is not set or there is no previous value.
+ */
+Blockly.CursorSvg.prototype.prev = function() {
+  if (this.isMarker_) {
+    return null;
+  }
+  return Blockly.CursorSvg.superClass_.prev.call(this);
+};
+
+/**
+ * Find the out connection, field, or block.
+ * Does nothing if this cursor is an immovable marker.
+ * @return {Blockly.ASTNode} The out element, or null if the current node is
+ *     not set or there is no out value.
+ */
+Blockly.CursorSvg.prototype.out = function() {
+  if (this.isMarker_) {
+    return null;
+  }
+  return Blockly.CursorSvg.superClass_.out.call(this);
 };

--- a/core/inject.js
+++ b/core/inject.js
@@ -230,6 +230,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   }
 
   Blockly.Navigation.setCursor(mainWorkspace.cursor);
+  Blockly.Navigation.setMarker(mainWorkspace.marker);
 
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -30,6 +30,12 @@ goog.require('Blockly.ASTNode');
 Blockly.Navigation.cursor_ = null;
 
 /**
+ * The marker that shows where a user has marked while navigating blocks.
+ * @type {!Blockly.CursorSvg}
+ */
+Blockly.Navigation.marker_ = null;
+
+/**
  * The current selected category if the toolbox is open or
  * last selected category if focus is on a different element.
  * @type {goog.ui.tree.BaseNode}
@@ -86,6 +92,16 @@ Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_WS;
  */
 Blockly.Navigation.setCursor = function(cursor) {
   Blockly.Navigation.cursor_ = cursor;
+};
+
+/**
+ * Set the navigation marker.
+ * @param {Blockly.CursorSvg} marker The marker that shows where a user has
+ *     marked while navigating blocks.
+ * @package
+ */
+Blockly.Navigation.setMarker = function(marker) {
+  Blockly.Navigation.marker_ = marker;
 };
 
 /**
@@ -297,6 +313,10 @@ Blockly.Navigation.insertFromFlyout = function() {
   //TODO: IF this is null then we need to add to the correct place on the
   //workspace.
   var connection = Blockly.Navigation.getInsertionConnection();
+  if (!connection) {
+    Blockly.Navigation.insertBlockToWs();
+    return;
+  }
   var cursor = Blockly.Navigation.cursor_;
   var flyoutBlock = Blockly.Navigation.flyoutBlock_;
   var workspace = Blockly.getMainWorkspace();
@@ -416,6 +436,45 @@ Blockly.Navigation.insertBlockFromWs = function() {
   // Perhaps position the block near the target connection?
 };
 
+/**
+ * Tries to connect the current location of the cursor and the insertion
+ * connection.
+ */
+Blockly.Navigation.insertBlockToWs = function() {
+  var marker = Blockly.Navigation.marker_;
+  if (!marker) {
+    return;
+  }
+  var markedNode = marker.getCurNode();
+  var flyoutBlock = Blockly.Navigation.flyoutBlock_;
+  var flyout = Blockly.getMainWorkspace().getFlyout();
+
+  var isWsNode = markedNode &&
+      markedNode.getType() === Blockly.ASTNode.types.WORKSPACE;
+
+  if (isWsNode && flyout && flyout.isVisible()) {
+    var newBlock = flyout.createBlock(flyoutBlock);
+    // Render to get the sizing right.
+    newBlock.render();
+    var position = markedNode.getWsCoordinate();
+    newBlock.moveTo(position);
+
+    // Move the cursor toe the right place on the inserted block.
+    Blockly.Navigation.focusWorkspace();
+    var prevConnection = newBlock.previousConnection;
+    var outConnection = newBlock.outputConnection;
+    var topConnection = prevConnection ? prevConnection : outConnection;
+    //TODO: This will have to be fixed when we add in a block that does not have
+    //a previous or output connection
+    var astNode = Blockly.ASTNode.createConnectionNode(topConnection);
+    Blockly.Navigation.cursor_.setLocation(astNode);
+    // Hide the marker.
+    marker.setLocation(null);
+    marker.hide();
+  }
+};
+
+
 /*************************/
 /** Keyboard Navigation **/
 /*************************/
@@ -519,6 +578,8 @@ Blockly.Navigation.handleEnterForWS = function() {
   } else {
     Blockly.Navigation.markConnection();
   }
+  // TODO: bring the cursor (blinking) in front of the marker (solid)
+  Blockly.Navigation.marker_.setLocation(curNode);
 };
 
 /**********************/

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -310,8 +310,6 @@ Blockly.Navigation.getFlyoutBlocks_ = function() {
  * it on the workspace.
  */
 Blockly.Navigation.insertFromFlyout = function() {
-  //TODO: IF this is null then we need to add to the correct place on the
-  //workspace.
   var connection = Blockly.Navigation.getInsertionConnection();
   if (!connection) {
     Blockly.Navigation.insertBlockToWs();
@@ -459,7 +457,7 @@ Blockly.Navigation.insertBlockToWs = function() {
     var position = markedNode.getWsCoordinate();
     newBlock.moveTo(position);
 
-    // Move the cursor toe the right place on the inserted block.
+    // Move the cursor to the right place on the inserted block.
     Blockly.Navigation.focusWorkspace();
     var prevConnection = newBlock.previousConnection;
     var outConnection = newBlock.outputConnection;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -30,6 +30,7 @@ goog.provide('Blockly.WorkspaceSvg');
 //goog.require('Blockly.BlockSvg');
 goog.require('Blockly.ConnectionDB');
 goog.require('Blockly.constants');
+goog.require('Blockly.CursorSvg');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Grid');
@@ -48,7 +49,6 @@ goog.require('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.Xml');
 goog.require('Blockly.ZoomControls');
-goog.require('Blockly.CursorSvg');
 
 goog.require('goog.dom');
 goog.require('goog.math.Coordinate');
@@ -121,6 +121,12 @@ Blockly.WorkspaceSvg = function(options,
     this.registerToolboxCategoryCallback(Blockly.PROCEDURE_CATEGORY_NAME,
         Blockly.Procedures.flyoutCategory);
   }
+
+  /**
+   * The marker that shows where a user has marked while navigating blocks.
+   * @type {!Blockly.CursorSvg}
+   */
+  this.marker = this.createMarker();
 };
 goog.inherits(Blockly.WorkspaceSvg, Blockly.Workspace);
 
@@ -383,6 +389,14 @@ Blockly.WorkspaceSvg.prototype.createCursor = function() {
 };
 
 /**
+ * Adds marker for keyboard navigation.
+ * @return {!Blockly.CursorSvg} Marker for keyboard navigation.
+ */
+Blockly.WorkspaceSvg.prototype.createMarker = function() {
+  return new Blockly.CursorSvg(this, true);
+};
+
+/**
  * Getter for the inverted screen CTM.
  * @return {SVGMatrix} The matrix to use in mouseToSvg
  */
@@ -556,6 +570,8 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   var svgCursor = this.cursor.createDom();
   this.svgGroup_.appendChild(svgCursor);
 
+  var svgMarker = this.marker.createDom();
+  this.svgGroup_.appendChild(svgMarker);
   return this.svgGroup_;
 };
 


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Progress on keyboard navigation.

### Proposed Changes

Add a `marker` to the workspace as well as the `cursor`.  A `marker` is a type of `cursorSvg` that cannot be moved with prev/next/in/out.  It can only be moved directly to known locations with `setLocation`.

When the user hits enter to mark a location on the workspace or a connection on a block, the marker renders.  It disappears again when the user inserts a block at that marker.

### Reason for Changes

It's important to know where your insertion location is when you're inserting blocks.

### Test Coverage
Tested in Chrome