### PR TITLE
Add compilation with informational output; clean up generator logs

### DIFF
--- a/tests/compile/compile_for_warnings.sh
+++ b/tests/compile/compile_for_warnings.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Run the compile script and print the number of warnings.
+
+# Figure out where we are.
+if [ -f ./compile.sh ]; then
+  echo "Running from tests/compile"
+  PREFIX="."
+elif [ -f tests/compile/compile.sh ]; then
+  echo "Running from blockly root"
+  PREFIX="./tests/compile"
+else
+  echo "ERROR: Cannot determine BLOCKLY_ROOT" 1>&2;
+  exit 1
+fi
+
+OUTPUT_NAME="$PREFIX/output.txt"
+
+$PREFIX/compile.sh 2&> $OUTPUT_NAME
+tail -3 $OUTPUT_NAME

--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -55,7 +55,8 @@ async function runGeneratorsInBrowser() {
   var options = {
       capabilities: {
           browserName: 'firefox'
-      }
+      },
+      logLevel: 'warn'
   };
 
   var url = 'file://' + __dirname + '/index.html';

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -65,7 +65,7 @@ run_test_command "mocha" "node tests/mocha/run_mocha_tests_in_browser.js"
 run_test_command "generators" "tests/scripts/run_generators.sh"
 
 # # Attempt advanced compilation of a Blockly app.
-# run_test_command "compile" "tests/compile/compile.sh"
+run_test_command "compile" "tests/compile/compile_for_warnings.sh"
 
 
 # End of tests.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None

### Proposed Changes

1. Add an extra "test" that just prints information about the number of compiler warnings.
2. Make generator tests quieter.

### Reason for Changes

1. A step toward tracking and reducing the number of compiler warnings, some of which are real.
2. Too much noise.

### Test Coverage
Added in travis.

### Additional Information

There are currently 642 warnings on develop.  Major jumps are a concern.