### PR TITLE
Remove sudo tag in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 node_js:
   - 8
   - 10
-sudo: required
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
