### PR TITLE
Fix RTL text field positioning bug by ensuring a reflow

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -161,7 +161,17 @@ Blockly.FieldTextInput.prototype.render_ = function() {
   // This logic is done in render_ rather than doValueInvalid_ or
   // doValueUpdate_ so that the code is more centralized.
   if (this.isBeingEdited_) {
-    this.resizeEditor_();
+    if (this.sourceBlock_.RTL) {
+      // in RTL, we need to let the browser reflow before resizing
+      // in order to get the correct bounding box of the borderRect
+      // avoiding issue #2777.
+      var field = this;
+      setTimeout(function() {
+        field.resizeEditor_();
+      }, 0);
+    } else {
+      this.resizeEditor_();
+    }
     if (!this.isTextValid_) {
       Blockly.utils.dom.addClass(this.htmlInput_, 'blocklyInvalidInput');
     } else {
@@ -247,7 +257,11 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
   htmlInput.value = htmlInput.defaultValue = this.value_;
   htmlInput.untypedDefaultValue_ = this.value_;
   htmlInput.oldValue_ = null;
-  this.resizeEditor_();
+  // Ensure the browser reflows before resizing to avoid issue #2777.
+  var field = this;
+  setTimeout(function() {
+    field.resizeEditor_();
+  }, 0);
 
   this.bindInputEvents_(htmlInput);
 


### PR DESCRIPTION
As user's type in the text input, it resizes the input field based on the field's borderRect. Currently it doesn't get a chance to reflow when resizing, and that causes an issue for RTL blocks as the left hand size is constantly changing as a user types. 

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/2777

### Proposed Changes

Reflow for RTL.

### Test Coverage

Tested on:
* Desktop Chrome (Mac)
* Desktop Firefox (Mac)
* Desktop Safari
* Edge18
* IE

### Additional Information

<!-- Anything else we should know? -->
