### PR TITLE
Added Field Value Tests

### DIFF
--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -32,7 +32,8 @@ goog.require('Blockly.utils');
 
 /**
  * Class for a checkbox field.
- * @param {string} state The initial state of the field ('TRUE' or 'FALSE').
+ * @param {string=} opt_state The initial state of the field ('TRUE' or
+ *    'FALSE'), defaults to 'FALSE'.
  * @param {Function=} opt_validator A function that is executed when a new
  *     option is selected.  Its sole argument is the new checkbox state.  If
  *     it returns a value, this becomes the new checkbox state, unless the
@@ -40,10 +41,10 @@ goog.require('Blockly.utils');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldCheckbox = function(state, opt_validator) {
+Blockly.FieldCheckbox = function(opt_state, opt_validator) {
   Blockly.FieldCheckbox.superClass_.constructor.call(this, '', opt_validator);
   // Set the initial state.
-  this.setValue(state);
+  this.setValue(opt_state);
 };
 goog.inherits(Blockly.FieldCheckbox, Blockly.Field);
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -34,7 +34,8 @@ goog.require('goog.style');
 
 /**
  * Class for a colour input field.
- * @param {string} colour The initial colour in '#rrggbb' format.
+ * @param {string=} opt_colour The initial colour in '#rrggbb' format, defaults
+ *    to the first value in the default colour array.
  * @param {Function=} opt_validator A function that is executed when a new
  *     colour is selected.  Its sole argument is the new colour value.  Its
  *     return value becomes the selected colour, unless it is undefined, in
@@ -43,8 +44,10 @@ goog.require('goog.style');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldColour = function(colour, opt_validator) {
-  Blockly.FieldColour.superClass_.constructor.call(this, colour, opt_validator);
+Blockly.FieldColour = function(opt_colour, opt_validator) {
+  opt_colour = opt_colour || Blockly.FieldColour.COLOURS[0];
+  Blockly.FieldColour.superClass_.constructor
+      .call(this, opt_colour, opt_validator);
   this.setText(Blockly.Field.NBSP + Blockly.Field.NBSP + Blockly.Field.NBSP);
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -40,7 +40,7 @@ goog.require('goog.ui.DatePicker');
 
 /**
  * Class for a date input field.
- * @param {string} date The initial date.
+ * @param {string=} opt_date The initial date, defaults to the current day.
  * @param {Function=} opt_validator A function that is executed when a new
  *     date is selected.  Its sole argument is the new date value.  Its
  *     return value becomes the selected date, unless it is undefined, in
@@ -49,12 +49,12 @@ goog.require('goog.ui.DatePicker');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldDate = function(date, opt_validator) {
-  if (!date) {
-    date = new goog.date.Date().toIsoString(true);
+Blockly.FieldDate = function(opt_date, opt_validator) {
+  if (!opt_date) {
+    opt_date = new goog.date.Date().toIsoString(true);
   }
-  Blockly.FieldDate.superClass_.constructor.call(this, date, opt_validator);
-  this.setValue(date);
+  Blockly.FieldDate.superClass_.constructor.call(this, opt_date, opt_validator);
+  this.setValue(opt_date);
 };
 goog.inherits(Blockly.FieldDate, Blockly.Field);
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -34,9 +34,9 @@ goog.require('goog.math.Size');
 
 /**
  * Class for an image on a block.
- * @param {string} src The URL of the image.
- * @param {number} width Width of the image.
- * @param {number} height Height of the image.
+ * @param {string=} opt_src The URL of the image, defaults to an empty string.
+ * @param {!(string|number)} width Width of the image.
+ * @param {!(string|number)} height Height of the image.
  * @param {string=} opt_alt Optional alt text for when block is collapsed.
  * @param {Function=} opt_onClick Optional function to be called when the image
  *     is clicked.  If opt_onClick is defined, opt_alt must also be defined.
@@ -44,19 +44,30 @@ goog.require('goog.math.Size');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldImage = function(src, width, height,
+Blockly.FieldImage = function(opt_src, width, height,
     opt_alt, opt_onClick, opt_flipRtl) {
   this.sourceBlock_ = null;
+
+
+  if (isNaN(height) || isNaN(width)) {
+    throw Error('Height and width values of an image field must cast to' +
+      ' numbers.');
+  }
 
   // Ensure height and width are numbers.  Strings are bad at math.
   this.height_ = Number(height);
   this.width_ = Number(width);
+  if (this.height_ <= 0 || this.width_ <= 0) {
+    throw Error('Height and width values of an image field must be greater' +
+      ' than 0.');
+  }
   this.size_ = new goog.math.Size(this.width_,
       this.height_ + 2 * Blockly.BlockSvg.INLINE_PADDING_Y);
+
   this.flipRtl_ = opt_flipRtl;
   this.tooltip_ = '';
-  this.setValue(src);
-  this.setText(opt_alt);
+  this.setValue(opt_src || '');
+  this.setText(opt_alt || '');
 
   if (typeof opt_onClick == 'function') {
     this.clickHandler_ = opt_onClick;

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -34,7 +34,7 @@ goog.require('goog.math.Size');
 
 /**
  * Class for an image on a block.
- * @param {string=} opt_src The URL of the image, defaults to an empty string.
+ * @param {string=} src The URL of the image, defaults to an empty string.
  * @param {!(string|number)} width Width of the image.
  * @param {!(string|number)} height Height of the image.
  * @param {string=} opt_alt Optional alt text for when block is collapsed.
@@ -44,7 +44,7 @@ goog.require('goog.math.Size');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldImage = function(opt_src, width, height,
+Blockly.FieldImage = function(src, width, height,
     opt_alt, opt_onClick, opt_flipRtl) {
   this.sourceBlock_ = null;
 
@@ -66,7 +66,7 @@ Blockly.FieldImage = function(opt_src, width, height,
 
   this.flipRtl_ = opt_flipRtl;
   this.tooltip_ = '';
-  this.setValue(opt_src || '');
+  this.setValue(src || '');
   this.setText(opt_alt || '');
 
   if (typeof opt_onClick == 'function') {

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -45,7 +45,10 @@ goog.require('goog.math.Size');
 Blockly.FieldLabel = function(text, opt_class) {
   this.size_ = new goog.math.Size(0, 17.5);
   this.class_ = opt_class;
-  this.setValue(text || '');
+  if (text === null || text === undefined) {
+    text = '';
+  }
+  this.setValue(String(text));
   this.tooltip_ = '';
 };
 goog.inherits(Blockly.FieldLabel, Blockly.Field);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -36,7 +36,8 @@ goog.require('goog.math.Size');
 
 /**
  * Class for a non-editable, non-serializable text field.
- * @param {string} text The initial content of the field.
+ * @param {string=} text The initial content of the field, defaults to an
+ *    empty string.
  * @param {string=} opt_class Optional CSS class for the field's text.
  * @extends {Blockly.Field}
  * @constructor
@@ -44,7 +45,7 @@ goog.require('goog.math.Size');
 Blockly.FieldLabel = function(text, opt_class) {
   this.size_ = new goog.math.Size(0, 17.5);
   this.class_ = opt_class;
-  this.setValue(text);
+  this.setValue(text || '');
   this.tooltip_ = '';
 };
 goog.inherits(Blockly.FieldLabel, Blockly.Field);

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -33,8 +33,8 @@ goog.require('Blockly.utils');
 
 /**
  * Class for a non-editable, serializable text field.
- * @param {string} text The initial content of the field.
- * @param {string} opt_class Optional CSS class for the field's text.
+ * @param {!string} text The initial content of the field.
+ * @param {string=} opt_class Optional CSS class for the field's text.
  * @extends {Blockly.FieldLabel}
  * @constructor
  *

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -37,7 +37,8 @@ goog.require('goog.math.Coordinate');
 
 /**
  * Class for an editable text field.
- * @param {string} text The initial content of the field.
+ * @param {string=} text The initial content of the field, defaults to an
+ *    empty string.
  * @param {Function=} opt_validator An optional function that is called
  *     to validate any constraints on what the user entered.  Takes the new
  *     text as an argument and returns either the accepted text, a replacement
@@ -46,7 +47,7 @@ goog.require('goog.math.Coordinate');
  * @constructor
  */
 Blockly.FieldTextInput = function(text, opt_validator) {
-  Blockly.FieldTextInput.superClass_.constructor.call(this, text,
+  Blockly.FieldTextInput.superClass_.constructor.call(this, text || '',
       opt_validator);
 };
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -47,7 +47,10 @@ goog.require('goog.math.Coordinate');
  * @constructor
  */
 Blockly.FieldTextInput = function(text, opt_validator) {
-  Blockly.FieldTextInput.superClass_.constructor.call(this, text || '',
+  if (text === null || text === undefined) {
+    text = '';
+  }
+  Blockly.FieldTextInput.superClass_.constructor.call(this, String(text),
       opt_validator);
 };
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -115,95 +115,90 @@ suite ('Angle Fields', function() {
     });
   });
   suite('setValue', function() {
-    test('Empty -> Null', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(null);
-      assertValueDefault(angleField);
+    suite('Empty -> New Value', function() {
+      var angleField;
+      setup(function() {
+        angleField = new Blockly.FieldAngle();
+      });
+      test('Null', function() {
+        var angleField = new Blockly.FieldAngle();
+        angleField.setValue(null);
+        assertValueDefault(angleField);
+      });
+      test('Undefined', function() {
+        angleField.setValue(undefined);
+        assertValueDefault(angleField);
+      });
+      test.skip('Non-Parsable String', function() {
+        angleField.setValue('bad');
+        assertValueDefault(angleField);
+      });
+      test('NaN', function() {
+        angleField.setValue(NaN);
+        assertValueDefault(angleField);
+      });
+      test('Integer', function() {
+        angleField.setValue(2);
+        assertValue(angleField, 2);
+      });
+      test('Float', function() {
+        angleField.setValue(2.5);
+        assertValue(angleField, 2.5);
+      });
+      test('Integer String', function() {
+        angleField.setValue('2');
+        assertValue(angleField, 2);
+      });
+      test('Float', function() {
+        angleField.setValue('2.5');
+        assertValue(angleField, 2.5);
+      });
+      test('>360°', function() {
+        angleField.setValue(361);
+        assertValue(angleField, 1);
+      });
     });
-    test('Value -> Null', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(null);
-      assertValue(angleField, 1);
-    });
-    test('Empty -> Undefined', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(undefined);
-      assertValueDefault(angleField);
-    });
-    test.skip('Value -> Undefined', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(undefined);
-      assertValue(angleField, 1);
-    });
-    test.skip('Empty -> Non-Parsable String', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue('bad');
-      assertValueDefault(angleField);
-    });
-    test.skip('Value -> Non-Parsable String', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue('bad');
-      assertValue(angleField, 1);
-    });
-    test('Empty -> NaN', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(NaN);
-      assertValueDefault(angleField);
-    });
-    test.skip('Value -> NaN', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(NaN);
-      assertValue(angleField, 1);
-    });
-    test('Empty -> Integer', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(2);
-      assertValue(angleField, 2);
-    });
-    test('Value -> Integer', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(2);
-      assertValue(angleField, 2);
-    });
-    test('Empty -> Float', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(2.5);
-      assertValue(angleField, 2.5);
-    });
-    test('Value -> Float', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(2.5);
-      assertValue(angleField, 2.5);
-    });
-    test('Empty -> Integer String', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue('2');
-      assertValue(angleField, 2);
-    });
-    test('Value -> Integer String', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue('2');
-      assertValue(angleField, 2);
-    });
-    test('Empty -> Float', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue('2.5');
-      assertValue(angleField, 2.5);
-    });
-    test('Value -> Float', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue('2.5');
-      assertValue(angleField, 2.5);
-    });
-    test('Empty -> >360°', function() {
-      var angleField = new Blockly.FieldAngle();
-      angleField.setValue(361);
-      assertValue(angleField, 1);
-    });
-    test('Value -> >360°', function() {
-      var angleField = new Blockly.FieldAngle(1);
-      angleField.setValue(361);
-      assertValue(angleField, 1);
+    suite('Value -> New Value', function() {
+      var angleField;
+      setup(function() {
+        angleField = new Blockly.FieldAngle(1);
+      });
+      test('Null', function() {
+        angleField.setValue(null);
+        assertValue(angleField, 1);
+      });
+      test.skip('Undefined', function() {
+        angleField.setValue(undefined);
+        assertValue(angleField, 1);
+      });
+      test.skip('Non-Parsable String', function() {
+        angleField.setValue('bad');
+        assertValue(angleField, 1);
+      });
+      test.skip('NaN', function() {
+        angleField.setValue(NaN);
+        assertValue(angleField, 1);
+      });
+      test('Integer', function() {
+        angleField.setValue(2);
+        assertValue(angleField, 2);
+      });
+      test('Float', function() {
+        angleField.setValue(2.5);
+        assertValue(angleField, 2.5);
+      });
+      test('Integer String', function() {
+        angleField.setValue('2');
+        assertValue(angleField, 2);
+      });
+      test('Float', function() {
+        angleField.setValue('2.5');
+        assertValue(angleField, 2.5);
+      });
+      test('>360°', function() {
+        angleField.setValue(361);
+        assertValue(angleField, 1);
+      });
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -68,8 +68,8 @@ suite ('Angle Fields', function() {
       assertValue(angleField, 1.5);
     });
     test('> 360°', function() {
-      var angleField = new Blockly.FieldAngle(361);
-      assertValue(angleField, 1);
+      var angleField = new Blockly.FieldAngle(362);
+      assertValue(angleField, 2);
     });
   });
   suite('fromJson', function() {
@@ -110,8 +110,8 @@ suite ('Angle Fields', function() {
       assertValue(angleField, 1.5);
     });
     test('> 360°', function() {
-      var angleField = Blockly.FieldAngle.fromJson({ angle:361 });
-      assertValue(angleField, 1);
+      var angleField = Blockly.FieldAngle.fromJson({ angle:362 });
+      assertValue(angleField, 2);
     });
   });
   suite('setValue', function() {
@@ -154,8 +154,8 @@ suite ('Angle Fields', function() {
         assertValue(angleField, 2.5);
       });
       test('>360°', function() {
-        angleField.setValue(361);
-        assertValue(angleField, 1);
+        angleField.setValue(362);
+        assertValue(angleField, 2);
       });
     });
     suite('Value -> New Value', function() {
@@ -196,8 +196,8 @@ suite ('Angle Fields', function() {
         assertValue(angleField, 2.5);
       });
       test('>360°', function() {
-        angleField.setValue(361);
-        assertValue(angleField, 1);
+        angleField.setValue(362);
+        assertValue(angleField, 2);
       });
     });
   });

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -67,6 +67,10 @@ suite ('Angle Fields', function() {
       var angleField = new Blockly.FieldAngle('1.5');
       assertValue(angleField, 1.5);
     });
