### PR TITLE
Fix checkbox rendering

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -288,7 +288,8 @@ Blockly.BlockRendering.Drawer.prototype.drawInternals_ = function() {
 Blockly.BlockRendering.Drawer.prototype.dealWithJackassFields_ = function(field) {
   if (field instanceof Blockly.FieldDropdown
       || field instanceof Blockly.FieldTextInput
-      || field instanceof Blockly.FieldColour) {
+      || field instanceof Blockly.FieldColour
+      || field instanceof Blockly.FieldCheckbox) {
     return 5;
   }
   return 0;

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -136,4 +136,16 @@ Blockly.FieldCheckbox.prototype.showEditor_ = function() {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * The checkbox field fills the entire border rect, rather than just using the
+ * text element.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldCheckbox.prototype.getCorrectedSize = function() {
+  this.getSize();
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
+};
 Blockly.Field.register('field_checkbox', Blockly.FieldCheckbox);


### PR DESCRIPTION

## The details
### Resolves
It looked like this before:
![image](https://user-images.githubusercontent.com/13686399/58585988-f39fcd00-820e-11e9-8e0a-14fc7073bf19.png)

### Proposed Changes

- Add checkboxes to the list of jackass fields.
- Override `getComputedSize` to include the size of the border rect.

### Reason for Changes

Checkboxes were allocated too little space, and offset when rendered.

### Test Coverage
test_fields_checkbox screenshot diff now passes.

