### PR TITLE
Changes the cursor look for a stack

### DIFF
--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -27,7 +27,7 @@
 goog.provide('Blockly.CursorSvg');
 
 goog.require('Blockly.Cursor');
-goog.require('Blockly.BlockSvg');
+goog.require('Blockly.BlockSvg.render');
 
 
 /**

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -250,20 +250,21 @@ Blockly.CursorSvg.prototype.showWithField_ = function() {
 Blockly.CursorSvg.prototype.showWithStack_ = function() {
   var block = this.getCurNode().getLocation();
 
-  //Gets the height and width of entire stack
+  // Gets the height and width of entire stack.
   var heightWidth = block.getHeightWidth();
 
-  //Add padding so that being on a stack looks different than being on a block
+  // Add padding so that being on a stack looks different than being on a block.
   var width = heightWidth.width + Blockly.CursorSvg.STACK_PADDING;
   var height = heightWidth.height + Blockly.CursorSvg.STACK_PADDING;
 
-  //Shift the rectangle slightly to upper left so padding is equal on all sides
+  // Shift the rectangle slightly to upper left so padding is equal on all sides.
   var x =  -1 * Blockly.CursorSvg.STACK_PADDING / 2;
   var y =  -1 * Blockly.CursorSvg.STACK_PADDING / 2;
 
-  //If the block has an output connection it needs more padding
+  // If the block has an output connection it needs more padding.
   if (block.outputConnection) {
-    x = -1 * Blockly.CursorSvg.STACK_PADDING;
+    x -= Blockly.BlockSvg.TAB_WIDTH;
+    // width += Blockly.BlockSvg.TAB_WIDTH;
   }
 
   this.currentCursorSvg = this.cursorSvgRect_;

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -77,7 +77,6 @@ Blockly.CursorSvg.VERTICAL_PADDING = 5;
  * @type {number}
  * @const
  */
-
 Blockly.CursorSvg.STACK_PADDING = 10;
 /**
  * Cursor color.
@@ -92,7 +91,6 @@ Blockly.CursorSvg.CURSOR_COLOR = '#cc0a0a';
  * @const
  */
 Blockly.CursorSvg.MARKER_COLOR = '#4286f4';
-
 
 /**
  * Parent svg element.

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -264,7 +264,6 @@ Blockly.CursorSvg.prototype.showWithStack_ = function() {
   // If the block has an output connection it needs more padding.
   if (block.outputConnection) {
     x -= Blockly.BlockSvg.TAB_WIDTH;
-    // width += Blockly.BlockSvg.TAB_WIDTH;
   }
 
   this.currentCursorSvg = this.cursorSvgRect_;

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -27,6 +27,7 @@
 goog.provide('Blockly.CursorSvg');
 
 goog.require('Blockly.Cursor');
+goog.require('Blockly.BlockSvg');
 
 
 /**

--- a/core/cursor_svg.js
+++ b/core/cursor_svg.js
@@ -73,6 +73,13 @@ Blockly.CursorSvg.NOTCH_START_LENGTH = 24;
 Blockly.CursorSvg.VERTICAL_PADDING = 5;
 
 /**
+ * Padding around a stack.
+ * @type {number}
+ * @const
+ */
+
+Blockly.CursorSvg.STACK_PADDING = 10;
+/**
  * Cursor color.
  * @type {string}
  * @const
@@ -85,6 +92,7 @@ Blockly.CursorSvg.CURSOR_COLOR = '#cc0a0a';
  * @const
  */
 Blockly.CursorSvg.MARKER_COLOR = '#4286f4';
+
 
 /**
  * Parent svg element.
@@ -237,6 +245,37 @@ Blockly.CursorSvg.prototype.showWithField_ = function() {
   this.showCurrent_();
 };
 
+/**
+ * Show the cursor using a stack.
+ * @private
+ */
+Blockly.CursorSvg.prototype.showWithStack_ = function() {
+  var block = this.getCurNode().getLocation();
+
+  //Gets the height and width of entire stack
+  var heightWidth = block.getHeightWidth();
+
+  //Add padding so that being on a stack looks different than being on a block
+  var width = heightWidth.width + Blockly.CursorSvg.STACK_PADDING;
+  var height = heightWidth.height + Blockly.CursorSvg.STACK_PADDING;
+
+  //Shift the rectangle slightly to upper left so padding is equal on all sides
+  var x =  -1 * Blockly.CursorSvg.STACK_PADDING / 2;
+  var y =  -1 * Blockly.CursorSvg.STACK_PADDING / 2;
+
+  //If the block has an output connection it needs more padding
+  if (block.outputConnection) {
+    x = -1 * Blockly.CursorSvg.STACK_PADDING;
+  }
+
+  this.currentCursorSvg = this.cursorSvgRect_;
+  this.setParent_(block.getSvgRoot());
+
+  this.positionRect_(x, y, width, height);
+  this.showCurrent_();
+};
+
+
 /**************************/
 /**** Position         ****/
 /**************************/
@@ -325,9 +364,7 @@ Blockly.CursorSvg.prototype.update_ = function() {
   } else if (curNode.getType() === Blockly.ASTNode.types.WORKSPACE) {
     this.showWithCoordinates_();
   } else if (curNode.getType() === Blockly.ASTNode.types.STACK) {
-    //TODO: This should be something else so that we show that we are at the
-    //stack level.
-    this.showWithBlock_();
+    this.showWithStack_();
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Having the cursor for a stack and a block be the same can be pretty confusing when trying to navigate through the blocks. 

### Proposed Changes
Make the cursor for a stack cover the entire stack of blocks as well as make it slightly cover a slightly larger area than the block. 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
<img width="345" alt="Screen Shot 2019-05-08 at 2 44 31 PM" src="https://user-images.githubusercontent.com/23059043/57410512-d80d4d80-719f-11e9-82c0-58971ad4d859.png">
