### PR TITLE
Prevent incorrectly drawing vertical line for zero height spacer rows in RTL.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -151,7 +151,9 @@ Blockly.blockRendering.Highlighter.prototype.drawRightSideRow = function(row) {
   }
   if (this.RTL_) {
     this.steps_.push('H', rightEdge);
-    this.steps_.push('V', row.yPos + row.height - this.highlightOffset_);
+    if (row.height > this.highlightOffset_) {
+      this.steps_.push('V', row.yPos + row.height - this.highlightOffset_);
+    }
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
## Proposed Changes

Check row height before drawing vertical highlight for right side row in RTL.

### Reason for Changes

Prevents incorrect highlight from being drawn.
Before:
![image](https://user-images.githubusercontent.com/6621618/63063327-0ee6b400-beb1-11e9-96d0-bd4c2f6ecbb9.png)

After:
![image](https://user-images.githubusercontent.com/6621618/63063330-127a3b00-beb1-11e9-82e5-b5319b2c6997.png)

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually on playground in LTR and RTL.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->