### PR TITLE
Minor refactor in drawing statement and value inputs

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -191,7 +191,7 @@ Blockly.blockRendering.Drawer.prototype.drawValueInput_ = function(row) {
   this.positionExternalValueConnection_(row);
 
   this.outlinePath_ +=
-      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width) +
+      Blockly.utils.svgPaths.lineOnAxis('H', input.xPos + input.width) +
       input.connectionShape.pathDown +
       Blockly.utils.svgPaths.lineOnAxis('v', row.height - input.connectionHeight);
 };
@@ -212,15 +212,18 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   var x = input.xPos + input.width;
 
   var innerTopLeftCorner =
-      Blockly.blockRendering.constants.NOTCH.pathRight + ' h -' +
-      (Blockly.blockRendering.constants.NOTCH_WIDTH -
-          Blockly.blockRendering.constants.CORNER_RADIUS) +
+      input.notchShape.pathRight +
+      Blockly.utils.svgPaths.lineOnAxis('h',
+          -(Blockly.blockRendering.constants.NOTCH_OFFSET_LEFT -
+              Blockly.blockRendering.constants.INSIDE_CORNERS.width)) +
       Blockly.blockRendering.constants.INSIDE_CORNERS.pathTop;
+
+  var innerHeight =
+      row.height -(2 * Blockly.blockRendering.constants.INSIDE_CORNERS.height);
 
   this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('H', x) +
       innerTopLeftCorner +
-      Blockly.utils.svgPaths.lineOnAxis('v',
-          row.height - (2 * Blockly.blockRendering.constants.INSIDE_CORNERS.height)) +
+      Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
       Blockly.blockRendering.constants.INSIDE_CORNERS.pathBottom;
 
   this.positionStatementInputConnection_(row);

--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -219,7 +219,7 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
       Blockly.blockRendering.constants.INSIDE_CORNERS.pathTop;
 
   var innerHeight =
-      row.height -(2 * Blockly.blockRendering.constants.INSIDE_CORNERS.height);
+      row.height - (2 * Blockly.blockRendering.constants.INSIDE_CORNERS.height);
 
   this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('H', x) +
       innerTopLeftCorner +

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -115,35 +115,39 @@ Blockly.blockRendering.Highlighter.prototype.drawJaggedEdge_ = function(row) {
 
 Blockly.blockRendering.Highlighter.prototype.drawValueInput = function(row) {
   var input = row.getLastInput();
+  var steps = '';
   if (this.RTL_) {
     var belowTabHeight = row.height - input.connectionHeight;
 
-    this.steps_.push(Blockly.utils.svgPaths.moveTo(
-        input.xPos + input.width - this.highlightOffset_, row.yPos));
-    this.steps_.push(this.puzzleTabPaths_.pathDown(this.RTL_));
-    this.steps_.push(
-        Blockly.utils.svgPaths.lineOnAxis('v', belowTabHeight));
+    steps =
+        Blockly.utils.svgPaths.moveTo(
+            input.xPos + input.width - this.highlightOffset_, row.yPos) +
+        this.puzzleTabPaths_.pathDown(this.RTL_) +
+        Blockly.utils.svgPaths.lineOnAxis('v', belowTabHeight);
   } else {
-    this.steps_.push(
-        Blockly.utils.svgPaths.moveTo(input.xPos + input.width, row.yPos));
-    this.steps_.push(this.puzzleTabPaths_.pathDown(this.RTL_));
+    steps =
+        Blockly.utils.svgPaths.moveTo(input.xPos + input.width, row.yPos) +
+        this.puzzleTabPaths_.pathDown(this.RTL_);
   }
+
+  this.steps_.push(steps);
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawStatementInput = function(row) {
-  var input = row.getLastInput();
+  var steps = '';
   if (this.RTL_) {
     var innerHeight = row.height - (2 * this.insideCornerPaths_.height);
-    this.steps_.push(Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos));
-    this.steps_.push(this.insideCornerPaths_.pathTop(this.RTL_));
-    this.steps_.push(
-        Blockly.utils.svgPaths.lineOnAxis('v', innerHeight));
-    this.steps_.push(this.insideCornerPaths_.pathBottom(this.RTL_));
+    steps =
+        Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos) +
+        this.insideCornerPaths_.pathTop(this.RTL_) +
+        Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
+        this.insideCornerPaths_.pathBottom(this.RTL_);
   } else {
-    this.steps_.push(
+    steps =
         Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos + row.height) +
-        this.insideCornerPaths_.pathBottom(this.RTL_));
+        this.insideCornerPaths_.pathBottom(this.RTL_);
   }
