### PR TITLE
Fixed How Fields Handle Size

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -230,6 +230,9 @@ Blockly.Field.prototype.init = function() {
     return;
   }
   this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+  if (!this.isVisible()) {
+    this.fieldGroup_.style.display = 'none';
+  }
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.initView();
   this.initModel();
@@ -240,9 +243,6 @@ Blockly.Field.prototype.init = function() {
  * @package
  */
 Blockly.Field.prototype.initView = function() {
-  if (!this.visible_) {
-    this.fieldGroup_.style.display = 'none';
-  }
   this.borderRect_ = Blockly.utils.createSvgElement('rect',
       {
         'rx': 4,
@@ -386,7 +386,6 @@ Blockly.Field.prototype.setVisible = function(visible) {
   var root = this.getSvgRoot();
   if (root) {
     root.style.display = visible ? 'block' : 'none';
-    this.size_.width = 0;
   }
 };
 
@@ -483,15 +482,28 @@ Blockly.Field.prototype.updateColour = function() {
  */
 Blockly.Field.prototype.render_ = function() {
   this.textElement_.textContent = this.getDisplayText_();
-  this.updateWidth();
+  this.updateSize_();
 };
 
 /**
- * Updates the width of the field. This calls getCachedWidth which won't cache
- * the approximated width on IE/Edge when `getComputedTextLength` fails. Once
- * it eventually does succeed, the result will be cached.
+ * Updates the width of the field. Redirects to updateSize_().
+ * @deprecated May 2019  Use Blockly.Field.updateSize_() to force an update
+ * to the size of the field, or Blockly.Field.getCachedWidth() to check the
+ * size of the field..
  */
 Blockly.Field.prototype.updateWidth = function() {
+  console.warn('Deprecated call to updateWidth, call' +
+    ' Blockly.Field.updateSize_ to force an update to the size of the' +
+    ' field, or Blockly.Field.getCachedWidth() to check the size of the' +
+    ' field.');
+  this.updateSize_();
+};
+
+/**
+ * Updates the size of the field based on the text.
+ * @protected
+ */
+Blockly.Field.prototype.updateSize_ = function() {
   var width = Blockly.Field.getCachedWidth(this.textElement_);
   if (this.borderRect_) {
     this.borderRect_.setAttribute('width',
@@ -568,6 +580,10 @@ Blockly.Field.stopCache = function() {
  * @return {!goog.math.Size} Height and width.
  */
 Blockly.Field.prototype.getSize = function() {
+  if (!this.isVisible()) {
+    return new goog.math.Size(0, 0);
+  }
+
   if (this.isDirty_) {
     this.render_();
     this.isDirty_ = false;

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -135,7 +135,7 @@ Blockly.FieldAngle.prototype.initView = function() {
 Blockly.FieldAngle.prototype.render_ = function() {
   this.textElement_.textContent = this.getDisplayText_();
   this.textElement_.appendChild(this.symbol_);
-  this.updateWidth();
+  this.updateSize_();
   this.updateGraph_();
 };
 

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -92,6 +92,15 @@ Blockly.FieldCheckbox.prototype.SERIALIZABLE = true;
 Blockly.FieldCheckbox.prototype.CURSOR = 'default';
 
 /**
+ * Used to tell if the field needs to be rendered the next time the block is
+ * rendered. Checkbox fields are statically sized, and only need to be
+ * rendered at initialization.
+ * @type {boolean}
+ * @private
+ */
+Blockly.FieldCheckbox.prototype.isDirty_ = false;
+
+/**
  * Create the block UI for this checkbox.
  * @package
  */
@@ -111,14 +120,6 @@ Blockly.FieldCheckbox.prototype.initView = function() {
     this.borderRect_.setAttribute('width',
         this.size_.width + Blockly.BlockSvg.SEP_SPACE_X);
   }
-};
-
-/**
- * Checkboxes have a constant width.
- * @private
- */
-Blockly.FieldCheckbox.prototype.render_ = function() {
-  this.size_.width = Blockly.FieldCheckbox.WIDTH;
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -97,6 +97,20 @@ Blockly.FieldColour.COLOUR_REGEX = new RegExp('#[0-9a-fA-F]{6}');
 Blockly.FieldColour.prototype.SERIALIZABLE = true;
 
 /**
+ * Mouse cursor style when over the hotspot that initiates the editor.
+ */
+Blockly.FieldColour.prototype.CURSOR = 'default';
+
+/**
+ * Used to tell if the field needs to be rendered the next time the block is
+ * rendered. Colour fields are statically sized, and only need to be
+ * rendered at initialization.
+ * @type {boolean}
+ * @private
+ */
+Blockly.FieldColour.prototype.isDirty_ = false;
+
+/**
  * Array of colours used by this field.  If null, use the global list.
  * @type {Array.<string>}
  * @private
@@ -150,24 +164,11 @@ Blockly.FieldColour.prototype.initView = function() {
 };
 
 /**
- * Mouse cursor style when over the hotspot that initiates the editor.
- */
-Blockly.FieldColour.prototype.CURSOR = 'default';
-
-/**
  * Close the colour picker if this input is being deleted.
  */
 Blockly.FieldColour.prototype.dispose = function() {
   Blockly.WidgetDiv.hideIfOwner(this);
   Blockly.FieldColour.superClass_.dispose.call(this);
-};
-
-/**
- * Render the colour field.
- * @private
- */
-Blockly.FieldColour.prototype.render_ = function() {
-  this.size_.width = Blockly.FieldColour.DEFAULT_WIDTH;
 };
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -511,28 +511,6 @@ Blockly.FieldDropdown.prototype.renderSelectedText_ = function() {
 };
 
 /**
- * Updates the width of the field. Overrides field.prototype.updateWidth to
- * deal with image selections on IE and Edge. If the selected item is not an
- * image, or if the browser is not IE / Edge, this simply calls the parent
- * implementation.
- */
-Blockly.FieldDropdown.prototype.updateWidth = function() {
-  if (this.imageJson_ &&
-      (Blockly.userAgent.IE || Blockly.userAgent.EDGE)) {
-    // Recalculate the full width.
-    var arrowWidth = Blockly.Field.getCachedWidth(this.arrow_);
-    var width = Number(this.imageJson_.width) + arrowWidth +
-        Blockly.BlockSvg.SEP_SPACE_X;
-    if (this.borderRect_) {
-      this.borderRect_.setAttribute('width', width);
-    }
-    this.size_.width = width;
-  } else {
-    Blockly.Field.prototype.updateWidth.call(this);
-  }
-};
-
-/**
  * Close the dropdown menu if this input is being deleted.
  */
 Blockly.FieldDropdown.prototype.dispose = function() {

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -104,6 +104,15 @@ Blockly.FieldImage.fromJson = function(options) {
 Blockly.FieldImage.prototype.EDITABLE = false;
 
 /**
+ * Used to tell if the field needs to be rendered the next time the block is
+ * rendered. Image fields are statically sized, and only need to be
+ * rendered at initialization.
+ * @type {boolean}
+ * @private
+ */
+Blockly.FieldImage.prototype.isDirty_ = false;
+
+/**
  * Create the block UI for this image.
  * @package
  */
@@ -215,15 +224,6 @@ Blockly.FieldImage.prototype.setText = function(alt) {
   if (this.imageElement_) {
     this.imageElement_.setAttribute('alt', alt || '');
   }
-};
-
-/**
- * Images are fixed width, no need to render.
- * @private
- */
-Blockly.FieldImage.prototype.render_ = function() {
-  this.size_.width = this.width_;
-  this.size_.height = this.height_ + 2 * Blockly.BlockSvg.INLINE_PADDING_Y;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2428 and some collapse/expand problems

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1. Makes it so visibility (return a size of 0) is handled inside getSize instead of inside setVisible.
2. Changes (public) updateWidth to (protected) updateSize_.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1. There were problems with collapsing when it was done the previous way. Now all blocks are expanded and collapsed correctly.
2. Makes it less confusing for outside developers who want to create a field with a dynamic height.

Note that the dropdown field's updateWidth function wasn't getting called from anywhere, so it could be safely removed.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![FieldsHandleSize](https://user-images.githubusercontent.com/25440652/58374343-68ae9200-7ef1-11e9-85d4-4e72b3a5e3db.gif)

I also tested collapsing and collapsing all of the default categories, and it all looks good.

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

Was not able to test on internet explorer or edge because of #2499

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
