### PR TITLE
Inject Blockly version into binaries

### DIFF
--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ else:
   from urllib.parse import urlencode
   from importlib import reload
 
-# Read package.json and extract the current Blockly version
+# Read package.json and extract the current Blockly version.
 blocklyVersion = json.loads(open('package.json', 'r').read())['version']
 
 def import_path(fullpath):
@@ -224,9 +224,12 @@ class Gen_compressed(threading.Thread):
       if filename.startswith(os.pardir + os.sep):  # '../'
         continue
       f = codecs.open(filename, encoding="utf-8")
-      params.append(("js_code", "".join(f.readlines()).encode("utf-8")))
+      code = "".join(f.readlines()).encode("utf-8")
+      # Inject the blockly version.
+      if filename == "core/blockly.js":
+        code = code.replace("Blockly.VERSION = 'unset';", "Blockly.VERSION = '" + blocklyVersion + "';")
+      params.append(("js_code", code))
       f.close()
-
     self.do_compile(params, target_filename, filenames, "")
 
   def gen_blocks(self):
@@ -348,7 +351,6 @@ class Gen_compressed(threading.Thread):
 
       code = HEADER + "\n" + json_data["compiledCode"]
       code = code.replace(remove, "")
-      code = code.replace('Blockly.version="unset"', 'Blockly.version="' + blocklyVersion + '"')
       code = self.trim_licence(code)
 
       stats = json_data["statistics"]

--- a/build.py
+++ b/build.py
@@ -56,6 +56,9 @@ else:
   from urllib.parse import urlencode
   from importlib import reload
 
+# Read package.json and extract the current Blockly version
+blocklyVersion = json.loads(open('package.json', 'r').read())['version']
+
 def import_path(fullpath):
   """Import a file with full path specification.
   Allows one to import from any directory, something __import__ does not do.
@@ -345,6 +348,7 @@ class Gen_compressed(threading.Thread):
 
       code = HEADER + "\n" + json_data["compiledCode"]
       code = code.replace(remove, "")
+      code = code.replace('Blockly.version="unset"', 'Blockly.version="' + blocklyVersion + '"')
       code = self.trim_licence(code)
 
       stats = json_data["statistics"]

--- a/build.py
+++ b/build.py
@@ -225,9 +225,9 @@ class Gen_compressed(threading.Thread):
         continue
       f = codecs.open(filename, encoding="utf-8")
       code = "".join(f.readlines()).encode("utf-8")
-      # Inject the blockly version.
+      # Inject the Blockly version.
       if filename == "core/blockly.js":
-        code = code.replace("Blockly.VERSION = 'unset';", "Blockly.VERSION = '" + blocklyVersion + "';")
+        code = code.replace("Blockly.VERSION = 'uncompiled';", "Blockly.VERSION = '" + blocklyVersion + "';")
       params.append(("js_code", code))
       f.close()
 

--- a/build.py
+++ b/build.py
@@ -230,6 +230,7 @@ class Gen_compressed(threading.Thread):
         code = code.replace("Blockly.VERSION = 'unset';", "Blockly.VERSION = '" + blocklyVersion + "';")
       params.append(("js_code", code))
       f.close()
+
     self.do_compile(params, target_filename, filenames, "")
 
   def gen_blocks(self):

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -133,6 +133,12 @@ Blockly.cache3dSupported_ = null;
 Blockly.theme_ = null;
 
 /**
+ * Blockly core version.
+ * @define {string}
+ */
+Blockly.version = "unset";
+
+/**
  * Returns the dimensions of the specified SVG image.
  * @param {!Element} svg SVG image.
  * @return {!Object} Contains width and height properties.

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -67,9 +67,13 @@ var CLOSURE_DEFINES = {'goog.DEBUG': false};
 
 /**
  * Blockly core version.
+ * This constant is overriden by the build script (build.py) to the value of the version
+ * in package.json. This is done during the gen_core build step.
+ * For local builds, you can pass --define='Blockly.VERSION=X.Y.Z' to the compiler
+ * to override this constant.
  * @define {string}
  */
-Blockly.VERSION = 'unset';
+Blockly.VERSION = 'uncompiled';
 
 /**
  * The main workspace most recently used.

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -66,6 +66,12 @@ var CLOSURE_DEFINES = {'goog.DEBUG': false};
 /* eslint-enable no-unused-vars */
 
 /**
+ * Blockly core version.
+ * @define {string}
+ */
+Blockly.VERSION = 'unset';
+
+/**
  * The main workspace most recently used.
  * Set by Blockly.WorkspaceSvg.prototype.markFocused
  * @type {Blockly.Workspace}
@@ -131,12 +137,6 @@ Blockly.cache3dSupported_ = null;
  * @private
  */
 Blockly.theme_ = null;
-
-/**
- * Blockly core version.
- * @define {string}
- */
-Blockly.version = "unset";
 
 /**
  * Returns the dimensions of the specified SVG image.


### PR DESCRIPTION
Inject the Blockly version from package.json into compressed Blockly builds.

This makes it easier for developers to let us know which version of Blockly they are running.

The way the variable is defined (Jsdoc), it lets us also use the --define flag when compiling locally. see --define flag for more info: https://github.com/google/closure-compiler/wiki/Flags-and-Options