### PR TITLE
Block min width; notch offsets

### DIFF
--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -316,7 +316,7 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     if (prev.isField() && prev.isEditable) {
       return BRC.MEDIUM_PADDING;
     }
-    // A block with just an icon is skinny.  Make it more substantial.
+    // Padding at the end of an icon-only row to make the block shape clearer.
     if (prev.isIcon()) {
       return (BRC.LARGE_PADDING * 2) + 1;
     }
@@ -383,10 +383,14 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     }
   }
 
-  // Spacing between a hat and a corner
   if (prev.isSquareCorner()) {
+    // Spacing between a hat and a corner
     if (next.isHat()) {
       return BRC.NO_PADDING;
+    }
+    // Spacing between a square corner and a previous or next connection
+    if (next.isPreviousConnection() || next.isNextConnection()) {
+      return BRC.NOTCH_OFFSET_LEFT;
     }
   }
 
@@ -396,13 +400,6 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
       return BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV;
     } else if (next.isNextConnection()) {
       return BRC.NOTCH_OFFSET_ROUNDED_CORNER_NEXT;
-    }
-  }
-
-  // Spacing between a square corner and a previous or next connection
-  if (prev.isSquareCorner()) {
-    if (next.isPreviousConnection() || next.isNextConnection()) {
-      return BRC.NOTCH_OFFSET_LEFT;
     }
   }
 

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -316,13 +316,16 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     if (prev.isField() && prev.isEditable) {
       return BRC.MEDIUM_PADDING;
     }
+    // A block with just an icon is skinny.  Make it more substantial.
+    if (prev.isIcon()) {
+      return (BRC.LARGE_PADDING * 2) + 1;
+    }
     if (prev.isHat()){
       return BRC.NO_PADDING;
     }
+    // Establish a minimum width for a block with a previous or next connection.
     if (prev.isPreviousConnection() || prev.isNextConnection()) {
-      // TODO: Need to figure out minimum padding between connection and end of
-      // the block.
-      return BRC.NO_PADDING;
+      return BRC.LARGE_PADDING;
     }
     // Between rounded corner and the end of the row.
     if (prev.isRoundedCorner()) {
@@ -389,8 +392,10 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
 
   // Spacing between a rounded corner and a previous or next connection
   if (prev.isRoundedCorner()){
-    if (next.isPreviousConnection() || next.isNextConnection()) {
-      return BRC.NOTCH_OFFSET_ROUNDED_CORNER;
+    if (next.isPreviousConnection()) {
+      return BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV;
+    } else if (next.isNextConnection()) {
+      return BRC.NOTCH_OFFSET_ROUNDED_CORNER_NEXT;
     }
   }
 

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -63,9 +63,14 @@ BRC.EMPTY_BLOCK_SPACER_HEIGHT = 16;
 // the left side of the notch.
 BRC.NOTCH_OFFSET_LEFT = BRC.NOTCH_WIDTH;
 
-// This is the width from where a rounded corner ends and a next or previous
+// This is the width from where a rounded corner ends to where a previous
 // connection starts.
-BRC.NOTCH_OFFSET_ROUNDED_CORNER = 7.5;
+BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV = 7;
+
+// This is the width from where a rounded corner ends to where a next
+// connection starts.
+BRC.NOTCH_OFFSET_ROUNDED_CORNER_NEXT =
+        BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV - 0.5;
 
 // This is the offset from the vertical part of a statement input
 // to where to start the notch, which is on the right side in LTR.


### PR DESCRIPTION
Tests passing: 65/109 -> 77/109 in LTR

- Increase padding between an icon and end of row (changes min width)
- Set padding between a notch (prev or next) and the end of a row (changes min width)
- Adjust padding between a notch (prev or next) and the beginning of the row (addresses misalignment)