### PR TITLE
Changed Image Field to New Configuration Paradigm.

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -147,7 +147,7 @@ Blockly.FieldImage.prototype.configure_ = function(
     config = opt_config;
   }
   if (doOldParams) {
-    var config = {};
+    config = {};
     // opt_onClick used to be opt_alt.
     config['alt'] = opt_onClick;
     // opt_config used to be opt_onClick.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -493,8 +493,10 @@ FactoryUtils.getFieldsJs_ = function(block) {
           var width = Number(block.getFieldValue('WIDTH'));
           var height = Number(block.getFieldValue('HEIGHT'));
           var alt = JSON.stringify(block.getFieldValue('ALT'));
+          var flipRtl = JSON.stringify(block.getFieldValue('FLIP_RTL'));
           fields.push('new Blockly.FieldImage(' +
-              src + ', ' + width + ', ' + height + ', ' + alt + ')');
+              src + ', ' + width + ', ' + height +
+              ', { alt: ' + alt + ', flipRtl: ' + flipRtl + ' })');
           break;
       }
     }

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -51,17 +51,6 @@ suite('Image Fields', function() {
         new Blockly.FieldImage('src', 'bad', 'bad');
       });
     });
-    // Note: passing invalid an src path doesn't need to throw errors
-    // because the developer can see they did it incorrectly when they view
-    // the block.
-    test('With Alt', function() {
-      var imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
-      assertValue(imageField, 'src', 'alt');
-    });
-    test('Without Alt', function() {
-      var imageField = new Blockly.FieldImage('src', 1, 1);
-      assertValue(imageField, 'src', '');
-    });
   });
   suite('fromJson', function() {
     test('Empty', function() {
@@ -96,23 +85,6 @@ suite('Image Fields', function() {
         });
       });
     });
