### PR TITLE
Fix bottom row element centerlines

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -659,8 +659,16 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     row.yPos = yCursor;
-    var xCursor = 0;
+    yCursor += row.height;
+    // Add padding to the bottom row if block height is less than minimum
+    if (row == this.bottomRow &&
+        yCursor < Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT) {
+      this.bottomRow.height +=
+          Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT - yCursor;
+      yCursor = Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT;
+    }
     if (!(row.isSpacer())) {
+      var xCursor = 0;
       for (var e = 0; e < row.elements.length; e++) {
         var elem = row.elements[e];
         elem.xPos = xCursor;
@@ -668,15 +676,8 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
         xCursor += elem.width;
       }
     }
-    yCursor += row.height;
   }
   this.blockBottom = yCursor;
-
-  // Add padding to the bottom row if block height is less than minimum
-  if (yCursor < Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT) {
-    this.bottomRow.height += Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT - yCursor;
-    yCursor = Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT;
-  }
 
   this.height = yCursor;
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Moves conditional update of bottom row height within finalize_ to before row element centerlines are computed.

### Reason for Changes

Fixes edge case where centerline for bottom row elements is computed incorectly.
Before:
![before-centerline](https://user-images.githubusercontent.com/6621618/62263300-8ce68d80-b3d0-11e9-8e1e-71100193d016.png)
After:
![after-centerline](https://user-images.githubusercontent.com/6621618/62263307-9112ab00-b3d0-11e9-9727-73dff3b0b0c1.png)


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

