### PR TITLE
Fix keyboard nav demo

### DIFF
--- a/demos/keyboard_nav/index.html
+++ b/demos/keyboard_nav/index.html
@@ -16,6 +16,10 @@
       font-weight: normal;
       font-size: 140%;
     }
+
+    .blockRenderDebug {
+      display: none;
+    }
   </style>
 </head>
 <body>
@@ -238,7 +242,7 @@
      * @package
      */
     function findNext() {
-      var cursor = Blockly.Navigation.cursor_;
+      var cursor = Blockly.navigation.cursor_;
       var curNode = cursor.getCurNode();
       return treeTraversal(curNode);
     }
@@ -250,7 +254,7 @@
     function demo() {
       var doNext = function() {
         var node = findNext();
-        Blockly.Navigation.cursor_.setLocation(node);
+        Blockly.navigation.cursor_.setLocation(node);
         if (node) {
           setTimeout(doNext, 1000);
         }
@@ -263,9 +267,9 @@
      * @package
      */
     function preOrderDemo() {
-      Blockly.Navigation.enableKeyboardAccessibility();
-      if (!Blockly.Navigation.cursor_.getCurNode()) {
-        Blockly.Navigation.focusWorkspace();
+      Blockly.navigation.enableKeyboardAccessibility();
+      if (!Blockly.navigation.cursor_.getCurNode()) {
+        Blockly.navigation.focusWorkspace();
       }
       demo();
     }
@@ -274,11 +278,10 @@
     * Turn on accessibility mode.
     * If there is a block on the workspace add the cursor to the block otherwise
     * add the cursor to the workspace.
-    * previous connection otherwise add
     * @package
     */
     function turnOnAccessibility() {
-      Blockly.Navigation.enableKeyboardAccessibility();
+      Blockly.navigation.enableKeyboardAccessibility();
       var blocks = Blockly.getMainWorkspace().getTopBlocks();
       if (blocks.length > 0) {
         var newNode;
@@ -287,9 +290,9 @@
         } else {
           newNode = Blockly.ASTNode.createBlockNode(blocks[0]);
         }
-        Blockly.Navigation.cursor_.setLocation(newNode);
+        Blockly.navigation.cursor_.setLocation(newNode);
       } else {
-        Blockly.Navigation.focusWorkspace();
+        Blockly.navigation.focusWorkspace();
       }
     }
   </script>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The keyboard navigation demo didn't get updated when I switched Blockly.Navigation -> Blockly.navigation. 

### Proposed Changes
Change Blockly.Navigation -> Blockly.navigation. Also update the css for blockRenderDebug to be display none so the rectangles don't show up on the demo.

### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
