### PR TITLE
Make screenshot tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "^5.13.0",
+    "fs": "0.0.1-security",
     "google-closure-compiler": "^20190618.0.0",
     "google-closure-library": "^20190618.0.0",
     "gulp": "^4.0.2",
@@ -34,6 +36,9 @@
     "gulp-series": "^1.0.2",
     "gulp-shell": "^0.7.1",
     "jshint": "^2.10.2",
+    "mocha": "^6.1.4",
+    "pixelmatch": "^4.0.2",
+    "pngjs": "^3.4.0",
     "webdriverio": "^5.11.5"
   },
   "jshintConfig": {

--- a/tests/screenshot/playground_new.html
+++ b/tests/screenshot/playground_new.html
@@ -34,17 +34,6 @@ limitations under the License.
 <script src="../../blocks/variables_dynamic.js"></script>
 <script src="../../blocks/procedures.js"></script>
 <script src="../blocks/test_blocks.js"></script>
-
-<script src="../../core/block_rendering_rewrite/measurables.js"></script>
-<script src="../../core/block_rendering_rewrite/block_render_info.js"></script>
-<script src="../../core/block_rendering_rewrite/block_render_draw.js"></script>
-<script src="../../core/block_rendering_rewrite/block_render_draw_debug.js"></script>
-<script src="../../core/block_rendering_rewrite/block_rendering_constants.js"></script>
-<script src="../../core/block_rendering_rewrite/block_render_draw_highlight.js"></script>
-<script>
-goog.require('Blockly.BlockRendering.RenderInfo');
-</script>
-
 <style>
 html, body {
   height: 100%;


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes screenshot tests

### Proposed Changes

- Adds new stuff to dev dependencies for the tests
- Removes explicit script tags containing the rendering files
- Removes explicit require

### Reason for Changes

Getting the tests to work on develop.  Now the tests diff the local blockly_uncompressed against the hosted blockly_compressed.  Both use the local block definitions, but those should not be changing much.

### Test Coverage

Ran the screenshot tests.  The results match, as we would expect.