### PR TITLE
Reduce ID collisions.

### DIFF
--- a/build.py
+++ b/build.py
@@ -390,30 +390,7 @@ class Gen_compressed(threading.Thread):
 
       code = HEADER + "\n" + json_data["compiledCode"]
       code = code.replace(remove, "")
-
-      # The Closure Compiler preserves licences.
-      # Trim out Google's and MIT's (and nobody else's) Apache licences.
-      # MIT's permission to do this is logged in Blockly issue 2412.
-      LICENSE = re.compile("""/\\*
-
- [\w ]+
-
- Copyright \\d+ (Google Inc.|Massachusetts Institute of Technology)
- (https://developers.google.com/blockly/|All rights reserved.)
-
- Licensed under the Apache License, Version 2.0 \(the "License"\);
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-\\*/""")
-      code = re.sub(LICENSE, "", code)
+      code = self.trim_licence(code)
 
       stats = json_data["statistics"]
       original_b = stats["originalSize"]
@@ -431,6 +408,40 @@ class Gen_compressed(threading.Thread):
             original_kb, compressed_kb, ratio))
       else:
         print("UNKNOWN ERROR")
+
+  def trim_licence(self, code):
+    """Strip out Google's and MIT's Apache licences.
+
+    JS Compiler preserves dozens of Apache licences in the Blockly code.
+    Remove these if they belong to Google or MIT.
+    MIT's permission to do this is logged in Blockly issue 2412.
+
+    Args:
+      code: Large blob of compiled source code.
+
+    Returns:
+      Code with Google's and MIT's Apache licences trimmed.
+    """
+    apache2 = re.compile("""/\\*
+
+ [\\w: ]+
+
+ (Copyright \\d+ (Google Inc.|Massachusetts Institute of Technology))
+ (https://developers.google.com/blockly/|All rights reserved.)
+
+ Licensed under the Apache License, Version 2.0 \\(the "License"\\);
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+\\*/""")
+    return re.sub(apache2, "", code)
 
 
 class Gen_langfiles(threading.Thread):

--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -907,7 +907,7 @@ Blockly.BlockSvg.prototype.renderInlineRow_ = function(pathObject, row, cursor,
   var steps = pathObject.steps;
   var highlightSteps = pathObject.highlightSteps;
 
-  for (var x = 0, input; input = row[x]; x++) {
+  for (var i = 0, input; input = row[i]; i++) {
     var fieldX = cursor.x;
     var fieldY = cursor.y;
     if (row.thicker) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -281,7 +281,7 @@ Blockly.copy_ = function(toCopy) {
   if (toCopy.isComment) {
     var xml = toCopy.toXmlWithXY();
   } else {
-    var xml = Blockly.Xml.blockToDom(toCopy);
+    var xml = Blockly.Xml.blockToDom(toCopy, true);
     // Copy only the selected block and internal blocks.
     Blockly.Xml.deleteNext(xml);
     // Encode start position in XML.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -794,7 +794,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   }
 
   // Create the new block by cloning the block in the flyout (via XML).
-  var xml = Blockly.Xml.blockToDom(oldBlock);
+  var xml = Blockly.Xml.blockToDom(oldBlock, true);
   // The target workspace would normally resize during domToBlock, which will
   // lead to weird jumps.  Save it for terminateDrag.
   targetWorkspace.setResizesEnabled(false);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -404,7 +404,7 @@ Blockly.Flyout.prototype.hide = function() {
   }
   this.setVisible(false);
   // Delete all the event listeners.
-  for (var x = 0, listen; listen = this.listeners_[x]; x++) {
+  for (var i = 0, listen; listen = this.listeners_[i]; i++) {
     Blockly.unbindEvent_(listen);
   }
   this.listeners_.length = 0;

--- a/core/generator.js
+++ b/core/generator.js
@@ -96,7 +96,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
   var code = [];
   this.init(workspace);
   var blocks = workspace.getTopBlocks(true);
-  for (var x = 0, block; block = blocks[x]; x++) {
+  for (var i = 0, block; block = blocks[i]; i++) {
     var line = this.blockToCode(block);
     if (Array.isArray(line)) {
       // Value blocks return tuples of code and operator order.

--- a/core/xml.js
+++ b/core/xml.js
@@ -250,8 +250,8 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
       while (node && !node.nextSibling) {
         textNode = node;
         node = node.parentNode;
-        if (textNode.nodeType == 3 && textNode.data.trim() == '' &&
-            node.firstChild != textNode) {
+        if (textNode.nodeType == Element.TEXT_NODE &&
+            textNode.data.trim() == '' && node.firstChild != textNode) {
           // Prune whitespace after a tag.
           Blockly.utils.removeNode(textNode);
         }
@@ -259,7 +259,8 @@ Blockly.Xml.cloneShadow_ = function(shadow) {
       if (node) {
         textNode = node;
         node = node.nextSibling;
-        if (textNode.nodeType == 3 && textNode.data.trim() == '') {
+        if (textNode.nodeType == Element.TEXT_NODE &&
+            textNode.data.trim() == '') {
           // Prune whitespace before a tag.
           Blockly.utils.removeNode(textNode);
         }
@@ -594,7 +595,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
 
   var blockChild = null;
   for (var i = 0, xmlChild; xmlChild = xmlBlock.childNodes[i]; i++) {
-    if (xmlChild.nodeType == 3) {
+    if (xmlChild.nodeType == Element.TEXT_NODE) {
       // Ignore any text at the <block> level.  It's all whitespace anyway.
       continue;
     }
@@ -604,7 +605,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     var childBlockElement = null;
     var childShadowElement = null;
     for (var j = 0, grandchild; grandchild = xmlChild.childNodes[j]; j++) {
-      if (grandchild.nodeType == 1) {
+      if (grandchild.nodeType == Element.ELEMENT_NODE) {
         if (grandchild.nodeName.toLowerCase() == 'block') {
           childBlockElement = /** @type {!Element} */ (grandchild);
         } else if (grandchild.nodeName.toLowerCase() == 'shadow') {


### PR DESCRIPTION
Realtime collaborators are liable to independently generate blocks with the same IDs due to the IDs being encoded in XML.  This PR fixes IDs in toolboxes and IDs in cut/copy/paste.

Also included are a couple of other minor cleanup commits that result in no functional changes.