### PR TITLE
Added a Better Example of Validating Multi-Part Values to the Custom Fields Demo

### DIFF
--- a/demos/custom-fields/blocks.js
+++ b/demos/custom-fields/blocks.js
@@ -51,9 +51,20 @@ Blockly.Blocks['turtle_nullifier'] = {
   },
 
   validate: function(newValue) {
+    this.cachedValidatedValue_ = Object.assign({}, newValue);
     if ((newValue.turtleName == 'Leonardo' && newValue.hat == 'Mask') ||
         (newValue.turtleName == 'Yertle' && newValue.hat == 'Crown') ||
         (newValue.turtleName == 'Franklin') && newValue.hat == 'Propeller') {
+
+      var currentValue = this.getValue();
+      if (newValue.turtleName != currentValue.turtleName) {
+        // Turtle name changed.
+        this.cachedValidatedValue_.turtleName = null;
+      } else {
+        // Hat must have changed.
+        this.cachedValidatedValue_.hat = null;
+      }
+
       return null;
     }
     return newValue;

--- a/demos/custom-fields/custom-fields.css
+++ b/demos/custom-fields/custom-fields.css
@@ -46,6 +46,7 @@
 }
 
 .customFieldsTurtleWidget .text {
+    height: 20px;
     color: #fff;
     flex-grow: 1;
     text-align: center;

--- a/demos/custom-fields/media/warning.svg
+++ b/demos/custom-fields/media/warning.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path style="fill: #00c; stroke: #fff; stroke-width: 1px;" d="M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z"></path>
+    <path style="fill: #fff;" d="m7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z"></path>
+    <rect style="fill: #fff;" x="7" y="11" height="2" width="2"></rect>
+</svg>


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
https://github.com/google/blockly/pull/2594#discussion_r302133456

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The turtle field now shows a warning icon next to the invalid property.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This better demonstrates validating multipart values. This pattern is also used in the class validator, but as Erik pointed out that could be solved by just using default values. This is a more applicable use case.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested that the warnings hide & show correct:
![Turtle_Display](https://user-images.githubusercontent.com/25440652/61746653-0935fc80-ad51-11e9-875f-87fa972598d5.gif)

Tested that the warning is "saved" when you hide & show the editor:
![Turtle_Saving](https://user-images.githubusercontent.com/25440652/61746681-194ddc00-ad51-11e9-98bf-2bd28d8240a0.gif)

Tested that it goes through XML correctly (it should save the last valid value, i.e. the stovepipe hat):
![Turtle_XML](https://user-images.githubusercontent.com/25440652/61746750-3aaec800-ad51-11e9-97ad-f661062d0bed.gif)

Tested that the other turtle blocks still function correctly:
![Turtle_Simple](https://user-images.githubusercontent.com/25440652/61746779-4c906b00-ad51-11e9-8cd4-44cea0582b18.gif)
![Turtle_Force](https://user-images.githubusercontent.com/25440652/61746780-4dc19800-ad51-11e9-8c5c-ea7420a1a7cd.gif)


Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
The turtle demo should be republished whenever it is convenient (sorry I didn't get this to you peoples sooner).

### Additional Information

<!-- Anything else we should know? -->
N/A
