### PR TITLE
Text input invalid accessibility

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -31,6 +31,7 @@ goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.Msg');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Size');
@@ -174,8 +175,10 @@ Blockly.FieldTextInput.prototype.render_ = function() {
     }
     if (!this.isTextValid_) {
       Blockly.utils.dom.addClass(this.htmlInput_, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', true);
     } else {
       Blockly.utils.dom.removeClass(this.htmlInput_, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', false);
     }
   }
 };


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Simple change to update the aria-invalid attribute when we change the UI of the text field to reflect invalid input.

### Proposed Changes

Add aria invalid for when a text input field is invalid

### Reason for Changes

Accessibility

### Additional Information

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute