### PR TITLE
Remove empty tests; clean up logs; open based on OS

### DIFF
--- a/tests/screenshot/gen_screenshots.js
+++ b/tests/screenshot/gen_screenshots.js
@@ -86,7 +86,8 @@ async function buildBrowser(url) {
   var options = {
     capabilities: {
       browserName: 'chrome'
-    }
+    },
+    logLevel: 'warn'
   };
   console.log('Starting webdriverio...');
   const browser = await webdriverio.remote(options);

--- a/tests/screenshot/run_differ.sh
+++ b/tests/screenshot/run_differ.sh
@@ -44,4 +44,8 @@ if [ -z "$1" ]
   fi
 
 # Open results.
-xdg-open 'tests/screenshot/diff_viewer.html'
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  xdg-open 'tests/screenshot/diff_viewer.html'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  open 'tests/screenshot/diff_viewer.html'
+fi

--- a/tests/screenshot/test_cases/colour
+++ b/tests/screenshot/test_cases/colour
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="colour">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/lists
+++ b/tests/screenshot/test_cases/lists
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="lists">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/logic
+++ b/tests/screenshot/test_cases/logic
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="logic">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/loops
+++ b/tests/screenshot/test_cases/loops
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="loops">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/math
+++ b/tests/screenshot/test_cases/math
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="math">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/procedures
+++ b/tests/screenshot/test_cases/procedures
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="procedures">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -1,10 +1,6 @@
 {
   "tests": [
     {
-      "title": "logic",
-      "skip": false
-    },
-    {
       "title": "logic_boolean",
       "skip": false
     },
@@ -49,10 +45,6 @@
       "skip": false
     },
     {
-      "title": "loops",
-      "skip": false
-    },
-    {
       "title": "controls_repeat_ext",
       "skip": false
     },
@@ -74,10 +66,6 @@
     },
     {
       "title": "controls_flow_statements",
-      "skip": false
-    },
-    {
-      "title": "math",
       "skip": false
     },
     {
@@ -134,14 +122,6 @@
     },
     {
       "title": "math_atan2",
-      "skip": false
-    },
-    {
-      "title": "texts",
-      "skip": false
-    },
-    {
-      "title": "text",
       "skip": false
     },
     {
@@ -213,10 +193,6 @@
       "skip": false
     },
     {
-      "title": "lists",
-      "skip": false
-    },
-    {
       "title": "lists_create_empty",
       "skip": false
     },
@@ -273,10 +249,6 @@
       "skip": false
     },
     {
-      "title": "colour",
-      "skip": false
-    },
-    {
       "title": "colour_picker",
       "skip": false
     },
@@ -293,10 +265,6 @@
       "skip": false
     },
     {
-      "title": "variables",
-      "skip": false
-    },
-    {
       "title": "variables_get",
       "skip": false
     },
@@ -310,10 +278,6 @@
     },
     {
       "title": "variables_set_dynamic",
-      "skip": false
-    },
-    {
-      "title": "procedures",
       "skip": false
     },
     {

--- a/tests/screenshot/test_cases/text
+++ b/tests/screenshot/test_cases/text
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="text">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/texts
+++ b/tests/screenshot/test_cases/texts
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="texts">
-	</block>
-</xml>

--- a/tests/screenshot/test_cases/variables
+++ b/tests/screenshot/test_cases/variables
@@ -1,4 +1,0 @@
-<xml xmlns="http://www.w3.org/1999/xhtml">
-	<block type="variables">
-	</block>
-</xml>


### PR DESCRIPTION
- Use less verbose logging for webdriverio
- Use `xdg-open` vs `open` based on OS ( I hope--need someone to test it on a mac)
- Delete empty tests