### PR TITLE
Filter tests based on command line argument

### DIFF
--- a/tests/screenshot/gen_screenshots.js
+++ b/tests/screenshot/gen_screenshots.js
@@ -26,6 +26,8 @@ var fs = require('fs');
 
 module.exports = genScreenshots;
 
+var filterText = process.argv[2] || '';
+
 function checkAndCreateDir(dirname) {
   if (!fs.existsSync(dirname)){
     fs.mkdirSync(dirname);
@@ -68,7 +70,7 @@ function getTestList() {
   var testSpecArr = json.tests;
   var testList = [];
   for (var i = 0, testSpec; testSpec = testSpecArr[i]; i++) {
-    if (!testSpec.skip) {
+    if (!testSpec.skip && testSpec.title.includes(filterText)) {
       testList.push(testSpec.title);
     }
   }

--- a/tests/screenshot/mocha.opts
+++ b/tests/screenshot/mocha.opts
@@ -1,2 +1,0 @@
---ui tdd
---reporter ./tests/screenshot/diff-reporter.js

--- a/tests/screenshot/run_differ.sh
+++ b/tests/screenshot/run_differ.sh
@@ -28,11 +28,14 @@ rm -rf tests/screenshot/outputs/diff
 rm tests/screenshot/outputs/test_output.js
 rm tests/screenshot/outputs/test_output.json
 
-node tests/screenshot/gen_screenshots.js
+# Generate screenshots, only running for tests with $1 in the name.
+node tests/screenshot/gen_screenshots.js $1
 
 echo
 
-./node_modules/.bin/mocha tests/screenshot/diff_screenshots.js --opts "./tests/screenshot/mocha.opts"
+# Diff screenshots and use a custom reporter to get results we can easily parse.
+# Only run tests that include $1 in the name.
+./node_modules/.bin/mocha tests/screenshot/diff_screenshots.js --ui tdd --reporter ./tests/screenshot/diff-reporter.js --fgrep $1
 
 # Open results.
 xdg-open 'tests/screenshot/diff_viewer.html'


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Use the first argument to `run_differ.sh` to filter tests.

### Reason for Changes

So that we don't have to get as many screenshots to see specific test cases, or scroll through piles of screenshots when we're only interested in a few.

### Test Coverage
Part of screenshot testing.

### Additional Information

Sample usage:
`tests/screenshot/run_differ.sh controls`