+    test('> 360°', function() {
+      var angleField = new Blockly.FieldAngle(361);
+      assertValue(angleField, 1);
+    });
   });
   suite('fromJson', function() {
     test('Empty', function() {
@@ -104,6 +108,10 @@ suite ('Angle Fields', function() {
     test('Float String', function() {
       var angleField = Blockly.FieldAngle.fromJson({ angle:'1.5' });
       assertValue(angleField, 1.5);
+    });
+    test('> 360°', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:361 });
+      assertValue(angleField, 1);
     });
   });
   suite('setValue', function() {
@@ -186,6 +194,16 @@ suite ('Angle Fields', function() {
       var angleField = new Blockly.FieldAngle(1);
       angleField.setValue('2.5');
       assertValue(angleField, 2.5);
+    });
+    test('Empty -> >360°', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(361);
+      assertValue(angleField, 1);
+    });
+    test('Value -> >360°', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(361);
+      assertValue(angleField, 1);
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -22,10 +22,10 @@ suite ('Angle Fields', function() {
   function assertValue(angleField, expectedValue, opt_expectedText) {
     var actualValue = angleField.getValue();
     var actualText = angleField.getText();
-    var stringExpectedValue = opt_expectedText || String(expectedValue);
-    assertEquals(String(actualValue), stringExpectedValue);
+    opt_expectedText = opt_expectedText || String(expectedValue);
+    assertEquals(String(actualValue), String(expectedValue));
     assertEquals(parseFloat(actualValue), expectedValue);
-    assertEquals(actualText, stringExpectedValue);
+    assertEquals(actualText, opt_expectedText);
   }
   function assertValueDefault(angleField) {
     assertValue(angleField, 0);
@@ -192,6 +192,12 @@ suite ('Angle Fields', function() {
     var angleField;
     setup(function() {
       angleField = new Blockly.FieldAngle(1);
+      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
+      Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
+      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
+    });
+    teardown(function() {
+      Blockly.FieldTextInput.htmlInput_ = null;
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -201,13 +207,14 @@ suite ('Angle Fields', function() {
       });
       test('When Editing', function() {
         angleField.isBeingEdited_ = true;
-        angleField.setValue(2);
+        Blockly.FieldTextInput.htmlInput_.value = '2';
+        angleField.onHtmlInputChange_(null);
         assertValue(angleField, 1, '2');
         angleField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
         angleField.setValue(2);
-        assertValue(angleField, 2);
+        assertValue(angleField, 1);
       });
     });
     suite('Force Mult of 30 Validator', function() {
@@ -218,7 +225,8 @@ suite ('Angle Fields', function() {
       });
       test('When Editing', function() {
         angleField.isBeingEdited_ = true;
-        angleField.setValue(25);
+        Blockly.FieldTextInput.htmlInput_.value = '25';
+        angleField.onHtmlInputChange_(null);
         assertValue(angleField, 30, '25');
         angleField.isBeingEdited_ = false;
       });

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Angle Fields', function() {
+  function assertValue(angleField, expectedValue, opt_expectedText) {
+    var actualValue = angleField.getValue();
+    var actualText = angleField.getText();
+    var stringExpectedValue = opt_expectedText || String(expectedValue);
+    assertEquals(String(actualValue), stringExpectedValue);
+    assertEquals(parseFloat(actualValue), expectedValue);
+    assertEquals(actualText, stringExpectedValue);
+  }
+  function assertValueDefault(angleField) {
+    assertValue(angleField, 0);
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var angleField = new Blockly.FieldAngle();
+      assertValueDefault(angleField);
+    });
+    test('Null', function() {
+      var angleField = new Blockly.FieldAngle(null);
+      assertValueDefault(angleField);
+    });
+    test('Undefined', function() {
+      var angleField = new Blockly.FieldAngle(undefined);
+      assertValueDefault(angleField);
+    });
+    test('Non-Parsable String', function() {
+      var angleField = new Blockly.FieldAngle('bad');
+      assertValueDefault(angleField);
+    });
+    test('NaN', function() {
+      var angleField = new Blockly.FieldAngle(NaN);
+      assertValueDefault(angleField);
+    });
+    test('Integer', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      assertValue(angleField, 1);
+    });
+    test('Float', function() {
+      var angleField = new Blockly.FieldAngle(1.5);
+      assertValue(angleField, 1.5);
+    });
+    test('Integer String', function() {
+      var angleField = new Blockly.FieldAngle('1');
+      assertValue(angleField, 1);
+    });
+    test('Float String', function() {
+      var angleField = new Blockly.FieldAngle('1.5');
+      assertValue(angleField, 1.5);
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var angleField = Blockly.FieldAngle.fromJson({});
+      assertValueDefault(angleField);
+    });
+    test('Null', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:null });
+      assertValueDefault(angleField);
+    });
+    test('Undefined', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:undefined });
+      assertValueDefault(angleField);
+    });
+    test('Non-Parsable String', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:'bad' });
+      assertValueDefault(angleField);
+    });
+    test('NaN', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:NaN });
+      assertValueDefault(angleField);
+    });
+    test('Integer', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:1 });
+      assertValue(angleField, 1);
+    });
+    test('Float', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:1.5 });
+      assertValue(angleField, 1.5);
+    });
+    test('Integer String', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:'1' });
+      assertValue(angleField, 1);
+    });
+    test('Float String', function() {
+      var angleField = Blockly.FieldAngle.fromJson({ angle:'1.5' });
+      assertValue(angleField, 1.5);
+    });
+  });
+  suite('setValue', function() {
+    test('Empty -> Null', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(null);
+      assertValueDefault(angleField);
+    });
+    test('Value -> Null', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(null);
+      assertValue(angleField, 1);
+    });
+    test('Empty -> Undefined', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(undefined);
+      assertValueDefault(angleField);
+    });
+    test.skip('Value -> Undefined', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(undefined);
+      assertValue(angleField, 1);
+    });
+    test.skip('Empty -> Non-Parsable String', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue('bad');
+      assertValueDefault(angleField);
+    });
+    test.skip('Value -> Non-Parsable String', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue('bad');
+      assertValue(angleField, 1);
+    });
+    test('Empty -> NaN', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(NaN);
+      assertValueDefault(angleField);
+    });
+    test.skip('Value -> NaN', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(NaN);
+      assertValue(angleField, 1);
+    });
+    test('Empty -> Integer', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(2);
+      assertValue(angleField, 2);
+    });
+    test('Value -> Integer', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(2);
+      assertValue(angleField, 2);
+    });
+    test('Empty -> Float', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue(2.5);
+      assertValue(angleField, 2.5);
+    });
+    test('Value -> Float', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue(2.5);
+      assertValue(angleField, 2.5);
+    });
+    test('Empty -> Integer String', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue('2');
+      assertValue(angleField, 2);
+    });
+    test('Value -> Integer String', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue('2');
+      assertValue(angleField, 2);
+    });
+    test('Empty -> Float', function() {
+      var angleField = new Blockly.FieldAngle();
+      angleField.setValue('2.5');
+      assertValue(angleField, 2.5);
+    });
+    test('Value -> Float', function() {
+      var angleField = new Blockly.FieldAngle(1);
+      angleField.setValue('2.5');
+      assertValue(angleField, 2.5);
+    });
+  });
+  suite.skip('Validators', function() {
+    var angleField;
+    setup(function() {
+      angleField = new Blockly.FieldAngle(1);
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        angleField.setValidator(function() {
+          return null;
+        });
+      });
+      test('When Editing', function() {
+        angleField.isBeingEdited_ = true;
+        angleField.setValue(2);
+        assertValue(angleField, 1, '2');
+        angleField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        angleField.setValue(2);
+        assertValue(angleField, 2);
+      });
+    });
+    suite('Force Mult of 30 Validator', function() {
+      setup(function() {
+        angleField.setValidator(function(newValue) {
+          return Math.round(newValue / 30) * 30;
+        });
+      });
+      test('When Editing', function() {
+        angleField.isBeingEdited_ = true;
+        angleField.setValue(25);
+        assertValue(angleField, 30, '25');
+        angleField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        angleField.setValue(25);
+        assertValue(angleField, 30);
+      });
+    });
+  });
+});

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -116,95 +116,91 @@ suite ('Angle Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var angleField;
       setup(function() {
-        angleField = new Blockly.FieldAngle();
+        this.angleField = new Blockly.FieldAngle();
       });
       test('Null', function() {
-        var angleField = new Blockly.FieldAngle();
-        angleField.setValue(null);
-        assertValueDefault(angleField);
+        this.angleField.setValue(null);
+        assertValueDefault(this.angleField);
       });
       test('Undefined', function() {
-        angleField.setValue(undefined);
-        assertValueDefault(angleField);
+        this.angleField.setValue(undefined);
+        assertValueDefault(this.angleField);
       });
       test.skip('Non-Parsable String', function() {
-        angleField.setValue('bad');
-        assertValueDefault(angleField);
+        this.angleField.setValue('bad');
+        assertValueDefault(this.angleField);
       });
       test('NaN', function() {
-        angleField.setValue(NaN);
-        assertValueDefault(angleField);
+        this.angleField.setValue(NaN);
+        assertValueDefault(this.angleField);
       });
       test('Integer', function() {
-        angleField.setValue(2);
-        assertValue(angleField, 2);
+        this.angleField.setValue(2);
+        assertValue(this.angleField, 2);
       });
       test('Float', function() {
-        angleField.setValue(2.5);
-        assertValue(angleField, 2.5);
+        this.angleField.setValue(2.5);
+        assertValue(this.angleField, 2.5);
       });
       test('Integer String', function() {
-        angleField.setValue('2');
-        assertValue(angleField, 2);
+        this.angleField.setValue('2');
+        assertValue(this.angleField, 2);
       });
       test('Float', function() {
-        angleField.setValue('2.5');
-        assertValue(angleField, 2.5);
+        this.angleField.setValue('2.5');
+        assertValue(this.angleField, 2.5);
       });
       test('>360°', function() {
-        angleField.setValue(362);
-        assertValue(angleField, 2);
+        this.angleField.setValue(362);
+        assertValue(this.angleField, 2);
       });
     });
     suite('Value -> New Value', function() {
-      var angleField;
       setup(function() {
-        angleField = new Blockly.FieldAngle(1);
+        this.angleField = new Blockly.FieldAngle(1);
       });
       test('Null', function() {
-        angleField.setValue(null);
-        assertValue(angleField, 1);
+        this.angleField.setValue(null);
+        assertValue(this.angleField, 1);
       });
       test.skip('Undefined', function() {
-        angleField.setValue(undefined);
-        assertValue(angleField, 1);
+        this.angleField.setValue(undefined);
+        assertValue(this.angleField, 1);
       });
       test.skip('Non-Parsable String', function() {
-        angleField.setValue('bad');
-        assertValue(angleField, 1);
+        this.angleField.setValue('bad');
+        assertValue(this.angleField, 1);
       });
       test.skip('NaN', function() {
-        angleField.setValue(NaN);
-        assertValue(angleField, 1);
+        this.angleField.setValue(NaN);
+        assertValue(this.angleField, 1);
       });
       test('Integer', function() {
-        angleField.setValue(2);
-        assertValue(angleField, 2);
+        this.angleField.setValue(2);
+        assertValue(this.angleField, 2);
       });
       test('Float', function() {
-        angleField.setValue(2.5);
-        assertValue(angleField, 2.5);
+        this.angleField.setValue(2.5);
+        assertValue(this.angleField, 2.5);
       });
       test('Integer String', function() {
-        angleField.setValue('2');
-        assertValue(angleField, 2);
+        this.angleField.setValue('2');
+        assertValue(this.angleField, 2);
       });
       test('Float', function() {
-        angleField.setValue('2.5');
-        assertValue(angleField, 2.5);
+        this.angleField.setValue('2.5');
+        assertValue(this.angleField, 2.5);
       });
       test('>360°', function() {
-        angleField.setValue(362);
-        assertValue(angleField, 2);
+        this.angleField.setValue(362);
+        assertValue(this.angleField, 2);
       });
     });
   });
   suite.skip('Validators', function() {
-    var angleField;
     setup(function() {
-      angleField = new Blockly.FieldAngle(1);
+      this.angleField = new Blockly.FieldAngle(1);
       Blockly.FieldTextInput.htmlInput_ = Object.create(null);
       Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
       Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
@@ -214,38 +210,38 @@ suite ('Angle Fields', function() {
     });
     suite('Null Validator', function() {
       setup(function() {
-        angleField.setValidator(function() {
+        this.angleField.setValidator(function() {
           return null;
         });
       });
       test('When Editing', function() {
-        angleField.isBeingEdited_ = true;
+        this.angleField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = '2';
-        angleField.onHtmlInputChange_(null);
-        assertValue(angleField, 1, '2');
-        angleField.isBeingEdited_ = false;
+        this.angleField.onHtmlInputChange_(null);
+        assertValue(this.angleField, 1, '2');
+        this.angleField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        angleField.setValue(2);
-        assertValue(angleField, 1);
+        this.angleField.setValue(2);
+        assertValue(this.angleField, 1);
       });
     });
     suite('Force Mult of 30 Validator', function() {
       setup(function() {
-        angleField.setValidator(function(newValue) {
+        this.angleField.setValidator(function(newValue) {
           return Math.round(newValue / 30) * 30;
         });
       });
       test('When Editing', function() {
-        angleField.isBeingEdited_ = true;
+        this.angleField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = '25';
-        angleField.onHtmlInputChange_(null);
-        assertValue(angleField, 30, '25');
-        angleField.isBeingEdited_ = false;
+        this.angleField.onHtmlInputChange_(null);
+        assertValue(this.angleField, 30, '25');
+        this.angleField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        angleField.setValue(25);
-        assertValue(angleField, 30);
+        this.angleField.setValue(25);
+        assertValue(this.angleField, 30);
       });
     });
   });

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite.skip('Checkbox Fields', function() {
+  function assertValue(checkboxField, expectedValue, expectedText) {
+    var actualValue = checkboxField.getValue();
+    var actualText = checkboxField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedText);
+  }
+  function assertValueDefault(checkboxField) {
+    assertValue(checkboxField, 'FALSE', 'false');
+  }
+  suite('Constructor', function() {
+    test('Null', function() {
+      var checkboxField = new Blockly.FieldCheckbox(null);
+      assertValueDefault(checkboxField);
+    });
+    test('Undefined', function() {
+      var checkboxField = new Blockly.FieldCheckbox(undefined);
+      assertValueDefault(checkboxField);
+    });
+    test('Non-Parsable String', function() {
+      var checkboxField = new Blockly.FieldCheckbox('bad');
+      assertValueDefault(checkboxField);
+    });
+    test('True', function() {
+      var checkboxField = new Blockly.FieldCheckbox(true);
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('False', function() {
+      var checkboxField = new Blockly.FieldCheckbox(false);
+      assertValue(checkboxField, 'FALSE', 'false');
+    });
+    test('String TRUE', function() {
+      var checkboxField = new Blockly.FieldCheckbox('TRUE');
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('String FALSE', function() {
+      var checkboxField = new Blockly.FieldCheckbox('FALSE');
+      assertValue(checkboxField, 'FALSE', 'false');
+    });
+  });
+  suite('fromJson', function() {
+    test('Null', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: null});
+      assertValueDefault(checkboxField);
+    });
+    test('Undefined', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: undefined});
+      assertValueDefault(checkboxField);
+    });
+    test('Non-Parsable String', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: 'bad'});
+      assertValueDefault(checkboxField);
+    });
+    test('True', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: true});
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('False', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: false});
+      assertValue(checkboxField, 'FALSE', 'false');
+    });
+    test('String TRUE', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: 'TRUE'});
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('String FALSE', function() {
+      var checkboxField = Blockly.FieldCheckbox.fromJson({ checked: 'FALSE'});
+      assertValue(checkboxField, 'FALSE', 'false');
+    });
+  });
+  suite('setValue', function() {
+    test('True -> Null', function() {
+      var checkboxField = new Blockly.FieldCheckbox('TRUE');
+      checkboxField.setValue(null);
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('True -> Undefined', function() {
+      var checkboxField = new Blockly.FieldCheckbox('TRUE');
+      checkboxField.setValue(undefined);
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('True -> Non-Parsable String', function() {
+      var checkboxField = new Blockly.FieldCheckbox('TRUE');
+      checkboxField.setValue('bad');
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+    test('True -> False', function() {
+      var checkboxField = new Blockly.FieldCheckbox('TRUE');
+      checkboxField.setValue('FALSE');
+      assertValue(checkboxField, 'FALSE', 'false');
+    });
+    test('False -> True', function() {
+      var checkboxField = new Blockly.FieldCheckbox('FALSE');
+      checkboxField.setValue('TRUE');
+      assertValue(checkboxField, 'TRUE', 'true');
+    });
+  });
+  suite('Validators', function() {
+    var checkboxField;
+    setup(function() {
+      checkboxField = new Blockly.FieldCheckbox(true);
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        checkboxField.setValidator(function() {
+          return null;
+        });
+      });
+      test('New Value', function() {
+        checkboxField.setValue('FALSE');
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
+    });
+    suite('Always True Validator', function() {
+      setup(function() {
+        checkboxField.setValidator(function() {
+          return 'TRUE';
+        });
+      });
+      test('New Value', function() {
+        checkboxField.setValue('FALSE');
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
+    });
+    suite('Always False Validator', function() {
+      setup(function() {
+        checkboxField.setValidator(function() {
+          return 'FALSE';
+        });
+      });
+      test('New Value', function() {
+        checkboxField.setValue('TRUE');
+        assertValue(checkboxField, 'FALSE', 'false');
+      });
+    });
+  });
+});

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -89,30 +89,49 @@ suite.skip('Checkbox Fields', function() {
     });
   });
   suite('setValue', function() {
-    test('True -> Null', function() {
-      var checkboxField = new Blockly.FieldCheckbox('TRUE');
-      checkboxField.setValue(null);
-      assertValue(checkboxField, 'TRUE', 'true');
+    suite('True -> New Value', function() {
+      var checkboxField;
+      setup(function() {
+        checkboxField = new Blockly.FieldCheckbox('TRUE');
+      });
+      test('Null', function() {
+        checkboxField.setValue(null);
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
+      test('Undefined', function() {
+        checkboxField.setValue(undefined);
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
+      test('Non-Parsable String', function() {
+        checkboxField.setValue('bad');
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
+      test('False', function() {
+        checkboxField.setValue('FALSE');
+        assertValue(checkboxField, 'FALSE', 'false');
+      });
     });
-    test('True -> Undefined', function() {
-      var checkboxField = new Blockly.FieldCheckbox('TRUE');
-      checkboxField.setValue(undefined);
-      assertValue(checkboxField, 'TRUE', 'true');
-    });
-    test('True -> Non-Parsable String', function() {
-      var checkboxField = new Blockly.FieldCheckbox('TRUE');
-      checkboxField.setValue('bad');
-      assertValue(checkboxField, 'TRUE', 'true');
-    });
-    test('True -> False', function() {
-      var checkboxField = new Blockly.FieldCheckbox('TRUE');
-      checkboxField.setValue('FALSE');
-      assertValue(checkboxField, 'FALSE', 'false');
-    });
-    test('False -> True', function() {
-      var checkboxField = new Blockly.FieldCheckbox('FALSE');
-      checkboxField.setValue('TRUE');
-      assertValue(checkboxField, 'TRUE', 'true');
+    suite('False -> New Value', function() {
+      var checkboxField;
+      setup(function() {
+        checkboxField = new Blockly.FieldCheckbox('FALSE');
+      });
+      test('Null', function() {
+        checkboxField.setValue(null);
+        assertValue(checkboxField, 'FALSE', 'false');
+      });
+      test('Undefined', function() {
+        checkboxField.setValue(undefined);
+        assertValue(checkboxField, 'FALSE', 'false');
+      });
+      test('Non-Parsable String', function() {
+        checkboxField.setValue('bad');
+        assertValue(checkboxField, 'FALSE', 'false');
+      });
+      test('True', function() {
+        checkboxField.setValue('TRUE');
+        assertValue(checkboxField, 'TRUE', 'true');
+      });
     });
   });
   suite('Validators', function() {

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -90,86 +90,83 @@ suite.skip('Checkbox Fields', function() {
   });
   suite('setValue', function() {
     suite('True -> New Value', function() {
-      var checkboxField;
       setup(function() {
-        checkboxField = new Blockly.FieldCheckbox('TRUE');
+        this.checkboxField = new Blockly.FieldCheckbox('TRUE');
       });
       test('Null', function() {
-        checkboxField.setValue(null);
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue(null);
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
       test('Undefined', function() {
-        checkboxField.setValue(undefined);
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue(undefined);
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
       test('Non-Parsable String', function() {
-        checkboxField.setValue('bad');
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue('bad');
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
       test('False', function() {
-        checkboxField.setValue('FALSE');
-        assertValue(checkboxField, 'FALSE', 'false');
+        this.checkboxField.setValue('FALSE');
+        assertValue(this.checkboxField, 'FALSE', 'false');
       });
     });
     suite('False -> New Value', function() {
-      var checkboxField;
       setup(function() {
-        checkboxField = new Blockly.FieldCheckbox('FALSE');
+        this.checkboxField = new Blockly.FieldCheckbox('FALSE');
       });
       test('Null', function() {
-        checkboxField.setValue(null);
-        assertValue(checkboxField, 'FALSE', 'false');
+        this.checkboxField.setValue(null);
+        assertValue(this.checkboxField, 'FALSE', 'false');
       });
       test('Undefined', function() {
-        checkboxField.setValue(undefined);
-        assertValue(checkboxField, 'FALSE', 'false');
+        this.checkboxField.setValue(undefined);
+        assertValue(this.checkboxField, 'FALSE', 'false');
       });
       test('Non-Parsable String', function() {
-        checkboxField.setValue('bad');
-        assertValue(checkboxField, 'FALSE', 'false');
+        this.checkboxField.setValue('bad');
+        assertValue(this.checkboxField, 'FALSE', 'false');
       });
       test('True', function() {
-        checkboxField.setValue('TRUE');
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue('TRUE');
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
     });
   });
   suite('Validators', function() {
-    var checkboxField;
     setup(function() {
-      checkboxField = new Blockly.FieldCheckbox(true);
+      this.checkboxField = new Blockly.FieldCheckbox(true);
     });
     suite('Null Validator', function() {
       setup(function() {
-        checkboxField.setValidator(function() {
+        this.checkboxField.setValidator(function() {
           return null;
         });
       });
       test('New Value', function() {
-        checkboxField.setValue('FALSE');
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue('FALSE');
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
     });
     suite('Always True Validator', function() {
       setup(function() {
-        checkboxField.setValidator(function() {
+        this.checkboxField.setValidator(function() {
           return 'TRUE';
         });
       });
       test('New Value', function() {
-        checkboxField.setValue('FALSE');
-        assertValue(checkboxField, 'TRUE', 'true');
+        this.checkboxField.setValue('FALSE');
+        assertValue(this.checkboxField, 'TRUE', 'true');
       });
     });
     suite('Always False Validator', function() {
       setup(function() {
-        checkboxField.setValidator(function() {
+        this.checkboxField.setValidator(function() {
           return 'FALSE';
         });
       });
       test('New Value', function() {
-        checkboxField.setValue('TRUE');
-        assertValue(checkboxField, 'FALSE', 'false');
+        this.checkboxField.setValue('TRUE');
+        assertValue(this.checkboxField, 'FALSE', 'false');
       });
     });
   });

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -35,15 +35,14 @@ suite ('Colour Fields', function() {
     assertValue(colourField, expectedValue, expectedText);
   }
 
-  var previousColours;
   setup(function() {
-    previousColours = Blockly.FieldColour.COLOURS;
+    this.previousColours = Blockly.FieldColour.COLOURS;
     Blockly.FieldColour.Colours = [
       '#ffffff', '#ff0000', '#00ff00', '#0000ff', '#ffffff'
     ];
   });
   teardown(function() {
-    Blockly.FieldColour.Colours = previousColours;
+    Blockly.FieldColour.Colours = this.previousColours;
   });
   suite('Constructor', function() {
     test('Empty', function() {
@@ -131,83 +130,80 @@ suite ('Colour Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var colourField;
       setup(function() {
-        colourField = new Blockly.FieldColour();
+        this.colourField = new Blockly.FieldColour();
       });
       test.skip('Null', function() {
-        colourField.setValue(null);
-        assertValueDefault(colourField);
+        this.colourField.setValue(null);
+        assertValueDefault(this.colourField);
       });
       test.skip('Undefined', function() {
-        colourField.setValue(undefined);
-        assertValueDefault(colourField);
+        this.colourField.setValue(undefined);
+        assertValueDefault(this.colourField);
       });
       test.skip('Non-Parsable String', function() {
-        colourField.setValue('bad');
-        assertValueDefault(colourField);
+        this.colourField.setValue('bad');
+        assertValueDefault(this.colourField);
       });
       test('#000000', function() {
-        colourField.setValue('#000000');
-        assertValue(colourField, '#000000', '#000');
+        this.colourField.setValue('#000000');
+        assertValue(this.colourField, '#000000', '#000');
       });
       test('#bcbcbc', function() {
-        colourField.setValue('#bcbcbc');
-        assertValue(colourField, '#bcbcbc', '#bcbcbc');
+        this.colourField.setValue('#bcbcbc');
+        assertValue(this.colourField, '#bcbcbc', '#bcbcbc');
       });
     });
     suite('Value -> New Value', function() {
-      var colourField;
       setup(function() {
-        colourField = new Blockly.FieldColour('#aaaaaa');
+        this.colourField = new Blockly.FieldColour('#aaaaaa');
       });
       test.skip('Null', function() {
-        colourField.setValue(null);
-        assertValue(colourField, '#aaaaaa', '#aaa');
+        this.colourField.setValue(null);
+        assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
       test.skip('Undefined', function() {
-        colourField.setValue(undefined);
-        assertValue(colourField, '#aaaaaa', '#aaa');
+        this.colourField.setValue(undefined);
+        assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
       test.skip('Non-Parsable String', function() {
-        colourField.setValue('bad');
-        assertValue(colourField, '#aaaaaa', '#aaa');
+        this.colourField.setValue('bad');
+        assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
       test('#000000', function() {
-        colourField.setValue('#000000');
-        assertValue(colourField, '#000000', '#000');
+        this.colourField.setValue('#000000');
+        assertValue(this.colourField, '#000000', '#000');
       });
       test('#bcbcbc', function() {
-        colourField.setValue('#bcbcbc');
-        assertValue(colourField, '#bcbcbc', '#bcbcbc');
+        this.colourField.setValue('#bcbcbc');
+        assertValue(this.colourField, '#bcbcbc', '#bcbcbc');
       });
     });
   });
   suite.skip('Validators', function() {
-    var colourField;
     setup(function() {
-      colourField = new Blockly.FieldColour('#aaaaaa');
+      this.colourField = new Blockly.FieldColour('#aaaaaa');
     });
     suite('Null Validator', function() {
       setup(function() {
-        colourField.setValidator(function() {
+        this.colourField.setValidator(function() {
           return null;
         });
       });
       test('New Value', function() {
-        colourField.setValue('#000000');
-        assertValue(colourField, '#aaaaaa', '#aaa');
+        this.colourField.setValue('#000000');
+        assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
     });
     suite('Force Full Red Validator', function() {
       setup(function() {
-        colourField.setValidator(function(newValue) {
+        this.colourField.setValidator(function(newValue) {
           return '#ff' + newValue.substr(3, 4);
         });
       });
       test('New Value', function() {
-        colourField.setValue('#000000');
-        assertValue(colourField, '#ff0000', '#f00');
+        this.colourField.setValue('#000000');
+        assertValue(this.colourField, '#ff0000', '#f00');
       });
     });
   });

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -136,15 +136,15 @@ suite ('Colour Fields', function() {
     });
     test.skip('#aaaaaa -> Null', function() {
       colourField.setValue(null);
-      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+      assertValue(colourField, '#aaaaaa', '#aaa');
     });
     test.skip('#aaaaaa -> Undefined', function() {
       colourField.setValue(undefined);
-      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+      assertValue(colourField, '#aaaaaa', '#aaa');
     });
     test.skip('#aaaaaa -> Non-Parsable String', function() {
       colourField.setValue('bad');
-      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+      assertValue(colourField, '#aaaaaa', '#aaa');
     });
     test('#aaaaaa -> #000000', function() {
       colourField.setValue('#000000');

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -130,29 +130,57 @@ suite ('Colour Fields', function() {
     });
   });
   suite('setValue', function() {
-    var colourField;
-    setup(function() {
-      colourField = new Blockly.FieldColour('#aaaaaa');
+    suite('Empty -> New Value', function() {
+      var colourField;
+      setup(function() {
+        colourField = new Blockly.FieldColour();
+      });
+      test.skip('Null', function() {
+        colourField.setValue(null);
+        assertValueDefault(colourField);
+      });
+      test.skip('Undefined', function() {
+        colourField.setValue(undefined);
+        assertValueDefault(colourField);
+      });
+      test.skip('Non-Parsable String', function() {
+        colourField.setValue('bad');
+        assertValueDefault(colourField);
+      });
+      test('#000000', function() {
+        colourField.setValue('#000000');
+        assertValue(colourField, '#000000', '#000');
+      });
+      test('#bcbcbc', function() {
+        colourField.setValue('#bcbcbc');
+        assertValue(colourField, '#bcbcbc', '#bcbcbc');
+      });
     });
-    test.skip('#aaaaaa -> Null', function() {
-      colourField.setValue(null);
-      assertValue(colourField, '#aaaaaa', '#aaa');
-    });
-    test.skip('#aaaaaa -> Undefined', function() {
-      colourField.setValue(undefined);
-      assertValue(colourField, '#aaaaaa', '#aaa');
-    });
-    test.skip('#aaaaaa -> Non-Parsable String', function() {
-      colourField.setValue('bad');
-      assertValue(colourField, '#aaaaaa', '#aaa');
-    });
-    test('#aaaaaa -> #000000', function() {
-      colourField.setValue('#000000');
-      assertValue(colourField, '#000000', '#000');
-    });
-    test('#aaaaaa -> #bcbcbc', function() {
-      colourField.setValue('#bcbcbc');
-      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    suite('Value -> New Value', function() {
+      var colourField;
+      setup(function() {
+        colourField = new Blockly.FieldColour('#aaaaaa');
+      });
+      test.skip('Null', function() {
+        colourField.setValue(null);
+        assertValue(colourField, '#aaaaaa', '#aaa');
+      });
+      test.skip('Undefined', function() {
+        colourField.setValue(undefined);
+        assertValue(colourField, '#aaaaaa', '#aaa');
+      });
+      test.skip('Non-Parsable String', function() {
+        colourField.setValue('bad');
+        assertValue(colourField, '#aaaaaa', '#aaa');
+      });
+      test('#000000', function() {
+        colourField.setValue('#000000');
+        assertValue(colourField, '#000000', '#000');
+      });
+      test('#bcbcbc', function() {
+        colourField.setValue('#bcbcbc');
+        assertValue(colourField, '#bcbcbc', '#bcbcbc');
+      });
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Colour Fields', function() {
+  function assertValue(colourField, expectedValue, expectedText) {
+    var actualValue = colourField.getValue();
+    var actualText = colourField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedText);
+  }
+  function assertValueDefault(colourField) {
+    var expectedValue = Blockly.FieldColour.COLOURS[0];
+    var expectedText = expectedValue;
+    var m = expectedValue.match(/^#(.)\1(.)\2(.)\3$/);
+    if (m) {
+      expectedText = '#' + m[1] + m[2] + m[3];
+    }
+    assertValue(colourField, expectedValue, expectedText);
+  }
+
+  var previousColours;
+  setup(function() {
+    previousColours = Blockly.FieldColour.COLOURS;
+    Blockly.FieldColour.Colours = [
+      '#ffffff', '#ff0000', '#00ff00', '#0000ff', '#ffffff'
+    ];
+  });
+  teardown(function() {
+    Blockly.FieldColour.Colours = previousColours;
+  });
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var colourField = new Blockly.FieldColour();
+      assertValueDefault(colourField);
+    });
+    test('Null', function() {
+      var colourField = new Blockly.FieldColour(null);
+      assertValueDefault(colourField);
+    });
+    test('Undefined', function() {
+      var colourField = new Blockly.FieldColour(undefined);
+      assertValueDefault(colourField);
+    });
+    test.skip('Non-Parsable String', function() {
+      var colourField = new Blockly.FieldColour('bad');
+      assertValueDefault(colourField);
+    });
+    test.skip('#AAAAAA', function() {
+      var colourField = new Blockly.FieldColour('#AAAAAA');
+      assertValue(colourField, '#aaaaaa', '#aaa');
+    });
+    test('#aaaaaa', function() {
+      var colourField = new Blockly.FieldColour('#aaaaaa');
+      assertValue(colourField, '#aaaaaa', '#aaa');
+    });
+    test.skip('#AAAA00', function() {
+      var colourField = new Blockly.FieldColour('#AAAA00');
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('#aaaa00', function() {
+      var colourField = new Blockly.FieldColour('#aaaa00');
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test.skip('#BCBCBC', function() {
+      var colourField = new Blockly.FieldColour('#BCBCBC');
+      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    });
+    test('#bcbcbc', function() {
+      var colourField = new Blockly.FieldColour('#bcbcbc');
+      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var colourField = new Blockly.FieldColour.fromJson({});
+      assertValueDefault(colourField);
+    });
+    test('Null', function() {
+      var colourField = new Blockly.FieldColour.fromJson({ colour:null });
+      assertValueDefault(colourField);
+    });
+    test('Undefined', function() {
+      var colourField = new Blockly.FieldColour.fromJson({ colour:undefined });
+      assertValueDefault(colourField);
+    });
+    test.skip('Non-Parsable String', function() {
+      var colourField = new Blockly.FieldColour.fromJson({ colour:'bad' });
+      assertValueDefault(colourField);
+    });
+    test.skip('#AAAAAA', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#AAAAAA' });
+      assertValue(colourField, '#aaaaaa', '#aaa');
+    });
+    test('#aaaaaa', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#aaaaaa' });
+      assertValue(colourField, '#aaaaaa', '#aaa');
+    });
+    test.skip('#AAAA00', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#AAAA00' });
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('#aaaa00', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#aaaa00' });
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test.skip('#BCBCBC', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#BCBCBC' });
+      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    });
+    test('#bcbcbc', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#bcbcbc' });
+      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    });
+  });
+  suite('setValue', function() {
+    var colourField;
+    setup(function() {
+      colourField = new Blockly.FieldColour('#aaaaaa');
+    });
+    test.skip('#aaaaaa -> Null', function() {
+      colourField.setValue(null);
+      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+    });
+    test.skip('#aaaaaa -> Undefined', function() {
+      colourField.setValue(undefined);
+      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+    });
+    test.skip('#aaaaaa -> Non-Parsable String', function() {
+      colourField.setValue('bad');
+      assertValue(colourField, '#aaaaaa', '#aaaaaa');
+    });
+    test('#aaaaaa -> #000000', function() {
+      colourField.setValue('#000000');
+      assertValue(colourField, '#000000', '#000');
+    });
+    test('#aaaaaa -> #bcbcbc', function() {
+      colourField.setValue('#bcbcbc');
+      assertValue(colourField, '#bcbcbc', '#bcbcbc');
+    });
+  });
+  suite.skip('Validators', function() {
+    var colourField;
+    setup(function() {
+      colourField = new Blockly.FieldColour('#aaaaaa');
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        colourField.setValidator(function() {
+          return null;
+        });
+      });
+      test('New Value', function() {
+        colourField.setValue('#000000');
+        assertValue(colourField, '#aaaaaa', '#aaa');
+      });
+    });
+    suite('Force Full Red Validator', function() {
+      setup(function() {
+        colourField.setValidator(function(newValue) {
+          return '#ff' + newValue.substr(3, 4);
+        });
+      });
+      test('New Value', function() {
+        colourField.setValue('#000000');
+        assertValue(colourField, '#ff0000', '#f00');
+      });
+    });
+  });
+});

--- a/tests/mocha/field_date_test.js
+++ b/tests/mocha/field_date_test.js
@@ -91,91 +91,88 @@ suite ('Date Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var dateField;
       setup(function() {
-        dateField = new Blockly.FieldDate();
+        this.dateField = new Blockly.FieldDate();
       });
       test.skip('Null', function() {
-        dateField.setValue(null);
-        assertValueDefault(dateField);
+        this.dateField.setValue(null);
+        assertValueDefault(this.dateField);
       });
       test.skip('Undefined', function() {
-        dateField.setValue(undefined);
-        assertValueDefault(dateField);
+        this.dateField.setValue(undefined);
+        assertValueDefault(this.dateField);
       });
       test.skip('Non-Parsable String', function() {
-        dateField.setValue('bad');
-        assertValueDefault(dateField);
+        this.dateField.setValue('bad');
+        assertValueDefault(this.dateField);
       });
       test.skip('Invalid Date - Month(2020-13-20)', function() {
-        dateField.setValue('2020-13-20');
-        assertValueDefault(dateField);
+        this.dateField.setValue('2020-13-20');
+        assertValueDefault(this.dateField);
       });
       test.skip('Invalid Date - Day(2020-02-32)', function() {
-        dateField.setValue('2020-02-32');
-        assertValueDefault(dateField);
+        this.dateField.setValue('2020-02-32');
+        assertValueDefault(this.dateField);
       });
       test('3030-03-30', function() {
-        dateField.setValue('3030-03-30');
-        assertValue(dateField, '3030-03-30');
+        this.dateField.setValue('3030-03-30');
+        assertValue(this.dateField, '3030-03-30');
       });
     });
     suite('Value -> New Value', function() {
-      var dateField;
       setup(function() {
-        dateField = new Blockly.FieldDate('2020-02-20');
+        this.dateField = new Blockly.FieldDate('2020-02-20');
       });
       test.skip('Null', function() {
-        dateField.setValue(null);
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue(null);
+        assertValue(this.dateField, '2020-02-20');
       });
       test.skip('Undefined', function() {
-        dateField.setValue(undefined);
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue(undefined);
+        assertValue(this.dateField, '2020-02-20');
       });
       test.skip('Non-Parsable String', function() {
-        dateField.setValue('bad');
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue('bad');
+        assertValue(this.dateField, '2020-02-20');
       });
       test.skip('Invalid Date - Month(2020-13-20)', function() {
-        dateField.setValue('2020-13-20');
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue('2020-13-20');
+        assertValue(this.dateField, '2020-02-20');
       });
       test.skip('Invalid Date - Day(2020-02-32)', function() {
-        dateField.setValue('2020-02-32');
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue('2020-02-32');
+        assertValue(this.dateField, '2020-02-20');
       });
       test('3030-03-30', function() {
-        dateField.setValue('3030-03-30');
-        assertValue(dateField, '3030-03-30');
+        this.dateField.setValue('3030-03-30');
+        assertValue(this.dateField, '3030-03-30');
       });
     });
   });
   suite.skip('Validators', function() {
-    var dateField;
     setup(function() {
-      dateField = new Blockly.FieldDate('2020-02-20');
+      this.dateField = new Blockly.FieldDate('2020-02-20');
     });
     suite('Null Validator', function() {
       setup(function() {
-        dateField.setValidator(function() {
+        this.dateField.setValidator(function() {
           return null;
         });
       });
       test('New Value', function() {
-        dateField.setValue('3030-03-30');
-        assertValue(dateField, '2020-02-20');
+        this.dateField.setValue('3030-03-30');
+        assertValue(this.dateField, '2020-02-20');
       });
     });
     suite('Force Day 20s Validator', function() {
       setup(function() {
-        dateField.setValidator(function(newValue) {
+        this.dateField.setValidator(function(newValue) {
           return newValue.substr(0, 8) + '2' + newValue.substr(9, 1);
         });
       });
       test('New Value', function() {
-        dateField.setValue('3030-03-30');
-        assertValue(dateField, '3030-03-20');
+        this.dateField.setValue('3030-03-30');
+        assertValue(this.dateField, '3030-03-20');
       });
     });
   });

--- a/tests/mocha/field_date_test.js
+++ b/tests/mocha/field_date_test.js
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Date Fields', function() {
+  function assertValue(dateField, expectedValue) {
+    var actualValue = dateField.getValue();
+    var actualText = dateField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedValue);
+  }
+  function assertValueDefault(dateField) {
+    var today = new goog.date.Date().toIsoString(true);
+    assertValue(dateField, today);
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var dateField = new Blockly.FieldDate();
+      assertValueDefault(dateField);
+    });
+    test('Null', function() {
+      var dateField = new Blockly.FieldDate(null);
+      assertValueDefault(dateField);
+    });
+    test('Undefined', function() {
+      var dateField = new Blockly.FieldDate(undefined);
+      assertValueDefault(dateField);
+    });
+    test.skip('Non-Parsable String', function() {
+      var dateField = new Blockly.FieldDate('bad');
+      assertValueDefault(dateField);
+    });
+    test('2020-02-20', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      assertValue(dateField, '2020-02-20');
+    });
+    test.skip('Invalid Date - Month(2020-13-20)', function() {
+      var dateField = new Blockly.FieldDate('2020-13-20');
+      assertValueDefault(dateField);
+    });
+    test.skip('Invalid Date - Day(2020-02-32)', function() {
+      var dateField = new Blockly.FieldDate('2020-02-32');
+      assertValueDefault(dateField);
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var dateField = Blockly.FieldDate.fromJson({});
+      assertValueDefault(dateField);
+    });
+    test('Null', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: null });
+      assertValueDefault(dateField);
+    });
+    test('Undefined', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: undefined });
+      assertValueDefault(dateField);
+    });
+    test.skip('Non-Parsable String', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: 'bad' });
+      assertValueDefault(dateField);
+    });
+    test('2020-02-20', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: '2020-02-20' });
+      assertValue(dateField, '2020-02-20');
+    });
+    test.skip('Invalid Date - Month(2020-13-20)', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: '2020-13-20' });
+      assertValueDefault(dateField);
+    });
+    test.skip('Invalid Date - Day(2020-02-32)', function() {
+      var dateField = Blockly.FieldDate.fromJson({ date: '2020-02-32' });
+      assertValueDefault(dateField);
+    });
+  });
+  suite('setValue', function() {
+    test.skip('Empty -> Null', function() {
+      var dateField = new Blockly.FieldDate();
+      dateField.setValue(null);
+      assertValueDefault(dateField);
+    });
+    test.skip('Value -> Null', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue(null);
+      assertValue(dateField, '2020-02-20');
+    });
+    test.skip('Empty -> Undefined', function() {
+      var dateField = new Blockly.FieldDate();
+      dateField.setValue(undefined);
+      assertValueDefault(dateField);
+    });
+    test.skip('Value -> Undefined', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue(undefined);
+      assertValue(dateField, '2020-02-20');
+    });
+    test.skip('Empty -> Non-Parsable String', function() {
+      var dateField = new Blockly.FieldDate();
+      dateField.setValue('bad');
+      assertValueDefault(dateField);
+    });
+    test.skip('Value -> Non-Parsable String', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue('bad');
+      assertValue(dateField, '2020-02-20');
+    });
+    test('2020-02-20 -> 3030-03-30', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue('3030-03-30');
+      assertValue(dateField, '3030-03-30');
+    });
+    test.skip('2020-02-20 -> Invalid Date - Month(2020-13-20)', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue('2020-13-20');
+      assertValue(dateField, '2020-02-20');
+    });
+    test.skip('2020-02-20 -> Invalid Date - Day(2020-02-32)', function() {
+      var dateField = new Blockly.FieldDate('2020-02-20');
+      dateField.setValue('2020-02-32');
+      assertValue(dateField, '2020-02-20');
+    });
+  });
+  suite.skip('Validators', function() {
+    var dateField;
+    setup(function() {
+      dateField = new Blockly.FieldDate('2020-02-20');
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        dateField.setValidator(function() {
+          return null;
+        });
+      });
+      test('New Value', function() {
+        dateField.setValue('3030-03-30');
+        assertValue(dateField, '2020-02-20');
+      });
+    });
+    suite('Force Day 20s Validator', function() {
+      setup(function() {
+        dateField.setValidator(function(newValue) {
+          return newValue.substr(0, 8) + '2' + newValue.substr(9, 1);
+        });
+      });
+      test('New Value', function() {
+        dateField.setValue('3030-03-30');
+        assertValue(dateField, '3030-03-20');
+      });
+    });
+  });
+});

--- a/tests/mocha/field_date_test.js
+++ b/tests/mocha/field_date_test.js
@@ -90,50 +90,65 @@ suite ('Date Fields', function() {
     });
   });
   suite('setValue', function() {
-    test.skip('Empty -> Null', function() {
-      var dateField = new Blockly.FieldDate();
-      dateField.setValue(null);
-      assertValueDefault(dateField);
+    suite('Empty -> New Value', function() {
+      var dateField;
+      setup(function() {
+        dateField = new Blockly.FieldDate();
+      });
+      test.skip('Null', function() {
+        dateField.setValue(null);
+        assertValueDefault(dateField);
+      });
+      test.skip('Undefined', function() {
+        dateField.setValue(undefined);
+        assertValueDefault(dateField);
+      });
+      test.skip('Non-Parsable String', function() {
+        dateField.setValue('bad');
+        assertValueDefault(dateField);
+      });
+      test.skip('Invalid Date - Month(2020-13-20)', function() {
+        dateField.setValue('2020-13-20');
+        assertValueDefault(dateField);
+      });
+      test.skip('Invalid Date - Day(2020-02-32)', function() {
+        dateField.setValue('2020-02-32');
+        assertValueDefault(dateField);
+      });
+      test('3030-03-30', function() {
+        dateField.setValue('3030-03-30');
+        assertValue(dateField, '3030-03-30');
+      });
     });
-    test.skip('Value -> Null', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue(null);
-      assertValue(dateField, '2020-02-20');
-    });
-    test.skip('Empty -> Undefined', function() {
-      var dateField = new Blockly.FieldDate();
-      dateField.setValue(undefined);
-      assertValueDefault(dateField);
-    });
-    test.skip('Value -> Undefined', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue(undefined);
-      assertValue(dateField, '2020-02-20');
-    });
-    test.skip('Empty -> Non-Parsable String', function() {
-      var dateField = new Blockly.FieldDate();
-      dateField.setValue('bad');
-      assertValueDefault(dateField);
-    });
-    test.skip('Value -> Non-Parsable String', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue('bad');
-      assertValue(dateField, '2020-02-20');
-    });
-    test('2020-02-20 -> 3030-03-30', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue('3030-03-30');
-      assertValue(dateField, '3030-03-30');
-    });
-    test.skip('2020-02-20 -> Invalid Date - Month(2020-13-20)', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue('2020-13-20');
-      assertValue(dateField, '2020-02-20');
-    });
-    test.skip('2020-02-20 -> Invalid Date - Day(2020-02-32)', function() {
-      var dateField = new Blockly.FieldDate('2020-02-20');
-      dateField.setValue('2020-02-32');
-      assertValue(dateField, '2020-02-20');
+    suite('Value -> New Value', function() {
+      var dateField;
+      setup(function() {
+        dateField = new Blockly.FieldDate('2020-02-20');
+      });
+      test.skip('Null', function() {
+        dateField.setValue(null);
+        assertValue(dateField, '2020-02-20');
+      });
+      test.skip('Undefined', function() {
+        dateField.setValue(undefined);
+        assertValue(dateField, '2020-02-20');
+      });
+      test.skip('Non-Parsable String', function() {
+        dateField.setValue('bad');
+        assertValue(dateField, '2020-02-20');
+      });
+      test.skip('Invalid Date - Month(2020-13-20)', function() {
+        dateField.setValue('2020-13-20');
+        assertValue(dateField, '2020-02-20');
+      });
+      test.skip('Invalid Date - Day(2020-02-32)', function() {
+        dateField.setValue('2020-02-32');
+        assertValue(dateField, '2020-02-20');
+      });
+      test('3030-03-30', function() {
+        dateField.setValue('3030-03-30');
+        assertValue(dateField, '3030-03-30');
+      });
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -140,55 +140,53 @@ suite ('Dropdown Fields', function() {
     });
   });
   suite('setValue', function() {
-    var dropdownField;
     setup(function() {
-      dropdownField = new Blockly.FieldDropdown(
+      this.dropdownField = new Blockly.FieldDropdown(
           [['a', 'A'], ['b', 'B'], ['c', 'C']]);
     });
     test('Null', function() {
-      dropdownField.setValue(null);
-      assertValue(dropdownField, 'A', 'a');
+      this.dropdownField.setValue(null);
+      assertValue(this.dropdownField, 'A', 'a');
     });
     test.skip('Undefined', function() {
-      dropdownField.setValue(undefined);
-      assertValue(dropdownField, 'A', 'a');
+      this.dropdownField.setValue(undefined);
+      assertValue(this.dropdownField, 'A', 'a');
     });
     test.skip('Invalid ID', function() {
-      dropdownField.setValue('bad');
-      assertValue(dropdownField, 'A', 'a');
+      this.dropdownField.setValue('bad');
+      assertValue(this.dropdownField, 'A', 'a');
     });
     test('Valid ID', function() {
-      dropdownField.setValue('B');
-      assertValue(dropdownField, 'B', 'b');
+      this.dropdownField.setValue('B');
+      assertValue(this.dropdownField, 'B', 'b');
     });
   });
   suite.skip('Validators', function() {
-    var dropdownField;
     setup(function() {
-      dropdownField = new Blockly.FieldDropdown([
+      this.dropdownField = new Blockly.FieldDropdown([
         ["1a","1A"], ["1b","1B"], ["1c","1C"],
         ["2a","2A"], ["2b","2B"], ["2c","2C"]]);
     });
     suite('Null Validator', function() {
       setup(function() {
-        dropdownField.setValidator(function() {
+        this.dropdownField.setValidator(function() {
           return null;
         });
       });
       test('New Value', function() {
-        dropdownField.setValue('1B');
-        assertValue(dropdownField, '1A', '1a');
+        this.dropdownField.setValue('1B');
+        assertValue(this.dropdownField, '1A', '1a');
       });
     });
     suite('Force 1s Validator', function() {
       setup(function() {
-        dropdownField.setValidator(function(newValue) {
+        this.dropdownField.setValidator(function(newValue) {
           return '1' + newValue.charAt(1);
         });
       });
       test('New Value', function() {
-        dropdownField.setValue('2B');
-        assertValue(dropdownField, '1B', '1b');
+        this.dropdownField.setValue('2B');
+        assertValue(this.dropdownField, '1B', '1b');
       });
     });
   });

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Dropdown Fields', function() {
+  function assertValue(dropdownField, expectedValue, expectedText) {
+    var actualValue = dropdownField.getValue();
+    var actualText = dropdownField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedText);
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown();
+      });
+    });
+    test('Null', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown(null);
+      });
+    });
+    test('Undefined', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown(undefined);
+      });
+    });
+    test('Array Items not Arrays', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown([1, 2, 3]);
+      });
+    });
+    test('Array Items with Invalid IDs', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown([['1', 1], ['2', 2], ['3', 3]]);
+      });
+    });
+    test('Array Items with Invalid Content', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        new Blockly.FieldDropdown([[1, '1'], [2, '2'], [3, '3']]);
+      });
+    });
+    test('Text Dropdown', function() {
+      var dropdownField = new Blockly.FieldDropdown(
+          [['a', 'A'], ['b', 'B'], ['c', 'C']]);
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test('Image Dropdown', function() {
+      var dropdownField = new Blockly.FieldDropdown([
+        [{ src:'scrA', alt:'a' }, 'A'],
+        [{ src:'scrB', alt:'b' }, 'B'],
+        [{ src:'scrC', alt:'c' }, 'C']]);
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test('Dynamic Dropdown Text', function() {
+      var dynamicDropdownFunc = function() {
+        return [['a', 'A'], ['b', 'B'], ['c', 'C']];
+      };
+      var dropdownField = new Blockly.FieldDropdown(dynamicDropdownFunc);
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test('Dynamic Dropdown Image', function() {
+      var dynamicDropdownFunc = function() {
+        return [
+          [{ src:'scrA', alt:'a' }, 'A'],
+          [{ src:'scrB', alt:'b' }, 'B'],
+          [{ src:'scrC', alt:'c' }, 'C']
+        ];
+      };
+      var dropdownField = new Blockly.FieldDropdown(dynamicDropdownFunc);
+      assertValue(dropdownField, 'A', 'a');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson({});
+      });
+    });
+    test('Null', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson({ options: null });
+      });
+    });
+    test('Undefined', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson({ options: undefined });
+      });
+    });
+    test('Array Items not Arrays', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson({ options: [1, 2, 3] });
+      });
+    });
+    test('Array Items with Invalid IDs', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson(
+            { options:[['1', 1], ['2', 2], ['3', 3]] });
+      });
+    });
+    test('Array Items with Invalid Content', function() {
+      console.log('You should see three console warnings after this message.');
+      chai.assert.throws(function() {
+        Blockly.FieldDropdown.fromJson(
+            { options:[[1, '1'], [2, '2'], [3, '3']] });
+      });
+    });
+    test('Text Dropdown', function() {
+      var dropdownField = Blockly.FieldDropdown.fromJson(
+          { options:[['a', 'A'], ['b', 'B'], ['c', 'C']] });
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test('Image Dropdown', function() {
+      var dropdownField = Blockly.FieldDropdown.fromJson({ options:[
+        [{ src:'scrA', alt:'a' }, 'A'],
+        [{ src:'scrB', alt:'b' }, 'B'],
+        [{ src:'scrC', alt:'c' }, 'C']] });
+      assertValue(dropdownField, 'A', 'a');
+    });
+  });
+  suite('setValue', function() {
+    var dropdownField;
+    setup(function() {
+      dropdownField = new Blockly.FieldDropdown(
+          [['a', 'A'], ['b', 'B'], ['c', 'C']]);
+    });
+    test('Null', function() {
+      dropdownField.setValue(null);
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test.skip('Undefined', function() {
+      dropdownField.setValue(undefined);
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test.skip('Invalid ID', function() {
+      dropdownField.setValue('bad');
+      assertValue(dropdownField, 'A', 'a');
+    });
+    test('Valid ID', function() {
+      dropdownField.setValue('B');
+      assertValue(dropdownField, 'B', 'b');
+    });
+  });
+  suite.skip('Validators', function() {
+    var dropdownField;
+    setup(function() {
+      dropdownField = new Blockly.FieldDropdown([
+        ["1a","1A"], ["1b","1B"], ["1c","1C"],
+        ["2a","2A"], ["2b","2B"], ["2c","2C"]]);
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        dropdownField.setValidator(function() {
+          return null;
+        });
+      });
+      test('New Value', function() {
+        dropdownField.setValue('1B');
+        assertValue(dropdownField, '1A', '1a');
+      });
+    });
+    suite('Force 1s Validator', function() {
+      setup(function() {
+        dropdownField.setValidator(function(newValue) {
+          return '1' + newValue.charAt(1);
+        });
+      });
+      test('New Value', function() {
+        dropdownField.setValue('2B');
+        assertValue(dropdownField, '1B', '1b');
+      });
+    });
+  });
+});

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Image Fields', function() {
+  function assertValue(imageField, expectedValue, expectedText) {
+    var actualValue = imageField.getValue();
+    var actualText = imageField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedText);
+  }
+  function assertValueDefault(imageField) {
+    assertValue(imageField, '', '');
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldImage();
+      });
+    });
+    test('Null Src', function() {
+      var imageField = new Blockly.FieldImage(null, 1, 1);
+      assertValueDefault(imageField);
+    });
+    test('Undefined Src', function() {
+      var imageField = new Blockly.FieldImage(undefined, 1, 1);
+      assertValueDefault(imageField);
+    });
+    test('Null Size', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldImage('src', null, null);
+      });
+    });
+    test('Undefined Size', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldImage('src', undefined, undefined);
+      });
+    });
+    test('Zero Size', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldImage('src', 0, 0);
+      });
+    });
+    test('Non-Parsable String for Size', function() {
+      chai.assert.throws(function() {
+        new Blockly.FieldImage('src', 'bad', 'bad');
+      });
+    });
+    // Note: passing invalid an src path doesn't need to throw errors
+    // because the developer can see they did it incorrectly when they view
+    // the block.
+    test('With Alt', function() {
+      var imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+      assertValue(imageField, 'src', 'alt');
+    });
+    test('Without Alt', function() {
+      var imageField = new Blockly.FieldImage('src', 1, 1);
+      assertValue(imageField, 'src', '');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldImage.fromJson({});
+      });
+    });
+    test('Null Src', function() {
+      var imageField = Blockly.FieldImage.fromJson({
+        src: null,
+        width: 1,
+        height: 1
+      });
+      assertValueDefault(imageField);
+    });
+    test('Undefined Src', function() {
+      var imageField = Blockly.FieldImage.fromJson({
+        src: undefined,
+        width: 1,
+        height: 1
+      });
+      assertValueDefault(imageField);
+    });
+    test('Null Size', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: null,
+          height: null
+        });
+      });
+    });
+    test('Undefined Size', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: undefined,
+          height: undefined
+        });
+      });
+    });
+    test('Non-Parsable String for Size', function() {
+      chai.assert.throws(function() {
+        Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: 'bad',
+          height: 'bad'
+        });
+      });
+    });
+    test('With Alt', function() {
+      var imageField = Blockly.FieldImage.fromJson({
+        src: 'src',
+        width: 1,
+        height: 1,
+        alt: 'alt'
+      });
+      assertValue(imageField, 'src', 'alt');
+    });
+    test('Without Alt', function() {
+      var imageField = Blockly.FieldImage.fromJson({
+        src: 'src',
+        width: 1,
+        height: 1
+      });
+      assertValue(imageField, 'src', '');
+    });
+  });
+  suite('setValue', function() {
+    var imageField;
+    setup(function() {
+      imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+    });
+    test('Null', function() {
+      imageField.setValue(null);
+      assertValue(imageField, 'src', 'alt');
+    });
+    test.skip('Undefined', function() {
+      imageField.setValue(undefined);
+      assertValue(imageField, 'src', 'alt');
+    });
+    test('New Src, New Alt', function() {
+      imageField.setValue('newSrc');
+      assertValue(imageField, 'newSrc', 'alt');
+      imageField.setText('newAlt');
+      assertValue(imageField, 'newSrc', 'newAlt');
+    });
+    test('New Alt, New Src', function() {
+      imageField.setText('newAlt');
+      assertValue(imageField, 'src', 'newAlt');
+      imageField.setValue('newSrc');
+      assertValue(imageField, 'newSrc', 'newAlt');
+    });
+  });
+});

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -142,29 +142,28 @@ suite ('Image Fields', function() {
     });
   });
   suite('setValue', function() {
-    var imageField;
     setup(function() {
-      imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+      this.imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
     });
     test('Null', function() {
-      imageField.setValue(null);
-      assertValue(imageField, 'src', 'alt');
+      this.imageField.setValue(null);
+      assertValue(this.imageField, 'src', 'alt');
     });
     test.skip('Undefined', function() {
-      imageField.setValue(undefined);
-      assertValue(imageField, 'src', 'alt');
+      this.imageField.setValue(undefined);
+      assertValue(this.imageField, 'src', 'alt');
     });
     test('New Src, New Alt', function() {
-      imageField.setValue('newSrc');
-      assertValue(imageField, 'newSrc', 'alt');
-      imageField.setText('newAlt');
-      assertValue(imageField, 'newSrc', 'newAlt');
+      this.imageField.setValue('newSrc');
+      assertValue(this.imageField, 'newSrc', 'alt');
+      this.imageField.setText('newAlt');
+      assertValue(this.imageField, 'newSrc', 'newAlt');
     });
     test('New Alt, New Src', function() {
-      imageField.setText('newAlt');
-      assertValue(imageField, 'src', 'newAlt');
-      imageField.setValue('newSrc');
-      assertValue(imageField, 'newSrc', 'newAlt');
+      this.imageField.setText('newAlt');
+      assertValue(this.imageField, 'src', 'newAlt');
+      this.imageField.setValue('newSrc');
+      assertValue(this.imageField, 'newSrc', 'newAlt');
     });
   });
 });

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -101,71 +101,69 @@ suite ('Label Serializable Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var labelField;
       setup(function() {
-        labelField = new Blockly.FieldLabelSerializable();
+        this.labelField = new Blockly.FieldLabelSerializable();
       });
       test('Null', function() {
-        labelField.setValue(null);
-        assertValueDefault(labelField);
+        this.labelField.setValue(null);
+        assertValueDefault(this.labelField);
       });
       test.skip('Undefined', function() {
-        labelField.setValue(undefined);
-        assertValueDefault(labelField);
+        this.labelField.setValue(undefined);
+        assertValueDefault(this.labelField);
       });
       test('New String', function() {
-        labelField.setValue('newValue');
-        assertValue(labelField, 'newValue');
+        this.labelField.setValue('newValue');
+        assertValue(this.labelField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        labelField.setValue(1);
-        assertValue(labelField, '1');
+        this.labelField.setValue(1);
+        assertValue(this.labelField, '1');
       });
       test.skip('Number (Falsy)', function() {
-        labelField.setValue(0);
-        assertValue(labelField, '0');
+        this.labelField.setValue(0);
+        assertValue(this.labelField, '0');
       });
       test('Boolean True', function() {
-        labelField.setValue(true);
-        assertValue(labelField, 'true');
+        this.labelField.setValue(true);
+        assertValue(this.labelField, 'true');
       });
       test.skip('Boolean False', function() {
-        labelField.setValue(false);
-        assertValue(labelField, 'false');
+        this.labelField.setValue(false);
+        assertValue(this.labelField, 'false');
       });
     });
     suite('Value -> New Value', function() {
-      var labelField;
       setup(function() {
-        labelField = new Blockly.FieldLabelSerializable('value');
+        this.labelField = new Blockly.FieldLabelSerializable('value');
       });
       test('Null', function() {
-        labelField.setValue(null);
-        assertValue(labelField, 'value');
+        this.labelField.setValue(null);
+        assertValue(this.labelField, 'value');
       });
       test.skip('Undefined', function() {
-        labelField.setValue(undefined);
-        assertValue(labelField, 'value');
+        this.labelField.setValue(undefined);
+        assertValue(this.labelField, 'value');
       });
       test('New String', function() {
-        labelField.setValue('newValue');
-        assertValue(labelField, 'newValue');
+        this.labelField.setValue('newValue');
+        assertValue(this.labelField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        labelField.setValue(1);
-        assertValue(labelField, '1');
+        this.labelField.setValue(1);
+        assertValue(this.labelField, '1');
       });
       test('Number (Falsy)', function() {
-        labelField.setValue(0);
-        assertValue(labelField, '0');
+        this.labelField.setValue(0);
+        assertValue(this.labelField, '0');
       });
       test('Boolean True', function() {
-        labelField.setValue(true);
-        assertValue(labelField, 'true');
+        this.labelField.setValue(true);
+        assertValue(this.labelField, 'true');
       });
       test('Boolean False', function() {
-        labelField.setValue(false);
-        assertValue(labelField, 'false');
+        this.labelField.setValue(false);
+        assertValue(this.labelField, 'false');
       });
     });
   });

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Label Serializable Fields', function() {
+  function assertValue(labelField, expectedValue) {
+    var actualValue = labelField.getValue();
+    var actualText = labelField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedValue);
+  }
+  function assertValueDefault(labelField) {
+    assertValue(labelField, '');
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var labelField = new Blockly.FieldLabelSerializable();
+      assertValueDefault(labelField);
+    });
+    test('Null', function() {
+      var labelField = new Blockly.FieldLabelSerializable(null);
+      assertValueDefault(labelField);
+    });
+    test('Undefined', function() {
+      var labelField = new Blockly.FieldLabelSerializable(undefined);
+      assertValueDefault(labelField);
+    });
+    test('String', function() {
+      var labelField = new Blockly.FieldLabelSerializable('value');
+      assertValue(labelField, 'value');
+    });
+    test('Number', function() {
+      var labelField = new Blockly.FieldLabelSerializable(1);
+      assertValue(labelField, '1');
+    });
+    test('Boolean', function() {
+      var labelField = new Blockly.FieldLabelSerializable(true);
+      assertValue(labelField, 'true');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var labelField = new Blockly.FieldLabelSerializable.fromJson({});
+      assertValueDefault(labelField);
+    });
+    test('Null', function() {
+      var labelField = new Blockly.FieldLabelSerializable
+          .fromJson({ text:null });
+      assertValueDefault(labelField);
+    });
+    test('Undefined', function() {
+      var labelField = new Blockly.FieldLabelSerializable
+          .fromJson({ text:undefined });
+      assertValueDefault(labelField);
+    });
+    test('String', function() {
+      var labelField = Blockly.FieldLabelSerializable
+          .fromJson({ text:'value' });
+      assertValue(labelField, 'value');
+    });
+    test('Number', function() {
+      var labelField = Blockly.FieldLabelSerializable.fromJson({ text:1 });
+      assertValue(labelField, '1');
+    });
+    test('Boolean', function() {
+      var labelField = Blockly.FieldLabelSerializable.fromJson({ text:true });
+      assertValue(labelField, 'true');
+    });
+  });
+  suite('setValue', function() {
+    var labelField;
+    setup(function() {
+      labelField = new Blockly.FieldLabelSerializable('value');
+    });
+    test('Null', function() {
+      labelField.setValue(null);
+      assertValue(labelField, 'value');
+    });
+    test.skip('Undefined', function() {
+      labelField.setValue(undefined);
+      assertValue(labelField, 'value');
+    });
+    test('New String', function() {
+      labelField.setValue('newValue');
+      assertValue(labelField, 'newValue');
+    });
+  });
+});

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -45,13 +45,21 @@ suite ('Label Serializable Fields', function() {
       var labelField = new Blockly.FieldLabelSerializable('value');
       assertValue(labelField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var labelField = new Blockly.FieldLabelSerializable(1);
       assertValue(labelField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var labelField = new Blockly.FieldLabelSerializable(0);
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
       var labelField = new Blockly.FieldLabelSerializable(true);
       assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      var labelField = new Blockly.FieldLabelSerializable(false);
+      assertValue(labelField, 'false');
     });
   });
   suite('fromJson', function() {
@@ -74,13 +82,21 @@ suite ('Label Serializable Fields', function() {
           .fromJson({ text:'value' });
       assertValue(labelField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var labelField = Blockly.FieldLabelSerializable.fromJson({ text:1 });
       assertValue(labelField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var labelField = Blockly.FieldLabelSerializable.fromJson({ text:0 });
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
       var labelField = Blockly.FieldLabelSerializable.fromJson({ text:true });
       assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      var labelField = Blockly.FieldLabelSerializable.fromJson({ text:false });
+      assertValue(labelField, 'false');
     });
   });
   suite('setValue', function() {
@@ -99,6 +115,22 @@ suite ('Label Serializable Fields', function() {
     test('New String', function() {
       labelField.setValue('newValue');
       assertValue(labelField, 'newValue');
+    });
+    test('Number (Truthy)', function() {
+      labelField.setValue(1);
+      assertValue(labelField, '1');
+    });
+    test('Number (Falsy)', function() {
+      labelField.setValue(0);
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
+      labelField.setValue(true);
+      assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      labelField.setValue(false);
+      assertValue(labelField, 'false');
     });
   });
 });

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -100,37 +100,73 @@ suite ('Label Serializable Fields', function() {
     });
   });
   suite('setValue', function() {
-    var labelField;
-    setup(function() {
-      labelField = new Blockly.FieldLabelSerializable('value');
+    suite('Empty -> New Value', function() {
+      var labelField;
+      setup(function() {
+        labelField = new Blockly.FieldLabelSerializable();
+      });
+      test('Null', function() {
+        labelField.setValue(null);
+        assertValueDefault(labelField);
+      });
+      test.skip('Undefined', function() {
+        labelField.setValue(undefined);
+        assertValueDefault(labelField);
+      });
+      test('New String', function() {
+        labelField.setValue('newValue');
+        assertValue(labelField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        labelField.setValue(1);
+        assertValue(labelField, '1');
+      });
+      test.skip('Number (Falsy)', function() {
+        labelField.setValue(0);
+        assertValue(labelField, '0');
+      });
+      test('Boolean True', function() {
+        labelField.setValue(true);
+        assertValue(labelField, 'true');
+      });
+      test.skip('Boolean False', function() {
+        labelField.setValue(false);
+        assertValue(labelField, 'false');
+      });
     });
-    test('Null', function() {
-      labelField.setValue(null);
-      assertValue(labelField, 'value');
-    });
-    test.skip('Undefined', function() {
-      labelField.setValue(undefined);
-      assertValue(labelField, 'value');
-    });
-    test('New String', function() {
-      labelField.setValue('newValue');
-      assertValue(labelField, 'newValue');
-    });
-    test('Number (Truthy)', function() {
-      labelField.setValue(1);
-      assertValue(labelField, '1');
-    });
-    test('Number (Falsy)', function() {
-      labelField.setValue(0);
-      assertValue(labelField, '0');
-    });
-    test('Boolean True', function() {
-      labelField.setValue(true);
-      assertValue(labelField, 'true');
-    });
-    test('Boolean False', function() {
-      labelField.setValue(false);
-      assertValue(labelField, 'false');
+    suite('Value -> New Value', function() {
+      var labelField;
+      setup(function() {
+        labelField = new Blockly.FieldLabelSerializable('value');
+      });
+      test('Null', function() {
+        labelField.setValue(null);
+        assertValue(labelField, 'value');
+      });
+      test.skip('Undefined', function() {
+        labelField.setValue(undefined);
+        assertValue(labelField, 'value');
+      });
+      test('New String', function() {
+        labelField.setValue('newValue');
+        assertValue(labelField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        labelField.setValue(1);
+        assertValue(labelField, '1');
+      });
+      test('Number (Falsy)', function() {
+        labelField.setValue(0);
+        assertValue(labelField, '0');
+      });
+      test('Boolean True', function() {
+        labelField.setValue(true);
+        assertValue(labelField, 'true');
+      });
+      test('Boolean False', function() {
+        labelField.setValue(false);
+        assertValue(labelField, 'false');
+      });
     });
   });
 });

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -45,13 +45,21 @@ suite ('Label Fields', function() {
       var labelField = new Blockly.FieldLabel('value');
       assertValue(labelField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var labelField = new Blockly.FieldLabel(1);
       assertValue(labelField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var labelField = new Blockly.FieldLabel(0);
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
       var labelField = new Blockly.FieldLabel(true);
       assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      var labelField = new Blockly.FieldLabel(false);
+      assertValue(labelField, 'false');
     });
   });
   suite('fromJson', function() {
@@ -71,13 +79,21 @@ suite ('Label Fields', function() {
       var labelField = Blockly.FieldLabel.fromJson({ text:'value' });
       assertValue(labelField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var labelField = Blockly.FieldLabel.fromJson({ text:1 });
       assertValue(labelField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var labelField = Blockly.FieldLabel.fromJson({ text:0 });
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
       var labelField = Blockly.FieldLabel.fromJson({ text:true });
       assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      var labelField = Blockly.FieldLabel.fromJson({ text:false });
+      assertValue(labelField, 'false');
     });
   });
   suite('setValue', function() {
@@ -96,6 +112,22 @@ suite ('Label Fields', function() {
     test('New String', function() {
       labelField.setValue('newValue');
       assertValue(labelField, 'newValue');
+    });
+    test('Number (Truthy)', function() {
+      labelField.setValue(1);
+      assertValue(labelField, '1');
+    });
+    test('Number (Falsy)', function() {
+      labelField.setValue(0);
+      assertValue(labelField, '0');
+    });
+    test('Boolean True', function() {
+      labelField.setValue(true);
+      assertValue(labelField, 'true');
+    });
+    test('Boolean False', function() {
+      labelField.setValue(false);
+      assertValue(labelField, 'false');
     });
   });
 });

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Label Fields', function() {
+  function assertValue(labelField, expectedValue) {
+    var actualValue = labelField.getValue();
+    var actualText = labelField.getText();
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, expectedValue);
+  }
+  function assertValueDefault(labelField) {
+    assertValue(labelField, '');
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var labelField = new Blockly.FieldLabel();
+      assertValueDefault(labelField);
+    });
+    test('Null', function() {
+      var labelField = new Blockly.FieldLabel(null);
+      assertValueDefault(labelField);
+    });
+    test('Undefined', function() {
+      var labelField = new Blockly.FieldLabel(undefined);
+      assertValueDefault(labelField);
+    });
+    test('String', function() {
+      var labelField = new Blockly.FieldLabel('value');
+      assertValue(labelField, 'value');
+    });
+    test('Number', function() {
+      var labelField = new Blockly.FieldLabel(1);
+      assertValue(labelField, '1');
+    });
+    test('Boolean', function() {
+      var labelField = new Blockly.FieldLabel(true);
+      assertValue(labelField, 'true');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var labelField = new Blockly.FieldLabel.fromJson({});
+      assertValueDefault(labelField);
+    });
+    test('Null', function() {
+      var labelField = new Blockly.FieldLabel.fromJson({ text:null });
+      assertValueDefault(labelField);
+    });
+    test('Undefined', function() {
+      var labelField = new Blockly.FieldLabel.fromJson({ text:undefined });
+      assertValueDefault(labelField);
+    });
+    test('String', function() {
+      var labelField = Blockly.FieldLabel.fromJson({ text:'value' });
+      assertValue(labelField, 'value');
+    });
+    test('Number', function() {
+      var labelField = Blockly.FieldLabel.fromJson({ text:1 });
+      assertValue(labelField, '1');
+    });
+    test('Boolean', function() {
+      var labelField = Blockly.FieldLabel.fromJson({ text:true });
+      assertValue(labelField, 'true');
+    });
+  });
+  suite('setValue', function() {
+    var labelField;
+    setup(function() {
+      labelField = new Blockly.FieldLabel('value');
+    });
+    test('Null', function() {
+      labelField.setValue(null);
+      assertValue(labelField, 'value');
+    });
+    test.skip('Undefined', function() {
+      labelField.setValue(undefined);
+      assertValue(labelField, 'value');
+    });
+    test('New String', function() {
+      labelField.setValue('newValue');
+      assertValue(labelField, 'newValue');
+    });
+  });
+});

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -97,37 +97,73 @@ suite ('Label Fields', function() {
     });
   });
   suite('setValue', function() {
-    var labelField;
-    setup(function() {
-      labelField = new Blockly.FieldLabel('value');
+    suite('Empty -> New Value', function() {
+      var labelField;
+      setup(function() {
+        labelField = new Blockly.FieldLabel();
+      });
+      test('Null', function() {
+        labelField.setValue(null);
+        assertValueDefault(labelField);
+      });
+      test.skip('Undefined', function() {
+        labelField.setValue(undefined);
+        assertValueDefault(labelField);
+      });
+      test('New String', function() {
+        labelField.setValue('newValue');
+        assertValue(labelField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        labelField.setValue(1);
+        assertValue(labelField, '1');
+      });
+      test.skip('Number (Falsy)', function() {
+        labelField.setValue(0);
+        assertValue(labelField, '0');
+      });
+      test('Boolean True', function() {
+        labelField.setValue(true);
+        assertValue(labelField, 'true');
+      });
+      test.skip('Boolean False', function() {
+        labelField.setValue(false);
+        assertValue(labelField, 'false');
+      });
     });
-    test('Null', function() {
-      labelField.setValue(null);
-      assertValue(labelField, 'value');
-    });
-    test.skip('Undefined', function() {
-      labelField.setValue(undefined);
-      assertValue(labelField, 'value');
-    });
-    test('New String', function() {
-      labelField.setValue('newValue');
-      assertValue(labelField, 'newValue');
-    });
-    test('Number (Truthy)', function() {
-      labelField.setValue(1);
-      assertValue(labelField, '1');
-    });
-    test('Number (Falsy)', function() {
-      labelField.setValue(0);
-      assertValue(labelField, '0');
-    });
-    test('Boolean True', function() {
-      labelField.setValue(true);
-      assertValue(labelField, 'true');
-    });
-    test('Boolean False', function() {
-      labelField.setValue(false);
-      assertValue(labelField, 'false');
+    suite('Value -> New Value', function() {
+      var labelField;
+      setup(function() {
+        labelField = new Blockly.FieldLabel('value');
+      });
+      test('Null', function() {
+        labelField.setValue(null);
+        assertValue(labelField, 'value');
+      });
+      test.skip('Undefined', function() {
+        labelField.setValue(undefined);
+        assertValue(labelField, 'value');
+      });
+      test('New String', function() {
+        labelField.setValue('newValue');
+        assertValue(labelField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        labelField.setValue(1);
+        assertValue(labelField, '1');
+      });
+      test('Number (Falsy)', function() {
+        labelField.setValue(0);
+        assertValue(labelField, '0');
+      });
+      test('Boolean True', function() {
+        labelField.setValue(true);
+        assertValue(labelField, 'true');
+      });
+      test('Boolean False', function() {
+        labelField.setValue(false);
+        assertValue(labelField, 'false');
+      });
     });
   });
 });

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -98,71 +98,69 @@ suite ('Label Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var labelField;
       setup(function() {
-        labelField = new Blockly.FieldLabel();
+        this.labelField = new Blockly.FieldLabel();
       });
       test('Null', function() {
-        labelField.setValue(null);
-        assertValueDefault(labelField);
+        this.labelField.setValue(null);
+        assertValueDefault(this.labelField);
       });
       test.skip('Undefined', function() {
-        labelField.setValue(undefined);
-        assertValueDefault(labelField);
+        this.labelField.setValue(undefined);
+        assertValueDefault(this.labelField);
       });
       test('New String', function() {
-        labelField.setValue('newValue');
-        assertValue(labelField, 'newValue');
+        this.labelField.setValue('newValue');
+        assertValue(this.labelField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        labelField.setValue(1);
-        assertValue(labelField, '1');
+        this.labelField.setValue(1);
+        assertValue(this.labelField, '1');
       });
       test.skip('Number (Falsy)', function() {
-        labelField.setValue(0);
-        assertValue(labelField, '0');
+        this.labelField.setValue(0);
+        assertValue(this.labelField, '0');
       });
       test('Boolean True', function() {
-        labelField.setValue(true);
-        assertValue(labelField, 'true');
+        this.labelField.setValue(true);
+        assertValue(this.labelField, 'true');
       });
       test.skip('Boolean False', function() {
-        labelField.setValue(false);
-        assertValue(labelField, 'false');
+        this.labelField.setValue(false);
+        assertValue(this.labelField, 'false');
       });
     });
     suite('Value -> New Value', function() {
-      var labelField;
       setup(function() {
-        labelField = new Blockly.FieldLabel('value');
+        this.labelField = new Blockly.FieldLabel('value');
       });
       test('Null', function() {
-        labelField.setValue(null);
-        assertValue(labelField, 'value');
+        this.labelField.setValue(null);
+        assertValue(this.labelField, 'value');
       });
       test.skip('Undefined', function() {
-        labelField.setValue(undefined);
-        assertValue(labelField, 'value');
+        this.labelField.setValue(undefined);
+        assertValue(this.labelField, 'value');
       });
       test('New String', function() {
-        labelField.setValue('newValue');
-        assertValue(labelField, 'newValue');
+        this.labelField.setValue('newValue');
+        assertValue(this.labelField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        labelField.setValue(1);
-        assertValue(labelField, '1');
+        this.labelField.setValue(1);
+        assertValue(this.labelField, '1');
       });
       test('Number (Falsy)', function() {
-        labelField.setValue(0);
-        assertValue(labelField, '0');
+        this.labelField.setValue(0);
+        assertValue(this.labelField, '0');
       });
       test('Boolean True', function() {
-        labelField.setValue(true);
-        assertValue(labelField, 'true');
+        this.labelField.setValue(true);
+        assertValue(this.labelField, 'true');
       });
       test('Boolean False', function() {
-        labelField.setValue(false);
-        assertValue(labelField, 'false');
+        this.labelField.setValue(false);
+        assertValue(this.labelField, 'false');
       });
     });
   });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -234,16 +234,11 @@ suite ('Number Fields', function() {
           numberField.setValue(123.456);
           assertValue(numberField, 123);
         });
-        test('1.5', function() {
+        test.skip('1.5', function() {
           var numberField = new Blockly.FieldNumber
               .fromJson({ precision: 1.5 });
           numberField.setValue(123.456);
-
-          var actualValue = numberField.getValue();
-          var actualText = numberField.getText();
-          assertEquals(String(actualValue), '123.0');
-          assertEquals(parseFloat(actualValue), 123);
-          assertEquals(actualText, '123.0');
+          assertValue(numberField, 123);
         });
       });
       suite('Min', function() {

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -1,0 +1,349 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Number Fields', function() {
+  function assertValue(numberField, expectedValue) {
+    var actualValue = numberField.getValue();
+    var actualText = numberField.getText();
+    var stringExpectedValue = String(expectedValue);
+    assertEquals(String(actualValue), stringExpectedValue);
+    assertEquals(parseFloat(actualValue), expectedValue);
+    assertEquals(actualText, stringExpectedValue);
+  }
+  function assertValueDefault(numberFieldField) {
+    assertValue(numberFieldField, 0);
+  }
+  function assertNumberField(numberField, expectedMin, expectedMax,
+      expectedPrecision, expectedValue) {
+    assertValue(numberField, expectedValue);
+    assertEquals(numberField.min_, expectedMin);
+    assertEquals(numberField.max_, expectedMax);
+    assertEquals(numberField.precision_, expectedPrecision);
+  }
+  function assertNumberFieldDefault(numberField) {
+    assertNumberField(numberField, -Infinity, Infinity, 0, 0);
+  }
+  function createNumberFieldSameValuesConstructor(value) {
+    return new Blockly.FieldNumber(value, value, value, value);
+  }
+  function createNumberFieldSameValuesJson(value) {
+    return Blockly.FieldNumber.fromJson(
+        { 'value': value, min: value, max: value, precision: value });
+  }
+  function assertNumberFieldSameValues(numberField, value) {
+    assertNumberField(numberField,  value, value, value, value);
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var numberField = new Blockly.FieldNumber();
+      assertNumberFieldDefault(numberField);
+    });
+    test('Null', function() {
+      var numberField = createNumberFieldSameValuesConstructor(null);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Undefined', function() {
+      var numberField = createNumberFieldSameValuesConstructor(undefined);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Non-Parsable String', function() {
+      var numberField = createNumberFieldSameValuesConstructor('bad');
+      assertNumberFieldDefault(numberField);
+    });
+    test('NaN', function() {
+      var numberField = createNumberFieldSameValuesConstructor(NaN);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Integer', function() {
+      var numberField = createNumberFieldSameValuesConstructor(1);
+      assertNumberFieldSameValues(numberField, 1);
+    });
+    test('Float', function() {
+      var numberField = createNumberFieldSameValuesConstructor(1.5);
+      assertNumberFieldSameValues(numberField, 1.5);
+    });
+    test('Integer String', function() {
+      var numberField = createNumberFieldSameValuesConstructor('1');
+      assertNumberFieldSameValues(numberField, 1);
+    });
+    test('Float String', function() {
+      var numberField = createNumberFieldSameValuesConstructor('1.5');
+      assertNumberFieldSameValues(numberField, 1.5);
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var numberField = Blockly.FieldNumber.fromJson({});
+      assertNumberFieldDefault(numberField);
+    });
+    test('Null', function() {
+      var numberField = createNumberFieldSameValuesJson(null);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Undefined', function() {
+      var numberField = createNumberFieldSameValuesJson(undefined);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Non-Parsable String', function() {
+      var numberField = createNumberFieldSameValuesJson('bad');
+      assertNumberFieldDefault(numberField);
+    });
+    test('NaN', function() {
+      var numberField = createNumberFieldSameValuesJson(NaN);
+      assertNumberFieldDefault(numberField);
+    });
+    test('Integer', function() {
+      var numberField = createNumberFieldSameValuesJson(1);
+      assertNumberFieldSameValues(numberField, 1);
+    });
+    test('Float', function() {
+      var numberField = createNumberFieldSameValuesJson(1.5);
+      assertNumberFieldSameValues(numberField, 1.5);
+    });
+    test('Integer String', function() {
+      var numberField = createNumberFieldSameValuesJson('1');
+      assertNumberFieldSameValues(numberField, 1);
+    });
+    test('Float String', function() {
+      var numberField = createNumberFieldSameValuesJson('1.5');
+      assertNumberFieldSameValues(numberField, 1.5);
+    });
+  });
+  suite('setValue', function() {
+    suite('Value Types', function() {
+      test('Empty -> Null', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue(null);
+        assertValueDefault(numberField);
+      });
+      test('Value -> Null', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue(null);
+        assertValue(numberField, 1);
+      });
+      test.skip('Empty -> Undefined', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue(undefined);
+        assertValueDefault(numberField);
+      });
+      test.skip('Value -> Undefined', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue(undefined);
+        assertValue(numberField, 1);
+      });
+      test.skip('Empty -> Non-Parsable String', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue('bad');
+        assertValueDefault(numberField);
+      });
+      test.skip('Value -> Non-Parsable String', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue('bad');
+        assertValue(numberField, 1);
+      });
+      test.skip('Empty -> NaN', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue(NaN);
+        assertValueDefault(numberField);
+      });
+      test.skip('Value -> NaN', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue(NaN);
+        assertValue(numberField, 1);
+      });
+      test('Empty -> Integer', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue(2);
+        assertValue(numberField, 2);
+      });
+      test('Value -> Integer', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue(2);
+        assertValue(numberField, 2);
+      });
+      test('Empty -> Float', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue(2.5);
+        assertValue(numberField, 2.5);
+      });
+      test('Value -> Float', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue(2.5);
+        assertValue(numberField, 2.5);
+      });
+      test('Empty -> Integer String', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue('2');
+        assertValue(numberField, 2);
+      });
+      test('Value -> Integer String', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue('2');
+        assertValue(numberField, 2);
+      });
+      test('Empty -> Float', function() {
+        var numberField = new Blockly.FieldNumber();
+        numberField.setValue('2.5');
+        assertValue(numberField, 2.5);
+      });
+      test('Value -> Float', function() {
+        var numberField = new Blockly.FieldNumber(1);
+        numberField.setValue('2.5');
+        assertValue(numberField, 2.5);
+      });
+    });
+    suite('Constraints', function() {
+      suite('Precision', function() {
+        test('Float', function() {
+          var numberField = new Blockly.FieldNumber();
+          numberField.setValue(123.456);
+          assertValue(numberField, 123.456);
+        });
+        test('0.01', function() {
+          var numberField = new Blockly.FieldNumber
+              .fromJson({ precision: .01 });
+          numberField.setValue(123.456);
+          assertValue(numberField, 123.46);
+        });
+        test('0.5', function() {
+          var numberField = new Blockly.FieldNumber
+              .fromJson({ precision: .5 });
+          numberField.setValue(123.456);
+          assertValue(numberField, 123.5);
+        });
+        test('1', function() {
+          var numberField = new Blockly.FieldNumber
+              .fromJson({ precision: 1 });
+          numberField.setValue(123.456);
+          assertValue(numberField, 123);
+        });
+        test('1.5', function() {
+          var numberField = new Blockly.FieldNumber
+              .fromJson({ precision: 1.5 });
+          numberField.setValue(123.456);
+
+          var actualValue = numberField.getValue();
+          var actualText = numberField.getText();
+          assertEquals(String(actualValue), '123.0');
+          assertEquals(parseFloat(actualValue), 123);
+          assertEquals(actualText, '123.0');
+        });
+      });
+      suite('Min', function() {
+        test('-10', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ min: -10 });
+          numberField.setValue(-20);
+          assertValue(numberField, -10);
+          numberField.setValue(0);
+          assertValue(numberField, 0);
+          numberField.setValue(20);
+          assertValue(numberField, 20);
+        });
+        test('0', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ min: 0 });
+          numberField.setValue(-20);
+          assertValue(numberField, 0);
+          numberField.setValue(0);
+          assertValue(numberField, 0);
+          numberField.setValue(20);
+          assertValue(numberField, 20);
+        });
+        test('+10', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ min: 10 });
+          numberField.setValue(-20);
+          assertValue(numberField, 10);
+          numberField.setValue(0);
+          assertValue(numberField, 10);
+          numberField.setValue(20);
+          assertValue(numberField, 20);
+        });
+      });
+      suite('Max', function() {
+        test('-10', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ max: -10 });
+          numberField.setValue(-20);
+          assertValue(numberField, -20);
+          numberField.setValue(0);
+          assertValue(numberField, -10);
+          numberField.setValue(20);
+          assertValue(numberField, -10);
+        });
+        test('0', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ max: 0 });
+          numberField.setValue(-20);
+          assertValue(numberField, -20);
+          numberField.setValue(0);
+          assertValue(numberField, 0);
+          numberField.setValue(20);
+          assertValue(numberField, 0);
+        });
+        test('+10', function() {
+          var numberField = new Blockly.FieldNumber.fromJson({ max: 10 });
+          numberField.setValue(-20);
+          assertValue(numberField, -20);
+          numberField.setValue(0);
+          assertValue(numberField, 0);
+          numberField.setValue(20);
+          assertValue(numberField, 10);
+        });
+      });
+    });
+  });
+  suite.skip('Validators', function() {
+    var numberFieldField;
+    setup(function() {
+      numberFieldField = new Blockly.FieldNumber(1);
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        numberFieldField.setValidator(function() {
+          return null;
+        });
+      });
+      test('When Editing', function() {
+        numberFieldField.isBeingEdited_ = true;
+        numberFieldField.setValue(2);
+        assertValue(numberFieldField, 1, '2');
+        numberFieldField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        numberFieldField.setValue(2);
+        assertValue(numberFieldField, 1);
+      });
+    });
+    suite('Force End with 6 Validator', function() {
+      setup(function() {
+        numberFieldField.setValidator(function(newValue) {
+          return newValue.replace(/.$/, "6");
+        });
+      });
+      test('When Editing', function() {
+        numberFieldField.isBeingEdited_ = true;
+        numberFieldField.setValue(25);
+        assertValue(numberFieldField, 26, '25');
+        numberFieldField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        numberFieldField.setValue(25);
+        assertValue(numberFieldField, 26);
+      });
+    });
+  });
+});

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -128,85 +128,82 @@ suite ('Number Fields', function() {
   });
   suite('setValue', function() {
     suite('Value Types', function() {
-      test('Empty -> Null', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue(null);
-        assertValueDefault(numberField);
+      suite('Empty -> New Value', function() {
+        var numberField;
+        setup(function() {
+          numberField = new Blockly.FieldNumber();
+        });
+        test('Null', function() {
+          numberField.setValue(null);
+          assertValueDefault(numberField);
+        });
+        test.skip('Undefined', function() {
+          numberField.setValue(undefined);
+          assertValueDefault(numberField);
+        });
+        test.skip('Non-Parsable String', function() {
+          numberField.setValue('bad');
+          assertValueDefault(numberField);
+        });
+        test.skip('NaN', function() {
+          numberField.setValue(NaN);
+          assertValueDefault(numberField);
+        });
+        test('Integer', function() {
+          numberField.setValue(2);
+          assertValue(numberField, 2);
+        });
+        test('Float', function() {
+          numberField.setValue(2.5);
+          assertValue(numberField, 2.5);
+        });
+        test('Integer String', function() {
+          numberField.setValue('2');
+          assertValue(numberField, 2);
+        });
+        test('Float', function() {
+          var numberField = new Blockly.FieldNumber();
+          numberField.setValue('2.5');
+          assertValue(numberField, 2.5);
+        });
       });
-      test('Value -> Null', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue(null);
-        assertValue(numberField, 1);
-      });
-      test.skip('Empty -> Undefined', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue(undefined);
-        assertValueDefault(numberField);
-      });
-      test.skip('Value -> Undefined', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue(undefined);
-        assertValue(numberField, 1);
-      });
-      test.skip('Empty -> Non-Parsable String', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue('bad');
-        assertValueDefault(numberField);
-      });
-      test.skip('Value -> Non-Parsable String', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue('bad');
-        assertValue(numberField, 1);
-      });
-      test.skip('Empty -> NaN', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue(NaN);
-        assertValueDefault(numberField);
-      });
-      test.skip('Value -> NaN', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue(NaN);
-        assertValue(numberField, 1);
-      });
-      test('Empty -> Integer', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue(2);
-        assertValue(numberField, 2);
-      });
-      test('Value -> Integer', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue(2);
-        assertValue(numberField, 2);
-      });
-      test('Empty -> Float', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue(2.5);
-        assertValue(numberField, 2.5);
-      });
-      test('Value -> Float', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue(2.5);
-        assertValue(numberField, 2.5);
-      });
-      test('Empty -> Integer String', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue('2');
-        assertValue(numberField, 2);
-      });
-      test('Value -> Integer String', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue('2');
-        assertValue(numberField, 2);
-      });
-      test('Empty -> Float', function() {
-        var numberField = new Blockly.FieldNumber();
-        numberField.setValue('2.5');
-        assertValue(numberField, 2.5);
-      });
-      test('Value -> Float', function() {
-        var numberField = new Blockly.FieldNumber(1);
-        numberField.setValue('2.5');
-        assertValue(numberField, 2.5);
+      suite('Value -> New Value', function() {
+        var numberField;
+        setup(function() {
+          numberField = new Blockly.FieldNumber(1);
+        });
+        test('Null', function() {
+          numberField.setValue(null);
+          assertValue(numberField, 1);
+        });
+        test.skip('Undefined', function() {
+          numberField.setValue(undefined);
+          assertValue(numberField, 1);
+        });
+        test.skip('Non-Parsable String', function() {
+          numberField.setValue('bad');
+          assertValue(numberField, 1);
+        });
+        test.skip('NaN', function() {
+          numberField.setValue(NaN);
+          assertValue(numberField, 1);
+        });
+        test('Integer', function() {
+          numberField.setValue(2);
+          assertValue(numberField, 2);
+        });
+        test('Float', function() {
+          numberField.setValue(2.5);
+          assertValue(numberField, 2.5);
+        });
+        test('Integer String', function() {
+          numberField.setValue('2');
+          assertValue(numberField, 2);
+        });
+        test('Float', function() {
+          numberField.setValue('2.5');
+          assertValue(numberField, 2.5);
+        });
       });
     });
     suite('Constraints', function() {

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -19,13 +19,13 @@
  */
 
 suite ('Number Fields', function() {
-  function assertValue(numberField, expectedValue) {
+  function assertValue(numberField, expectedValue, opt_expectedText) {
     var actualValue = numberField.getValue();
     var actualText = numberField.getText();
-    var stringExpectedValue = String(expectedValue);
-    assertEquals(String(actualValue), stringExpectedValue);
+    opt_expectedText = opt_expectedText || String(expectedValue);
+    assertEquals(String(actualValue), String(expectedValue));
     assertEquals(parseFloat(actualValue), expectedValue);
-    assertEquals(actualText, stringExpectedValue);
+    assertEquals(actualText, opt_expectedText);
   }
   function assertValueDefault(numberFieldField) {
     assertValue(numberFieldField, 0);
@@ -310,6 +310,9 @@ suite ('Number Fields', function() {
     var numberFieldField;
     setup(function() {
       numberFieldField = new Blockly.FieldNumber(1);
+      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
+      Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
+      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -319,7 +322,8 @@ suite ('Number Fields', function() {
       });
       test('When Editing', function() {
         numberFieldField.isBeingEdited_ = true;
-        numberFieldField.setValue(2);
+        Blockly.FieldTextInput.htmlInput_.value = '2';
+        numberFieldField.onHtmlInputChange_(null);
         assertValue(numberFieldField, 1, '2');
         numberFieldField.isBeingEdited_ = false;
       });
@@ -331,12 +335,13 @@ suite ('Number Fields', function() {
     suite('Force End with 6 Validator', function() {
       setup(function() {
         numberFieldField.setValidator(function(newValue) {
-          return newValue.replace(/.$/, "6");
+          return String(newValue).replace(/.$/, "6");
         });
       });
       test('When Editing', function() {
         numberFieldField.isBeingEdited_ = true;
-        numberFieldField.setValue(25);
+        Blockly.FieldTextInput.htmlInput_.value = '25';
+        numberFieldField.onHtmlInputChange_(null);
         assertValue(numberFieldField, 26, '25');
         numberFieldField.isBeingEdited_ = false;
       });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -129,80 +129,77 @@ suite ('Number Fields', function() {
   suite('setValue', function() {
     suite('Value Types', function() {
       suite('Empty -> New Value', function() {
-        var numberField;
         setup(function() {
-          numberField = new Blockly.FieldNumber();
+          this.numberField = new Blockly.FieldNumber();
         });
         test('Null', function() {
-          numberField.setValue(null);
-          assertValueDefault(numberField);
+          this.numberField.setValue(null);
+          assertValueDefault(this.numberField);
         });
         test.skip('Undefined', function() {
-          numberField.setValue(undefined);
-          assertValueDefault(numberField);
+          this.numberField.setValue(undefined);
+          assertValueDefault(this.numberField);
         });
         test.skip('Non-Parsable String', function() {
-          numberField.setValue('bad');
-          assertValueDefault(numberField);
+          this.numberField.setValue('bad');
+          assertValueDefault(this.numberField);
         });
         test.skip('NaN', function() {
-          numberField.setValue(NaN);
-          assertValueDefault(numberField);
+          this.numberField.setValue(NaN);
+          assertValueDefault(this.numberField);
         });
         test('Integer', function() {
-          numberField.setValue(2);
-          assertValue(numberField, 2);
+          this.numberField.setValue(2);
+          assertValue(this.numberField, 2);
         });
         test('Float', function() {
-          numberField.setValue(2.5);
-          assertValue(numberField, 2.5);
+          this.numberField.setValue(2.5);
+          assertValue(this.numberField, 2.5);
         });
         test('Integer String', function() {
-          numberField.setValue('2');
-          assertValue(numberField, 2);
+          this.numberField.setValue('2');
+          assertValue(this.numberField, 2);
         });
-        test('Float', function() {
-          var numberField = new Blockly.FieldNumber();
-          numberField.setValue('2.5');
-          assertValue(numberField, 2.5);
+        test('Float String', function() {
+          this.numberField.setValue('2.5');
+          assertValue(this.numberField, 2.5);
         });
       });
       suite('Value -> New Value', function() {
-        var numberField;
         setup(function() {
-          numberField = new Blockly.FieldNumber(1);
+          this.numberField = new Blockly.FieldNumber(1);
         });
         test('Null', function() {
-          numberField.setValue(null);
-          assertValue(numberField, 1);
+          this.numberField.setValue(null);
+          assertValue(this.numberField, 1);
         });
         test.skip('Undefined', function() {
-          numberField.setValue(undefined);
-          assertValue(numberField, 1);
+          this.numberField.setValue(undefined);
+          assertValue(this.numberField, 1);
         });
         test.skip('Non-Parsable String', function() {
-          numberField.setValue('bad');
-          assertValue(numberField, 1);
+          this.numberField.setValue('bad');
+          assertValue(this.numberField, 1);
         });
         test.skip('NaN', function() {
-          numberField.setValue(NaN);
-          assertValue(numberField, 1);
+          this.numberField.setValue(NaN);
+          assertValue(this.numberField, 1);
         });
         test('Integer', function() {
-          numberField.setValue(2);
-          assertValue(numberField, 2);
+          this.numberField.setValue(2);
+          assertValue(this.numberField, 2);
         });
         test('Float', function() {
-          numberField.setValue(2.5);
-          assertValue(numberField, 2.5);
+          this.numberField.setValue(2.5);
+          assertValue(this.numberField, 2.5);
         });
         test('Integer String', function() {
-          numberField.setValue('2');
-          assertValue(numberField, 2);
+          this.numberField.setValue('2');
+          assertValue(this.numberField, 2);
         });
-        test('Float', function() {
-          numberField.setValue('2.5');
-          assertValue(numberField, 2.5);
+        test('Float String', function() {
+          this.numberField.setValue('2.5');
+          assertValue(this.numberField, 2.5);
         });
       });
     });
@@ -299,47 +296,46 @@ suite ('Number Fields', function() {
     });
   });
   suite.skip('Validators', function() {
-    var numberFieldField;
     setup(function() {
-      numberFieldField = new Blockly.FieldNumber(1);
+      this.numberFieldField = new Blockly.FieldNumber(1);
       Blockly.FieldTextInput.htmlInput_ = Object.create(null);
       Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
       Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
     });
     suite('Null Validator', function() {
       setup(function() {
-        numberFieldField.setValidator(function() {
+        this.numberFieldField.setValidator(function() {
           return null;
         });
       });
       test('When Editing', function() {
-        numberFieldField.isBeingEdited_ = true;
+        this.numberFieldField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = '2';
-        numberFieldField.onHtmlInputChange_(null);
-        assertValue(numberFieldField, 1, '2');
-        numberFieldField.isBeingEdited_ = false;
+        this.numberFieldField.onHtmlInputChange_(null);
+        assertValue(this.numberFieldField, 1, '2');
+        this.numberFieldField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        numberFieldField.setValue(2);
-        assertValue(numberFieldField, 1);
+        this.numberFieldField.setValue(2);
+        assertValue(this.numberFieldField, 1);
       });
     });
     suite('Force End with 6 Validator', function() {
       setup(function() {
-        numberFieldField.setValidator(function(newValue) {
+        this.numberFieldField.setValidator(function(newValue) {
           return String(newValue).replace(/.$/, "6");
         });
       });
       test('When Editing', function() {
-        numberFieldField.isBeingEdited_ = true;
+        this.numberFieldField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = '25';
-        numberFieldField.onHtmlInputChange_(null);
-        assertValue(numberFieldField, 26, '25');
-        numberFieldField.isBeingEdited_ = false;
+        this.numberFieldField.onHtmlInputChange_(null);
+        assertValue(this.numberFieldField, 26, '25');
+        this.numberFieldField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        numberFieldField.setValue(25);
-        assertValue(numberFieldField, 26);
+        this.numberFieldField.setValue(25);
+        assertValue(this.numberFieldField, 26);
       });
     });
   });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -46,13 +46,21 @@ suite ('Text Input Fields', function() {
       var textInputField = new Blockly.FieldTextInput('value');
       assertValue(textInputField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var textInputField = new Blockly.FieldTextInput(1);
       assertValue(textInputField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var textInputField = new Blockly.FieldTextInput(0);
+      assertValue(textInputField, '0');
+    });
+    test('Boolean True', function() {
       var textInputField = new Blockly.FieldTextInput(true);
       assertValue(textInputField, 'true');
+    });
+    test('Boolean False', function() {
+      var textInputField = new Blockly.FieldTextInput(false);
+      assertValue(textInputField, 'false');
     });
   });
   suite('fromJson', function() {
@@ -73,13 +81,21 @@ suite ('Text Input Fields', function() {
       var textInputField = Blockly.FieldTextInput.fromJson({ text:'value' });
       assertValue(textInputField, 'value');
     });
-    test('Number', function() {
+    test('Number (Truthy)', function() {
       var textInputField = Blockly.FieldTextInput.fromJson({ text:1 });
       assertValue(textInputField, '1');
     });
-    test('Boolean', function() {
+    test('Number (Falsy)', function() {
+      var textInputField = Blockly.FieldTextInput.fromJson({ text:0 });
+      assertValue(textInputField, '0');
+    });
+    test('Boolean True', function() {
       var textInputField = Blockly.FieldTextInput.fromJson({ text:true });
       assertValue(textInputField, 'true');
+    });
+    test('Boolean False', function() {
+      var textInputField = Blockly.FieldTextInput.fromJson({ text:false });
+      assertValue(textInputField, 'false');
     });
   });
   suite('setValue', function() {
@@ -98,6 +114,22 @@ suite ('Text Input Fields', function() {
     test('New String', function() {
       textInputField.setValue('newValue');
       assertValue(textInputField, 'newValue');
+    });
+    test('Number (Truthy)', function() {
+      textInputField.setValue(1);
+      assertValue(textInputField, '1');
+    });
+    test('Number (Falsy)', function() {
+      textInputField.setValue(0);
+      assertValue(textInputField, '0');
+    });
+    test('Boolean True', function() {
+      textInputField.setValue(true);
+      assertValue(textInputField, 'true');
+    });
+    test('Boolean False', function() {
+      textInputField.setValue(false);
+      assertValue(textInputField, 'false');
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -100,116 +100,113 @@ suite ('Text Input Fields', function() {
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
-      var textInputField;
       setup(function() {
-        textInputField = new Blockly.FieldTextInput();
+        this.textInputField = new Blockly.FieldTextInput();
       });
       test('Null', function() {
-        textInputField.setValue(null);
-        assertValueDefault(textInputField);
+        this.textInputField.setValue(null);
+        assertValueDefault(this.textInputField);
       });
       test.skip('Undefined', function() {
-        textInputField.setValue(undefined);
-        assertValueDefault(textInputField);
+        this.textInputField.setValue(undefined);
+        assertValueDefault(this.textInputField);
       });
       test('New String', function() {
-        textInputField.setValue('newValue');
-        assertValue(textInputField, 'newValue');
+        this.textInputField.setValue('newValue');
+        assertValue(this.textInputField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        textInputField.setValue(1);
-        assertValue(textInputField, '1');
+        this.textInputField.setValue(1);
+        assertValue(this.textInputField, '1');
       });
       test.skip('Number (Falsy)', function() {
-        textInputField.setValue(0);
-        assertValue(textInputField, '0');
+        this.textInputField.setValue(0);
+        assertValue(this.textInputField, '0');
       });
       test('Boolean True', function() {
-        textInputField.setValue(true);
-        assertValue(textInputField, 'true');
+        this.textInputField.setValue(true);
+        assertValue(this.textInputField, 'true');
       });
       test.skip('Boolean False', function() {
-        textInputField.setValue(false);
-        assertValue(textInputField, 'false');
+        this.textInputField.setValue(false);
+        assertValue(this.textInputField, 'false');
       });
     });
     suite('Value -> New Value', function() {
-      var textInputField;
       setup(function() {
-        textInputField = new Blockly.FieldTextInput('value');
+        this.textInputField = new Blockly.FieldTextInput('value');
       });
       test('Null', function() {
-        textInputField.setValue(null);
-        assertValue(textInputField, 'value');
+        this.textInputField.setValue(null);
+        assertValue(this.textInputField, 'value');
       });
       test.skip('Undefined', function() {
-        textInputField.setValue(undefined);
-        assertValue(textInputField, 'value');
+        this.textInputField.setValue(undefined);
+        assertValue(this.textInputField, 'value');
       });
       test('New String', function() {
-        textInputField.setValue('newValue');
-        assertValue(textInputField, 'newValue');
+        this.textInputField.setValue('newValue');
+        assertValue(this.textInputField, 'newValue');
       });
       test('Number (Truthy)', function() {
-        textInputField.setValue(1);
-        assertValue(textInputField, '1');
+        this.textInputField.setValue(1);
+        assertValue(this.textInputField, '1');
       });
       test('Number (Falsy)', function() {
-        textInputField.setValue(0);
-        assertValue(textInputField, '0');
+        this.textInputField.setValue(0);
+        assertValue(this.textInputField, '0');
       });
       test('Boolean True', function() {
-        textInputField.setValue(true);
-        assertValue(textInputField, 'true');
+        this.textInputField.setValue(true);
+        assertValue(this.textInputField, 'true');
       });
       test('Boolean False', function() {
-        textInputField.setValue(false);
-        assertValue(textInputField, 'false');
+        this.textInputField.setValue(false);
+        assertValue(this.textInputField, 'false');
       });
     });
   });
   suite.skip('Validators', function() {
-    var textInputField;
     setup(function() {
-      textInputField = new Blockly.FieldTextInput('value');
+      this.textInputField = new Blockly.FieldTextInput('value');
       Blockly.FieldTextInput.htmlInput_ = Object.create(null);
       Blockly.FieldTextInput.htmlInput_.oldValue_ = 'value';
       Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 'value';
     });
     suite('Null Validator', function() {
       setup(function() {
-        textInputField.setValidator(function() {
+        this.textInputField.setValidator(function() {
           return null;
         });
       });
       test('When Editing', function() {
-        textInputField.isBeingEdited_ = true;
+        this.textInputField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = 'newValue';
-        textInputField.onHtmlInputChange_(null);
-        assertValue(textInputField, 'value', 'newValue');
-        textInputField.isBeingEdited_ = false;
+        this.textInputField.onHtmlInputChange_(null);
+        assertValue(this.textInputField, 'value', 'newValue');
+        this.textInputField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        textInputField.setValue('newValue');
-        assertValue(textInputField, 'value');
+        this.textInputField.setValue('newValue');
+        assertValue(this.textInputField, 'value');
       });
     });
     suite('Remove \'a\' Validator', function() {
       setup(function() {
-        textInputField.setValidator(function(newValue) {
+        this.textInputField.setValidator(function(newValue) {
           return newValue.replace(/a/g, '');
         });
       });
       test('When Editing', function() {
-        textInputField.isBeingEdited_ = true;
+        this.textInputField.isBeingEdited_ = true;
         Blockly.FieldTextInput.htmlInput_.value = 'bbbaaa';
-        textInputField.onHtmlInputChange_(null);
-        assertValue(textInputField, 'bbb', 'bbbaaa');
-        textInputField.isBeingEdited_ = false;
+        this.textInputField.onHtmlInputChange_(null);
+        assertValue(this.textInputField, 'bbb', 'bbbaaa');
+        this.textInputField.isBeingEdited_ = false;
       });
       test('When Not Editing', function() {
-        textInputField.setValue('bbbaaa');
-        assertValue(textInputField, 'bbb');
+        this.textInputField.setValue('bbbaaa');
+        assertValue(this.textInputField, 'bbb');
       });
     });
   });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -136,6 +136,9 @@ suite ('Text Input Fields', function() {
     var textInputField;
     setup(function() {
       textInputField = new Blockly.FieldTextInput('value');
+      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
+      Blockly.FieldTextInput.htmlInput_.oldValue_ = 'value';
+      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 'value';
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -145,7 +148,8 @@ suite ('Text Input Fields', function() {
       });
       test('When Editing', function() {
         textInputField.isBeingEdited_ = true;
-        textInputField.setValue('newValue');
+        Blockly.FieldTextInput.htmlInput_.value = 'newValue';
+        textInputField.onHtmlInputChange_(null);
         assertValue(textInputField, 'value', 'newValue');
         textInputField.isBeingEdited_ = false;
       });
@@ -162,7 +166,8 @@ suite ('Text Input Fields', function() {
       });
       test('When Editing', function() {
         textInputField.isBeingEdited_ = true;
-        textInputField.setValue('bbbaaa');
+        Blockly.FieldTextInput.htmlInput_.value = 'bbbaaa';
+        textInputField.onHtmlInputChange_(null);
         assertValue(textInputField, 'bbb', 'bbbaaa');
         textInputField.isBeingEdited_ = false;
       });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -99,37 +99,73 @@ suite ('Text Input Fields', function() {
     });
   });
   suite('setValue', function() {
-    var textInputField;
-    setup(function() {
-      textInputField = new Blockly.FieldTextInput('value');
+    suite('Empty -> New Value', function() {
+      var textInputField;
+      setup(function() {
+        textInputField = new Blockly.FieldTextInput();
+      });
+      test('Null', function() {
+        textInputField.setValue(null);
+        assertValueDefault(textInputField);
+      });
+      test.skip('Undefined', function() {
+        textInputField.setValue(undefined);
+        assertValueDefault(textInputField);
+      });
+      test('New String', function() {
+        textInputField.setValue('newValue');
+        assertValue(textInputField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        textInputField.setValue(1);
+        assertValue(textInputField, '1');
+      });
+      test.skip('Number (Falsy)', function() {
+        textInputField.setValue(0);
+        assertValue(textInputField, '0');
+      });
+      test('Boolean True', function() {
+        textInputField.setValue(true);
+        assertValue(textInputField, 'true');
+      });
+      test.skip('Boolean False', function() {
+        textInputField.setValue(false);
+        assertValue(textInputField, 'false');
+      });
     });
-    test('Null', function() {
-      textInputField.setValue(null);
-      assertValue(textInputField, 'value');
-    });
-    test.skip('Undefined', function() {
-      textInputField.setValue(undefined);
-      assertValue(textInputField, 'value');
-    });
-    test('New String', function() {
-      textInputField.setValue('newValue');
-      assertValue(textInputField, 'newValue');
-    });
-    test('Number (Truthy)', function() {
-      textInputField.setValue(1);
-      assertValue(textInputField, '1');
-    });
-    test('Number (Falsy)', function() {
-      textInputField.setValue(0);
-      assertValue(textInputField, '0');
-    });
-    test('Boolean True', function() {
-      textInputField.setValue(true);
-      assertValue(textInputField, 'true');
-    });
-    test('Boolean False', function() {
-      textInputField.setValue(false);
-      assertValue(textInputField, 'false');
+    suite('Value -> New Value', function() {
+      var textInputField;
+      setup(function() {
+        textInputField = new Blockly.FieldTextInput('value');
+      });
+      test('Null', function() {
+        textInputField.setValue(null);
+        assertValue(textInputField, 'value');
+      });
+      test.skip('Undefined', function() {
+        textInputField.setValue(undefined);
+        assertValue(textInputField, 'value');
+      });
+      test('New String', function() {
+        textInputField.setValue('newValue');
+        assertValue(textInputField, 'newValue');
+      });
+      test('Number (Truthy)', function() {
+        textInputField.setValue(1);
+        assertValue(textInputField, '1');
+      });
+      test('Number (Falsy)', function() {
+        textInputField.setValue(0);
+        assertValue(textInputField, '0');
+      });
+      test('Boolean True', function() {
+        textInputField.setValue(true);
+        assertValue(textInputField, 'true');
+      });
+      test('Boolean False', function() {
+        textInputField.setValue(false);
+        assertValue(textInputField, 'false');
+      });
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite ('Text Input Fields', function() {
+  function assertValue(textInputField, expectedValue, opt_expectedText) {
+    var actualValue = textInputField.getValue();
+    var actualText = textInputField.getText();
+    opt_expectedText = opt_expectedText || expectedValue;
+    assertEquals(actualValue, expectedValue);
+    assertEquals(actualText, opt_expectedText);
+  }
+  function assertValueDefault(textInputField) {
+    assertValue(textInputField, '');
+  }
+  suite('Constructor', function() {
+    test('Empty', function() {
+      var textInputField = new Blockly.FieldTextInput();
+      assertValueDefault(textInputField);
+    });
+    test('Null', function() {
+      var textInputField = new Blockly.FieldTextInput(null);
+      assertValueDefault(textInputField);
+    });
+    test('Undefined', function() {
+      var textInputField = new Blockly.FieldTextInput(undefined);
+      assertValueDefault(textInputField);
+    });
+    test('String', function() {
+      var textInputField = new Blockly.FieldTextInput('value');
+      assertValue(textInputField, 'value');
+    });
+    test('Number', function() {
+      var textInputField = new Blockly.FieldTextInput(1);
+      assertValue(textInputField, '1');
+    });
+    test('Boolean', function() {
+      var textInputField = new Blockly.FieldTextInput(true);
+      assertValue(textInputField, 'true');
+    });
+  });
+  suite('fromJson', function() {
+    test('Empty', function() {
+      var textInputField = new Blockly.FieldTextInput.fromJson({});
+      assertValueDefault(textInputField);
+    });
+    test('Null', function() {
+      var textInputField = new Blockly.FieldTextInput.fromJson({ text: null});
+      assertValueDefault(textInputField);
+    });
+    test('Undefined', function() {
+      var textInputField = new Blockly.FieldTextInput
+          .fromJson({ text: undefined});
+      assertValueDefault(textInputField);
+    });
+    test('String', function() {
+      var textInputField = Blockly.FieldTextInput.fromJson({ text:'value' });
+      assertValue(textInputField, 'value');
+    });
+    test('Number', function() {
+      var textInputField = Blockly.FieldTextInput.fromJson({ text:1 });
+      assertValue(textInputField, '1');
+    });
+    test('Boolean', function() {
+      var textInputField = Blockly.FieldTextInput.fromJson({ text:true });
+      assertValue(textInputField, 'true');
+    });
+  });
+  suite('setValue', function() {
+    var textInputField;
+    setup(function() {
+      textInputField = new Blockly.FieldTextInput('value');
+    });
+    test('Null', function() {
+      textInputField.setValue(null);
+      assertValue(textInputField, 'value');
+    });
+    test.skip('Undefined', function() {
+      textInputField.setValue(undefined);
+      assertValue(textInputField, 'value');
+    });
+    test('New String', function() {
+      textInputField.setValue('newValue');
+      assertValue(textInputField, 'newValue');
+    });
+  });
+  suite.skip('Validators', function() {
+    var textInputField;
+    setup(function() {
+      textInputField = new Blockly.FieldTextInput('value');
+    });
+    suite('Null Validator', function() {
+      setup(function() {
+        textInputField.setValidator(function() {
+          return null;
+        });
+      });
+      test('When Editing', function() {
+        textInputField.isBeingEdited_ = true;
+        textInputField.setValue('newValue');
+        assertValue(textInputField, 'value', 'newValue');
+        textInputField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        textInputField.setValue('newValue');
+        assertValue(textInputField, 'value');
+      });
+    });
+    suite('Remove \'a\' Validator', function() {
+      setup(function() {
+        textInputField.setValidator(function(newValue) {
+          return newValue.replace(/a/g, '');
+        });
+      });
+      test('When Editing', function() {
+        textInputField.isBeingEdited_ = true;
+        textInputField.setValue('bbbaaa');
+        assertValue(textInputField, 'bbb', 'bbbaaa');
+        textInputField.isBeingEdited_ = false;
+      });
+      test('When Not Editing', function() {
+        textInputField.setValue('bbbaaa');
+        assertValue(textInputField, 'bbb');
+      });
+    });
+  });
+});

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -175,7 +175,7 @@ suite('Variable Fields', function() {
       });
       test('New Value', function() {
         variableField.setValue('id2');
-        assertValue(variableField, 'name1');
+        assertValue(variableField, 'name1', 'id1');
       });
     });
     suite('Force \'id\' ID Validator', function() {
@@ -188,7 +188,7 @@ suite('Variable Fields', function() {
         // Must create the var so that the field doesn't throw an error.
         this.workspace.createVariable('thing2', null, 'other2');
         variableField.setValue('other2');
-        assertValue(variableField, 'name2');
+        assertValue(variableField, 'name2', 'id2');
       });
     });
   });

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -160,35 +160,34 @@ suite('Variable Fields', function() {
     });
   });
   suite.skip('Validators', function() {
-    var variableField;
     setup(function() {
       this.workspace.createVariable('name1', null, 'id1');
       this.workspace.createVariable('name2', null, 'id2');
       this.workspace.createVariable('name3', null, 'id3');
-      variableField = createAndInitFieldConstructor(this.workspace, 'name1');
+      this.variableField = createAndInitFieldConstructor(this.workspace, 'name1');
     });
     suite('Null Validator', function() {
       setup(function() {
-        variableField.setValidator(function() {
+        this.variableField.setValidator(function() {
           return null;
         });
       });
       test('New Value', function() {
-        variableField.setValue('id2');
-        assertValue(variableField, 'name1', 'id1');
+        this.variableField.setValue('id2');
+        assertValue(this.variableField, 'name1', 'id1');
       });
     });
     suite('Force \'id\' ID Validator', function() {
       setup(function() {
-        variableField.setValidator(function(newValue) {
+        this.variableField.setValidator(function(newValue) {
           return 'id' + newValue.charAt(newValue.length - 1);
         });
       });
       test('New Value', function() {
         // Must create the var so that the field doesn't throw an error.
         this.workspace.createVariable('thing2', null, 'other2');
-        variableField.setValue('other2');
-        assertValue(variableField, 'name2', 'id2');
+        this.variableField.setValue('other2');
+        assertValue(this.variableField, 'name2', 'id2');
       });
     });
   });

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -133,12 +133,11 @@ suite('Variable Fields', function() {
       variableField.setValue(null);
       assertValue(variableField, 'name1');
     });
-    test('Undefined', function() {
+    test.skip('Undefined', function() {
       var variableField = createAndInitFieldConstructor(
           this.workspace, 'name1');
-      chai.assert.throws(function() {
-        variableField.setValue(undefined);
-      });
+      variableField.setValue(undefined);
+      assertValue(variableField, 'name1');
     });
     test('New Variable ID', function() {
       this.workspace.createVariable('name2', null, 'id2');
@@ -153,12 +152,11 @@ suite('Variable Fields', function() {
       assertEquals('id2', variableField.getValue());
       chai.assert.notEqual(oldId, variableField.getValue());
     });
-    test('Variable Does not Exist', function() {
+    test.skip('Variable Does not Exist', function() {
       var variableField = createAndInitFieldConstructor(
           this.workspace, 'name1');
-      chai.assert.throws(function() {
-        variableField.setValue('id1');
-      });
+      variableField.setValue('id1');
+      assertValue(variableField, 'name1');
     });
   });
   suite.skip('Validators', function() {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -19,11 +19,23 @@
         ui: 'tdd'
       });
     </script>
+
     <script src="test_helpers.js"></script>
+
     <script src="block_test.js"></script>
     <script src="event_test.js"></script>
     <script src="connection_test.js"></script>
     <script src="field_test.js"></script>
+    <script src="field_angle_test.js"></script>
+    <script src="field_checkbox_test.js"></script>
+    <script src="field_colour_test.js"></script>
+    <script src="field_date_test.js"></script>
+    <script src="field_dropdown_test.js"></script>
+    <script src="field_image_test.js"></script>
+    <script src="field_label_test.js"></script>
+    <script src="field_label_serializable_test.js"></script>
+    <script src="field_number_test.js"></script>
+    <script src="field_textinput_test.js"></script>
     <script src="field_variable_test.js"></script>
     <script src="xml_test.js"></script>
     <script src="utils_test.js"></script>

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -104,5 +104,5 @@ function assertNotUndefined() {
   _validateArguments(1, arguments);
   var commentArg = _commentArg(1, arguments);
   var val = _nonCommentArg(1, 1, arguments);
-  chai.assert.isNotUndefined(val, commentArg);
+  chai.assert.isDefined(val, commentArg);
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2169 specifically [this](https://github.com/google/blockly/issues/2169#issuecomment-488471207).

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds tests to document how fields should react to different values.

Also clarifies which fields have default values and which do not.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Tests needed to be added before #2441 possibly breaks the world.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

This is tests silly!

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

So... a lot of these tests are actually failing! But that's not because the tests are broken, it's because the fields are broken.

Examples:
* Most validator tests fail because atm most fields don't validate unless they are attached to a block. ([link](https://github.com/google/blockly/issues/2169#issuecomment-491080867))
* All checkbox field tests are failing because checkboxes don't handle their text_ properly.
* Lots of fields have less severe checks on setValue than on their constructors, so several setValue tests are failing (e.g. most fields fail the non-parsable string test).

Plus a smattering of other field-specific bugs.

### Important information

I have some TODO notes in the tests, these are requests for information on what the intended behavior is.

For example, most fields will revert to a default value (meaning the value they would have had had they been constructed no parameters) when passed a non-parsable value. I believe this is a bug, and non-parsable values should validated to null inside a field's doClassValidation_ function, but I wanted confirmation.
