### PR TITLE
Define BORDER_RECT_DEFAULT_HEIGHT constant

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -118,6 +118,13 @@ Blockly.Field.cacheWidths_ = null;
 Blockly.Field.cacheReference_ = 0;
 
 /**
+ * The default height of the border rect on any field.
+ * @type {number}
+ * @package
+ */
+Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT = 16;
+
+/**
  * Name of field.  Unique within each block.
  * Static labels are usually unnamed.
  * @type {string|undefined}
@@ -278,7 +285,7 @@ Blockly.Field.prototype.createBorderRect_ = function() {
         'ry': 4,
         'x': -Blockly.BlockSvg.SEP_SPACE_X / 2,
         'y': 0,
-        'height': 16,
+        'height': Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT,
         'width': this.size_.width + Blockly.BlockSvg.SEP_SPACE_X
       }, this.fieldGroup_);
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -442,7 +442,8 @@ Blockly.FieldTextInput.prototype.getCorrectedSize = function() {
   // the logic to figure out whether to rerender, just call getSize.
   this.getSize();
   // TODO (#2562): Remove getCorrectedSize.
-  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X, 16);
+  return new goog.math.Size(this.size_.width + Blockly.BlockSvg.SEP_SPACE_X,
+      Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT);
 };
 
 Blockly.Field.register('field_input', Blockly.FieldTextInput);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Missing definition of this property.

### Proposed Changes

Define it, and use it in two places.

### Reason for Changes

Remove magic numbers.  Also, I was already using this in the new rendering code, but didn't have the definition in.

