### PR TITLE
Fixed Field Disposal, and Reorganized Editor Creation

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -463,7 +463,16 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
   if (Blockly.DropDownDiv.animateOutTimer_) {
     clearTimeout(Blockly.DropDownDiv.animateOutTimer_);
   }
-  Blockly.DropDownDiv.positionInternal_();
+
+  // Reset style properties in case this gets called directly
+  // instead of hide() - see discussion on #2551.
+  var div = Blockly.DropDownDiv.DIV_;
+  div.style.transform = '';
+  div.style.left = '';
+  div.style.top = '';
+  div.style.opacity = 0;
+  div.style.display = 'none';
+
   Blockly.DropDownDiv.clearContent();
   Blockly.DropDownDiv.owner_ = null;
   if (Blockly.DropDownDiv.onHide_) {
@@ -475,37 +484,36 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
 
 /**
  * Set the dropdown div's position.
- * @param {number} initialX Initial Horizontal location (window coordinates, not body).
- * @param {number} initialY Initial Vertical location (window coordinates, not body).
- * @param {number} finalX Final Horizontal location (window coordinates, not body).
- * @param {number} finalY Final Vertical location (window coordinates, not body).
+ * @param {!number} initialX Initial Horizontal location
+ *    (window coordinates, not body).
+ * @param {!number} initialY Initial Vertical location
+ *    (window coordinates, not body).
+ * @param {!number} finalX Final Horizontal location
+ *    (window coordinates, not body).
+ * @param {!number} finalY Final Vertical location
+ *    (window coordinates, not body).
  * @private
  */
 Blockly.DropDownDiv.positionInternal_ = function(initialX, initialY, finalX, finalY) {
-  initialX = initialX == null ? initialX : Math.floor(initialX);
-  initialY = initialY == null ? initialY : Math.floor(initialY);
-  finalX = finalX == null ? finalX : Math.floor(finalX);
-  finalY = finalY == null ? finalY : Math.floor(finalY);
+  initialX = Math.floor(initialX);
+  initialY = Math.floor(initialY);
+  finalX = Math.floor(finalX);
+  finalY = Math.floor(finalY);
 
   var div = Blockly.DropDownDiv.DIV_;
   // First apply initial translation.
-  div.style.left = initialX != null ? initialX + 'px' : '';
-  div.style.top = initialY != null ? initialY + 'px' : '';
-  if (finalX != null) {
-    // Show the div.
-    div.style.display = 'block';
-    div.style.opacity = 1;
-    // Add final translate, animated through `transition`.
-    // Coordinates are relative to (initialX, initialY),
-    // where the drop-down is absolutely positioned.
-    var dx = (finalX - initialX);
-    var dy = (finalY - initialY);
-    div.style.transform = 'translate(' + dx + 'px,' + dy + 'px)';
-  } else {
-    // Hide the div.
-    div.style.display = 'none';
-    div.style.transform = '';
-  }
+  div.style.left = initialX + 'px';
+  div.style.top = initialY + 'px';
+
+  // Show the div.
+  div.style.display = 'block';
+  div.style.opacity = 1;
+  // Add final translate, animated through `transition`.
+  // Coordinates are relative to (initialX, initialY),
+  // where the drop-down is absolutely positioned.
+  var dx = (finalX - initialX);
+  var dy = (finalY - initialY);
+  div.style.transform = 'translate(' + dx + 'px,' + dy + 'px)';
 };
 
 /**

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -139,6 +139,8 @@ Blockly.DropDownDiv.createDom = function() {
   div.appendChild(arrow);
   Blockly.DropDownDiv.arrow_ = arrow;
 
+  Blockly.DropDownDiv.DIV_.style.opacity = 0;
+
   // Transition animation for transform: translate() and opacity.
   Blockly.DropDownDiv.DIV_.style.transition = 'transform ' +
     Blockly.DropDownDiv.ANIMATION_TIME + 's, ' +

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -484,13 +484,13 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
 
 /**
  * Set the dropdown div's position.
- * @param {!number} initialX Initial Horizontal location
+ * @param {number} initialX Initial Horizontal location
  *    (window coordinates, not body).
- * @param {!number} initialY Initial Vertical location
+ * @param {number} initialY Initial Vertical location
  *    (window coordinates, not body).
- * @param {!number} finalX Final Horizontal location
+ * @param {number} finalX Final Horizontal location
  *    (window coordinates, not body).
- * @param {!number} finalY Final Vertical location
+ * @param {number} finalY Final Vertical location
  *    (window coordinates, not body).
  * @private
  */
@@ -511,8 +511,8 @@ Blockly.DropDownDiv.positionInternal_ = function(initialX, initialY, finalX, fin
   // Add final translate, animated through `transition`.
   // Coordinates are relative to (initialX, initialY),
   // where the drop-down is absolutely positioned.
-  var dx = (finalX - initialX);
-  var dy = (finalY - initialY);
+  var dx = finalX - initialX;
+  var dy = finalY - initialY;
   div.style.transform = 'translate(' + dx + 'px,' + dy + 'px)';
 };
 

--- a/core/field.js
+++ b/core/field.js
@@ -111,7 +111,6 @@ Blockly.Field.cacheWidths_ = null;
  */
 Blockly.Field.cacheReference_ = 0;
 
-
 /**
  * Name of field.  Unique within each block.
  * Static labels are usually unnamed.
@@ -126,12 +125,12 @@ Blockly.Field.prototype.name = undefined;
 Blockly.Field.prototype.maxDisplayLength = 50;
 
 /**
- * Get the current value of the field.
- * @return {*} Current value.
+ * A generic value possessed by the field.
+ * Should generally be non-null, only null when the field is created.
+ * @type {*}
+ * @protected
  */
-Blockly.Field.prototype.getValue = function() {
-  return this.value_;
-};
+Blockly.Field.prototype.value_ = null;
 
 /**
  * Visible text to display.
@@ -329,8 +328,12 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 
 /**
  * Dispose of all DOM objects belonging to this editable field.
+ * @package
  */
 Blockly.Field.prototype.dispose = function() {
+  Blockly.DropDownDiv.hideIfOwner(this);
+  Blockly.WidgetDiv.hideIfOwner(this);
+
   if (this.mouseDownWrapper_) {
     Blockly.unbindEvent_(this.mouseDownWrapper_);
     this.mouseDownWrapper_ = null;
@@ -785,12 +788,12 @@ Blockly.Field.prototype.setValue = function(newValue) {
 };
 
 /**
- * A generic value possessed by the field.
- * Should generally be non-null, only null when the field is created.
- * @type {*}
- * @protected
+ * Get the current value of the field.
+ * @return {*} Current value.
  */
-Blockly.Field.prototype.value_ = null;
+Blockly.Field.prototype.getValue = function() {
+  return this.value_;
+};
 
 /**
  * Used to validate a value. Returns input by default. Can be overridden by

--- a/core/field.js
+++ b/core/field.js
@@ -327,7 +327,7 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 };
 
 /**
- * Dispose of all DOM objects belonging to this editable field.
+ * Dispose of all DOM objects and events belonging to this editable field.
  * @package
  */
 Blockly.Field.prototype.dispose = function() {
@@ -336,16 +336,11 @@ Blockly.Field.prototype.dispose = function() {
 
   if (this.mouseDownWrapper_) {
     Blockly.unbindEvent_(this.mouseDownWrapper_);
-    this.mouseDownWrapper_ = null;
   }
-  this.sourceBlock_ = null;
-  if (this.fieldGroup_) {
-    Blockly.utils.dom.removeNode(this.fieldGroup_);
-    this.fieldGroup_ = null;
-  }
-  this.textElement_ = null;
-  this.borderRect_ = null;
-  this.validator_ = null;
+
+  Blockly.utils.dom.removeNode(this.fieldGroup_);
+
+  this.disposed = true;
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -146,9 +146,9 @@ Blockly.FieldAngle.prototype.render_ = function() {
 Blockly.FieldAngle.prototype.showEditor_ = function() {
   // Mobile browsers have issues with in-line textareas (focus & keyboards).
   var noFocus =
-      Blockly.userAgent.MOBILE ||
-      Blockly.userAgent.ANDROID ||
-      Blockly.userAgent.IPAD;
+      Blockly.utils.userAgent.MOBILE ||
+      Blockly.utils.userAgent.ANDROID ||
+      Blockly.utils.userAgent.IPAD;
   Blockly.FieldAngle.superClass_.showEditor_.call(this, noFocus);
 
   var editor = this.dropdownCreate_();
@@ -170,7 +170,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
  * @private
  */
 Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
-  var svg = Blockly.utils.createSvgElement('svg', {
+  var svg = Blockly.utils.dom.createSvgElement('svg', {
     'xmlns': 'http://www.w3.org/2000/svg',
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
     'xmlns:xlink': 'http://www.w3.org/1999/xlink',
@@ -178,16 +178,16 @@ Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
     'height': (Blockly.FieldAngle.HALF * 2) + 'px',
     'width': (Blockly.FieldAngle.HALF * 2) + 'px'
   }, null);
-  var circle = Blockly.utils.createSvgElement('circle', {
+  var circle = Blockly.utils.dom.createSvgElement('circle', {
     'cx': Blockly.FieldAngle.HALF,
     'cy': Blockly.FieldAngle.HALF,
     'r': Blockly.FieldAngle.RADIUS,
     'class': 'blocklyAngleCircle'
   }, svg);
-  this.gauge_ = Blockly.utils.createSvgElement('path', {
+  this.gauge_ = Blockly.utils.dom.createSvgElement('path', {
     'class': 'blocklyAngleGauge'
   }, svg);
-  this.line_ = Blockly.utils.createSvgElement('line', {
+  this.line_ = Blockly.utils.dom.createSvgElement('line', {
     'x1': Blockly.FieldAngle.HALF,
     'y1': Blockly.FieldAngle.HALF,
     'class': 'blocklyAngleLine'
@@ -236,6 +236,7 @@ Blockly.FieldAngle.prototype.dropdownDispose_ = function() {
  */
 Blockly.FieldAngle.prototype.hide_ = function() {
   Blockly.DropDownDiv.hideIfOwner(this);
+  Blockly.WidgetDiv.hide();
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -171,9 +171,9 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
  */
 Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
   var svg = Blockly.utils.dom.createSvgElement('svg', {
-    'xmlns': 'http://www.w3.org/2000/svg',
-    'xmlns:html': 'http://www.w3.org/1999/xhtml',
-    'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+    'xmlns': Blockly.utils.dom.SVG_NS,
+    'xmlns:html': Blockly.utils.dom.HTML_NS,
+    'xmlns:xlink': Blockly.utils.dom.XLINK_NS,
     'version': '1.1',
     'height': (Blockly.FieldAngle.HALF * 2) + 'px',
     'width': (Blockly.FieldAngle.HALF * 2) + 'px'

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -237,7 +237,6 @@ Blockly.FieldAngle.prototype.dropdownDispose_ = function() {
  */
 Blockly.FieldAngle.prototype.hide_ = function() {
   Blockly.DropDownDiv.hideIfOwner(this);
-  Blockly.WidgetDiv.hide();
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -131,15 +131,6 @@ Blockly.FieldAngle.prototype.initView = function() {
 };
 
 /**
- * Dispose of references to DOM elements and events belonging to this field.
- * @package
- */
-Blockly.FieldAngle.prototype.dispose = function() {
-  Blockly.FieldAngle.superClass_.dispose.call(this);
-  this.symbol_ = null;
-};
-
-/**
  * Updates the graph when the field rerenders.
  * @private
  */
@@ -231,13 +222,10 @@ Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
 };
 
 /**
- * Dispose of references to DOM elements and events belonging
- * to the angle editor.
+ * Dispose of events belonging to the angle editor.
  * @private
  */
 Blockly.FieldAngle.prototype.dropdownDispose_ = function() {
-  this.gauge_ = null;
-  this.line_ = null;
   Blockly.unbindEvent_(this.clickWrapper_);
   Blockly.unbindEvent_(this.moveWrapper1_);
   Blockly.unbindEvent_(this.moveWrapper2_);

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -155,8 +155,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
   var border = this.sourceBlock_.getColourBorder();
-  border = border.colourBorder == null ?
-      border.colourLight : border.colourBorder;
+  border = border.colourBorder || border.colourLight;
   Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
 
   Blockly.DropDownDiv.showPositionedByField(

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -155,14 +155,6 @@ Blockly.FieldColour.prototype.initView = function() {
 };
 
 /**
- * Close the colour picker if this input is being deleted.
- */
-Blockly.FieldColour.prototype.dispose = function() {
-  Blockly.WidgetDiv.hideIfOwner(this);
-  Blockly.FieldColour.superClass_.dispose.call(this);
-};
-
-/**
  * Ensure that the input value is a valid colour.
  * @param {string=} newValue The input value.
  * @return {?string} A valid colour, or null if invalid.
@@ -271,20 +263,18 @@ Blockly.FieldColour.prototype.setColumns = function(columns) {
 };
 
 /**
- * Create a palette under the colour field.
+ * Create and show the colour field's editor.
  * @private
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-  var picker = this.createWidget_();
+  var picker = this.dropdownCreate_();
   Blockly.DropDownDiv.getContentDiv().appendChild(picker);
+
   Blockly.DropDownDiv.setColour(
       this.DROPDOWN_BACKGROUND_COLOUR, this.DROPDOWN_BORDER_COLOUR);
 
-  Blockly.DropDownDiv.showPositionedByField(this);
-
-  // Configure event handler on the table to listen for any event in a cell.
-  Blockly.FieldColour.onUpWrapper_ = Blockly.bindEvent_(picker,
-      'mouseup', this, this.onClick_);
+  Blockly.DropDownDiv.showPositionedByField(
+      this, this.dropdownDispose_.bind(this));
 };
 
 /**
@@ -299,22 +289,17 @@ Blockly.FieldColour.prototype.onClick_ = function(e) {
     cell = cell.parentNode;
   }
   var colour = cell && cell.label;
-  Blockly.WidgetDiv.hide();
-  if (this.sourceBlock_) {
-    // Call any validation function, and allow it to override.
-    colour = this.callValidator(colour);
-  }
   if (colour !== null) {
     this.setValue(colour);
   }
 };
 
 /**
- * Create a colour picker widget.
+ * Create a colour picker dropdown editor.
  * @return {!Element} The newly created colour picker.
  * @private
  */
-Blockly.FieldColour.prototype.createWidget_ = function() {
+Blockly.FieldColour.prototype.dropdownCreate_ = function() {
   var columns = this.columns_ || Blockly.FieldColour.COLUMNS;
   var colours = this.colours_ || Blockly.FieldColour.COLOURS;
   var titles = this.titles_ || Blockly.FieldColour.TITLES;
@@ -339,18 +324,20 @@ Blockly.FieldColour.prototype.createWidget_ = function() {
       div.className = 'blocklyColourSelected';
     }
   }
+
+  // Configure event handler on the table to listen for any event in a cell.
+  this.onUpWrapper_ = Blockly.bindEvent_(table, 'mouseup', this, this.onClick_);
+
   return table;
 };
 
 /**
- * Hide the colour picker widget.
+ * Dispose of references to DOM elements and events belonging
+ * to the colour editor.
  * @private
  */
-Blockly.FieldColour.widgetDispose_ = function() {
-  if (Blockly.FieldColour.onUpWrapper_) {
-    Blockly.unbindEvent_(Blockly.FieldColour.onUpWrapper_);
-  }
-  Blockly.Events.setGroup(false);
+Blockly.FieldColour.prototype.dropdownDispose_ = function() {
+  Blockly.unbindEvent_(this.onUpWrapper_);
 };
 
 Blockly.Field.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -332,8 +332,7 @@ Blockly.FieldColour.prototype.dropdownCreate_ = function() {
 };
 
 /**
- * Dispose of references to DOM elements and events belonging
- * to the colour editor.
+ * Dispose of events belonging to the colour editor.
  * @private
  */
 Blockly.FieldColour.prototype.dropdownDispose_ = function() {

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -240,7 +240,6 @@ Blockly.FieldDate.prototype.dropdownCreate_ = function() {
  * @private
  */
 Blockly.FieldDate.prototype.dropdownDispose_ = function() {
-  this.picker_ = null;
   goog.events.unlistenByKey(this.changeEventKey_);
   goog.events.unlistenByKey(this.activeMonthEventKey_);
 };

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -246,7 +246,6 @@ Blockly.FieldDate.prototype.dropdownDispose_ = function() {
 
 /**
  * Handle a CHANGE event in the date picker.
- * TODO: Not sure what the type for goog event information is.
  * @param {!Event} event The CHANGE event.
  * @private
  */

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -155,15 +155,6 @@ Blockly.FieldDropdown.prototype.initView = function() {
 };
 
 /**
- * Dispose of references to DOM elements and events belonging to this field.
- */
-Blockly.FieldDropdown.prototype.dispose = function() {
-  Blockly.FieldDropdown.superClass_.dispose.call(this);
-  this.imageElement_ = null;
-  this.arrow_ = null;
-};
-
-/**
  * Create a dropdown menu under the text.
  * @private
  */
@@ -223,8 +214,11 @@ Blockly.FieldDropdown.prototype.widgetCreate_ = function() {
   return menu;
 };
 
+/**
+ * Dispose of events belonging to the dropdown editor.
+ * @private
+ */
 Blockly.FieldDropdown.prototype.widgetDispose_ = function() {
-  this.menu_ = null;
   goog.events.unlistenByKey(this.menuActionEventKey_);
 };
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -165,7 +165,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
 
   this.menu_.render(Blockly.WidgetDiv.DIV);
   // Element gets created in render.
-  Blockly.utils.addClass(this.menu_.getElement(), 'blocklyDropdownMenu');
+  Blockly.utils.dom.addClass(this.menu_.getElement(), 'blocklyDropdownMenu');
 
   this.positionMenu_(this.menu_);
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -224,7 +224,6 @@ Blockly.FieldDropdown.prototype.widgetDispose_ = function() {
 
 /**
  * Handle an ACTION event in the dropdown menu.
- * TODO: Not sure what the type for goog event information is.
  * @param {!Event} event The CHANGE event.
  * @private
  */

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -130,16 +130,6 @@ Blockly.FieldImage.prototype.initView = function() {
 };
 
 /**
- * Dispose of all DOM objects belonging to this text.
- */
-Blockly.FieldImage.prototype.dispose = function() {
-  Blockly.FieldImage.superClass_.dispose.call(this);
-  this.imageElement_ = null;
-  // TODO: Do we need to dispose of this?
-  this.clickHandler_ = null;
-};
-
-/**
  * Ensure that the input value (the source URL) is a string.
  * @param {string=} newValue The input value
  * @return {?string} A string, or null if invalid.

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -133,11 +133,10 @@ Blockly.FieldImage.prototype.initView = function() {
  * Dispose of all DOM objects belonging to this text.
  */
 Blockly.FieldImage.prototype.dispose = function() {
-  if (this.fieldGroup_) {
-    Blockly.utils.dom.removeNode(this.fieldGroup_);
-    this.fieldGroup_ = null;
-  }
+  Blockly.FieldImage.superClass_.dispose.call(this);
   this.imageElement_ = null;
+  // TODO: Do we need to dispose of this?
+  this.clickHandler_ = null;
 };
 
 /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -88,16 +88,6 @@ Blockly.FieldLabel.prototype.initView = function() {
 };
 
 /**
- * Dispose of all DOM objects belonging to this text.
- */
-Blockly.FieldLabel.prototype.dispose = function() {
-  if (this.textElement_) {
-    Blockly.utils.dom.removeNode(this.textElement_);
-    this.textElement_ = null;
-  }
-};
-
-/**
  * Ensure that the input value casts to a valid string.
  * @param {string=} newValue The input value.
  * @return {?string} A valid string, or null if invalid.

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -89,14 +89,6 @@ Blockly.FieldTextInput.prototype.SERIALIZABLE = true;
 Blockly.FieldTextInput.FONTSIZE = 11;
 
 /**
- * The HTML input element for the user to type, or null if no FieldTextInput
- * editor is currently open.
- * @type {HTMLInputElement}
- * @protected
- */
-Blockly.FieldTextInput.htmlInput_ = null;
-
-/**
  * Mouse cursor style when over the hotspot that initiates the editor.
  */
 Blockly.FieldTextInput.prototype.CURSOR = 'text';

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -230,8 +230,6 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
     this.htmlInput_.focus();
     this.htmlInput_.select();
   }
-
-  this.bindInputEvents_();
 };
 
 Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
@@ -257,22 +255,24 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
 };
 
 /**
- * Bind handlers for user input on the text input field's editor..
+ * Bind handlers for user input on the text input field's editor.
+ * @param {!HTMLInputElement} htmlInput The htmlInput to which event
+ *    handlers will be bound.
  * @private
  */
-Blockly.FieldTextInput.prototype.bindInputEvents_ = function() {
+Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
   // Trap Enter without IME and Esc to hide.
   this.onKeyDownWrapper_ =
       Blockly.bindEventWithChecks_(
-          this.htmlInput_, 'keydown', this, this.onHtmlInputKeyDown_);
+          htmlInput, 'keydown', this, this.onHtmlInputKeyDown_);
   // Resize after every keystroke.
   this.onKeyUpWrapper_ =
       Blockly.bindEventWithChecks_(
-          this.htmlInput_, 'keyup', this, this.onHtmlInputChange_);
+          htmlInput, 'keyup', this, this.onHtmlInputChange_);
   // Repeatedly resize when holding down a key.
   this.onKeyPressWrapper_ =
       Blockly.bindEventWithChecks_(
-          this.htmlInput_, 'keypress', this, this.onHtmlInputChange_);
+          htmlInput, 'keypress', this, this.onHtmlInputChange_);
 
   // TODO: Figure out if this is necessary.
   this.onWorkspaceChangeWrapper_ = this.resizeEditor_.bind(this);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -26,7 +26,6 @@
 
 goog.provide('Blockly.FieldTextInput');
 
-goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
@@ -226,7 +225,7 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
 
 /**
  * Create the text input editor widget.
- * @return {HTMLInputElement} The newly created text input editor.
+ * @return {!HTMLInputElement} The newly created text input editor.
  * @private
  */
 Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
@@ -236,7 +235,7 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
   htmlInput.className = 'blocklyHtmlInput';
   htmlInput.setAttribute('spellcheck', this.spellcheck_);
   var fontSize =
-    (Blockly.FieldTextInput.FONTSIZE * this.workspace_.scale) + 'pt';
+      (Blockly.FieldTextInput.FONTSIZE * this.workspace_.scale) + 'pt';
   div.style.fontSize = fontSize;
   htmlInput.style.fontSize = fontSize;
   div.appendChild(htmlInput);
@@ -320,8 +319,7 @@ Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
   Blockly.unbindEvent_(this.onKeyDownWrapper_);
   Blockly.unbindEvent_(this.onKeyUpWrapper_);
   Blockly.unbindEvent_(this.onKeyPressWrapper_);
-  this.workspace_.removeChangeListener(
-      this.onWorkspaceChangeWrapper_);
+  this.workspace_.removeChangeListener(this.onWorkspaceChangeWrapper_);
 };
 
 /**
@@ -333,14 +331,11 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
   var tabKey = 9, enterKey = 13, escKey = 27;
   if (e.keyCode == enterKey) {
     Blockly.WidgetDiv.hide();
-    Blockly.DropDownDiv.hideIfOwner(this);
   } else if (e.keyCode == escKey) {
     this.htmlInput_.value = this.htmlInput_.defaultValue;
     Blockly.WidgetDiv.hide();
-    Blockly.DropDownDiv.hideIfOwner(this);
   } else if (e.keyCode == tabKey) {
     Blockly.WidgetDiv.hide();
-    Blockly.DropDownDiv.hideIfOwner(this);
     this.sourceBlock_.tab(this, !e.shiftKey);
     e.preventDefault();
   }

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -232,6 +232,11 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
   }
 };
 
+/**
+ * Create the text input editor widget.
+ * @return {HTMLInputElement} The newly created text input editor.
+ * @private
+ */
 Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
   var div = Blockly.WidgetDiv.DIV;
 
@@ -252,6 +257,42 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
   this.bindInputEvents_(htmlInput);
 
   return htmlInput;
+};
+
+/**
+ * Close the editor, save the results, and dispose any events bound to the
+ * text input's editor.
+ * @private
+ */
+Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
+  // Finalize value.
+  this.isBeingEdited_ = false;
+  // No need to call setValue because if the widget is being closed the
+  // latest input text has already been validated.
+  if (this.value_ !== this.text_) {
+    // At the end of an edit the text should be the same as the value. It
+    // may not be if the input text is different than the validated text.
+    // We should fix that.
+    this.text_ = String(this.value_);
+    this.isTextValid_ = true;
+    this.forceRerender();
+  }
+  // Otherwise don't rerender.
+
+  // Call onFinishEditing
+  // TODO: Get rid of this or make it less of a hack.
+  if (this.onFinishEditing_) {
+    this.onFinishEditing_(this.value_);
+  }
+
+  // Remove htmlInput events.
+  this.unbindInputEvents_();
+
+  // Delete style properties.
+  var style = Blockly.WidgetDiv.DIV.style;
+  style.width = 'auto';
+  style.height = 'auto';
+  style.fontSize = '';
 };
 
 /**
@@ -363,43 +404,6 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
   }
   div.style.left = xy.x + 'px';
   div.style.top = xy.y + 'px';
-};
-
-/**
- * Close the editor, save the results, and dispose of the editable
- * text field's elements.
- * @private
- */
-Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
-  // Finalize value.
-  this.isBeingEdited_ = false;
-  // No need to call setValue because if the widget is being closed the
-  // latest input text has already been validated.
-  if (this.value_ !== this.text_) {
-    // At the end of an edit the text should be the same as the value. It
-    // may not be if the input text is different than the validated text.
-    // We should fix that.
-    this.text_ = String(this.value_);
-    this.isTextValid_ = true;
-    this.forceRerender();
-  }
-  // Otherwise don't rerender.
-
-  // Call onFinishEditing
-  // TODO: Get rid of this or make it less of a hack.
-  if (this.onFinishEditing_) {
-    this.onFinishEditing_(this.value_);
-  }
-
-  // Remove htmlInput.
-  this.unbindInputEvents_();
-  this.htmlInput_ = null;
-
-  // Delete style properties.
-  var style = Blockly.WidgetDiv.DIV.style;
-  style.width = 'auto';
-  style.height = 'auto';
-  style.fontSize = '';
 };
 
 /**

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -158,16 +158,6 @@ Blockly.FieldVariable.prototype.toXml = function(fieldElement) {
 };
 
 /**
- * Dispose of this field.
- * @public
- */
-Blockly.FieldVariable.prototype.dispose = function() {
-  Blockly.FieldVariable.superClass_.dispose.call(this);
-  this.workspace_ = null;
-  this.variableMap_ = null;
-};
-
-/**
  * Attach this field to a block.
  * @param {!Blockly.Block} block The block containing this field.
  */

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -211,9 +211,6 @@ Blockly.Tooltip.onMouseMove_ = function(e) {
   if (!Blockly.Tooltip.element_ || !Blockly.Tooltip.element_.tooltip) {
     // No tooltip here to show.
     return;
-  } else if (Blockly.WidgetDiv.isVisible()) {
-    // Don't display a tooltip if a widget is open (tooltip would be under it).
-    return;
   } else if (Blockly.Tooltip.blocked_) {
     // Someone doesn't want us to show tooltips.  We are probably handling a
     // user gesture, such as a click or drag.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1913,6 +1913,8 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
+  Blockly.hideChaff(/* opt_allowToolbox */ true);
+
   // Keep scrolling within the bounds of the content.
   var metrics = this.getMetrics();
   // This is the offset of the top-left corner of the view from the
@@ -1945,10 +1947,6 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
     this.scrollbar.vScroll.setHandlePosition(-(y + metrics.contentTop) *
         this.scrollbar.vScroll.ratio_);
   }
-
-  // Hide the WidgetDiv without animation. This is to prevent a disposal
-  // animation from happening in the wrong location.
-  Blockly.WidgetDiv.hide(true);
   // We have to shift the translation so that when the canvas is at 0, 0 the
   // workspace origin is not underneath the toolbox.
   x += metrics.absoluteLeft;

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -201,13 +201,13 @@ suite ('Angle Fields', function() {
   suite('Validators', function() {
     setup(function() {
       this.angleField = new Blockly.FieldAngle(1);
-      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
-      Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
-      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
+      this.angleField.htmlInput_ = Object.create(null);
+      this.angleField.htmlInput_.oldValue_ = '1';
+      this.angleField.htmlInput_.untypedDefaultValue_ = 1;
     });
     teardown(function() {
       this.angleField.setValidator(null);
-      Blockly.FieldTextInput.htmlInput_ = null;
+      this.angleField.htmlInput_ = null;
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -217,7 +217,7 @@ suite ('Angle Fields', function() {
       });
       test('When Editing', function() {
         this.angleField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '2';
+        this.angleField.htmlInput_.value = '2';
         this.angleField.onHtmlInputChange_(null);
         assertValue(this.angleField, 1, '2');
         this.angleField.isBeingEdited_ = false;
@@ -235,7 +235,7 @@ suite ('Angle Fields', function() {
       });
       test('When Editing', function() {
         this.angleField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '25';
+        this.angleField.htmlInput_.value = '25';
         this.angleField.onHtmlInputChange_(null);
         assertValue(this.angleField, 30, '25');
         this.angleField.isBeingEdited_ = false;
@@ -251,7 +251,7 @@ suite ('Angle Fields', function() {
       });
       test('When Editing', function() {
         this.angleField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '2';
+        this.angleField.htmlInput_.value = '2';
         this.angleField.onHtmlInputChange_(null);
         assertValue(this.angleField, 2);
         this.angleField.isBeingEdited_ = false;

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -298,13 +298,13 @@ suite ('Number Fields', function() {
   suite('Validators', function() {
     setup(function() {
       this.numberField = new Blockly.FieldNumber(1);
-      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
-      Blockly.FieldTextInput.htmlInput_.oldValue_ = '1';
-      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 1;
+      this.numberField.htmlInput_ = Object.create(null);
+      this.numberField.htmlInput_.oldValue_ = '1';
+      this.numberField.htmlInput_.untypedDefaultValue_ = 1;
     });
     teardown(function() {
       this.numberField.setValidator(null);
-      Blockly.FieldTextInput.htmlInput_ = null;
+      this.numberField.htmlInput_ = null;
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -314,7 +314,7 @@ suite ('Number Fields', function() {
       });
       test('When Editing', function() {
         this.numberField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '2';
+        this.numberField.htmlInput_.value = '2';
         this.numberField.onHtmlInputChange_(null);
         assertValue(this.numberField, 1, '2');
         this.numberField.isBeingEdited_ = false;
@@ -332,7 +332,7 @@ suite ('Number Fields', function() {
       });
       test('When Editing', function() {
         this.numberField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '25';
+        this.numberField.htmlInput_.value = '25';
         this.numberField.onHtmlInputChange_(null);
         assertValue(this.numberField, 26, '25');
         this.numberField.isBeingEdited_ = false;
@@ -348,7 +348,7 @@ suite ('Number Fields', function() {
       });
       test('When Editing', function() {
         this.numberField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = '2';
+        this.numberField.htmlInput_.value = '2';
         this.numberField.onHtmlInputChange_(null);
         assertValue(this.numberField, 2);
         this.numberField.isBeingEdited_ = false;

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -169,9 +169,9 @@ suite ('Text Input Fields', function() {
   suite('Validators', function() {
     setup(function() {
       this.textInputField = new Blockly.FieldTextInput('value');
-      Blockly.FieldTextInput.htmlInput_ = Object.create(null);
-      Blockly.FieldTextInput.htmlInput_.oldValue_ = 'value';
-      Blockly.FieldTextInput.htmlInput_.untypedDefaultValue_ = 'value';
+      this.textInputField.htmlInput_ = Object.create(null);
+      this.textInputField.htmlInput_.oldValue_ = 'value';
+      this.textInputField.htmlInput_.untypedDefaultValue_ = 'value';
     });
     teardown(function() {
       this.textInputField.setValidator(null);
@@ -185,7 +185,7 @@ suite ('Text Input Fields', function() {
       });
       test('When Editing', function() {
         this.textInputField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = 'newValue';
+        this.textInputField.htmlInput_.value = 'newValue';
         this.textInputField.onHtmlInputChange_(null);
         assertValue(this.textInputField, 'value', 'newValue');
         this.textInputField.isBeingEdited_ = false;
@@ -203,7 +203,7 @@ suite ('Text Input Fields', function() {
       });
       test('When Editing', function() {
         this.textInputField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = 'bbbaaa';
+        this.textInputField.htmlInput_.value = 'bbbaaa';
         this.textInputField.onHtmlInputChange_(null);
         assertValue(this.textInputField, 'bbb', 'bbbaaa');
         this.textInputField.isBeingEdited_ = false;
@@ -219,7 +219,7 @@ suite ('Text Input Fields', function() {
       });
       test('When Editing', function() {
         this.textInputField.isBeingEdited_ = true;
-        Blockly.FieldTextInput.htmlInput_.value = 'newValue';
+        this.textInputField.htmlInput_.value = 'newValue';
         this.textInputField.onHtmlInputChange_(null);
         assertValue(this.textInputField, 'newValue');
         this.textInputField.isBeingEdited_ = false;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Related to [this](https://github.com/LLK/scratch-blocks/issues/1947).

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that fields properly dispose of themselves and their editors.
Reorganizes some editor creation code to make it more readable (lookin at you dropdowns).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Cleaning up after yourself is polite.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Got rid of some now-redundant code from #802. Could not reproduce #779 or #651. (pass)

Changed some stuff that could have affected #1329 (the dropdown equivalent) could not reproduce with dropdowns. (pass)

Here's all of the editors working:
![Dispose_Angle](https://user-images.githubusercontent.com/25440652/59067659-0b0e3400-8867-11e9-8b57-8315684ddea8.gif)
![Dispose_Colour](https://user-images.githubusercontent.com/25440652/59067669-0cd7f780-8867-11e9-9a19-b3ab46bd1a68.gif)
![Dispose_Date](https://user-images.githubusercontent.com/25440652/59067671-0e092480-8867-11e9-86d1-fbaa65078dfa.gif)
![Dispose_Dropdown](https://user-images.githubusercontent.com/25440652/59067675-0fd2e800-8867-11e9-89b3-4a8e811a1437.gif)
![Dispose_Number](https://user-images.githubusercontent.com/25440652/59067677-11041500-8867-11e9-89fb-a618176d2ca2.gif)
![Dispose_Text](https://user-images.githubusercontent.com/25440652/59067682-12cdd880-8867-11e9-9f53-2212a47377e8.gif)
![Dispose_Variable](https://user-images.githubusercontent.com/25440652/59067685-13ff0580-8867-11e9-8fd5-1d60b9a92777.gif)


Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

There are a few TODO's with little questions, but my big question is what all do we need to dispose of? Is it just references to DOM elements and events? Or is it all field properties?
