### PR TITLE
Restricts bottom row length after a statement input

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -163,7 +163,11 @@ Blockly.BlockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   this.steps_.push(BRC.INNER_TOP_LEFT_CORNER);
   this.steps_.push('v', row.height - 2 * BRC.CORNER_RADIUS);
   this.steps_.push(BRC.INNER_BOTTOM_LEFT_CORNER);
-  this.steps_.push('H', this.info_.width);
+  if (this.info_.bottomRow.maxLength) {
+    this.steps_.push('H', this.info_.bottomRow.maxLength);
+  } else {
+    this.steps_.push('H', this.info_.width);
+  }
 
   // Move the connection.
   var input = row.getLastInput();

--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -163,11 +163,6 @@ Blockly.BlockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   this.steps_.push(BRC.INNER_TOP_LEFT_CORNER);
   this.steps_.push('v', row.height - 2 * BRC.CORNER_RADIUS);
   this.steps_.push(BRC.INNER_BOTTOM_LEFT_CORNER);
-  if (this.info_.bottomRow.maxLength) {
-    this.steps_.push('H', this.info_.bottomRow.maxLength);
-  } else {
-    this.steps_.push('H', this.info_.width);
-  }
 
   // Move the connection.
   var input = row.getLastInput();

--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -111,7 +111,11 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
         (row.yPos + row.height - BRC.DISTANCE_45_OUTSIDE));
     this.highlightSteps_.push(
         BRC.INNER_BOTTOM_LEFT_CORNER_HIGHLIGHT_LTR);
-    this.highlightSteps_.push('H', this.info_.width - BRC.HIGHLIGHT_OFFSET);
+    if (this.info_.bottomRow.maxLength) {
+      this.highlightSteps_.push('H', this.info_.bottomRow.maxLength);
+    } else {
+      this.highlightSteps_.push('H', this.info_.width - BRC.HIGHLIGHT_OFFSET);
+    }
   }
 };
 

--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -111,11 +111,6 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
         (row.yPos + row.height - BRC.DISTANCE_45_OUTSIDE));
     this.highlightSteps_.push(
         BRC.INNER_BOTTOM_LEFT_CORNER_HIGHLIGHT_LTR);
-    if (this.info_.bottomRow.maxLength) {
-      this.highlightSteps_.push('H', this.info_.bottomRow.maxLength);
-    } else {
-      this.highlightSteps_.push('H', this.info_.width - BRC.HIGHLIGHT_OFFSET);
-    }
   }
 };
 

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -441,6 +441,9 @@ Blockly.BlockRendering.RenderInfo.prototype.alignRowElements_ = function() {
     if (!row.hasStatement && !row.hasInlineInput) {
       var currentWidth = row.width;
       var desiredWidth = this.width;
+      if (row.type === 'bottom row' && row.maxLength) {
+        desiredWidth = Math.min(row.maxLength, desiredWidth);
+      }
       var missingSpace = desiredWidth - currentWidth;
       if (missingSpace) {
         this.addAlignmentPadding_(row, missingSpace);
@@ -521,6 +524,13 @@ Blockly.BlockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next
  * @private
  */
 Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
+  // The width of the spacer before the bottom row should be the same as the
+  // bottom row.
+  if (next.type === 'bottom row'
+      && next.maxLength
+      && next.maxLength < this.width) {
+    return next.maxLength;
+  }
   return this.width;
 };
 

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -441,8 +441,8 @@ Blockly.BlockRendering.RenderInfo.prototype.alignRowElements_ = function() {
     if (!row.hasStatement && !row.hasInlineInput) {
       var currentWidth = row.width;
       var desiredWidth = this.width;
-      if (row.type === 'bottom row' && row.maxLength) {
-        desiredWidth = Math.min(row.maxLength, desiredWidth);
+      if (row.type === 'bottom row' && row.hasFixedWidth) {
+        desiredWidth = BRC.MAX_BOTTOM_WIDTH;
       }
       var missingSpace = desiredWidth - currentWidth;
       if (missingSpace) {
@@ -527,9 +527,8 @@ Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, 
   // The width of the spacer before the bottom row should be the same as the
   // bottom row.
   if (next.type === 'bottom row'
-      && next.maxLength
-      && next.maxLength < this.width) {
-    return next.maxLength;
+      && next.hasFixedWidth) {
+    return next.width;
   }
   return this.width;
 };

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -72,6 +72,10 @@ BRC.NOTCH_OFFSET_RIGHT = BRC.NOTCH_OFFSET_LEFT + BRC.NOTCH_WIDTH;
 
 BRC.STATEMENT_BOTTOM_SPACER = 5;
 
+// This is the max width of a bottom row that follows a statement input and
+// has inputs inline.
+BRC.MAX_BOTTOM_WIDTH = 66.5;
+
 /**
  * Rounded corner radius.
  * @const

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -449,20 +449,15 @@ Blockly.BlockRendering.BottomRow = function(block) {
   this.type = 'bottom row';
   this.hasNextConnection = !!block.nextConnection;
   this.connection = block.nextConnection;
-  this.maxLength = null;
 
   var followsStatement =
       block.inputList.length &&
       block.inputList[block.inputList.length - 1].type == Blockly.NEXT_STATEMENT;
+  this.hasFixedWidth = followsStatement && block.getInputsInline();
 
   // This is the minimum height for the row. If one of it's elements has a greater
   // height it will be overwritten in the compute pass.
   if (followsStatement) {
-    // Add a max length so that the bottom of a statement input doesn't become
-    // too long.
-    if (block.getInputsInline()) {
-      this.maxLength = 66.5;
-    }
     this.height = BRC.LARGE_PADDING;
   } else {
     this.height = BRC.NOTCH_HEIGHT;
@@ -475,3 +470,4 @@ goog.inherits(Blockly.BlockRendering.BottomRow,
 Blockly.BlockRendering.BottomRow.prototype.isSpacer = function() {
   return true;
 };
+

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -449,6 +449,7 @@ Blockly.BlockRendering.BottomRow = function(block) {
   this.type = 'bottom row';
   this.hasNextConnection = !!block.nextConnection;
   this.connection = block.nextConnection;
+  this.maxLength = null;
 
   var followsStatement =
       block.inputList.length &&
@@ -457,6 +458,11 @@ Blockly.BlockRendering.BottomRow = function(block) {
   // This is the minimum height for the row. If one of it's elements has a greater
   // height it will be overwritten in the compute pass.
   if (followsStatement) {
+    // Add a max length so that the bottom of a statement input doesn't become
+    // too long.
+    if (block.getInputsInline()) {
+      this.maxLength = 66.5;
+    }
     this.height = BRC.LARGE_PADDING;
   } else {
     this.height = BRC.NOTCH_HEIGHT;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Problem where the bottom row after statement input with inputs in line is always length of the block.
### Proposed Changes
Add a max length to the bottom row so that it doesn't exceed that length. This way if someone adds a lot of inputs the bottom row will not be as wide as the entire block.
### Reason for Changes
It is how we have it in current rendering.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
