### PR TITLE
Textfield input border size with scale

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -89,6 +89,11 @@ Blockly.FieldTextInput.prototype.SERIALIZABLE = true;
 Blockly.FieldTextInput.FONTSIZE = 11;
 
 /**
+ * Pixel size of input border radius.  Should match blocklyText's border-radius in CSS.
+ */
+Blockly.FieldTextInput.BORDERRADIUS = 4;
+
+/**
  * Mouse cursor style when over the hotspot that initiates the editor.
  */
 Blockly.FieldTextInput.prototype.CURSOR = 'text';
@@ -252,6 +257,9 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
       (Blockly.FieldTextInput.FONTSIZE * this.workspace_.scale) + 'pt';
   div.style.fontSize = fontSize;
   htmlInput.style.fontSize = fontSize;
+  var borderRadius =
+      (Blockly.FieldTextInput.BORDERRADIUS * this.workspace_.scale) + 'px';
+  htmlInput.style.borderRadius = borderRadius;
   div.appendChild(htmlInput);
 
   htmlInput.value = htmlInput.defaultValue = this.value_;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Text input border size is 4px regardless of workspace scale.

### Proposed Changes

Set the border size on a text input to take into account scaling.

### Reason for Changes

🎨

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
* IE 11
* Edge 18

### Additional Information

Not selected: 
<img width="423" alt="Screen Shot 2019-08-15 at 2 47 44 PM" src="https://user-images.githubusercontent.com/16690124/63129230-de178500-bf6b-11e9-86a8-0d7527d4e5e9.png">

Before: 
<img width="492" alt="Screen Shot 2019-08-15 at 2 57 02 PM" src="https://user-images.githubusercontent.com/16690124/63129648-f76d0100-bf6c-11e9-886e-405b1da4b546.png">


After: 
<img width="439" alt="Screen Shot 2019-08-15 at 2 46 07 PM" src="https://user-images.githubusercontent.com/16690124/63129251-e5d72980-bf6b-11e9-9658-9192cddec780.png">
