### PR TITLE
Update statementInput width to reflect what is actually being rendered.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -198,8 +198,9 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   if (this.highlighter_) {
     this.highlighter_.drawStatementInput(row);
   }
+  var input = row.getLastInput();
   // Where to start drawing the notch, which is on the right side in LTR.
-  var x = row.xPos + row.statementEdge +
+  var x = row.xPos + input.xPos +
     Blockly.blockRendering.constants.NOTCH_OFFSET_LEFT +
     Blockly.blockRendering.constants.NOTCH.width;
 

--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -200,9 +200,7 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   }
   var input = row.getLastInput();
   // Where to start drawing the notch, which is on the right side in LTR.
-  var x = row.xPos + input.xPos +
-    Blockly.blockRendering.constants.NOTCH_OFFSET_LEFT +
-    Blockly.blockRendering.constants.NOTCH.width;
+  var x = input.xPos + input.width;
 
   var innerTopLeftCorner =
       Blockly.blockRendering.constants.NOTCH.pathRight + ' h -' +

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -487,9 +487,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     row.measure();
-    if (!row.hasStatement) {
-      blockWidth = Math.max(blockWidth, row.width);
-    }
+    blockWidth = Math.max(blockWidth, row.width);
     if (row.hasStatement) {
       var statementInput = row.getLastInput();
       var innerWidth = row.width - statementInput.width;
@@ -502,13 +500,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
 
   this.statementEdge = widestStatementRowFields;
 
-  if (widestStatementRowFields) {
-    this.width =
-        Math.max(blockWidth,
-            widestStatementRowFields + Blockly.blockRendering.constants.NOTCH.width * 2);
-  } else {
-    this.width = blockWidth;
-  }
+  this.width = blockWidth;
 
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];

--- a/core/renderers/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/renderers/block_rendering_rewrite/block_rendering_constants.js
@@ -126,11 +126,6 @@ Blockly.blockRendering.constants.EXTERNAL_VALUE_INPUT_PADDING = 2;
 Blockly.blockRendering.constants.EMPTY_STATEMENT_INPUT_HEIGHT =
     Blockly.blockRendering.constants.MIN_BLOCK_HEIGHT;
 
-Blockly.blockRendering.constants.EMPTY_STATEMENT_INPUT_WIDTH = 32;
-
-Blockly.blockRendering.constants.POPULATED_STATEMENT_INPUT_WIDTH = 25;
-
-
 Blockly.blockRendering.constants.START_POINT = Blockly.utils.svgPaths.moveBy(0, 0);
 
 /**

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -292,7 +292,8 @@ Blockly.blockRendering.StatementInput = function(input) {
       this.height -= this.notchShape.height;
     }
   }
-  this.width = this.notchShape.width * 2;
+  this.width = Blockly.blockRendering.constants.NOTCH_OFFSET_LEFT +
+      this.notchShape.width;
 };
 goog.inherits(Blockly.blockRendering.StatementInput,
     Blockly.blockRendering.Input);

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -285,15 +285,14 @@ Blockly.blockRendering.StatementInput = function(input) {
 
   if (!this.connectedBlock) {
     this.height = Blockly.blockRendering.constants.EMPTY_STATEMENT_INPUT_HEIGHT;
-    this.width = Blockly.blockRendering.constants.EMPTY_STATEMENT_INPUT_WIDTH;
   } else {
-    this.width = Blockly.blockRendering.constants.POPULATED_STATEMENT_INPUT_WIDTH;
     this.height =
         this.connectedBlockHeight + Blockly.blockRendering.constants.STATEMENT_BOTTOM_SPACER;
     if (this.connectedBlock.nextConnection) {
       this.height -= this.notchShape.height;
     }
   }
+  this.width = this.notchShape.width * 2;
 };
 goog.inherits(Blockly.blockRendering.StatementInput,
     Blockly.blockRendering.Input);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Changing width set for StatementInput measurable and simplified computation in computeBounds to use the width of the element.

### Reason for Changes

Updated width is the actual width of the rendered element.

### Test Coverage
Tested manually on playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
