### PR TITLE
Updating debug rendering for RTL blocks.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -65,13 +65,15 @@ Blockly.blockRendering.Debug.prototype.clearElems = function() {
  * Draw a debug rectangle for a spacer (empty) row.
  * @param {!Blockly.blockRendering.Row} row The row to render
  * @param {number} cursorY The y position of the top of the row.
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
+ *     the block to debug.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
+Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, info) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowSpacerRect blockRenderDebug',
-        'x': 0,
+        'x': info.RTL ? -row.width : 0,
         'y': cursorY,
         'width': row.width,
         'height': row.height,
@@ -82,17 +84,22 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY) {
 /**
  * Draw a debug rectangle for a horizontal spacer.
  * @param {!Blockly.BlockSvg.InRowSpacer} elem The spacer to render
- * @param {number} cursorX The x position of the left of the row.
  * @param {number} rowHeight The height of the container row.
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
+ *     the block to debug.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, rowHeight) {
+Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight, info) {
+  var xPos = elem.xPos;
+  if (info.RTL) {
+    xPos = -(xPos + elem.width);
+  }
   var debugRenderedHeight = Math.min(elem.height, rowHeight);
   var yPos = elem.centerline - debugRenderedHeight / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemSpacerRect blockRenderDebug',
-        'x': cursorX,
+        'x': xPos,
         'y': yPos,
         'width': elem.width,
         'height': debugRenderedHeight,
@@ -103,19 +110,23 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, cursorX, 
 /**
  * Draw a debug rectangle for an in-row element.
  * @param {!Blockly.BlockSvg.Measurable} elem The element to render
- * @param {number} cursorX The x position of the left of the row.
- * @param {number} centerY The y position of the center of the row, vertically.
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
+ *     the block to debug.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, cursorX) {
+Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, info) {
+  var xPos = elem.xPos;
+  if (info.RTL) {
+    xPos = -(xPos + elem.width);
+  }
   var yPos = elem.centerline - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowRenderingRect blockRenderDebug',
-        'x': cursorX,
+        'x': xPos,
         'y': yPos,
         'width': elem.width,
-        'height': elem.height ,
+        'height': elem.height,
       },
       this.svgRoot_));
 
@@ -168,13 +179,15 @@ Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
  * Draw a debug rectangle for a non-empty row.
  * @param {!Blockly.BlockSvg.Row} row The non-empty row to render.
  * @param {number} cursorY The y position of the top of the row.
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
+ *     the block to debug.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) {
+Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, info) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemRenderingRect blockRenderDebug',
-        'x': 0,
+        'x': info.RTL ? -row.width : 0,
         'y': cursorY ,
         'width': row.width,
         'height': row.height,
@@ -186,20 +199,20 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY) 
  * Draw debug rectangles for a non-empty row and all of its subcomponents.
  * @param {!Blockly.BlockSvg.Row} row The non-empty row to render.
  * @param {number} cursorY The y position of the top of the row.
+ * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
+ *     the block to debug.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY) {
-  var cursorX = 0;
+Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY, info) {
   for (var e = 0; e < row.elements.length; e++) {
     var elem = row.elements[e];
     if (elem.isSpacer()) {
-      this.drawSpacerElem(elem, cursorX, row.height);
+      this.drawSpacerElem(elem, row.height, info);
     } else {
-      this.drawRenderedElem(elem, cursorX);
+      this.drawRenderedElem(elem, info);
     }
-    cursorX += elem.width;
   }
-  this.drawRenderedRow(row, cursorY);
+  this.drawRenderedRow(row, cursorY, info);
 };
 
 /**
@@ -216,9 +229,9 @@ Blockly.blockRendering.Debug.prototype.drawDebug = function(block, info) {
   for (var r = 0; r < info.rows.length; r++) {
     var row = info.rows[r];
     if (row.isSpacer()) {
-      this.drawSpacerRow(row, cursorY);
+      this.drawSpacerRow(row, cursorY, info);
     } else {
-      this.drawRowWithElements(row, cursorY);
+      this.drawRowWithElements(row, cursorY, info);
     }
     cursorY += row.height;
   }

--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -65,15 +65,14 @@ Blockly.blockRendering.Debug.prototype.clearElems = function() {
  * Draw a debug rectangle for a spacer (empty) row.
  * @param {!Blockly.blockRendering.Row} row The row to render
  * @param {number} cursorY The y position of the top of the row.
- * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
- *     the block to debug.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, info) {
+Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, isRtl) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowSpacerRect blockRenderDebug',
-        'x': info.RTL ? -row.width : 0,
+        'x': isRtl ? -row.width : 0,
         'y': cursorY,
         'width': row.width,
         'height': row.height,
@@ -85,13 +84,12 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, in
  * Draw a debug rectangle for a horizontal spacer.
  * @param {!Blockly.BlockSvg.InRowSpacer} elem The spacer to render
  * @param {number} rowHeight The height of the container row.
- * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
- *     the block to debug.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight, info) {
+Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight, isRtl) {
   var xPos = elem.xPos;
-  if (info.RTL) {
+  if (isRtl) {
     xPos = -(xPos + elem.width);
   }
   var debugRenderedHeight = Math.min(elem.height, rowHeight);
@@ -110,13 +108,12 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
 /**
  * Draw a debug rectangle for an in-row element.
  * @param {!Blockly.BlockSvg.Measurable} elem The element to render
- * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
- *     the block to debug.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, info) {
+Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) {
   var xPos = elem.xPos;
-  if (info.RTL) {
+  if (isRtl) {
     xPos = -(xPos + elem.width);
   }
   var yPos = elem.centerline - elem.height / 2;
@@ -179,15 +176,14 @@ Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
  * Draw a debug rectangle for a non-empty row.
  * @param {!Blockly.BlockSvg.Row} row The non-empty row to render.
  * @param {number} cursorY The y position of the top of the row.
- * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
- *     the block to debug.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, info) {
+Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, isRtl) {
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemRenderingRect blockRenderDebug',
-        'x': info.RTL ? -row.width : 0,
+        'x': isRtl ? -row.width : 0,
         'y': cursorY ,
         'width': row.width,
         'height': row.height,
@@ -199,20 +195,19 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, 
  * Draw debug rectangles for a non-empty row and all of its subcomponents.
  * @param {!Blockly.BlockSvg.Row} row The non-empty row to render.
  * @param {number} cursorY The y position of the top of the row.
- * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
- *     the block to debug.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
  * @package
  */
-Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY, info) {
+Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY, isRtl) {
   for (var e = 0; e < row.elements.length; e++) {
     var elem = row.elements[e];
     if (elem.isSpacer()) {
-      this.drawSpacerElem(elem, row.height, info);
+      this.drawSpacerElem(elem, row.height, isRtl);
     } else {
-      this.drawRenderedElem(elem, info);
+      this.drawRenderedElem(elem, isRtl);
     }
   }
-  this.drawRenderedRow(row, cursorY, info);
+  this.drawRenderedRow(row, cursorY, isRtl);
 };
 
 /**
@@ -229,9 +224,9 @@ Blockly.blockRendering.Debug.prototype.drawDebug = function(block, info) {
   for (var r = 0; r < info.rows.length; r++) {
     var row = info.rows[r];
     if (row.isSpacer()) {
-      this.drawSpacerRow(row, cursorY, info);
+      this.drawSpacerRow(row, cursorY, info.RTL);
     } else {
-      this.drawRowWithElements(row, cursorY, info);
+      this.drawRowWithElements(row, cursorY, info.RTL);
     }
     cursorY += row.height;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Changes how debug rectangles are drawn to take into consideration whether a block is RTL for determining x position.

### Reason for Changes

More accurate debug rendering for RTL blocks.

![image](https://user-images.githubusercontent.com/6621618/62404689-0dc99480-b54b-11e9-941f-b4a696b05e9d.png)

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
