### PR TITLE
Center some fields and inputs vertically

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -678,13 +678,10 @@ Blockly.blockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(prev,
  */
 Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
   var result = row.yPos;
-  if (elem.isField()) {
-    result += (elem.height / 2);
-    if (row.hasInlineInput || row.hasStatement) {
-      result += Blockly.blockRendering.constants.TALL_INPUT_FIELD_OFFSET_Y;
-    }
-  } else if (elem.isInlineInput()) {
-    result += elem.height / 2;
+  if (elem.isField() && row.hasStatement) {
+    var offset = Blockly.blockRendering.constants.TALL_INPUT_FIELD_OFFSET_Y +
+        elem.height / 2;
+    result += offset;
   } else if (elem.isNextConnection()) {
     result += (row.height - row.overhangY + elem.height / 2);
   } else {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1346
https://github.com/google/blockly/issues/333

### Proposed Changes

Center fields and inputs vertically within a row.

### Reason for Changes

Alignment

### Test Coverage
Checked in the playground.
New:
![image](https://user-images.githubusercontent.com/13686399/63115897-24a9b700-bf4d-11e9-9bf3-579017b1c441.png)


Old:

![image](https://user-images.githubusercontent.com/13686399/63115913-31c6a600-bf4d-11e9-9e0b-2bc4aa34409d.png)
