### PR TITLE
Removed Extra DropDownDiv Calls

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -172,9 +172,6 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   // Mobile browsers have issues with in-line textareas (focus & keyboards).
   Blockly.FieldAngle.superClass_.showEditor_.call(this, noFocus);
 
-  // If there is an existing drop-down someone else owns, hide it immediately and clear it.
-  Blockly.DropDownDiv.hideWithoutAnimation();
-  Blockly.DropDownDiv.clearContent();
   var div = Blockly.DropDownDiv.getContentDiv();
 
   // Build the SVG DOM.

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -285,10 +285,6 @@ Blockly.FieldColour.prototype.setColumns = function(columns) {
  * @private
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-
-  Blockly.DropDownDiv.hideWithoutAnimation();
-  Blockly.DropDownDiv.clearContent();
-
   var picker = this.createWidget_();
   Blockly.DropDownDiv.getContentDiv().appendChild(picker);
   Blockly.DropDownDiv.setColour(

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -198,9 +198,6 @@ Blockly.FieldDate.prototype.updateEditor_ = function() {
  * @private
  */
 Blockly.FieldDate.prototype.showEditor_ = function() {
-  Blockly.DropDownDiv.hideWithoutAnimation();
-  Blockly.DropDownDiv.clearContent();
-
   this.picker_ = this.createWidget_();
   this.picker_.render(Blockly.DropDownDiv.getContentDiv());
   Blockly.utils.addClass(this.picker_.getElement(), 'blocklyDatePicker');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes extra calls to `hideWithoutAnimation()` and `clearContent()`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Duplicate work is bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Every gesture starts with a call to hideChaff, which calls `hideWithoutAnimation`, which calls `clearContent`. So there's no reason for fields to call hide as well.

Here's a gif of before (observe the duplicate calls):
![Divs_DoubleLogsGif](https://user-images.githubusercontent.com/25440652/58766467-d5e6a680-8533-11e9-95aa-1befc9dc04cd.gif)

And a pic of the logs:
![Divs_DoubleLogsPic](https://user-images.githubusercontent.com/25440652/58766469-db43f100-8533-11e9-8895-c6abd8461fe3.jpg)

Here's a gif of it still working (observe no duplicate calls):
![Divs_SingleLogsGif](https://user-images.githubusercontent.com/25440652/58766525-8ce32200-8534-11e9-8427-96e4cbccb7ea.gif)


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A