### PR TITLE
Account for shadow in block size.

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -74,18 +74,28 @@ Blockly.BlockRendering.Drawer = function(block) {
  * @private
  */
 Blockly.BlockRendering.Drawer.prototype.draw_ = function() {
-  this.block_.height = this.info_.height;
-  this.block_.width = this.info_.widthWithChildren;
   this.drawOutline_();
   this.drawInternals_();
   this.block_.setPaths_(this.pathObject_);
   this.moveConnections_();
   this.block_.renderingDebugger.drawDebug(this.block_, this.info_);
-
-  // Someone out there depends on this existing.
-  this.block_.startHat_ = this.info_.topRow.startHat;
+  this.recordSizeOnBlock_();
 };
 
+/**
+ * Save sizing information back to the block
+ * Most of the rendering information can be thrown away at the end of the render.
+ * Anything that needs to be kept around should be set in this function.
+ * @private
+ */
+Blockly.BlockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
+  // This is used when the block is reporting its size to anyone else.
+  // The dark path adds to the size of the block in both X and Y.
+  this.block_.height = this.info_.height + BRC.DARK_PATH_OFFSET;
+  this.block_.width = this.info_.widthWithChildren + BRC.DARK_PATH_OFFSET;
+  // The flyout uses this information.
+  this.block_.startHat_ = this.info_.topRow.startHat;
+};
 
 /**
  * Create the outline of the block.  This is a single continuous path.

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -616,6 +616,8 @@ Blockly.BlockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, e
     } else if (row.hasStatement) {
       result += BRC.STATEMENT_FIELD_OFFSET_Y;
     }
+  } else if (elem.isInlineInput()) {
+    result += elem.height / 2;
   } else {
     result += (row.height / 2);
   }

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -43,6 +43,10 @@ BRC.INLINE_INPUT_FIELD_OFFSET_Y = BRC.MEDIUM_PADDING;
 
 BRC.HIGHLIGHT_OFFSET = 0.5;
 
+// The dark/shadow path in classic rendering is the same as the normal block
+// path, but translated down one and right one.
+BRC.DARK_PATH_OFFSET = 1;
+
 BRC.TAB_HEIGHT = 15;
 
 BRC.TAB_OFFSET_FROM_TOP = 5;

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -215,8 +215,10 @@ Blockly.BlockRendering.InlineInput = function(input) {
     this.height = BRC.EMPTY_INLINE_INPUT_HEIGHT;
     this.width = BRC.EMPTY_INLINE_INPUT_WIDTH;
   } else {
-    this.width = this.connectedBlockWidth + BRC.TAB_WIDTH + 1;
-    this.height = this.connectedBlockHeight + 2;
+    // We allow the dark path to show on the parent block so that the child
+    // block looks embossed.  This takes up an extra pixel in both x and y.
+    this.width = this.connectedBlockWidth + BRC.TAB_WIDTH + BRC.DARK_PATH_OFFSET;
+    this.height = this.connectedBlockHeight + BRC.DARK_PATH_OFFSET;
   }
 };
 goog.inherits(Blockly.BlockRendering.InlineInput, Blockly.BlockRendering.Input);


### PR DESCRIPTION
Changes:
- Add the shadow/dark path size to the reported size of all blocks (in block_render_draw)
- Vertically align inline inputs to match classic rendering (in block_render_info)
- Account for the shadow/dark path in the size of an inline input (in measurables.js)
- Use a constant for the size of the dark path, to make it easier to later remove it

One additional test passes.

Diffs looked like this:
![image](https://user-images.githubusercontent.com/13686399/58909362-c1d3ae00-86c7-11e9-90df-1e67131bde49.png)

Now they look like this:
![image](https://user-images.githubusercontent.com/13686399/58909388-d31cba80-86c7-11e9-8724-b2e37693dd2c.png)

Note that the remaining error here is an instance of #2535:
![image](https://user-images.githubusercontent.com/13686399/58909506-268f0880-86c8-11e9-8417-ea450926130f.png)

