### PR TITLE
Remove edit handler that is just eating events

### DIFF
--- a/demos/mobile/android/app/src/main/java/com/google/blockly/android/webview/JsDialogHelper.java
+++ b/demos/mobile/android/app/src/main/java/com/google/blockly/android/webview/JsDialogHelper.java
@@ -115,19 +115,6 @@ public class JsDialogHelper {
             builder.setNegativeButton(android.R.string.cancel, new CancelListener());
         }
         final AlertDialog dialog = builder.show();
-
-        if (edit != null) {  // Is it a prompt dialog?
-            edit.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-                @Override
-                public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                    if (actionId == EditorInfo.IME_ACTION_DONE) {
-                        // TODO: Accept input, close keyboard, close dialog
-                        return true;
-                    }
-                    return false;
-                }
-            });
-        }
     }
 
     private class CancelListener implements DialogInterface.OnCancelListener,


### PR DESCRIPTION
This handler should be unnecessary on most versions of Android, and it's currently just swallowing events that would be handled by default. Removing it to let the system take the default action.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2340

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/2634)
<!-- Reviewable:end -->
