### PR TITLE
Add test case files for screenshot testing

### DIFF
--- a/tests/screenshot/test_cases/colour_blend
+++ b/tests/screenshot/test_cases/colour_blend
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_blend">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_picker
+++ b/tests/screenshot/test_cases/colour_picker
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_picker">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_random
+++ b/tests/screenshot/test_cases/colour_random
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_random">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/colour_rgb
+++ b/tests/screenshot/test_cases/colour_rgb
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="colour_rgb">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_flow_statements
+++ b/tests/screenshot/test_cases/controls_flow_statements
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_flow_statements">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_for
+++ b/tests/screenshot/test_cases/controls_for
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_for">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_forEach
+++ b/tests/screenshot/test_cases/controls_forEach
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_forEach">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if
+++ b/tests/screenshot/test_cases/controls_if
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_else
+++ b/tests/screenshot/test_cases/controls_if_else
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_else">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_elseif
+++ b/tests/screenshot/test_cases/controls_if_elseif
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_elseif">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_if_if
+++ b/tests/screenshot/test_cases/controls_if_if
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_if_if">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_ifelse
+++ b/tests/screenshot/test_cases/controls_ifelse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_ifelse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_repeat
+++ b/tests/screenshot/test_cases/controls_repeat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_repeat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_repeat_ext
+++ b/tests/screenshot/test_cases/controls_repeat_ext
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_repeat_ext">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/controls_whileUntil
+++ b/tests/screenshot/test_cases/controls_whileUntil
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="controls_whileUntil">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_empty
+++ b/tests/screenshot/test_cases/lists_create_empty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_empty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with
+++ b/tests/screenshot/test_cases/lists_create_with
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with_container
+++ b/tests/screenshot/test_cases/lists_create_with_container
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with_container">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_create_with_item
+++ b/tests/screenshot/test_cases/lists_create_with_item
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_create_with_item">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_getIndex
+++ b/tests/screenshot/test_cases/lists_getIndex
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_getIndex">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_getSublist
+++ b/tests/screenshot/test_cases/lists_getSublist
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_getSublist">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_indexOf
+++ b/tests/screenshot/test_cases/lists_indexOf
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_indexOf">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_isEmpty
+++ b/tests/screenshot/test_cases/lists_isEmpty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_isEmpty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_length
+++ b/tests/screenshot/test_cases/lists_length
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_length">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_repeat
+++ b/tests/screenshot/test_cases/lists_repeat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_repeat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_reverse
+++ b/tests/screenshot/test_cases/lists_reverse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_reverse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_setIndex
+++ b/tests/screenshot/test_cases/lists_setIndex
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_setIndex">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_sort
+++ b/tests/screenshot/test_cases/lists_sort
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_sort">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/lists_split
+++ b/tests/screenshot/test_cases/lists_split
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="lists_split">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_boolean
+++ b/tests/screenshot/test_cases/logic_boolean
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_boolean">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_compare
+++ b/tests/screenshot/test_cases/logic_compare
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_compare">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_negate
+++ b/tests/screenshot/test_cases/logic_negate
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_negate">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_null
+++ b/tests/screenshot/test_cases/logic_null
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_null">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_operation
+++ b/tests/screenshot/test_cases/logic_operation
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_operation">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/logic_ternary
+++ b/tests/screenshot/test_cases/logic_ternary
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="logic_ternary">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_addition
+++ b/tests/screenshot/test_cases/math_addition
@@ -1,0 +1,15 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="math_arithmetic">
+    <field name="OP">ADD</field>
+    <value name="A">
+      <shadow type="math_number">
+        <field name="NUM">1</field>
+      </shadow>
+    </value>
+    <value name="B">
+      <shadow type="math_number">
+        <field name="NUM">1</field>
+      </shadow>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/math_arithmetic
+++ b/tests/screenshot/test_cases/math_arithmetic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_arithmetic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_atan2
+++ b/tests/screenshot/test_cases/math_atan2
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_atan2">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_change
+++ b/tests/screenshot/test_cases/math_change
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_change">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_constant
+++ b/tests/screenshot/test_cases/math_constant
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_constant">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_constrain
+++ b/tests/screenshot/test_cases/math_constrain
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_constrain">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_modulo
+++ b/tests/screenshot/test_cases/math_modulo
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_modulo">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_number
+++ b/tests/screenshot/test_cases/math_number
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_number">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_number_property
+++ b/tests/screenshot/test_cases/math_number_property
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_number_property">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_on_list
+++ b/tests/screenshot/test_cases/math_on_list
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_on_list">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_random_float
+++ b/tests/screenshot/test_cases/math_random_float
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_random_float">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_random_int
+++ b/tests/screenshot/test_cases/math_random_int
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_random_int">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_round
+++ b/tests/screenshot/test_cases/math_round
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_round">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_single
+++ b/tests/screenshot/test_cases/math_single
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_single">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/math_subtraction
+++ b/tests/screenshot/test_cases/math_subtraction
@@ -1,0 +1,15 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="math_arithmetic">
+    <field name="OP">MINUS</field>
+    <value name="A">
+      <shadow type="math_number">
+        <field name="NUM">3</field>
+      </shadow>
+    </value>
+    <value name="B">
+      <shadow type="math_number">
+        <field name="NUM">4</field>
+      </shadow>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/math_trig
+++ b/tests/screenshot/test_cases/math_trig
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="math_trig">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/multi_block_1
+++ b/tests/screenshot/test_cases/multi_block_1
@@ -1,0 +1,74 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id=";yuq?=_C|_qk64!)f:m^">item</variable>
+  </variables>
+  <block type="controls_ifelse">
+    <statement name="ELSE">
+      <block type="controls_ifelse">
+        <value name="IF0">
+          <block type="logic_compare">
+            <field name="OP">EQ</field>
+            <value name="A">
+              <block type="logic_negate">
+                <value name="BOOL">
+                  <block type="logic_boolean">
+                    <field name="BOOL">TRUE</field>
+                  </block>
+                </value>
+              </block>
+            </value>
+            <value name="B">
+              <block type="logic_compare">
+                <field name="OP">EQ</field>
+                <value name="A">
+                  <block type="math_arithmetic">
+                    <field name="OP">MULTIPLY</field>
+                    <value name="A">
+                      <shadow type="math_number">
+                        <field name="NUM">-1</field>
+                      </shadow>
+                    </value>
+                    <value name="B">
+                      <shadow type="math_number">
+                        <field name="NUM">42</field>
+                      </shadow>
+                    </value>
+                  </block>
+                </value>
+              </block>
+            </value>
+          </block>
+        </value>
+        <statement name="DO0">
+          <block type="controls_repeat_ext">
+            <value name="TIMES">
+              <shadow type="math_number">
+                <field name="NUM">900</field>
+              </shadow>
+            </value>
+          </block>
+        </statement>
+        <statement name="ELSE">
+          <block type="text_append">
+            <field name="VAR" id=";yuq?=_C|_qk64!)f:m^" variabletype="">item</field>
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">f00</field>
+              </shadow>
+            </value>
+            <next>
+              <block type="text_append">
+                <field name="VAR" id=";yuq?=_C|_qk64!)f:m^" variabletype="">item</field>
+                <value name="TEXT">
+                  <shadow type="text">
+                    <field name="TEXT">bar</field>
+                  </shadow>
+                </value>
+              </block>
+            </next>
+          </block>
+        </statement>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/multi_block_logic
+++ b/tests/screenshot/test_cases/multi_block_logic
@@ -1,0 +1,34 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="logic_compare">
+    <field name="OP">EQ</field>
+    <value name="A">
+      <block type="logic_negate">
+        <value name="BOOL">
+          <block type="logic_boolean">
+            <field name="BOOL">TRUE</field>
+          </block>
+        </value>
+      </block>
+    </value>
+    <value name="B">
+      <block type="logic_compare">
+        <field name="OP">EQ</field>
+        <value name="A">
+          <block type="math_arithmetic">
+            <field name="OP">MULTIPLY</field>
+            <value name="A">
+              <shadow type="math_number">
+                <field name="NUM">-1</field>
+              </shadow>
+            </value>
+            <value name="B">
+              <shadow type="math_number">
+                <field name="NUM">42</field>
+              </shadow>
+            </value>
+          </block>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/multi_colour_with_external
+++ b/tests/screenshot/test_cases/multi_colour_with_external
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="colour_rgb">
+    <value name="RED">
+      <shadow type="math_number">
+        <field name="NUM">100</field>
+      </shadow>
+      <block type="math_modulo">
+        <value name="DIVIDEND">
+          <shadow type="math_number">
+            <field name="NUM">64</field>
+          </shadow>
+        </value>
+        <value name="DIVISOR">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+    <value name="GREEN">
+      <shadow type="math_number">
+        <field name="NUM">50</field>
+      </shadow>
+    </value>
+    <value name="BLUE">
+      <shadow type="math_number">
+        <field name="NUM">0</field>
+      </shadow>
+      <block type="math_arithmetic">
+        <field name="OP">ADD</field>
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/multi_colour_with_internal
+++ b/tests/screenshot/test_cases/multi_colour_with_internal
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="colour_rgb" inline="true">
+    <value name="RED">
+      <shadow type="math_number">
+        <field name="NUM">100</field>
+      </shadow>
+      <block type="math_modulo">
+        <value name="DIVIDEND">
+          <shadow type="math_number">
+            <field name="NUM">64</field>
+          </shadow>
+        </value>
+        <value name="DIVISOR">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+    <value name="GREEN">
+      <shadow type="math_number">
+        <field name="NUM">50</field>
+      </shadow>
+    </value>
+    <value name="BLUE">
+      <shadow type="math_number">
+        <field name="NUM">0</field>
+      </shadow>
+      <block type="math_arithmetic">
+        <field name="OP">ADD</field>
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/multi_stack
+++ b/tests/screenshot/test_cases/multi_stack
@@ -1,0 +1,53 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id="YUz?xxnE}SFx_,jmW#s;">item</variable>
+  </variables>
+  <block type="text_append">
+    <field name="VAR" id="YUz?xxnE}SFx_,jmW#s;" variabletype="">item</field>
+    <value name="TEXT">
+      <shadow type="text">
+        <field name="TEXT">one</field>
+      </shadow>
+    </value>
+    <next>
+      <block type="text_append">
+        <field name="VAR" id="YUz?xxnE}SFx_,jmW#s;" variabletype="">item</field>
+        <value name="TEXT">
+          <shadow type="text">
+            <field name="TEXT">two</field>
+          </shadow>
+        </value>
+        <next>
+          <block type="text_append">
+            <field name="VAR" id="YUz?xxnE}SFx_,jmW#s;" variabletype="">item</field>
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">three</field>
+              </shadow>
+            </value>
+            <next>
+              <block type="text_append">
+                <field name="VAR" id="YUz?xxnE}SFx_,jmW#s;" variabletype="">item</field>
+                <value name="TEXT">
+                  <shadow type="text">
+                    <field name="TEXT">four</field>
+                  </shadow>
+                </value>
+                <next>
+                  <block type="text_append">
+                    <field name="VAR" id="YUz?xxnE}SFx_,jmW#s;" variabletype="">item</field>
+                    <value name="TEXT">
+                      <shadow type="text">
+                        <field name="TEXT">five</field>
+                      </shadow>
+                    </value>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/not_true
+++ b/tests/screenshot/test_cases/not_true
@@ -1,0 +1,9 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="logic_negate">
+    <value name="BOOL">
+      <block type="logic_boolean">
+        <field name="BOOL">TRUE</field>
+      </block>
+    </value>
+  </block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_callnoreturn
+++ b/tests/screenshot/test_cases/procedures_callnoreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_callnoreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_callreturn
+++ b/tests/screenshot/test_cases/procedures_callreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_callreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_defnoreturn
+++ b/tests/screenshot/test_cases/procedures_defnoreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_defnoreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_defreturn
+++ b/tests/screenshot/test_cases/procedures_defreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_defreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_ifreturn
+++ b/tests/screenshot/test_cases/procedures_ifreturn
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_ifreturn">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_mutatorarg
+++ b/tests/screenshot/test_cases/procedures_mutatorarg
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_mutatorarg">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/procedures_mutatorcontainer
+++ b/tests/screenshot/test_cases/procedures_mutatorcontainer
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="procedures_mutatorcontainer">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_empty
+++ b/tests/screenshot/test_cases/test_basic_empty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_empty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_empty_with_mutator
+++ b/tests/screenshot/test_cases/test_basic_empty_with_mutator
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_empty_with_mutator">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_limit_instances
+++ b/tests/screenshot/test_cases/test_basic_limit_instances
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_limit_instances">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_value_to_stack
+++ b/tests/screenshot/test_cases/test_basic_value_to_stack
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_value_to_stack">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_basic_value_to_statement
+++ b/tests/screenshot/test_cases/test_basic_value_to_statement
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_basic_value_to_statement">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_cases.json
+++ b/tests/screenshot/test_cases/test_cases.json
@@ -1,0 +1,480 @@
+{
+  "tests": [
+    {
+      "title": "logic_boolean",
+      "skip": false
+    },
+    {
+      "title": "controls_if",
+      "skip": false
+    },
+    {
+      "title": "controls_ifelse",
+      "skip": false
+    },
+    {
+      "title": "logic_compare",
+      "skip": false
+    },
+    {
+      "title": "logic_operation",
+      "skip": false
+    },
+    {
+      "title": "logic_negate",
+      "skip": false
+    },
+    {
+      "title": "logic_null",
+      "skip": false
+    },
+    {
+      "title": "logic_ternary",
+      "skip": false
+    },
+    {
+      "title": "controls_if_if",
+      "skip": false
+    },
+    {
+      "title": "controls_if_elseif",
+      "skip": false
+    },
+    {
+      "title": "controls_if_else",
+      "skip": false
+    },
+    {
+      "title": "controls_repeat_ext",
+      "skip": false
+    },
+    {
+      "title": "controls_repeat",
+      "skip": false
+    },
+    {
+      "title": "controls_whileUntil",
+      "skip": false
+    },
+    {
+      "title": "controls_for",
+      "skip": false
+    },
+    {
+      "title": "controls_forEach",
+      "skip": false
+    },
+    {
+      "title": "controls_flow_statements",
+      "skip": false
+    },
+    {
+      "title": "math_number",
+      "skip": false
+    },
+    {
+      "title": "math_arithmetic",
+      "skip": false
+    },
+    {
+      "title": "math_single",
+      "skip": false
+    },
+    {
+      "title": "math_trig",
+      "skip": false
+    },
+    {
+      "title": "math_constant",
+      "skip": false
+    },
+    {
+      "title": "math_number_property",
+      "skip": false
+    },
+    {
+      "title": "math_change",
+      "skip": false
+    },
+    {
+      "title": "math_round",
+      "skip": false
+    },
+    {
+      "title": "math_on_list",
+      "skip": false
+    },
+    {
+      "title": "math_modulo",
+      "skip": false
+    },
+    {
+      "title": "math_constrain",
+      "skip": false
+    },
+    {
+      "title": "math_random_int",
+      "skip": false
+    },
+    {
+      "title": "math_random_float",
+      "skip": false
+    },
+    {
+      "title": "math_atan2",
+      "skip": false
+    },
+    {
+      "title": "text_join",
+      "skip": false
+    },
+    {
+      "title": "text_create_join_container",
+      "skip": false
+    },
+    {
+      "title": "text_create_join_item",
+      "skip": false
+    },
+    {
+      "title": "text_append",
+      "skip": false
+    },
+    {
+      "title": "text_length",
+      "skip": false
+    },
+    {
+      "title": "text_isEmpty",
+      "skip": false
+    },
+    {
+      "title": "text_indexOf",
+      "skip": false
+    },
+    {
+      "title": "text_charAt",
+      "skip": false
+    },
+    {
+      "title": "text_getSubstring",
+      "skip": false
+    },
+    {
+      "title": "text_changeCase",
+      "skip": false
+    },
+    {
+      "title": "text_trim",
+      "skip": false
+    },
+    {
+      "title": "text_print",
+      "skip": false
+    },
+    {
+      "title": "text_prompt_ext",
+      "skip": false
+    },
+    {
+      "title": "text_prompt",
+      "skip": false
+    },
+    {
+      "title": "text_count",
+      "skip": false
+    },
+    {
+      "title": "text_replace",
+      "skip": false
+    },
+    {
+      "title": "text_reverse",
+      "skip": false
+    },
+    {
+      "title": "lists_create_empty",
+      "skip": false
+    },
+    {
+      "title": "lists_repeat",
+      "skip": false
+    },
+    {
+      "title": "lists_reverse",
+      "skip": false
+    },
+    {
+      "title": "lists_isEmpty",
+      "skip": false
+    },
+    {
+      "title": "lists_length",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with_container",
+      "skip": false
+    },
+    {
+      "title": "lists_create_with_item",
+      "skip": false
+    },
+    {
+      "title": "lists_indexOf",
+      "skip": false
+    },
+    {
+      "title": "lists_getIndex",
+      "skip": false
+    },
+    {
+      "title": "lists_setIndex",
+      "skip": false
+    },
+    {
+      "title": "lists_getSublist",
+      "skip": false
+    },
+    {
+      "title": "lists_sort",
+      "skip": false
+    },
+    {
+      "title": "lists_split",
+      "skip": false
+    },
+    {
+      "title": "colour_picker",
+      "skip": false
+    },
+    {
+      "title": "colour_random",
+      "skip": false
+    },
+    {
+      "title": "colour_rgb",
+      "skip": false
+    },
+    {
+      "title": "colour_blend",
+      "skip": false
+    },
+    {
+      "title": "variables_get",
+      "skip": false
+    },
+    {
+      "title": "variables_set",
+      "skip": false
+    },
+    {
+      "title": "variables_get_dynamic",
+      "skip": false
+    },
+    {
+      "title": "variables_set_dynamic",
+      "skip": false
+    },
+    {
+      "title": "procedures_defnoreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_defreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_mutatorcontainer",
+      "skip": true
+    },
+    {
+      "title": "procedures_mutatorarg",
+      "skip": true
+    },
+    {
+      "title": "procedures_callnoreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_callreturn",
+      "skip": true
+    },
+    {
+      "title": "procedures_ifreturn",
+      "skip": true
+    },
+    {
+      "title": "test_basic_empty",
+      "skip": false
+    },
+    {
+      "title": "test_basic_value_to_stack",
+      "skip": false
+    },
+    {
+      "title": "test_basic_value_to_statement",
+      "skip": false
+    },
+    {
+      "title": "test_basic_limit_instances",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_long",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_images",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_images_and_text",
+      "skip": false
+    },
+    {
+      "title": "test_fields_angle",
+      "skip": false
+    },
+    {
+      "title": "test_fields_date",
+      "skip": false
+    },
+    {
+      "title": "test_fields_text_input",
+      "skip": false
+    },
+    {
+      "title": "test_fields_checkbox",
+      "skip": false
+    },
+    {
+      "title": "test_fields_colour",
+      "skip": false
+    },
+    {
+      "title": "test_fields_variable",
+      "skip": false
+    },
+    {
+      "title": "test_fields_label_serializable",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_float",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_whole",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_hundredths",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_halves",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_three_halves",
+      "skip": false
+    },
+    {
+      "title": "test_numbers_whole_bounded",
+      "skip": false
+    },
+    {
+      "title": "test_images_datauri",
+      "skip": false
+    },
+    {
+      "title": "test_images_small",
+      "skip": false
+    },
+    {
+      "title": "test_images_large",
+      "skip": false
+    },
+    {
+      "title": "test_images_fliprtl",
+      "skip": false
+    },
+    {
+      "title": "test_images_missing",
+      "skip": false
+    },
+    {
+      "title": "test_images_many_icons",
+      "skip": false
+    },
+    {
+      "title": "test_style_hat",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex1",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex2",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex3",
+      "skip": false
+    },
+    {
+      "title": "test_style_no_colour",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex4",
+      "skip": false
+    },
+    {
+      "title": "test_style_hex5",
+      "skip": false
+    },
+    {
+      "title": "test_style_emoji",
+      "skip": false
+    },
+    {
+      "title": "test_basic_empty_with_mutator",
+      "skip": false
+    },
+    {
+      "title": "test_dropdowns_dynamic",
+      "skip": false
+    },
+    {
+      "title": "multi_block_1",
+      "skip": false
+    },
+    {
+      "title": "multi_block_logic",
+      "skip": false
+    },
+    {
+      "title": "multi_colour_with_external",
+      "skip": false
+    },
+    {
+      "title": "multi_colour_with_internal",
+      "skip": false
+    },
+    {
+      "title": "not_true",
+      "skip": false
+    },
+    {
+      "title": "multi_stack",
+      "skip": false
+    }
+  ]
+}

