### PR TITLE
Fix mocha

### DIFF
--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -12,7 +12,7 @@
   <body>
 
     <div id="mocha"></div>
-    <div id="failureCount" style="display:none"></div>
+    <div id="failureCount" style="display:none" tests_failed="unset"></div>
     <script src="https://unpkg.com/chai/chai.js"></script>
     <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
     <script src="https://unpkg.com/sinon/pkg/sinon.js"></script>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Mocha tests were giving null tests failed and failing intermittently on CI. 

### Proposed Changes
Adds tests_failed="unset" to the failureCount div.

### Reason for Changes
The browser's wait until method was checking that the tests_failed text != unset. The value was not initialized with "unset" so it would only check once before moving on. This resulted was null tests failed if the tests did not finish fast enough.
### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
