### PR TITLE
Change alignment on previous and next connections

### DIFF
--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -389,8 +389,12 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
       return BRC.NO_PADDING;
     }
     // Spacing between a square corner and a previous or next connection
-    if (next.isPreviousConnection() || next.isNextConnection()) {
+    if (next.isPreviousConnection()) {
       return BRC.NOTCH_OFFSET_LEFT;
+    } else if (next.isNextConnection()) {
+      // Next connections are shifted slightly to the left (in both LTR and RTL)
+      // to make the dark path under the previous connection show through.
+      return BRC.NOTCH_OFFSET_LEFT + (this.RTL ? 0.5 : - 0.5);
     }
   }
 
@@ -399,7 +403,9 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     if (next.isPreviousConnection()) {
       return BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV;
     } else if (next.isNextConnection()) {
-      return BRC.NOTCH_OFFSET_ROUNDED_CORNER_NEXT;
+      // Next connections are shifted slightly to the left (in both LTR and RTL)
+      // to make the dark path under the previous connection show through.
+      return BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV + (this.RTL ? 0.5 : - 0.5);
     }
   }
 

--- a/core/block_rendering_rewrite/block_render_info.js
+++ b/core/block_rendering_rewrite/block_render_info.js
@@ -369,7 +369,7 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
 
   // Spacing between an icon and an icon or field.
   if (prev.isIcon() && !next.isInput) {
-    return BRC.LARGE_PADDING + 1;
+    return BRC.LARGE_PADDING;
   }
 
   // Spacing between an inline input and a field.

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -70,11 +70,6 @@ BRC.NOTCH_OFFSET_LEFT = BRC.NOTCH_WIDTH;
 // connection starts.
 BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV = 7;
 
-// This is the width from where a rounded corner ends to where a next
-// connection starts.
-BRC.NOTCH_OFFSET_ROUNDED_CORNER_NEXT =
-        BRC.NOTCH_OFFSET_ROUNDED_CORNER_PREV - 0.5;
-
 // This is the offset from the vertical part of a statement input
 // to where to start the notch, which is on the right side in LTR.
 BRC.NOTCH_OFFSET_RIGHT = BRC.NOTCH_OFFSET_LEFT + BRC.NOTCH_WIDTH;

--- a/core/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/block_rendering_rewrite/block_rendering_constants.js
@@ -97,12 +97,27 @@ BRC.START_HAT_WIDTH = 100;
 
 BRC.SPACER_DEFAULT_HEIGHT = 15;
 
+BRC.MIN_BLOCK_HEIGHT = 24;
 
 BRC.EMPTY_INLINE_INPUT_WIDTH = 22.5;
 
 BRC.EMPTY_INLINE_INPUT_HEIGHT = 26;
 
-BRC.MIN_BLOCK_HEIGHT = 24;
+BRC.EXTERNAL_VALUE_INPUT_WIDTH = 10;
+
+/**
+ * The height of an empty statement input.  Note that in the old rendering this
+ * varies slightly depending on whether the block has external or inline inputs.
+ * In the new rendering this is consistent.  It seems unlikely that the old
+ * behaviour was intentional.
+ * @const
+ * @type {number}
+ */
+BRC.EMPTY_STATEMENT_INPUT_HEIGHT = BRC.MIN_BLOCK_HEIGHT;
+
+BRC.EMPTY_STATEMENT_INPUT_WIDTH = 32;
+
+BRC.POPULATED_STATEMENT_INPUT_WIDTH = 25;
 
 
 BRC.START_POINT = 'm 0,0';

--- a/core/block_rendering_rewrite/measurables.js
+++ b/core/block_rendering_rewrite/measurables.js
@@ -173,8 +173,9 @@ Blockly.BlockRendering.Icon = function(icon) {
   this.isVisible = icon.isVisible();
   this.type = 'icon';
 
-  this.height = 16;
-  this.width = 16;
+  var size = icon.getCorrectedSize();
+  this.height = size.height;
+  this.width = size.width;
 };
 goog.inherits(Blockly.BlockRendering.Icon, Blockly.BlockRendering.Measurable);
 
