### PR TITLE
Adding missing padding to statement input rows.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -536,9 +536,14 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
 Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
-    if (!row.hasStatement && !row.hasInlineInput) {
+    if (!row.hasInlineInput) {
       var currentWidth = row.width;
-      var desiredWidth = this.width - this.startX;
+      if (row.hasStatement) {
+        var statementInput = row.getLastInput();
+        currentWidth -= statementInput.width;
+      }
+      var desiredWidth = row.hasStatement ? this.statementEdge : this.width;
+      desiredWidth -= this.startX;
       if (row.type === 'bottom row' && row.hasFixedWidth) {
         desiredWidth = Blockly.blockRendering.constants.MAX_BOTTOM_WIDTH;
       }
@@ -564,7 +569,7 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
   if (input) {
     var firstSpacer = row.getFirstSpacer();
     var lastSpacer = row.getLastSpacer();
-    if (row.hasExternalInput) {
+    if (row.hasExternalInput || row.hasStatement) {
       // Get the spacer right before the input socket.
       lastSpacer = elems[elems.length - 3];
     }

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -537,13 +537,14 @@ Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     if (!row.hasInlineInput) {
-      var currentWidth = row.width;
       if (row.hasStatement) {
         var statementInput = row.getLastInput();
-        currentWidth -= statementInput.width;
+        var currentWidth = row.width - statementInput.width;
+        var desiredWidth = this.statementEdge - this.startX;
+      } else {
+        var currentWidth = row.width;
+        var desiredWidth = this.width - this.startX;
       }
-      var desiredWidth = row.hasStatement ? this.statementEdge : this.width;
-      desiredWidth -= this.startX;
       if (row.type === 'bottom row' && row.hasFixedWidth) {
         desiredWidth = Blockly.blockRendering.constants.MAX_BOTTOM_WIDTH;
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Aligning padding on statement input rows.

### Reason for Changes

Previously, padding before statement input edge was not updated. This change makes the xPos for statement inputs accurate and enables using the xPos on that element for draw.

#### Before:
![image](https://user-images.githubusercontent.com/6621618/62975383-1897eb00-bdcf-11e9-8c17-db7b8caffeef.png)

#### After:
![image](https://user-images.githubusercontent.com/6621618/62975259-da023080-bdce-11e9-8b15-07dc3a66c3a7.png)


### Test Coverage
Tested manually on playground/
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

