### PR TITLE
Using centerline for debug rendering.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -83,24 +83,22 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
  * Draw a debug rectangle for a horizontal spacer.
  * @param {!Blockly.BlockSvg.InRowSpacer} elem The spacer to render
  * @param {number} cursorX The x position of the left of the row.
- * @param {number} centerY The y position of the center of the row, vertically.
  * @param {number} rowHeight The height of the container row.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerElem =
-    function(elem, cursorX,  centerY, rowHeight) {
-      var debugRenderedHeight = Math.min(15, rowHeight);
-      var yPos = centerY - debugRenderedHeight / 2;
-      this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
-          {
-            'class': 'elemSpacerRect blockRenderDebug',
-            'x': cursorX,
-            'y': yPos,
-            'width': elem.width,
-            'height': debugRenderedHeight,
-          },
-          this.svgRoot_));
-    };
+Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, rowHeight) {
+  var debugRenderedHeight = Math.min(elem.height, rowHeight);
+  var yPos = elem.centerline - debugRenderedHeight / 2;
+  this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
+      {
+        'class': 'elemSpacerRect blockRenderDebug',
+        'x': cursorX,
+        'y': yPos,
+        'width': elem.width,
+        'height': debugRenderedHeight,
+      },
+      this.svgRoot_));
+};
 
 /**
  * Draw a debug rectangle for an in-row element.
@@ -109,8 +107,8 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem =
  * @param {number} centerY The y position of the center of the row, vertically.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX, centerY) {
-  var yPos = centerY - elem.height / 2;
+Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX) {
+  var yPos = elem.centerline - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowRenderingRect blockRenderDebug',
@@ -191,14 +189,13 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) 
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY) {
-  var centerY = cursorY + row.height / 2;
   var cursorX = 0;
   for (var e = 0; e < row.elements.length; e++) {
     var elem = row.elements[e];
     if (elem.isSpacer()) {
-      this.drawSpacerElem(elem, cursorX, centerY, row.height);
+      this.drawSpacerElem(elem, cursorX, row.height);
     } else {
-      this.drawRenderedElem(elem, cursorX, centerY);
+      this.drawRenderedElem(elem, cursorX);
     }
     cursorX += elem.width;
   }

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -637,6 +637,8 @@ Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, e
     }
   } else if (elem.isInlineInput()) {
     result += elem.height / 2;
+  } else if (elem.isNextConnection()) {
+    result += row.height + elem.height / 2;
   } else {
     result += (row.height / 2);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Uses computed centerline for debug rendering and updates how next connection centerline is computed.

### Reason for Changes

Results in a more accurate debug rendering view.
![render-centerline](https://user-images.githubusercontent.com/6621618/61908975-cfe2c580-aee5-11e9-9129-c4c28ce99918.png)


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
