### PR TITLE
TDD: tests for navigation insert/modify, currently skipped

### DIFF
--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -28,6 +28,25 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": []
   },
   {
+    "type": "test_basic_stack",
+    "message0": "stack block",
+    "previousStatement": null,
+    "nextStatement": null,
+    "style": "math_blocks"
+  },
+  {
+    "type": "test_basic_row",
+    "message0": "row block %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "INPUT"
+      }
+    ],
+    "output": null,
+    "style": "math_blocks"
+  },
+  {
     "type": "test_basic_value_to_stack",
     "message0": "value to stack",
     "nextStatement": null,

--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -13,7 +13,9 @@
         "assertFalse": true,
         "isEqualArrays": true,
         "assertUndefined": true,
-        "assertNotUndefined": true
+        "assertNotUndefined": true,
+        "defineStackBlock": true,
+        "defineRowBlock": true
 
     },
     "extends": "../../.eslintrc.json"

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -29,6 +29,7 @@
     <script src="field_variable_test.js"></script>
     <script src="xml_test.js"></script>
     <script src="utils_test.js"></script>
+    <script src="navigation_modify_test.js"></script>
     <script src="navigation_test.js"></script>
 
     <div id="blocklyDiv"></div>
@@ -36,7 +37,6 @@
       <block type="basic_block"></block>
     </xml>
 
