### PR TITLE
Additional fixes to unhiding connections

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -317,8 +317,8 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
  *   If true, also render block's parent, grandparent, etc.  Defaults to true.
  */
 Blockly.BlockSvg.prototype.render = function(opt_bubble) {
-  if (!this.workspace) {
-    // This block is being deleted so don't try to render it.
+  if (!this.workspace || !this.eventsInit_) {
+    // This block is being deleted or created so don't try to render it.
     return;
   }
   Blockly.Field.startCache();

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -241,6 +241,7 @@ Blockly.RenderedConnection.prototype.unhideAll = function() {
   }
   var block = this.targetBlock();
   if (block) {
+    renderList[0] = block;
     var connections;
     if (block.isCollapsed()) {
       // This block should only be partially revealed since it is collapsed.
@@ -254,10 +255,6 @@ Blockly.RenderedConnection.prototype.unhideAll = function() {
     }
     for (var i = 0; i < connections.length; i++) {
       renderList.push.apply(renderList, connections[i].unhideAll());
-    }
-    if (!renderList.length) {
-      // Leaf block.
-      renderList[0] = block;
     }
   }
   return renderList;
@@ -348,7 +345,11 @@ Blockly.RenderedConnection.prototype.connect = function(otherConnection) {
     if (superiorConnection.hidden_) {
       superiorConnection.hideAll();
     } else {
-      superiorConnection.unhideAll();
+      var renderList = superiorConnection.unhideAll();
+      for (var i = 0; i < renderList.length; i++) {
+        var block = renderList[i];
+        block.render();
+      }
     }
   }
 };


### PR DESCRIPTION
Fixes some positioning issues when undoing a block delete in a
stack of blocks.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Followup on https://github.com/google/blockly/pull/2666 to fix a positioning issue
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

When blocks are connected and visible they need to be rerendered to be placed correctly.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/2674)
<!-- Reviewable:end -->
