### PR TITLE
Fix text y location on statement inputs

### DIFF
--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -611,10 +611,8 @@ Blockly.BlockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, e
   var result = row.yPos;
   if (elem.isField()) {
     result += (elem.height / 2);
-    if (row.hasInlineInput) {
-      result += BRC.INLINE_INPUT_FIELD_OFFSET_Y;
-    } else if (row.hasStatement) {
-      result += BRC.STATEMENT_FIELD_OFFSET_Y;
+    if (row.hasInlineInput || row.hasStatement) {
+      result += BRC.TALL_INPUT_FIELD_OFFSET_Y;
     }
   } else {
     result += (row.height / 2);

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -33,13 +33,10 @@ BRC.MEDIUM_PADDING = 5;
 BRC.MEDIUM_LARGE_PADDING = 8;
 BRC.LARGE_PADDING = 10;
 
-// Offset from the top of the row for placing fields on statement input rows.
+// Offset from the top of the row for placing fields on inline input rows
+// and statement input rows.
 // Matches existing rendering (in 2019).
-BRC.STATEMENT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING - 1;
-
-// Offset from the top of the row for placing fields on inline input rows.
-// Matches existing rendering (in 2019).
-BRC.INLINE_INPUT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING;
+BRC.TALL_INPUT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING;
 
 BRC.HIGHLIGHT_OFFSET = 0.5;
 


### PR DESCRIPTION
In current rendering, text on inline inputs and statement inputs is placed a set distance below the top of the row.  I had two different constants for this, but that was masking a different error.

If/when we switch to vertically centering the fields in a row, this goes away entirely.
