### PR TITLE
Fixes case where we do not have a toolbox

### DIFF
--- a/core/navigation.js
+++ b/core/navigation.js
@@ -258,13 +258,19 @@ Blockly.Navigation.outCategory = function() {
  * Change focus to the flyout.
  */
 Blockly.Navigation.focusFlyout = function() {
+  var topBlock = null;
   Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_FLYOUT;
   var workspace = Blockly.getMainWorkspace();
   var toolbox = workspace.getToolbox();
   var cursor = Blockly.Navigation.cursor_;
-  var topBlock;
-  if (toolbox.flyout_ && toolbox.flyout_.getWorkspace()) {
-    var topBlocks = toolbox.flyout_.getWorkspace().getTopBlocks();
+  var flyout = toolbox ? toolbox.flyout_ : workspace.getFlyout();
+
+  if (!Blockly.Navigation.marker_.getCurNode()) {
+    Blockly.Navigation.markAtCursor();
+  }
+
+  if (flyout && flyout.getWorkspace()) {
+    var topBlocks = flyout.getWorkspace().getTopBlocks();
     if (topBlocks.length > 0) {
       topBlock = topBlocks[0];
       Blockly.Navigation.flyoutBlock_ = topBlock;
@@ -330,8 +336,9 @@ Blockly.Navigation.getFlyoutBlocks_ = function() {
   var workspace = Blockly.getMainWorkspace();
   var toolbox = workspace.getToolbox();
   var topBlocks = [];
-  if (toolbox.flyout_ && toolbox.flyout_.getWorkspace()) {
-    topBlocks = toolbox.flyout_.getWorkspace().getTopBlocks();
+  var flyout = toolbox ? toolbox.flyout_ : workspace.getFlyout();
+  if (flyout && flyout.getWorkspace()) {
+    topBlocks = flyout.getWorkspace().getTopBlocks();
   }
   return topBlocks;
 };
@@ -557,7 +564,9 @@ Blockly.Navigation.disconnectBlocks = function() {
  */
 Blockly.Navigation.focusWorkspace = function() {
   var cursor = Blockly.Navigation.cursor_;
-  Blockly.Navigation.resetFlyout(true /* shouldHide */);
+  var reset = Blockly.getMainWorkspace().getToolbox() ? true : false;
+
+  Blockly.Navigation.resetFlyout(reset);
   Blockly.Navigation.currentState_ = Blockly.Navigation.STATE_WS;
   Blockly.Navigation.enableKeyboardAccessibility();
   if (Blockly.selected) {
@@ -653,8 +662,14 @@ Blockly.Navigation.handleEnterForWS = function() {
 Blockly.Navigation.navigate = function(e) {
   var curState = Blockly.Navigation.currentState_;
   if (e.keyCode === goog.events.KeyCodes.T) {
-    Blockly.Navigation.focusToolbox();
-    Blockly.Navigation.log('T: Focus Toolbox');
+    var workspace = Blockly.getMainWorkspace();
+    if (!workspace.getToolbox()) {
+      Blockly.Navigation.focusFlyout();
+      Blockly.Navigation.log('F: Focus Flyout');
+    } else {
+      Blockly.Navigation.focusToolbox();
+      Blockly.Navigation.log('T: Focus Toolbox');
+    }
     return true;
   } else if (curState === Blockly.Navigation.STATE_FLYOUT) {
     return Blockly.Navigation.flyoutKeyHandler(e);

--- a/core/navigation.js
+++ b/core/navigation.js
@@ -665,7 +665,7 @@ Blockly.Navigation.navigate = function(e) {
     var workspace = Blockly.getMainWorkspace();
     if (!workspace.getToolbox()) {
       Blockly.Navigation.focusFlyout();
-      Blockly.Navigation.log('F: Focus Flyout');
+      Blockly.Navigation.log('T: Focus Flyout');
     } else {
       Blockly.Navigation.focusToolbox();
       Blockly.Navigation.log('T: Focus Toolbox');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
There is currently no way to get to the flyout when we do not have a toolbox.

### Proposed Changes
Adds the ability to go to the flyout directly if no toolbox is available. The user would get there by hitting T. 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
