### PR TITLE
Render/bottom inline highlight

### DIFF
--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -412,7 +412,7 @@ Blockly.BlockRendering.Drawer.prototype.positionNextConnection_ = function() {
   var bottomRow = this.info_.bottomRow;
 
   if (bottomRow.hasNextConnection) {
-    var connX = (this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT);
+    var connX = this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT;
     bottomRow.connection.setOffsetInBlock(
         connX, this.info_.height + BRC.DARK_PATH_OFFSET);
   }

--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -399,7 +399,7 @@ Blockly.BlockRendering.Drawer.prototype.positionExternalValueConnection_ = funct
  */
 Blockly.BlockRendering.Drawer.prototype.positionPreviousConnection_ = function() {
   if (this.info_.topRow.hasPreviousConnection) {
-    var connX = (this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT);
+    var connX = this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT;
     this.info_.topRow.connection.setOffsetInBlock(connX, 0);
   }
 };
@@ -413,8 +413,8 @@ Blockly.BlockRendering.Drawer.prototype.positionNextConnection_ = function() {
 
   if (bottomRow.hasNextConnection) {
     var connX = (this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT);
-    // TODO use a constant here when fixing block height calculation.
-    bottomRow.connection.setOffsetInBlock(connX, this.info_.height - 1);
+    bottomRow.connection.setOffsetInBlock(
+        connX, this.info_.height + BRC.DARK_PATH_OFFSET);
   }
 };
 

--- a/core/block_rendering_rewrite/block_render_draw.js
+++ b/core/block_rendering_rewrite/block_render_draw.js
@@ -227,7 +227,7 @@ Blockly.BlockRendering.Drawer.prototype.drawBottom_ = function() {
 Blockly.BlockRendering.Drawer.prototype.drawLeft_ = function() {
   this.highlighter_.drawLeft();
 
-  this.positionOutpuConnection_();
+  this.positionOutputConnection_();
   if (this.info_.hasOutputConnection) {
     // Draw a line up to the bottom of the tab.
     this.steps_.push('V', BRC.TAB_OFFSET_FROM_TOP + BRC.TAB_HEIGHT);
@@ -423,7 +423,7 @@ Blockly.BlockRendering.Drawer.prototype.positionNextConnection_ = function() {
  * @param {!Blockly.BlockRendering.BottomRow} row The bottom row on the block.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionOutpuConnection_ = function() {
+Blockly.BlockRendering.Drawer.prototype.positionOutputConnection_ = function() {
   if (this.info_.hasOutputConnection) {
     this.block_.outputConnection.setOffsetInBlock(0, BRC.TAB_OFFSET_FROM_TOP);
   }

--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -136,7 +136,6 @@ Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(_row) {
   var elems = this.info_.bottomRow.elements;
 
   if (this.info_.RTL) {
-    height -= BRC.BOTTOM_HIGHLIGHT_OFFSET;
     this.highlightSteps_.push('V', height);
   }
 

--- a/core/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/block_rendering_rewrite/block_render_draw_highlight.js
@@ -213,7 +213,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawInlineInput = function(input) {
         (x + width + BRC.HIGHLIGHT_OFFSET) + ',' +
         (yPos + BRC.HIGHLIGHT_OFFSET));
     this.highlightInlineSteps_.push('v', height);
-    this.highlightInlineSteps_.push('h -', bottomHighlightWidth);
+    this.highlightInlineSteps_.push('h ', -bottomHighlightWidth);
     // Short highlight glint at bottom of tab.
     // Bad: reference to Blockly.BlockSvg
     this.highlightInlineSteps_.push('M',

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -646,7 +646,6 @@ Blockly.BlockRendering.RenderInfo.prototype.finalize_ = function() {
     yCursor += row.height;
   }
   this.blockBottom = yCursor;
-  this.overhang = 0;
 
   // Add padding to the bottom row if block height is less than minimum
   if (yCursor < BRC.MIN_BLOCK_HEIGHT) {
@@ -654,9 +653,5 @@ Blockly.BlockRendering.RenderInfo.prototype.finalize_ = function() {
     yCursor = BRC.MIN_BLOCK_HEIGHT;
   }
 
-  if (!this.hasOutputConnection) {
-    // No output and no next.
-    this.overhang = 2; // for the shadow.
-  }
-  this.height = yCursor + this.overhang;
+  this.height = yCursor;
 };

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -87,8 +87,6 @@ BRC.BETWEEN_STATEMENT_PADDING_Y = 4;
 // has inputs inline.
 BRC.MAX_BOTTOM_WIDTH = 66.5;
 
-BRC.BOTTOM_HIGHLIGHT_OFFSET = 2;
-
 /**
  * Rounded corner radius.
  * @const


### PR DESCRIPTION
- Fix highlight on ltr  inline inputs (broken in my last commit)
- Fix height and remove offset constant
- Move next connection based on correct height

Tested in both ltr and rtl.