### PR TITLE
Center text field input when editing

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -538,7 +538,8 @@ Blockly.Css.CONTENT = [
     'margin: 0;',
     'outline: none;',
     'padding: 0 1px;',
-    'width: 100%',
+    'width: 100%;',
+    'text-align: center;',
   '}',
 
   '.blocklyMainBackground {',

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -301,14 +301,10 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
   this.onKeyDownWrapper_ =
       Blockly.bindEventWithChecks_(
           htmlInput, 'keydown', this, this.onHtmlInputKeyDown_);
-  // Resize after every keystroke.
-  this.onKeyUpWrapper_ =
+  // Resize after every input change.
+  this.onKeyInputWrapper_ =
       Blockly.bindEventWithChecks_(
-          htmlInput, 'keyup', this, this.onHtmlInputChange_);
-  // Repeatedly resize when holding down a key.
-  this.onKeyPressWrapper_ =
-      Blockly.bindEventWithChecks_(
-          htmlInput, 'keypress', this, this.onHtmlInputChange_);
+          htmlInput, 'input', this, this.onHtmlInputChange_);
 };
 
 /**
@@ -317,8 +313,7 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
  */
 Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
   Blockly.unbindEvent_(this.onKeyDownWrapper_);
-  Blockly.unbindEvent_(this.onKeyUpWrapper_);
-  Blockly.unbindEvent_(this.onKeyPressWrapper_);
+  Blockly.unbindEvent_(this.onKeyInputWrapper_);
 };
 
 /**


### PR DESCRIPTION
Make field text centered and use input instead of keyup/press.

Old behaviour: 
![old](https://user-images.githubusercontent.com/16690124/62406459-162cca00-b561-11e9-9fd1-18059ae3d127.gif)
Notice how the text jumps left when editing.

New behaviour:
![new](https://user-images.githubusercontent.com/16690124/62406428-9999eb80-b560-11e9-94f3-4a51c3c327ef.gif)

The keypress / keydown event combo was used to support IE9- browsers. Since we've dropped compatibility, we can use the input event which is available on all browsers we support: https://caniuse.com/input-event.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

N/A

### Proposed Changes

Center the text in the input widget and use the input change event to detect changes instead of the keypress / keyup event.

### Reason for Changes

It looks better when the text doesn't jump out of place when you're editing.

### Test Coverage

Tested typing characters, clearing input, select all and delete, escape, enter, and pressing and holding (all with expected behaviour)

Tested on:
- Desktop Chrome
- Desktop Safari

### Additional Information

The input even is available on all the browsers we support: 
https://caniuse.com/#feat=input-event
