### PR TITLE
Add debug rendering to playground

### DIFF
--- a/tests/compile/index.html
+++ b/tests/compile/index.html
@@ -13,6 +13,9 @@
       font-weight: normal;
       font-size: 140%;
     }
+    .blockRenderDebug {
+      display: none;
+    }
   </style>
 </head>
 <body>

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -136,6 +136,9 @@ function start() {
     // Restore event logging state.
     var state = sessionStorage.getItem('logEvents');
     logEvents(Boolean(Number(state)));
+    // Restore render debug state.
+    var renderDebugState = sessionStorage.getItem('blockRenderDebug');
+    toggleRenderingDebug(Boolean(Number(renderDebugState)));
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);
@@ -327,6 +330,19 @@ function logEvents(state) {
   }
 }
 
+function toggleRenderingDebug(state) {
+  var checkbox = document.getElementById('blockRenderDebugCheck');
+  checkbox.checked = state;
+  if (sessionStorage) {
+    sessionStorage.setItem('blockRenderDebug', Number(state));
+  }
+  if (state) {
+    document.getElementById('blocklyDiv').className = 'renderingDebug';
+  } else {
+    document.getElementById('blocklyDiv').className = '';
+  }
+}
+
 function logger(e) {
   console.log(e);
 }
@@ -420,6 +436,40 @@ h1 {
   font-style: italic;
 }
 
+#blocklyDiv.renderingDebug .blockRenderDebug {
+  display: block;
+}
+
+.blockRenderDebug {
+  display: none;
+}
+
+.rowRenderingRect {
+  stroke: black;
+  fill: none;
+  stroke-width: 1px;
+}
+
+.elemRenderingRect {
+  stroke: red;
+  fill: none;
+  stroke-width: 1px;
+}
+
+.rowSpacerRect {
+  stroke: blue;
+  fill-opacity: 0.5;
+  fill: blue;
+  stroke-width: 1px;
+}
+
+.elemSpacerRect {
+  stroke: pink;
+  fill-opacity: 0.5;
+  fill: pink;
+  stroke-width: 1px;
+}
+
 </style>
 </head>
 <body onload="start()">
@@ -481,6 +531,11 @@ h1 {
   <p>
     Log events: &nbsp;
     <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
+  </p>
+
+  <p>
+    Block rendering debug: &nbsp;
+    <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
   </p>
 
   <!-- The next three blocks of XML are sample toolboxes for testing basic


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Add necessary css, checkbox, and callback to playground.html so that debug rendering rectangles can be toggled on and off.
Also add some of that css to the compilation test.

### Reason for Changes

Pulling stuff in from render/collab.

### Test Coverage
Tested that the new checkbox shows up in the playground.