### PR TITLE
Used moveBy in moveTo

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -396,21 +396,8 @@ Blockly.BlockSvg.prototype.moveToDragSurface_ = function() {
  * @param {Blockly.utils.Coordinate} xy The position to move to in workspace units.
  */
 Blockly.BlockSvg.prototype.moveTo = function(xy) {
-  if (this.parentBlock_) {
-    throw Error('Block has parent.');
-  }
-  var eventsEnabled = Blockly.Events.isEnabled();
-  if (eventsEnabled) {
-    var event = new Blockly.Events.BlockMove(this);
-  }
   var curXY = this.getRelativeToSurfaceXY();
-  this.translate(xy.x, xy.y);
-  this.moveConnections_(xy.x - curXY.x, xy.y - curXY.y);
-  if (eventsEnabled) {
-    event.recordNew();
-    Blockly.Events.fire(event);
-  }
-  this.workspace.resizeContents();
+  this.moveBy(xy.x - curXY.x, xy.y - curXY.y);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The new moveTo function was duplicating a lot of the functionality in moveBy.

### Proposed Changes
Compute the difference in moveTo and pass the dx and dy to moveBy.

### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
