### PR TITLE
Render insertion markers

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -301,22 +301,31 @@ Blockly.BlockRendering.Drawer.prototype.dealWithJackassFields_ = function(field)
  * @private
  */
 Blockly.BlockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
+  if (fieldInfo.type == 'field') {
+    var svgGroup = fieldInfo.field.getSvgRoot();
+  } else if (fieldInfo.type == 'icon') {
+    var svgGroup = fieldInfo.icon.iconGroup_;
+  }
+
   var yPos = fieldInfo.centerline - fieldInfo.height / 2;
   var xPos = fieldInfo.xPos;
   if (this.info_.RTL) {
     xPos = -(xPos + fieldInfo.width);
   }
   if (fieldInfo.type == 'icon') {
-    var icon = fieldInfo.icon;
-    icon.iconGroup_.setAttribute('display', 'block');
-    icon.iconGroup_.setAttribute('transform', 'translate(' + xPos + ',' +
-        yPos + ')');
-    icon.computeIconLocation();
+    svgGroup.setAttribute('display', 'block');
+    svgGroup.setAttribute('transform', 'translate(' + xPos + ',' + yPos + ')');
+    fieldInfo.icon.computeIconLocation();
   } else {
     xPos += this.dealWithJackassFields_(fieldInfo.field);
 
-    fieldInfo.field.getSvgRoot().setAttribute('transform',
-        'translate(' + xPos + ',' + yPos + ')');
+    svgGroup.setAttribute('transform', 'translate(' + xPos + ',' + yPos + ')');
+  }
+
+  if (this.info_.isInsertionMarker) {
+    // Fields and icons are invisible on insertion marker.  They still have to
+    // be rendered so that the block can be sized correctly.
+    svgGroup.setAttribute('display', 'none');
   }
 };
 

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -59,6 +59,13 @@ Blockly.BlockRendering.RenderInfo = function(block) {
   this.isInline = block.getInputsInline() && !block.isCollapsed();
 
   /**
+   * Whether the block is an insertion marker.  Insertion markers are the same
+   * shape as normal blocks, but don't show fields.
+   * @type {boolean}
+   */
+  this.isInsertionMarker = block.isInsertionMarker();
+
+  /**
    * True if the block should be rendered right-to-left.
    * @type {boolean}
    */


### PR DESCRIPTION
## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

New rendering couldn't handle insertion markers before.

### Proposed Changes

Hide fields and icons on insertion markers.

### Additional Information

Insertion marker color seems to be handled by css.
