### PR TITLE
Helper to check whether an ast node points to a connection

### DIFF
--- a/core/ast_node.js
+++ b/core/ast_node.js
@@ -41,7 +41,8 @@ Blockly.ASTNode = function(type, location, params) {
   if (!location) {
     throw Error('Cannot create a node without a location.');
   }
-  /*
+
+  /**
    * The type of the location.
    * One of Blockly.ASTNode.types
    * @type {string}
@@ -49,7 +50,14 @@ Blockly.ASTNode = function(type, location, params) {
    */
   this.type_ = type;
 
-  /*
+  /**
+   * Whether the location points to a connection.
+   * @type {boolean}
+   * @private
+   */
+  this.isConnection_ = Blockly.ASTNode.isConnectionType(type);
+
+  /**
    * The location of the ast node.
    * @type {!(Blockly.Block|Blockly.Connection|Blockly.Field|Blockly.Workspace)}
    * @private
@@ -89,6 +97,23 @@ Blockly.ASTNode.wsMove_ = 10;
  * @private
  */
 Blockly.ASTNode.DEFAULT_OFFSET_Y = -20;
+
+/**
+ * Whether an ast node of the given type points to a connection.
+ * @param {string} type The type to check.  One of Blockly.ASTNode.types.
+ * @return {boolean} True if a node of the given type points to a connection.
+ * @package
+ */
+Blockly.ASTNode.isConnectionType = function(type) {
+  switch (type) {
+    case Blockly.ASTNode.types.PREVIOUS:
+    case Blockly.ASTNode.types.NEXT:
+    case Blockly.ASTNode.types.INPUT:
+    case Blockly.ASTNode.types.OUTPUT:
+      return true;
+  }
+  return false;
+};
 
 /**
  * Create an ast node pointing to a field.
@@ -231,6 +256,15 @@ Blockly.ASTNode.prototype.getWsCoordinate = function() {
  */
 Blockly.ASTNode.prototype.getParentInput = function() {
   return this.parentInput_;
+};
+
+/**
+ * Whether the node points to a connection.
+ * @return {boolean} [description]
+ * @package
+ */
+Blockly.ASTNode.prototype.isConnection = function() {
+  return this.isConnection_;
 };
 
 /**

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -555,12 +555,8 @@ Blockly.Navigation.keyboardOut = function() {
  */
 Blockly.Navigation.markConnection = function() {
   var curNode = Blockly.Navigation.cursor_.getCurNode();
-  var location = curNode.getLocation();
-
-  //TODO: Add a helper function for identifying if a node is a connection.
-  if (location instanceof Blockly.Connection) {
-    Blockly.Navigation.insertionNode_ =
-      Blockly.Navigation.cursor_.getCurNode();
+  if (curNode.isConnection()) {
+    Blockly.Navigation.insertionNode_ = curNode;
   }
 };
 

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -762,18 +762,21 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createFieldNode(field);
         assertEquals(node.getLocation(), field);
         assertEquals(node.getType(), Blockly.ASTNode.types.FIELD);
+        assertFalse(node.isConnection());
       });
       test('createConnectionNode', function() {
         var prevConnection = this.blocks.statementInput4.previousConnection;
         var node = Blockly.ASTNode.createConnectionNode(prevConnection);
         assertEquals(node.getLocation(), prevConnection);
         assertEquals(node.getType(), Blockly.ASTNode.types.PREVIOUS);
+        assertTrue(node.isConnection());
       });
       test('createInputNode', function() {
         var input = this.blocks.statementInput1.inputList[0];
         var node = Blockly.ASTNode.createInputNode(input);
         assertEquals(node.getLocation(), input.connection);
         assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
+        assertTrue(node.isConnection());
       });
       test('createWorkspaceNode', function() {
         var coordinate = new goog.math.Coordinate(100,100);
@@ -782,6 +785,7 @@ suite('ASTNode', function() {
         assertEquals(node.getLocation(), this.workspace);
         assertEquals(node.getType(), Blockly.ASTNode.types.WORKSPACE);
         assertEquals(node.getWsCoordinate(), coordinate);
+        assertFalse(node.isConnection());
       });
       test('createStatementConnectionNode', function() {
         var nextConnection = this.blocks.statementInput1.inputList[1].connection;
@@ -789,6 +793,7 @@ suite('ASTNode', function() {
         var node = Blockly.ASTNode.createConnectionNode(nextConnection);
         assertEquals(node.getLocation(), inputConnection);
         assertEquals(node.getType(), Blockly.ASTNode.types.INPUT);
+        assertTrue(node.isConnection());
       });
     });
   });


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Store whether an ast node points to a connection on the node, and add a getter.

This is a pretty common check and easy to know from the type.

### Reason for Changes

Helper function

### Test Coverage
Added checks to the ast node constructor tests.