### PR TITLE
Refactored field.init into field.initView and field.initModel

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -202,15 +202,26 @@ Blockly.Field.prototype.setSourceBlock = function(block) {
 };
 
 /**
- * Install this field on a block.
+ * Initialize everything to render this field. Override
+ * methods initModel and initView rather than this method.
+ * @package
  */
 Blockly.Field.prototype.init = function() {
   if (this.fieldGroup_) {
     // Field has already been initialized once.
     return;
   }
-  // Build the DOM.
   this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+  this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
+  this.initView();
+  this.initModel();
+};
+
+/**
+ * Create the block UI for this field.
+ * @package
+ */
+Blockly.Field.prototype.initView = function() {
   if (!this.visible_) {
     this.fieldGroup_.style.display = 'none';
   }
@@ -230,7 +241,6 @@ Blockly.Field.prototype.init = function() {
   this.updateEditable();
 
   this.clickTarget_ = this.getSvgRoot();
-  this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.mouseDownWrapper_ =
       Blockly.bindEventWithChecks_(
           this.clickTarget_, 'mousedown', this, this.onMouseDown_);
@@ -239,6 +249,7 @@ Blockly.Field.prototype.init = function() {
 /**
  * Initializes the model of the field after it has been installed on a block.
  * No-op by default.
+ * @package
  */
 Blockly.Field.prototype.initModel = function() {
 };

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -77,14 +77,12 @@ Blockly.FieldCheckbox.CHECK_CHAR = '\u2713';
 Blockly.FieldCheckbox.prototype.CURSOR = 'default';
 
 /**
- * Install this checkbox on a block.
+ * Create the block UI for this checkbox.
+ * @package
  */
-Blockly.FieldCheckbox.prototype.init = function() {
-  if (this.fieldGroup_) {
-    // Checkbox has already been initialized once.
-    return;
-  }
-  Blockly.FieldCheckbox.superClass_.init.call(this);
+Blockly.FieldCheckbox.prototype.initView = function() {
+  Blockly.FieldCheckbox.superClass_.initView.call(this);
+
   // The checkbox doesn't use the inherited text element.
   // Instead it uses a custom checkmark element that is either visible or not.
   this.checkElement_ = Blockly.utils.createSvgElement('text',

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -124,10 +124,12 @@ Blockly.FieldColour.prototype.DROPDOWN_BORDER_COLOUR = 'silver';
 Blockly.FieldColour.prototype.DROPDOWN_BACKGROUND_COLOUR = 'white';
 
 /**
- * Install this field on a block.
+ * Create the block UI for this colour field.
+ * @package
  */
-Blockly.FieldColour.prototype.init = function() {
-  Blockly.FieldColour.superClass_.init.call(this);
+Blockly.FieldColour.prototype.initView = function() {
+  Blockly.FieldColour.superClass_.initView.call(this);
+
   this.size_ = new goog.math.Size(Blockly.FieldColour.DEFAULT_WIDTH,
       Blockly.FieldColour.DEFAULT_HEIGHT);
   this.borderRect_.style['fillOpacity'] = 1;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -127,20 +127,17 @@ Blockly.FieldDropdown.prototype.imageElement_ = null;
 Blockly.FieldDropdown.prototype.imageJson_ = null;
 
 /**
- * Install this dropdown on a block.
+ * Create the block UI for this dropdown.
+ * @package
  */
-Blockly.FieldDropdown.prototype.init = function() {
-  if (this.fieldGroup_) {
-    // Dropdown has already been initialized once.
-    return;
-  }
+Blockly.FieldDropdown.prototype.initView = function() {
+  Blockly.FieldDropdown.superClass_.initView.call(this);
+
   // Add dropdown arrow: "option ▾" (LTR) or "▾ אופציה" (RTL)
   this.arrow_ = Blockly.utils.createSvgElement('tspan', {}, null);
   this.arrow_.appendChild(document.createTextNode(this.sourceBlock_.RTL ?
       Blockly.FieldDropdown.ARROW_CHAR + ' ' :
       ' ' + Blockly.FieldDropdown.ARROW_CHAR));
-
-  Blockly.FieldDropdown.superClass_.init.call(this);
 };
 
 /**

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -92,20 +92,10 @@ Blockly.FieldImage.fromJson = function(options) {
 Blockly.FieldImage.prototype.EDITABLE = false;
 
 /**
- * Install this image on a block.
+ * Create the block UI for this image.
+ * @package
  */
-Blockly.FieldImage.prototype.init = function() {
-  if (this.fieldGroup_) {
-    // Image has already been initialized once.
-    return;
-  }
-  // Build the DOM.
-  /** @type {SVGElement} */
-  this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
-  if (!this.visible_) {
-    this.fieldGroup_.style.display = 'none';
-  }
-  /** @type {SVGElement} */
+Blockly.FieldImage.prototype.initView = function() {
   this.imageElement_ = Blockly.utils.createSvgElement(
       'image',
       {

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -71,23 +71,18 @@ Blockly.FieldLabel.fromJson = function(options) {
 Blockly.FieldLabel.prototype.EDITABLE = false;
 
 /**
- * Install this text on a block.
+ * Create block UI for this label.
+ * @package
  */
-Blockly.FieldLabel.prototype.init = function() {
-  if (this.textElement_) {
-    // Text has already been initialized once.
-    return;
-  }
-  // Build the DOM.
+Blockly.FieldLabel.prototype.initView = function() {
   this.textElement_ = Blockly.utils.createSvgElement('text',
-      {'class': 'blocklyText', 'y': this.size_.height - 5}, null);
+      {
+        'class': 'blocklyText',
+        'y': this.size_.height - 5
+      }, this.fieldGroup_);
   if (this.class_) {
     Blockly.utils.addClass(this.textElement_, this.class_);
   }
-  if (!this.visible_) {
-    this.textElement_.style.display = 'none';
-  }
-  this.sourceBlock_.getSvgRoot().appendChild(this.textElement_);
 
   if (this.tooltip_) {
     this.textElement_.tooltip = this.tooltip_;
@@ -106,15 +101,6 @@ Blockly.FieldLabel.prototype.dispose = function() {
     Blockly.utils.removeNode(this.textElement_);
     this.textElement_ = null;
   }
-};
-
-/**
- * Gets the group element for this field.
- * Used for measuring the size and for positioning.
- * @return {!Element} The group element.
- */
-Blockly.FieldLabel.prototype.getSvgRoot = function() {
-  return /** @type {!Element} */ (this.textElement_);
 };
 
 /**

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -87,22 +87,6 @@ Blockly.FieldVariable.fromJson = function(options) {
 Blockly.FieldVariable.prototype.SERIALIZABLE = true;
 
 /**
- * Initialize everything needed to render this field.  This includes making sure
- * that the field's value is valid.
- * @public
- */
-Blockly.FieldVariable.prototype.init = function() {
-  if (this.fieldGroup_) {
-    // Dropdown has already been initialized once.
-    return;
-  }
-  Blockly.FieldVariable.superClass_.init.call(this);
-
-  // TODO (#1010): Change from init/initModel to initView/initModel
-  this.initModel();
-};
-
-/**
  * Initialize the model for this field if it has not already been initialized.
  * If the value has not been set to a variable by the first render, we make up a
  * variable rather than let the value be invalid.

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1288,7 +1288,7 @@ h1 {
         <block type="test_images_missing"></block>
         <block type="test_images_many_icons"></block>
       </category>
-      <category name="Emoji! o((*>ᴗ<*))o">
+      <category name="Emoji! o((*^ᴗ^*))o">
         <label text="Unicode & Emojis"></label>
         <block type="test_style_emoji"></block>
         <block type="text">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1010

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves init logic into an initView function. The init function now calls initView and initModel.

I also had to change the emoji testblocks category label because apparently IE just couldn't handle the beauty of it.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Firstly makes the lifecycle more clear. Secondly the abstract init() function now creates the field group, so fields that want to do custom dom structures (e.g. not include the border rect or text element) don't need to remember to create a field group named 'fieldGroup_'.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Looked through test blocks and assured that everything was rendering correctly. RTL and LTR
Also ran mocha tests locally.

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
 * Windows Internet Explorer 11
 * Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
[Here](https://i.imgur.com/izzAxcV.jpg)'s a picture of how the flow works now.

If the field does not have a concrete init function (which for any future fields it should not!) any callers will hit the abstract init imediately and then the it'll just work how you'd expect. The sub-most class gets it's concrete initView called first and then that flows back up to the abstract class etc.
