### PR TITLE
Include next connection in block's bounding box

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -147,7 +147,7 @@ Blockly.blockRendering.Drawer.prototype.drawTop_ = function() {
     } else if (elem.isSpacer()) {
       this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('h', elem.width);
     }
-    // No branch for a square corner, because it's a no-op.
+    // No branch for a 'square corner', because it's a no-op.
   }
   this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
 };
@@ -183,7 +183,7 @@ Blockly.blockRendering.Drawer.prototype.drawValueInput_ = function(row) {
 
   this.outlinePath_ +=
       Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width) +
-      Blockly.blockRendering.constants.PUZZLE_TAB.pathDown +
+      input.connectionShape.pathDown +
       Blockly.utils.svgPaths.lineOnAxis('v', row.height - input.connectionHeight);
 };
 
@@ -248,7 +248,8 @@ Blockly.blockRendering.Drawer.prototype.drawBottom_ = function() {
   }
   this.positionNextConnection_();
 
-  this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', bottomRow.height);
+  this.outlinePath_ +=
+    Blockly.utils.svgPaths.lineOnAxis('v', bottomRow.height - bottomRow.overhangY);
 
   for (var i = elems.length - 1; i >= 0; i--) {
     var elem = elems[i];
@@ -280,8 +281,9 @@ Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
   if (outputConnection) {
     var tabBottom = outputConnection.connectionOffsetY + outputConnection.height;
     // Draw a line up to the bottom of the tab.
-    this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('V', tabBottom);
-    this.outlinePath_ += Blockly.blockRendering.constants.PUZZLE_TAB.pathUp;
+    this.outlinePath_ +=
+        Blockly.utils.svgPaths.lineOnAxis('V', tabBottom) +
+        outputConnection.connectionShape.pathUp;
   }
   // Close off the path.  This draws a vertical line up to the start of the
   // block's path, which may be either a rounded or a sharp corner.
@@ -466,7 +468,7 @@ Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
     var x = connInfo.xPos; // Already contains info about startX
     var connX = (this.info_.RTL ? -x : x) + 0.5;
     bottomRow.connection.setOffsetInBlock(
-        connX, this.info_.height +
+        connX, (connInfo.centerline - connInfo.height / 2) +
             Blockly.blockRendering.constants.DARK_PATH_OFFSET);
   }
 };

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -156,7 +156,7 @@ Blockly.blockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawBottomRow = function(row) {
-  var height = row.yPos + row.height;
+  var height = row.yPos + row.height - row.overhangY;
 
   // Highlight the vertical edge of the bottom row on the input side.
   // Highlighting is always from the top left, both in LTR and RTL.

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -688,7 +688,7 @@ Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, e
   } else if (elem.isInlineInput()) {
     result += elem.height / 2;
   } else if (elem.isNextConnection()) {
-    result += row.height + elem.height / 2;
+    result += (row.height - row.overhangY + elem.height / 2);
   } else {
     result += (row.height / 2);
   }

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -311,7 +311,7 @@ Blockly.blockRendering.ExternalValueInput = function(input) {
   this.type = 'external value input';
 
   if (!this.connectedBlock) {
-    this.height = Blockly.blockRendering.constants.TAB_HEIGHT;
+    this.height = this.connectionShape.height;
   } else {
     this.height =
         this.connectedBlockHeight - 2 * Blockly.blockRendering.constants.TAB_OFFSET_FROM_TOP;
@@ -564,6 +564,7 @@ Blockly.blockRendering.BottomRow = function(block) {
   this.type = 'bottom row';
   this.hasNextConnection = !!block.nextConnection;
   this.connection = block.nextConnection;
+  this.overhangY = 0;
 
   var followsStatement =
       block.inputList.length &&
@@ -586,4 +587,19 @@ Blockly.blockRendering.BottomRow.prototype.getNextConnection = function() {
     return this.elements[2];
   }
   return null;
+};
+
+Blockly.blockRendering.BottomRow.prototype.measure = function() {
+  for (var e = 0; e < this.elements.length; e++) {
+    var elem = this.elements[e];
+    this.width += elem.width;
+    if (!(elem.isSpacer())) {
+      if (elem.type == 'next connection') {
+        this.height = this.height + elem.height;
+        this.overhangY = elem.height;
+      }
+      this.height = Math.max(this.height, elem.height);
+    }
+  }
+  this.widthWithConnectedBlocks = this.width;
 };


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Next connection was not correctly part of the height of the last row.

### Proposed Changes

- Give the bottom row the concept of overhang, and adjust drawing of the bottom of the block accordingly.
- Remove more explicit references to connection shape objects, and use the connection measurable's connectionShape property instead.  Tested by replacing the puzzle tab with a different shape in measurables.js:
```
Blockly.blockRendering.Measurable.prototype.connectionShape =
    Blockly.blockRendering.constants.TRIANGLE;
```
### Reason for Changes

- Block height and width should include all parts of the block.
- All input and output connections should be drawn the same way right now.

### Test Coverage
Tested on chrome in the playground.

### Documentation


### Additional Information

Followup: look into getHeightWidth in block_render_svg, and move it block_svg.