### PR TITLE
Add single-block test cases

### DIFF
--- a/tests/screenshot/diff_viewer.html
+++ b/tests/screenshot/diff_viewer.html
@@ -96,6 +96,12 @@ function addImageCell(row, name, dir, displayed) {
 .testName {
   cursor: pointer;
 }
+.failedTest .testName {
+  background: lightgrey;
+}
+.passedTest .testName {
+  background: forestgreen;
+}
 td {
   border: 1px solid black;
 }

--- a/tests/screenshot/gen_screenshots.js
+++ b/tests/screenshot/gen_screenshots.js
@@ -88,7 +88,7 @@ async function buildBrowser(url) {
   };
   console.log('Starting webdriverio...');
   const browser = await webdriverio.remote(options);
-  await browser.setWindowSize(1000, 1000);
+  await browser.setWindowSize(500, 500);
   console.log('Initialized.\nLoading url: ' + url);
   await browser.url(url);
   return browser;

--- a/tests/screenshot/playground_new.html
+++ b/tests/screenshot/playground_new.html
@@ -103,7 +103,7 @@ h1 {
 .ioLabel>.blocklyFlyoutLabelText {
   font-style: italic;
 }
-.displayable {
+.blockRenderDebug {
   display: none;
 }
 

--- a/tests/screenshot/run_differ.sh
+++ b/tests/screenshot/run_differ.sh
@@ -23,8 +23,15 @@
 # preferably not by redownloading everything every time.
 # For now, open a new terminal and run:
 # tests/scripts/test_setup.sh
+rm -rf tests/screenshot/outputs/new
+rm -rf tests/screenshot/outputs/diff
+rm tests/screenshot/outputs/test_output.js
+rm tests/screenshot/outputs/test_output.json
+
 node tests/screenshot/gen_screenshots.js
-clear
+
+echo
+
 ./node_modules/.bin/mocha tests/screenshot/diff_screenshots.js --opts "./tests/screenshot/mocha.opts"
 
 # Open results.

--- a/tests/screenshot/test_cases/colour
+++ b/tests/screenshot/test_cases/colour
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_blend
+++ b/tests/screenshot/test_cases/colour_blend
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_blend">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_picker
+++ b/tests/screenshot/test_cases/colour_picker
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_picker">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_random
+++ b/tests/screenshot/test_cases/colour_random
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_random">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_rgb
+++ b/tests/screenshot/test_cases/colour_rgb
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_rgb">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_flow_statements
+++ b/tests/screenshot/test_cases/controls_flow_statements
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_flow_statements">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_for
+++ b/tests/screenshot/test_cases/controls_for
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_for">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_forEach
+++ b/tests/screenshot/test_cases/controls_forEach
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_forEach">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if
+++ b/tests/screenshot/test_cases/controls_if
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_else
+++ b/tests/screenshot/test_cases/controls_if_else
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_else">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_elseif
+++ b/tests/screenshot/test_cases/controls_if_elseif
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_elseif">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_if
+++ b/tests/screenshot/test_cases/controls_if_if
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_if">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_ifelse
+++ b/tests/screenshot/test_cases/controls_ifelse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_ifelse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_repeat
+++ b/tests/screenshot/test_cases/controls_repeat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_repeat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_repeat_ext
+++ b/tests/screenshot/test_cases/controls_repeat_ext
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_repeat_ext">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_whileUntil
+++ b/tests/screenshot/test_cases/controls_whileUntil
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_whileUntil">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists
+++ b/tests/screenshot/test_cases/lists
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_empty
+++ b/tests/screenshot/test_cases/lists_create_empty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_empty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with
+++ b/tests/screenshot/test_cases/lists_create_with
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with_container
+++ b/tests/screenshot/test_cases/lists_create_with_container
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with_container">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with_item
+++ b/tests/screenshot/test_cases/lists_create_with_item
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with_item">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_getIndex
+++ b/tests/screenshot/test_cases/lists_getIndex
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_getIndex">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_getSublist
+++ b/tests/screenshot/test_cases/lists_getSublist
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_getSublist">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_indexOf
+++ b/tests/screenshot/test_cases/lists_indexOf
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_indexOf">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_isEmpty
+++ b/tests/screenshot/test_cases/lists_isEmpty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_isEmpty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_length
+++ b/tests/screenshot/test_cases/lists_length
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_length">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_repeat
+++ b/tests/screenshot/test_cases/lists_repeat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_repeat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_reverse
+++ b/tests/screenshot/test_cases/lists_reverse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_reverse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_setIndex
+++ b/tests/screenshot/test_cases/lists_setIndex
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_setIndex">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_sort
+++ b/tests/screenshot/test_cases/lists_sort
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_sort">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_split
+++ b/tests/screenshot/test_cases/lists_split
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_split">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic
+++ b/tests/screenshot/test_cases/logic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_boolean
+++ b/tests/screenshot/test_cases/logic_boolean
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_boolean">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_compare
+++ b/tests/screenshot/test_cases/logic_compare
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_compare">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_negate
+++ b/tests/screenshot/test_cases/logic_negate
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_negate">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_null
+++ b/tests/screenshot/test_cases/logic_null
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_null">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_operation
+++ b/tests/screenshot/test_cases/logic_operation
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_operation">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_ternary
+++ b/tests/screenshot/test_cases/logic_ternary
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_ternary">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/loops
+++ b/tests/screenshot/test_cases/loops
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="loops">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math
+++ b/tests/screenshot/test_cases/math
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_arithmetic
+++ b/tests/screenshot/test_cases/math_arithmetic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_arithmetic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_atan2
+++ b/tests/screenshot/test_cases/math_atan2
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_atan2">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_change
+++ b/tests/screenshot/test_cases/math_change
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_change">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_constant
+++ b/tests/screenshot/test_cases/math_constant
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_constant">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_constrain
+++ b/tests/screenshot/test_cases/math_constrain
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_constrain">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_modulo
+++ b/tests/screenshot/test_cases/math_modulo
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_modulo">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_number
+++ b/tests/screenshot/test_cases/math_number
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_number">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_number_property
+++ b/tests/screenshot/test_cases/math_number_property
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_number_property">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_on_list
+++ b/tests/screenshot/test_cases/math_on_list
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_on_list">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_random_float
+++ b/tests/screenshot/test_cases/math_random_float
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_random_float">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_random_int
+++ b/tests/screenshot/test_cases/math_random_int
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_random_int">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_round
+++ b/tests/screenshot/test_cases/math_round
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_round">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_single
+++ b/tests/screenshot/test_cases/math_single
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_single">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_trig
+++ b/tests/screenshot/test_cases/math_trig
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_trig">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures
+++ b/tests/screenshot/test_cases/procedures
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_callnoreturn
+++ b/tests/screenshot/test_cases/procedures_callnoreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_callnoreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_callreturn
+++ b/tests/screenshot/test_cases/procedures_callreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_callreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_defnoreturn
+++ b/tests/screenshot/test_cases/procedures_defnoreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_defnoreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_defreturn
+++ b/tests/screenshot/test_cases/procedures_defreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_defreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_ifreturn
+++ b/tests/screenshot/test_cases/procedures_ifreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_ifreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_mutatorarg
+++ b/tests/screenshot/test_cases/procedures_mutatorarg
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_mutatorarg">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_mutatorcontainer
+++ b/tests/screenshot/test_cases/procedures_mutatorcontainer
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_mutatorcontainer">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_empty
+++ b/tests/screenshot/test_cases/test_basic_empty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_empty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_empty_with_mutator
+++ b/tests/screenshot/test_cases/test_basic_empty_with_mutator
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_empty_with_mutator">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_limit_instances
+++ b/tests/screenshot/test_cases/test_basic_limit_instances
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_limit_instances">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_value_to_stack
+++ b/tests/screenshot/test_cases/test_basic_value_to_stack
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_value_to_stack">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_value_to_statement
+++ b/tests/screenshot/test_cases/test_basic_value_to_statement
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_value_to_statement">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -1,11 +1,492 @@
 {
   "tests": [
     {
-      "title": "math_addition"
+      "title": "logic",
+      "skip": false
     },
     {
-      "title": "math_subtraction",
+      "title": "logic_boolean",
+      "skip": false
+    },
+    {
+      "title": "controls_if",
+      "skip": false
+    },
+    {
+      "title": "controls_ifelse",
+      "skip": false
+    },
+    {
+      "title": "logic_compare",
+      "skip": false
+    },
+    {
+      "title": "logic_operation",
+      "skip": false
+    },
+    {
+      "title": "logic_negate",
+      "skip": false
+    },
+    {
+      "title": "logic_null",
+      "skip": false
+    },
+    {
+      "title": "logic_ternary",
+      "skip": false
+    },
+    {
+      "title": "controls_if_if",
+      "skip": false
+    },
+    {
+      "title": "controls_if_elseif",
+      "skip": false
+    },
+    {
+      "title": "controls_if_else",
+      "skip": false
+    },
+    {
+      "title": "loops",
+      "skip": false
+    },
+    {
+      "title": "controls_repeat_ext",
+      "skip": false
+    },
+    {
+      "title": "controls_repeat",
+      "skip": false
+    },
+    {
+      "title": "controls_whileUntil",
+      "skip": false
+    },
+    {
+      "title": "controls_for",
+      "skip": false
+    },
+    {
+      "title": "controls_forEach",
+      "skip": false
+    },
+    {
+      "title": "controls_flow_statements",
+      "skip": false
+    },
+    {
+      "title": "math",
+      "skip": false
+    },
+    {
+      "title": "math_number",
+      "skip": false
+    },
+    {
+      "title": "math_arithmetic",
+      "skip": false
+    },
+    {
+      "title": "math_single",
+      "skip": false
+    },
+    {
+      "title": "math_trig",
+      "skip": false
+    },
+    {
+      "title": "math_constant",
+      "skip": false
+    },
+    {
+      "title": "math_number_property",
+      "skip": false
+    },
+    {
+      "title": "math_change",
+      "skip": false
+    },
+    {
+      "title": "math_round",
+      "skip": false
+    },
+    {
+      "title": "math_on_list",
+      "skip": false
+    },
+    {
+      "title": "math_modulo",
+      "skip": false
+    },
+    {
+      "title": "math_constrain",
+      "skip": false
+    },
+    {
+      "title": "math_random_int",
+      "skip": false
+    },
+    {
+      "title": "math_random_float",
+      "skip": false
+    },
+    {
+      "title": "math_atan2",
+      "skip": false
+    },
+    {
+      "title": "texts",
+      "skip": false
+    },
+    {
+      "title": "text",
+      "skip": false
+    },
+    {
+      "title": "text_join",
+      "skip": false
+    },
+    {
+      "title": "text_create_join_container",
+      "skip": false
+    },
+    {
+      "title": "text_create_join_item",
+      "skip": false
+    },
+    {
+      "title": "text_append",
+      "skip": false
+    },
+    {
+      "title": "text_length",
+      "skip": false
+    },
+    {
+      "title": "text_isEmpty",
+      "skip": false
+    },
+    {
+      "title": "text_indexOf",
+      "skip": false
+    },
+    {
+      "title": "text_charAt",
+      "skip": false
+    },
+    {
+      "title": "text_getSubstring",
+      "skip": false
+    },
+    {
+      "title": "text_changeCase",
+      "skip": false
+    },
+    {
+      "title": "text_trim",
+      "skip": false
+    },
+    {
+      "title": "text_print",
+      "skip": false
+    },
+    {
+      "title": "text_prompt_ext",
+      "skip": false
+    },
+    {
+      "title": "text_prompt",
+      "skip": false
+    },
+    {
+      "title": "text_count",
+      "skip": false
+    },
+    {
+      "title": "text_replace",
+      "skip": false
+    },
+    {
+      "title": "text_reverse",
+      "skip": false
+    },
+    {
+      "title": "lists",
+      "skip": false
+    },
+    {
+      "title": "lists_create_empty",
+      "skip": false
+    },
+    {
+      "title": "lists_repeat",
+      "skip": false
+    },
+    {
+      "title": "lists_reverse",
+      "skip": false
+    },
+    {
+      "title": "lists_isEmpty",
+      "skip": false
+    },
+    {
+      "title": "lists_length",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with_container",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with_item",
+      "skip": false
+    },
+    {
+      "title": "lists_indexOf",
+      "skip": false
+    },
+    {
+      "title": "lists_getIndex",
+      "skip": false
+    },
+    {
+      "title": "lists_setIndex",
+      "skip": false
+    },
+    {
+      "title": "lists_getSublist",
+      "skip": false
+    },
+    {
+      "title": "lists_sort",
+      "skip": false
+    },
+    {
+      "title": "lists_split",
+      "skip": false
+    },
+    {
+      "title": "colour",
+      "skip": false
+    },
+    {
+      "title": "colour_picker",
+      "skip": false
+    },
+    {
+      "title": "colour_random",
+      "skip": false
+    },
+    {
+      "title": "colour_rgb",
+      "skip": false
+    },
+    {
+      "title": "colour_blend",
+      "skip": false
+    },
+    {
+      "title": "variables",
+      "skip": false
+    },
+    {
+      "title": "variables_get",
+      "skip": false
+    },
+    {
+      "title": "variables_set",
+      "skip": false
+    },
+    {
+      "title": "variables_get_dynamic",
+      "skip": false
+    },
+    {
+      "title": "variables_set_dynamic",
+      "skip": false
+    },
+    {
+      "title": "procedures",
+      "skip": false
+    },
+    {
+      "title": "procedures_defnoreturn",
       "skip": true
+    },
+    {
+      "title": "procedures_defreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_mutatorcontainer",
+      "skip": true
+    },
+    {
+      "title": "procedures_mutatorarg",
+      "skip": true
+    },
+    {
+      "title": "procedures_callnoreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_callreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_ifreturn",
+      "skip": true
+    },
+    {
+      "title": "test_basic_empty",
+      "skip": false
+    },
+    {
+      "title": "test_basic_value_to_stack",
+      "skip": false
+    },
+    {
+      "title": "test_basic_value_to_statement",
+      "skip": false
+    },
+    {
+      "title": "test_basic_limit_instances",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_long",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_images",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_images_and_text",
+      "skip": false
+    },
+    {
+      "title": "test_fields_angle",
+      "skip": false
+    },
+    {
+      "title": "test_fields_date",
+      "skip": false
+    },
+    {
+      "title": "test_fields_text_input",
+      "skip": false
+    },
+    {
+      "title": "test_fields_checkbox",
+      "skip": false
+    },
+    {
+      "title": "test_fields_colour",
+      "skip": false
+    },
+    {
+      "title": "test_fields_variable",
+      "skip": false
+    },
+    {
+      "title": "test_fields_label_serializable",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_float",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_whole",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_hundredths",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_halves",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_three_halves",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_whole_bounded",
+      "skip": false
+    },
+    {
+      "title": "test_images_datauri",
+      "skip": false
+    },
+    {
+      "title": "test_images_small",
+      "skip": false
+    },
+    {
+      "title": "test_images_large",
+      "skip": false
+    },
+    {
+      "title": "test_images_fliprtl",
+      "skip": false
+    },
+    {
+      "title": "test_images_missing",
+      "skip": false
+    },
+    {
+      "title": "test_images_many_icons",
+      "skip": false
+    },
+    {
+      "title": "test_style_hat",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex1",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex2",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex3",
+      "skip": false
+    },
+    {
+      "title": "test_style_no_colour",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex4",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex5",
+      "skip": false
+    },
+    {
+      "title": "test_style_emoji",
+      "skip": false
+    },
+    {
+      "title": "test_basic_empty_with_mutator",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_dynamic",
+      "skip": false
     }
   ]
 }

--- a/tests/screenshot/test_cases/test_dropdowns_dynamic
+++ b/tests/screenshot/test_cases/test_dropdowns_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_dynamic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_images
+++ b/tests/screenshot/test_cases/test_dropdowns_images
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_images">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_images_and_text
+++ b/tests/screenshot/test_cases/test_dropdowns_images_and_text
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_images_and_text">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_long
+++ b/tests/screenshot/test_cases/test_dropdowns_long
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_long">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_angle
+++ b/tests/screenshot/test_cases/test_fields_angle
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_angle">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_checkbox
+++ b/tests/screenshot/test_cases/test_fields_checkbox
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_checkbox">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_colour
+++ b/tests/screenshot/test_cases/test_fields_colour
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_colour">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_date
+++ b/tests/screenshot/test_cases/test_fields_date
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_date">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_label_serializable
+++ b/tests/screenshot/test_cases/test_fields_label_serializable
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_label_serializable">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_text_input
+++ b/tests/screenshot/test_cases/test_fields_text_input
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_text_input">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_variable
+++ b/tests/screenshot/test_cases/test_fields_variable
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_variable">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_datauri
+++ b/tests/screenshot/test_cases/test_images_datauri
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_datauri">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_fliprtl
+++ b/tests/screenshot/test_cases/test_images_fliprtl
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_fliprtl">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_large
+++ b/tests/screenshot/test_cases/test_images_large
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_large">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_many_icons
+++ b/tests/screenshot/test_cases/test_images_many_icons
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_many_icons">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_missing
+++ b/tests/screenshot/test_cases/test_images_missing
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_missing">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_small
+++ b/tests/screenshot/test_cases/test_images_small
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_small">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_float
+++ b/tests/screenshot/test_cases/test_numbers_float
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_float">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_halves
+++ b/tests/screenshot/test_cases/test_numbers_halves
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_halves">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_hundredths
+++ b/tests/screenshot/test_cases/test_numbers_hundredths
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_hundredths">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_three_halves
+++ b/tests/screenshot/test_cases/test_numbers_three_halves
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_three_halves">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_whole
+++ b/tests/screenshot/test_cases/test_numbers_whole
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_whole">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_whole_bounded
+++ b/tests/screenshot/test_cases/test_numbers_whole_bounded
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_whole_bounded">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_emoji
+++ b/tests/screenshot/test_cases/test_style_emoji
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_emoji">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hat
+++ b/tests/screenshot/test_cases/test_style_hat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex1
+++ b/tests/screenshot/test_cases/test_style_hex1
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex1">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex2
+++ b/tests/screenshot/test_cases/test_style_hex2
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex2">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex3
+++ b/tests/screenshot/test_cases/test_style_hex3
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex3">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex4
+++ b/tests/screenshot/test_cases/test_style_hex4
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex4">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex5
+++ b/tests/screenshot/test_cases/test_style_hex5
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex5">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_no_colour
+++ b/tests/screenshot/test_cases/test_style_no_colour
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_no_colour">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text
+++ b/tests/screenshot/test_cases/text
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_append
+++ b/tests/screenshot/test_cases/text_append
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_append">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_changeCase
+++ b/tests/screenshot/test_cases/text_changeCase
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_changeCase">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_charAt
+++ b/tests/screenshot/test_cases/text_charAt
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_charAt">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_count
+++ b/tests/screenshot/test_cases/text_count
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_count">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_create_join_container
+++ b/tests/screenshot/test_cases/text_create_join_container
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_create_join_container">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_create_join_item
+++ b/tests/screenshot/test_cases/text_create_join_item
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_create_join_item">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_getSubstring
+++ b/tests/screenshot/test_cases/text_getSubstring
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_getSubstring">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_indexOf
+++ b/tests/screenshot/test_cases/text_indexOf
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_indexOf">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_isEmpty
+++ b/tests/screenshot/test_cases/text_isEmpty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_isEmpty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_join
+++ b/tests/screenshot/test_cases/text_join
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_join">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_length
+++ b/tests/screenshot/test_cases/text_length
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_length">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_print
+++ b/tests/screenshot/test_cases/text_print
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_print">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_prompt
+++ b/tests/screenshot/test_cases/text_prompt
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_prompt">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_prompt_ext
+++ b/tests/screenshot/test_cases/text_prompt_ext
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_prompt_ext">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_replace
+++ b/tests/screenshot/test_cases/text_replace
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_replace">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_reverse
+++ b/tests/screenshot/test_cases/text_reverse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_reverse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_trim
+++ b/tests/screenshot/test_cases/text_trim
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_trim">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/texts
+++ b/tests/screenshot/test_cases/texts
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="texts">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables
+++ b/tests/screenshot/test_cases/variables
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_get
+++ b/tests/screenshot/test_cases/variables_get
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_get">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_get_dynamic
+++ b/tests/screenshot/test_cases/variables_get_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_get_dynamic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_set
+++ b/tests/screenshot/test_cases/variables_set
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_set">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_set_dynamic
+++ b/tests/screenshot/test_cases/variables_set_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_set_dynamic">
+	</block>
+</xml>


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Add single-block test cases for screenshot diffing for all blocks referenced in the playground except for procedure-related blocks.

For procedure-related blocks I added the test files but disabled them because they were causing the rest of the tests to break or exit early, I suspect due to some assumptions about matching blocks existing or mutators existing.

### Reason for Changes

Screenshot diffing for fun and profit!

### Test Coverage
From the root of the blockly directory:
-(once) open a new terminal tab and run `tests/scripts/test_setup.sh`.  This will get chromedriver and get selenium going, and you can check it to see if selenium went down.
- (on every run) run `tests/screenshot/run_differ.sh`

### Additional Information

<!-- Anything else we should know? -->
