### PR TITLE
Math.sign -> Math.sin

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -290,7 +290,7 @@ Blockly.Workspace.prototype.getBlocksByType = function(type, ordered) {
   var blocks = this.typedBlocksDB_[type].slice(0);
   if (ordered && blocks.length > 1) {
     this.sortObjects_.offset =
-        Math.sign(Blockly.utils.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
+        Math.sin(Blockly.utils.math.toRadians(Blockly.Workspace.SCAN_ANGLE));
     if (this.RTL) {
       this.sortObjects_.offset *= -1;
     }


### PR DESCRIPTION
There was a typo at some point that introduced this. 
Note for all,`` Math.sign`` is not available on IE, and needs a polyfill if we want to use it.

In this case, it was just a typo, and ``sin`` was the intended method.

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
