### PR TITLE
Rendering tweaks

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -155,7 +155,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawLeft = function() {
   }
 
   if (!this.info_.RTL) {
-    if (this.info_.topRow.squareCorner) {
+    if (this.info_.topRow.elements[0].isSquareCorner()) {
       this.highlightSteps_.push('V', BRC.HIGHLIGHT_OFFSET);
     } else {
       this.highlightSteps_.push('V', BRC.CORNER_RADIUS);

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -511,9 +511,34 @@ Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev,
   if (prev.hasExternalInput && next.hasExternalInput) {
     return BRC.LARGE_PADDING;
   }
+  if (prev.hasStatement && next.hasStatement) {
+    return BRC.LARGE_PADDING;
+  }
   return BRC.MEDIUM_PADDING;
 };
 
+/**
+ * Calculate the centerline of an element in a rendered row.
+ * @param {Blockly.BlockRendering.Row} row The row containing the element.
+ * @param {Blockly.BlockRendering.Measurable} elem The element to place.
+ * @return {number} The desired centerline of the given element, as an offset
+ *     from the top left of the block.
+ * @private
+ */
+Blockly.BlockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
+  var result = row.yPos;
+  if (elem.isField()) {
+    result += (elem.height / 2);
+    if (row.hasInlineInput) {
+      result += BRC.INLINE_INPUT_FIELD_OFFSET_Y;
+    } else if (row.hasStatement) {
+      result += BRC.STATEMENT_FIELD_OFFSET_Y;
+    }
+  } else {
+    result += (row.height / 2);
+  }
+  return result;
+};
 /**
  * Make any final changes to the rendering information object.  In particular,
  * store the y position of each row, and record the height of the full block.
@@ -529,11 +554,10 @@ Blockly.BlockRendering.RenderInfo.prototype.finalize_ = function() {
     row.yPos = yCursor;
     var xCursor = 0;
     if (!(row.isSpacer())) {
-      var centerline = yCursor + row.height / 2;
       for (var e = 0; e < row.elements.length; e++) {
         var elem = row.elements[e];
         elem.xPos = xCursor;
-        elem.centerline = centerline;
+        elem.centerline = this.getElemCenterline_(row, elem);
         xCursor += elem.width;
       }
     }

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -32,6 +32,14 @@ BRC.SMALL_PADDING = 3;
 BRC.MEDIUM_PADDING = 5;
 BRC.LARGE_PADDING = 10;
 
+// Offset from the top of the row for placing fields on statement input rows.
+// Matches existing rendering (in 2019).
+BRC.STATEMENT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING - 1;
+
+// Offset from the top of the row for placing fields on inline input rows.
+// Matches existing rendering (in 2019).
+BRC.INLINE_INPUT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING;
+
 BRC.HIGHLIGHT_OFFSET = 0.5;
 
 BRC.TAB_HEIGHT = 15;


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

- top left corner highlight was too thick on a square corner
- empty rows between statement inputs were too short
- fields were centered vertically in rows.  It's good to be able to do it, but this change makes it match the current rendering and leaves a clear place to change field vertical alignment.

### Proposed Changes
- topRow no longer has a `squareCorner` property, so check the element instead
- One extra condition in `getSpacerRowHeight_`
- pull centerline calculation out into its own function
