### PR TITLE
Load a list of tests to run from a file; connect test output to dif-viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ npm-debug.log
 
 tests/compile/main_compressed.js
 tests/compile/*compiler*.jar
+tests/screenshot/outputs/*
 local_build/*compiler*.jar
 local_build/local_*_compressed.js

--- a/tests/screenshot/diff-reporter.js
+++ b/tests/screenshot/diff-reporter.js
@@ -23,7 +23,7 @@
 /**
  * @fileoverview Reporter that prints results to the console with the same
  * format as the spec reporter, but also saves a test_output.js file with a
- * that just wraps a json object, for use in diff_viewer.html.
+ * variable that just wraps a json object, for use in diff_viewer.html.
  */
 var mocha = require('mocha');
 var fs = require("fs");

--- a/tests/screenshot/diff-reporter.js
+++ b/tests/screenshot/diff-reporter.js
@@ -1,0 +1,131 @@
+// diff-reporter.js
+
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Reporter that prints results to the console with the same
+ * format as the spec reporter, but also saves a test_output.js file with a
+ * that just wraps a json object, for use in diff_viewer.html.
+ */
+var mocha = require('mocha');
+var fs = require("fs");
+module.exports = DiffReporter;
+
+
+function DiffReporter(runner) {
+  mocha.reporters.Base.call(this, runner);
+  var passes = 0;
+  var failures = 0;
+
+  // Values for the JSON output.
+  var json_tests = [];
+
+  // From the spec reporter.
+  var self = this;
+  var indents = 0;
+  var n = 0;
+  var color = mocha.reporters.Base.color;
+
+  function indent() {
+    return Array(indents).join('  ');
+  }
+
+  // Indent/unindent correctly.
+  runner.on('start', function() {
+    console.log();
+  });
+  runner.on('suite', function(suite) {
+    ++indents;
+    console.log(color('suite', '%s%s'), indent(), suite.title);
+  });
+  runner.on('suite end', function() {
+    --indents;
+    if (indents === 1) {
+      console.log();
+    }
+  });
+
+  runner.on('pass', function(test) {
+    passes++;
+    json_tests.push(test);
+
+    // Print test information the way the spec reporter would.
+    var fmt;
+    if (test.speed === 'fast') {
+      fmt =
+        indent() +
+        color('checkmark', '  ' + Base.symbols.ok) +
+        color('pass', ' %s');
+      console.log(fmt, test.title);
+    } else {
+      fmt =
+        indent() +
+        color('checkmark', '  ' + Base.symbols.ok) +
+        color('pass', ' %s') +
+        color(test.speed, ' (%dms)');
+      console.log(fmt, test.title, test.duration);
+    }
+  });
+
+  runner.on('fail', function(test, err) {
+    failures++;
+    json_tests.push(test);
+    // Print test information the way the spec reporter would.
+    console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+  });
+
+  runner.on('end', function() {
+    console.log('\n%d/%d tests passed\n', passes, passes + failures);
+    var jsonObj = {
+      passes: passes,
+      failures: failures,
+      total: passes + failures,
+      tests: json_tests.map(clean)
+    }
+    runner.testResults = jsonObj;
+
+    let json = JSON.stringify(jsonObj, null, 2)
+    let jsonOutput = writeJSON(json, 'test_output')
+  });
+
+
+  function clean(test) {
+    return {
+      title: test.title,
+      fullTitle: test.fullTitle(),
+      state: test.state
+    };
+  }
+
+  function writeJSON(data, filename){
+    let output_dir = `${process.cwd()}/tests/screenshot/outputs`
+    let output= `${output_dir}/${filename}`
+
+    if (!fs.existsSync(output_dir)){
+      fs.mkdirSync(output_dir);
+    }
+    fs.writeFileSync(output + '.json', data)
+
+    fs.writeFileSync(output + '.js', 'var results = ' + data);
+    return output
+  }
+}
+mocha.utils.inherits(DiffReporter, mocha.reporters.Spec);

