### PR TITLE
Fix setOnClickHandler jsdoc

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -205,7 +205,7 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
 
 /**
  * Set the function that is called when this image  is clicked.
- * @param {function} func The function that is called when the image
+ * @param {Function} func The function that is called when the image
  *    is clicked. It will receive the image field as a parameter.
  * @public
  */


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes setOnClickHandler jsdoc parameter.

### Proposed Changes

function -> Function

### Reason for Changes

Uppercase ``Function`` is the type of a generic function. 
Lowercase ``function`` is a specific type. eg: ``function(...): ...`` Generally the more specific type is preferred, but we'd have to define the function signature we are expecting. If unknown, use the uppercase ``Function``.

More on the closure type system: https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System

@BeksOmega FYI

### Additional Information

<!-- Anything else we should know? -->
