### PR TITLE
Added JSON Customization Support For Angle Fields

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -435,11 +435,11 @@ Blockly.FieldAngle.prototype.doClassValidation_ = function(newValue) {
  * @param {boolean=} clockwise Whether the graphical angle editor should
  *    increase as it is moved clockwise (true) or counterclockwise (false)
  *    or the global setting (null).
+ * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
  */
 Blockly.FieldAngle.prototype.setClockwise = function(clockwise) {
-  // TODO: Handle undefined.
   this.clockwise_ = clockwise;
-  // TODO: Do render update?
+  return this;
 };
 
 /**
@@ -448,10 +448,11 @@ Blockly.FieldAngle.prototype.setClockwise = function(clockwise) {
  *    by. Always offsets in the clockwise direction independent of the
  *    Clockwise property. Pass null to use the
  *    global setting.
+ * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
  */
 Blockly.FieldAngle.prototype.setOffset = function(offset) {
   this.offset_ = offset;
-  // TODO: Do render update?
+  return this;
 };
 
 /**
@@ -460,10 +461,11 @@ Blockly.FieldAngle.prototype.setOffset = function(offset) {
  * Usually either 360 (for 0 to 359.9) or 180 (for -179.9 to 180).
  * @param {number=} wrap The wrap value of the angle field. Pass null to use
  *    the global setting.
+ * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
  */
 Blockly.FieldAngle.prototype.setWrap = function(wrap) {
   this.wrap_ = wrap;
-  // TODO: Do render update? May also need to call setValue to reevaluate value?
+  return this;
 };
 
 /**
@@ -471,10 +473,11 @@ Blockly.FieldAngle.prototype.setWrap = function(wrap) {
  * @param {number=} round The value (when input through the graphical
  *    editor) will be rounded to the nearest multiple of this number. Pass 0
  *    to disable rounding. Pass null to use the global setting.
+ * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
  */
 Blockly.FieldAngle.prototype.setRound = function(round) {
   this.round_ = round;
-  // TODO: Do render update?
+  return this;
 };
 
 /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -432,7 +432,7 @@ Blockly.FieldAngle.prototype.doClassValidation_ = function(newValue) {
 
 /**
  * Set which direction should make the graphical angle editor increase.
- * @param {boolean=} clockwise Whether the graphical angle editor should
+ * @param {?boolean} clockwise Whether the graphical angle editor should
  *    increase as it is moved clockwise (true) or counterclockwise (false)
  *    or the global setting (null).
  * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
@@ -444,7 +444,7 @@ Blockly.FieldAngle.prototype.setClockwise = function(clockwise) {
 
 /**
  * Set the offset of zero degrees. Usually 0 (right) or 90 (up).
- * @param {number=} offset The amount to offset the location of 0 degrees
+ * @param {?number} offset The amount to offset the location of 0 degrees
  *    by. Always offsets in the clockwise direction independent of the
  *    Clockwise property. Pass null to use the
  *    global setting.
@@ -459,7 +459,7 @@ Blockly.FieldAngle.prototype.setOffset = function(offset) {
  * Set the wrap/range of the angle field. The range is equal to (-360 +
  * WRAP, WRAP).
  * Usually either 360 (for 0 to 359.9) or 180 (for -179.9 to 180).
- * @param {number=} wrap The wrap value of the angle field. Pass null to use
+ * @param {?number} wrap The wrap value of the angle field. Pass null to use
  *    the global setting.
  * @return {!Blockly.FieldAngle} Returns itself (for method chaining).
  */
@@ -470,7 +470,7 @@ Blockly.FieldAngle.prototype.setWrap = function(wrap) {
 
 /**
  * Set the rounding of the angle field's graphical editor.
- * @param {number=} round The value (when input through the graphical
+ * @param {?number} round The value (when input through the graphical
  *    editor) will be rounded to the nearest multiple of this number. Pass 0
  *    to disable rounding. Pass null to use the global setting.
  * @return {!Blockly.FieldAngle} Returns itself (for method chaining).

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -412,6 +412,104 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "A midi note."
   },
   {
+    "type": "test_angles_clockwise",
+    "message0": "clockwise %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "clockwise": true
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_offset",
+    "message0": "offset 90 %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "offset": 90
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_wrap",
+    "message0": "wrap %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "wrap": 180
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_round_30",
+    "message0": "round 30 %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "round": 30
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_round_0",
+    "message0": "no round %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "round": 0
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_protractor",
+    "message0": "protractor %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "mode": "protractor"
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
+    "type": "test_angles_compass",
+    "message0": "compass %1",
+    "args0": [
+      {
+        "type": "field_angle",
+        "name": "FIELDNAME",
+        "angle": 0,
+        "mode": "compass"
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
     "type": "test_images_datauri",
     "message0": "Image data: URI %1",
     "args0": [

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1392,6 +1392,17 @@ h1 {
           <field name="NOTE">60</field>
         </block>
       </category>
+      <category name="Angles">
+        <label text="Modes"></label>
+        <block type="test_angles_protractor"></block>
+        <block type="test_angles_compass"></block>
+        <label text="Properties"></label>
+        <block type="test_angles_clockwise"></block>
+        <block type="test_angles_offset"></block>
+        <block type="test_angles_wrap"></block>
+        <block type="test_angles_round_30"></block>
+        <block type="test_angles_round_0"></block>
+      </category>
       <category name="Drop-downs">
         <label text="Dynamic"></label>
         <block type="test_dropdowns_dynamic"></block>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2315 plus some

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Adds modes: Compass and Protractor to the angle field JSON definition.
* Also adds properties: clockwise, offset, wrap, and round to the angle field JSON definition.
* Adds functions for setting the individual properties programmatically.
* Adds functions for getting the value of the property (with respect for globals).

### Reason for Changes

* Requested.
* More info below.
* Good practice.
* Good practice.

#### Why did I add individual properties?

I absolutely love love love angle fields. I think they're probably the coolest field in Blockly and I think they're super under utilized. I would hate to see them hamstrung by the JSON.

For example, if there were only the two modes available you couldn't make super cool blocks like this:
![AngelJSON](https://user-images.githubusercontent.com/25440652/61407936-c0370180-a893-11e9-8189-d9b4db360599.gif)

which have built-in affordances for directionally-challenged users.

Providing the modes & the properties (with the properties given override power since they're more specific) is the best of both ease of use, and power.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added test blocks for all of the modes and all of the properties.

Tested all of the blocks to make sure they were functioning properly.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

- [ ] Doc ticket should be created once this is merged.

Setting round to 0 looks crazy lol:
![AngelJSON_Round0](https://user-images.githubusercontent.com/25440652/61408215-608d2600-a894-11e9-9a5a-66ae3f461bde.gif)

But devs can fix it by setting round to 1 instead, so it doesn't need a fix.
