### PR TITLE
Make the test reporter function when tests pass

### DIFF
--- a/tests/screenshot/diff-reporter.js
+++ b/tests/screenshot/diff-reporter.js
@@ -42,7 +42,53 @@ function DiffReporter(runner) {
   var self = this;
   var indents = 0;
   var n = 0;
-  var color = mocha.reporters.Base.color;
+  var colors = {
+    pass: 32,
+    fail: 31,
+    'bright pass': 92,
+    'bright fail': 91,
+    'bright yellow': 93,
+    pending: 36,
+    suite: 0,
+    'error title': 0,
+    'error message': 31,
+    'error stack': 90,
+    checkmark: 32,
+    fast: 90,
+    medium: 33,
+    slow: 31,
+    green: 32,
+    light: 90,
+    'diff gutter': 90,
+    'diff added': 32,
+    'diff removed': 31
+  };
+
+  var symbols = {
+    ok: '✓',
+    err: '✖',
+    dot: '․',
+    comma: ',',
+    bang: '!'
+  };
+
+  /**
+   * Color `str` with the given `type`,
+   * allowing colors to be disabled,
+   * as well as user-defined color
+   * schemes.
+   *
+   * @private
+   * @param {string} type
+   * @param {string} str
+   * @return {string}
+   */
+  var color = function(type, str) {
+    if (!colors) {
+      return String(str);
+    }
+    return '\u001b[' + colors[type] + 'm' + str + '\u001b[0m';
+  };
 
   function indent() {
     return Array(indents).join('  ');
@@ -62,27 +108,14 @@ function DiffReporter(runner) {
       console.log();
     }
   });
-
   runner.on('pass', function(test) {
     passes++;
     json_tests.push(test);
-
-    // Print test information the way the spec reporter would.
-    var fmt;
-    if (test.speed === 'fast') {
-      fmt =
-        indent() +
-        color('checkmark', '  ' + Base.symbols.ok) +
-        color('pass', ' %s');
-      console.log(fmt, test.title);
-    } else {
-      fmt =
-        indent() +
-        color('checkmark', '  ' + Base.symbols.ok) +
-        color('pass', ' %s') +
-        color(test.speed, ' (%dms)');
-      console.log(fmt, test.title, test.duration);
-    }
+    var logStr =
+      indent() +
+      color('checkmark', '  ' + symbols.ok) +
+      color('pass', ' ' + test.title);
+      console.log(logStr);
   });
 
   runner.on('fail', function(test, err) {


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

The test reporter was dereferencing something it couldn't find (but only when tests passed) and failing with no helpful warnings.  We only found this when we got a test to pass for the first time.

Also, the color used by the reporter for passing tests is exactly the same as my terminal background so I couldn't see it.  Which is funny, but not useful, so I changed it from dark grey to green.  It should be fine on a white background as well.

### Proposed Changes

Directly add the code for coloring outputs and displaying checkmarks, instead of trying to reference it and failing.

### Reason for Changes

Tests broke when I asserted that 0 equaled 0.  This made me unhappy.