-    <div id="blocklyDiv"></div>
     <xml id="toolbox-connections" style="display: none">
       <block type="stack_block"></block>
       <block type="row_block"></block>

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -31,20 +31,17 @@ suite.skip('Insert/Modify', function() {
   });
 
   suite('Marked Connection', function() {
-    test('Cursor on workspace', function() {
-      Blockly.Navigation.marker_.setLocation(
-          Blockly.ASTNode.createConnectionNode(
-              this.stack_block_1.nextConnection));
-      Blockly.Navigation.cursor_.setLocation(
-          Blockly.ASTNode.createWorkspaceNode(this.workspace,
-              new goog.math.Coordinate(0, 0)));
-      chai.assert.isFalse(Blockly.Navigation.modify());
-    });
     suite('Marker on next', function() {
       setup(function() {
         Blockly.Navigation.marker_.setLocation(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_1.nextConnection));
+      });
+      test('Cursor on workspace', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createWorkspaceNode(this.workspace,
+                new goog.math.Coordinate(0, 0)));
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
       test('Cursor on compatible connection', function() {
         Blockly.Navigation.cursor_.setLocation(

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -108,6 +108,13 @@ suite('Insert/Modify', function() {
         chai.assert.isTrue(Blockly.Navigation.modify());
         chai.assert.equal(this.stack_block_1.getPreviousBlock().id, 'stack_block_2');
       });
+      test('Cursor on incompatible block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_1));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+        chai.assert.isNull(this.stack_block_1.getPreviousBlock());
+      });
     });
 
     suite('Marker on value input', function() {
@@ -200,8 +207,7 @@ suite('Insert/Modify', function() {
       chai.assert.equal(200, pos.y);
     });
 
-    test('Cursor on connection', function() {
-      // TODO: Does the type of the connection matter?
+    test('Cursor on output connection', function() {
       Blockly.Navigation.cursor_.setLocation(
           Blockly.ASTNode.createConnectionNode(
               this.row_block_1.outputConnection));
@@ -209,6 +215,30 @@ suite('Insert/Modify', function() {
       var pos = this.row_block_1.getRelativeToSurfaceXY();
       chai.assert.equal(100, pos.x);
       chai.assert.equal(200, pos.y);
+    });
+
+    test('Cursor on previous connection', function() {
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createConnectionNode(
+              this.stack_block_1.previousConnection));
+      chai.assert.isTrue(Blockly.Navigation.modify());
+      var pos = this.stack_block_1.getRelativeToSurfaceXY();
+      chai.assert.equal(100, pos.x);
+      chai.assert.equal(200, pos.y);
+    });
+
+    test('Cursor on input connection', function() {
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createConnectionNode(
+              this.row_block_1.inputList[0].connection));
+      chai.assert.isFalse(Blockly.Navigation.modify());
+    });
+
+    test('Cursor on next connection', function() {
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createConnectionNode(
+              this.stack_block_1.nextConnection));
+      chai.assert.isFalse(Blockly.Navigation.modify());
     });
 
     test('Cursor on child block (row)', function() {
@@ -221,6 +251,9 @@ suite('Insert/Modify', function() {
 
       chai.assert.isTrue(Blockly.Navigation.modify());
       chai.assert.isNull(this.row_block_2.getParent());
+      var pos = this.row_block_2.getRelativeToSurfaceXY();
+      chai.assert.equal(100, pos.x);
+      chai.assert.equal(200, pos.y);
     });
 
     test('Cursor on child block (stack)', function() {
@@ -233,6 +266,9 @@ suite('Insert/Modify', function() {
 
       chai.assert.isTrue(Blockly.Navigation.modify());
       chai.assert.isNull(this.stack_block_2.getParent());
+      var pos = this.stack_block_2.getRelativeToSurfaceXY();
+      chai.assert.equal(100, pos.x);
+      chai.assert.equal(200, pos.y);
     });
 
     test('Cursor on workspace', function() {

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -1,4 +1,4 @@
-suite.skip('Insert/Modify', function() {
+suite('Insert/Modify', function() {
   setup(function() {
     var xmlText = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
       '<block type="stack_block" id="stack_block_1" x="12" y="38"></block>' +
@@ -31,6 +31,7 @@ suite.skip('Insert/Modify', function() {
   });
 
   suite('Marked Connection', function() {
+    // TODO: Marked connection or cursor connection is already connected.
     suite('Marker on next', function() {
       setup(function() {
         Blockly.Navigation.marker_.setLocation(
@@ -109,45 +110,220 @@ suite.skip('Insert/Modify', function() {
       });
     });
 
-    suite('Value input', function() {
+    suite('Marker on value input', function() {
       setup(function() {
-
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_1.inputList[0].connection));
       });
-
-      teardown(function() {
-
+      test('Cursor on compatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.outputConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.row_block_2.getParent().id, 'row_block_1');
       });
-
-      test('', function() {
-
+      test('Cursor on incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.inputList[0].connection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+      });
+      test('Cursor on really incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_1.previousConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+      });
+      test('Cursor on block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_2));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.row_block_2.getParent().id, 'row_block_1');
       });
     });
 
     suite('Statement input', function() {
+      // TODO: fill this out.
+    });
+
+    suite('Marker on output', function() {
       setup(function() {
-
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_1.outputConnection));
       });
-
-      teardown(function() {
-
+      test('Cursor on compatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.inputList[0].connection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.row_block_2.getParent().id, 'row_block_1');
       });
+      test('Cursor on incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.outputConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+      });
+      test('Cursor on really incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_1.previousConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+      });
+      test('Cursor on block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_2));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.row_block_1.getParent().id, 'row_block_2');
+      });
+    });
+  });
 
-      test('', function() {
+
+  suite('Marked Workspace', function() {
+    setup(function() {
+      Blockly.Navigation.marker_.setLocation(
+          Blockly.ASTNode.createWorkspaceNode(
+              this.workspace, new goog.math.Coordinate(100, 100)));
+    });
+    test('Cursor on row block', function() {
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createBlockNode(
+              this.row_block_1));
+      chai.assert.isTrue(Blockly.Navigation.modify());
+      chai.assert.equal(100, this.row_block_1.xy_.x);
+      chai.assert.equal(100, this.row_block_1.xy_.x);
+    });
+
+    test('Cursor on connection', function() {
+      // TODO: Does the type of the connection matter?
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createConnectionNode(
+              this.row_block_1.outputConnection));
+      chai.assert.isTrue(Blockly.Navigation.modify());
+      chai.assert.equal(100, this.row_block_1.xy_.x);
+      chai.assert.equal(100, this.row_block_1.xy_.x);
+    });
+
+    test('Cursor on child block (row)', function() {
+      this.row_block_1.inputList[0].connection.connect(
+          this.row_block_2.outputConnection);
+
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createBlockNode(
+              this.row_block_2));
+
+      chai.assert.isTrue(Blockly.Navigation.modify());
+      chai.assert.isNull(this.row_block_2.getParent());
+    });
+
+    test('Cursor on child block (stack)', function() {
+      this.stack_block_1.nextConnection.connect(
+          this.stack_block_2.previousConnection);
+
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createBlockNode(
+              this.stack_block_2));
+
+      chai.assert.isTrue(Blockly.Navigation.modify());
+      chai.assert.isNull(this.stack_block_2.getParent());
+    });
+
+    test('Cursor on workspace', function() {
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createWorkspaceNode(
+              this.workspace, new goog.math.Coordinate(100, 100)));
+      chai.assert.isFalse(Blockly.Navigation.modify());
+    });
+  });
+
+  suite('Marked Block', function() {
+    suite('Marked any block', function() {
+      // These tests are using a stack block, but do not depend on the type of
+      // the block.
+      setup(function() {
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_1));
+      });
+      test('Cursor on workspace', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createWorkspaceNode(
+                this.workspace, new goog.math.Coordinate(100, 100)));
+        chai.assert.isFalse(Blockly.Navigation.modify());
 
       });
     });
-
-    suite('Output', function() {
+    suite('Marked stack block', function() {
       setup(function() {
-
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_1));
       });
-
-      teardown(function() {
-
+      test('Cursor on row block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_1));
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
-
-      test('', function() {
-
+      test('Cursor on stack block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_1));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        // TODO: figure out which one ends up above and which below.
+      });
+      test('Cursor on next connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.nextConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equals(this.stack_block_1.getParent().id, 'stack_block_2');
+      });
+      test('Cursor on previous connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.previousConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equals(this.stack_block_2.getParent().id, 'stack_block_1');
+      });
+    });
+    suite('Marked row block', function() {
+      setup(function() {
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_1));
+      });
+      test('Cursor on stack block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_1));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+      });
+      test('Cursor on row block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.row_block_1));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        // TODO: Figure out which one ends up first and which second.
+      });
+      test('Cursor on value input connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.inputList[0].connection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equals(this.row_block_1.getParent().id, 'row_block_2');
+      });
+      test('Cursor on output connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_2.outputConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equals(this.row_block_2.getParent().id, 'row_block_1');
       });
     });
   });

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -1,0 +1,157 @@
+suite.skip('Insert/Modify', function() {
+  setup(function() {
+    var xmlText = '<xml xmlns="http://www.w3.org/1999/xhtml">' +
+      '<block type="stack_block" id="stack_block_1" x="12" y="38"></block>' +
+      '<block type="stack_block" id="stack_block_2" x="12" y="113"></block>' +
+      '<block type="row_block" id="row_block_1" x="13" y="213"></block>' +
+      '<block type="row_block" id="row_block_2" x="12" y="288"></block>' +
+    '</xml>';
+    defineStackBlock();
+    defineRowBlock();
+
+    var toolbox = document.getElementById('toolbox-connections');
+    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xmlText), this.workspace);
+
+    this.stack_block_1 = this.workspace.getBlockById('stack_block_1');
+    this.stack_block_2 = this.workspace.getBlockById('stack_block_2');
+    this.row_block_1 = this.workspace.getBlockById('row_block_1');
+    this.row_block_2 = this.workspace.getBlockById('row_block_2');
+
+    Blockly.Navigation.enableKeyboardAccessibility();
+    Blockly.Navigation.focusWorkspace();
+  });
+
+  teardown(function() {
+    delete Blockly.Blocks['stack_block'];
+    delete Blockly.Blocks['row_block'];
+    this.workspace.dispose();
+    // Does disposing of the workspace dispose of cursors and markers
+    // correctly?
+  });
+
+  suite('Marked Connection', function() {
+    test('Cursor on workspace', function() {
+      Blockly.Navigation.marker_.setLocation(
+          Blockly.ASTNode.createConnectionNode(
+              this.stack_block_1.nextConnection));
+      Blockly.Navigation.cursor_.setLocation(
+          Blockly.ASTNode.createWorkspaceNode(this.workspace,
+              new goog.math.Coordinate(0, 0)));
+      chai.assert.isFalse(Blockly.Navigation.modify());
+    });
+    suite('Marker on next', function() {
+      setup(function() {
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_1.nextConnection));
+      });
+      test('Cursor on compatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.previousConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.stack_block_1.getNextBlock().id, 'stack_block_2');
+      });
+      test('Cursor on incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.nextConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+        chai.assert.isNull(this.stack_block_1.getNextBlock());
+      });
+      test('Cursor on really incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_1.outputConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+        chai.assert.isNull(this.stack_block_1.getNextBlock());
+      });
+      test('Cursor on block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_2));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.stack_block_1.getNextBlock().id, 'stack_block_2');
+      });
+    });
+
+    suite('Marker on previous', function() {
+      setup(function() {
+        Blockly.Navigation.marker_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_1.previousConnection));
+      });
+      test('Cursor on compatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.nextConnection));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.stack_block_1.getPreviousBlock().id, 'stack_block_2');
+      });
+      test('Cursor on incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.stack_block_2.previousConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+        chai.assert.isNull(this.stack_block_1.getPreviousBlock());
+      });
+      test('Cursor on really incompatible connection', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createConnectionNode(
+                this.row_block_1.outputConnection));
+        chai.assert.isFalse(Blockly.Navigation.modify());
+        chai.assert.isNull(this.stack_block_1.getNextBlock());
+      });
+      test('Cursor on block', function() {
+        Blockly.Navigation.cursor_.setLocation(
+            Blockly.ASTNode.createBlockNode(
+                this.stack_block_2));
+        chai.assert.isTrue(Blockly.Navigation.modify());
+        chai.assert.equal(this.stack_block_1.getPreviousBlock().id, 'stack_block_2');
+      });
+    });
+
+    suite('Value input', function() {
+      setup(function() {
+
+      });
+
+      teardown(function() {
+
+      });
+
+      test('', function() {
+
+      });
+    });
+
+    suite('Statement input', function() {
+      setup(function() {
+
+      });
+
+      teardown(function() {
+
+      });
+
+      test('', function() {
+
+      });
+    });
+
+    suite('Output', function() {
+      setup(function() {
+
+      });
+
+      teardown(function() {
+
+      });
+
+      test('', function() {
+
+      });
+    });
+  });
+});

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -159,7 +159,7 @@ suite('Insert/Modify', function() {
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.inputList[0].connection));
         chai.assert.isTrue(Blockly.Navigation.modify());
-        chai.assert.equal(this.row_block_2.getParent().id, 'row_block_1');
+        chai.assert.equal(this.row_block_1.getParent().id, 'row_block_2');
       });
       test('Cursor on incompatible connection', function() {
         Blockly.Navigation.cursor_.setLocation(
@@ -188,15 +188,16 @@ suite('Insert/Modify', function() {
     setup(function() {
       Blockly.Navigation.marker_.setLocation(
           Blockly.ASTNode.createWorkspaceNode(
-              this.workspace, new goog.math.Coordinate(100, 100)));
+              this.workspace, new goog.math.Coordinate(100, 200)));
     });
     test('Cursor on row block', function() {
       Blockly.Navigation.cursor_.setLocation(
           Blockly.ASTNode.createBlockNode(
               this.row_block_1));
       chai.assert.isTrue(Blockly.Navigation.modify());
-      chai.assert.equal(100, this.row_block_1.xy_.x);
-      chai.assert.equal(100, this.row_block_1.xy_.x);
+      var pos = this.row_block_1.getRelativeToSurfaceXY();
+      chai.assert.equal(100, pos.x);
+      chai.assert.equal(200, pos.y);
     });
 
     test('Cursor on connection', function() {
@@ -205,8 +206,9 @@ suite('Insert/Modify', function() {
           Blockly.ASTNode.createConnectionNode(
               this.row_block_1.outputConnection));
       chai.assert.isTrue(Blockly.Navigation.modify());
-      chai.assert.equal(100, this.row_block_1.xy_.x);
-      chai.assert.equal(100, this.row_block_1.xy_.x);
+      var pos = this.row_block_1.getRelativeToSurfaceXY();
+      chai.assert.equal(100, pos.x);
+      chai.assert.equal(200, pos.y);
     });
 
     test('Cursor on child block (row)', function() {
@@ -242,6 +244,8 @@ suite('Insert/Modify', function() {
   });
 
   suite('Marked Block', function() {
+    // TODO: Decide whether it ever makes sense to mark a block, and what to do
+    // if so.  For now all of these attempted modifications will fail.
     suite('Marked any block', function() {
       // These tests are using a stack block, but do not depend on the type of
       // the block.
@@ -274,22 +278,19 @@ suite('Insert/Modify', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createBlockNode(
                 this.stack_block_1));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        // TODO: figure out which one ends up above and which below.
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
       test('Cursor on next connection', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_2.nextConnection));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        chai.assert.equals(this.stack_block_1.getParent().id, 'stack_block_2');
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
       test('Cursor on previous connection', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_2.previousConnection));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        chai.assert.equals(this.stack_block_2.getParent().id, 'stack_block_1');
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
     });
     suite('Marked row block', function() {
@@ -308,22 +309,19 @@ suite('Insert/Modify', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createBlockNode(
                 this.row_block_1));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        // TODO: Figure out which one ends up first and which second.
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
       test('Cursor on value input connection', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.inputList[0].connection));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        chai.assert.equals(this.row_block_1.getParent().id, 'row_block_2');
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
       test('Cursor on output connection', function() {
         Blockly.Navigation.cursor_.setLocation(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.outputConnection));
-        chai.assert.isTrue(Blockly.Navigation.modify());
-        chai.assert.equals(this.row_block_2.getParent().id, 'row_block_1');
+        chai.assert.isFalse(Blockly.Navigation.modify());
       });
     });
   });

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -1,5 +1,6 @@
 /* exported assertEquals, assertTrue, assertFalse, assertNull, assertNotNull,
-   isEqualArrays, assertUndefined, assertNotUndefined */
+   isEqualArrays, assertUndefined, assertNotUndefined,
+   defineRowBlock, defineStackBlock */
 function _argumentsIncludeComments(expectedNumberOfNonCommentArgs, args) {
   return args.length == expectedNumberOfNonCommentArgs + 1;
 }

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -106,3 +106,26 @@ function assertNotUndefined() {
   var val = _nonCommentArg(1, 1, arguments);
   chai.assert.isNotUndefined(val, commentArg);
 }
+
+function defineStackBlock() {
+  Blockly.defineBlocksWithJsonArray([{
+    "type": "stack_block",
+    "message0": "",
+    "previousStatement": null,
+    "nextStatement": null
+  }]);
+}
+
+function defineRowBlock() {
+  Blockly.defineBlocksWithJsonArray([{
+    "type": "row_block",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "INPUT"
+      }
+    ],
+    "output": null
+  }]);
+}

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1122,6 +1122,8 @@ h1 {
     <category name="Basic">
       <block type="test_basic_empty"></block>
       <block type="test_basic_empty_with_mutator"></block>
+      <block type="test_basic_stack"></block>
+      <block type="test_basic_row"></block>
       <block type="test_basic_value_to_stack"></block>
       <block type="test_basic_value_to_statement"></block>
       <block type="test_basic_limit_instances"></block>


### PR DESCRIPTION
I'm working on unifying all of the `insertBlockToWs`, `insertBlockFromWs`, etc. code into a single function, `Blockly.Navigation.modify`.  That function acts based on the state of the cursor and the marker.  I'm currently assuming that it will return a boolean specifying whether it actually made a change (or whether it made the expected change?) but that's still flexible.

This is a start on tests for this, so that we can lay out the desired behaviour.  I'm still adding more, but want to get this out for comment.

The first commit has tests for the marker being on a previous or next connection, and the cursor being on a workspace, block, previous connection, next connection, or output connection.