### PR TITLE
Fixed Procedure Argument Escaping

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -165,16 +165,16 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    */
   decompose: function(workspace) {
     /*
-    * Creates the following XML
-    * <block type="procedures_mutatorcontainer">
-    *   <statement name="STACK>
-    *     <block type="procedures_mutatorarg">
-    *       <field name="NAME">arg1_name</field>
-    *       <next>etc...</next
-    *     </block>
-    *   </statement>
-    * </block>
-    */
+     * Creates the following XML:
+     * <block type="procedures_mutatorcontainer">
+     *   <statement name="STACK">
+     *     <block type="procedures_mutatorarg">
+     *       <field name="NAME">arg1_name</field>
+     *       <next>etc...</next>
+     *     </block>
+     *   </statement>
+     * </block>
+     */
 
     var containerBlockNode = Blockly.utils.xml.createElement('block');
     containerBlockNode.setAttribute('type', 'procedures_mutatorcontainer');
@@ -195,15 +195,13 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       argBlockNode.appendChild(nextNode);
 
       node.appendChild(argBlockNode);
-
       node = nextNode;
     }
 
     var containerBlock = Blockly.Xml.domToBlock(containerBlockNode, workspace);
 
     if (this.type == 'procedures_defreturn') {
-      containerBlock.setFieldValue(
-        this.hasStatements_ ? 'TRUE' : 'FALSE', 'STATEMENTS');
+      containerBlock.setFieldValue(this.hasStatements_, 'STATEMENTS');
     } else {
       containerBlock.removeInput('STATEMENT_INPUT');
     }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -164,22 +164,42 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @this Blockly.Block
    */
   decompose: function(workspace) {
-    var xml = Blockly.Xml.textToDom(
-        '<block type="procedures_mutatorcontainer">' +
-        '  <statement name="STACK"></statement>' +
-        '</block>');
-    var node = xml.getElementsByTagName('statement')[0];
+    /*
+    * Creates the following XML
+    * <block type="procedures_mutatorcontainer">
+    *   <statement name="STACK>
+    *     <block type="procedures_mutatorarg">
+    *       <field name="NAME">arg1_name</field>
+    *       <next>etc...</next
+    *     </block>
+    *   </statement>
+    * </block>
+    */
+
+    var containerBlockNode = Blockly.utils.xml.createElement('block');
+    containerBlockNode.setAttribute('type', 'procedures_mutatorcontainer');
+    var statementNode = Blockly.utils.xml.createElement('statement');
+    statementNode.setAttribute('name', 'STACK');
+    containerBlockNode.appendChild(statementNode);
+
+    var node = statementNode;
     for (var i = 0; i < this.arguments_.length; i++) {
-      node.appendChild(Blockly.Xml.textToDom(
-          '<block type="procedures_mutatorarg">' +
-          '  <field name="NAME">' + this.arguments_[i] + '</field>' +
-          '  <next></next>' +
-          '</block>'
-      ));
-      node = node.getElementsByTagName('next')[0];
+      var argBlockNode = Blockly.utils.xml.createElement('block');
+      argBlockNode.setAttribute('type', 'procedures_mutatorarg');
+      var fieldNode = Blockly.utils.xml.createElement('field');
+      fieldNode.setAttribute('name', 'NAME');
+      var argumentName = Blockly.utils.xml.createTextNode(this.arguments_[i]);
+      fieldNode.appendChild(argumentName);
+      argBlockNode.appendChild(fieldNode);
+      var nextNode = Blockly.utils.xml.createElement('next');
+      argBlockNode.appendChild(nextNode);
+
+      node.appendChild(argBlockNode);
+
+      node = nextNode;
     }
 
-    var containerBlock = Blockly.Xml.domToBlock(xml, workspace);
+    var containerBlock = Blockly.Xml.domToBlock(containerBlockNode, workspace);
 
     if (this.type == 'procedures_defreturn') {
       containerBlock.setFieldValue(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2624 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Refactors procedure decompose to build the xml node-by-node (as suggested by neil). Also fixes arguments not being properly escaped.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs be bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tried the reproduction steps given, the bug did not reproduce.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
Gonna work on more procedure unit tests today.
