### PR TITLE
Handle escape in the toolbox/flyout.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -219,6 +219,9 @@ Blockly.onKeyDown_ = function(e) {
   if (e.keyCode == 27) {
     // Pressing esc closes the context menu.
     Blockly.hideChaff();
+    if (Blockly.keyboardAccessibilityMode) {
+      Blockly.Navigation.navigate(e);
+    }
   } else if (e.keyCode == 8 || e.keyCode == 46) {
     // Delete or backspace.
     // Stop the browser from going back to the previous page.

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -631,9 +631,10 @@ Blockly.Navigation.flyoutKeyHandler = function(e) {
     Blockly.Navigation.insertFromFlyout();
     console.log('Enter: Flyout : Select');
     return true;
-  } else if (e.keyCode === goog.events.KeyCodes.E) {
+  } else if (e.keyCode === goog.events.KeyCodes.E ||
+      e.keyCode === goog.events.KeyCodes.ESC) {
     Blockly.Navigation.focusWorkspace();
-    console.log('E: Flyout: Exit');
+    console.log('E or ESC: Flyout: Exit');
     return true;
   }
   return false;
@@ -664,8 +665,9 @@ Blockly.Navigation.toolboxKeyHandler = function(e) {
   } else if (e.keyCode === goog.events.KeyCodes.ENTER) {
     //TODO: focus on flyout OR open if the category is nested
     return true;
-  } else if (e.keyCode === goog.events.KeyCodes.E) {
-    console.log('E: Toolbox: Exit');
+  } else if (e.keyCode === goog.events.KeyCodes.E ||
+      e.keyCode === goog.events.KeyCodes.ESC) {
+    console.log('E or ESC: Toolbox: Exit');
     Blockly.Navigation.focusWorkspace();
     return true;
   }

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -13,7 +13,7 @@ suite('Navigation', function() {
       this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     });
 
-    test('Focuses workspace from flyout', function() {
+    test('Focuses workspace from flyout (e)', function() {
       Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_FLYOUT;
       var mockEvent = {
         keyCode: goog.events.KeyCodes.E
@@ -23,6 +23,15 @@ suite('Navigation', function() {
           Blockly.Navigation.STATE_WS);
     });
 
+    test('Focuses workspace from flyout (escape)', function() {
+      Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_FLYOUT;
+      var mockEvent = {
+        keyCode: goog.events.KeyCodes.ESC
+      };
+      chai.assert.isTrue(Blockly.Navigation.navigate(mockEvent));
+      chai.assert.equal(Blockly.Navigation.currentState_,
+          Blockly.Navigation.STATE_WS);
+    });
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
@@ -127,10 +136,19 @@ suite('Navigation', function() {
       chai.assert.equal(Blockly.Navigation.flyoutBlock_.getFieldValue("TEXT"), "First");
     });
 
-    test('Focuses workspace from toolbox', function() {
+    test('Focuses workspace from toolbox (e)', function() {
       Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_TOOLBOX;
       var mockEvent = {
         keyCode: goog.events.KeyCodes.E
+      };
+      chai.assert.isTrue(Blockly.Navigation.navigate(mockEvent));
+      chai.assert.equal(Blockly.Navigation.currentState_,
+          Blockly.Navigation.STATE_WS);
+    });
+    test('Focuses workspace from toolbox (escape)', function() {
+      Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_TOOLBOX;
+      var mockEvent = {
+        keyCode: goog.events.KeyCodes.ESC
       };
       chai.assert.isTrue(Blockly.Navigation.navigate(mockEvent));
       chai.assert.equal(Blockly.Navigation.currentState_,


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes getting into a bad state when exiting the toolbox or flyout with escape.

### Proposed Changes

If we're in accessibility mode, give the navigation key handler a chance to handle the escape key (in addition to Blockly's normal call to hideChaff).

### Reason for Changes

Exiting the toolbox with E worked differently from exiting with ESC before.

### Test Coverage

Mocha tests added.

### Additional Information
