### PR TITLE
Moved Serializing the Field's Name up to xml.js

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -292,7 +292,6 @@ Blockly.Field.prototype.fromXml = function(fieldElement) {
  * @package
  */
 Blockly.Field.prototype.toXml = function(fieldElement) {
-  fieldElement.setAttribute('name', this.name);
   fieldElement.textContent = this.getValue();
   return fieldElement;
 };

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -151,7 +151,6 @@ Blockly.FieldVariable.prototype.toXml = function(fieldElement) {
   // Make sure the variable is initialized.
   this.initModel();
 
-  fieldElement.setAttribute('name', this.name);
   fieldElement.setAttribute('id', this.variable_.getId());
   fieldElement.textContent = this.variable_.name;
   fieldElement.setAttribute('variableType', this.variable_.type);

--- a/core/xml.js
+++ b/core/xml.js
@@ -109,6 +109,7 @@ Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
 Blockly.Xml.fieldToDom_ = function(field) {
   if (field.isSerializable()) {
     var container = Blockly.Xml.utils.createElement('field');
+    container.setAttribute('name', field.name);
     return field.toXml(container);
   }
   return null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Has xml.js handle serializing the field's name.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Expecting every field that overrides toXml to remember to save the name is error prone.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Covered by mocha serialization tests.

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A