### PR TITLE
Add tests with external and inline inputs; set shadow colour

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -989,11 +989,13 @@ Blockly.BlockSvg.prototype.setBorderColour_ = function() {
  */
 Blockly.BlockSvg.prototype.setShadowColour_ = function() {
   this.svgPathLight_.style.display = 'none';
-  this.svgPathDark_.style.display = 'none';
   this.svgPath_.setAttribute('stroke', 'none');
 
   var shadowColour = this.getColourShadow();
   this.svgPath_.setAttribute('fill', shadowColour);
+
+  this.svgPathDark_.style.display = '';
+  this.svgPathDark_.setAttribute('fill', shadowColour);
   return shadowColour;
 };
 

--- a/tests/screenshot/test_cases/multi_colour_with_external
+++ b/tests/screenshot/test_cases/multi_colour_with_external
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="colour_rgb">
+    <value name="RED">
+      <shadow type="math_number">
+        <field name="NUM">100</field>
+      </shadow>
+      <block type="math_modulo">
+        <value name="DIVIDEND">
+          <shadow type="math_number">
+            <field name="NUM">64</field>
+          </shadow>
+        </value>
+        <value name="DIVISOR">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+    <value name="GREEN">
+      <shadow type="math_number">
+        <field name="NUM">50</field>
+      </shadow>
+    </value>
+    <value name="BLUE">
+      <shadow type="math_number">
+        <field name="NUM">0</field>
+      </shadow>
+      <block type="math_arithmetic">
+        <field name="OP">ADD</field>
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/multi_colour_with_internal
+++ b/tests/screenshot/test_cases/multi_colour_with_internal
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="colour_rgb" inline="true">
+    <value name="RED">
+      <shadow type="math_number">
+        <field name="NUM">100</field>
+      </shadow>
+      <block type="math_modulo">
+        <value name="DIVIDEND">
+          <shadow type="math_number">
+            <field name="NUM">64</field>
+          </shadow>
+        </value>
+        <value name="DIVISOR">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+    <value name="GREEN">
+      <shadow type="math_number">
+        <field name="NUM">50</field>
+      </shadow>
+    </value>
+    <value name="BLUE">
+      <shadow type="math_number">
+        <field name="NUM">0</field>
+      </shadow>
+      <block type="math_arithmetic">
+        <field name="OP">ADD</field>
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -461,6 +461,14 @@
       "skip": false
     },
     {
+      "title": "multi_colour_with_external",
+      "skip": false
+    },
+    {
+      "title": "multi_colour_with_internal",
+      "skip": false
+    },
+    {
       "title": "not_true",
       "skip": false
     }


### PR DESCRIPTION
Changes:
- Add two new test cases (see below)
- Set shadow colour of block correctly (makes 3 tests pass, total 85/111 passing)

@alschmiedt if this looks like a good fix for the shadow block colour, I can make a similar PR against develop.

New test cases: 
![image](https://user-images.githubusercontent.com/13686399/58910452-6b1ba380-86ca-11e9-9420-fdf4e658f091.png)

![image](https://user-images.githubusercontent.com/13686399/58910464-71118480-86ca-11e9-9215-73e187d26076.png)
