### PR TITLE
Fix cursor svg to work with new rendering

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -88,13 +88,6 @@ Blockly.BlockSvg.TAB_WIDTH = 8;
  * @const
  */
 Blockly.BlockSvg.START_HAT = false;
-/**
- * SVG path for drawing a horizontal puzzle tab from top to bottom.
- * @const
- */
-Blockly.BlockSvg.TAB_PATH_DOWN = 'v 5 c 0,10 -' + Blockly.BlockSvg.TAB_WIDTH +
-    ',-8 -' + Blockly.BlockSvg.TAB_WIDTH + ',7.5 s ' +
-    Blockly.BlockSvg.TAB_WIDTH + ',-2.5 ' + Blockly.BlockSvg.TAB_WIDTH + ',7.5';
 
 /**
  * Returns a bounding box describing the dimensions of this block

--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -191,6 +191,9 @@ Blockly.CursorSvg.prototype.showWithInputOutput_ = function() {
   var connection = /** @type {Blockly.Connection} */
       (this.getCurNode().getLocation());
   this.currentCursorSvg = this.cursorInputOutput_;
+  var path = Blockly.utils.svgPaths.moveTo(0,0) +
+    Blockly.blockRendering.constants.PUZZLE_TAB.pathDown;
+  this.cursorInputOutput_.setAttribute('d', path);
   this.setParent_(connection.getSourceBlock().getSvgRoot());
   this.positionInputOutput_(connection);
   this.showCurrent_();
@@ -260,11 +263,6 @@ Blockly.CursorSvg.prototype.showWithStack_ = function() {
   // Shift the rectangle slightly to upper left so padding is equal on all sides.
   var x = -1 * Blockly.CursorSvg.STACK_PADDING / 2;
   var y = -1 * Blockly.CursorSvg.STACK_PADDING / 2;
-
-  // If the block has an output connection it needs more padding.
-  if (block.outputConnection) {
-    x -= Blockly.BlockSvg.TAB_WIDTH;
-  }
 
   this.currentCursorSvg = this.cursorSvgRect_;
   this.setParent_(block.getSvgRoot());
@@ -416,7 +414,6 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
       {
         'width': Blockly.CursorSvg.CURSOR_WIDTH,
         'height': Blockly.CursorSvg.CURSOR_HEIGHT,
-        'd': 'm 0,0 ' + Blockly.BlockSvg.TAB_PATH_DOWN + ' v 5',
         'transform':'',
         'style':'display: none;',
         'fill': colour

--- a/tests/rendering/svg_paths.html
+++ b/tests/rendering/svg_paths.html
@@ -66,7 +66,6 @@ function addPathAt(path, x, y) {
 
 function start() {
   svgSpace = document.getElementById('workspace');
-  addPathAt(Blockly.BlockSvg.TAB_PATH_DOWN, 0, 0);
   addPathAt(Blockly.BlockSvg.START_HAT_PATH, 0, 40);
   addPathAt(Blockly.BlockSvg.NOTCH_PATH_LEFT, 0, 60);
   addPathAt(Blockly.BlockSvg.NOTCH_PATH_RIGHT, 0, 70);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The input and output puzzle piece was being drawn in the incorrect places.

### Proposed Changes
Use the new rendering constants to draw it in the correct place.

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
