### PR TITLE
Angle Field Fixes

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -264,6 +264,8 @@ Blockly.FieldAngle.prototype.onMouseMove = function(e) {
   } else if (dy > 0) {
     angle += 360;
   }
+
+  // Do offsetting.
   if (Blockly.FieldAngle.CLOCKWISE) {
     angle = Blockly.FieldAngle.OFFSET + 360 - angle;
   } else {
@@ -272,9 +274,16 @@ Blockly.FieldAngle.prototype.onMouseMove = function(e) {
   if (angle > 360) {
     angle -= 360;
   }
+
+  // Do rounding.
   if (Blockly.FieldAngle.ROUND) {
     angle = Math.round(angle / Blockly.FieldAngle.ROUND) *
         Blockly.FieldAngle.ROUND;
+  }
+
+  // Do wrapping.
+  if (angle > Blockly.FieldAngle.WRAP) {
+    angle -= 360;
   }
 
   // Update value.

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -307,6 +307,7 @@ Blockly.FieldAngle.prototype.updateGraph_ = function() {
   }
   // Always display the input (i.e. getText) even if it is invalid.
   var angleDegrees = Number(this.getText()) + Blockly.FieldAngle.OFFSET;
+  angleDegrees = angleDegrees % 360;
   var angleRadians = Blockly.utils.toRadians(angleDegrees);
   var path = ['M ', Blockly.FieldAngle.HALF, ',', Blockly.FieldAngle.HALF];
   var x2 = Blockly.FieldAngle.HALF;

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -267,7 +267,10 @@ Blockly.FieldAngle.prototype.onMouseMove = function(e) {
   if (Blockly.FieldAngle.CLOCKWISE) {
     angle = Blockly.FieldAngle.OFFSET + 360 - angle;
   } else {
-    angle -= Blockly.FieldAngle.OFFSET;
+    angle = 360 - (Blockly.FieldAngle.OFFSET - angle);
+  }
+  if (angle > 360) {
+    angle -= 360;
   }
   if (Blockly.FieldAngle.ROUND) {
     angle = Math.round(angle / Blockly.FieldAngle.ROUND) *

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -307,7 +307,7 @@ Blockly.FieldAngle.prototype.updateGraph_ = function() {
   }
   // Always display the input (i.e. getText) even if it is invalid.
   var angleDegrees = Number(this.getText()) + Blockly.FieldAngle.OFFSET;
-  angleDegrees = angleDegrees % 360;
+  angleDegrees %= 360;
   var angleRadians = Blockly.utils.toRadians(angleDegrees);
   var path = ['M ', Blockly.FieldAngle.HALF, ',', Blockly.FieldAngle.HALF];
   var x2 = Blockly.FieldAngle.HALF;
@@ -347,7 +347,7 @@ Blockly.FieldAngle.prototype.doClassValidation_ = function(newValue) {
     return null;
   }
   var n = parseFloat(newValue || 0);
-  n = n % 360;
+  n %= 360;
   if (n < 0) {
     n += 360;
   }

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -396,7 +396,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
     thisField.isBeingEdited_ = false;
     // No need to call setValue because if the widget is being closed the
     // latest input text has already been validated.
-    if (thisField.value_ != thisField.text_) {
+    if (thisField.value_ !== thisField.text_) {
       // At the end of an edit the text should be the same as the value. It
       // may not be if the input text is different than the validated text.
       // We should fix that.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1. Fixes the angle offset property.
2. Angle field now displays wrapped values correctly.
3. Fixed the gauge not displaying correctly at high angle values (like the millions or something, only applies to text input)
4. Angle field now displays zero if given empty text input.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1. It was broken. (The below is a clockwise angle field)
![Angle_Clockwise_Offset90](https://user-images.githubusercontent.com/25440652/58375971-60b41980-7f14-11e9-8893-26d0c124c223.gif)

2. It was always displaying between 0 and 360. It's pretty confusing if it changes when you close th editor.
3. This just bugged me.
4. Angle fields should always display a number value (this is different from pure text inputs, which can be empty).

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I tested lots of combinations of CLOCKWISE, OFFSET, and WRAP. Here are some highlights:
* Clockwise, Offset 90
![Angle_Clockwise_Offset90_Good!](https://user-images.githubusercontent.com/25440652/58376045-061bbd00-7f16-11e9-9fc3-af8be468fba1.gif)

* Widdershins, Offset 90
![Angle_Wittershins_Offset90](https://user-images.githubusercontent.com/25440652/58376047-0916ad80-7f16-11e9-947e-8b539bfeba92.gif)

* Widdershins, Wrap 180
![Angle_Wittershins_Wrap180](https://user-images.githubusercontent.com/25440652/58376048-0a47da80-7f16-11e9-9787-7566c94922b7.gif)

* Widdershins, Wrap 180, Offset 90
![Angle_Wittershins_Wrap180_Offset90](https://user-images.githubusercontent.com/25440652/58376049-0c119e00-7f16-11e9-8911-171c47f6bbb8.gif)

And here's it now working with the empty string:
![Angle_EmptyString](https://user-images.githubusercontent.com/25440652/58376057-3d8a6980-7f16-11e9-85a6-f602132ab029.gif)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
