### PR TITLE
Fix references to createSvgElement

### DIFF
--- a/demos/minimap/minimap.js
+++ b/demos/minimap/minimap.js
@@ -81,7 +81,7 @@ Minimap.init = function(workspace, minimap) {
   this.rect = document.getElementById('mapDiv').getBoundingClientRect();
 
   // Create a svg overlay on the top of mapDiv for the minimap.
-  this.svg = Blockly.utils.createSvgElement('svg', {
+  this.svg = Blockly.utils.dom.createSvgElement('svg', {
     'xmlns': 'http://www.w3.org/2000/svg',
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
     'xmlns:xlink': 'http://www.w3.org/1999/xlink',
@@ -94,7 +94,7 @@ Minimap.init = function(workspace, minimap) {
   this.svg.style.left = this.rect.left + 'px';
 
   // Creating a rectangle in the minimap that represents current view.
-  Blockly.utils.createSvgElement('rect', {
+  Blockly.utils.dom.createSvgElement('rect', {
     'width': 100,
     'height': 100,
     'class': 'mapDragger'

--- a/tests/rendering/svg_paths.html
+++ b/tests/rendering/svg_paths.html
@@ -48,11 +48,11 @@ limitations under the License.
 var svgSpace;
 
 function addPathAt(path, x, y) {
-  var group = Blockly.utils.createSvgElement('g',
+  var group = Blockly.utils.dom.createSvgElement('g',
       {
         'transform': 'translate(' + (x + 50) + ', ' + y + ')'
       }, svgSpace);
-  Blockly.utils.createSvgElement('path', {
+  Blockly.utils.dom.createSvgElement('path', {
     'd': 'M 0,0 ' + path,
     'marker-start': 'url(#startDot)',
     'marker-end': 'url(#endDot)',


### PR DESCRIPTION
A couple of references to createSvgElement weren't moved when it moved under Blockly.utils.dom.

