### PR TITLE
Updating debug rendering for top and bottom block rows.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -87,7 +87,8 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
  * @param {number} rowHeight The height of the container row.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, centerY, rowHeight) {
+Blockly.blockRendering.Debug.prototype.drawSpacerElem =
+    function(elem, cursorX, centerY, rowHeight) {
   var debugRenderedHeight = Math.min(15, rowHeight);
   var yPos = centerY - debugRenderedHeight / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',

--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -84,17 +84,19 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
  * @param {!Blockly.BlockSvg.InRowSpacer} elem The spacer to render
  * @param {number} cursorX The x position of the left of the row.
  * @param {number} centerY The y position of the center of the row, vertically.
+ * @param {number} rowHeight The height of the container row.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, centerY) {
-  var yPos = centerY - elem.height / 2;
+Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, centerY, rowHeight) {
+  var debugRenderedHeight = Math.min(15, rowHeight);
+  var yPos = centerY - debugRenderedHeight / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemSpacerRect blockRenderDebug',
         'x': cursorX,
         'y': yPos,
         'width': elem.width,
-        'height': 15,
+        'height': debugRenderedHeight,
       },
       this.svgRoot_));
 };
@@ -193,7 +195,7 @@ Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, curso
   for (var e = 0; e < row.elements.length; e++) {
     var elem = row.elements[e];
     if (elem.isSpacer()) {
-      this.drawSpacerElem(elem, cursorX, centerY);
+      this.drawSpacerElem(elem, cursorX, centerY, row.height);
     } else {
       this.drawRenderedElem(elem, cursorX, centerY);
     }

--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -88,19 +88,19 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawSpacerElem =
-    function(elem, cursorX, centerY, rowHeight) {
-  var debugRenderedHeight = Math.min(15, rowHeight);
-  var yPos = centerY - debugRenderedHeight / 2;
-  this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
-      {
-        'class': 'elemSpacerRect blockRenderDebug',
-        'x': cursorX,
-        'y': yPos,
-        'width': elem.width,
-        'height': debugRenderedHeight,
-      },
-      this.svgRoot_));
-};
+    function(elem, cursorX,  centerY, rowHeight) {
+      var debugRenderedHeight = Math.min(15, rowHeight);
+      var yPos = centerY - debugRenderedHeight / 2;
+      this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
+          {
+            'class': 'elemSpacerRect blockRenderDebug',
+            'x': cursorX,
+            'y': yPos,
+            'width': elem.width,
+            'height': debugRenderedHeight,
+          },
+          this.svgRoot_));
+    };
 
 /**
  * Draw a debug rectangle for an in-row element.

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -453,11 +453,6 @@ Blockly.blockRendering.TopRow = function(block) {
 };
 goog.inherits(Blockly.blockRendering.TopRow, Blockly.blockRendering.Row);
 
-
-Blockly.blockRendering.TopRow.prototype.isSpacer = function() {
-  return true;
-};
-
 Blockly.blockRendering.BottomRow = function(block) {
   Blockly.blockRendering.BottomRow.superClass_.constructor.call(this);
   this.type = 'bottom row';
@@ -480,8 +475,3 @@ Blockly.blockRendering.BottomRow = function(block) {
 };
 goog.inherits(Blockly.blockRendering.BottomRow,
     Blockly.blockRendering.Row);
-
-Blockly.blockRendering.BottomRow.prototype.isSpacer = function() {
-  return true;
-};
-


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Updates debug rendering for top and bottom row to treat them like rows with elements rather than spacer rows.

### Reason for Changes

Displays more information useful for debugging rendering.

old debug rendering:
![old](https://user-images.githubusercontent.com/6621618/61833806-605bd000-ae2a-11e9-88cb-d315e18a39f8.png)

new debug rendering:
![new](https://user-images.githubusercontent.com/6621618/61833813-65b91a80-ae2a-11e9-8b0c-732eeabb31d3.png)


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->