### PR TITLE
Add debug rendering that shows the bounding box of the block

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -211,6 +211,27 @@ Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, curso
 };
 
 /**
+ * Draw a debug rectangle around the entire block.
+ * @param {number} width The width of the block.
+ * @param {number} height The height of the block.
+ * @param {boolean} isRtl Whether the block is rendered RTL.
+ * @package
+ */
+Blockly.blockRendering.Debug.prototype.drawBoundingBox = function(width, height, isRtl) {
+  var xPos = isRtl ? -width : 0;
+  var yPos = 0;
+
+  this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
+      {
+        'class': 'blockBoundingBox blockRenderDebug',
+        'x': xPos,
+        'y': yPos,
+        'width': width,
+        'height': height,
+      },
+      this.svgRoot_));
+};
+/**
  * Do all of the work to draw debug information for the whole block.
  * @param {!Blockly.BlockSvg} block The block to draw debug information for.
  * @param {!Blockly.blockRendering.RenderInfo} info Rendering information about
@@ -240,4 +261,6 @@ Blockly.blockRendering.Debug.prototype.drawDebug = function(block, info) {
   if (block.outputConnection) {
     this.drawConnection(block.outputConnection);
   }
+
+  this.drawBoundingBox(info.width, info.height, info.isRtl);
 };

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -472,6 +472,13 @@ h1 {
   stroke-width: 1px;
 }
 
+.blockBoundingBox {
+  stroke: black;
+  stroke-dasharray: 5,5;
+  fill: none;
+  stroke-width: 1px;
+}
+
 </style>
 </head>
 <body onload="start()">

--- a/tests/screenshot/playground_new.html
+++ b/tests/screenshot/playground_new.html
@@ -98,6 +98,13 @@ h1 {
 .connectionRenderingDot {
   display: none;
 }
+
+.blockBoundingBox {
+  stroke: black;
+  stroke-dasharray: 5,5;
+  fill: none;
+  stroke-width: 1px;
+}
 </style>
 </head>
 <body onload="start()">


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Adds a dashed line bounding box around each block in debug rendering.
![image](https://user-images.githubusercontent.com/13686399/62904564-bd58f080-bd1b-11e9-9cb0-0d200aff7757.png)

### Reason for Changes

Improve debug tools for rendering changes.

### Test Coverage
Tested in the playground.