### PR TITLE
Update to webdriverio v5; fix resulting test breakages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - 10
 sudo: required
 addons:
+  firefox: latest
   apt:
     packages:
     - google-chrome-stable

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-series": "^1.0.2",
     "gulp-shell": "^0.6.5",
     "jshint": "^2.10.1",
-    "webdriverio": "^4.14.1"
+    "webdriverio": "^5.8.0"
   },
   "jshintConfig": {
     "globalstrict": true,

--- a/tests/scripts/get_geckdriver.sh
+++ b/tests/scripts/get_geckdriver.sh
@@ -7,9 +7,9 @@ fi
 echo "downloading gechdriver"
 
 if [[ $os_name == 'Linux' ]]; then
-  cd ../ && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz | tar xz
+  cd ../ && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz | tar xz
   sleep 5
 elif [[ $os_name == 'Darwin' ]]; then
-  cd ../ &&  curl -L https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-macos.tar.gz | tar xz
+  cd ../ &&  curl -L https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-macos.tar.gz | tar xz
   sleep 5
 fi


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2283 
Fixes #2117
Fixes #2118

### Proposed Changes

- update webdriverio to v5
- switch to async/await syntax in our testing files--v5 doesn't support chaining
- update geckodriver--the older version didn't work with newer webdriverio

### Reason for Changes

Webdriverio v5 had some pretty significant changes: https://webdriver.io/blog/2018/12/19/webdriverio-v5-released.html

I want to get to v5 for two reasons: first, so that we don't get completely stale and second, because it looks like running mocha tests on travis will be easier with v5.  Now that both Abby and Beka are writing those tests regularly, I want them to run on all PRs.  This is a step in that direction.

### Test Coverage
Generator tests and jsunit tests pass.  I also checked to make sure I could make them fail.
