### PR TITLE
Add mocha tests to npm test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ gulpfile.js
 /tests/compile/*
 /tests/jsunit/*
 /tests/generators/*
+/tests/mocha/run_mocha_tests_in_browser.js
 /tests/test_runner.js
 /tests/workspace_svg/*
 /generators/*

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -105,7 +105,7 @@ suite('Blocks', function() {
         // Add extra input to middle block
         blocks.B.appendValueInput("INPUT").setCheck(null);
         blocks.B.unplug(true);
-        assertUnpluggedNoheal(blocks);
+        assertUnpluggedHealed(blocks);
       });
 
       test('Child block has multiple inputs', function() {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -10,6 +10,7 @@
   <body>
 
     <div id="mocha"></div>
+    <div id="failureCount" style="display:none"></div>
     <script src="https://unpkg.com/chai/chai.js"></script>
     <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
     <script src="https://unpkg.com/sinon/pkg/sinon.js"></script>
@@ -34,7 +35,10 @@
     </xml>
 
     <script>
-      mocha.run();
+      mocha.run(function(failures) {
+        var failureDiv = document.getElementById('failureCount');
+        failureDiv.setAttribute('tests_failed', failures);
+      });
     </script>
   </body>
 </html>

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2018 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Node.js script to run JsUnit tests in Chrome, via webdriver.
+ */
+var webdriverio = require('webdriverio');
+
+module.exports = runMochaTestsInBrowser;
+
+/**
+ * Runs the Mocha tests in this directory in Chrome. It uses webdriverio to
+ * launch Chrome and load index.html. Outputs a summary of the test results
+ * to the console.
+ * @return 0 on success, 1 on failure.
+ */
+async function runMochaTestsInBrowser() {
+  var options = {
+      capabilities: {
+          browserName: 'chrome'
+      }
+  };
+
+  var url = 'file://' + __dirname + '/index.html';
+  console.log('Starting webdriverio...');
+  const browser = await webdriverio.remote(options);
+  console.log('Initialized.\nLoading url: ' + url);
+  await browser.url(url);
+
+  await browser.waitUntil(async () => {
+    var elem = await browser.$('#failureCount');
+    var text = await elem.getAttribute('tests_failed');
+    return text != 'unset';
+  })
+
+  const elem = await browser.$('#failureCount')
+  const numOfFailure = await elem.getAttribute('tests_failed');
+
+  console.log('============Blockly Mocha Test Summary=================');
+  console.log(numOfFailure);
+  console.log(numOfFailure + ' tests failed');
+  console.log('============Blockly Mocha Test Summary=================');
+  if (parseInt(numOfFailure) !== 0) {
+    await browser.deleteSession();
+    return 1;
+  }
+  await browser.deleteSession();
+  return 0;
+}
+
+if (require.main === module) {
+  runMochaTestsInBrowser().catch(e => {
+    console.error(e);
+    process.exit(1);
+  }).then(function(result) {
+    if (result) {
+      console.log('Mocha tests failed');
+      process.exit(1);
+    } else {
+      console.log('Mocha tests passed');
+      process.exit(0);
+    }
+  });
+}

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -2,7 +2,7 @@
  * @license
  * Visual Blocks Editor
  *
- * Copyright 2018 Google Inc.
+ * Copyright 2019 Google Inc.
  * https://developers.google.com/blockly/
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
  */
 
 /**
- * @fileoverview Node.js script to run JsUnit tests in Chrome, via webdriver.
+ * @fileoverview Node.js script to run Mocha tests in Chrome, via webdriver.
  */
 var webdriverio = require('webdriverio');
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -57,7 +57,9 @@ run_test_command "eslint" "eslint ."
 
 # Run JSUnit tests inside a browser.
 run_test_command "jsunit" "node tests/jsunit/run_jsunit_tests_in_browser.js"
-# TODO: Make sure jsunit output is captured.  Child process?
+
+# Run Mocha tests inside a browser.
+run_test_command "mocha" "node tests/mocha/run_mocha_tests_in_browser.js"
 
 # Run generator tests inside a browser and check the results.
 run_test_command "generators" "tests/scripts/run_generators.sh"


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Run mocha tests with webdriverio (the same way we run jsunit and generator tests) and check the results.

Not all of our tests actually need to be run in a browser, but some do, so right now we're running all of them in the browser.  Both mocha and jsunit tests can be run locally by opening their respective `index.html` files.

### Reason for Changes

Another step in moving from jsunit to mocha.

### Test Coverage
Added mocha tests, and ran with tests broken and all tests passing.

### Additional Information

The first push of this should have a broken test, to make sure it works.  Then I'll fix that test and push to make sure it works when tests pass as well.