### PR TITLE
Properly handle cases when sound.play() does not return a promise

### DIFF
--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -128,12 +128,6 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
     
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.
-    if (goog.userAgent.IPAD || goog.userAgent.IPHONE) {
-      break;
-    }
-    
-    // iOS can only process one sound at a time.  Trying to load more than one
-    // corrupts the earlier ones.  Just load one and leave the others uncached.
     if (Blockly.utils.userAgent.IPAD || Blockly.utils.userAgent.IPHONE) {
       break;
     }

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -113,11 +113,10 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
     var sound = this.SOUNDS_[name];
     sound.volume = 0.01;
     var playPromise = sound.play();
-    
     // Edge does not return a promise, so we need to check.
-    if (playPromise) {
-      // If we don't wait for the play request to complete before calling pause() we will get an exception:
-      // Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
+    if (playPromise !== undefined) {
+      // If we don't wait for the play request to complete before calling pause()
+      // we will get an exception: (DOMException: The play() request was interrupted)
       // See more: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
       playPromise.then(sound.pause).catch(function() {
         // Play without user interaction was prevented.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

Fixes the issue that was introduced by https://github.com/google/blockly/pull/2162 in browsers such as Edge, in which `sound.play()` does not return a promise. Adds in the same changes that were added in scratch-blocks in https://github.com/LLK/scratch-blocks/pull/1959.