### PR TITLE
Fix the local npm compiler build script

### DIFF
--- a/local_build/local_build.sh
+++ b/local_build/local_build.sh
@@ -53,8 +53,10 @@ fi
 # Find the Closure Compiler.
 if [ -f "$(npm root)/google-closure-compiler/compiler.jar" ]; then
   COMPILER="$(npm root)/google-closure-compiler/compiler.jar"
+  CLOSURE_LIBRARY="$(npm root)/google-closure-library"
 elif [ -f closure-compiler*.jar ]; then
   COMPILER="closure-compiler*.jar"
+  CLOSURE_LIBRARY="../../closure-library"
   # TODO: Check whether multiple files were found.
 else
   echo "ERROR: Closure Compiler not found."
@@ -64,12 +66,13 @@ else
 fi
 
 echo Using $COMPILER as the compiler.
+echo Using $CLOSURE_LIBRARY as the closure library.
 rm local_blockly_compressed.js 2> /dev/null
 echo Compiling Blockly core...
 java -jar $COMPILER \
   --js='../core/**.js' \
-  --js='../../closure-library/closure/goog/**.js' \
-  --js='../../closure-library/third_party/closure/goog/**.js' \
+  --js="$CLOSURE_LIBRARY/closure/goog/**.js" \
+  --js="$CLOSURE_LIBRARY/third_party/closure/goog/**.js" \
   --generate_exports \
   --warning_level='DEFAULT' \
   --compilation_level SIMPLE_OPTIMIZATIONS \
@@ -96,8 +99,8 @@ echo -e "'use strict';\ngoog.provide('Blockly');goog.provide('Blockly.Blocks');"
 cat ../blocks/*.js| grep -v "^'use strict';" >> temp.js
 java -jar $COMPILER \
   --js='temp.js' \
-  --js='../../closure-library/closure/goog/**.js' \
-  --js='../../closure-library/third_party/closure/goog/**.js' \
+  --js="$CLOSURE_LIBRARY/closure/goog/**.js" \
+  --js="$CLOSURE_LIBRARY/third_party/closure/goog/**.js" \
   --generate_exports \
   --warning_level='DEFAULT' \
   --compilation_level SIMPLE_OPTIMIZATIONS \

--- a/local_build/local_build.sh
+++ b/local_build/local_build.sh
@@ -51,8 +51,8 @@ if [[ ${PWD##*/} != $EXPECTED_PWD ]]; then
 fi
 
 # Find the Closure Compiler.
-if [ -f "$(npm root)/google-closure-compiler/compiler.jar" ]; then
-  COMPILER="$(npm root)/google-closure-compiler/compiler.jar"
+if [ -f "$(npm root)/google-closure-compiler-java/compiler.jar" ]; then
+  COMPILER="$(npm root)/google-closure-compiler-java/compiler.jar"
   CLOSURE_LIBRARY="$(npm root)/google-closure-library"
 elif [ -f closure-compiler*.jar ]; then
   COMPILER="closure-compiler*.jar"

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -23,8 +23,8 @@ fi
 
 # Find the Closure Compiler.
 if [ -n $NODE_MODULES ] && \
-  [ -s $NODE_MODULES/google-closure-compiler/compiler.jar ]; then
-  COMPILER=$NODE_MODULES/google-closure-compiler/compiler.jar
+  [ -s $NODE_MODULES/google-closure-compiler-java/compiler.jar ]; then
+  COMPILER=$NODE_MODULES/google-closure-compiler-java/compiler.jar
   echo "Found npm google-closure-compiler:"
   echo "  $COMPILER"
   npm list google-closure-compiler | grep google-closure-compiler


### PR DESCRIPTION
The google closure compiler has moved the java compiler into it's own package under google-closure-compiler-java.  Updating paths to reflect that.

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Local build script depending on the npm google closure compiler and library is broken from a change of paths in the package.

### Proposed Changes

Updating paths in local build scripts.

### Test Coverage

Tested on a mac. Ran the local_build.sh script and the tests/compile/compile.sh script.

### Additional Information
