### PR TITLE
Updated How Connections Dispose of Themselves

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -316,12 +316,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
     this.inputList.length = 0;
     // Dispose of any remaining connections (next/previous/output).
     var connections = this.getConnections_(true);
-    for (var i = 0; i < connections.length; i++) {
-      var connection = connections[i];
-      if (connection.isConnected()) {
-        connection.disconnect();
-      }
-      connections[i].dispose();
+    for (var i = 0, connection; connection = connections[i]; i++) {
+      connection.dispose();
     }
   } finally {
     Blockly.Events.enable();
@@ -1759,17 +1755,6 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     if (input.name == name) {
-      if (input.connection && input.connection.isConnected()) {
-        input.connection.setShadowDom(null);
-        var block = input.connection.targetBlock();
-        if (block.isShadow()) {
-          // Destroy any attached shadow block.
-          block.dispose();
-        } else {
-          // Disconnect any attached normal block.
-          block.unplug();
-        }
-      }
       input.dispose();
       this.inputList.splice(i, 1);
       return;

--- a/core/block.js
+++ b/core/block.js
@@ -321,9 +321,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
     }
   } finally {
     Blockly.Events.enable();
+    this.disposed = true;
   }
-
-  this.disposed = true;
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -322,6 +322,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
   } finally {
     Blockly.Events.enable();
   }
