### PR TITLE
Changed Colour Field Class Validator to Accept all Documented Values

### DIFF
--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -32,6 +32,7 @@ goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 
 goog.require('goog.math.Size');
+goog.require('goog.color');
 
 
 /**
@@ -176,8 +177,11 @@ Blockly.FieldColour.prototype.render_ = function() {
  * @protected
  */
 Blockly.FieldColour.prototype.doClassValidation_ = function(newValue) {
-  if (Blockly.FieldColour.COLOUR_REGEX.test(newValue)) {
-    return newValue.toLowerCase();
+  if (typeof newValue != 'string') {
+    return null;
+  }
+  if (goog.color.isValidColor(newValue)) {
+    return goog.color.parse(newValue).hex;
   }
   return null;
 };

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -58,7 +58,7 @@ suite ('Colour Fields', function() {
       assertValueDefault(colourField);
     });
     test('Non-Parsable String', function() {
-      var colourField = new Blockly.FieldColour('bad');
+      var colourField = new Blockly.FieldColour('not_a_colour');
       assertValueDefault(colourField);
     });
     test('#AAAAAA', function() {
@@ -85,6 +85,22 @@ suite ('Colour Fields', function() {
       var colourField = new Blockly.FieldColour('#bcbcbc');
       assertValue(colourField, '#bcbcbc', '#bcbcbc');
     });
+    test('#AA0', function() {
+      var colourField = new Blockly.FieldColour('#AA0');
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('#aa0', function() {
+      var colourField = new Blockly.FieldColour('#aa0');
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('rgb(170, 170, 0)', function() {
+      var colourField = new Blockly.FieldColour('rgb(170, 170, 0)');
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('red', function() {
+      var colourField = new Blockly.FieldColour('red');
+      assertValue(colourField, '#ff0000', '#f00');
+    });
   });
   suite('fromJson', function() {
     test('Empty', function() {
@@ -100,7 +116,8 @@ suite ('Colour Fields', function() {
       assertValueDefault(colourField);
     });
     test('Non-Parsable String', function() {
-      var colourField = new Blockly.FieldColour.fromJson({ colour:'bad' });
+      var colourField = new Blockly.FieldColour.fromJson(
+          { colour:'not_a_colour' });
       assertValueDefault(colourField);
     });
     test('#AAAAAA', function() {
@@ -127,6 +144,23 @@ suite ('Colour Fields', function() {
       var colourField = Blockly.FieldColour.fromJson({ colour: '#bcbcbc' });
       assertValue(colourField, '#bcbcbc', '#bcbcbc');
     });
+    test('#AA0', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#AA0' });
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('#aa0', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: '#aa0' });
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('rgb(170, 170, 0)', function() {
+      var colourField = Blockly.FieldColour.fromJson(
+          { colour: 'rgb(170, 170, 0)' });
+      assertValue(colourField, '#aaaa00', '#aa0');
+    });
+    test('red', function() {
+      var colourField = Blockly.FieldColour.fromJson({ colour: 'red' });
+      assertValue(colourField, '#ff0000', '#f00');
+    });
   });
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
@@ -142,7 +176,7 @@ suite ('Colour Fields', function() {
         assertValueDefault(this.colourField);
       });
       test('Non-Parsable String', function() {
-        this.colourField.setValue('bad');
+        this.colourField.setValue('not_a_colour');
         assertValueDefault(this.colourField);
       });
       test('#000000', function() {
@@ -152,6 +186,18 @@ suite ('Colour Fields', function() {
       test('#bcbcbc', function() {
         this.colourField.setValue('#bcbcbc');
         assertValue(this.colourField, '#bcbcbc', '#bcbcbc');
+      });
+      test('#aa0', function() {
+        this.colourField.setValue('#aa0');
+        assertValue(this.colourField, '#aaaa00', '#aa0');
+      });
+      test('rgb(170, 170, 0)', function() {
+        this.colourField.setValue('rgb(170, 170, 0)');
+        assertValue(this.colourField, '#aaaa00', '#aa0');
+      });
+      test('red', function() {
+        this.colourField.setValue('red');
+        assertValue(this.colourField, '#ff0000', '#f00');
       });
     });
     suite('Value -> New Value', function() {
@@ -167,7 +213,7 @@ suite ('Colour Fields', function() {
         assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
       test('Non-Parsable String', function() {
-        this.colourField.setValue('bad');
+        this.colourField.setValue('not_a_colour');
         assertValue(this.colourField, '#aaaaaa', '#aaa');
       });
       test('#000000', function() {
@@ -177,6 +223,18 @@ suite ('Colour Fields', function() {
       test('#bcbcbc', function() {
         this.colourField.setValue('#bcbcbc');
         assertValue(this.colourField, '#bcbcbc', '#bcbcbc');
+      });
+      test('#aa0', function() {
+        this.colourField.setValue('#aa0');
+        assertValue(this.colourField, '#aaaa00', '#aa0');
+      });
+      test('rgb(170, 170, 0)', function() {
+        this.colourField.setValue('rgb(170, 170, 0)');
+        assertValue(this.colourField, '#aaaa00', '#aa0');
+      });
+      test('red', function() {
+        this.colourField.setValue('red');
+        assertValue(this.colourField, '#ff0000', '#f00');
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the class validator accepts any string that can be parsed by [goog.color](https://google.github.io/closure-library/api/goog.color.html).parse. If it can be parsed it converts it to #rrggbb format.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I noticed that the [documentation ](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#colour_picker_field)stated any css colour string was valid, so I wanted to make sure the colour field still worked if people had defined their colours that way.

I did not change the documentation of the field constructor, because I think it's best if people input strings in #rrggbb format, because that's the format validators will need to parse.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests for strings: '#AA0', '#aa0', 'rgb(170, 170, 0)', and 'red'.

<!-- Tested on:  -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