+  this.steps_.push(steps);
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawRightSideRow = function(row) {

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -134,6 +134,7 @@ Blockly.blockRendering.Highlighter.prototype.drawValueInput = function(row) {
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawStatementInput = function(row) {
+  var input = row.getLastInput();
   var steps = '';
   if (this.RTL_) {
     var innerHeight = row.height - (2 * this.insideCornerPaths_.height);

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -115,40 +115,35 @@ Blockly.blockRendering.Highlighter.prototype.drawJaggedEdge_ = function(row) {
 
 Blockly.blockRendering.Highlighter.prototype.drawValueInput = function(row) {
   var input = row.getLastInput();
-  var steps = '';
   if (this.RTL_) {
     var belowTabHeight = row.height - input.connectionHeight;
 
-    steps =
-        Blockly.utils.svgPaths.moveTo(
-            row.xPos + row.width - this.highlightOffset_, row.yPos) +
-        this.puzzleTabPaths_.pathDown(this.RTL_) +
-        Blockly.utils.svgPaths.lineOnAxis('v', belowTabHeight);
+    this.steps_.push(Blockly.utils.svgPaths.moveTo(
+        input.xPos + input.width - this.highlightOffset_, row.yPos));
+    this.steps_.push(this.puzzleTabPaths_.pathDown(this.RTL_));
+    this.steps_.push(
+        Blockly.utils.svgPaths.lineOnAxis('v', belowTabHeight));
   } else {
-    steps =
-        Blockly.utils.svgPaths.moveTo(row.xPos + row.width, row.yPos) +
-        this.puzzleTabPaths_.pathDown(this.RTL_);
+    this.steps_.push(
+        Blockly.utils.svgPaths.moveTo(input.xPos + input.width, row.yPos));
+    this.steps_.push(this.puzzleTabPaths_.pathDown(this.RTL_));
   }
-
-  this.steps_.push(steps);
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawStatementInput = function(row) {
-  var steps = '';
-  var statementEdge = row.xPos + row.statementEdge;
+  var input = row.getLastInput();
   if (this.RTL_) {
     var innerHeight = row.height - (2 * this.insideCornerPaths_.height);
-    steps =
-        Blockly.utils.svgPaths.moveTo(statementEdge, row.yPos) +
-        this.insideCornerPaths_.pathTop(this.RTL_) +
-        Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
-        this.insideCornerPaths_.pathBottom(this.RTL_);
+    this.steps_.push(Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos));
+    this.steps_.push(this.insideCornerPaths_.pathTop(this.RTL_));
+    this.steps_.push(
+        Blockly.utils.svgPaths.lineOnAxis('v', innerHeight));
+    this.steps_.push(this.insideCornerPaths_.pathBottom(this.RTL_));
   } else {
-    steps =
-        Blockly.utils.svgPaths.moveTo(statementEdge, row.yPos + row.height) +
-        this.insideCornerPaths_.pathBottom(this.RTL_);
+    this.steps_.push(
+        Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos + row.height) +
+        this.insideCornerPaths_.pathBottom(this.RTL_));
   }
-  this.steps_.push(steps);
 };
 
 Blockly.blockRendering.Highlighter.prototype.drawRightSideRow = function(row) {

--- a/core/renderers/block_rendering_rewrite/block_rendering_constants.js
+++ b/core/renderers/block_rendering_rewrite/block_rendering_constants.js
@@ -289,6 +289,7 @@ Blockly.blockRendering.constants.INSIDE_CORNERS = (function() {
       Blockly.utils.svgPaths.point(radius, radius));
 
   return {
+    width: radius,
     height: radius,
     pathTop: innerTopLeftCorner,
     pathBottom: innerBottomLeftCorner


### PR DESCRIPTION
… and more approriate constants.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

block_render_draw:
* Updated drawValueInput and drawStatementInput to use the element xPos
* Updated constants used in drawStatementInput to more accurately reflect what is happening.
block_render_draw_highlight:
* Using xPos for drawing highlight for value input and statement input
* Using svgPaths function and appending to this.steps_ rather than creating a local variable to follow patterns used in other functions in file.

### Reason for Changes

The change in constants more accurately represent what is happening in computation.
Using xPos and the highlight minor refactor more closely matches pattern used in other functions and does not change output.

### Test Coverage

Tested on playground in RTL and LTR.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