+
+  this.disposed = true;
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -227,6 +227,13 @@ Blockly.Block.obtain = function(workspace, prototypeName) {
 Blockly.Block.prototype.data = null;
 
 /**
+ * Has this block been disposed of?
+ * @type {boolean}
+ * @package
+ */
+Blockly.Block.prototype.disposed = false;
+
+/**
  * Colour of the block as HSV hue value (0-360)
  * This may be null if the block colour was not set via a hue number.
  * @type {?number}

--- a/core/connection.js
+++ b/core/connection.js
@@ -72,6 +72,13 @@ Blockly.Connection.REASON_SHADOW_PARENT = 6;
 Blockly.Connection.prototype.targetConnection = null;
 
 /**
+ * Has this connection been disposed of?
+ * @type {boolean}
+ * @package
+ */
+Blockly.Connection.prototype.disposed = false;
+
+/**
  * List of compatible value types.  Null if all types are compatible.
  * @type {Array}
  * @private

--- a/core/connection.js
+++ b/core/connection.js
@@ -233,15 +233,29 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
 };
 
 /**
- * Sever all links to this connection (not including from the source object).
+ * Dispose of this connection. Deal with connected blocks and remove this
+ * connection from the database.
  */
 Blockly.Connection.prototype.dispose = function() {
+
+  // isConnected returns true for shadows and non-shadows.
   if (this.isConnected()) {
-    throw Error('Disconnect connection before disposing of it.');
+    this.setShadowDom(null);
+    var targetBlock = this.targetBlock();
+    if (targetBlock.isShadow()) {
+      // Destroy the attached shadow block & its children.
+      targetBlock.dispose();
+    } else {
+      // Disconnect the attached normal block.
+      targetBlock.unplug();
+    }
   }
+
   if (this.inDB_) {
     this.db_.removeConnection_(this);
   }
+
+  this.disposed = true;
 };
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -235,6 +235,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
 /**
  * Dispose of this connection. Deal with connected blocks and remove this
  * connection from the database.
+ * @package
  */
 Blockly.Connection.prototype.dispose = function() {
 

--- a/core/field.js
+++ b/core/field.js
@@ -149,12 +149,20 @@ Blockly.Field.X_PADDING = 10;
  * @type {[type]}
  */
 Blockly.Field.DEFAULT_TEXT_OFFSET = Blockly.Field.X_PADDING / 2;
+
 /**
  * Name of field.  Unique within each block.
  * Static labels are usually unnamed.
  * @type {string|undefined}
  */
 Blockly.Field.prototype.name = undefined;
+
+/**
+ * Has this field been disposed of?
+ * @type {boolean}
+ * @package
+ */
+Blockly.Field.prototype.disposed = false;
 
 /**
  * Maximum characters of text to display before adding an ellipsis.

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -104,27 +104,35 @@ suite('Blocks', function() {
         blocks.B.unplug(true);
         assertUnpluggedNoheal(blocks);
       });
-      test('Parent has multiple inputs', function() {
+      test('A has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to parent
         blocks.A.appendValueInput("INPUT").setCheck(null);
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
-      test('Middle block has multiple inputs', function() {
+      test('B has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to middle block
         blocks.B.appendValueInput("INPUT").setCheck(null);
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
-      test('Child block has multiple inputs', function() {
+      test('C has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to child block
         blocks.C.appendValueInput("INPUT").setCheck(null);
         // Child block input count doesn't matter.
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
+      });
+      test('C is Shadow', function() {
+        var blocks = this.blocks;
+        blocks.C.setShadow(true);
+        blocks.B.unplug(true);
+        // Even though we're asking to heal, it will appear as if it has not
+        // healed because shadows always stay with the parent.
+        assertUnpluggedNoheal(blocks);
       });
     });
     suite('Stack', function() {
@@ -176,6 +184,14 @@ suite('Blocks', function() {
         assertNull(blocks.B.getParent());
         // C is the top of its stack.
         assertNull(blocks.C.getParent());
+      });
+      test('C is Shadow', function() {
+        var blocks = this.blocks;
+        blocks.C.setShadow(true);
+        blocks.B.unplug(true);
+        // Even though we're asking to heal, it will appear as if it has not
+        // healed because shadows always stay with the parent.
+        assertUnpluggedNoheal(blocks);
       });
     });
   });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -19,25 +19,14 @@
  */
 
 suite('Blocks', function() {
-  suite('Unplug', function() {
-    function assertUnpluggedNoheal(blocks) {
-      // A has nothing connected to it.
-      assertEquals(0, blocks.A.getChildren().length);
-      // B and C are still connected.
-      assertEquals(blocks.B, blocks.C.getParent());
-      // B is the top of its stack.
-      assertNull(blocks.B.getParent());
-    }
-    function assertUnpluggedHealed(blocks) {
-      // A and C are connected.
-      assertEquals(1, blocks.A.getChildren().length);
-      assertEquals(blocks.A, blocks.C.getParent());
-      // B has nothing connected to it.
-      assertEquals(0, blocks.B.getChildren().length);
-      // B is the top of its stack.
-      assertNull(blocks.B.getParent());
-    }
+  setup(function() {
+    this.workspace = new Blockly.Workspace();
+  });
+  teardown(function() {
+    this.workspace.dispose();
+  });
 
+  suite('Connection Management', function() {
     setup(function() {
       Blockly.defineBlocksWithJsonArray([{
         "type": "stack_block",
@@ -56,142 +45,285 @@ suite('Blocks', function() {
         ],
         "output": null
       }]);
-
-      this.workspace = new Blockly.Workspace();
     });
     teardown(function() {
       delete Blockly.Blocks['stack_block'];
       delete Blockly.Blocks['row_block'];
-
-      this.workspace.dispose();
     });
 
-    suite('Row', function() {
-      setup(function() {
-        var blockA = this.workspace.newBlock('row_block');
-        var blockB = this.workspace.newBlock('row_block');
-        var blockC = this.workspace.newBlock('row_block');
-
-        blockA.inputList[0].connection.connect(blockB.outputConnection);
-        blockB.inputList[0].connection.connect(blockC.outputConnection);
-
-        assertEquals(blockB, blockC.getParent());
-
-        this.blocks = {
-          A: blockA,
-          B: blockB,
-          C: blockC
-        };
-      });
-
-      test('Don\'t heal', function() {
-        this.blocks.B.unplug(false);
-        assertUnpluggedNoheal(this.blocks);
-      });
-      test('Heal', function() {
-        this.blocks.B.unplug(true);
-        // Each block has only one input, and the types work.
-        assertUnpluggedHealed(this.blocks);
-      });
-      test('Heal with bad checks', function() {
-        var blocks = this.blocks;
-
-        // A and C can't connect, but both can connect to B.
-        blocks.A.inputList[0].connection.setCheck('type1');
-        blocks.C.outputConnection.setCheck('type2');
-
-        // Each block has only one input, but the types don't work.
-        blocks.B.unplug(true);
-        assertUnpluggedNoheal(blocks);
-      });
-      test('A has multiple inputs', function() {
-        var blocks = this.blocks;
-        // Add extra input to parent
-        blocks.A.appendValueInput("INPUT").setCheck(null);
-        blocks.B.unplug(true);
-        assertUnpluggedHealed(blocks);
-      });
-      test('B has multiple inputs', function() {
-        var blocks = this.blocks;
-        // Add extra input to middle block
-        blocks.B.appendValueInput("INPUT").setCheck(null);
-        blocks.B.unplug(true);
-        assertUnpluggedHealed(blocks);
-      });
-      test('C has multiple inputs', function() {
-        var blocks = this.blocks;
-        // Add extra input to child block
-        blocks.C.appendValueInput("INPUT").setCheck(null);
-        // Child block input count doesn't matter.
-        blocks.B.unplug(true);
-        assertUnpluggedHealed(blocks);
-      });
-      test('C is Shadow', function() {
-        var blocks = this.blocks;
-        blocks.C.setShadow(true);
-        blocks.B.unplug(true);
-        // Even though we're asking to heal, it will appear as if it has not
-        // healed because shadows always stay with the parent.
-        assertUnpluggedNoheal(blocks);
-      });
-    });
-    suite('Stack', function() {
-      setup(function() {
-        var blockA = this.workspace.newBlock('stack_block');
-        var blockB = this.workspace.newBlock('stack_block');
-        var blockC = this.workspace.newBlock('stack_block');
-
-        blockA.nextConnection.connect(blockB.previousConnection);
-        blockB.nextConnection.connect(blockC.previousConnection);
-
-        assertEquals(blockB, blockC.getParent());
-
-        this.blocks = {
-          A: blockA,
-          B: blockB,
-          C: blockC
-        };
-      });
-
-      test('Don\'t heal', function() {
-        this.blocks.B.unplug();
-        assertUnpluggedNoheal(this.blocks);
-      });
-      test('Heal', function() {
-        this.blocks.B.unplug(true);
-        assertUnpluggedHealed(this.blocks);
-      });
-      test('Heal with bad checks', function() {
-        var blocks = this.blocks;
-        // A and C can't connect, but both can connect to B.
-        blocks.A.nextConnection.setCheck('type1');
-        blocks.C.previousConnection.setCheck('type2');
-
-        // The types don't work.
-        blocks.B.unplug(true);
-
-        // Stack blocks unplug before checking whether the types match.
-        // TODO (#1994): Check types before unplugging.
+    suite('Unplug', function() {
+      function assertUnpluggedNoheal(blocks) {
         // A has nothing connected to it.
         assertEquals(0, blocks.A.getChildren().length);
-        // B has nothing connected to it.
-        assertEquals(0, blocks.B.getChildren().length);
-        // C has nothing connected to it.
-        assertEquals(0, blocks.C.getChildren().length);
-        // A is the top of its stack.
-        assertNull(blocks.A.getParent());
+        // B and C are still connected.
+        assertEquals(blocks.B, blocks.C.getParent());
         // B is the top of its stack.
         assertNull(blocks.B.getParent());
-        // C is the top of its stack.
-        assertNull(blocks.C.getParent());
+      }
+      function assertUnpluggedHealed(blocks) {
+        // A and C are connected.
+        assertEquals(1, blocks.A.getChildren().length);
+        assertEquals(blocks.A, blocks.C.getParent());
+        // B has nothing connected to it.
+        assertEquals(0, blocks.B.getChildren().length);
+        // B is the top of its stack.
+        assertNull(blocks.B.getParent());
+      }
+
+      suite('Row', function() {
+        setup(function() {
+          var blockA = this.workspace.newBlock('row_block');
+          var blockB = this.workspace.newBlock('row_block');
+          var blockC = this.workspace.newBlock('row_block');
+
+          blockA.inputList[0].connection.connect(blockB.outputConnection);
+          blockB.inputList[0].connection.connect(blockC.outputConnection);
+
+          assertEquals(blockB, blockC.getParent());
+
+          this.blocks = {
+            A: blockA,
+            B: blockB,
+            C: blockC
+          };
+        });
+
+        test('Don\'t heal', function() {
+          this.blocks.B.unplug(false);
+          assertUnpluggedNoheal(this.blocks);
+        });
+        test('Heal', function() {
+          this.blocks.B.unplug(true);
+          // Each block has only one input, and the types work.
+          assertUnpluggedHealed(this.blocks);
+        });
+        test('Heal with bad checks', function() {
+          var blocks = this.blocks;
+
+          // A and C can't connect, but both can connect to B.
+          blocks.A.inputList[0].connection.setCheck('type1');
+          blocks.C.outputConnection.setCheck('type2');
+
+          // Each block has only one input, but the types don't work.
+          blocks.B.unplug(true);
+          assertUnpluggedNoheal(blocks);
+        });
+        test('A has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to parent
+          blocks.A.appendValueInput("INPUT").setCheck(null);
+          blocks.B.unplug(true);
+          assertUnpluggedHealed(blocks);
+        });
+        test('B has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to middle block
+          blocks.B.appendValueInput("INPUT").setCheck(null);
+          blocks.B.unplug(true);
+          assertUnpluggedHealed(blocks);
+        });
+        test('C has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to child block
+          blocks.C.appendValueInput("INPUT").setCheck(null);
+          // Child block input count doesn't matter.
+          blocks.B.unplug(true);
+          assertUnpluggedHealed(blocks);
+        });
+        test('C is Shadow', function() {
+          var blocks = this.blocks;
+          blocks.C.setShadow(true);
+          blocks.B.unplug(true);
+          // Even though we're asking to heal, it will appear as if it has not
+          // healed because shadows always stay with the parent.
+          assertUnpluggedNoheal(blocks);
+        });
       });
-      test('C is Shadow', function() {
-        var blocks = this.blocks;
-        blocks.C.setShadow(true);
-        blocks.B.unplug(true);
-        // Even though we're asking to heal, it will appear as if it has not
-        // healed because shadows always stay with the parent.
-        assertUnpluggedNoheal(blocks);
+      suite('Stack', function() {
+        setup(function() {
+          var blockA = this.workspace.newBlock('stack_block');
+          var blockB = this.workspace.newBlock('stack_block');
+          var blockC = this.workspace.newBlock('stack_block');
+
+          blockA.nextConnection.connect(blockB.previousConnection);
+          blockB.nextConnection.connect(blockC.previousConnection);
+
+          assertEquals(blockB, blockC.getParent());
+
+          this.blocks = {
+            A: blockA,
+            B: blockB,
+            C: blockC
+          };
+        });
+
+        test('Don\'t heal', function() {
+          this.blocks.B.unplug();
+          assertUnpluggedNoheal(this.blocks);
+        });
+        test('Heal', function() {
+          this.blocks.B.unplug(true);
+          assertUnpluggedHealed(this.blocks);
+        });
+        test.skip('Heal with bad checks', function() {
+          var blocks = this.blocks;
+          // A and C can't connect, but both can connect to B.
+          blocks.A.nextConnection.setCheck('type1');
+          blocks.C.previousConnection.setCheck('type2');
+
+          // The types don't work.
+          blocks.B.unplug(true);
+
+          // TODO (#1994): Check types before unplugging. Currently
+          //  everything disconnects, when C should stick with B
+          assertUnpluggedNoheal();
+        });
+        test('C is Shadow', function() {
+          var blocks = this.blocks;
+          blocks.C.setShadow(true);
+          blocks.B.unplug(true);
+          // Even though we're asking to heal, it will appear as if it has not
+          // healed because shadows always stay with the parent.
+          assertUnpluggedNoheal(blocks);
+        });
+      });
+    });
+    suite('Dispose', function() {
+      function assertDisposedNoheal(blocks) {
+        chai.assert.isNotOk(blocks.A.disposed);
+        // A has nothing connected to it.
+        chai.assert.equal(0, blocks.A.getChildren().length);
+        // B is disposed.
+        chai.assert.isTrue(blocks.B.disposed);
+        // And C is disposed.
+        chai.assert.isTrue(blocks.C.disposed);
+      }
+      function assertDisposedHealed(blocks) {
+        chai.assert.isNotOk(blocks.A.disposed);
+        chai.assert.isNotOk(blocks.C.disposed);
+        // A and C are connected.
+        assertEquals(1, blocks.A.getChildren().length);
+        assertEquals(blocks.A, blocks.C.getParent());
+        // B is disposed.
+        chai.assert.isTrue(blocks.B.disposed);
+      }
+
+      suite('Row', function() {
+        setup(function() {
+          var blockA = this.workspace.newBlock('row_block');
+          var blockB = this.workspace.newBlock('row_block');
+          var blockC = this.workspace.newBlock('row_block');
+
+          blockA.inputList[0].connection.connect(blockB.outputConnection);
+          blockB.inputList[0].connection.connect(blockC.outputConnection);
+
+          assertEquals(blockB, blockC.getParent());
+
+          this.blocks = {
+            A: blockA,
+            B: blockB,
+            C: blockC
+          };
+        });
+
+        test('Don\'t heal', function() {
+          this.blocks.B.dispose(false);
+          assertDisposedNoheal(this.blocks);
+        });
+        test('Heal', function() {
+          this.blocks.B.dispose(true);
+          // Each block has only one input, and the types work.
+          assertDisposedHealed(this.blocks);
+        });
+        test('Heal with bad checks', function() {
+          var blocks = this.blocks;
+
+          // A and C can't connect, but both can connect to B.
+          blocks.A.inputList[0].connection.setCheck('type1');
+          blocks.C.outputConnection.setCheck('type2');
+
+          // Each block has only one input, but the types don't work.
+          blocks.B.dispose(true);
+          assertDisposedNoheal(blocks);
+        });
+        test('A has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to parent
+          blocks.A.appendValueInput("INPUT").setCheck(null);
+          blocks.B.dispose(true);
+          assertDisposedHealed(blocks);
+        });
+        test('B has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to middle block
+          blocks.B.appendValueInput("INPUT").setCheck(null);
+          blocks.B.dispose(true);
+          assertDisposedHealed(blocks);
+        });
+        test('C has multiple inputs', function() {
+          var blocks = this.blocks;
+          // Add extra input to child block
+          blocks.C.appendValueInput("INPUT").setCheck(null);
+          // Child block input count doesn't matter.
+          blocks.B.dispose(true);
+          assertDisposedHealed(blocks);
+        });
+        test('C is Shadow', function() {
+          var blocks = this.blocks;
+          blocks.C.setShadow(true);
+          blocks.B.dispose(true);
+          // Even though we're asking to heal, it will appear as if it has not
+          // healed because shadows always get destroyed.
+          assertDisposedNoheal(blocks);
+        });
+      });
+      suite('Stack', function() {
+        setup(function() {
+          var blockA = this.workspace.newBlock('stack_block');
+          var blockB = this.workspace.newBlock('stack_block');
+          var blockC = this.workspace.newBlock('stack_block');
+
+          blockA.nextConnection.connect(blockB.previousConnection);
+          blockB.nextConnection.connect(blockC.previousConnection);
+
+          assertEquals(blockB, blockC.getParent());
+
+          this.blocks = {
+            A: blockA,
+            B: blockB,
+            C: blockC
+          };
+        });
+
+        test('Don\'t heal', function() {
+          this.blocks.B.dispose();
+          assertDisposedNoheal(this.blocks);
+        });
+        test('Heal', function() {
+          this.blocks.B.dispose(true);
+          assertDisposedHealed(this.blocks);
+        });
+        test.skip('Heal with bad checks', function() {
+          var blocks = this.blocks;
+          // A and C can't connect, but both can connect to B.
+          blocks.A.nextConnection.setCheck('type1');
+          blocks.C.previousConnection.setCheck('type2');
+
+          // The types don't work.
+          blocks.B.dispose(true);
+
+          // TODO (#1994): Check types before unplugging. Current C gets
+          //  left behind when it should get disposed with B.
+          assertDisposedNoheal(blocks);
+        });
+        test('C is Shadow', function() {
+          var blocks = this.blocks;
+          blocks.C.setShadow(true);
+          blocks.B.dispose(true);
+          // Even though we're asking to heal, it will appear as if it has not
+          // healed because shadows always get destroyed.
+          assertDisposedNoheal(blocks);
+        });
       });
     });
   });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -326,5 +326,95 @@ suite('Blocks', function() {
         });
       });
     });
+    suite('Remove Input', function() {
+      setup(function() {
+        Blockly.defineBlocksWithJsonArray([
+          {
+            "type": "value_block",
+            "message0": "%1",
+            "args0": [
+              {
+                "type": "input_value",
+                "name": "VALUE"
+              }
+            ]
+          },
+          {
+            "type": "statement_block",
+            "message0": "%1",
+            "args0": [
+              {
+                "type": "input_statement",
+                "name": "STATEMENT"
+              }
+            ]
+          },
+        ]);
+      });
+      teardown(function() {
+        delete Blockly.Blocks['value_block'];
+        delete Blockly.Blocks['statement_block'];
+      });
+
+      suite('Value', function() {
+        setup(function() {
+          this.blockA = this.workspace.newBlock('value_block');
+        });
+
+        test('No Connected', function() {
+          this.blockA.removeInput('VALUE');
+          chai.assert.isNull(this.blockA.getInput('VALUE'));
+        });
+        test('Block Connected', function() {
+          var blockB = this.workspace.newBlock('row_block');
+          this.blockA.getInput('VALUE').connection
+              .connect(blockB.outputConnection);
+
+          this.blockA.removeInput('VALUE');
+          chai.assert.isNotOk(blockB.disposed);
+          chai.assert.equal(this.blockA.getChildren().length, 0);
+        });
+        test('Shadow Connected', function() {
+          var blockB = this.workspace.newBlock('row_block');
+          blockB.setShadow(true);
+          this.blockA.getInput('VALUE').connection
+              .connect(blockB.outputConnection);
+
+          this.blockA.removeInput('VALUE');
+          chai.assert.isTrue(blockB.disposed);
+          chai.assert.equal(this.blockA.getChildren().length, 0);
+        });
+      });
+      suite('Statement', function() {
+        setup(function() {
+          this.blockA = this.workspace.newBlock('statement_block');
+        });
+
+        test('No Connected', function() {
+          this.blockA.removeInput('STATEMENT');
+          chai.assert.isNull(this.blockA.getInput('STATEMENT'));
+        });
+        test('Block Connected', function() {
+          var blockB = this.workspace.newBlock('stack_block');
+          this.blockA.getInput('STATEMENT').connection
+              .connect(blockB.previousConnection);
+
+          this.blockA.removeInput('STATEMENT');
+          chai.assert.isNotOk(blockB.disposed);
+          chai.assert.equal(this.blockA.getChildren().length, 0);
+        });
+        test('Shadow Connected', function() {
+          var blockB = this.workspace.newBlock('stack_block');
+          blockB.setShadow(true);
+          this.blockA.getInput('STATEMENT').connection
+              .connect(blockB.previousConnection);
+
+          this.blockA.removeInput('STATEMENT');
+          console.log(blockB.disposed, blockB);
+          chai.assert.isTrue(blockB.disposed);
+          chai.assert.equal(this.blockA.getChildren().length, 0);
+        });
+      });
+    });
   });
 });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -190,7 +190,7 @@ suite('Blocks', function() {
     });
     suite('Dispose', function() {
       function assertDisposedNoheal(blocks) {
-        chai.assert.isNotOk(blocks.A.disposed);
+        chai.assert.isFalse(blocks.A.disposed);
         // A has nothing connected to it.
         chai.assert.equal(0, blocks.A.getChildren().length);
         // B is disposed.
@@ -199,8 +199,8 @@ suite('Blocks', function() {
         chai.assert.isTrue(blocks.C.disposed);
       }
       function assertDisposedHealed(blocks) {
-        chai.assert.isNotOk(blocks.A.disposed);
-        chai.assert.isNotOk(blocks.C.disposed);
+        chai.assert.isFalse(blocks.A.disposed);
+        chai.assert.isFalse(blocks.C.disposed);
         // A and C are connected.
         assertEquals(1, blocks.A.getChildren().length);
         assertEquals(blocks.A, blocks.C.getParent());
@@ -371,7 +371,7 @@ suite('Blocks', function() {
               .connect(blockB.outputConnection);
 
           this.blockA.removeInput('VALUE');
-          chai.assert.isNotOk(blockB.disposed);
+          chai.assert.isFalse(blockB.disposed);
           chai.assert.equal(this.blockA.getChildren().length, 0);
         });
         test('Shadow Connected', function() {
@@ -400,7 +400,7 @@ suite('Blocks', function() {
               .connect(blockB.previousConnection);
 
           this.blockA.removeInput('STATEMENT');
-          chai.assert.isNotOk(blockB.disposed);
+          chai.assert.isFalse(blockB.disposed);
           chai.assert.equal(this.blockA.getChildren().length, 0);
         });
         test('Shadow Connected', function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1,7 +1,24 @@
-
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 suite('Blocks', function() {
-
   suite('Unplug', function() {
     function assertUnpluggedNoheal(blocks) {
       // A has nothing connected to it.
@@ -11,7 +28,6 @@ suite('Blocks', function() {
       // B is the top of its stack.
       assertNull(blocks.B.getParent());
     }
-
     function assertUnpluggedHealed(blocks) {
       // A and C are connected.
       assertEquals(1, blocks.A.getChildren().length);
@@ -43,7 +59,6 @@ suite('Blocks', function() {
 
       this.workspace = new Blockly.Workspace();
     });
-
     teardown(function() {
       delete Blockly.Blocks['stack_block'];
       delete Blockly.Blocks['row_block'];
@@ -73,13 +88,11 @@ suite('Blocks', function() {
         this.blocks.B.unplug(false);
         assertUnpluggedNoheal(this.blocks);
       });
-
       test('Heal', function() {
         this.blocks.B.unplug(true);
         // Each block has only one input, and the types work.
         assertUnpluggedHealed(this.blocks);
       });
-
       test('Heal with bad checks', function() {
         var blocks = this.blocks;
 
@@ -91,7 +104,6 @@ suite('Blocks', function() {
         blocks.B.unplug(true);
         assertUnpluggedNoheal(blocks);
       });
-
       test('Parent has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to parent
@@ -99,7 +111,6 @@ suite('Blocks', function() {
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
-
       test('Middle block has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to middle block
@@ -107,7 +118,6 @@ suite('Blocks', function() {
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
-
       test('Child block has multiple inputs', function() {
         var blocks = this.blocks;
         // Add extra input to child block
@@ -117,8 +127,6 @@ suite('Blocks', function() {
         assertUnpluggedHealed(blocks);
       });
     });
-
-
     suite('Stack', function() {
       setup(function() {
         var blockA = this.workspace.newBlock('stack_block');
@@ -141,12 +149,10 @@ suite('Blocks', function() {
         this.blocks.B.unplug();
         assertUnpluggedNoheal(this.blocks);
       });
-
       test('Heal', function() {
         this.blocks.B.unplug(true);
         assertUnpluggedHealed(this.blocks);
       });
-
       test('Heal with bad checks', function() {
         var blocks = this.blocks;
         // A and C can't connect, but both can connect to B.

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -1,6 +1,25 @@
-
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 suite('Connections', function() {
+
 
   suite.skip('Rendered', function() {
     function assertAllConnectionsHiddenState(block, hidden) {

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -20,7 +20,6 @@
 
 suite('Connections', function() {
 
-
   suite.skip('Rendered', function() {
     function assertAllConnectionsHiddenState(block, hidden) {
       var connections = block.getConnections_(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2152

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Connections now have a default behavior for dealing with connected blocks on dispose.
  * This matches the previous behavior which was stored in block.js.
  * This does not affect how blocks dispose of their children (which is different than the default behavior depending on the healstack property), because all disposal of children is handled before the disposal of connections.
* Connections now have a disposed property.
* Blocks also have a disposed property, because it was needed for unit tests.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Code simplification.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

#### Added unit tests for:
* Unplugging with connected shadow blocks.
* Dispose tests that correspond to all of the unplug tests (including the new shadow ones).
* Remove input tests for:
  * No connected block.
  * Connected shadow block.
  * Connected corporeal block.

#### I ran a memory test for disposing following the below procedure:
1. Defined the below function.
```
function memoryStrike(n) {
  for (var i = 0; i < n; i++) {
    spaghetti(8);
    workspace.getTopBlocks()[0].dispose(false);
  }
}
```
2. Attached the function to a button with an `n` value of 30.
3. Started a Timeline recording following the procedure described [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/#visualize_memory_leaks_with_timeline_recordings).
4. Ran the memoryStrike.
5. Ended the Timeline recording following the procedure described [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/#visualize_memory_leaks_with_timeline_recordings).

Repeating the same test on develop showed that the memory consumption was comparable.
[DisposeProfiles.zip](https://github.com/google/blockly/files/3462706/DisposeProfiles.zip)

#### I ran a smaller scale detached-nodes check following the below procedure:
1. Ran spaghetti stress test.
2. Deleted all blocks.
3. Created a heap snapshot following the procedure described [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/#discover_detached_dom_tree_memory_leaks_with_heap_snapshots).
4. Observed how all detached nodes were related to events (undo/redo) or workspace audio.

Repeating the same test on develop yielded the same number of detached nodes (17072)

#### I ran a similar memory test for removing inputs:
1. Modified the memoryStrike to look like so:
```
function memoryStrike(n) {
        for (var i = 0; i < n; i++) {
          spaghetti(8);
          var blocks = workspace.getBlocksByType('logic_compare');
          for(var j = 0, block; block = blocks[j]; j++) {
            block.removeInput('A');
            block.removeInput('B');
          }
        }
      }
```
2. Attached the function to a button with an `n` value of 1.
3. Started a Timeline recording following the procedure described [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/#visualize_memory_leaks_with_timeline_recordings).
4. Ran the memoryStrike.
5. Ended the Timeline recording following the procedure described [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/#visualize_memory_leaks_with_timeline_recordings).

Repeating the same test on develop showed that the memory consumption was comparable.
[RemoveInputProfiles.zip](https://github.com/google/blockly/files/3462708/RemoveInputProfiles.zip)

#### I also created a heap snapshot to check for detached nodes.

I observed how all detached nodes were related to events (undo/redo) or workspace audio.

Repeating the same test on develop yielded the same number of detached nodes (8686)

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Nope!

### Additional Information

<!-- Anything else we should know? -->
Each commit can be reviewed separately.
