### PR TITLE
Moved the Date Field to the Dropdown Div, and Restyled It

### DIFF
--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -914,7 +914,10 @@ Blockly.Blocks['test_validators_date_null'] = {
   },
 
   validate: function(newValue) {
-    return null;
+    // We should be able to expect validators to like their initial values.
+    if (newValue != '2020-02-20') {
+      return null;
+    }
   }
 };
 Blockly.Blocks['test_validators_date_force_20s'] = {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1) Moves the date picker from the widget div to the dropdown div.
2) Removes the automatic closing of the picker upon selection (this comes with some tradeoffs).
3) Makes the picker look butiful (maybe?)
![Date_New](https://user-images.githubusercontent.com/25440652/58516115-ccd48e80-815b-11e9-8a3c-3c814327fe0c.jpg)

Note: The darker colour denotes "Today" and the lighter colour denotes the selected day. It is based on how G-cal's mini-calendar looks:
![Date_GCal](https://user-images.githubusercontent.com/25440652/58517601-d7455700-8160-11e9-81dd-faff11c26f17.jpg)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) The date field was sad because it wasn't in the dropdown div club.
2) Makes it so the dropdown div works consistently.
3) Sticking with the old UI meant one of two options had to be picked:
![Date_BorderDefault](https://user-images.githubusercontent.com/25440652/58515963-4d46bf80-815b-11e9-8ac8-bf2f15e6288f.jpg)
![Date_BorderlessDefault](https://user-images.githubusercontent.com/25440652/58515968-4f108300-815b-11e9-92c4-5c2793672bef.jpg)
Both of which look ugly (imo).

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
The closure date picker is missing some functionality that we need, which is the ability to undo a date selection. Because there's no perfect way to do this, the date field has some quirky behavior when dealing with null validators. But as no one uses date fields, and especially no one validates them, I think this is ok.

Closing and Reopening:
![Date_CloseReopen](https://user-images.githubusercontent.com/25440652/58517474-5e45ff80-8160-11e9-88c9-6f49857925a1.gif)

Today Button:
![Date_TodayButton](https://user-images.githubusercontent.com/25440652/58517479-62721d00-8160-11e9-9eff-ac7a85aee4ae.gif)

Correctly Updating When Month Changes 1:
![Date_HidingMonthChanges](https://user-images.githubusercontent.com/25440652/58517488-6736d100-8160-11e9-94d1-1895e6fa2874.gif)

Correctly Updating when Month Changes 2:
![Date_ChangingDayMonthChanges](https://user-images.githubusercontent.com/25440652/58517491-6d2cb200-8160-11e9-8927-99c127d6fa46.gif)

Not Updating for Nulls:
![Date_NullsNotReacting](https://user-images.githubusercontent.com/25440652/58517495-71f16600-8160-11e9-8c83-6054e3c1f82c.gif)

Validated Values Updating:
![Date_DifUpdating](https://user-images.githubusercontent.com/25440652/58517499-7453c000-8160-11e9-9df2-36b08b57d326.gif)

And here's the bit of odd behavior I mentioned. If you are looking at a different month than the one containing the currently selected date, and you select a new date that validates to null, it will bump you back to the old month:
![Date_NullsChangesMonth](https://user-images.githubusercontent.com/25440652/58517513-7ddd2800-8160-11e9-90f0-e8fe9ebab30c.gif)

There's no reasonable way to get around this with closure's[ current DatePicker API](https://google.github.io/closure-library/api/goog.ui.DatePicker.html).

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
