### PR TITLE
Call getSize in getCorrectedSize

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -563,6 +563,11 @@ Blockly.Field.prototype.getSize = function() {
   return this.size_;
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.Field.prototype.getCorrectedSize = function() {
   return this.getSize();
 };

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -360,9 +360,9 @@ Blockly.FieldColour.widgetDispose_ = function() {
  * @package
  */
 Blockly.FieldColour.prototype.getCorrectedSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
   return new goog.math.Size(
       this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
       Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -587,10 +587,11 @@ Blockly.FieldDropdown.validateOptions_ = function(options) {
 };
 
 Blockly.FieldDropdown.prototype.getCorrectedSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
-  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X, this.size_.height - 9);
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      this.size_.height - 9);
 };
 
 Blockly.Field.register('field_dropdown', Blockly.FieldDropdown);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -586,6 +586,11 @@ Blockly.FieldDropdown.validateOptions_ = function(options) {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.FieldDropdown.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -237,6 +237,11 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.FieldImage.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -238,9 +238,9 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
 };
 
 Blockly.FieldImage.prototype.getCorrectedSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
   return new goog.math.Size(this.size_.width, this.height_);
 };
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -115,6 +115,11 @@ Blockly.FieldLabel.prototype.setTooltip = function(newTip) {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.FieldLabel.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -116,9 +116,9 @@ Blockly.FieldLabel.prototype.setTooltip = function(newTip) {
 };
 
 Blockly.FieldLabel.prototype.getCorrectedSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
   return new goog.math.Size(this.size_.width, this.size_.height - 5);
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -447,6 +447,11 @@ Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
   return n;
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
 Blockly.FieldTextInput.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -448,9 +448,9 @@ Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
 };
 
 Blockly.FieldTextInput.prototype.getCorrectedSize = function() {
-  if (!this.size_.width) {
-    this.render_();
-  }
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
   return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X, 16);
 };
 Blockly.Field.register('field_input', Blockly.FieldTextInput);


### PR DESCRIPTION
## The basics

- [x] I branched from `render/collab`
- [x] My pull request is against `render/collab`
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Changing the field value didn't update the appearance of the field, even though the value was changed internally.

### Proposed Changes

Call `getSize` from `getCorrectedSize`

### Reason for Changes

`getSize` rerenders the field if necessary.  I don't want to duplicate its internal logic, especially since that's an active area of code, so I'm just calling it here.

Another option would be to call `getSize` and then `getCorrectedSize` in sequence in `measurables.js`.  That would put it in only one place, which would be nice, but it's also a weird place for it.

