### PR TITLE
Fix reference error in block_render_draw

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -307,7 +307,6 @@ Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
 Blockly.blockRendering.Drawer.prototype.drawInternals_ = function() {
   for (var i = 0, row; row = this.info_.rows[i]; i++) {
     for (var j = 0, elem; elem = row.elements[j]; j++) {
-      var elem = row.elements[e];
       if (elem.isInlineInput()) {
         this.drawInlineInput_(elem);
       } else if (elem.isIcon() || elem.isField()) {


### PR DESCRIPTION
Fix ``Uncaught ReferenceError: e is not defined`` introduced by:
https://github.com/google/blockly/pull/2865 