### PR TITLE
Fix regular expressions.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -282,7 +282,7 @@ Blockly.Css.CONTENT = [
     'cursor: -webkit-grab;',
   '}',
 
-   '.blocklyDragging {',
+  '.blocklyDragging {',
     /* backup for browsers (e.g. IE11) that don't support grabbing */
     'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
     'cursor: grabbing;',
@@ -647,10 +647,9 @@ Blockly.Css.CONTENT = [
     'padding: 0 !important;',
   '}',
 
-  /* Override the default Closure URL. */
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon {',
-    'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px !important;',
+    'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
   '}',
 
   /* Category tree in Toolbox. */
@@ -964,8 +963,6 @@ Blockly.Css.CONTENT = [
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon, ',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox, ',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
-     /* Client apps may override the URL at which they serve the sprite. */
-    'background: url(//ssl.gstatic.com/editor/editortoolbar.png) no-repeat -512px 0;',
     'position: static;', /* Scroll with the menu. */
     'float: left;',
     'margin-left: -24px;',

--- a/core/css.js
+++ b/core/css.js
@@ -49,11 +49,11 @@ Blockly.Css.Cursor = {
 Blockly.Css.currentCursor_ = '';
 
 /**
- * Large stylesheet added by Blockly.Css.inject.
- * @type {Element}
+ * Has CSS already been injected?
+ * @type {boolean}
  * @private
  */
-Blockly.Css.styleSheet_ = null;
+Blockly.Css.injected_ = false;
 
 /**
  * Path to media directory, with any trailing slash removed.
@@ -74,13 +74,15 @@ Blockly.Css.mediaPath_ = '';
  */
 Blockly.Css.inject = function(hasCss, pathToMedia) {
   // Only inject the CSS once.
-  if (Blockly.Css.styleSheet_) {
+  if (Blockly.Css.injected_) {
     return;
   }
+  Blockly.Css.injected_ = true;
   // Placeholder for cursor rule.  Must be first rule (index 0).
   var text = '.blocklyDraggable {}\n';
   if (hasCss) {
     text += Blockly.Css.CONTENT.join('\n');
+    Blockly.Css.CONTENT = null;  // Garbage collect 13 KB.
     if (Blockly.FieldDate) {
       text += Blockly.FieldDate.CSS.join('\n');
     }
@@ -88,13 +90,12 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
   // Strip off any trailing slash (either Unix or Windows).
   Blockly.Css.mediaPath_ = pathToMedia.replace(/[\\\/]$/, '');
   text = text.replace(/<<<PATH>>>/g, Blockly.Css.mediaPath_);
+
   // Inject CSS tag at start of head.
   var cssNode = document.createElement('style');
-  document.head.insertBefore(cssNode, document.head.firstChild);
-
   var cssTextNode = document.createTextNode(text);
   cssNode.appendChild(cssTextNode);
-  Blockly.Css.styleSheet_ = cssNode.sheet;
+  document.head.insertBefore(cssNode, document.head.firstChild);
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -194,9 +194,8 @@ Blockly.FieldColour.prototype.doValueUpdate_ = function(newValue) {
 Blockly.FieldColour.prototype.getText = function() {
   var colour = this.value_;
   // Try to use #rgb format if possible, rather than #rrggbb.
-  var m = colour.match(/^#(.)\1(.)\2(.)\3$/);
-  if (m) {
-    colour = '#' + m[1] + m[2] + m[3];
+  if (/^#(.)\1(.)\2(.)\3$/.test(colour)) {
+    colour = '#' + colour[1] + colour[3] + colour[5];
   }
   return colour;
 };

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -29,6 +29,7 @@ goog.provide('Blockly.FieldDate');
 goog.require('Blockly.Events');
 goog.require('Blockly.Field');
 goog.require('Blockly.utils.dom');
+goog.require('Blockly.utils.string');
 
 goog.require('goog.date');
 goog.require('goog.date.DateTime');
@@ -255,13 +256,13 @@ Blockly.FieldDate.widgetDispose_ = function() {
  * @private
  */
 Blockly.FieldDate.loadLanguage_ = function() {
-  var reg = /^DateTimeSymbols_(.+)$/;
   for (var prop in goog.i18n) {
-    var m = prop.match(reg);
-    if (m) {
-      var lang = m[1].toLowerCase().replace('_', '.');  // E.g. 'pt.br'
+    if (Blockly.utils.string.startsWith(prop, 'DateTimeSymbols_')) {
+      var lang = prop.substr(16).toLowerCase().replace('_', '.');
+      // E.g. 'DateTimeSymbols_pt_BR' -> 'pt.br'
       if (goog.getObjectByName(lang, Blockly.Msg)) {
         goog.i18n.DateTimeSymbols = goog.i18n[prop];
+        break;
       }
     }
   }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -160,7 +160,7 @@ Blockly.Procedures.isNameUsed = function(name, workspace, opt_exclude) {
  */
 Blockly.Procedures.rename = function(name) {
   // Strip leading and trailing whitespace.  Beyond this, all names are legal.
-  name = name.replace(/^[\s\xa0]+|[\s\xa0]+$/g, '');
+  name = name.trim();
 
   // Ensure two identically-named procedures don't exist.
   var legalName = Blockly.Procedures.findLegalName(name, this.getSourceBlock());

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -32,6 +32,7 @@ goog.require('Blockly.Flyout');
 goog.require('Blockly.HorizontalFlyout');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.VerticalFlyout');
@@ -396,17 +397,22 @@ Blockly.Toolbox.prototype.setColour_ = function(colourValue, childOut,
   if (colour === null || colour === '') {
     // No attribute. No colour.
     childOut.hexColour = '';
-  } else if (/^#[0-9a-fA-F]{6}$/.test(colour)) {
-    childOut.hexColour = colour;
-    this.hasColours_ = true;
-  } else if (typeof colour === 'number' ||
-      (typeof colour === 'string' && !isNaN(Number(colour)))) {
-    childOut.hexColour = Blockly.hueToHex(Number(colour));
-    this.hasColours_ = true;
   } else {
-    childOut.hexColour = '';
-    console.warn('Toolbox category "' + categoryName +
-        '" has unrecognized colour attribute: ' + colour);
+    var hue = Number(colour);
+    if (!isNaN(hue)) {
+      childOut.hexColour = Blockly.hueToHex(hue);
+      this.hasColours_ = true;
+    } else {
+      var hex = Blockly.utils.colour.parse(colour);
+      if (hex) {
+        childOut.hexColour = hex;
+        this.hasColours_ = true;
+      } else {
+        childOut.hexColour = '';
+        console.warn('Toolbox category "' + categoryName +
+            '" has unrecognized colour attribute: ' + colour);
+      }
+    }
   }
 };
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -256,23 +256,13 @@ Blockly.utils.checkMessageReferences = function(message) {
 
   // TODO (#1169): Implement support for other string tables,
   // prefixes other than BKY_.
-  var regex = /%{(BKY_[A-Z][A-Z0-9_]*)}/gi;
-  var match = regex.exec(message);
-  while (match) {
-    var msgKey = match[1];
-    msgKey = msgKey.toUpperCase();
-    if (msgKey.substr(0, 4) != 'BKY_') {
-      console.log('WARNING: Unsupported message table prefix in %{' +
-          match[1] + '}.');
-      validSoFar = false;  // Continue to report other errors.
-    } else if (msgTable[msgKey.substr(4)] == undefined) {
-      console.log('WARNING: No message string for %{' + match[1] + '}.');
+  var m = message.match(/%{BKY_[A-Z]\w*}/ig);
+  for (var i = 0; i < m.length; i++) {
+    var msgKey = m[i].toUpperCase();
+    if (msgTable[msgKey.slice(6, -1)] == undefined) {
+      console.log('WARNING: No message string for ' + m[i] + ' in ' + message);
       validSoFar = false;  // Continue to report other errors.
     }
-
-    // Re-run on remainder of string.
-    message = message.substring(match.index + msgKey.length + 1);
-    match = regex.exec(message);
   }
 
   return validSoFar;
@@ -350,7 +340,7 @@ Blockly.utils.tokenizeInterpolation_ = function(message,
         buffer.push(c);
       } else  {
         var rawKey = buffer.join('');
-        if (/[a-zA-Z][a-zA-Z0-9_]*/.test(rawKey)) {  // Strict matching
+        if (/[A-Z]\w*/i.test(rawKey)) {  // Strict matching
           // Found a valid string key. Attempt case insensitive match.
           var keyUpper = rawKey.toUpperCase();
 

--- a/core/variables.js
+++ b/core/variables.js
@@ -399,7 +399,7 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
     // Merge runs of whitespace.  Strip leading and trailing whitespace.
     // Beyond this, all names are legal.
     if (newVar) {
-      newVar = newVar.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');
+      newVar = newVar.replace(/[\s\xa0]+/g, ' ').trim();
       if (newVar == Blockly.Msg['RENAME_VARIABLE'] ||
           newVar == Blockly.Msg['NEW_VARIABLE']) {
         // Ok, not ALL names are legal...


### PR DESCRIPTION
1) Simplifications/elimination of regular expressions.
2) Enable toolbox category colours to be specified using the full range of CSS formats (not just hue or #rrggbb).
3) Fix bug where `Blockly.utils.checkMessageReferences('%{BKY_today}  %{BKY_xxx}')` returns true.
4) Reduce memory footprint of CSS.
5) Remove potential for fetching gstatic.com resource.