--- a/tests/screenshot/test_cases/test_dropdowns_dynamic
+++ b/tests/screenshot/test_cases/test_dropdowns_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_dynamic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_images
+++ b/tests/screenshot/test_cases/test_dropdowns_images
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_images">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_images_and_text
+++ b/tests/screenshot/test_cases/test_dropdowns_images_and_text
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_images_and_text">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_dropdowns_long
+++ b/tests/screenshot/test_cases/test_dropdowns_long
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_dropdowns_long">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_angle
+++ b/tests/screenshot/test_cases/test_fields_angle
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_angle">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_checkbox
+++ b/tests/screenshot/test_cases/test_fields_checkbox
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_checkbox">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_colour
+++ b/tests/screenshot/test_cases/test_fields_colour
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_colour">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_date
+++ b/tests/screenshot/test_cases/test_fields_date
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_date">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_label_serializable
+++ b/tests/screenshot/test_cases/test_fields_label_serializable
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_label_serializable">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_text_input
+++ b/tests/screenshot/test_cases/test_fields_text_input
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_text_input">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_fields_variable
+++ b/tests/screenshot/test_cases/test_fields_variable
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_fields_variable">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_datauri
+++ b/tests/screenshot/test_cases/test_images_datauri
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_datauri">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_fliprtl
+++ b/tests/screenshot/test_cases/test_images_fliprtl
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_fliprtl">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_large
+++ b/tests/screenshot/test_cases/test_images_large
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_large">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_many_icons
+++ b/tests/screenshot/test_cases/test_images_many_icons
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_many_icons">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_missing
+++ b/tests/screenshot/test_cases/test_images_missing
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_missing">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_images_small
+++ b/tests/screenshot/test_cases/test_images_small
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_images_small">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_float
+++ b/tests/screenshot/test_cases/test_numbers_float
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_float">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_halves
+++ b/tests/screenshot/test_cases/test_numbers_halves
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_halves">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_hundredths
+++ b/tests/screenshot/test_cases/test_numbers_hundredths
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_hundredths">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_three_halves
+++ b/tests/screenshot/test_cases/test_numbers_three_halves
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_three_halves">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_whole
+++ b/tests/screenshot/test_cases/test_numbers_whole
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_whole">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_numbers_whole_bounded
+++ b/tests/screenshot/test_cases/test_numbers_whole_bounded
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_numbers_whole_bounded">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_emoji
+++ b/tests/screenshot/test_cases/test_style_emoji
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_emoji">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hat
+++ b/tests/screenshot/test_cases/test_style_hat
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hat">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex1
+++ b/tests/screenshot/test_cases/test_style_hex1
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex1">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex2
+++ b/tests/screenshot/test_cases/test_style_hex2
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex2">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex3
+++ b/tests/screenshot/test_cases/test_style_hex3
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex3">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex4
+++ b/tests/screenshot/test_cases/test_style_hex4
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex4">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_hex5
+++ b/tests/screenshot/test_cases/test_style_hex5
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_hex5">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/test_style_no_colour
+++ b/tests/screenshot/test_cases/test_style_no_colour
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="test_style_no_colour">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_append
+++ b/tests/screenshot/test_cases/text_append
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_append">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_changeCase
+++ b/tests/screenshot/test_cases/text_changeCase
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_changeCase">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_charAt
+++ b/tests/screenshot/test_cases/text_charAt
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_charAt">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_count
+++ b/tests/screenshot/test_cases/text_count
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_count">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_create_join_container
+++ b/tests/screenshot/test_cases/text_create_join_container
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_create_join_container">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_create_join_item
+++ b/tests/screenshot/test_cases/text_create_join_item
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_create_join_item">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_getSubstring
+++ b/tests/screenshot/test_cases/text_getSubstring
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_getSubstring">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_indexOf
+++ b/tests/screenshot/test_cases/text_indexOf
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_indexOf">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_isEmpty
+++ b/tests/screenshot/test_cases/text_isEmpty
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_isEmpty">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_join
+++ b/tests/screenshot/test_cases/text_join
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_join">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_length
+++ b/tests/screenshot/test_cases/text_length
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_length">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_print
+++ b/tests/screenshot/test_cases/text_print
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_print">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_prompt
+++ b/tests/screenshot/test_cases/text_prompt
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_prompt">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_prompt_ext
+++ b/tests/screenshot/test_cases/text_prompt_ext
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_prompt_ext">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_replace
+++ b/tests/screenshot/test_cases/text_replace
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_replace">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_reverse
+++ b/tests/screenshot/test_cases/text_reverse
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_reverse">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/text_trim
+++ b/tests/screenshot/test_cases/text_trim
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="text_trim">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_get
+++ b/tests/screenshot/test_cases/variables_get
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_get">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_get_dynamic
+++ b/tests/screenshot/test_cases/variables_get_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_get_dynamic">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_set
+++ b/tests/screenshot/test_cases/variables_set
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_set">
+	</block>
+</xml>

--- a/tests/screenshot/test_cases/variables_set_dynamic
+++ b/tests/screenshot/test_cases/variables_set_dynamic
@@ -1,0 +1,4 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+	<block type="variables_set_dynamic">
+	</block>
+</xml>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of merging `render/collab` back to `develop`.

### Proposed Changes

Creates the tests/screenshots/test_cases folder.
Adds 121 test cases (files contain XML) and 1 file that says which tests to run. (`test_cases.json`)
The test cases include every block in the playground individually, as well as a few basic stacks.

### Reason for Changes
I need to start pulling the rendering changes into develop.  These files clutter the diffs heavily despite being easy to review on their own.

### Test Coverage
Part of screenshot diff testing.