### PR TITLE
Fix colour and image fields

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -281,7 +281,8 @@ Blockly.BlockRendering.Drawer.prototype.drawInternals_ = function() {
  */
 Blockly.BlockRendering.Drawer.prototype.dealWithJackassFields_ = function(field) {
   if (field instanceof Blockly.FieldDropdown
-      || field instanceof Blockly.FieldTextInput) {
+      || field instanceof Blockly.FieldTextInput
+      || field instanceof Blockly.FieldColour) {
     return 5;
   }
   return 0;

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -390,8 +390,8 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     }
   }
 
-  // Spacing between an editable field and another editable field
-  if (!prev.isInput && prev.isEditable && !next.isInput && next.isEditable) {
+  // Spacing between two fields of the same editability.
+  if (!prev.isInput && !next.isInput && (prev.isEditable == next.isEditable)) {
     return BRC.LARGE_PADDING;
   }
 

--- a/core/field.js
+++ b/core/field.js
@@ -78,6 +78,12 @@ Blockly.Field.register = function(type, fieldClass) {
 };
 
 /**
+ * The default height of the border rect on any field.
+ * @type {number}
+ */
+Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT = 16;
+
+/**
  * Construct a Field from a JSON arg object.
  * Finds the appropriate registered field by the type name as registered using
  * Blockly.Field.register.
@@ -231,7 +237,7 @@ Blockly.Field.prototype.initView = function() {
         'ry': 4,
         'x': -Blockly.BlockSvg.SEP_SPACE_X / 2,
         'y': 0,
-        'height': 16
+        'height': Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT
       }, this.fieldGroup_);
   /** @type {!Element} */
   this.textElement_ = Blockly.utils.createSvgElement('text',

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -352,4 +352,13 @@ Blockly.FieldColour.widgetDispose_ = function() {
   Blockly.Events.setGroup(false);
 };
 
+Blockly.FieldColour.prototype.getCorrectedSize = function() {
+  if (!this.size_.width) {
+    this.render_();
+  }
+  return new goog.math.Size(
+      this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      this.size_.height + 4);
+};
+
 Blockly.Field.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -352,13 +352,20 @@ Blockly.FieldColour.widgetDispose_ = function() {
   Blockly.Events.setGroup(false);
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * The colour field fills the bounding box with colour and takes up the full
+ * space of the bounding box.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.FieldColour.prototype.getCorrectedSize = function() {
   if (!this.size_.width) {
     this.render_();
   }
   return new goog.math.Size(
       this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
-      this.size_.height + 4);
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
 };
 
 Blockly.Field.register('field_colour', Blockly.FieldColour);


### PR DESCRIPTION
## The basics
- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Image and colour fields were rendering wrong.
### Proposed Changes

Add a `getCorrectedSize` function for images and add them to the list of jackass fields--they're placed to the left of their ostensible top-left corner.

Add padding between pairs of non-editable fields.

