### PR TITLE
Fixes copy paste to work with the marker

### DIFF
--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -542,6 +542,9 @@ Blockly.Navigation.insertBlock = function(block, targetConnection) {
   if (bestConnection && bestConnection.isConnected() &&
       !bestConnection.targetBlock().isShadow()) {
     bestConnection.disconnect();
+  } else if (!bestConnection) {
+    Blockly.Navigation.warn(
+    'This block can not be inserted at the marked location. Moved to workspace.');
   }
   return Blockly.Navigation.connect(bestConnection, targetConnection);
 };

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -544,7 +544,7 @@ Blockly.Navigation.insertBlock = function(block, targetConnection) {
     bestConnection.disconnect();
   } else if (!bestConnection) {
     Blockly.Navigation.warn(
-    'This block can not be inserted at the marked location. Moved to workspace.');
+        'This block can not be inserted at the marked location. Moved to workspace.');
   }
   return Blockly.Navigation.connect(bestConnection, targetConnection);
 };

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -544,7 +544,7 @@ Blockly.Navigation.insertBlock = function(block, targetConnection) {
     bestConnection.disconnect();
   } else if (!bestConnection) {
     Blockly.Navigation.warn(
-        'This block can not be inserted at the marked location. Moved to workspace.');
+        'This block can not be inserted at the marked location.');
   }
   return Blockly.Navigation.connect(bestConnection, targetConnection);
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1081,6 +1081,14 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
   Blockly.Events.disable();
   try {
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
+
+    // Handle paste for keyboard navigation
+    var markedNode = Blockly.Navigation.marker_.getCurNode();
+    if (Blockly.keyboardAccessibilityMode && markedNode) {
+      Blockly.Navigation.insertBlock(block, markedNode.getLocation());
+      return;
+    }
+
     // Move the duplicate to original position.
     var blockX = parseInt(xmlBlock.getAttribute('x'), 10);
     var blockY = parseInt(xmlBlock.getAttribute('y'), 10);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Copy paste was broken for keyboard navigation.

### Proposed Changes
If we are in accessibility mode and a connection has been marked then try to insert the copied block at the marked location. If the marker is not at a valid connection point, then warn the user. 

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
