### PR TITLE
Add getCorrectedSize functions to fields

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -645,6 +645,15 @@ Blockly.Field.prototype.getSize = function() {
 };
 
 /**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.Field.prototype.getCorrectedSize = function() {
+  return this.getSize();
+};
+
+/**
  * Returns the bounding box of the rendered field, accounting for workspace
  * scaling.
  * @return {!Object} An object with top, bottom, left, and right in pixels

--- a/core/field.js
+++ b/core/field.js
@@ -650,6 +650,7 @@ Blockly.Field.prototype.getSize = function() {
  * @package
  */
 Blockly.Field.prototype.getCorrectedSize = function() {
+  // TODO (#2562): Remove getCorrectedSize.
   return this.getSize();
 };
 

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -218,6 +218,8 @@ Blockly.FieldCheckbox.prototype.convertValueToBool_ = function(value) {
  */
 Blockly.FieldCheckbox.prototype.getCorrectedSize = function() {
   this.getSize();
+
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
       Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
 };

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -209,4 +209,16 @@ Blockly.FieldCheckbox.prototype.convertValueToBool_ = function(value) {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * The checkbox field fills the entire border rect, rather than just using the
+ * text element.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldCheckbox.prototype.getCorrectedSize = function() {
+  this.getSize();
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
+};
 Blockly.Field.register('field_checkbox', Blockly.FieldCheckbox);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -340,4 +340,20 @@ Blockly.FieldColour.prototype.dropdownDispose_ = function() {
   Blockly.unbindEvent_(this.onUpWrapper_);
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * The colour field fills the bounding box with colour and takes up the full
+ * space of the bounding box.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldColour.prototype.getCorrectedSize = function() {
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  return new goog.math.Size(
+      this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT - 1);
+};
+
 Blockly.Field.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -351,6 +351,7 @@ Blockly.FieldColour.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(
       this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
       Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT - 1);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -556,6 +556,9 @@ Blockly.FieldDropdown.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
+  // This extra 9 was probably to add padding between rows.
+  // It's also found in render_, renderSelectedImage_, and renderSelectedText_.
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
       this.size_.height - 9);
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -547,4 +547,17 @@ Blockly.FieldDropdown.validateOptions_ = function(options) {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldDropdown.prototype.getCorrectedSize = function() {
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      this.size_.height - 9);
+};
+
 Blockly.Field.register('field_dropdown', Blockly.FieldDropdown);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -201,7 +201,7 @@ Blockly.FieldImage.prototype.getCorrectedSize = function() {
   // Old rendering adds an extra pixel under the image.  We include this in the
   // height of the image in new rendering, rather than having the spacer below
   // know that there was an image in the previous row.
-  // TODO: Remove.
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(this.size_.width, this.height_ + 1);
 };
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -189,4 +189,20 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
   }
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldImage.prototype.getCorrectedSize = function() {
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  // Old rendering adds an extra pixel under the image.  We include this in the
+  // height of the image in new rendering, rather than having the spacer below
+  // know that there was an image in the previous row.
+  // TODO: Remove.
+  return new goog.math.Size(this.size_.width, this.height_ + 1);
+};
+
 Blockly.Field.register('field_image', Blockly.FieldImage);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -100,4 +100,16 @@ Blockly.FieldLabel.prototype.doClassValidation_ = function(newValue) {
   return String(newValue);
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldLabel.prototype.getCorrectedSize = function() {
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  return new goog.math.Size(this.size_.width, this.size_.height - 5);
+};
+
 Blockly.Field.register('field_label', Blockly.FieldLabel);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -109,6 +109,9 @@ Blockly.FieldLabel.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
+  // This extra 5 was probably to add padding between rows.
+  // It's also found in the constructor and in initView.
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(this.size_.width, this.size_.height - 5);
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -432,4 +432,16 @@ Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
   return n;
 };
 
+/**
+ * Get the size of the visible field, as used in new rendering.
+ * @return {!goog.math.Size} The size of the visible field.
+ * @package
+ */
+Blockly.FieldTextInput.prototype.getCorrectedSize = function() {
+  // getSize also renders and updates the size if needed.  Rather than duplicate
+  // the logic to figure out whether to rerender, just call getSize.
+  this.getSize();
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X, 16);
+};
+
 Blockly.Field.register('field_input', Blockly.FieldTextInput);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -441,6 +441,7 @@ Blockly.FieldTextInput.prototype.getCorrectedSize = function() {
   // getSize also renders and updates the size if needed.  Rather than duplicate
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
+  // TODO (#2562): Remove getCorrectedSize.
   return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X, 16);
 };
 

--- a/core/icon.js
+++ b/core/icon.js
@@ -205,3 +205,15 @@ Blockly.Icon.prototype.computeIconLocation = function() {
 Blockly.Icon.prototype.getIconLocation = function() {
   return this.iconXY_;
 };
+
+/**
+ * Get the size of the icon as used for rendering.
+ * This differs from the actual size of the icon, because it bulges slightly
+ * out of its row rather than increasing the height of its row.
+ * TODO (#2562): Remove getCorrectedSize.
+ * @return {!goog.math.Size} Height and width.
+ */
+Blockly.Icon.prototype.getCorrectedSize = function() {
+  return new goog.math.Size(
+      Blockly.Icon.prototype.SIZE, Blockly.Icon.prototype.SIZE - 2);
+};


### PR DESCRIPTION
## The basics

Note: This is a chunk of code from `render/collab` which I'm pulling in piecewise, because the rebase is terrible.

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of new rendering.

### Proposed Changes

Adds `getCorrectedSize` functions to fields and icons.

### Reason for Changes

`getSize` is not guaranteed to return a bounding box on the field, and I don't want to touch it now because that will break old rendering.
New rendering uses `getCorrectedSize`, which calls `getSize` if `getSize` already does the correct thing.

As we get rid of the old rendering I will change `getSize` functions to be correct, and eventually remove `getCorrectedSize` entirely.

### Additional Information

@BeksOmega because this touches fields.