### PR TITLE
Fix tree traversal to work for multiple stacks

### DIFF
--- a/demos/keyboard-nav/index.html
+++ b/demos/keyboard-nav/index.html
@@ -215,12 +215,14 @@
       } else if (newNode) {
         return treeTraversal(newNode);
       } else {
-        var siblingOrParent = findSiblingOrParent(node);
+        var siblingOrParent = findSiblingOrParent(node.out());
         if (validNode(siblingOrParent)) {
           return siblingOrParent;
         } else if (siblingOrParent
           && siblingOrParent.getType() !== Blockly.ASTNode.types.WORKSPACE) {
           return treeTraversal(siblingOrParent);
+        } else {
+          return null;
         }
       }
     }

--- a/demos/keyboard-nav/index.html
+++ b/demos/keyboard-nav/index.html
@@ -190,8 +190,9 @@
       if (!node) {
         return null;
       }
-      if (validNode(node.next())) {
-        return node.next();
+      var nextNode = node.next();
+      if (nextNode) {
+        return nextNode;
       }
       return findSiblingOrParent(node.out());
     }
@@ -214,7 +215,13 @@
       } else if (newNode) {
         return treeTraversal(newNode);
       } else {
-        return findSiblingOrParent(node);
+        var siblingOrParent = findSiblingOrParent(node);
+        if (validNode(siblingOrParent)) {
+          return siblingOrParent;
+        } else if (siblingOrParent
+          && siblingOrParent.getType() !== Blockly.ASTNode.types.WORKSPACE) {
+          return treeTraversal(siblingOrParent);
+        }
       }
     }
 

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -209,17 +209,6 @@ suite('Navigation', function() {
           Blockly.Navigation.STATE_WS);
     });
 
-    test('Add block to workspace with a marked workspace node', function() {
-      var coordinate = new goog.math.Coordinate(100,100);
-      var wsNode = Blockly.ASTNode.createWorkspaceNode(this.workspace, coordinate);
-      Blockly.Navigation.marker_.setLocation(wsNode);
-
-      Blockly.Navigation.insertBlockToWs(this.basicBlock);
-
-      chai.assert.equal(this.basicBlock.getRelativeToSurfaceXY().x, 100);
-      chai.assert.equal(this.basicBlock.getRelativeToSurfaceXY().y, 100);
-    });
-
     test('Connect two blocks that are on the workspace', function() {
       var targetNode = Blockly.ASTNode.createConnectionNode(this.basicBlock.previousConnection);
       Blockly.Navigation.marker_.setLocation(targetNode);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Tree traversal was not working for multiple stacks when a stack was not valid. 

### Proposed Changes
If the sibling or parent node is not valid traverse the sub tree to look for a valid node. We don't want to traverse the tree if we are at the top workspace node. 

### Reason for Changes
Before if the node was not valid then we skipped the sub tree underneath it and just went to the next out node. 

### Test Coverage

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
