### PR TITLE
Added Setting a Colour Field's Options Through JSON

### DIFF
--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -63,7 +63,14 @@ goog.inherits(Blockly.FieldColour, Blockly.Field);
  * @nocollapse
  */
 Blockly.FieldColour.fromJson = function(options) {
-  return new Blockly.FieldColour(options['colour']);
+  var field = new Blockly.FieldColour(options['colour']);
+  if (options['colourOptions']) {
+    field.setColours(options['colourOptions'], options['colourTitles']);
+  }
+  if (options['columns']) {
+    field.setColumns(options['columns']);
+  }
+  return field;
 };
 
 /**

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -236,6 +236,26 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": ""
   },
   {
+    "type": "test_fields_colour_options",
+    "message0": "colour options %1",
+    "args0": [
+      {
+        "type": "field_colour",
+        "name": "COLOUR",
+        "colour": "#ff4040",
+        "colourOptions":
+          ['#ff4040', '#ff8080', '#ffc0c0',
+            '#4040ff', '#8080ff', '#c0c0ff'],
+        "colourTitles":
+          ['dark pink', 'pink', 'light pink',
+            'dark blue', 'blue', 'light blue'],
+        "columns": 3
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
     "type": "test_fields_variable",
     "message0": "variable %1",
     "args0": [

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1304,6 +1304,7 @@ h1 {
         <block type="test_fields_date"></block>
         <block type="test_fields_checkbox"></block>
         <block type="test_fields_colour"></block>
+        <block type="test_fields_colour_options"></block>
         <block type="test_fields_text_input"></block>
         <block type="test_fields_variable"></block>
         <button text="randomize label text" callbackKey="randomizeLabelText"></button>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#286 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds the ability to set a colour field's options, their titles, and the number of columns through JSON:
* colourOptions
* colourTitles (maybe titleOptions would be better?)
* columns

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Gotta give the JSON some love.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added  a test block to the playground, it works as expected.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

- [ ] Doc ticket should be created once this gets merged.
