### PR TITLE
Correctly calculate widths of blocks with children on external inputs.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -565,6 +565,7 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
     if (row.hasExternalInput || row.hasStatement) {
       // Get the spacer right before the input socket.
       lastSpacer = elems[elems.length - 3];
+      row.widthWithConnectedBlocks += missingSpace;
     }
     // Decide where the extra padding goes.
     if (input.align == Blockly.ALIGN_LEFT) {
@@ -701,12 +702,16 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
   // Performance note: this could be combined with the draw pass, if the time
   // that this takes is excessive.  But it shouldn't be, because it only
   // accesses and sets properties that already exist on the objects.
+  var widestRowWithConnectedBlocks = 0;
   var yCursor = 0;
   for (var r = 0; r < this.rows.length; r++) {
     var row = this.rows[r];
     row.yPos = yCursor;
     row.xPos = this.startX;
     yCursor += row.height;
+
+    widestRowWithConnectedBlocks =
+        Math.max(widestRowWithConnectedBlocks, row.widthWithConnectedBlocks);
     // Add padding to the bottom row if block height is less than minimum
     var heightWithoutHat = yCursor - this.topRow.startY;
     if (row == this.bottomRow &&
@@ -726,6 +731,8 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
       }
     }
   }
+
+  this.widthWithChildren = widestRowWithConnectedBlocks + this.startX;
 
   this.height = yCursor;
 };

--- a/core/renderers/block_rendering_rewrite/measurables.js
+++ b/core/renderers/block_rendering_rewrite/measurables.js
@@ -426,6 +426,7 @@ Blockly.blockRendering.Row = function() {
   this.elements = [];
   this.width = 0;
   this.height = 0;
+  this.widthWithConnectedBlocks = 0;
 
   this.hasExternalInput = false;
   this.hasStatement = false;
@@ -454,7 +455,8 @@ Blockly.blockRendering.Row.prototype.measure = function() {
     if (elem.isInput) {
       if (elem.type == 'statement input') {
         connectedBlockWidths += elem.connectedBlockWidth;
-      } else if (elem.type == 'external value input') {
+      } else if (elem.type == 'external value input' &&
+          elem.connectedBlockWidth != 0) {
         connectedBlockWidths += (elem.connectedBlockWidth - elem.connectionWidth);
       }
     }
@@ -494,6 +496,7 @@ Blockly.blockRendering.BetweenRowSpacer = function(height, width) {
   this.width = width;
   this.height = height;
   this.followsStatement = false;
+  this.widthWithConnectedBlocks = 0;
 };
 goog.inherits(Blockly.blockRendering.BetweenRowSpacer,
     Blockly.blockRendering.Measurable);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #2821 

### Proposed Changes

In render_draw_debug:
- Adds rendering rectangles for the width of a row with connected blocks and the width of a block with connected blocks
- Adds a config object so it's easy to turn on and off parts of the debug rendering--there's too much going on otherwise.
- Uses random colours for some parts, to distinguish between blocks at boundaries

In the other three files:
- Improves calculation of widthWithConnectedBlocks on rows
- Defines widthWithConnectedBlocks on rows
- When adding alignment padding to a row, records the size change in widthWithConnectedBlocks (only for external value inputs)

### Reason for Changes

Block width was wrong before, and the missing amount was the amount that had been added in alignment padding on the given row (so it was showing up for external value inputs but not otherwise).

### Test Coverage
Tested on the playground with the new debug rendering.

### Documentation
Description of debug rendering, at some point.

### Additional Information

SO MANY COLORED RECTANGLES