### PR TITLE
Maybe fix mocha tests

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -293,17 +293,22 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
             Blockly.Events.setGroup(e.group);
           }
 
+          var shouldBump = false;
           switch (e.type) {
             case Blockly.Events.BLOCK_CREATE:
             case Blockly.Events.BLOCK_MOVE:
               var object = mainWorkspace.getBlockById(e.blockId);
+              if (object && !object.getParent()) {
+                shouldBump = true;
+              }
               break;
             case Blockly.Events.COMMENT_CREATE:
             case Blockly.Events.COMMENT_MOVE:
               var object = mainWorkspace.getCommentById(e.commentId);
+              shouldBump = true;
               break;
           }
-          if (object) {
+          if (object && shouldBump) {
             var objectMetrics = object.getBoundingRectangle();
 
             // Bump any object that's above the top back inside.


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

In the bump function that happens on all simple workspaces, don't bump if the block has a parent.
### Reason for Changes

Tests are failing intermittently.  I think that's because the bump function runs on some delay/setTimeout after loading the blocks from XML, and the blocks getting bumped have already been attached by the time that setTimeout runs.  One solution is to switch to a workspace that scrolls infinitely for these tests, but I think this is safer.

### Test Coverage
Tested locally in the browser.

### Additional Information
