### PR TITLE
package.json no longer private

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "./blockly-node.js": "./blockly.js"
   },
   "license": "Apache-2.0",
-  "private": true,
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^5.13.0",


### PR DESCRIPTION
Remove private attribute from package.json as the package is now published on ``npm``.
