### PR TITLE
Fixes highlight for bottom row

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -67,7 +67,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawTopCorner = function(row) {
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_RTL :
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_LTR);
     } else if (elem.isSpacer()) {
-      this.highlightSteps_.push('h', elem.width);
+      this.highlightSteps_.push('h', elem.width - BRC.HIGHLIGHT_OFFSET);
     }
   }
 
@@ -104,7 +104,6 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
         row.height - 2 * BRC.CORNER_RADIUS);
     this.highlightSteps_.push(
         BRC.INNER_BOTTOM_LEFT_CORNER_HIGHLIGHT_RTL);
-    this.highlightSteps_.push('H', this.info_.width - BRC.HIGHLIGHT_OFFSET);
   } else {
     this.highlightSteps_.push('M',
         (x + BRC.DISTANCE_45_OUTSIDE) + ',' +
@@ -116,6 +115,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
 
 Blockly.BlockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
   if (this.info_.RTL) {
+    this.highlightSteps_.push('H', row.width);
     this.highlightSteps_.push('v', row.height);
   }
 };
@@ -124,8 +124,8 @@ Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(row) {
   var height = this.info_.height;
   var elems = this.info_.bottomRow.elements;
 
-  height -= 2;
   if (this.info_.RTL) {
+    height -= BRC.BOTTOM_HIGHLIGHT_OFFSET;
     this.highlightSteps_.push('V', height);
   }
 
@@ -138,6 +138,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(row) {
       }
     } else if (elem.type === 'round corner') {
       if (!this.info_.RTL) {
+        height -= BRC.BOTTOM_HIGHLIGHT_OFFSET;
         this.highlightSteps_.push(BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_START +
             (height - Blockly.BlockSvg.DISTANCE_45_INSIDE) +
             BRC.BOTTOM_LEFT_CORNER_HIGHLIGHT_MID +

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -79,6 +79,8 @@ BRC.BETWEEN_STATEMENT_PADDING_Y = 4;
 // has inputs inline.
 BRC.MAX_BOTTOM_WIDTH = 66.5;
 
+BRC.BOTTOM_HIGHLIGHT_OFFSET = 2;
+
 /**
  * Rounded corner radius.
  * @const


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes highlight on the bottom row and an extra highlight on bottom rows following statement inputs in RTL. 

### Proposed Changes
Subtract offset from the height of the bottom row when drawing a rounded corner or when in rtl. 

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