--- a/tests/screenshot/diff_screenshots.js
+++ b/tests/screenshot/diff_screenshots.js
@@ -30,13 +30,14 @@ var fs = require('fs'),
 var old_dir = 'tests/screenshot/outputs/old/';
 var new_dir = 'tests/screenshot/outputs/new/';
 var diff_dir = 'tests/screenshot/outputs/diff/';
+var test_list_location ='tests/screenshot/test_cases/test_cases.json';
 
 if (!fs.existsSync(diff_dir)){
   fs.mkdirSync(diff_dir);
 }
 
 function getTestList() {
-  var file = fs.readFileSync('tests/screenshot/test_cases/test_cases.json');
+  var file = fs.readFileSync(test_list_location);
   var json = JSON.parse(file);
   var testSpecArr = json.tests;
   var testList = [];

--- a/tests/screenshot/diff_viewer.html
+++ b/tests/screenshot/diff_viewer.html
@@ -22,24 +22,37 @@ limitations under the License.
 <head>
 <meta charset="utf-8">
 <title>Diff Viewer</title>
+<script src="outputs/test_output.js"></script>
 <script>
 'use strict';
 function start() {
+
+  var test_list = results.tests;
+
   var table = document.getElementById('results_table');
-  addTest(table, 'math_addition');
-  //addTest(table, 'another-screenshot');
+
+  for (var i = 0, test; test = test_list[i]; i++) {
+    addTest(table, test);
+  }
 }
 
-function addTest(table, name) {
+function addTest(table, test) {
   var row = table.insertRow(-1);
-  row.className = 'tableRow';
+  var className = 'tableRow';
+  if (test.state == 'failed') {
+    className += ' failedTest'
+  } else {
+    className += ' passedTest';
+  }
+  row.className = className;
   var cell1 = row.insertCell(0);
-  cell1.innerHTML = name;
-  cell1.displayed = true;
+  cell1.innerHTML = test.title;
+  var displayed = (test.state == "failed")
+  cell1.displayed = displayed;
   cell1.className = 'testName';
-  var cell2 = addImageCell(row, name, 'old');
-  var cell3 = addImageCell(row, name, 'new');
-  var cell4 = addImageCell(row, name, 'diff');
+  var cell2 = addImageCell(row, test.title, 'old', displayed);
+  var cell3 = addImageCell(row, test.title, 'new', displayed);
+  var cell4 = addImageCell(row, test.title, 'diff', displayed);
 
   cell1.onclick = function() {
     var display = !cell1.displayed;
@@ -48,22 +61,26 @@ function addTest(table, name) {
     setVisibility(cell3, display);
     setVisibility(cell4, display);
   }
+
 }
 
-function setVisibility(cell, hidden) {
+function setVisibility(cell, displayed) {
   var img = cell.firstChild;
-  if (hidden) {
-    img.className = 'hidden';
-  } else {
+  if (displayed) {
     img.className = '';
+  } else {
+    img.className = 'hidden';
   }
 }
-function addImageCell(row, name, dir) {
+function addImageCell(row, name, dir, displayed) {
   var cell = row.insertCell();
   cell.className = 'imageCell';
   var img = document.createElement('img');
   img.src = 'outputs/' + dir + '/' + name + '.png';
   cell.appendChild(img);
+  if (!displayed) {
+    img.className = 'hidden';
+  }
   return cell;
 }
 </script>

--- a/tests/screenshot/gen_screenshots.js
+++ b/tests/screenshot/gen_screenshots.js
@@ -26,6 +26,12 @@ var fs = require('fs');
 
 module.exports = genScreenshots;
 
+function checkAndCreateDir(dirname) {
+  if (!fs.existsSync(dirname)){
+    fs.mkdirSync(dirname);
+  }
+};
+
 /**
  * Opens two different webdriverio browsers.  One uses the hosted version of
  * blockly_compressed.js; the other uses the local blockly_uncompressed.js.
@@ -34,23 +40,37 @@ module.exports = genScreenshots;
  * both playgrounds and saves a screenshot of each.
  */
 async function genScreenshots() {
-  // TODOs:
-  // - open the test cases folder
-  // - iterate over all files in the test cases folder
-  // - use the input file name for the output file names
-  var prefix = './tests/screenshot/';
-  var xml_url = prefix + 'test_cases/math_addition';
-  var xml = fs.readFileSync(xml_url, 'utf8');
-  var url_prefix = 'file://' + __dirname + '/playground';
+  var output_url = 'tests/screenshot/outputs'
+  checkAndCreateDir(output_url)
+  checkAndCreateDir(output_url + '/old');
+  checkAndCreateDir(output_url + '/new');
 
+  var url_prefix = 'file://' + __dirname + '/playground';
   var browser_new = await buildBrowser(url_prefix + '_new.html');
   var browser_old = await buildBrowser(url_prefix + '_old.html');
 
-  await genSingleScreenshot(browser_new, 'new', 'math_addition');
-  await genSingleScreenshot(browser_old, 'old', 'math_addition');
+  var test_list = getTestList();
+
+  for (var i = 0, testName; testName = test_list[i]; i++) {
+    await genSingleScreenshot(browser_new, 'new', testName);
+    await genSingleScreenshot(browser_old, 'old', testName);
+  }
 
   await cleanUp(browser_new, browser_old);
   return 0;
+}
+
+function getTestList() {
+  var file = fs.readFileSync('tests/screenshot/test_cases/test_cases.json');
+  var json = JSON.parse(file);
+  var testSpecArr = json.tests;
+  var testList = [];
+  for (var i = 0, testSpec; testSpec = testSpecArr[i]; i++) {
+    if (!testSpec.skip) {
+      testList.push(testSpec.title);
+    }
+  }
+  return testList;
 }
 
 async function cleanUp(browser_new, browser_old) {

--- a/tests/screenshot/gen_screenshots.js
+++ b/tests/screenshot/gen_screenshots.js
@@ -53,7 +53,9 @@ async function genScreenshots() {
 
   for (var i = 0, testName; testName = test_list[i]; i++) {
     await genSingleScreenshot(browser_new, 'new', testName);
-    await genSingleScreenshot(browser_old, 'old', testName);
+    if (!fs.existsSync(output_url + '/old/' + testName)) {
+      await genSingleScreenshot(browser_old, 'old', testName);
+    }
   }
 
   await cleanUp(browser_new, browser_old);

--- a/tests/screenshot/mocha.opts
+++ b/tests/screenshot/mocha.opts
@@ -1,1 +1,2 @@
 --ui tdd
+--reporter ./tests/screenshot/diff-reporter.js

--- a/tests/screenshot/run_differ.sh
+++ b/tests/screenshot/run_differ.sh
@@ -25,14 +25,7 @@
 # tests/scripts/test_setup.sh
 node tests/screenshot/gen_screenshots.js
 clear
-# TODO: check whether outputs/ folders exist, and make them if they don't
-# For now, create:
-# outputs
-# - diff
-# - old
-# - new
-#
-# Inside the tests/screenshot folder.
 ./node_modules/.bin/mocha tests/screenshot/diff_screenshots.js --opts "./tests/screenshot/mocha.opts"
 
-# To see results visually, open tests/screenshot/diff_viewer.html
+# Open results.
+xdg-open 'tests/screenshot/diff_viewer.html'

--- a/tests/screenshot/test_cases/math_subtraction
+++ b/tests/screenshot/test_cases/math_subtraction
@@ -1,0 +1,15 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="math_arithmetic">
+    <field name="OP">MINUS</field>
+    <value name="A">
+      <shadow type="math_number">
+        <field name="NUM">3</field>
+      </shadow>
+    </value>
+    <value name="B">
+      <shadow type="math_number">
+        <field name="NUM">4</field>
+      </shadow>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "title": "math_addition"
+    },
+    {
+      "title": "math_subtraction",
+      "skip": true
+    }
+  ]
+}


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

^ None of these, but the style guide doesn't currently apply in this directory.

## The details
### Resolves


### Proposed Changes

- Use a `test_cases.json` file to specify which tests to run.
- Use a custom reporter for mocha to output test results in a way that's easy to use.
- Use those results in `diff_viewer.html`.
- Make sure folders exist
- Automatically open `diff_viewer.html` after running tests
