### PR TITLE
Adds fill to svg dark path

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -999,11 +999,11 @@ Blockly.BlockSvg.prototype.setBorderColour_ = function() {
  * @return {?string} The background colour of the block.
  */
 Blockly.BlockSvg.prototype.setShadowColour_ = function() {
-  this.svgPathLight_.style.display = 'none';
-  this.svgPathDark_.style.display = 'none';
-  this.svgPath_.setAttribute('stroke', 'none');
-
   var shadowColour = this.getColourShadow();
+
+  this.svgPathLight_.style.display = 'none';
+  this.svgPathDark_.setAttribute('fill', shadowColour);
+  this.svgPath_.setAttribute('stroke', 'none');
   this.svgPath_.setAttribute('fill', shadowColour);
   return shadowColour;
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2535

### Proposed Changes
Add fill colour to the block's svgPathDark and remove display: none.
<img width="546" alt="Screen Shot 2019-07-03 at 2 09 19 PM" src="https://user-images.githubusercontent.com/23059043/60625489-d37aa500-9d9c-11e9-9c2b-39637220b770.png">

### Reason for Changes
There was a gap between the right and bottom side of shadow blocks and their parent block. 
<img width="592" alt="Screen Shot 2019-07-03 at 2 13 44 PM" src="https://user-images.githubusercontent.com/23059043/60625483-ccec2d80-9d9c-11e9-80df-00ad34cca72f.png">


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
