### PR TITLE
Removed textToDom Needing <xml> Documents

### DIFF
--- a/core/block_events.js
+++ b/core/block_events.js
@@ -197,9 +197,8 @@ Blockly.Events.Change.prototype.run = function(forward) {
         oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
       }
       if (block.domToMutation) {
-        value = value || '<mutation></mutation>';
-        var dom = Blockly.Xml.textToDom('<xml>' + value + '</xml>');
-        block.domToMutation(dom.firstChild);
+        var dom = Blockly.Xml.textToDom(value || '<mutation></mutation>');
+        block.domToMutation(dom);
       }
       Blockly.Events.fire(new Blockly.Events.Change(
           block, 'mutation', null, oldMutation, value));
@@ -261,7 +260,7 @@ Blockly.Events.Create.prototype.toJson = function() {
  */
 Blockly.Events.Create.prototype.fromJson = function(json) {
   Blockly.Events.Create.superClass_.fromJson.call(this, json);
-  this.xml = Blockly.Xml.textToDom('<xml>' + json['xml'] + '</xml>').firstChild;
+  this.xml = Blockly.Xml.textToDom(json['xml']);
   this.ids = json['ids'];
 };
 

--- a/core/options.js
+++ b/core/options.js
@@ -26,8 +26,9 @@
 
 goog.provide('Blockly.Options');
 
-goog.require('Blockly.Xml');
 goog.require('Blockly.Themes.Classic');
+goog.require('Blockly.utils.userAgent');
+goog.require('Blockly.Xml');
 
 
 /**
@@ -48,7 +49,8 @@ Blockly.Options = function(options) {
     var hasDisable = false;
     var hasSounds = false;
   } else {
-    var languageTree = Blockly.Options.parseToolboxTree(options['toolbox']);
+    var languageTree =
+        Blockly.Options.parseToolboxTree(options['toolbox'] || null);
     var hasCategories = Boolean(languageTree &&
         languageTree.getElementsByTagName('category').length);
     var hasTrashcan = options['trashcan'];
@@ -263,11 +265,11 @@ Blockly.Options.parseGridOptions_ = function(options) {
 Blockly.Options.parseToolboxTree = function(tree) {
   if (tree) {
     if (typeof tree != 'string') {
-      if (typeof XSLTProcessor == 'undefined' && tree.outerHTML) {
+      if (Blockly.utils.userAgent.IE && tree.outerHTML) {
         // In this case the tree will not have been properly built by the
         // browser. The HTML will be contained in the element, but it will
         // not have the proper DOM structure since the browser doesn't support
-        // XSLTProcessor (XML -> HTML). This is the case in IE 9+.
+        // XSLTProcessor (XML -> HTML).
         tree = tree.outerHTML;
       } else if (!(tree instanceof Element)) {
         tree = null;
@@ -275,6 +277,9 @@ Blockly.Options.parseToolboxTree = function(tree) {
     }
     if (typeof tree == 'string') {
       tree = Blockly.Xml.textToDom(tree);
+      if (tree.nodeName.toLowerCase() != 'xml') {
+        throw TypeError('Toolbox should be an <xml> document.');
+      }
     }
   } else {
     tree = null;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -431,7 +431,7 @@ Blockly.Trashcan.prototype.click = function() {
 
   var xml = [];
   for (var i = 0, text; text = this.contents_[i]; i++) {
-    xml[i] = Blockly.Xml.textToDom(text).firstChild;
+    xml[i] = Blockly.Xml.textToDom(text);
   }
   this.flyout_.show(xml);
 };
@@ -531,5 +531,5 @@ Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
     }
     node = nextNode;
   }
-  return '<xml>' + Blockly.Xml.domToText(xmlBlock) + '</xml>';
+  return Blockly.Xml.domToText(xmlBlock);
 };

--- a/core/variables.js
+++ b/core/variables.js
@@ -175,39 +175,33 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
           variableModelList[variableModelList.length - 1]);
     if (Blockly.Blocks['variables_set']) {
       var gap = Blockly.Blocks['math_change'] ? 8 : 24;
-      var blockText = '<xml>' +
-          '<block type="variables_set" gap="' + gap + '">' +
+      var blockText = '<block type="variables_set" gap="' + gap + '">' +
           mostRecentVariableFieldXmlString +
-          '</block>' +
-          '</xml>';
-      var block = Blockly.Xml.textToDom(blockText).firstChild;
+          '</block>';
+      var block = Blockly.Xml.textToDom(blockText);
       xmlList.push(block);
     }
     if (Blockly.Blocks['math_change']) {
       var gap = Blockly.Blocks['variables_get'] ? 20 : 8;
-      var blockText = '<xml>' +
-          '<block type="math_change" gap="' + gap + '">' +
+      var blockText = '<block type="math_change" gap="' + gap + '">' +
           mostRecentVariableFieldXmlString +
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +
           '</shadow>' +
           '</value>' +
-          '</block>' +
-          '</xml>';
-      var block = Blockly.Xml.textToDom(blockText).firstChild;
+          '</block>';
+      var block = Blockly.Xml.textToDom(blockText);
       xmlList.push(block);
     }
 
     if (Blockly.Blocks['variables_get']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
       for (var i = 0, variable; variable = variableModelList[i]; i++) {
-        var blockText = '<xml>' +
-            '<block type="variables_get" gap="8">' +
+        var blockText = '<block type="variables_get" gap="8">' +
             Blockly.Variables.generateVariableFieldXmlString(variable) +
-            '</block>' +
-            '</xml>';
-        var block = Blockly.Xml.textToDom(blockText).firstChild;
+            '</block>';
+        var block = Blockly.Xml.textToDom(blockText);
         xmlList.push(block);
       }
     }
@@ -481,10 +475,7 @@ Blockly.Variables.generateVariableFieldXmlString = function(variableModel) {
 Blockly.Variables.generateVariableFieldDom = function(variableModel) {
   var xmlFieldString =
       Blockly.Variables.generateVariableFieldXmlString(variableModel);
-  var text = '<xml>' + xmlFieldString + '</xml>';
-  var dom = Blockly.Xml.textToDom(text);
-  var fieldDom = dom.firstChild;
-  return fieldDom;
+  return Blockly.Xml.textToDom(xmlFieldString);
 };
 
 /**

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -93,23 +93,19 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
     if (Blockly.Blocks['variables_set_dynamic']) {
       var firstVariable = variableModelList[variableModelList.length - 1];
       var gap = 24;
-      var blockText = '<xml>' +
-          '<block type="variables_set_dynamic" gap="' + gap + '">' +
+      var blockText = '<block type="variables_set_dynamic" gap="' + gap + '">' +
           Blockly.Variables.generateVariableFieldXmlString(firstVariable) +
-          '</block>' +
-          '</xml>';
-      var block = Blockly.Xml.textToDom(blockText).firstChild;
+          '</block>';
+      var block = Blockly.Xml.textToDom(blockText);
       xmlList.push(block);
     }
     if (Blockly.Blocks['variables_get_dynamic']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
       for (var i = 0, variable; variable = variableModelList[i]; i++) {
-        var blockText = '<xml>' +
-            '<block type="variables_get_dynamic" gap="8">' +
+        var blockText = '<block type="variables_get_dynamic" gap="8">' +
             Blockly.Variables.generateVariableFieldXmlString(variable) +
-            '</block>' +
-            '</xml>';
-        var block = Blockly.Xml.textToDom(blockText).firstChild;
+            '</block>';
+        var block = Blockly.Xml.textToDom(blockText);
         xmlList.push(block);
       }
     }

--- a/core/xml.js
+++ b/core/xml.js
@@ -326,11 +326,8 @@ Blockly.Xml.domToPrettyText = function(dom) {
  */
 Blockly.Xml.textToDom = function(text) {
   var doc = Blockly.Xml.utils.textToDomDocument(text);
-  // This function only accepts <xml> documents.
-  if (!doc || !doc.documentElement ||
-      doc.documentElement.nodeName.toLowerCase() != 'xml') {
-    // Whatever we got back from the parser is not the expected structure.
-    throw TypeError('Blockly.Xml.textToDom expected an <xml> document.');
+  if (!doc || !doc.documentElement) {
+    throw Error('textToDom was unable to parse: ' + text);
   }
   return doc.documentElement;
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -325,7 +325,8 @@ Blockly.Xml.domToPrettyText = function(dom) {
  */
 Blockly.Xml.textToDom = function(text) {
   var doc = Blockly.Xml.utils.textToDomDocument(text);
-  if (!doc || !doc.documentElement) {
+  if (!doc || !doc.documentElement ||
+      doc.getElementsByTagName('parsererror').length) {
     throw Error('textToDom was unable to parse: ' + text);
   }
   return doc.documentElement;

--- a/core/xml.js
+++ b/core/xml.js
@@ -317,12 +317,11 @@ Blockly.Xml.domToPrettyText = function(dom) {
 };
 
 /**
- * Converts an XML string into a DOM structure. It requires the XML to have a
- * root element of <xml>. Other XML string will result in throwing an error.
+ * Converts an XML string into a DOM structure.
  * @param {string} text An XML string.
  * @return {!Element} A DOM object representing the singular child of the
  *     document element.
- * @throws if XML doesn't parse or is not the expected structure.
+ * @throws if the text doesn't parse.
  */
 Blockly.Xml.textToDom = function(text) {
   var doc = Blockly.Xml.utils.textToDomDocument(text);

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -287,9 +287,7 @@ suite("Trashcan", function() {
     test("Max 0", function() {
       workspace.options.maxTrashcanContents = 0;
       sendDeleteEvent(
-          '<xml>' +
-          '  <block type="dummy_type"/>' +
-          '</xml>'
+          '<block type="dummy_type"/>'
       );
       chai.assert.equal(this.trashcan.contents_.length, 0);
       workspace.options.maxTrashcanContents = Infinity;

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -299,7 +299,7 @@ suite("Trashcan", function() {
       chai.assert.equal(this.trashcan.contents_.length, 1);
       chai.assert.equal(
           Blockly.Xml.textToDom(this.trashcan.contents_[0])
-              .children[0].getAttribute('type'),
+              .getAttribute('type'),
           'dummy_type2'
       );
       workspace.options.maxTrashcanContents = Infinity;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2029 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
textToDom is now less picky. It accepts whatever you give it and throws a generic parsing error if it doesn't parse.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
It's annoying to have to wrap and unwrap text in `<xml>` tags to get it to parse.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Added the below code to the playground:
```
Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
    '<block type="controls_if"/>'
), workspace);
Blockly.Xml.appendDomToWorkspace(Blockly.Xml.textToDom(
    '<xml><block type="controls_if"/></xml>'
), workspace);
```
2. Observed how both blocks were created correctly.

There are also some unit tests that cover the xml.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
