### PR TITLE
Make XML request in test/generators async

### DIFF
--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -102,7 +102,7 @@ function start() {
  * If some tests are failing, load test suites individually to continue
  * debugging.
  */
-function loadSelected() {
+async function loadSelected() {
   var output = document.getElementById('importExport');
   output.style.background = 'gray';
 
@@ -117,7 +117,7 @@ function loadSelected() {
     if (boxList[i].checked) {
       var testUrl = boxList[i].value;
       if (testUrl) {
-        var xmlText = fetchFile(testUrl);
+        var xmlText = await fetchFile(testUrl);
         if (xmlText !== null) {
           fromXml(testUrl, xmlText, /* opt_append */ true);
         }
@@ -143,23 +143,33 @@ function loadOther() {
 }
 
 function fetchFile(xmlUrl) {
-  try {
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.open('GET', xmlUrl, false);
-    xmlHttp.setRequestHeader('Content-Type', 'text/xml');
-    xmlHttp.send('');
-  } catch (e) {
-    // Attempt to diagnose the problem.
-    var msg = 'Error: Unable to load XML data.\n';
-    if (window.location.protocol == 'file:') {
-      msg += 'This may be due to a security restriction preventing\n' +
-          'access when using the file:// protocol.\n' +
-          'Use an http webserver, or a less paranoid browser.\n';
+  return new Promise( function(resolve, reject) {
+    try {
+      var xmlHttp = new XMLHttpRequest();
+      xmlHttp.open('GET', xmlUrl);
+      xmlHttp.setRequestHeader('Content-Type', 'text/xml');
+      xmlHttp.onload = function(e) {
+        if (xmlHttp.readyState === 4) {
+          if (xmlHttp.status === 200) {
+            resolve(xmlHttp.responseText);
+          }
+        }
+      }
+      xmlHttp.send('')
     }
-    alert(msg + '\n' + e);
-    return null;
-  }
-  return xmlHttp.responseText;
+    catch (e) {
+      // Attempt to diagnose the problem.
+      var msg = 'Error: Unable to load XML data.\n';
+      if (window.location.protocol == 'file:') {
+        msg += 'This may be due to a security restriction preventing\n' +
+            'access when using the file:// protocol.\n' +
+            'Use an http webserver, or a less paranoid browser.\n';
+      }
+      alert(msg + '\n' + e);
+      resolve(null);
+      }
+    }
+  ); 
 }
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
[Issue #1800](https://github.com/google/blockly/issues/1800)

### Proposed Changes
Modifies index.html in tests/generators to use async XML requests and promises, to resolve [Issue #1800](https://github.com/google/blockly/issues/1800).

### Reason for Changes
Eliminates the use of synchronous XML requests and associated warnings in index.html.

### Test Coverage

Tested on:
Desktop Firefox v66 on Windows 10 v1809, and no longer produces an XML sync warning.
