### PR TITLE
Focus indicator styling

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -194,6 +194,11 @@ Blockly.Css.CONTENT = [
     'border-radius: 2px;',
     'padding: 4px;',
     '-webkit-user-select: none;',
+    'box-shadow: 0px 0px 3px 1px rgba(0, 0, 0, .3);',
+  '}',
+
+  '.blocklyDropDownDiv.focused {',
+    'box-shadow: 0px 0px 6px 1px rgba(0, 0, 0, .3);',
   '}',
 
   '.blocklyDropDownContent {',
@@ -645,7 +650,23 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropdownMenu {',
+    'border-radius: 2px;',
     'padding: 0 !important;',
+  '}',
+
+  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem, ',
+  '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem {',
+    /* 28px on the left for icon or checkbox. */
+    'padding-left: 28px;',
+  '}',
+
+  /* BiDi override for the resting state. */
+  /* #noflip */
+  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl, ',
+  '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl {',
+     /* Flip left/right padding for BiDi. */
+    'padding-left: 5px;',
+    'padding-right: 28px;',
   '}',
 
   '.blocklyVerticalCursor {',
@@ -654,7 +675,9 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon {',
+  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
+  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
   '}',
 
@@ -818,7 +841,7 @@ Blockly.Css.CONTENT = [
 
   '.blocklyWidgetDiv .goog-menu {',
     'background: #fff;',
-    'border-color: #ccc #666 #666 #ccc;',
+    'border-color: transparent;',
     'border-style: solid;',
     'border-width: 1px;',
     'cursor: default;',
@@ -831,6 +854,11 @@ Blockly.Css.CONTENT = [
     'overflow-x: hidden;',
     'max-height: 100%;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
+    'box-shadow: 0px 0px 3px 1px rgba(0, 0, 0, .3);',
+  '}',
+
+  '.blocklyWidgetDiv .goog-menu.focused {',
+    'box-shadow: 0px 0px 6px 1px rgba(0, 0, 0, .3);',
   '}',
 
   '.blocklyDropDownDiv .goog-menu {',
@@ -875,19 +903,12 @@ Blockly.Css.CONTENT = [
     'font: normal 13px Arial, sans-serif;',
     'list-style: none;',
     'margin: 0;',
-     /* 28px on the left for icon or checkbox; 7em on the right for shortcut. */
+     /* 7em on the right for shortcut. */
     'min-width: 7em;',
-    'padding: 5px 5px 5px 28px;',
+    'border: none;',
+    'padding: 6px 15px;',
     'white-space: nowrap;',
-  '}',
-
-  /* BiDi override for the resting state. */
-  /* #noflip */
-  '.blocklyWidgetDiv .goog-menuitem.goog-menuitem-rtl, ',
-  '.blocklyDropDownDiv .goog-menuitem.goog-menuitem-rtl {',
-     /* Flip left/right padding for BiDi. */
-    'padding-left: 5px;',
-    'padding-right: 28px;',
+    'cursor: pointer;',
   '}',
 
   /* If a menu doesn't have checkable items or items with icons,
@@ -910,11 +931,23 @@ Blockly.Css.CONTENT = [
 
   '.blocklyWidgetDiv .goog-menuitem-content, ',
   '.blocklyDropDownDiv .goog-menuitem-content {',
-    'color: #000;',
     'font: normal 13px Arial, sans-serif;',
   '}',
 
+  '.blocklyWidgetDiv .goog-menuitem-content {',
+    'color: #000;',
+  '}',
+
+  '.blocklyDropDownDiv .goog-menuitem-content {',
+    'color: #fff;',
+  '}',
+
   /* State: disabled. */
+  '.blocklyWidgetDiv .goog-menuitem-disabled, ',
+  '.blocklyDropDownDiv .goog-menuitem-disabled {',
+    'cursor: inherit;',
+  '}',
+
   '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-accel, ',
   '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-content, ',
   '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-accel, ',
@@ -931,14 +964,7 @@ Blockly.Css.CONTENT = [
   /* State: hover. */
   '.blocklyWidgetDiv .goog-menuitem-highlight, ',
   '.blocklyWidgetDiv .goog-menuitem-hover {',
-    'background-color: #d6e9f8;',
-     /* Use an explicit top and bottom border so that the selection is visible',
-      * in high contrast mode. */
-    'border-color: #d6e9f8;',
-    'border-style: dotted;',
-    'border-width: 1px 0;',
-    'padding-bottom: 4px;',
-    'padding-top: 4px;',
+    'background-color: #f1f3f4;',
   '}',
 
   '.blocklyDropDownDiv .goog-menuitem-highlight, ',


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Shows visual indicator when a dropdowndiv or dropdown menu is focused. It's a slight box shadow by default but can be changed by developers to make it stand out further.

Also removing left padding for context menu as it's not necessary (since there's no checkbox)

### Proposed Changes

CSS styling for focused indicator.

### Reason for Changes

Accessibility

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Safari 

Tested with RTL. 

### Screenshots

#### Dropdown div [focused]
<img width="241" alt="Screen Shot 2019-08-19 at 10 22 07 AM" src="https://user-images.githubusercontent.com/16690124/63285739-51224380-c26b-11e9-8da6-a81348cafb9c.png">

#### Dropdown div [unfocused]
<img width="230" alt="Screen Shot 2019-08-19 at 10 22 11 AM" src="https://user-images.githubusercontent.com/16690124/63285745-541d3400-c26b-11e9-9786-3ae0b5f01935.png">

#### Dropdown menu [focused]
<img width="187" alt="Screen Shot 2019-08-19 at 10 17 13 AM" src="https://user-images.githubusercontent.com/16690124/63285752-58e1e800-c26b-11e9-8a0e-85fbea15806a.png">

<img width="282" alt="Screen Shot 2019-08-19 at 10 17 04 AM" src="https://user-images.githubusercontent.com/16690124/63285772-613a2300-c26b-11e9-85d5-d5058cec92df.png">

#### Dropdown menu [unfocused]
<img width="164" alt="Screen Shot 2019-08-19 at 10 17 18 AM" src="https://user-images.githubusercontent.com/16690124/63285755-5b444200-c26b-11e9-9782-5dd9f88c804b.png">

<img width="313" alt="Screen Shot 2019-08-19 at 10 17 09 AM" src="https://user-images.githubusercontent.com/16690124/63285781-66976d80-c26b-11e9-9276-0df8699fbfef.png">

