### PR TITLE
Removed Explicitly Setting Variable Type to Two Single Quotes

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -466,9 +466,6 @@ Blockly.Variables.generateVariableFieldXmlString = function(variableModel) {
   // The variable name may be user input, so it may contain characters that
   // need to be escaped to create valid XML.
   var typeString = variableModel.type;
-  if (typeString == '') {
-    typeString = '\'\'';
-  }
   var text = '<field name="VAR" id="' + variableModel.getId() +
       '" variabletype="' + goog.string.htmlEscape(typeString) +
       '">' + goog.string.htmlEscape(variableModel.name) + '</field>';

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -287,6 +287,138 @@ suite('XML', function() {
     });
   });
   suite('Deserialization', function() {
+    suite('Dynamic Category Blocks', function() {
+      test('Untyped Variables', function() {
+        Blockly.defineBlocksWithJsonArray([{
+          "type": "variables_get",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR",
+            }
+          ]
+        },
+        {
+          "type": "variables_set",
+          "message0": "%1 %2",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR"
+            },
+            {
+              "type": "input_value",
+              "name": "VALUE"
+            }
+          ]
+        },
+        {
+          "type": "math_change",
+          "message0": "%1 %2",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR",
+            },
+            {
+              "type": "input_value",
+              "name": "DELTA",
+              "check": "Number"
+            }
+          ]
+        },
+        {
+          "type": "math_number",
+          "message0": "%1",
+          "args0": [{
+            "type": "field_number",
+            "name": "NUM",
+            "value": 0
+          }],
+          "output": "Number"
+        }]);
 
+        this.workspace.createVariable('name1', '', 'id1');
+        var blocksArray = Blockly.Variables.flyoutCategoryBlocks(this.workspace);
+        try {
+          for (var i = 0, xml; xml = blocksArray[i]; i++) {
+            Blockly.Xml.domToBlock(xml, this.workspace);
+          }
+        } finally {
+          delete Blockly.Blocks['variables_get'];
+          delete Blockly.Blocks['variables_set'];
+          delete Blockly.Blocks['math_change'];
+          delete Blockly.Blocks['math_number'];
+        }
+      });
+      test('Typed Variables', function() {
+        Blockly.defineBlocksWithJsonArray([{
+          "type": "variables_get",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR",
+            }
+          ]
+        },
+        {
+          "type": "variables_set",
+          "message0": "%1 %2",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR"
+            },
+            {
+              "type": "input_value",
+              "name": "VALUE"
+            }
+          ]
+        },
+        {
+          "type": "math_change",
+          "message0": "%1 %2",
+          "args0": [
+            {
+              "type": "field_variable",
+              "name": "VAR",
+            },
+            {
+              "type": "input_value",
+              "name": "DELTA",
+              "check": "Number"
+            }
+          ]
+        },
+        {
+          "type": "math_number",
+          "message0": "%1",
+          "args0": [{
+            "type": "field_number",
+            "name": "NUM",
+            "value": 0
+          }],
+          "output": "Number"
+        }]);
+
+        this.workspace.createVariable('name1', 'String', 'id1');
+        this.workspace.createVariable('name2', 'Number', 'id2');
+        this.workspace.createVariable('name3', 'Colour', 'id3');
+        var blocksArray = Blockly.VariablesDynamic
+            .flyoutCategoryBlocks(this.workspace);
+        try {
+          for (var i = 0, xml; xml = blocksArray[i]; i++) {
+            Blockly.Xml.domToBlock(xml, this.workspace);
+          }
+        } finally {
+          delete Blockly.Blocks['variables_get'];
+          delete Blockly.Blocks['variables_set'];
+          delete Blockly.Blocks['math_change'];
+          delete Blockly.Blocks['math_number'];
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes explicitly setting the variable type to two single quotes.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before the toXml/fromXml pr went in there was a check in domToFieldVariable_ to change an string containing two single quotes to an empty string, with a comment that maybe this wasn't necessary. I believe the only purpose of that chunk of code was to undo the thing that I am removing now (where the string containing two double quotes is created).

This all seems a bit weird though so I'm not sure if there was a secret purpose behind it. I did check the git blame and found the [original PR](https://github.com/google/blockly/pull/1495/files), but I didn't see any information about why it was set up this way.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I discovered this because field_variable's fromXml was throwing an errow when it was trying to deserialize the dynamic category XML, so I added tests for both the untyped and typed variable dynamic categories.

![DynamicCategoryTests](https://user-images.githubusercontent.com/25440652/57021234-7584e200-6be0-11e9-9837-0422307041ef.jpg)

I also manually tested creating variables through the flyout buttons, and that is working.
And I checked the test blocks' variable field block, and it is working. 

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
