### PR TITLE
Changed Colour field to New Configuration Paradigm

### DIFF
--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -45,16 +45,28 @@ goog.require('Blockly.utils.Size');
  * @param {Function=} opt_validator A function that is called to validate
  *    changes to the field's value. Takes in a colour string & returns a
  *    validated colour string ('#rrggbb' format), or null to abort the change.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the documentation for a list of properties this parameter supports.
+ *    https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/colour
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldColour = function(opt_value, opt_validator) {
+Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
+  if (opt_config) {
+    if (opt_config['colourOptions']) {
+      this.setColours(opt_config['colourOptions'], opt_config['colourTitles']);
+    }
+    if (opt_config['columns']) {
+      this.setColumns(opt_config['columns']);
+    }
+  }
+
   opt_value = this.doClassValidation_(opt_value);
   if (opt_value === null) {
     opt_value = Blockly.FieldColour.COLOURS[0];
   }
   Blockly.FieldColour.superClass_.constructor.call(
-      this, opt_value, opt_validator);
+      this, opt_value, opt_validator, opt_config);
 };
 goog.inherits(Blockly.FieldColour, Blockly.Field);
 
@@ -66,14 +78,7 @@ goog.inherits(Blockly.FieldColour, Blockly.Field);
  * @nocollapse
  */
 Blockly.FieldColour.fromJson = function(options) {
-  var field = new Blockly.FieldColour(options['colour']);
-  if (options['colourOptions']) {
-    field.setColours(options['colourOptions'], options['colourTitles']);
-  }
-  if (options['columns']) {
-    field.setColumns(options['columns']);
-  }
-  return field;
+  return new Blockly.FieldColour(options['colour'], null, options);
 };
 
 /**

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -269,4 +269,119 @@ suite('Colour Fields', function() {
       });
     });
   });
+  suite('Customizations', function() {
+    suite('Colours and Titles', function() {
+      function assertColoursAndTitles(field, colours, titles) {
+        var editor = field.dropdownCreate_();
+        var index = 0;
+        var node = editor.firstChild.firstChild;
+        while (node) {
+          chai.assert.equal(node.getAttribute('title'), titles[index]);
+          chai.assert.equal(
+              Blockly.utils.colour.parse(
+                  node.style.backgroundColor),
+              colours[index]);
+
+          var nextNode = node.nextSibling;
+          if (!nextNode) {
+            nextNode = node.parentElement.nextSibling;
+            if (!nextNode) {
+              break;
+            }
+            nextNode = nextNode.firstChild;
+          }
+          node = nextNode;
+
+          index++;
+        }
+      }
+      test('Constants', function() {
+        var colours = Blockly.FieldColour.COLOURS;
+        var titles = Blockly.FieldColour.TITLES;
+        // Note: Developers shouldn't actually do this. IMO they should
+        // change the file and then recompile. But this is fine for testing.
+        Blockly.FieldColour.COLOURS = ['#aaaaaa'];
+        Blockly.FieldColour.TITLES = ['grey'];
+        var field = new Blockly.FieldColour();
+
+        assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
+
+        Blockly.FieldColour.COLOURS = colours;
+        Blockly.FieldColour.TITLES = titles;
+      });
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldColour('#aaaaaa', null, {
+          colourOptions: ['#aaaaaa'],
+          colourTitles: ['grey']
+        });
+        assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldColour.fromJson({
+          colour: '#aaaaaa',
+          colourOptions: ['#aaaaaa'],
+          colourTitles: ['grey']
+        });
+        assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
+      });
+      test('setColours', function() {
+        var field = new Blockly.FieldColour();
+        field.setColours(['#aaaaaa'], ['grey']);
+        assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
+      });
+      test('Titles Undefined', function() {
+        var field = new Blockly.FieldColour();
+        field.setColours(['#aaaaaa']);
+        assertColoursAndTitles(field, ['#aaaaaa'], ['#aaaaaa']);
+      });
+      test('Some Titles Undefined', function() {
+        var field = new Blockly.FieldColour();
+        field.setColours(['#aaaaaa', '#ff0000'], ['grey']);
+        assertColoursAndTitles(field,
+            ['#aaaaaa', '#ff0000'], ['grey', '#ff0000']);
+      });
+      // This is kinda derpy behavior, but I wanted to document it.
+      test('Overwriting Colours While Leaving Titles', function() {
+        var field = new Blockly.FieldColour();
+        field.setColours(['#aaaaaa'], ['grey']);
+        field.setColours(['#ff0000']);
+        assertColoursAndTitles(field, ['#ff0000'], ['grey']);
+      });
+    });
+    suite('Columns', function() {
+      function assertColumns(field, columns) {
+        var editor = field.dropdownCreate_();
+        chai.assert.equal(editor.firstChild.children.length, columns);
+      }
+      test('Constants', function() {
+        var columns = Blockly.FieldColour.COLUMNS;
+        // Note: Developers shouldn't actually do this. IMO they should edit
+        // the file and tehn recompile. But this is fine for testing.
+        Blockly.FieldColour.COLUMNS = 3;
+        var field = new Blockly.FieldColour();
+
+        assertColumns(field, 3);
+
+        Blockly.FieldColour.COLUMNS = columns;
+      });
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldColour('#ffffff', null, {
+          columns: 3
+        });
+        assertColumns(field, 3);
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldColour.fromJson({
+          'colour': '#ffffff',
+          'columns': 3
+        });
+        assertColumns(field, 3);
+      });
+      test('setColumns', function() {
+        var field = new Blockly.FieldColour();
+        field.setColumns(3);
+        assertColumns(field, 3);
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Added an opt_config property to the JS Constructor which accepts the same properties as the JSON Definition (colourOptions, colourTitles, and columns)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for:
* Configuring via constants.
* Configuring via the JS Constructor.
* Configuring via the JSON Definition.
* Configuring via setColours() and setColumns()
* Also some documentary tests about how the title and colour arrays interact.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Yes, the [colour configuration](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/colour#customization) section should be updated with new information.

### Additional Information

<!-- Anything else we should know? -->
N/A
