### PR TITLE
Make the TabList exclude hidden fields

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -605,7 +605,7 @@ Blockly.BlockSvg.prototype.createTabList_ = function() {
   var list = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldTextInput) {
+      if (field instanceof Blockly.FieldTextInput && field.visible_) {
         // TODO (#1276): Also support dropdown fields.
         list.push(field);
       }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -605,7 +605,7 @@ Blockly.BlockSvg.prototype.createTabList_ = function() {
   var list = [];
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
-      if (field instanceof Blockly.FieldTextInput && field.visible_) {
+      if (field instanceof Blockly.FieldTextInput && field.isVisible()) {
         // TODO (#1276): Also support dropdown fields.
         list.push(field);
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

When using the tab button and pressing tab from a visible field, the code does not skip over hidden fields.

### Proposed Changes

Added a check if the field is visible

### Reason for Changes

Behavior not logical

### Test Coverage

None

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
* Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

None

### Additional Information

<!-- Anything else we should know? -->
