### PR TITLE
Fixed Block Factory XML not Getting Properly Cleaned

### DIFF
--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -921,7 +921,7 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
   // Each XML element should contain a single child element with a 'block' tag
   if (blockXml1.tagName.toLowerCase() != 'xml' ||
       blockXml2.tagName.toLowerCase() != 'xml') {
-    throw new Error('Expected two XML elements, recieved elements with tag ' +
+    throw new Error('Expected two XML elements, received elements with tag ' +
         'names: ' + blockXml1.tagName + ' and ' + blockXml2.tagName + '.');
   }
 
@@ -948,6 +948,12 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
   return blockXmlText1 == blockXmlText2;
 };
 
+/**
+ * Strips the provided xml of any attributes that don't describe the
+ * 'structure' of the blocks (i.e. block order, field values, etc).
+ * @param {Node} xml The xml to clean.
+ * @return {Node}
+ */
 FactoryUtils.cleanXml = function(xml) {
   var newXml = xml.cloneNode(true);
   var node = newXml;

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -926,7 +926,7 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
   }
 
   // Compare the block elements directly. The XML tags may include other meta
-  // information we want to igrore.
+  // information we want to ignore.
   var blockElement1 = blockXml1.getElementsByTagName('block')[0];
   var blockElement2 = blockXml2.getElementsByTagName('block')[0];
 
@@ -934,8 +934,11 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
     throw new Error('Could not get find block element in XML.');
   }
 
-  var blockXmlText1 = Blockly.Xml.domToText(blockElement1);
-  var blockXmlText2 = Blockly.Xml.domToText(blockElement2);
+  var cleanBlockXml1 = FactoryUtils.cleanXml(blockElement1);
+  var cleanBlockXml2 = FactoryUtils.cleanXml(blockElement2);
+
+  var blockXmlText1 = Blockly.Xml.domToText(cleanBlockXml1);
+  var blockXmlText2 = Blockly.Xml.domToText(cleanBlockXml2);
 
   // Strip white space.
   blockXmlText1 = blockXmlText1.replace(/\s+/g, '');
@@ -943,6 +946,41 @@ FactoryUtils.sameBlockXml = function(blockXml1, blockXml2) {
 
   // Return whether or not changes have been saved.
   return blockXmlText1 == blockXmlText2;
+};
+
+FactoryUtils.cleanXml = function(xml) {
+  var newXml = xml.cloneNode(true);
+  var node = newXml;
+  while (node) {
+    // Things like text inside tags are still treated as nodes, but they
+    // don't have attributes (or the removeAttribute function) so we can
+    // skip removing attributes from them.
+    if (node.removeAttribute) {
+      node.removeAttribute('xmlns');
+      node.removeAttribute('x');
+      node.removeAttribute('y');
+      node.removeAttribute('id');
+    }
+
+    // Try to go down the tree
+    var nextNode = node.firstChild || node.nextSibling;
+    // If we can't go down, try to go back up the tree.
+    if (!nextNode) {
+      nextNode = node.parentNode;
+      while (nextNode) {
+        // We are valid again!
+        if (nextNode.nextSibling) {
+          nextNode = nextNode.nextSibling;
+          break;
+        }
+        // Try going up again. If parentNode is null that means we have
+        // reached the top, and we will break out of both loops.
+        nextNode = nextNode.parentNode;
+      }
+    }
+    node = nextNode;
+  }
+  return newXml;
 };
 
 /*


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#636 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that all unimportant attributes (x, y, id, xmlns) are removed from the xml before comparing.

### Reason for Changes / Underlying Problem

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The reason diffing was failing before is that an output shadow block was being created with a different ID before the one in XML could be loaded.

This is because validators are now called whenever a value is loaded from XML, which makes [this](https://github.com/google/blockly/blob/de39d5f2d056f0f380dbbfb8f86cfa82ea449f55/demos/blockfactory/blocks.js#L48) trigger the creation of a new shadow.

The changes proposed negate this problem by ignoring the ID when diffing.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Could not replicated #636

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
The [trashcan ](https://github.com/google/blockly/blob/de39d5f2d056f0f380dbbfb8f86cfa82ea449f55/core/trashcan.js#L503)and the blockfactory are now both doing this cleaning/diffing combo. It may be worth it at some point in the future to create explicit workspace diffing functions. If there was such a system cross-save-format diffing could also be added (e.g. is this JSON the same as this XML) if other save formats are ever added.
