### PR TITLE
Fixed Procedure Empty Names & Procedure Parameters

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -570,14 +570,16 @@ Blockly.Blocks['procedures_mutatorarg'] = {
    * @this Blockly.FieldTextInput
    */
   validator_: function(varName) {
-    var outerWs = Blockly.Mutator.findParentWs(this.getSourceBlock().workspace);
+    var sourceBlock = this.getSourceBlock();
+    var outerWs = Blockly.Mutator.findParentWs(sourceBlock.workspace);
     varName = varName.replace(/[\s\xa0]+/g, ' ').replace(/^ | $/g, '');
     if (!varName) {
       return null;
     }
+
     // Prevents duplicate parameter names in functions
-    var blocks = this.getSourceBlock().workspace.getAllBlocks();
-    for (var i = 0; i < blocks.length; i += 1) {
+    var blocks = sourceBlock.workspace.getAllBlocks();
+    for (var i = 0; i < blocks.length; i++) {
       if (blocks[i].id == this.getSourceBlock().id) {
         continue;
       }
@@ -585,11 +587,11 @@ Blockly.Blocks['procedures_mutatorarg'] = {
         return null;
       }
     }
+
     var model = outerWs.getVariable(varName, '');
     if (model && model.name != varName) {
       // Rename the variable (case change)
-      // TODO: This function doesn't exist on the workspace.
-      outerWs.renameVarById(model.getId(), varName);
+      outerWs.renameVariableById(model.getId(), varName);
     }
     if (!model) {
       model = outerWs.createVariable(varName, '');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -331,7 +331,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   displayRenamedVar_: function(oldName, newName) {
     this.updateParams_();
     // Update the mutator's variables if the mutator is open.
-    if (this.mutator.isVisible()) {
+    if (this.mutator && this.mutator.isVisible()) {
       var blocks = this.mutator.workspace_.getAllBlocks(false);
       for (var i = 0, block; block = blocks[i]; i++) {
         if (block.type == 'procedures_mutatorarg' &&

--- a/core/names.js
+++ b/core/names.js
@@ -172,7 +172,7 @@ Blockly.Names.prototype.getDistinctName = function(name, type) {
  */
 Blockly.Names.prototype.safeName_ = function(name) {
   if (!name) {
-    name = 'unnamed';
+    name = Blockly.Msg['UNNAMED_KEY'] || 'unnamed';
   } else {
     // Unfortunately names in non-latin characters will look like
     // _E9_9F_B3_E4_B9_90 which is pretty meaningless.

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -92,6 +92,8 @@ Blockly.Procedures.procTupleComparator_ = function(ta, tb) {
 
 /**
  * Ensure two identically-named procedures don't exist.
+ * Take the proposed procedure name, and return a legal name i.e. one that
+ * is not empty and doesn't collide with other procedures.
  * @param {string} name Proposed procedure name.
  * @param {!Blockly.Block} block Block to disambiguate.
  * @return {string} Non-colliding name.
@@ -101,6 +103,7 @@ Blockly.Procedures.findLegalName = function(name, block) {
     // Flyouts can have multiple procedures called 'do something'.
     return name;
   }
+  name = name || Blockly.Msg['UNNAMED_KEY'];
   while (!Blockly.Procedures.isLegalName_(name, block.workspace, block)) {
     // Collision with another procedure.
     var r = name.match(/^(.*?)(\d+)$/);
@@ -162,7 +165,6 @@ Blockly.Procedures.rename = function(name) {
   // Strip leading and trailing whitespace.  Beyond this, all names are legal.
   name = name.trim();
 
-  // Ensure two identically-named procedures don't exist.
   var legalName = Blockly.Procedures.findLegalName(name, this.getSourceBlock());
   var oldName = this.getValue();
   if (oldName != name && oldName != legalName) {

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -103,7 +103,7 @@ Blockly.Procedures.findLegalName = function(name, block) {
     // Flyouts can have multiple procedures called 'do something'.
     return name;
   }
-  name = name || Blockly.Msg['UNNAMED_KEY'];
+  name = name || Blockly.Msg['UNNAMED_KEY'] || 'unnamed';
   while (!Blockly.Procedures.isLegalName_(name, block.workspace, block)) {
     // Collision with another procedure.
     var r = name.match(/^(.*?)(\d+)$/);

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -71,6 +71,9 @@ Blockly.Msg.PROCEDURES_HUE = '290';
 /// For more context, see
 /// [[Translating:Blockly#infrequent_message_types]].\n{{Identical|Item}}
 Blockly.Msg.VARIABLES_DEFAULT_NAME = 'item';
+/// default name - A simple, default name for an unnamed function or
+// variable. Preferably indicates that the key is unnamed.
+Blockly.Msg.UNNAMED_KEY = 'unnamed';
 /// button text - Button that sets a calendar to today's date.\n{{Identical|Today}}
 Blockly.Msg.TODAY = 'Today';
 

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -141,9 +141,7 @@ suite('Procedures', function() {
         chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'start name');
       }, 'start name');
     });
-    // TODO: Simple fix, oldText needs to be trimmed too, or we just discard
-    //  the checking (params don't check).
-    test.skip('Whitespace then Text', function() {
+    test('Whitespace then Text', function() {
       this.callForAllTypes(function() {
         var defInput = this.defBlock.getField('NAME');
         defInput.htmlInput_ = Object.create(null);

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -165,16 +165,15 @@ suite('Procedures', function() {
 
         defInput.htmlInput_.value = '';
         defInput.onHtmlInputChange_(null);
-        chai.assert.equal(this.defBlock.getFieldValue('NAME'), '');
-        chai.assert.equal(this.callBlock.getFieldValue('NAME'), '');
+        chai.assert.equal(
+            this.defBlock.getFieldValue('NAME'),
+            Blockly.Msg['UNNAMED_KEY']);
+        chai.assert.equal(
+            this.callBlock.getFieldValue('NAME'),
+            Blockly.Msg['UNNAMED_KEY']);
       }, 'start name');
     });
-    // TODO: Procedures do not handle having no name correctly. It is a
-    //  problem with newly created procedure blocks having '' as the
-    //  oldName, just like empty procedures. The renameProcedure function
-    //  gets confused when a procedure's name is initially set. This is
-    //  basically #503 again.
-    test.skip('Set Empty, and Create New', function() {
+    test('Set Empty, and Create New', function() {
       this.callForAllTypes(function() {
         var defInput = this.defBlock.getField('NAME');
         defInput.htmlInput_ = Object.create(null);
@@ -185,8 +184,12 @@ suite('Procedures', function() {
         defInput.onHtmlInputChange_(null);
         var newDefBlock = new Blockly.Block(this.workspace, this.defType);
         newDefBlock.setFieldValue('new name', 'NAME');
-        chai.assert.equal(this.defBlock.getFieldValue('NAME'), '');
-        chai.assert.equal(this.callBlock.getFieldValue('NAME'), '');
+        chai.assert.equal(
+            this.defBlock.getFieldValue('NAME'),
+            Blockly.Msg['UNNAMED_KEY']);
+        chai.assert.equal(
+            this.callBlock.getFieldValue('NAME'),
+            Blockly.Msg['UNNAMED_KEY']);
 
         newDefBlock.dispose();
       }, 'start name');

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -377,7 +377,7 @@ suite('Procedures', function() {
           clearVariables.call(this);
         }, 'name');
       });
-      test.skip('lower -> CAPS', function() {
+      test('lower -> CAPS', function() {
         this.callForAllTypes(function() {
           createMutator.call(this, ['arg']);
           this.argBlock.setFieldValue('ARG', 'NAME');
@@ -386,7 +386,7 @@ suite('Procedures', function() {
           clearVariables.call(this);
         }, 'name');
       });
-      test.skip('CAPS -> lower', function() {
+      test('CAPS -> lower', function() {
         this.callForAllTypes(function() {
           createMutator.call(this, ['ARG']);
           this.argBlock.setFieldValue('arg', 'NAME');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2591 
#2592 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
If a procedure is renamed to empty it instead gets renamed to 'unnamed' (or a translated version of the same).

Procedure parameters can now be renamed without throwing errors.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bug fixes.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Re-enabled all applicable tests. They pass!

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
N/A
