### PR TITLE
Fixed Dropdown Arrow Missing Padding

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -142,7 +142,9 @@ Blockly.FieldDropdown.prototype.initView = function() {
 
   this.arrow_ = Blockly.utils.createSvgElement('tspan', {}, this.textElement_);
   this.arrow_.appendChild(document.createTextNode(
-      Blockly.FieldDropdown.ARROW_CHAR));
+      this.sourceBlock_.RTL ?
+      Blockly.FieldDropdown.ARROW_CHAR + ' ' :
+      ' ' + Blockly.FieldDropdown.ARROW_CHAR));
   if (this.sourceBlock_.RTL) {
     this.textElement_.insertBefore(this.arrow_, this.textContent_);
   } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2527 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Readds dropdown arrow padding.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Never supposed to be removed.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![DropdownPadding_Empty](https://user-images.githubusercontent.com/25440652/58728345-8d948080-839b-11e9-993b-50f6ddf3db84.jpg)
![DropdownPadding_WithText](https://user-images.githubusercontent.com/25440652/58728347-8f5e4400-839b-11e9-9468-31ac8a76a728.jpg)


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

I don't know if this is /the best/ way to handle padding, but it's how it worked before.
