### PR TITLE
Fixing basic warnings in block_render_draw_debug.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -44,7 +44,7 @@ Blockly.blockRendering.Debug = function() {
   /**
    * The SVG root of the block that is being rendered.  Debug elements will
    * be attached to this root.
-   * @type {!SVGElement}
+   * @type {SVGElement}
    */
   this.svgRoot_ = null;
 
@@ -68,7 +68,8 @@ Blockly.blockRendering.Debug = function() {
  * @package
  */
 Blockly.blockRendering.Debug.prototype.clearElems = function() {
-  for (var i = 0, elem; elem = this.debugElements_[i]; i++) {
+  for (var i = 0, elem; i < this.debugElements_.length; i++) {
+    elem = this.debugElements_[i];
     Blockly.utils.dom.removeNode(elem);
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Updates annotation for svgRoot to allow for null.
Minor refactor of for loop to declare variable inside the loop block.

### Reason for Changes

Cleans up warnings, code health.

### Test Coverage

Checked things still work in playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
