### PR TITLE
Fixed how the Trashcan Handles Shadow Blocks

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -470,7 +470,8 @@ Blockly.Trashcan.prototype.onDelete_ = function() {
     if (trashcan.workspace_.options.maxTrashcanContents <= 0) {
       return;
     }
-    if (event.type == Blockly.Events.BLOCK_DELETE) {
+    if (event.type == Blockly.Events.BLOCK_DELETE &&
+        event.oldXml.tagName.toLowerCase() != 'shadow') {
       var cleanedXML = trashcan.cleanBlockXML_(event.oldXml);
       if (trashcan.contents_.indexOf(cleanedXML) != -1) {
         return;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2538 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the trashcan ignores top-level shadow blocks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixes buggy behavior

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Dragged math "+" block onto workspace.
2. Dragged math "123" block into "+" block.
3. Observed how there was no change in the trashcan, and it was not interactable.

![TrashcanShadows](https://user-images.githubusercontent.com/25440652/58973070-eb4a1380-8773-11e9-8424-cbd12238a6bb.gif)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
