### PR TITLE
Adds alignment padding to dummy inputs

### DIFF
--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -153,7 +153,7 @@ Blockly.BlockRendering.RenderInfo.prototype.createRows_ = function() {
     // All of the fields in an input go on the same row.
     for (var f = 0; f < input.fieldRow.length; f++) {
       var field = input.fieldRow[f];
-      activeRow.elements.push(new Blockly.BlockRendering.Field(field));
+      activeRow.elements.push(new Blockly.BlockRendering.Field(field, input));
     }
     this.addInput_(input, activeRow);
   }
@@ -478,23 +478,28 @@ Blockly.BlockRendering.RenderInfo.prototype.alignRowElements_ = function() {
  */
 Blockly.BlockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   var elems = row.elements;
-  if (row.hasExternalInput) { // TODO: handle for dummy inputs.
-    var externalInput = row.getLastInput();
+  var input = row.getLastInput();
+  if (input) {
+    var firstSpacer = row.getFirstSpacer();
+    var lastSpacer = row.getLastSpacer();
+    if (row.hasExternalInput) {
+      // Get the spacer right before the input socket.
+      lastSpacer = elems[elems.length - 3];
+    }
     // Decide where the extra padding goes.
-    if (externalInput.align == Blockly.ALIGN_LEFT) {
-      // Add padding just before the input socket.
-      elems[elems.length - 3].width += missingSpace;
-    } else if (externalInput.align == Blockly.ALIGN_CENTRE) {
-      // Split the padding between the beginning of the row and just
-      // before the socket.
-      row.getFirstSpacer().width += missingSpace / 2;
-      elems[elems.length - 3].width += missingSpace / 2;
-    } else if (externalInput.align == Blockly.ALIGN_RIGHT) {
+    if (input.align == Blockly.ALIGN_LEFT) {
+      // Add padding to the end of the row.
+      lastSpacer.width += missingSpace;
+    } else if (input.align == Blockly.ALIGN_CENTRE) {
+      // Split the padding between the beginning and end of the row.
+      firstSpacer.width += missingSpace / 2;
+      lastSpacer.width += missingSpace / 2;
+    } else if (input.align == Blockly.ALIGN_RIGHT) {
       // Add padding at the beginning of the row.
-      row.getFirstSpacer().width += missingSpace;
+      firstSpacer.width += missingSpace;
     }
     row.width += missingSpace;
-    // Top and bottom rows are always left aligned
+    // Top and bottom rows are always left aligned.
   } else if (row.type === 'top row' || row.type === 'bottom row') {
     row.getLastSpacer().width += missingSpace;
     row.width += missingSpace;

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -179,10 +179,11 @@ goog.inherits(Blockly.BlockRendering.Icon, Blockly.BlockRendering.Measurable);
  * An object containing information about the space a field takes up during
  * rendering
  * @param {!Blockly.Field} field The field to measure and store information for.
+ * @param {!Blockly.Input} parentInput The parent input for the field.
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Field = function(field) {
+Blockly.BlockRendering.Field = function(field, parentInput) {
   Blockly.BlockRendering.Field.superClass_.constructor.call(this);
   this.field = field;
   this.isEditable = field.isCurrentlyEditable();
@@ -191,6 +192,7 @@ Blockly.BlockRendering.Field = function(field) {
   var size = this.field.getCorrectedSize();
   this.height = size.height;
   this.width = size.width;
+  this.parentInput = parentInput;
 };
 goog.inherits(Blockly.BlockRendering.Field, Blockly.BlockRendering.Measurable);
 
@@ -377,10 +379,11 @@ Blockly.BlockRendering.Row.prototype.getLastInput = function() {
   // There's always a spacer after the last input, unless there are no inputs.
   if (this.elements.length > 1) {
     var elem = this.elements[this.elements.length - 2];
-    if (!elem.isInput) {
-      return null;
+    if (elem.isInput) {
+      return elem;
+    } else if (elem.isField()) {
+      return elem.parentInput;
     }
-    return elem;
   }
   // Return null if there are no inputs.
   return null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Dummy inputs were not getting aligned properly.

### Proposed Changes
Add the input to the field measurable so that we can get the alignment information for dummy inputs. Depending on whether the row has an external input or not add missing space to the last spacer or the spacer before the external input.

### Reason for Changes
Dummy inputs were not getting aligned properly.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
