### PR TITLE
Replace --dependency_mode=STRICT with PRUNE.

### DIFF
--- a/local_build/local_build.sh
+++ b/local_build/local_build.sh
@@ -101,7 +101,7 @@ java -jar $COMPILER \
   --generate_exports \
   --warning_level='DEFAULT' \
   --compilation_level SIMPLE_OPTIMIZATIONS \
-  --dependency_mode=STRICT \
+  --dependency_mode=PRUNE \
   --entry_point=Blockly \
   --js_output_file local_blocks_compressed.js
 rm temp.js 2> /dev/null


### PR DESCRIPTION
STRICT is a deprecated alias for PRUNE.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

N/A

### Proposed Changes

Migrate off of deprecated Closure Compiler --dependency_mode=STRICT flag.

### Reason for Changes

See above.

### Test Coverage

Tested by running local_build.sh locally.

### Additional Information

N/A