### PR TITLE
Properly set the display style on blocks when connections are unhidden

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -368,7 +368,7 @@ Blockly.RenderedConnection.prototype.disconnect = function() {
   if (rehide) {
     // Set the hidden state for the connection back to true so shadow blocks
     // will be hidden.
-    superiorConnection.setHidden(true);
+    superiorConnection.hideAll();
   }
 };
 

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -283,6 +283,12 @@ Blockly.RenderedConnection.prototype.setHidden = function(hidden) {
   } else if (!hidden && !this.inDB_) {
     this.db_.addConnection(this);
   }
+  if (this.isSuperior() && this.targetBlock()) {
+    var display = hidden ? 'none' : 'block';
+    var renderedBlock = this.targetBlock();
+    renderedBlock.getSvgRoot().style.display = display;
+    renderedBlock.rendered = !hidden;
+  }
 };
 
 /**
@@ -344,11 +350,6 @@ Blockly.RenderedConnection.prototype.connect = function(otherConnection) {
     } else {
       superiorConnection.unhideAll();
     }
-
-    var renderedBlock = superiorConnection.targetBlock();
-    var display = superiorConnection.hidden_ ? 'none' : 'block';
-    renderedBlock.getSvgRoot().style.display = display;
-    renderedBlock.rendered = !superiorConnection.hidden_;
   }
 };
 
@@ -358,17 +359,17 @@ Blockly.RenderedConnection.prototype.connect = function(otherConnection) {
  */
 Blockly.RenderedConnection.prototype.disconnect = function() {
   var superiorConnection = this.isSuperior() ? this : this.targetConnection;
+  var rehide = false;
   if (this.targetConnection && superiorConnection.hidden_) {
     superiorConnection.unhideAll();
-    var renderedBlock = superiorConnection.targetBlock();
-    renderedBlock.getSvgRoot().style.display = 'block';
-    renderedBlock.rendered = true;
-
+    rehide = true;
+  }
+  Blockly.RenderedConnection.superClass_.disconnect.call(this);
+  if (rehide) {
     // Set the hidden state for the connection back to true so shadow blocks
     // will be hidden.
     superiorConnection.setHidden(true);
   }
-  Blockly.RenderedConnection.superClass_.disconnect.call(this);
 };
 
 /**


### PR DESCRIPTION
We weren't always setting the display style on blocks when the hidden
state changed on a connection. This meant that sometimes unhiding a
connection would cause the attached block to be invisible.

This moves the display style code into the setHidden so it is never
skipped.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/2660
https://github.com/google/blockly/issues/2632

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/2666)
<!-- Reviewable:end -->
