### PR TITLE
Fix IE flyout button callback

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -79,7 +79,9 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
    * @type {string}
    * @private
    */
-  this.callbackKey_ = xml.getAttribute('callbackKey');
+  this.callbackKey_ = xml.getAttribute('callbackKey')
+  /* Check the lower case version too to satisfy IE */
+                   || xml.getAttribute('callbackkey');
 
   /**
    * If specified, a CSS class to add to this button.


### PR DESCRIPTION

##  The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/2672


### Proposed Changes

IE doesn't like cases in the xml so it converts them all to lower case. This check the lowercase version of the callbackKey attribute as well to make sure we wire up the button callback.

### Reason for Changes

Flyout buttons broken in IE.

### Test Coverage

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
