### PR TITLE
upgrade gulp to v4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,7 @@ if (typeof DOMParser !== 'function') {
 }
 if (typeof module === 'object') { module.exports = Blockly; }
 if (typeof window === 'object') { window.Blockly = Blockly; }\n`))
-      .pipe(gulp.dest(''));
+      .pipe(gulp.dest('.'));
 });
 
 /**
@@ -97,7 +97,7 @@ function buildWatchTaskFn(concatTask) {
     var options = {
       debounceDelay: 2000   // Milliseconds to delay rebuild.
     };
-    gulp.watch(srcs, options, tasks);
+    gulp.watch(srcs, options, gulp.parallel(tasks));
   };
 }
 
@@ -107,4 +107,4 @@ gulp.task('watch', buildWatchTaskFn('blockly_javascript_en'));
 
 // The default task concatenates files for Node.js, using English language
 // blocks and the JavaScript generator.
-gulp.task('default', ['build', 'blockly_javascript_en']);
+gulp.task('default', gulp.series(['build', 'blockly_javascript_en']));

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "^5.13.0",
     "google-closure-compiler": "^20190121.0.0",
     "google-closure-library": "^20190121.0.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-insert": "^0.5.0",
     "gulp-series": "^1.0.2",


### PR DESCRIPTION
As of NodeJS v12.4.0, gulp v3 fails to run at all. This small change
should allow for future compatibility with NodeJS.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Resolves: https://github.com/google/blockly/issues/2582

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

This pull request will update gulp to v4 and also update the gulpfile to use
the new v4 syntax.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Without this change, any attempt to use blockly in a NodeJS  (or NodeJS-built) v12.4.0 project fails.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
