### PR TITLE
Draws highlight on the bottom of a statement input

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -114,6 +114,9 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
 };
 
 Blockly.BlockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
+  if (row.followsStatement) {
+    this.highlightSteps_.push('H', row.width);
+  }
   if (this.info_.RTL) {
     this.highlightSteps_.push('H', row.width);
     this.highlightSteps_.push('v', row.height);

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -532,7 +532,11 @@ Blockly.BlockRendering.RenderInfo.prototype.addRowSpacing_ = function() {
 Blockly.BlockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
   var height = this.getSpacerRowHeight_(prev, next);
   var width = this.getSpacerRowWidth_(prev, next);
-  return new Blockly.BlockRendering.BetweenRowSpacer(height, width);
+  var spacer = new Blockly.BlockRendering.BetweenRowSpacer(height, width);
+  if (prev.hasStatement) {
+    spacer.followsStatement = true;
+  }
+  return spacer;
 };
 
 /**

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -401,6 +401,7 @@ Blockly.BlockRendering.BetweenRowSpacer = function(height, width) {
   this.type = 'between-row spacer';
   this.width = width;
   this.height = height;
+  this.followsStatement = false;
 };
 goog.inherits(Blockly.BlockRendering.BetweenRowSpacer,
     Blockly.BlockRendering.Measurable);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The highlight on the bottom of a statement input was not being displayed.

### Proposed Changes
Have the spacer draw a highlight if it follows a statement input.
### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
