### PR TITLE
Added Field Tooltip Support to the JSON

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1630,6 +1630,8 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
               input = this.appendDummyInput(element['name']);
               break;
             default:
+              // This should handle all field JSON parsing, including
+              // options that can be applied to any field type.
               field = Blockly.Field.fromJson(element);
 
               // Unknown field.

--- a/core/field.js
+++ b/core/field.js
@@ -92,7 +92,13 @@ Blockly.Field.register = function(type, fieldClass) {
 Blockly.Field.fromJson = function(options) {
   var fieldClass = Blockly.Field.TYPE_MAP_[options['type']];
   if (fieldClass) {
-    return fieldClass.fromJson(options);
+    var field = fieldClass.fromJson(options);
+    if (options['tooltip'] !== undefined) {
+      var rawValue = options['tooltip'];
+      var localizedText = Blockly.utils.replaceMessageReferences(rawValue);
+      field.setTooltip(localizedText);
+    }
+    return field;
   }
   return null;
 };

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -63,6 +63,28 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "style": "math_blocks",
   },
   {
+    "type": "test_basic_tooltips",
+    "message0": "%1 %2 %3",
+    "args0": [
+      {
+        "type": "field_label",
+        "name": "NAME",
+        "text": "field tooltip",
+        "tooltip": "This is a JSON tooltip for the *field*."
+      },
+      {
+        "type": "input_dummy"
+      },
+      {
+        "type": "field_label",
+        "name": "NAME",
+        "text": "block tooltip"
+      }
+    ],
+    "tooltip": "This is a JSON tooltip for the *block*.",
+    "style": "math_blocks"
+  },
+  {
     "type": "test_dropdowns_long",
     "message0": "long: %1",
     "args0": [

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1207,6 +1207,7 @@ h1 {
       <block type="test_basic_value_to_stack"></block>
       <block type="test_basic_value_to_statement"></block>
       <block type="test_basic_limit_instances"></block>
+      <block type="test_basic_tooltips"></block>
     </category>
     <category name="Drag">
       <label text="Drag each to the workspace"></label>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Allows the developer to set a field's tooltip through the block's JSON definition, to match block tooltips.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Consistency and usability!

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added a test block that covers field tooltips and block tooltips.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

- [ ] A doc ticket should be created once this gets merged.

As with the last two PRs, would you like this added to the block factory? If you do I would love some guidance on how to go about it (b/c I haven't got a clue).
