### PR TITLE
Set node version explicitly for travis on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: node_js
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      node_js: stable
-      sudo: required
-      addons:
-        apt:
-          packages:
-          - google-chrome-stable
+os: linux
+dist: trusty
+node_js:
+  - 8
+  - 10
+sudo: required
+addons:
+  apt:
+    packages:
+    - google-chrome-stable
     # TODO (#2114): reenable osx build.
     # - os: osx
     #   node_js: stable


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Tests are currently failing on master

### Proposed Changes

Explicitly use node 8 and node 10.  Travis now uses node 12 by default, and that breaks with gulp.

### Reason for Changes

We previously ran into this problem on develop.  I think we hadn't seen it on master because the tests only run when we push to master, and we haven't done that in a while.

See #2403

### Test Coverage
Tests should pass on travis.
