### PR TITLE
Fixes spacing problem in procedure name

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -164,7 +164,7 @@ Blockly.Procedures.rename = function(name) {
 
   // Ensure two identically-named procedures don't exist.
   var legalName = Blockly.Procedures.findLegalName(name, this.getSourceBlock());
-  var oldName = this.text_;
+  var oldName = this.getValue();
   if (oldName != name && oldName != legalName) {
     // Rename any callers.
     var blocks = this.getSourceBlock().workspace.getAllBlocks(false);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2590
### Proposed Changes
Use getValue instead of this.text_ to get the name of the procedure. 

### Reason for Changes
When a procedure name is changed we look through all the blocks for a caller with the same name and then update the caller with the new name. We do not allow procedures to be named with trailing white spaces. Whenever a user types in a trailing or leading white space we ignore it and do not update the caller. 

The problem was that we were storing the trailing white spaces as part of the procedure name, but were not updating the caller to have the same name. When we looked through the list of blocks for the procedure name with the trailing white space it did not exist and would not get updated. (ex. Looking for callers named “do something   “ instead of “do something”). 

### Test Coverage

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