-    test('With Alt', function() {
-      var imageField = Blockly.FieldImage.fromJson({
-        src: 'src',
-        width: 1,
-        height: 1,
-        alt: 'alt'
-      });
-      assertValue(imageField, 'src', 'alt');
-    });
-    test('Without Alt', function() {
-      var imageField = Blockly.FieldImage.fromJson({
-        src: 'src',
-        width: 1,
-        height: 1
-      });
-      assertValue(imageField, 'src', '');
-    });
   });
   suite('setValue', function() {
     setup(function() {
@@ -131,43 +103,155 @@ suite('Image Fields', function() {
       assertValue(this.imageField, 'newSrc', 'alt');
     });
   });
-  suite('setAlt', function() {
-    suite('No Alt -> New Alt', function() {
-      setup(function() {
-        this.imageField = new Blockly.FieldImage('src', 1, 1);
+  suite('Backwards-Compat - Constructor', function() {
+    test('All Provided', function() {
+      var onClick = function() {
+        console.log('on click');
+      };
+      var field = new Blockly.FieldImage('scr', 10, 10, 'alt', onClick, true);
+
+      chai.assert.equal(field.text_, 'alt');
+      chai.assert.equal(field.clickHandler_, onClick);
+      chai.assert.isTrue(field.flipRtl_);
+    });
+    test('Just Alt', function() {
+      var field = new Blockly.FieldImage('scr', 10, 10, 'alt');
+      chai.assert.equal(field.text_, 'alt');
+      chai.assert.isNotOk(field.clickHandler_);
+      chai.assert.isFalse(field.flipRtl_);
+    });
+    test('Just onClick', function() {
+      var onClick = function() {
+        console.log('on click');
+      };
+      var field = new Blockly.FieldImage('scr', 10, 10, null, onClick);
+      chai.assert.equal(field.text_, '');
+      chai.assert.equal(field.clickHandler_, onClick);
+      chai.assert.isFalse(field.flipRtl_);
+    });
+    test('Just FlipRtl', function() {
+      var field = new Blockly.FieldImage('scr', 10, 10, null, null, true);
+
+      chai.assert.equal(field.text_, '');
+      chai.assert.isNotOk(field.clickHandler_);
+      chai.assert.isTrue(field.flipRtl_);
+    });
+    test('Alt & OnClick', function() {
+      var onClick = function() {
+        console.log('on click');
+      };
+      var field = new Blockly.FieldImage('scr', 10, 10, 'alt', onClick);
+
+      chai.assert.equal(field.text_, 'alt');
+      chai.assert.equal(field.clickHandler_, onClick);
+      chai.assert.isFalse(field.flipRtl_);
+    });
+    test('Alt & FlipRtl', function() {
+      var field = new Blockly.FieldImage('scr', 10, 10, 'alt', null, true);
+
+      chai.assert.equal(field.text_, 'alt');
+      chai.assert.isNotOk(field.clickHandler_);
+      chai.assert.isTrue(field.flipRtl_);
+    });
+    test('OnClick & FlipRtl', function() {
+      var onClick = function() {
+        console.log('on click');
+      };
+      var field = new Blockly.FieldImage('scr', 10, 10, null, onClick, true);
+
+      chai.assert.equal(field.text_, '');
+      chai.assert.equal(field.clickHandler_, onClick);
+      chai.assert.isTrue(field.flipRtl_);
+    });
+  });
+  suite('Customizations', function() {
+    suite('OnClick', function() {
+      test('JS Constructor', function() {
+        var onClick = function() {
+          console.log('on click');
+        };
+        var field = new Blockly.FieldImage('src', 10, 10, onClick);
+        chai.assert.equal(field.clickHandler_, onClick);
       });
-      test('Backwards Compat - setText', function() {
-        this.imageField.setText('newAlt');
-        assertValue(this.imageField, 'src', 'newAlt');
-      });
-      test('Null', function() {
-        this.imageField.setText(null);
-        assertValue(this.imageField, 'src', '');
-      });
-      test('Good Alt', function() {
-        this.imageField.setText('newAlt');
-        assertValue(this.imageField, 'src', 'newAlt');
+      test('setOnClickHandler', function() {
+        var onClick = function() {
+          console.log('on click');
+        };
+        var field = new Blockly.FieldImage('src', 10, 10);
+        field.setOnClickHandler(onClick);
+        chai.assert.equal(field.clickHandler_, onClick);
       });
     });
-    suite('Alt -> New Alt', function() {
-      setup(function() {
-        this.imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+    suite('Alt', function() {
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, {
+          alt: 'alt'
+        });
+        chai.assert.equal(field.text_, 'alt');
       });
-      test('Backwards Compat - setText', function() {
-        this.imageField.setText('newAlt');
-        assertValue(this.imageField, 'src', 'newAlt');
+      test('JSON Definition', function() {
+        var field = Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: 10,
+          height: 10,
+          alt: 'alt'
+        });
+        chai.assert.equal(field.text_, 'alt');
       });
-      test('Null', function() {
-        this.imageField.setText(null);
-        assertValue(this.imageField, 'src', 'alt');
+      suite('No Alt -> New Alt', function() {
+        setup(function() {
+          this.imageField = new Blockly.FieldImage('src', 1, 1);
+        });
+        test('Backwards Compat - setText', function() {
+          this.imageField.setText('newAlt');
+          assertValue(this.imageField, 'src', 'newAlt');
+        });
+        test('Null', function() {
+          this.imageField.setText(null);
+          assertValue(this.imageField, 'src', '');
+        });
+        test('Good Alt', function() {
+          this.imageField.setText('newAlt');
+          assertValue(this.imageField, 'src', 'newAlt');
+        });
       });
-      test('Empty String', function() {
-        this.imageField.setText('');
-        assertValue(this.imageField, 'src', '');
+      suite('Alt -> New Alt', function() {
+        setup(function() {
+          this.imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+        });
+        test('Backwards Compat - setText', function() {
+          this.imageField.setText('newAlt');
+          assertValue(this.imageField, 'src', 'newAlt');
+        });
+        test('Null', function() {
+          this.imageField.setText(null);
+          assertValue(this.imageField, 'src', 'alt');
+        });
+        test('Empty String', function() {
+          this.imageField.setText('');
+          assertValue(this.imageField, 'src', '');
+        });
+        test('Good Alt', function() {
+          this.imageField.setText('newAlt');
+          assertValue(this.imageField, 'src', 'newAlt');
+        });
       });
-      test('Good Alt', function() {
-        this.imageField.setText('newAlt');
-        assertValue(this.imageField, 'src', 'newAlt');
+    });
+    suite('FlipRtl', function() {
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, {
+          flipRtl: true
+        });
+        chai.assert.isTrue(field.flipRtl_);
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: 10,
+          height: 10,
+          flipRtl: true
+        });
+        chai.assert.isTrue(field.flipRtl_);
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Changed JS Constructor to look like: function(src, width, height, opt_onClick, opt_config) where the opt_config accepts opt_alt and opt_flipRTL properties.
* Also fixed the block factory's image field JS (JSON was already correct).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests for:
* Backwards compatibility with the old constructor signature.
* Setting the click listener via JS Constructor.
* Setting the click listener via setOnClick function.
* Setting the flipRtl property via JS Constructor.
* Setting the flipRtl property via JSON Definition.

Also moved the setAlt tests into the new customization suite.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Yes, the [image creation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/image#creation), and [on click](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/image#click_handler) sections should be updated with new information.

### Additional Information

<!-- Anything else we should know? -->
N/A
