### PR TITLE
Fix IE not unhighlighting

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -639,7 +639,7 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
  * @returns {Array} Context menu options
  */
 Blockly.BlockSvg.prototype.generateContextMenu = function() {
-  
+
   if (this.workspace.options.readOnly || !this.contextMenu) {
     return;
   }
@@ -740,7 +740,7 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
  */
 Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
   var menuOptions = this.generateContextMenu();
-  
+
   if (menuOptions && menuOptions.length) {
     Blockly.ContextMenu.show(e, menuOptions, this.RTL);
     Blockly.ContextMenu.currentBlock = this;
@@ -1207,8 +1207,8 @@ Blockly.BlockSvg.prototype.setHighlighted = function(highlighted) {
         'url(#' + this.workspace.options.embossFilterId + ')');
     this.svgPathLight_.style.display = 'none';
   } else {
-    this.svgPath_.removeAttribute('filter');
-    delete this.svgPathLight_.style.display;
+    this.svgPath_.setAttribute('filter', 'none');
+    this.svgPathLight_.style.display = 'inline';
   }
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -636,12 +636,11 @@ Blockly.BlockSvg.prototype.showHelp_ = function() {
 /**
  * Generate the context menu for this block.
  * @protected
- * @returns {Array} Context menu options
+ * @returns {Array.<!Object>} Context menu options
  */
 Blockly.BlockSvg.prototype.generateContextMenu = function() {
-
   if (this.workspace.options.readOnly || !this.contextMenu) {
-    return;
+    return null;
   }
   // Save the current block in a variable for use in closures.
   var block = this;


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This is a rework of PR #2580.  That PR has issues in its handling of the block's highlight.

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
* Windows Internet Explorer 11
* Windows Edge

### Additional Information

I hate IE.