### PR TITLE
Fixed flyout scrollbars not being updated when the flyout was dragged.

### DIFF
--- a/core/flyout_dragger.js
+++ b/core/flyout_dragger.js
@@ -62,19 +62,24 @@ Blockly.FlyoutDragger = function(flyout) {
 goog.inherits(Blockly.FlyoutDragger, Blockly.WorkspaceDragger);
 
 /**
- * Move the appropriate scrollbar to drag the flyout.
- * Since flyouts only scroll in one direction at a time, this will discard one
- * of the calculated values.
- * x and y are in pixels.
- * @param {number} x The new x position to move the scrollbar to.
- * @param {number} y The new y position to move the scrollbar to.
- * @private
+ * Move the flyout based on the most recent mouse movements.
+ * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
+ *     moved from the position at the start of the drag, in pixel coordinates.
+ * @package
  */
-Blockly.FlyoutDragger.prototype.updateScroll_ = function(x, y) {
-  // Move the scrollbar and the flyout will scroll automatically.
+Blockly.FlyoutDragger.prototype.drag = function(currentDragDeltaXY) {
+  // startScrollXY_ is assigned by the superclass.
+  var newXY = Blockly.utils.Coordinate.sum(this.startScrollXY_, currentDragDeltaXY);
+
+  // We can't call workspace.scroll because the flyout's workspace doesn't own
+  // it's own scrollbars. This is because (as of 2.20190722.1) the
+  // workspace's scrollbar property must be a scrollbar pair, rather than a
+  // single scrollbar.
+  // Instead we'll just expect setting the scrollbar to update the scroll of
+  // the workspace as well.
   if (this.horizontalLayout_) {
-    this.scrollbar_.set(x);
+    this.scrollbar_.set(-newXY.x);
   } else {
-    this.scrollbar_.set(y);
+    this.scrollbar_.set(-newXY.y);
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2728

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so dragging flyouts scrolls the scrollbars.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs are bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Currently there is no way to unit tests gestures.

Tested scrolling each flyout position on the multiplayground, simple toolbox & categories.

![FlyoutScroll_Good](https://user-images.githubusercontent.com/25440652/62085537-b2c53400-b210-11e9-90f4-36f648596116.gif)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No docs needed.

### Additional Information

<!-- Anything else we should know? -->
Not my prefered solution, but it works and I didn't want to tear into scrollbars right now.
