### PR TITLE
Adding logic to flip FieldImages in RTL with flipRtl flag set.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -315,15 +315,22 @@ Blockly.blockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
 
   var yPos = fieldInfo.centerline - fieldInfo.height / 2;
   var xPos = fieldInfo.xPos;
+  var scale = '';
   if (this.info_.RTL) {
     xPos = -(xPos + fieldInfo.width);
+    if (fieldInfo.flipRtl) {
+      xPos += fieldInfo.width;
+      scale = 'scale(-1 1)';
+    }
   }
   if (fieldInfo.type == 'icon') {
     svgGroup.setAttribute('display', 'block');
-    svgGroup.setAttribute('transform', 'translate(' + xPos + ',' + yPos + ')');
+    svgGroup.setAttribute(
+        'transform','translate(' + xPos + ',' + yPos + ')' + scale);
     fieldInfo.icon.computeIconLocation();
   } else {
-    svgGroup.setAttribute('transform', 'translate(' + xPos + ',' + yPos + ')');
+    svgGroup.setAttribute(
+        'transform', 'translate(' + xPos + ',' + yPos + ')' + scale);
   }
 
   if (this.info_.isInsertionMarker) {

--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -325,7 +325,7 @@ Blockly.blockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
   }
   if (fieldInfo.type == 'icon') {
     svgGroup.setAttribute('display', 'block');
-    svgGroup.setAttribute('transform','translate(' + xPos + ',' + yPos + ')');
+    svgGroup.setAttribute('transform', 'translate(' + xPos + ',' + yPos + ')');
     fieldInfo.icon.computeIconLocation();
   } else {
     svgGroup.setAttribute(

--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -325,8 +325,7 @@ Blockly.blockRendering.Drawer.prototype.layoutField_ = function(fieldInfo) {
   }
   if (fieldInfo.type == 'icon') {
     svgGroup.setAttribute('display', 'block');
-    svgGroup.setAttribute(
-        'transform','translate(' + xPos + ',' + yPos + ')' + scale);
+    svgGroup.setAttribute('transform','translate(' + xPos + ',' + yPos + ')');
     fieldInfo.icon.computeIconLocation();
   } else {
     svgGroup.setAttribute(

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -215,6 +215,7 @@ Blockly.blockRendering.Field = function(field, parentInput) {
   Blockly.blockRendering.Field.superClass_.constructor.call(this);
   this.field = field;
   this.isEditable = field.isCurrentlyEditable();
+  this.flipRtl = field instanceof Blockly.FieldImage && field.getFlipRtl();
   this.type = 'field';
 
   var size = this.field.getSize();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Stores flag for flipRtl on BlockInfo and flips image in block_render_draw if in RTL and flipRtl is set.

### Reason for Changes

Enabling flipRtl behaviour makes new renderer more consistent with old renderer features.

### Test Coverage

Tested manually in playground and compared using screenshot tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
