### PR TITLE
Fixes bug with using dynamic variable in toolbox

### DIFF
--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -150,7 +150,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
    */
   onchange: function(_e) {
     var id = this.getFieldValue('VAR');
-    var variableModel = this.workspace.getVariableById(id);
+    var variableModel = Blockly.Variables.getVariable(this.workspace, id);
     if (this.type == 'variables_get_dynamic') {
       this.outputConnection.setCheck(variableModel.type);
     } else {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -359,7 +359,7 @@ Blockly.VariableMap.prototype.getVariablesOfType = function(type) {
 Blockly.VariableMap.prototype.getVariableTypes = function(ws) {
   var potentialTypes = [];
   if (ws && ws.getPotentialVariableMap()) {
-      potentialTypes = Object.keys(ws.getPotentialVariableMap().variableMap_);
+    potentialTypes = Object.keys(ws.getPotentialVariableMap().variableMap_);
   }
   var types = Object.keys(this.variableMap_).concat(potentialTypes);
   var hasEmpty = false;

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -348,12 +348,20 @@ Blockly.VariableMap.prototype.getVariablesOfType = function(type) {
 };
 
 /**
- * Return all variable types.  This list always contains the empty string.
+ * Return all variable and potential variable types.  This list always contains
+ * the empty string.
+ * @param {?Blockly.Workspace} ws The workspace used to look for potential
+ * variables. This can be different than the workspace stored on this object
+ * if the passed in ws is a flyout workspace.
  * @return {!Array.<string>} List of variable types.
  * @package
  */
-Blockly.VariableMap.prototype.getVariableTypes = function() {
-  var types = Object.keys(this.variableMap_);
+Blockly.VariableMap.prototype.getVariableTypes = function(ws) {
+  var potentialTypes = [];
+  if (ws && ws.getPotentialVariableMap()) {
+      potentialTypes = Object.keys(ws.getPotentialVariableMap().variableMap_);
+  }
+  var types = Object.keys(this.variableMap_).concat(potentialTypes);
   var hasEmpty = false;
   for (var i = 0; i < types.length; i++) {
     if (types[i] == '') {

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -491,7 +491,7 @@ Blockly.Workspace.prototype.getVariablesOfType = function(type) {
  * @package
  */
 Blockly.Workspace.prototype.getVariableTypes = function() {
-  return this.variableMap_.getVariableTypes();
+  return this.variableMap_.getVariableTypes(this);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2557

### Proposed Changes
1. Use getVariable() instead of getVariableById(). getVariable looks through both the potential variable map as well as the variable map. This fixes the original error.
2. Look through the potential variable map and the regular variable map when getting variable types. This fixes the error we were getting when we have a block like the one below that accepts any type.
<img width="188" alt="Screen Shot 2019-07-09 at 11 16 42 AM" src="https://user-images.githubusercontent.com/23059043/60912888-0f00ed80-a23b-11e9-9150-dbbc412e4965.png">

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
