### PR TITLE
Block rendering namespace

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -34,28 +34,16 @@ goog.require('BRC');
 goog.require('Blockly.blockRendering.Measurable');
 
 /**
- * Render the given block.
- * @param {!Blockly.BlockSvg} block The block to render
- * @public
- */
-Blockly.blockRendering.render = function(block) {
-  if (!block.renderingDebugger) {
-    block.renderingDebugger = new Blockly.blockRendering.Debug();
-  }
-  new Blockly.blockRendering.Drawer(block).draw_();
-};
-
-/**
  * An object that draws a block based on the given rendering information.
  * @param {!Blockly.BlockSvg} block The block to render
  * @param {!Blockly.blockRendering.RenderInfo} info An object containing all
  *   information needed to render this block.
- * @private
+ * @package
  */
-Blockly.blockRendering.Drawer = function(block) {
+Blockly.blockRendering.Drawer = function(block, info) {
   this.block_ = block;
+  this.info_ = info;
   this.topLeft_ = block.getRelativeToSurfaceXY();
-  this.info_ = new Blockly.blockRendering.RenderInfo(block);
   this.pathObject_ = new Blockly.BlockSvg.PathObject();
   this.steps_ = this.pathObject_.steps;
   this.inlineSteps_ = this.pathObject_.inlineSteps;

--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -24,43 +24,43 @@
  */
 
 //'use strict';
-goog.provide('Blockly.BlockRendering.Drawer');
+goog.provide('Blockly.blockRendering.Drawer');
 
-goog.require('Blockly.BlockRendering.Debug');
-goog.require('Blockly.BlockRendering.RenderInfo');
-goog.require('Blockly.BlockRendering.Highlighter');
+goog.require('Blockly.blockRendering.Debug');
+goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.blockRendering.Highlighter');
 goog.require('BRC');
 /* global BRC */
-goog.require('Blockly.BlockRendering.Measurable');
+goog.require('Blockly.blockRendering.Measurable');
 
 /**
  * Render the given block.
  * @param {!Blockly.BlockSvg} block The block to render
  * @public
  */
-Blockly.BlockRendering.render = function(block) {
+Blockly.blockRendering.render = function(block) {
   if (!block.renderingDebugger) {
-    block.renderingDebugger = new Blockly.BlockRendering.Debug();
+    block.renderingDebugger = new Blockly.blockRendering.Debug();
   }
-  new Blockly.BlockRendering.Drawer(block).draw_();
+  new Blockly.blockRendering.Drawer(block).draw_();
 };
 
 /**
  * An object that draws a block based on the given rendering information.
  * @param {!Blockly.BlockSvg} block The block to render
- * @param {!Blockly.BlockRendering.RenderInfo} info An object containing all
+ * @param {!Blockly.blockRendering.RenderInfo} info An object containing all
  *   information needed to render this block.
  * @private
  */
-Blockly.BlockRendering.Drawer = function(block) {
+Blockly.blockRendering.Drawer = function(block) {
   this.block_ = block;
   this.topLeft_ = block.getRelativeToSurfaceXY();
-  this.info_ = new Blockly.BlockRendering.RenderInfo(block);
+  this.info_ = new Blockly.blockRendering.RenderInfo(block);
   this.pathObject_ = new Blockly.BlockSvg.PathObject();
   this.steps_ = this.pathObject_.steps;
   this.inlineSteps_ = this.pathObject_.inlineSteps;
   this.highlighter_ =
-      new Blockly.BlockRendering.Highlighter(this.info_, this.pathObject_);
+      new Blockly.blockRendering.Highlighter(this.info_, this.pathObject_);
 };
 
 /**
@@ -73,7 +73,7 @@ Blockly.BlockRendering.Drawer = function(block) {
  * required.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.draw_ = function() {
+Blockly.blockRendering.Drawer.prototype.draw_ = function() {
   this.drawOutline_();
   this.drawInternals_();
   this.block_.setPaths_(this.pathObject_);
@@ -87,7 +87,7 @@ Blockly.BlockRendering.Drawer.prototype.draw_ = function() {
  * Anything that needs to be kept around should be set in this function.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
+Blockly.blockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
   // This is used when the block is reporting its size to anyone else.
   // The dark path adds to the size of the block in both X and Y.
   this.block_.height = this.info_.height + BRC.DARK_PATH_OFFSET;
@@ -100,7 +100,7 @@ Blockly.BlockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
  * Create the outline of the block.  This is a single continuous path.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawOutline_ = function() {
+Blockly.blockRendering.Drawer.prototype.drawOutline_ = function() {
   this.drawTop_();
   for (var r = 1; r < this.info_.rows.length - 1; r++) {
     var row = this.info_.rows[r];
@@ -122,7 +122,7 @@ Blockly.BlockRendering.Drawer.prototype.drawOutline_ = function() {
  * details such as hats and rounded corners.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawTop_ = function() {
+Blockly.blockRendering.Drawer.prototype.drawTop_ = function() {
   var topRow = this.info_.topRow;
   var elements = topRow.elements;
 
@@ -150,11 +150,11 @@ Blockly.BlockRendering.Drawer.prototype.drawTop_ = function() {
 /**
  * Add steps for an external value input, rendered as a notch in the side
  * of the block.
- * @param {!Blockly.BlockRendering.Row} row The row that this input
+ * @param {!Blockly.blockRendering.Row} row The row that this input
  *     belongs to.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawValueInput_ = function(row) {
+Blockly.blockRendering.Drawer.prototype.drawValueInput_ = function(row) {
   this.highlighter_.drawValueInput(row);
   this.steps_.push('H', row.width);
   this.steps_.push(BRC.TAB_PATH_DOWN);
@@ -165,11 +165,11 @@ Blockly.BlockRendering.Drawer.prototype.drawValueInput_ = function(row) {
 
 /**
  * Add steps for a statement input.
- * @param {!Blockly.BlockRendering.Row} row The row that this input
+ * @param {!Blockly.blockRendering.Row} row The row that this input
  *     belongs to.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
+Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   this.highlighter_.drawStatementInput(row);
   var x = row.statementEdge + BRC.NOTCH_OFFSET_RIGHT;
   this.steps_.push('H', x);
@@ -183,11 +183,11 @@ Blockly.BlockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
 /**
  * Add steps for the right side of a row that does not have value or
  * statement input connections.
- * @param {!Blockly.BlockRendering.Row} row The row to draw the
+ * @param {!Blockly.blockRendering.Row} row The row to draw the
  *     side of.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
+Blockly.blockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
   this.highlighter_.drawRightSideRow(row);
   this.steps_.push('H', row.width);
   this.steps_.push('v', row.height);
@@ -199,7 +199,7 @@ Blockly.BlockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
  * for the next connection
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawBottom_ = function() {
+Blockly.blockRendering.Drawer.prototype.drawBottom_ = function() {
   var bottomRow = this.info_.bottomRow;
   var elems = bottomRow.elements;
   this.highlighter_.drawBottomCorner(bottomRow);
@@ -224,7 +224,7 @@ Blockly.BlockRendering.Drawer.prototype.drawBottom_ = function() {
  * connection
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawLeft_ = function() {
+Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
   this.highlighter_.drawLeft();
 
   this.positionOutputConnection_();
@@ -243,7 +243,7 @@ Blockly.BlockRendering.Drawer.prototype.drawLeft_ = function() {
  * not depend on the outer path for placement.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawInternals_ = function() {
+Blockly.blockRendering.Drawer.prototype.drawInternals_ = function() {
   for (var r = 0; r < this.info_.rows.length; r++) {
     var row = this.info_.rows[r];
     if (!(row.isSpacer())) {
@@ -267,7 +267,7 @@ Blockly.BlockRendering.Drawer.prototype.drawInternals_ = function() {
  * @return {number} How far to offset the field in the x direction.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.dealWithOffsetFields_ = function(field) {
+Blockly.blockRendering.Drawer.prototype.dealWithOffsetFields_ = function(field) {
   if (field instanceof Blockly.FieldDropdown
       || field instanceof Blockly.FieldTextInput
       || field instanceof Blockly.FieldColour
@@ -279,11 +279,11 @@ Blockly.BlockRendering.Drawer.prototype.dealWithOffsetFields_ = function(field) 
 
 /**
  * Push a field or icon's new position to its SVG root.
- * @param {!Blockly.BlockRendering.Icon|!Blockly.BlockRendering.Field} fieldInfo
+ * @param {!Blockly.blockRendering.Icon|!Blockly.blockRendering.Field} fieldInfo
  *     The rendering information for the field or icon.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
+Blockly.blockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
   if (fieldInfo.type == 'field') {
     var svgGroup = fieldInfo.field.getSvgRoot();
   } else if (fieldInfo.type == 'icon') {
@@ -314,11 +314,11 @@ Blockly.BlockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
 
 /**
  * Add steps for an inline input.
- * @param {Blockly.BlockRendering.RenderableInput} input The information about the
+ * @param {Blockly.blockRendering.RenderableInput} input The information about the
  * input to render.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.drawInlineInput_ = function(input) {
+Blockly.blockRendering.Drawer.prototype.drawInlineInput_ = function(input) {
   this.highlighter_.drawInlineInput(input);
   var width = input.width;
   var height = input.height;
@@ -340,11 +340,11 @@ Blockly.BlockRendering.Drawer.prototype.drawInlineInput_ = function(input) {
  * Position the connection on an inline value input, taking into account
  * RTL and the small gap between the parent block and child block which lets the
  * parent block's dark path show through.
- * @param {Blockly.BlockRendering.RenderableInput} input The information about
+ * @param {Blockly.blockRendering.RenderableInput} input The information about
  * the input that the connection is on.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionInlineInputConnection_ = function(input) {
+Blockly.blockRendering.Drawer.prototype.positionInlineInputConnection_ = function(input) {
   var yPos = input.centerline - input.height / 2;
   // Move the connection.
   if (input.connection) {
@@ -361,10 +361,10 @@ Blockly.BlockRendering.Drawer.prototype.positionInlineInputConnection_ = functio
  * Position the connection on a statement input, taking into account
  * RTL and the small gap between the parent block and child block which lets the
  * parent block's dark path show through.
- * @param {!Blockly.BlockRendering.Row} row The row that the connection is on.
+ * @param {!Blockly.blockRendering.Row} row The row that the connection is on.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionStatementInputConnection_ = function(row) {
+Blockly.blockRendering.Drawer.prototype.positionStatementInputConnection_ = function(row) {
   var input = row.getLastInput();
   if (input.connection) {
     var connX = row.statementEdge + BRC.NOTCH_OFFSET_LEFT + BRC.DARK_PATH_OFFSET;
@@ -379,10 +379,10 @@ Blockly.BlockRendering.Drawer.prototype.positionStatementInputConnection_ = func
  * Position the connection on an external value input, taking into account
  * RTL and the small gap between the parent block and child block which lets the
  * parent block's dark path show through.
- * @param {!Blockly.BlockRendering.Row} row The row that the connection is on.
+ * @param {!Blockly.blockRendering.Row} row The row that the connection is on.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionExternalValueConnection_ = function(row) {
+Blockly.blockRendering.Drawer.prototype.positionExternalValueConnection_ = function(row) {
   var input = row.getLastInput();
   if (input.connection) {
     var connX = row.width + BRC.DARK_PATH_OFFSET;
@@ -397,7 +397,7 @@ Blockly.BlockRendering.Drawer.prototype.positionExternalValueConnection_ = funct
  * Position the previous connection on a block.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionPreviousConnection_ = function() {
+Blockly.blockRendering.Drawer.prototype.positionPreviousConnection_ = function() {
   if (this.info_.topRow.hasPreviousConnection) {
     var connX = this.info_.RTL ? -BRC.NOTCH_OFFSET_LEFT : BRC.NOTCH_OFFSET_LEFT;
     this.info_.topRow.connection.setOffsetInBlock(connX, 0);
@@ -408,7 +408,7 @@ Blockly.BlockRendering.Drawer.prototype.positionPreviousConnection_ = function()
  * Position the next connection on a block.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionNextConnection_ = function() {
+Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
   var bottomRow = this.info_.bottomRow;
 
   if (bottomRow.hasNextConnection) {
@@ -420,10 +420,10 @@ Blockly.BlockRendering.Drawer.prototype.positionNextConnection_ = function() {
 
 /**
  * Position the output connection on a block.
- * @param {!Blockly.BlockRendering.BottomRow} row The bottom row on the block.
+ * @param {!Blockly.blockRendering.BottomRow} row The bottom row on the block.
  * @private
  */
-Blockly.BlockRendering.Drawer.prototype.positionOutputConnection_ = function() {
+Blockly.blockRendering.Drawer.prototype.positionOutputConnection_ = function() {
   if (this.info_.hasOutputConnection) {
     this.block_.outputConnection.setOffsetInBlock(0, BRC.TAB_OFFSET_FROM_TOP);
   }

--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -24,17 +24,17 @@
  */
 
 //'use strict';
-goog.provide('Blockly.BlockRendering.Debug');
-goog.require('Blockly.BlockRendering.RenderInfo');
-goog.require('Blockly.BlockRendering.Highlighter');
+goog.provide('Blockly.blockRendering.Debug');
+goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.blockRendering.Highlighter');
 goog.require('BRC');
-goog.require('Blockly.BlockRendering.Measurable');
+goog.require('Blockly.blockRendering.Measurable');
 
 /**
  * An object that renders rectangles and dots for debugging rendering code.
  * @package
  */
-Blockly.BlockRendering.Debug = function() {
+Blockly.blockRendering.Debug = function() {
   /**
    * An array of SVG elements that have been created by this object.
    * @type {Array.<!SVGElement>}
@@ -53,7 +53,7 @@ Blockly.BlockRendering.Debug = function() {
  * Remove all elements the this object created on the last pass.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.clearElems = function() {
+Blockly.blockRendering.Debug.prototype.clearElems = function() {
   for (var i = 0, elem; elem = this.debugElements_[i]; i++) {
     Blockly.utils.dom.removeNode(elem);
   }
@@ -63,11 +63,11 @@ Blockly.BlockRendering.Debug.prototype.clearElems = function() {
 
 /**
  * Draw a debug rectangle for a spacer (empty) row.
- * @param {!Blockly.BlockRendering.Row} row The row to render
+ * @param {!Blockly.blockRendering.Row} row The row to render
  * @param {number} cursorY The y position of the top of the row.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
+Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowSpacerRect blockRenderDebug',
@@ -86,7 +86,7 @@ Blockly.BlockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
  * @param {number} centerY The y position of the center of the row, vertically.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, centerY) {
+Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, centerY) {
   var yPos = centerY - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
@@ -106,7 +106,7 @@ Blockly.BlockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, 
  * @param {number} centerY The y position of the center of the row, vertically.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX, centerY) {
+Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX, centerY) {
   var yPos = centerY - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
@@ -130,7 +130,7 @@ Blockly.BlockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX
  * @param {Blockly.RenderedConnection} conn The connection to circle.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawConnection = function(conn) {
+Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
   var colour;
   var size;
   var fill;
@@ -169,7 +169,7 @@ Blockly.BlockRendering.Debug.prototype.drawConnection = function(conn) {
  * @param {number} cursorY The y position of the top of the row.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) {
+Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemRenderingRect blockRenderDebug',
@@ -187,7 +187,7 @@ Blockly.BlockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) 
  * @param {number} cursorY The y position of the top of the row.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY) {
+Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY) {
   var centerY = cursorY + row.height / 2;
   var cursorX = 0;
   for (var e = 0; e < row.elements.length; e++) {
@@ -205,11 +205,11 @@ Blockly.BlockRendering.Debug.prototype.drawRowWithElements = function(row, curso
 /**
  * Do all of the work to draw debug information for the whole block.
  * @param {!Blockly.BlockSvg} block The block to draw debug information for.
- * @param {!Blockly.BlockRendering.RenderInfo} info Rendering information about
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
  *     the block to debug.
  * @package
  */
-Blockly.BlockRendering.Debug.prototype.drawDebug = function(block, info) {
+Blockly.blockRendering.Debug.prototype.drawDebug = function(block, info) {
   this.clearElems();
   this.svgRoot_ = block.getSvgRoot();
   var cursorY = 0;

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -24,12 +24,12 @@
  */
 
 //'use strict';
-goog.provide('Blockly.BlockRendering.Highlighter');
+goog.provide('Blockly.blockRendering.Highlighter');
 
-goog.require('Blockly.BlockRendering.RenderInfo');
+goog.require('Blockly.blockRendering.RenderInfo');
 goog.require('BRC');
 /* global BRC */
-goog.require('Blockly.BlockRendering.Measurable');
+goog.require('Blockly.blockRendering.Measurable');
 
 /**
  * An object that adds highlights to a block based on the given rendering
@@ -42,20 +42,20 @@ goog.require('Blockly.BlockRendering.Measurable');
  * or closed paths.  The highlights for tabs and notches are loosely based on
  * tab and notch shapes, but are not exactly the same.
  *
- * @param {!Blockly.BlockRendering.RenderInfo} info An object containing all
+ * @param {!Blockly.blockRendering.RenderInfo} info An object containing all
  *     information needed to render this block.
  * @param {!Blockly.BlockSvg.PathObject} pathObject An object that stores all of
  *     the block's paths before they are propagated to the page.
  * @package
  */
-Blockly.BlockRendering.Highlighter = function(info, pathObject) {
+Blockly.blockRendering.Highlighter = function(info, pathObject) {
   this.info_ = info;
   this.pathObject_ = pathObject;
   this.highlightSteps_ = this.pathObject_.highlightSteps;
   this.highlightInlineSteps_ = this.pathObject_.highlightInlineSteps;
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawTopCorner = function(row) {
+Blockly.blockRendering.Highlighter.prototype.drawTopCorner = function(row) {
   for (var i = 0, elem; elem = row.elements[i]; i++) {
     if (elem.type === 'square corner') {
       this.highlightSteps_.push(BRC.START_POINT_HIGHLIGHT);
@@ -78,7 +78,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawTopCorner = function(row) {
   this.highlightSteps_.push('H', row.width - BRC.HIGHLIGHT_OFFSET);
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawValueInput = function(row) {
+Blockly.blockRendering.Highlighter.prototype.drawValueInput = function(row) {
   //var v = row.height - BRC.TAB_HEIGHT;
 
   if (this.info_.RTL) {
@@ -100,7 +100,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawValueInput = function(row) {
   }
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) {
+Blockly.blockRendering.Highlighter.prototype.drawStatementInput = function(row) {
   var x = row.statementEdge;
   if (this.info_.RTL) {
     this.highlightSteps_.push('M',
@@ -121,7 +121,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawStatementInput = function(row) 
   }
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
+Blockly.blockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
   if (row.followsStatement) {
     this.highlightSteps_.push('H', row.width);
   }
@@ -131,7 +131,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
   }
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(_row) {
+Blockly.blockRendering.Highlighter.prototype.drawBottomCorner = function(_row) {
   var height = this.info_.height;
   var elems = this.info_.bottomRow.elements;
 
@@ -157,7 +157,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawBottomCorner = function(_row) {
   }
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawLeft = function() {
+Blockly.blockRendering.Highlighter.prototype.drawLeft = function() {
   if (this.info_.hasOutputConnection) {
     if (this.info_.RTL) {
       this.highlightSteps_.push(BRC.OUTPUT_CONNECTION_HIGHLIGHT_RTL);
@@ -175,7 +175,7 @@ Blockly.BlockRendering.Highlighter.prototype.drawLeft = function() {
   }
 };
 
-Blockly.BlockRendering.Highlighter.prototype.drawInlineInput = function(input) {
+Blockly.blockRendering.Highlighter.prototype.drawInlineInput = function(input) {
   var width = input.width;
   var height = input.height;
   var x = input.xPos;

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -25,11 +25,11 @@
 
 //'use strict';
 
-goog.provide('Blockly.BlockRendering.RenderInfo');
+goog.provide('Blockly.blockRendering.RenderInfo');
 
 goog.require('BRC');
 /* global BRC */
-goog.require('Blockly.BlockRendering.Measurable');
+goog.require('Blockly.blockRendering.Measurable');
 
 /**
  * An object containing all sizing information needed to draw this block.
@@ -42,7 +42,7 @@ goog.require('Blockly.BlockRendering.Measurable');
  * @constructor
  * @package
  */
-Blockly.BlockRendering.RenderInfo = function(block) {
+Blockly.blockRendering.RenderInfo = function(block) {
   this.block_ = block;
 
   /**
@@ -119,7 +119,7 @@ Blockly.BlockRendering.RenderInfo = function(block) {
  * @param {!Blockly.BlockSvg} block The block to measure.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.measure_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.measure_ = function() {
   this.createRows_();
   this.addElemSpacing_();
   this.computeBounds_();
@@ -136,18 +136,18 @@ Blockly.BlockRendering.RenderInfo.prototype.measure_ = function() {
  * @param {!Blockly.BlockSvg}  block The block to create rows from.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.createRows_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
   this.createTopRow_();
   this.rows.push(this.topRow);
 
-  var activeRow = new Blockly.BlockRendering.Row();
+  var activeRow = new Blockly.blockRendering.Row();
 
   // Icons always go on the first row, before anything else.
   var icons = this.block_.getIcons();
   if (icons.length) {
     for (var i = 0; i < icons.length; i++) {
       activeRow.elements.push(
-          new Blockly.BlockRendering.Icon(icons[i]));
+          new Blockly.blockRendering.Icon(icons[i]));
     }
   }
 
@@ -158,13 +158,13 @@ Blockly.BlockRendering.RenderInfo.prototype.createRows_ = function() {
     if (this.shouldStartNewRow_(input, this.block_.inputList[i - 1])) {
       // Finish this row and create a new one.
       this.rows.push(activeRow);
-      activeRow = new Blockly.BlockRendering.Row();
+      activeRow = new Blockly.blockRendering.Row();
     }
 
     // All of the fields in an input go on the same row.
     for (var f = 0; f < input.fieldRow.length; f++) {
       var field = input.fieldRow[f];
-      activeRow.elements.push(new Blockly.BlockRendering.Field(field, input));
+      activeRow.elements.push(new Blockly.blockRendering.Field(field, input));
     }
     this.addInput_(input, activeRow);
   }
@@ -180,24 +180,24 @@ Blockly.BlockRendering.RenderInfo.prototype.createRows_ = function() {
  * Create the top row and fill the elements list with all non-spacer elements
  * created.
  */
-Blockly.BlockRendering.RenderInfo.prototype.createTopRow_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.createTopRow_ = function() {
   var hasHat = this.block_.hat ? this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT;
   var hasPrevious = !!this.block_.previousConnection;
   var prevBlock = this.block_.getPreviousBlock();
   var squareCorner = !!this.block_.outputConnection ||
       hasHat || (prevBlock && prevBlock.getNextBlock() == this.block_);
-  this.topRow = new Blockly.BlockRendering.TopRow(this.block_);
+  this.topRow = new Blockly.blockRendering.TopRow(this.block_);
 
   if (squareCorner) {
-    this.topRow.elements.push(new Blockly.BlockRendering.SquareCorner());
+    this.topRow.elements.push(new Blockly.blockRendering.SquareCorner());
   } else {
-    this.topRow.elements.push(new Blockly.BlockRendering.RoundCorner());
+    this.topRow.elements.push(new Blockly.blockRendering.RoundCorner());
   }
 
   if (hasHat) {
-    this.topRow.elements.push(new Blockly.BlockRendering.Hat());
+    this.topRow.elements.push(new Blockly.blockRendering.Hat());
   } else if (hasPrevious) {
-    this.topRow.elements.push(new Blockly.BlockRendering.PreviousConnection());
+    this.topRow.elements.push(new Blockly.blockRendering.PreviousConnection());
   }
 };
 
@@ -205,18 +205,18 @@ Blockly.BlockRendering.RenderInfo.prototype.createTopRow_ = function() {
  * Create the bottom row and fill the elements list with all non-spacer elements
  * created.
  */
-Blockly.BlockRendering.RenderInfo.prototype.createBottomRow_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.createBottomRow_ = function() {
   var squareCorner = !!this.block_.outputConnection || !!this.block_.getNextBlock();
-  this.bottomRow = new Blockly.BlockRendering.BottomRow(this.block_);
+  this.bottomRow = new Blockly.blockRendering.BottomRow(this.block_);
 
   if (squareCorner) {
-    this.bottomRow.elements.push(new Blockly.BlockRendering.SquareCorner());
+    this.bottomRow.elements.push(new Blockly.blockRendering.SquareCorner());
   } else {
-    this.bottomRow.elements.push(new Blockly.BlockRendering.RoundCorner());
+    this.bottomRow.elements.push(new Blockly.blockRendering.RoundCorner());
   }
 
   if (this.bottomRow.hasNextConnection) {
-    this.bottomRow.elements.push(new Blockly.BlockRendering.NextConnection());
+    this.bottomRow.elements.push(new Blockly.blockRendering.NextConnection());
   }
 };
 
@@ -225,20 +225,20 @@ Blockly.BlockRendering.RenderInfo.prototype.createBottomRow_ = function() {
  * Add an input element to the active row, if needed, and record the type of the
  * input on the row.
  * @param {!Blockly.Input} input The input to record information about.
- * @param {!Blockly.BlockRendering.Row} activeRow The row that is currently being
+ * @param {!Blockly.blockRendering.Row} activeRow The row that is currently being
  *     populated.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.addInput_ = function(input, activeRow) {
+Blockly.blockRendering.RenderInfo.prototype.addInput_ = function(input, activeRow) {
   // Non-dummy inputs have visual representations onscreen.
   if (this.isInline && input.type == Blockly.INPUT_VALUE) {
-    activeRow.elements.push(new Blockly.BlockRendering.InlineInput(input));
+    activeRow.elements.push(new Blockly.blockRendering.InlineInput(input));
     activeRow.hasInlineInput = true;
   } else if (input.type == Blockly.NEXT_STATEMENT) {
-    activeRow.elements.push(new Blockly.BlockRendering.StatementInput(input));
+    activeRow.elements.push(new Blockly.blockRendering.StatementInput(input));
     activeRow.hasStatement = true;
   } else if (input.type == Blockly.INPUT_VALUE) {
-    activeRow.elements.push(new Blockly.BlockRendering.ExternalValueInput(input));
+    activeRow.elements.push(new Blockly.blockRendering.ExternalValueInput(input));
     activeRow.hasExternalInput = true;
   } else if (input.type == Blockly.DUMMY_INPUT) {
     // Dummy inputs have no visual representation, but the information is still
@@ -254,7 +254,7 @@ Blockly.BlockRendering.RenderInfo.prototype.addInput_ = function(input, activeRo
  * @return {boolean} True if the next input should be rendered on a new row.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.shouldStartNewRow_ = function(input, lastInput) {
+Blockly.blockRendering.RenderInfo.prototype.shouldStartNewRow_ = function(input, lastInput) {
   // If this is the first input, just add to the existing row.
   // That row is either empty or has some icons in it.
   if (!lastInput) {
@@ -275,7 +275,7 @@ Blockly.BlockRendering.RenderInfo.prototype.shouldStartNewRow_ = function(input,
  * Add horizontal spacing between and around elements within each row.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     var oldElems = row.elements;
@@ -283,14 +283,14 @@ Blockly.BlockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
     // No spacing needed before the corner on the top row or the bottom row.
     if (row.type != 'top row' && row.type != 'bottom row') {
       // There's a spacer before the first element in the row.
-      row.elements.push(new Blockly.BlockRendering.InRowSpacer(
+      row.elements.push(new Blockly.blockRendering.InRowSpacer(
           this.getInRowSpacing_(null, oldElems[0])));
     }
 
     for (var e = 0; e < oldElems.length; e++) {
       row.elements.push(oldElems[e]);
       var spacing = this.getInRowSpacing_(oldElems[e], oldElems[e + 1]);
-      row.elements.push(new Blockly.BlockRendering.InRowSpacer(spacing));
+      row.elements.push(new Blockly.blockRendering.InRowSpacer(spacing));
     }
   }
 };
@@ -299,13 +299,13 @@ Blockly.BlockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
  * Calculate the width of a spacer element in a row based on the previous and
  * next elements in that row.  For instance, extra padding is added between two
  * editable fields.
- * @param {Blockly.BlockRendering.Measurable} prev The element before the
+ * @param {Blockly.blockRendering.Measurable} prev The element before the
  *     spacer.
- * @param {Blockly.BlockRendering.Measurable} next The element after the spacer.
+ * @param {Blockly.blockRendering.Measurable} next The element after the spacer.
  * @return {number} The size of the spacing between the two elements.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
+Blockly.blockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next.isField() && next.isEditable) {
@@ -435,7 +435,7 @@ Blockly.BlockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
  * TODO: More cleanup.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.computeBounds_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
   var widestStatementRowFields = 0;
   var blockWidth = 0;
   var widestRowWithConnectedBlocks = 0;
@@ -482,7 +482,7 @@ Blockly.BlockRendering.RenderInfo.prototype.computeBounds_ = function() {
  * the sizes of all rows.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.alignRowElements_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     if (!row.hasStatement && !row.hasInlineInput) {
@@ -503,11 +503,11 @@ Blockly.BlockRendering.RenderInfo.prototype.alignRowElements_ = function() {
  * Modify the given row to add the given amount of padding around its fields.
  * The exact location of the padding is based on the alignment property of the
  * last input in the field.
- * @param {Blockly.BlockRendering.Row} row The row to add padding to.
+ * @param {Blockly.blockRendering.Row} row The row to add padding to.
  * @param {number} missingSpace How much padding to add.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
+Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   var elems = row.elements;
   var input = row.getLastInput();
   if (input) {
@@ -541,7 +541,7 @@ Blockly.BlockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
  * Add spacers between rows and set their sizes.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.addRowSpacing_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.addRowSpacing_ = function() {
   var oldRows = this.rows;
   this.rows = [];
 
@@ -555,15 +555,15 @@ Blockly.BlockRendering.RenderInfo.prototype.addRowSpacing_ = function() {
 
 /**
  * Create a spacer row to go between prev and next, and set its size.
- * @param {?Blockly.BlockRendering.Measurable} prev The previous row, or null.
- * @param {?Blockly.BlockRendering.Measurable} next The next row, or null.
+ * @param {?Blockly.blockRendering.Measurable} prev The previous row, or null.
+ * @param {?Blockly.blockRendering.Measurable} next The next row, or null.
  * @return {!Blockly.BlockSvg.BetweenRowSpacer} The newly created spacer row.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
+Blockly.blockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
   var height = this.getSpacerRowHeight_(prev, next);
   var width = this.getSpacerRowWidth_(prev, next);
-  var spacer = new Blockly.BlockRendering.BetweenRowSpacer(height, width);
+  var spacer = new Blockly.blockRendering.BetweenRowSpacer(height, width);
   if (prev.hasStatement) {
     spacer.followsStatement = true;
   }
@@ -574,12 +574,12 @@ Blockly.BlockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next
  * Calculate the width of a spacer row.  Almost all spacers will be the full
  * width of the block, but there are some exceptions (e.g. the small spacer row
  * after a statement input)
- * @param {Blockly.BlockRendering.Row} prev The row before the spacer.
- * @param {Blockly.BlockRendering.Row} next The row after the spacer.
+ * @param {Blockly.blockRendering.Row} prev The row before the spacer.
+ * @param {Blockly.blockRendering.Row} next The row after the spacer.
  * @return {number} The desired width of the spacer row between these two rows.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
+Blockly.blockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
   // The width of the spacer before the bottom row should be the same as the
   // bottom row.
   if (next.type === 'bottom row'
@@ -591,12 +591,12 @@ Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, 
 
 /**
  * Calculate the height of a spacer row.
- * @param {Blockly.BlockRendering.Row} prev The row before the spacer.
- * @param {Blockly.BlockRendering.Row} next The row after the spacer.
+ * @param {Blockly.blockRendering.Row} prev The row before the spacer.
+ * @param {Blockly.blockRendering.Row} next The row after the spacer.
  * @return {number} The desired height of the spacer row between these two rows.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev, next) {
+Blockly.blockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev, next) {
   // If we have an empty block add a spacer to increase the height
   if (prev.type === 'top row' && next.type === 'bottom row') {
     return BRC.EMPTY_BLOCK_SPACER_HEIGHT;
@@ -622,13 +622,13 @@ Blockly.BlockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev,
 
 /**
  * Calculate the centerline of an element in a rendered row.
- * @param {Blockly.BlockRendering.Row} row The row containing the element.
- * @param {Blockly.BlockRendering.Measurable} elem The element to place.
+ * @param {Blockly.blockRendering.Row} row The row containing the element.
+ * @param {Blockly.blockRendering.Measurable} elem The element to place.
  * @return {number} The desired centerline of the given element, as an offset
  *     from the top left of the block.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
+Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
   var result = row.yPos;
   if (elem.isField()) {
     result += (elem.height / 2);
@@ -647,7 +647,7 @@ Blockly.BlockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, e
  * store the y position of each row, and record the height of the full block.
  * @private
  */
-Blockly.BlockRendering.RenderInfo.prototype.finalize_ = function() {
+Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
   // Performance note: this could be combined with the draw pass, if the time
   // that this takes is excessive.  But it shouldn't be, because it only
   // accesses and sets properties that already exist on the objects.

--- a/core/renderers/block_rendering_rewrite/block_rendering.js
+++ b/core/renderers/block_rendering_rewrite/block_rendering.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Namespace for block rendering functionality.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+
+'use strict';
+/**
+ * The top level namespace for block rendering.
+ * @namespace Blockly.blockRendering
+ */
+goog.provide('Blockly.blockRendering');
+
+goog.require('Blockly.blockRendering.Debug');
+goog.require('Blockly.blockRendering.Drawer');
+goog.require('Blockly.blockRendering.RenderInfo');
+
+/**
+ * Render the given block.
+ * @param {!Blockly.BlockSvg} block The block to render
+ * @public
+ */
+Blockly.blockRendering.render = function(block) {
+  if (!block.renderingDebugger) {
+    block.renderingDebugger = new Blockly.blockRendering.Debug();
+  }
+  var info = new Blockly.blockRendering.RenderInfo(block);
+  new Blockly.blockRendering.Drawer(block, info).draw_();
+};

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -1,4 +1,4 @@
-goog.provide('Blockly.BlockRendering.Measurable');
+goog.provide('Blockly.blockRendering.Measurable');
 
 goog.require('BRC');
 /* global BRC */
@@ -10,7 +10,7 @@ goog.require('BRC');
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Measurable = function() {
+Blockly.blockRendering.Measurable = function() {
   this.isInput = false;
   this.width = 0;
   this.height = 0;
@@ -28,7 +28,7 @@ Blockly.BlockRendering.Measurable = function() {
  * @return {boolean} True if this object stores information about a field.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isField = function() {
+Blockly.blockRendering.Measurable.prototype.isField = function() {
   return this.type == 'field';
 };
 
@@ -37,7 +37,7 @@ Blockly.BlockRendering.Measurable.prototype.isField = function() {
  * @return {boolean} True if this object stores information about a hat.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isHat = function() {
+Blockly.blockRendering.Measurable.prototype.isHat = function() {
   return this.type == 'hat';
 };
 
@@ -46,7 +46,7 @@ Blockly.BlockRendering.Measurable.prototype.isHat = function() {
  * @return {boolean} True if this object stores information about an icon.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isIcon = function() {
+Blockly.blockRendering.Measurable.prototype.isIcon = function() {
   return this.type == 'icon';
 };
 
@@ -55,7 +55,7 @@ Blockly.BlockRendering.Measurable.prototype.isIcon = function() {
  * @return {boolean} True if this object stores information about a spacer.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isSpacer = function() {
+Blockly.blockRendering.Measurable.prototype.isSpacer = function() {
   return this.type == 'between-row spacer' || this.type == 'in-row spacer';
 };
 
@@ -65,7 +65,7 @@ Blockly.BlockRendering.Measurable.prototype.isSpacer = function() {
  * input.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isExternalInput = function() {
+Blockly.blockRendering.Measurable.prototype.isExternalInput = function() {
   return this.type == 'external value input';
 };
 
@@ -75,7 +75,7 @@ Blockly.BlockRendering.Measurable.prototype.isExternalInput = function() {
  * input.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isInlineInput = function() {
+Blockly.blockRendering.Measurable.prototype.isInlineInput = function() {
   return this.type == 'inline input';
 };
 
@@ -85,7 +85,7 @@ Blockly.BlockRendering.Measurable.prototype.isInlineInput = function() {
  * input.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isStatementInput = function() {
+Blockly.blockRendering.Measurable.prototype.isStatementInput = function() {
   return this.type == 'statement input';
 };
 
@@ -95,7 +95,7 @@ Blockly.BlockRendering.Measurable.prototype.isStatementInput = function() {
  * connection.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isPreviousConnection = function() {
+Blockly.blockRendering.Measurable.prototype.isPreviousConnection = function() {
   return this.type == 'previous connection';
 };
 
@@ -105,7 +105,7 @@ Blockly.BlockRendering.Measurable.prototype.isPreviousConnection = function() {
  * connection.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isNextConnection = function() {
+Blockly.blockRendering.Measurable.prototype.isNextConnection = function() {
   return this.type == 'next connection';
 };
 
@@ -115,7 +115,7 @@ Blockly.BlockRendering.Measurable.prototype.isNextConnection = function() {
  * corner.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isRoundedCorner = function() {
+Blockly.blockRendering.Measurable.prototype.isRoundedCorner = function() {
   return this.type == 'round corner';
 };
 
@@ -125,7 +125,7 @@ Blockly.BlockRendering.Measurable.prototype.isRoundedCorner = function() {
  * corner.
  * @package
  */
-Blockly.BlockRendering.Measurable.prototype.isSquareCorner = function() {
+Blockly.blockRendering.Measurable.prototype.isSquareCorner = function() {
   return this.type == 'square corner';
 };
 /**
@@ -135,8 +135,8 @@ Blockly.BlockRendering.Measurable.prototype.isSquareCorner = function() {
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Input = function(input) {
-  Blockly.BlockRendering.Input.superClass_.constructor.call(this);
+Blockly.blockRendering.Input = function(input) {
+  Blockly.blockRendering.Input.superClass_.constructor.call(this);
 
   this.isInput = true;
   this.input = input;
@@ -157,7 +157,7 @@ Blockly.BlockRendering.Input = function(input) {
   this.connectionOffsetX = 0;
   this.connectionOffsetY = 0;
 };
-goog.inherits(Blockly.BlockRendering.Input, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.Input, Blockly.blockRendering.Measurable);
 
 
 /**
@@ -167,8 +167,8 @@ goog.inherits(Blockly.BlockRendering.Input, Blockly.BlockRendering.Measurable);
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Icon = function(icon) {
-  Blockly.BlockRendering.Icon.superClass_.constructor.call(this);
+Blockly.blockRendering.Icon = function(icon) {
+  Blockly.blockRendering.Icon.superClass_.constructor.call(this);
   this.icon = icon;
   this.isVisible = icon.isVisible();
   this.type = 'icon';
@@ -177,7 +177,7 @@ Blockly.BlockRendering.Icon = function(icon) {
   this.height = size.height;
   this.width = size.width;
 };
-goog.inherits(Blockly.BlockRendering.Icon, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.Icon, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space a field takes up during
@@ -187,8 +187,8 @@ goog.inherits(Blockly.BlockRendering.Icon, Blockly.BlockRendering.Measurable);
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Field = function(field, parentInput) {
-  Blockly.BlockRendering.Field.superClass_.constructor.call(this);
+Blockly.blockRendering.Field = function(field, parentInput) {
+  Blockly.blockRendering.Field.superClass_.constructor.call(this);
   this.field = field;
   this.isEditable = field.isCurrentlyEditable();
   this.type = 'field';
@@ -198,7 +198,7 @@ Blockly.BlockRendering.Field = function(field, parentInput) {
   this.width = size.width;
   this.parentInput = parentInput;
 };
-goog.inherits(Blockly.BlockRendering.Field, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.Field, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space an inline input takes up
@@ -208,8 +208,8 @@ goog.inherits(Blockly.BlockRendering.Field, Blockly.BlockRendering.Measurable);
  * @package
  * @constructor
  */
-Blockly.BlockRendering.InlineInput = function(input) {
-  Blockly.BlockRendering.InlineInput.superClass_.constructor.call(this, input);
+Blockly.blockRendering.InlineInput = function(input) {
+  Blockly.blockRendering.InlineInput.superClass_.constructor.call(this, input);
   this.type = 'inline input';
 
   if (!this.connectedBlock) {
@@ -222,7 +222,7 @@ Blockly.BlockRendering.InlineInput = function(input) {
     this.height = this.connectedBlockHeight + BRC.DARK_PATH_OFFSET;
   }
 };
-goog.inherits(Blockly.BlockRendering.InlineInput, Blockly.BlockRendering.Input);
+goog.inherits(Blockly.blockRendering.InlineInput, Blockly.blockRendering.Input);
 
 /**
  * An object containing information about the space a statement input takes up
@@ -232,8 +232,8 @@ goog.inherits(Blockly.BlockRendering.InlineInput, Blockly.BlockRendering.Input);
  * @package
  * @constructor
  */
-Blockly.BlockRendering.StatementInput = function(input) {
-  Blockly.BlockRendering.StatementInput.superClass_.constructor.call(this, input);
+Blockly.blockRendering.StatementInput = function(input) {
+  Blockly.blockRendering.StatementInput.superClass_.constructor.call(this, input);
   this.type = 'statement input';
 
   if (!this.connectedBlock) {
@@ -247,8 +247,8 @@ Blockly.BlockRendering.StatementInput = function(input) {
     }
   }
 };
-goog.inherits(Blockly.BlockRendering.StatementInput,
-    Blockly.BlockRendering.Input);
+goog.inherits(Blockly.blockRendering.StatementInput,
+    Blockly.blockRendering.Input);
 
 /**
  * An object containing information about the space an external value input
@@ -258,8 +258,8 @@ goog.inherits(Blockly.BlockRendering.StatementInput,
  * @package
  * @constructor
  */
-Blockly.BlockRendering.ExternalValueInput = function(input) {
-  Blockly.BlockRendering.ExternalValueInput.superClass_.constructor.call(this, input);
+Blockly.blockRendering.ExternalValueInput = function(input) {
+  Blockly.blockRendering.ExternalValueInput.superClass_.constructor.call(this, input);
   this.type = 'external value input';
 
   if (!this.connectedBlock) {
@@ -269,8 +269,8 @@ Blockly.BlockRendering.ExternalValueInput = function(input) {
   }
   this.width = BRC.EXTERNAL_VALUE_INPUT_WIDTH;
 };
-goog.inherits(Blockly.BlockRendering.ExternalValueInput,
-    Blockly.BlockRendering.Input);
+goog.inherits(Blockly.blockRendering.ExternalValueInput,
+    Blockly.blockRendering.Input);
 
 /**
  * An object containing information about the space a previous connection takes
@@ -278,14 +278,14 @@ goog.inherits(Blockly.BlockRendering.ExternalValueInput,
  * @package
  * @constructor
  */
-Blockly.BlockRendering.PreviousConnection = function() {
-  Blockly.BlockRendering.PreviousConnection.superClass_.constructor.call(this);
+Blockly.blockRendering.PreviousConnection = function() {
+  Blockly.blockRendering.PreviousConnection.superClass_.constructor.call(this);
   this.type = 'previous connection';
   this.height = BRC.NOTCH_HEIGHT;
   this.width = BRC.NOTCH_WIDTH;
 
 };
-goog.inherits(Blockly.BlockRendering.PreviousConnection, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.PreviousConnection, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space a next connection takes
@@ -293,13 +293,13 @@ goog.inherits(Blockly.BlockRendering.PreviousConnection, Blockly.BlockRendering.
  * @package
  * @constructor
  */
-Blockly.BlockRendering.NextConnection = function() {
-  Blockly.BlockRendering.NextConnection.superClass_.constructor.call(this);
+Blockly.blockRendering.NextConnection = function() {
+  Blockly.blockRendering.NextConnection.superClass_.constructor.call(this);
   this.type = 'next connection';
   this.height = BRC.NOTCH_HEIGHT;
   this.width = BRC.NOTCH_WIDTH;
 };
-goog.inherits(Blockly.BlockRendering.NextConnection, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.NextConnection, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space a hat takes up during
@@ -307,14 +307,14 @@ goog.inherits(Blockly.BlockRendering.NextConnection, Blockly.BlockRendering.Meas
  * @package
  * @constructor
  */
-Blockly.BlockRendering.Hat = function() {
-  Blockly.BlockRendering.Hat.superClass_.constructor.call(this);
+Blockly.blockRendering.Hat = function() {
+  Blockly.blockRendering.Hat.superClass_.constructor.call(this);
   this.type = 'hat';
   this.height = BRC.NO_PADDING;
   this.width = BRC.START_HAT_WIDTH;
 
 };
-goog.inherits(Blockly.BlockRendering.Hat, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.Hat, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space a square corner takes up
@@ -322,14 +322,14 @@ goog.inherits(Blockly.BlockRendering.Hat, Blockly.BlockRendering.Measurable);
  * @package
  * @constructor
  */
-Blockly.BlockRendering.SquareCorner = function() {
-  Blockly.BlockRendering.SquareCorner.superClass_.constructor.call(this);
+Blockly.blockRendering.SquareCorner = function() {
+  Blockly.blockRendering.SquareCorner.superClass_.constructor.call(this);
   this.type = 'square corner';
   this.height = BRC.NOTCH_HEIGHT;
   this.width = BRC.NO_PADDING;
 
 };
-goog.inherits(Blockly.BlockRendering.SquareCorner, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.SquareCorner, Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about the space a rounded corner takes up
@@ -337,8 +337,8 @@ goog.inherits(Blockly.BlockRendering.SquareCorner, Blockly.BlockRendering.Measur
  * @package
  * @constructor
  */
-Blockly.BlockRendering.RoundCorner = function() {
-  Blockly.BlockRendering.RoundCorner.superClass_.constructor.call(this);
+Blockly.blockRendering.RoundCorner = function() {
+  Blockly.blockRendering.RoundCorner.superClass_.constructor.call(this);
   this.type = 'round corner';
   this.width = BRC.CORNER_RADIUS;
   // The rounded corner extends into the next row by 4 so we only take the
@@ -346,10 +346,10 @@ Blockly.BlockRendering.RoundCorner = function() {
   this.height = BRC.NOTCH_HEIGHT;
 
 };
-goog.inherits(Blockly.BlockRendering.RoundCorner, Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.RoundCorner, Blockly.blockRendering.Measurable);
 
 
-Blockly.BlockRendering.Row = function() {
+Blockly.blockRendering.Row = function() {
   this.type = 'row';
   this.yPos = 0;
   this.elements = [];
@@ -362,11 +362,11 @@ Blockly.BlockRendering.Row = function() {
   this.hasDummyInput = false;
 };
 
-Blockly.BlockRendering.Row.prototype.isSpacer = function() {
+Blockly.blockRendering.Row.prototype.isSpacer = function() {
   return false;
 };
 
-Blockly.BlockRendering.Row.prototype.measure = function() {
+Blockly.blockRendering.Row.prototype.measure = function() {
   var connectedBlockWidths = 0;
   for (var e = 0; e < this.elements.length; e++) {
     var elem = this.elements[e];
@@ -382,7 +382,7 @@ Blockly.BlockRendering.Row.prototype.measure = function() {
   this.widthWithConnectedBlocks = this.width + connectedBlockWidths;
 };
 
-Blockly.BlockRendering.Row.prototype.getLastInput = function() {
+Blockly.blockRendering.Row.prototype.getLastInput = function() {
   // There's always a spacer after the last input, unless there are no inputs.
   if (this.elements.length > 1) {
     var elem = this.elements[this.elements.length - 2];
@@ -396,30 +396,30 @@ Blockly.BlockRendering.Row.prototype.getLastInput = function() {
   return null;
 };
 
-Blockly.BlockRendering.Row.prototype.getFirstSpacer = function() {
+Blockly.blockRendering.Row.prototype.getFirstSpacer = function() {
   return this.elements[0];
 };
 
-Blockly.BlockRendering.Row.prototype.getLastSpacer = function() {
+Blockly.blockRendering.Row.prototype.getLastSpacer = function() {
   return this.elements[this.elements.length - 1];
 };
 
-Blockly.BlockRendering.BetweenRowSpacer = function(height, width) {
+Blockly.blockRendering.BetweenRowSpacer = function(height, width) {
   this.type = 'between-row spacer';
   this.width = width;
   this.height = height;
   this.followsStatement = false;
 };
-goog.inherits(Blockly.BlockRendering.BetweenRowSpacer,
-    Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.BetweenRowSpacer,
+    Blockly.blockRendering.Measurable);
 
-Blockly.BlockRendering.InRowSpacer = function(width) {
+Blockly.blockRendering.InRowSpacer = function(width) {
   this.type = 'in-row spacer';
   this.width = width;
   this.height = BRC.SPACER_DEFAULT_HEIGHT;
 };
-goog.inherits(Blockly.BlockRendering.InRowSpacer,
-    Blockly.BlockRendering.Measurable);
+goog.inherits(Blockly.blockRendering.InRowSpacer,
+    Blockly.blockRendering.Measurable);
 
 /**
  * An object containing information about what elements are in the top row of a
@@ -428,8 +428,8 @@ goog.inherits(Blockly.BlockRendering.InRowSpacer,
  * @param {[type]} block [description]
  * @package
  */
-Blockly.BlockRendering.TopRow = function(block) {
-  Blockly.BlockRendering.TopRow.superClass_.constructor.call(this);
+Blockly.blockRendering.TopRow = function(block) {
+  Blockly.blockRendering.TopRow.superClass_.constructor.call(this);
 
   this.elements = [];
   this.type = 'top row';
@@ -448,15 +448,15 @@ Blockly.BlockRendering.TopRow = function(block) {
     this.height = BRC.MEDIUM_PADDING;
   }
 };
-goog.inherits(Blockly.BlockRendering.TopRow, Blockly.BlockRendering.Row);
+goog.inherits(Blockly.blockRendering.TopRow, Blockly.blockRendering.Row);
 
 
-Blockly.BlockRendering.TopRow.prototype.isSpacer = function() {
+Blockly.blockRendering.TopRow.prototype.isSpacer = function() {
   return true;
 };
 
-Blockly.BlockRendering.BottomRow = function(block) {
-  Blockly.BlockRendering.BottomRow.superClass_.constructor.call(this);
+Blockly.blockRendering.BottomRow = function(block) {
+  Blockly.blockRendering.BottomRow.superClass_.constructor.call(this);
   this.type = 'bottom row';
   this.hasNextConnection = !!block.nextConnection;
   this.connection = block.nextConnection;
@@ -475,10 +475,10 @@ Blockly.BlockRendering.BottomRow = function(block) {
   }
 
 };
-goog.inherits(Blockly.BlockRendering.BottomRow,
-    Blockly.BlockRendering.Row);
+goog.inherits(Blockly.blockRendering.BottomRow,
+    Blockly.blockRendering.Row);
 
-Blockly.BlockRendering.BottomRow.prototype.isSpacer = function() {
+Blockly.blockRendering.BottomRow.prototype.isSpacer = function() {
   return true;
 };
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes)
- Rename `Blockly.BlockRendering` to `Blockly.blockRendering` because it's a namespace (first commit)
- Create a block_rendering.js file that defines `render`, instead of having that in block_render_draw.js (second commit)

### Reason for Changes

- Naming scheme we agreed on
- Having the definition of render in draw was confusing

### Additional Information

Next steps:
- Rename `BRC` to `Blockly.blockRendering.constants` and fix up resulting lint (after #2686) lands
- Remove `/* global BRC */` comments
- Uncomment `'use strict';`