@@ -236,10 +237,10 @@ Blockly.BlockRendering.StatementInput = function(input) {
   this.type = 'statement input';
 
   if (!this.connectedBlock) {
-    this.height = 24;
-    this.width = 32;
+    this.height = BRC.EMPTY_STATEMENT_INPUT_HEIGHT;
+    this.width = BRC.EMPTY_STATEMENT_INPUT_WIDTH;
   } else {
-    this.width = 25;
+    this.width = BRC.POPULATED_STATEMENT_INPUT_WIDTH;
     this.height = this.connectedBlockHeight + BRC.STATEMENT_BOTTOM_SPACER;
     if (this.connectedBlock.nextConnection) {
       this.height -= BRC.NOTCH_HEIGHT;
@@ -262,11 +263,11 @@ Blockly.BlockRendering.ExternalValueInput = function(input) {
   this.type = 'external value input';
 
   if (!this.connectedBlock) {
-    this.height = 15;
+    this.height = BRC.TAB_HEIGHT;
   } else {
     this.height = this.connectedBlockHeight - 2 * BRC.TAB_OFFSET_FROM_TOP;
   }
-  this.width = 10;
+  this.width = BRC.EXTERNAL_VALUE_INPUT_WIDTH;
 };
 goog.inherits(Blockly.BlockRendering.ExternalValueInput,
     Blockly.BlockRendering.Input);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -380,7 +380,7 @@ Blockly.FieldColour.prototype.getCorrectedSize = function() {
   this.getSize();
   return new goog.math.Size(
       this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
-      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT - 1);
 };
 
 Blockly.Field.register('field_colour', Blockly.FieldColour);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -208,7 +208,11 @@ Blockly.FieldImage.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
-  return new goog.math.Size(this.size_.width, this.height_);
+  // Old rendering adds an extra pixel under the image.  We include this in the
+  // height of the image in new rendering, rather than having the spacer below
+  // know that there was an image in the previous row.
+  // TODO: Remove.
+  return new goog.math.Size(this.size_.width, this.height_ + 1);
 };
 
 Blockly.Field.register('field_image', Blockly.FieldImage);

--- a/core/icon.js
+++ b/core/icon.js
@@ -207,7 +207,10 @@ Blockly.Icon.prototype.getIconLocation = function() {
 };
 
 /**
- * Get the size of the icon, as used for rendering.
+ * Get the size of the icon as used for rendering.
+ * This differs from the actual size of the icon, because it bulges slightly
+ * out of its row rather than increasing the height of its row.
+ * TODO (#2562): Remove getCorrectedSize.
  * @return {!goog.math.Size} Height and width.
  */
 Blockly.Icon.prototype.getCorrectedSize = function() {

--- a/core/icon.js
+++ b/core/icon.js
@@ -205,3 +205,12 @@ Blockly.Icon.prototype.computeIconLocation = function() {
 Blockly.Icon.prototype.getIconLocation = function() {
   return this.iconXY_;
 };
+
+/**
+ * Get the size of the icon, as used for rendering.
+ * @return {!goog.math.Size} Height and width.
+ */
+Blockly.Icon.prototype.getCorrectedSize = function() {
+  return new goog.math.Size(
+      Blockly.Icon.prototype.SIZE, Blockly.Icon.prototype.SIZE - 2);
+};

--- a/core/input.js
+++ b/core/input.js
@@ -249,3 +249,12 @@ Blockly.Input.prototype.dispose = function() {
   }
   this.sourceBlock_ = null;
 };
+
+/**
+ * Get the block that this input is on.
+ * @return {Blockly.Block} The block that this input is attached to.
+ * @package
+ */
+Blockly.Input.prototype.getSourceBlock = function() {
+  return this.sourceBlock_;
+};


### PR DESCRIPTION
Makes the logic similar for square and round corners.

Removes extra constant.

I don't know where the 0.5 comes from.

Tests passing:
87/112 in LTR
77/112 in RTL

