### PR TITLE
Fix @throw jsdoc issue

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -53,7 +53,7 @@ goog.require('Blockly.Workspace');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @constructor
- * @throw When block is not valid or block name is not allowed.
+ * @throws When block is not valid or block name is not allowed.
  */
 Blockly.Block = function(workspace, prototypeName, opt_id) {
   if (typeof Blockly.Generator.prototype[prototypeName] !== 'undefined') {


### PR DESCRIPTION
The JavaScript closure compiler barfs at this. No such thing as JSDOC @throw.
