### PR TITLE
Remove check for renderer name from build and compile scripts

### DIFF
--- a/build.py
+++ b/build.py
@@ -491,26 +491,10 @@ class Arguments:
     self.core = False
     self.generators = False
     self.langfiles = False
-    self.render_name = "block_rendering_rewrite"
-
-# Add all directories to the path list except for any extra renderers.
-def find_path(args, directories):
-  new_list = []
-  render_path = 'core/renderers/' + args.render_name
-  core_search_paths = calcdeps.ExpandDirectories(directories)
-  for path in core_search_paths:
-    # If it is the desired renderer
-    if path.find('core/renderers') > -1 and path.find(render_path) > -1:
-      new_list.append(path)
-    # If it is not a renderer
-    elif (path.find('core/renderers') == -1):
-      new_list.append(path)
-  return sorted(new_list)
 
 # Setup the argument parser.
 def setup_parser():
-  parser = argparse.ArgumentParser(description="Decide which files to build with what renderer.")
-  parser.add_argument('-renderer', dest="render_name", default="block_rendering_rewrite", help="The name of the desired renderer. The name should corresspond to the name of a folder in core/renderers")
+  parser = argparse.ArgumentParser(description="Decide which files to build.")
   parser.add_argument('-core', action="store_true", default=False, help="Build core")
   parser.add_argument('-generators', action="store_true", default=False, help="Build the generators")
   parser.add_argument('-langfiles', action="store_true", default=False, help="Build all the language files")
@@ -530,16 +514,7 @@ def get_args():
     args.langfiles = 'langfiles' in sys.argv
     if 'accessible' in sys.argv:
       print("The Blockly accessibility demo has moved to https://github.com/google/blockly-experimental")
-    if '-renderer' in sys.argv:
-      print ("Please use the new arguments -core, -generators, -langfiles")
-      sys.exit()
-  verify_render_name(args.render_name)
   return args
-
-# Verify that the passed in renderer name can be found in the renderers directory.
-def verify_render_name(render_name):
-  if (not render_name in next(os.walk('core/renderers'))[1]):
-    print (render_name + " is not a valid renderer.")
 
 if __name__ == "__main__":
   try:
@@ -565,7 +540,9 @@ if __name__ == "__main__":
 developers.google.com/blockly/guides/modify/web/closure""")
     sys.exit(1)
 
-  full_search_paths = find_path(args, ["core", os.path.join(os.path.pardir, "closure-library")])
+  full_search_paths = calcdeps.ExpandDirectories(
+      ["core", os.path.join(os.path.pardir, "closure-library")])
+  full_search_paths = sorted(full_search_paths)  # Deterministic build.
 
   # Uncompressed and compressed are run in parallel threads.
   # Uncompressed is limited by processor speed.

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -73,54 +73,28 @@ if [ -f "$BLOCKLY_ROOT/tests/compile/main_compressed.js" ]; then
   rm "$BLOCKLY_ROOT/tests/compile/main_compressed.js"
 fi
 
-# If an argument is passed and is a valid renderer name use it. Otherwise use
-# the default renderer name.
-if [[ $# == 1 ]]; then
-  if [ $(find "$BLOCKLY_ROOT/core" -name "$1") ]; then
-    renderName=$1
-  else
-    echo "A renderer with the name $1 does not exist"
-    echo "Please provide a valid renderer name"
-    exit 1
-  fi
-else
-  renderName="block_rendering_rewrite"
-fi
-
 tempPath="$BLOCKLY_ROOT/temp_core"
 corePath="$BLOCKLY_ROOT/core/*"
 mkdir $tempPath
 cp $corePath $tempPath
 
-# Copy over all files except for the extra renderers to the temp_core directory.
-for dir in ./core/*/ ; do
-  # If we are in the renderers directory
-  if [[ $dir == *"/renderers/"* ]]; then
-    renderers="$dir*"
-    # Go through all folders in the renderers direcotry
-    for renderer in $renderers ; do
-      if [[ $renderer == *"${renderName}" ]]; then
-        # Copy over all files from the desired render folder
-        find $renderer -type f -exec cp {} $tempPath \;
-      fi
-    done
-  else
-    # For all files in the directory and any subdirectories rename them to
-    # include the subirectory name and copy them to temporary directory.
-    # Ex: subdir/file.js -> temp_core/subdir_file.js
-    for file in $(find $dir -name \*.js); do
-      # Replace all / with _ and remove core
-      newName="${file//\//_}"
-      newName="${newName//._core_/}"
-      newFilePath="$tempPath/$newName"
-      cp $file $newFilePath
-    done
-  fi
+# Copy over all files in core and any subdirectories to the temp_core directory.
+for dir in "$corePath/" ; do
+  # For all files in the directory and any subdirectories rename them to
+  # include the subirectory name and copy them to temporary directory.
+  # Ex: subdir/file.js -> temp_core/subdir_file.js
+  for file in $(find $dir -name \*.js); do
+    # Replace all / with _ and remove core
+    newName="${file//\//_}"
+    newName="${newName//._core_/}"
+    newFilePath="$tempPath/$newName"
+    cp $file $newFilePath
+  done
 done
 
 echo "Compiling Blockly..."
 COMPILATION_COMMAND="java -jar $COMPILER --js='$BLOCKLY_ROOT/tests/compile/main.js' \
-  --js='$BLOCKLY_ROOT/$tempPath/**.js' \
+  --js='$tempPath/**.js' \
   --js='$BLOCKLY_ROOT/blocks/**.js' \
   --js='$BLOCKLY_ROOT/generators/**.js' \
   --js='$BLOCKLY_ROOT/msg/js/**.js' \


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#2838

### Proposed Changes
Removes filtering out rendering subdirectories.

### Reason for Changes
We decided against choosing which renderer to use at compile time.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
