### PR TITLE
Added Sending the Bad Value to doValueInvalid

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -830,10 +830,10 @@ Blockly.Field.prototype.doValueUpdate_ = function(newValue) {
  * Used to notify the field an invalid value was input. Can be overidden by
  * subclasses, see FieldTextInput.
  * No-op by default.
- * @param {*} _newValue The input value that was determined to be invalid.
+ * @param {*} _invalidValue The input value that was determined to be invalid.
  * @protected
  */
-Blockly.Field.prototype.doValueInvalid_ = function(_newValue) {
+Blockly.Field.prototype.doValueInvalid_ = function(_invalidValue) {
   // NOP
 };
 

--- a/core/field.js
+++ b/core/field.js
@@ -779,15 +779,15 @@ Blockly.Field.prototype.setValue = function(newValue) {
  */
 Blockly.Field.prototype.processValidation_ = function(newValue,
     validatedValue) {
-  if (validatedValue !== undefined) {
-    newValue = validatedValue;
-  }
-  if (newValue === null) {
-    this.doValueInvalid_();
+  if (validatedValue === null) {
+    this.doValueInvalid_(newValue);
     if (this.isDirty_) {
       this.forceRerender();
     }
     return Error();
+  }
+  if (validatedValue !== undefined) {
+    newValue = validatedValue;
   }
   return newValue;
 };
@@ -827,12 +827,13 @@ Blockly.Field.prototype.doValueUpdate_ = function(newValue) {
 };
 
 /**
- * Used to notify the field an invalid value was input. Can be overiden by
+ * Used to notify the field an invalid value was input. Can be overidden by
  * subclasses, see FieldTextInput.
  * No-op by default.
+ * @param {*} _newValue The input value that was determined to be invalid.
  * @protected
  */
-Blockly.Field.prototype.doValueInvalid_ = function() {
+Blockly.Field.prototype.doValueInvalid_ = function(_newValue) {
   // NOP
 };
 

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -117,17 +117,6 @@ Blockly.FieldDate.prototype.doClassValidation_ = function(newValue) {
 };
 
 /**
- * Called when the given value is invalid. If the picker is shown, set
- * isDirty to true so that it gets reset to the previous selection.
- * @protected
- */
-Blockly.FieldDate.prototype.doValueInvalid_ = function() {
-  if (this.picker_) {
-    this.isDirty_ = true;
-  }
-};
-
-/**
  * Render the field. If the picker is shown make sure it has the current
  * date selected.
  * @protected

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -115,9 +115,12 @@ Blockly.FieldTextInput.prototype.doClassValidation_ = function(newValue) {
  * Called by setValue if the text input is not valid. If the field is
  * currently being edited it reverts value of the field to the previous
  * value while allowing the display text to be handled by the htmlInput_.
+ * @param {*} _newValue The input value that was determined to be invalid.
+ *    This is not used by the text input because its display value is stored on
+ *    the htmlInput_.
  * @protected
  */
-Blockly.FieldTextInput.prototype.doValueInvalid_ = function() {
+Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_newValue) {
   if (this.isBeingEdited_) {
     this.isTextValid_ = false;
     var oldValue = this.value_;

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -115,12 +115,12 @@ Blockly.FieldTextInput.prototype.doClassValidation_ = function(newValue) {
  * Called by setValue if the text input is not valid. If the field is
  * currently being edited it reverts value of the field to the previous
  * value while allowing the display text to be handled by the htmlInput_.
- * @param {*} _newValue The input value that was determined to be invalid.
+ * @param {*} _invalidValue The input value that was determined to be invalid.
  *    This is not used by the text input because its display value is stored on
  *    the htmlInput_.
  * @protected
  */
-Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_newValue) {
+Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_invalidValue) {
   if (this.isBeingEdited_) {
     this.isTextValid_ = false;
     var oldValue = this.value_;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
doValueInvalid_() now recieves the invalid value.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Makes it easier for fields to display invalid values if they wish.

This was not added previously because the only core field that uses doValueInvalid is the text input field, and its display value is stored on the htmlInput. But when I was working on the custom fields demo I found that this was useful.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

N/A

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
