### PR TITLE
Render/rtl top right

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -60,14 +60,14 @@ Blockly.BlockRendering.Highlighter.prototype.drawTopCorner = function(row) {
     if (elem.type === 'square corner') {
       this.highlightSteps_.push(BRC.START_POINT_HIGHLIGHT);
     } else if (elem.type === 'round corner') {
-      this.highlightSteps_.push(this.RTL ?
-          Blockly.BlockSvg.TOP_LEFT_CORNER_START_HIGHLIGHT_RTL :
-          Blockly.BlockSvg.TOP_LEFT_CORNER_START_HIGHLIGHT_LTR);
-      this.highlightSteps_.push(Blockly.BlockSvg.TOP_LEFT_CORNER_HIGHLIGHT);
+      this.highlightSteps_.push(this.info_.RTL ?
+          BRC.TOP_LEFT_CORNER_START_HIGHLIGHT_RTL :
+          BRC.TOP_LEFT_CORNER_START_HIGHLIGHT_LTR);
+      this.highlightSteps_.push(BRC.TOP_LEFT_CORNER_HIGHLIGHT);
     } else if (elem.type === 'previous connection') {
       this.highlightSteps_.push(BRC.NOTCH_PATH_LEFT_HIGHLIGHT);
     } else if (elem.type === 'hat') {
-      this.highlightSteps_.push(this.RTL ?
+      this.highlightSteps_.push(this.info_.RTL ?
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_RTL :
           Blockly.BlockSvg.START_HAT_HIGHLIGHT_LTR);
     } else if (elem.isSpacer()) {

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -177,7 +177,8 @@ BRC.NOTCH_PATH_LEFT = 'l 6,4 3,0 6,-4';
  * highlighting.
  * @const
  */
-BRC.NOTCH_PATH_LEFT_HIGHLIGHT = BRC.NOTCH_PATH_LEFT;
+BRC.NOTCH_PATH_LEFT_HIGHLIGHT =
+    'h ' + BRC.HIGHLIGHT_OFFSET + ' ' + BRC.NOTCH_PATH_LEFT;
 
 /**
  * SVG path for drawing next/previous notch from right to left.

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -284,3 +284,41 @@ BRC.OUTPUT_CONNECTION_HIGHLIGHT_LTR =
 BRC.OUTPUT_CONNECTION_HIGHLIGHT_RTL =
     'M ' + (BRC.TAB_WIDTH * -0.25) + ',8.4 l ' +
     (BRC.TAB_WIDTH * -0.45) + ',-2.1';
+
+/**
+ * SVG start point for drawing the top-left corner's highlight in RTL.
+ * @const
+ */
+BRC.TOP_LEFT_CORNER_START_HIGHLIGHT_RTL =
+    'm ' + BRC.DISTANCE_45_INSIDE + ',' +
+    BRC.DISTANCE_45_INSIDE;
+
+/**
+ * SVG start point for drawing the top-left corner's highlight in LTR.
+ * @const
+ */
+BRC.TOP_LEFT_CORNER_START_HIGHLIGHT_LTR =
+    'm 0.5,' + (BRC.CORNER_RADIUS - 0.5);
+
+/**
+ * SVG path for drawing the highlight on the rounded top-left corner.
+ * @const
+ */
+BRC.TOP_LEFT_CORNER_HIGHLIGHT =
+    'A ' + (BRC.CORNER_RADIUS - 0.5) + ',' +
+    (BRC.CORNER_RADIUS - 0.5) + ' 0 0,1 ' +
+    BRC.CORNER_RADIUS + ',0.5';
+
+/**
+ * Path of the top hat's curve's highlight in LTR.
+ * @const
+ */
+BRC.START_HAT_HIGHLIGHT_LTR =
+    'c 17.8,-9.2 45.3,-14.9 75,-8.7 M 100.5,0.5';
+
+/**
+ * Path of the top hat's curve's highlight in RTL.
+ * @const
+ */
+BRC.START_HAT_HIGHLIGHT_RTL =
+    'm 25,-8.7 c 29.7,-6.2 57.2,-0.5 75,8.7';


### PR DESCRIPTION
Two changes: 
- Correctly check RTL mode and use BRC constants instead of Blockly.BlockSvg constants for the top-right-corner highlight in RTL mode (chops off an extra tail)
- Shift the previous connection highlight by BRC.HIGHLIGHT_OFFSET.  This fixes a slight misalignment that show up when you have blocks stacked vertically.