### PR TITLE
Pull Request: Split showContextMenu_

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -633,12 +633,8 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
   }
 };
 
-/**
- * Show the context menu for this block.
- * @param {!Event} e Mouse event.
- * @private
- */
-Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
+Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
+  
   if (this.workspace.options.readOnly || !this.contextMenu) {
     return;
   }
@@ -729,8 +725,21 @@ Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
     this.customContextMenu(menuOptions);
   }
 
-  Blockly.ContextMenu.show(e, menuOptions, this.RTL);
-  Blockly.ContextMenu.currentBlock = this;
+  return menuOptions
+}
+
+/**
+ * Show the context menu for this block.
+ * @param {!Event} e Mouse event.
+ * @private
+ */
+Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
+  var menuOptions = this.generateContextMenu_();
+  
+  if(menuOptions && menuOptions.length) {
+    Blockly.ContextMenu.show(e, menuOptions, this.RTL);
+    Blockly.ContextMenu.currentBlock = this;  
+  }
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -633,6 +633,10 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
   }
 };
 
+/**
+ * Generate the context menu for this block.
+ * @private
+ */
 Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
   
   if (this.workspace.options.readOnly || !this.contextMenu) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -636,6 +636,7 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
 /**
  * Generate the context menu for this block.
  * @private
+ * @returns {Array} Context menu options
  */
 Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
   
@@ -729,8 +730,8 @@ Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
     this.customContextMenu(menuOptions);
   }
 
-  return menuOptions
-}
+  return menuOptions;
+};
 
 /**
  * Show the context menu for this block.
@@ -740,9 +741,9 @@ Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
 Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = this.generateContextMenu_();
   
-  if(menuOptions && menuOptions.length) {
+  if (menuOptions && menuOptions.length) {
     Blockly.ContextMenu.show(e, menuOptions, this.RTL);
-    Blockly.ContextMenu.currentBlock = this;  
+    Blockly.ContextMenu.currentBlock = this;
   }
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -635,10 +635,10 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
 
 /**
  * Generate the context menu for this block.
- * @private
+ * @protected
  * @returns {Array} Context menu options
  */
-Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
+Blockly.BlockSvg.prototype.generateContextMenu = function() {
   
   if (this.workspace.options.readOnly || !this.contextMenu) {
     return;
@@ -739,7 +739,7 @@ Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
  * @private
  */
 Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
-  var menuOptions = this.generateContextMenu_();
+  var menuOptions = this.generateContextMenu();
   
   if (menuOptions && menuOptions.length) {
     Blockly.ContextMenu.show(e, menuOptions, this.RTL);


### PR DESCRIPTION
## The basics

- [ x ] I branched from develop
- [ x ] My pull request is against develop
- [ x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
Split showContextMenu_ into generateContextMenu_ and showContextMenu_.

### Resolves
No issue created, but I can create one if that would make for easier tracking.

### Proposed Changes
Split showContextMenu_ into generateContextMenu_ and showContextMenu_.


### Reason for Changes

This allows for custom Blockly forks to easily extend the context menu options available on all blocks by just doing something like

```
var oldGenerateContextMenu_ = Blockly.BlockSvg.prototype.generateContextMenu_;
Blockly.BlockSvg.prototype.generateContextMenu_ = function() {
  var menuOptions = oldGenerateContextMenu_() || [];
  // Push other options into menuOptions
  return menuOptions;
}
```

Rather than having to modify the core code in such a way as to cause unnecessary maintenance overhead when upgrading Blockly versions, which is our use case.

### Test Coverage

Tested on:
* Desktop Chrome

### Additional Information

This is a fairly minor change but one which will make it a lot easier when developers need to extend the context menu options for all blocks, rather than only for individual blocks.
