### PR TITLE
Add a checkbox to toggle rendering debug visualizations in the playground

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/block_rendering_rewrite/block_render_draw_debug.js
@@ -29,7 +29,7 @@ goog.provide('Blockly.BlockRendering.Debug');
 Blockly.BlockRendering.Debug.drawSpacerRow = function(row, cursorY, svgRoot) {
   row.rect = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'rowSpacerRect displayable',
+        'class': 'rowSpacerRect blockRenderDebug',
         'x': 0,
         'y': cursorY,
         'width': row.width,
@@ -41,7 +41,7 @@ Blockly.BlockRendering.Debug.drawSpacerRow = function(row, cursorY, svgRoot) {
 Blockly.BlockRendering.Debug.drawSpacerElem = function(elem, cursorX, centerY, svgRoot) {
   elem.rect = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'elemSpacerRect displayable',
+        'class': 'elemSpacerRect blockRenderDebug',
         'x': cursorX,
         'y': centerY - elem.height / 2,
         'width': elem.width,
@@ -54,7 +54,7 @@ Blockly.BlockRendering.Debug.drawRenderedElem = function(elem, cursorX, centerY,
   var yPos = centerY - elem.height / 2;
   elem.rect = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'rowRenderingRect displayable',
+        'class': 'rowRenderingRect blockRenderDebug',
         'x': cursorX,
         'y': yPos,
         'width': elem.width,
@@ -90,7 +90,7 @@ Blockly.BlockRendering.Debug.drawConnection = function(conn, svgRoot) {
   }
   Blockly.utils.createSvgElement('circle',
       {
-        'class': 'connectionRenderingDot',
+        'class': 'blockRenderDebug',
         'cx': conn.offsetInBlock_.x,
         'cy': conn.offsetInBlock_.y,
         'r': size,
@@ -103,7 +103,7 @@ Blockly.BlockRendering.Debug.drawConnection = function(conn, svgRoot) {
 Blockly.BlockRendering.Debug.drawRenderedRow = function(row, cursorY, svgRoot) {
   row.rect = Blockly.utils.createSvgElement('rect',
       {
-        'class': 'elemRenderingRect displayable',
+        'class': 'elemRenderingRect blockRenderDebug',
         'x': 0,
         'y': cursorY ,
         'width': row.width,

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -144,6 +144,10 @@ function start() {
     // Restore event logging state.
     var state = sessionStorage.getItem('logEvents');
     logEvents(Boolean(Number(state)));
+
+    // Restore render debug state.
+    var renderDebugState = sessionStorage.getItem('blockRenderDebug');
+    toggleRenderingDebug(Boolean(Number(renderDebugState)));
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);
@@ -282,6 +286,19 @@ function logEvents(state) {
   }
 }
 
+function toggleRenderingDebug(state) {
+  var checkbox = document.getElementById('blockRenderDebugCheck');
+  checkbox.checked = state;
+  if (sessionStorage) {
+    sessionStorage.setItem('blockRenderDebug', Number(state));
+  }
+  if (state) {
+    document.getElementById('blocklyDiv').className = 'renderingDebug';
+  } else {
+    document.getElementById('blocklyDiv').className = '';
+  }
+}
+
 function logger(e) {
   console.log(e);
 }
@@ -375,7 +392,11 @@ h1 {
   font-style: italic;
 }
 
-.displayable {
+#blocklyDiv.renderingDebug .blockRenderDebug {
+  display: block;
+}
+
+.blockRenderDebug {
   display: none;
 }
 
@@ -403,9 +424,6 @@ h1 {
   fill-opacity: 0.5;
   fill: pink;
   stroke-width: 1px;
-}
-
-.connectionRenderingDot {
 }
 
 </style>
@@ -471,6 +489,10 @@ h1 {
     <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
   </p>
 
+  <p>
+    Block rendering debug: &nbsp;
+    <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
+  </p>
   <!-- The next three blocks of XML are sample toolboxes for testing basic
   configurations.  For more information on building toolboxes, see https://developers.google.com/blockly/guides/configure/web/toolbox -->
 


### PR DESCRIPTION
Like the logEvents checkbox, it persists its state across reloads.

It controls both rectangles and connection dots.