### PR TITLE
Out cleanup

### DIFF
--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -487,7 +487,8 @@ Blockly.ASTNode.prototype.findTopOfSubStack_ = function(sourceBlock) {
   var topBlock = sourceBlock;
   while (topBlock && topBlock.previousConnection
     && topBlock.previousConnection.targetConnection
-    && !topBlock.previousConnection.targetConnection.getParentInput()) {
+    && topBlock.previousConnection.targetBlock().nextConnection
+    == topBlock.previousConnection.targetConnection) {
     topBlock = topBlock.previousConnection.targetBlock();
   }
   return topBlock;

--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -447,15 +447,15 @@ Blockly.ASTNode.prototype.findTopASTNodeForBlock_ = function(block) {
 
 /**
  * Get the ast node pointing to the input that the block is nested under or if
- * the block is not neested then get the stack ast node.
+ * the block is not nested then get the stack ast node.
  * @param {Blockly.Block} block The source block of the current location.
  * @return {Blockly.ASTNode} The ast node pointing to the input connection or
  *     the top block of the stack this block is in.
  * @private
  */
 Blockly.ASTNode.prototype.getOutAstNodeForBlock_ = function(block) {
-  //Find top block
-  var topBlock = this.findTopBlock_(block);
+  //Find top block of sub stack
+  var topBlock = this.findTopOfSubStack_(block);
   var topConnection = topBlock.previousConnection || topBlock.outputConnection;
   //If the top connection has a parentInput, create an ast node pointing to that input
   if (topConnection && topConnection.targetConnection &&
@@ -470,13 +470,14 @@ Blockly.ASTNode.prototype.getOutAstNodeForBlock_ = function(block) {
 
 /**
  * Walk backwards from the given block up through the stack of blocks to find
- * the top block. If we are nested in a statement input only find the top most
- * nested block. Do not go all the way to the top of the stack.
+ * the top block of the sub stack. If we are nested in a statement input only
+ * find the top most nested block. Do not go all the way to the top of the
+ * stack.
  * @param {!Blockly.Block} sourceBlock A block in the stack.
  * @return {!Blockly.Block} The top block in a stack.
  * @private
  */
-Blockly.ASTNode.prototype.findTopBlock_ = function(sourceBlock) {
+Blockly.ASTNode.prototype.findTopOfSubStack_ = function(sourceBlock) {
   var topBlock = sourceBlock;
   while (topBlock && topBlock.previousConnection
     && topBlock.previousConnection.targetConnection

--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -454,8 +454,14 @@ Blockly.ASTNode.prototype.findTopASTNodeForBlock_ = function(block) {
  * @private
  */
 Blockly.ASTNode.prototype.getOutAstNodeForBlock_ = function(block) {
-  //Find top block of sub stack
-  var topBlock = this.findTopOfSubStack_(block);
+  var topBlock = null;
+  //If the block doesn't have a previous connection then it is the top of the
+  //substack
+  if (!block.previousConnection) {
+    topBlock = block;
+  } else {
+    topBlock = this.findTopOfSubStack_(block);
+  }
   var topConnection = topBlock.previousConnection || topBlock.outputConnection;
   //If the top connection has a parentInput, create an ast node pointing to that input
   if (topConnection && topConnection.targetConnection &&

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -62,24 +62,26 @@ suite('ASTNode', function() {
     ]);
     this.workspace = new Blockly.Workspace();
     this.cursor = this.workspace.cursor;
-    var blockA = this.workspace.newBlock('input_statement');
-    var blockB = this.workspace.newBlock('input_statement');
-    var blockC = this.workspace.newBlock('input_statement');
-    var blockD = this.workspace.newBlock('input_statement');
-    var blockE = this.workspace.newBlock('field_input');
-    var blockF = this.workspace.newBlock('value_input');
+    var statementInput1 = this.workspace.newBlock('input_statement');
+    var statementInput2 = this.workspace.newBlock('input_statement');
+    var statementInput3 = this.workspace.newBlock('input_statement');
+    var statementInput4 = this.workspace.newBlock('input_statement');
+    var fieldWithOutput = this.workspace.newBlock('field_input');
+    var valueInput = this.workspace.newBlock('value_input');
 
-    blockA.nextConnection.connect(blockB.previousConnection);
-    blockA.inputList[0].connection.connect(blockE.outputConnection);
-    blockB.inputList[1].connection.connect(blockC.previousConnection);
+    statementInput1.nextConnection.connect(statementInput2.previousConnection);
+    statementInput1.inputList[0].connection
+        .connect(fieldWithOutput.outputConnection);
+    statementInput2.inputList[1].connection
+        .connect(statementInput3.previousConnection);
 
     this.blocks = {
-      A: blockA,
-      B: blockB,
-      C: blockC,
-      D: blockD,
-      E: blockE,
-      F: blockF
+      statementInput1: statementInput1,
+      statementInput2: statementInput2,
+      statementInput3: statementInput3,
+      statementInput4: statementInput4,
+      fieldWithOutput: fieldWithOutput,
+      valueInput: valueInput
     };
     sinon.stub(Blockly, "getMainWorkspace").returns(new Blockly.Workspace());
   });
@@ -94,7 +96,7 @@ suite('ASTNode', function() {
 
   suite('HelperFunctions', function() {
     test('findNextEditableField_', function() {
-      var input = this.blocks.A.inputList[0];
+      var input = this.blocks.statementInput1.inputList[0];
       var field = input.fieldRow[0];
       var nextField = input.fieldRow[1];
       var node = Blockly.ASTNode.createFieldNode(field);
@@ -103,7 +105,7 @@ suite('ASTNode', function() {
     });
 
     test('findNextEditableFieldFirst_', function() {
-      var input = this.blocks.A.inputList[0];
+      var input = this.blocks.statementInput1.inputList[0];
       var field = input.fieldRow[1];
       var node = Blockly.ASTNode.createFieldNode(field);
       var editableField = node.findNextEditableField_(field, input, true);
@@ -111,7 +113,7 @@ suite('ASTNode', function() {
     });
 
     test('findPreviousEditableField_', function() {
-      var input = this.blocks.A.inputList[0];
+      var input = this.blocks.statementInput1.inputList[0];
       var field = input.fieldRow[1];
       var prevField = input.fieldRow[0];
       var node = Blockly.ASTNode.createFieldNode(prevField);
@@ -120,7 +122,7 @@ suite('ASTNode', function() {
     });
 
     test('findPreviousEditableFieldLast_', function() {
-      var input = this.blocks.A.inputList[0];
+      var input = this.blocks.statementInput1.inputList[0];
       var field = input.fieldRow[0];
       var node = Blockly.ASTNode.createFieldNode(field);
       var editableField = node.findPreviousEditableField_(field, input, true);
@@ -128,8 +130,8 @@ suite('ASTNode', function() {
     });
 
     test('findNextForInput_', function() {
-      var input = this.blocks.A.inputList[0];
-      var input2 = this.blocks.A.inputList[1];
+      var input = this.blocks.statementInput1.inputList[0];
+      var input2 = this.blocks.statementInput1.inputList[1];
       var connection = input.connection;
       var node = Blockly.ASTNode.createConnectionNode(connection);
       var newASTNode = node.findNextForInput_(connection, input);
@@ -137,8 +139,8 @@ suite('ASTNode', function() {
     });
 
     test('findPrevForInput_', function() {
-      var input = this.blocks.A.inputList[0];
-      var input2 = this.blocks.A.inputList[1];
+      var input = this.blocks.statementInput1.inputList[0];
+      var input2 = this.blocks.statementInput1.inputList[1];
       var connection = input2.connection;
       var node = Blockly.ASTNode.createConnectionNode(connection);
       var newASTNode = node.findPrevForInput_(connection, input2);
@@ -146,18 +148,18 @@ suite('ASTNode', function() {
     });
 
     test('findNextForField_', function() {
-      var input = this.blocks.A.inputList[0];
-      var field = this.blocks.A.inputList[0].fieldRow[0];
-      var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      var input = this.blocks.statementInput1.inputList[0];
+      var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+      var field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       var node = Blockly.ASTNode.createFieldNode(field2);
       var newASTNode = node.findNextForField_(field, input);
       assertEquals(newASTNode.getLocation(), field2);
     });
 
     test('findPrevForField_', function() {
-      var input = this.blocks.A.inputList[0];
-      var field = this.blocks.A.inputList[0].fieldRow[0];
-      var field2 = this.blocks.A.inputList[0].fieldRow[1];
+      var input = this.blocks.statementInput1.inputList[0];
+      var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+      var field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       var node = Blockly.ASTNode.createFieldNode(field2);
       var newASTNode = node.findPrevForField_(field2, input);
       assertEquals(newASTNode.getLocation(), field);
@@ -165,72 +167,82 @@ suite('ASTNode', function() {
 
     test('navigateBetweenStacks_Forward', function() {
       var node = new Blockly.ASTNode(
-          Blockly.ASTNode.types.NEXT, this.blocks.A.nextConnection);
+          Blockly.ASTNode.types.NEXT, this.blocks.statementInput1.nextConnection);
       var newASTNode = node.navigateBetweenStacks_(true);
-      assertEquals(newASTNode.getLocation(), this.blocks.D);
+      assertEquals(newASTNode.getLocation(), this.blocks.statementInput4);
     });
 
     test('navigateBetweenStacks_Backward', function() {
-      var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
+      var node = new Blockly.ASTNode(
+          Blockly.ASTNode.types.BLOCK, this.blocks.statementInput4);
       var newASTNode = node.navigateBetweenStacks_(false);
-      assertEquals(newASTNode.getLocation(), this.blocks.A);
+      assertEquals(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('findTopOfSubStack_', function() {
-      var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
-      var block = node.findTopOfSubStack_(this.blocks.D);
-      assertEquals(block, this.blocks.D);
+      var node = new Blockly.ASTNode(
+          Blockly.ASTNode.types.BLOCK, this.blocks.statementInput4);
+      var block = node.findTopOfSubStack_(this.blocks.statementInput4);
+      assertEquals(block, this.blocks.statementInput4);
     });
     test('getOutAstNodeForBlock_', function() {
-      var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.B);
-      var newASTNode = node.getOutAstNodeForBlock_(this.blocks.B);
-      assertEquals(newASTNode.getLocation(), this.blocks.A);
+      var node = new Blockly.ASTNode(
+          Blockly.ASTNode.types.BLOCK, this.blocks.statementInput2);
+      var newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput2);
+      assertEquals(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_OneBlock', function() {
-      var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
-      var newASTNode = node.getOutAstNodeForBlock_(this.blocks.D);
-      assertEquals(newASTNode.getLocation(), this.blocks.D);
+      var node = new Blockly.ASTNode(
+          Blockly.ASTNode.types.BLOCK, this.blocks.statementInput4);
+      var newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput4);
+      assertEquals(newASTNode.getLocation(), this.blocks.statementInput4);
     });
   });
 
   suite('NavigationFunctions', function() {
     suite('Next', function() {
       test('previousConnection', function() {
-        var node = Blockly.ASTNode.createConnectionNode(this.blocks.A.previousConnection);
+        var prevConnection = this.blocks.statementInput1.previousConnection;
+        var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.A);
+        assertEquals(nextNode.getLocation(), this.blocks.statementInput1);
       });
       test('block', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
+        var nextConnection = this.blocks.statementInput1.nextConnection;
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput1);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.A.nextConnection);
+        assertEquals(nextNode.getLocation(), nextConnection);
       });
       test('nextConnection', function() {
-        var node = Blockly.ASTNode.createConnectionNode(this.blocks.A.nextConnection);
+        var nextConnection = this.blocks.statementInput1.nextConnection;
+        var prevConnection = this.blocks.statementInput2.previousConnection;
+        var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.B.previousConnection);
+        assertEquals(nextNode.getLocation(), prevConnection);
       });
       test('input', function() {
-        var input = this.blocks.A.inputList[0];
+        var input = this.blocks.statementInput1.inputList[0];
+        var inputConnection = this.blocks.statementInput1.inputList[1].connection;
         var node = Blockly.ASTNode.createInputNode(input);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.A.inputList[1].connection);
+        assertEquals(nextNode.getLocation(), inputConnection);
       });
       test('output', function() {
-        var output = this.blocks.E.outputConnection;
+        var output = this.blocks.fieldWithOutput.outputConnection;
         var node = Blockly.ASTNode.createConnectionNode(output);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.E);
+        assertEquals(nextNode.getLocation(), this.blocks.fieldWithOutput);
       });
       test('field', function() {
-        var field = this.blocks.A.inputList[0].fieldRow[1];
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[1];
+        var inputConnection = this.blocks.statementInput1.inputList[0].connection;
         var node = Blockly.ASTNode.createFieldNode(field);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.A.inputList[0].connection);
+        assertEquals(nextNode.getLocation(), inputConnection);
       });
       test('isStack', function() {
-        var node = Blockly.ASTNode.createStackNode(this.blocks.A);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.statementInput1);
         var nextNode = node.next();
-        assertEquals(nextNode.getLocation(), this.blocks.D);
+        assertEquals(nextNode.getLocation(), this.blocks.statementInput4);
         assertEquals(nextNode.getType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
@@ -245,50 +257,52 @@ suite('ASTNode', function() {
 
     suite('Previous', function() {
       test('previousConnectionTopBlock', function() {
-        var prevConnection = this.blocks.A.previousConnection;
+        var prevConnection = this.blocks.statementInput1.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('previousConnection', function() {
-        var prevConnection = this.blocks.B.previousConnection;
+        var prevConnection = this.blocks.statementInput2.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A.nextConnection);
+        var nextConnection = this.blocks.statementInput1.nextConnection;
+        assertEquals(prevNode.getLocation(), nextConnection);
       });
       test('block', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput1);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A.previousConnection);
+        var prevConnection = this.blocks.statementInput1.previousConnection;
+        assertEquals(prevNode.getLocation(), prevConnection);
       });
       test('nextConnection', function() {
-        var nextConnection = this.blocks.A.nextConnection;
+        var nextConnection = this.blocks.statementInput1.nextConnection;
         var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A);
+        assertEquals(prevNode.getLocation(), this.blocks.statementInput1);
       });
       test('input', function() {
-        var input = this.blocks.A.inputList[0];
+        var input = this.blocks.statementInput1.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         var prevNode = node.prev();
         assertEquals(prevNode.getLocation(), input.fieldRow[1]);
       });
       test('output', function() {
-        var output = this.blocks.E.outputConnection;
+        var output = this.blocks.fieldWithOutput.outputConnection;
         var node = Blockly.ASTNode.createConnectionNode(output);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('field', function() {
-        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         var node = Blockly.ASTNode.createFieldNode(field);
         var prevNode = node.prev();
         assertEquals(prevNode, null);
       });
       test('isStack', function() {
-        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.statementInput4);
         var prevNode = node.prev();
-        assertEquals(prevNode.getLocation(), this.blocks.A);
+        assertEquals(prevNode.getLocation(), this.blocks.statementInput1);
         assertEquals(prevNode.getType(), Blockly.ASTNode.types.STACK);
       });
       test('workspace', function() {
@@ -303,37 +317,39 @@ suite('ASTNode', function() {
 
     suite('In', function() {
       test('block', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput1);
         var inNode = node.in();
-        assertEquals(inNode.getLocation(), this.blocks.A.inputList[0].fieldRow[0]);
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        assertEquals(inNode.getLocation(), field);
       });
       test('input', function() {
-        var input = this.blocks.A.inputList[0];
+        var input = this.blocks.statementInput1.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         var inNode = node.in();
-        assertEquals(inNode.getLocation(), this.blocks.E.outputConnection);
+        var outputConnection = this.blocks.fieldWithOutput.outputConnection;
+        assertEquals(inNode.getLocation(), outputConnection);
       });
       test('blockToInput', function() {
-        var input = this.blocks.F.inputList[0];
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.F);
+        var input = this.blocks.valueInput.inputList[0];
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.valueInput);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), input.connection);
       });
       test('output', function() {
-        var output = this.blocks.E.outputConnection;
+        var output = this.blocks.fieldWithOutput.outputConnection;
         var node = Blockly.ASTNode.createConnectionNode(output);
         var inNode = node.in();
         assertEquals(inNode, null);
       });
       test('field', function() {
-        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         var node = Blockly.ASTNode.createFieldNode(field);
         var inNode = node.in();
         assertEquals(inNode, null);
       });
       test('isStack', function() {
-        var prevConnection = this.blocks.D.previousConnection;
-        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
+        var prevConnection = this.blocks.statementInput4.previousConnection;
+        var node = Blockly.ASTNode.createStackNode(this.blocks.statementInput4);
         var inNode = node.in();
         assertEquals(inNode.getLocation(), prevConnection);
         assertEquals(inNode.getType(), Blockly.ASTNode.types.PREVIOUS);
@@ -367,59 +383,59 @@ suite('ASTNode', function() {
           "helpUrl": "",
           "nextStatement": null
         }]);
-        var startBlock = this.workspace.newBlock('start_block');
+        var noPrevConnection = this.workspace.newBlock('start_block');
         var secondBlock = this.workspace.newBlock('input_statement');
         var outputNextBlock = this.workspace.newBlock('output_next');
-        var fieldInput = this.workspace.newBlock('field_input');
+        var fieldWithOutput2 = this.workspace.newBlock('field_input');
 
-        startBlock.nextConnection.connect(secondBlock.previousConnection);
+        noPrevConnection.nextConnection.connect(secondBlock.previousConnection);
         secondBlock.inputList[0].connection
             .connect(outputNextBlock.outputConnection);
-        this.blocks.G = startBlock;
-        this.blocks.H = secondBlock;
-        this.blocks.I = outputNextBlock;
-        this.blocks.J = fieldInput;
+        this.blocks.noPrevConnection = noPrevConnection;
+        this.blocks.secondBlock = secondBlock;
+        this.blocks.outputNextBlock = outputNextBlock;
+        this.blocks.fieldWithOutput2 = fieldWithOutput2;
       });
       teardown(function() {
-        delete this.blocks.G;
-        delete this.blocks.H;
-        delete this.blocks.I;
-        delete this.blocks.J;
+        delete this.blocks.noPrevConnection;
+        delete this.blocks.secondBlock;
+        delete this.blocks.outputNextBlock;
+        delete this.blocks.fieldWithOutput2;
       });
 
       test('fromInputToBlock', function() {
-        var input = this.blocks.A.inputList[0];
+        var input = this.blocks.statementInput1.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.BLOCK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromOutputToInput', function() {
-        var output = this.blocks.E.outputConnection;
+        var output = this.blocks.fieldWithOutput.outputConnection;
         var node = Blockly.ASTNode.createConnectionNode(output);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(),
-            this.blocks.A.inputList[0].connection);
+            this.blocks.statementInput1.inputList[0].connection);
       });
       test('fromOutputToStack', function() {
-        var output = this.blocks.J.outputConnection;
+        var output = this.blocks.fieldWithOutput2.outputConnection;
         var node = Blockly.ASTNode.createConnectionNode(output);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.J);
+        chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromFieldToBlock', function() {
-        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         var node = Blockly.ASTNode.createFieldNode(field);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.BLOCK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromStackToWorkspace', function() {
-        var stub = sinon.stub(this.blocks.D,
+        var stub = sinon.stub(this.blocks.statementInput4,
             "getRelativeToSurfaceXY").returns({x: 10, y:10});
-        var node = Blockly.ASTNode.createStackNode(this.blocks.D);
+        var node = Blockly.ASTNode.createStackNode(this.blocks.statementInput4);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.WORKSPACE);
         chai.assert.equal(outNode.wsCoordinate_.x, 10);
@@ -427,82 +443,82 @@ suite('ASTNode', function() {
         stub.restore();
       });
       test('fromPreviousToInput', function() {
-        var previous = this.blocks.C.previousConnection;
-        var inputConnection = this.blocks.B.inputList[1].connection;
+        var previous = this.blocks.statementInput3.previousConnection;
+        var inputConnection = this.blocks.statementInput2.inputList[1].connection;
         var node = Blockly.ASTNode.createConnectionNode(previous);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromPreviousToStack', function() {
-        var previous = this.blocks.B.previousConnection;
+        var previous = this.blocks.statementInput2.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(previous);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToInput', function() {
-        var next = this.blocks.C.nextConnection;
-        var inputConnection = this.blocks.B.inputList[1].connection;
+        var next = this.blocks.statementInput3.nextConnection;
+        var inputConnection = this.blocks.statementInput2.inputList[1].connection;
         var node = Blockly.ASTNode.createConnectionNode(next);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromNextToStack', function() {
-        var next = this.blocks.B.nextConnection;
+        var next = this.blocks.statementInput2.nextConnection;
         var node = Blockly.ASTNode.createConnectionNode(next);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToStack_NoPreviousConnection', function() {
-        var next = this.blocks.H.nextConnection;
+        var next = this.blocks.secondBlock.nextConnection;
         var node = Blockly.ASTNode.createConnectionNode(next);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.G);
+        chai.assert.equal(outNode.getLocation(), this.blocks.noPrevConnection);
       });
       /**
        * This is where there is a block with both an output connection and a
        * next connection attached to an input.
        */
       test('fromNextToInput_OutputAndPreviousConnection', function() {
-        var next = this.blocks.I.nextConnection;
+        var next = this.blocks.outputNextBlock.nextConnection;
         var node = Blockly.ASTNode.createConnectionNode(next);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(),
-            this.blocks.H.inputList[0].connection);
+            this.blocks.secondBlock.inputList[0].connection);
       });
       test('fromBlockToStack', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.B);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput2);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToInput', function() {
-        var input = this.blocks.B.inputList[1].connection;
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.C);
+        var input = this.blocks.statementInput2.inputList[1].connection;
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput3);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), input);
       });
       test('fromTopBlockToStack', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.A);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.statementInput1);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.A);
+        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToStack_OutputConnection', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.J);
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.fieldWithOutput2);
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.J);
+        chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromBlockToInput_OutputConnection', function() {
-        var node = Blockly.ASTNode.createBlockNode(this.blocks.I);
-        var inputConnection = this.blocks.H.inputList[0].connection;
+        var node = Blockly.ASTNode.createBlockNode(this.blocks.outputNextBlock);
+        var inputConnection = this.blocks.secondBlock.inputList[0].connection;
         var outNode = node.out();
         chai.assert.equal(outNode.getType(), Blockly.ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
@@ -511,19 +527,19 @@ suite('ASTNode', function() {
 
     suite('createFunctions', function() {
       test('createFieldNode', function() {
-        var field = this.blocks.A.inputList[0].fieldRow[0];
+        var field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         var node = Blockly.ASTNode.createFieldNode(field);
         assertEquals(node.getLocation(), field);
         assertEquals(node.getType(), Blockly.ASTNode.types.FIELD);
       });
       test('createConnectionNode', function() {
-        var prevConnection = this.blocks.D.previousConnection;
+        var prevConnection = this.blocks.statementInput4.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         assertEquals(node.getLocation(), prevConnection);
         assertEquals(node.getType(), Blockly.ASTNode.types.PREVIOUS);
       });
       test('createInputNode', function() {
-        var input = this.blocks.A.inputList[0];
+        var input = this.blocks.statementInput1.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         assertEquals(node.getLocation(), input.connection);
         assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
@@ -537,9 +553,10 @@ suite('ASTNode', function() {
         assertEquals(node.getWsCoordinate(), coordinate);
       });
       test('createStatementConnectionNode', function() {
-        var nextConnection = this.blocks.A.inputList[1].connection;
+        var nextConnection = this.blocks.statementInput1.inputList[1].connection;
+        var inputConnection = this.blocks.statementInput1.inputList[1].connection;
         var node = Blockly.ASTNode.createConnectionNode(nextConnection);
-        assertEquals(node.getLocation(), this.blocks.A.inputList[1].connection);
+        assertEquals(node.getLocation(), inputConnection);
         assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
       });
     });

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -175,9 +175,9 @@ suite('ASTNode', function() {
       var newASTNode = node.navigateBetweenStacks_(false);
       assertEquals(newASTNode.getLocation(), this.blocks.A);
     });
-    test('findTopBlock', function() {
+    test('findTopOfSubStack_', function() {
       var node = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, this.blocks.D);
-      var block = node.findTopBlock_(this.blocks.D);
+      var block = node.findTopOfSubStack_(this.blocks.D);
       assertEquals(block, this.blocks.D);
     });
     test('getOutAstNodeForBlock_', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Out cleanup
### Proposed Changes
Fixes out functionality for blocks, previous connection, next connection(all same problem) and output connections.
### Reason for Changes
Out functionality on ast was not working properly.

### Test Coverage
Added tests in mocha.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
