### PR TITLE
Refactor workspace.connectionDBList

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -242,8 +242,6 @@ Blockly.Connection.prototype.dispose = function() {
   if (this.inDB_) {
     this.db_.removeConnection_(this);
   }
-  this.db_ = null;
-  this.dbOpposite_ = null;
 };
 
 /**

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -287,15 +287,15 @@ Blockly.ConnectionDB.prototype.searchForClosest = function(conn, maxRadius,
 };
 
 /**
- * Initialize a set of connection DBs for a specified workspace.
- * @param {!Blockly.Workspace} workspace The workspace this DB is for.
+ * Initialize a set of connection DBs for a workspace.
+ * @return {!Array.<!Blockly.ConnectionDB>} Array of databases.
  */
-Blockly.ConnectionDB.init = function(workspace) {
+Blockly.ConnectionDB.init = function() {
   // Create four databases, one for each connection type.
   var dbList = [];
   dbList[Blockly.INPUT_VALUE] = new Blockly.ConnectionDB();
   dbList[Blockly.OUTPUT_VALUE] = new Blockly.ConnectionDB();
   dbList[Blockly.NEXT_STATEMENT] = new Blockly.ConnectionDB();
   dbList[Blockly.PREVIOUS_STATEMENT] = new Blockly.ConnectionDB();
-  workspace.connectionDBList = dbList;
+  return dbList;
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -136,6 +136,12 @@ Blockly.Workspace.prototype.isClearing = false;
 Blockly.Workspace.prototype.MAX_UNDO = 1024;
 
 /**
+ * Set of databases for rapid lookup of connection locations.
+ * @type {Array.<!Blockly.ConnectionDB>}
+ */
+Blockly.Workspace.prototype.connectionDBList = null;
+
+/**
  * Dispose of this workspace.
  * Unlink from all DOM elements to prevent memory leaks.
  */

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -74,7 +74,7 @@ Blockly.WorkspaceSvg = function(options,
   this.setMetrics =
       options.setMetrics || Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_;
 
-  Blockly.ConnectionDB.init(this);
+  this.connectionDBList = Blockly.ConnectionDB.init();
 
   if (opt_blockDragSurface) {
     this.blockDragSurface_ = opt_blockDragSurface;
@@ -606,6 +606,8 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
     this.grid_.dispose();
     this.grid_ = null;
   }
+
+  this.connectionDBList = null;
 
   this.toolboxCategoryCallbacks_ = null;
   this.flyoutButtonCallbacks_ = null;


### PR DESCRIPTION
It seems wrong that Blockly.ConnectionDB.init reaches in to create a property on workspace.
It seems wrong that this database isn’t disposed of when the workspace is.
It seems unnecessary that disposed connections need to drop their reference *to* the workspace’s database since the connection object is going away anyway, and the databases aren’t.
