### PR TITLE
Focus in/out on dropdowndiv

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -145,6 +145,15 @@ Blockly.DropDownDiv.createDom = function() {
   Blockly.DropDownDiv.DIV_.style.transition = 'transform ' +
     Blockly.DropDownDiv.ANIMATION_TIME + 's, ' +
     'opacity ' + Blockly.DropDownDiv.ANIMATION_TIME + 's';
+
+  // Handle focusin/out events to add a visual indicator when
+  // a child is focused or blurred.
+  div.addEventListener('focusin', function() {
+    Blockly.utils.dom.addClass(div, 'focused');
+  });
+  div.addEventListener('focusout', function() {
+    Blockly.utils.dom.removeClass(div, 'focused');
+  });
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Adding support for eventually adding a visual indicator of focus on the dropdowndiv. 

### Proposed Changes

Listen to focusin/out events when the dropdowndiv is created. Since the dropdowndiv is never disposed, we don't need to dispose of these events.

### Reason for Changes

As any element is focused inside the dropdowndiv, we can use the .focused class to show a visual indicator of focus on the div.


Here's an example: 

![example_focusin](https://user-images.githubusercontent.com/16690124/63200928-f0f78b80-c037-11e9-970e-4cd2f02b232b.gif)
