### PR TITLE
Refactors bottom row to be a row instead of measurable

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -198,24 +198,21 @@ Blockly.BlockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
  */
 Blockly.BlockRendering.Drawer.prototype.drawBottom_ = function() {
   var bottomRow = this.info_.bottomRow;
+  var elems = bottomRow.elements;
   this.highlighter_.drawBottomCorner(bottomRow);
-  if (bottomRow.hasNextConnection) {
-    this.steps_.push('v', bottomRow.height - BRC.NOTCH_HEIGHT);
-    this.steps_.push('H', (BRC.NOTCH_OFFSET_RIGHT + (this.info_.RTL ? 0.5 : - 0.5)) +
-        ' ' + BRC.NOTCH_PATH_RIGHT);
-  } else {
-    this.steps_.push('v', bottomRow.height);
+  this.steps_.push('v', bottomRow.height);
+  for (var i = elems.length - 1; i >= 0; i--) {
+    var elem = elems[i];
+    if (elem.type === 'next connection') {
+      this.steps_.push(BRC.NOTCH_PATH_RIGHT);
+    } else if (elem.type === 'square corner') {
+      this.steps_.push('H 0');
+    } else if (elem.type === 'round corner') {
+      this.steps_.push(BRC.BOTTOM_LEFT_CORNER);
+    } else if (elem.isSpacer()) {
+      this.steps_.push('h', elem.width * -1);
+    }
   }
-
-  this.steps_.push('H', BRC.CORNER_RADIUS);
-
-  if (bottomRow.squareCorner) {
-    this.steps_.push('H 0');
-  } else {
-    this.steps_.push(BRC.BOTTOM_LEFT_CORNER);
-  }
-
-
 
   if (bottomRow.hasNextConnection) {
     var connectionX;
@@ -226,7 +223,7 @@ Blockly.BlockRendering.Drawer.prototype.drawBottom_ = function() {
     }
 
     bottomRow.connection.setOffsetInBlock(connectionX,
-        this.info_.height - BRC.NOTCH_HEIGHT - 1);
+        this.info_.height - 1);
     bottomRow.connection.moveToOffset(this.topLeft_);
     if (bottomRow.connection.isConnected()) {
       bottomRow.connection.tighten_();

--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -67,7 +67,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawTopCorner = function(row) {
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_RTL :
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_LTR);
     } else if (elem.isSpacer()) {
-      this.highlightSteps_.push('h', elem.width)
+      this.highlightSteps_.push('h', elem.width);
     }
   }
 
@@ -123,24 +123,27 @@ Blockly.BlockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
 
 Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(row) {
   var height = this.info_.height;
-  if (row.hasNextConnection) {
-    height -= BRC.NOTCH_HEIGHT;
-  }
+  var elems = this.info_.bottomRow.elements;
+
   height -= 2;
   if (this.info_.RTL) {
     this.highlightSteps_.push('V', height);
   }
-  if (row.squareCorner) {
-    if (!this.info_.RTL) {
-      this.highlightSteps_.push('M',
-          BRC.HIGHLIGHT_OFFSET + ',' + (height - BRC.HIGHLIGHT_OFFSET));
-    }
-  } else {
-    if (!this.info_.RTL) {
-      this.highlightSteps_.push(BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_START +
-          (height - Blockly.BlockSvg.DISTANCE_45_INSIDE) +
-          BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_MID +
-          (height - Blockly.BlockSvg.CORNER_RADIUS));
+
+  for (var i = elems.length - 1; i >= 0; i--) {
+    var elem = elems[i];
+    if (elem.type === 'square corner') {
+      if (!this.info_.RTL) {
+        this.highlightSteps_.push('M',
+            BRC.HIGHLIGHT_OFFSET + ',' + (height - BRC.HIGHLIGHT_OFFSET));
+      }
+    } else if (elem.type === 'round corner') {
+      if (!this.info_.RTL) {
+        this.highlightSteps_.push(BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_START +
+            (height - Blockly.BlockSvg.DISTANCE_45_INSIDE) +
+            BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_MID +
+            (height - Blockly.BlockSvg.CORNER_RADIUS));
+      }
     }
   }
 };

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -191,7 +191,7 @@ Blockly.BlockRendering.RenderInfo.prototype.createTopRow_ = function() {
 };
 
 /**
- * Create the top row and fill the elements list with all non-spacer elements
+ * Create the bottom row and fill the elements list with all non-spacer elements
  * created.
  */
 Blockly.BlockRendering.RenderInfo.prototype.createBottomRow_ = function() {
@@ -257,7 +257,7 @@ Blockly.BlockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
     var row = this.rows[r];
     var oldElems = row.elements;
     row.elements = [];
-    // No spacing needed before the corner on the top row.
+    // No spacing needed before the corner on the top row or the bottom row.
     if (row.type != 'top row' && row.type != 'bottom row') {
       // There's a spacer before the first element in the row.
       row.elements.push(new Blockly.BlockRendering.InRowSpacer(
@@ -365,14 +365,14 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     }
   }
 
-  // Spacing between a rounded corner and a previous connection
+  // Spacing between a rounded corner and a previous or next connection
   if (prev.isRoundedCorner()){
     if (next.isPreviousConnection() || next.isNextConnection()) {
       return BRC.NOTCH_OFFSET_ROUNDED_CORNER;
     }
   }
 
-  // Spacing between a square corner and a previous connection
+  // Spacing between a square corner and a previous or next connection
   if (prev.isSquareCorner()) {
     if (next.isPreviousConnection() || next.isNextConnection()) {
       return BRC.NOTCH_OFFSET_LEFT;
@@ -536,7 +536,7 @@ Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev,
   if (prev.type === 'top row' && next.type === 'bottom row') {
     return BRC.EMPTY_BLOCK_SPACER_HEIGHT;
   }
-  // Top row acts a spacer so we don't need any extra padding
+  // Top and bottom rows act as a spacer so we don't need any extra padding
   if (prev.type === 'top row' || next.type === 'bottom row') {
     return BRC.NO_PADDING;
   }

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -43,6 +43,12 @@ BRC.TAB_WIDTH = 8;
 BRC.NOTCH_WIDTH = 15;
 BRC.NOTCH_HEIGHT = 4;
 
+// This is the minimum width of a block measuring from the end of a rounded
+// corner
+BRC.MIN_BLOCK_WIDTH = 12;
+
+BRC.EMPTY_BLOCK_SPACER_HEIGHT = 16;
+
 
 // Offset from the left side of a block or the inside of a statement input to
 // the left side of the notch.

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -317,7 +317,7 @@ goog.inherits(Blockly.BlockRendering.Hat, Blockly.BlockRendering.Measurable);
 Blockly.BlockRendering.SquareCorner = function() {
   Blockly.BlockRendering.SquareCorner.superClass_.constructor.call(this);
   this.type = 'square corner';
-  this.height = BRC.MEDIUM_PADDING;
+  this.height = BRC.NOTCH_HEIGHT;
   this.width = BRC.NO_PADDING;
 
 };
@@ -422,10 +422,6 @@ Blockly.BlockRendering.TopRow = function(block) {
 
   this.elements = [];
   this.type = 'top row';
-  /**
-   *
-   * @type {boolean}
-   */
 
   this.hasPreviousConnection = !!block.previousConnection;
   this.connection = block.previousConnection;
@@ -433,7 +429,8 @@ Blockly.BlockRendering.TopRow = function(block) {
   var precedesStatement = block.inputList.length &&
       block.inputList[0].type == Blockly.NEXT_STATEMENT;
 
-  //
+  // This is the minimum height for the row. If one of it's elements has a greater
+  // height it will be overwritten in the compute pass.
   if (precedesStatement) {
     this.height = BRC.LARGE_PADDING;
   } else {
@@ -447,32 +444,27 @@ Blockly.BlockRendering.TopRow.prototype.isSpacer = function() {
   return true;
 };
 
-Blockly.BlockRendering.BottomRow = function(block, width) {
-
+Blockly.BlockRendering.BottomRow = function(block) {
+  Blockly.BlockRendering.BottomRow.superClass_.constructor.call(this);
+  this.type = 'bottom row';
   this.hasNextConnection = !!block.nextConnection;
   this.connection = block.nextConnection;
-  /**
-   * True if the bottom left corner of the block should be squared.
-   * @type {boolean}
-   */
-  this.squareCorner = !!block.outputConnection || !!block.getNextBlock();
 
-  this.followsStatement =
+  var followsStatement =
       block.inputList.length &&
       block.inputList[block.inputList.length - 1].type == Blockly.NEXT_STATEMENT;
 
   // This is the minimum height for the row. If one of it's elements has a greater
   // height it will be overwritten in the compute pass.
-  if (this.followsStatement) {
+  if (followsStatement) {
     this.height = BRC.LARGE_PADDING;
   } else {
-    this.height = BRC.MEDIUM_PADDING;
+    this.height = BRC.NOTCH_HEIGHT;
   }
 
-  this.width = width;
 };
 goog.inherits(Blockly.BlockRendering.BottomRow,
-    Blockly.BlockRendering.Measurable);
+    Blockly.BlockRendering.Row);
 
 Blockly.BlockRendering.BottomRow.prototype.isSpacer = function() {
   return true;

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -429,7 +429,7 @@ Blockly.BlockRendering.TopRow = function(block) {
   var precedesStatement = block.inputList.length &&
       block.inputList[0].type == Blockly.NEXT_STATEMENT;
 
-  // This is the minimum height for the row. If one of it's elements has a greater
+  // This is the minimum height for the row. If one of its elements has a greater
   // height it will be overwritten in the compute pass.
   if (precedesStatement) {
     this.height = BRC.LARGE_PADDING;

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -366,7 +366,7 @@
     },
     {
       "title": "test_dropdowns_images",
-      "skip": false
+      "skip": true
     },
     {
       "title": "test_dropdowns_images_and_text",

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -366,7 +366,7 @@
     },
     {
       "title": "test_dropdowns_images",
-      "skip": true
+      "skip": false
     },
     {
       "title": "test_dropdowns_images_and_text",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes
Turns the bottom row into a row so that it can hold elements such as corner and next connection.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
