### PR TITLE
Updating for loops in renderers to use constent pattern.

### DIFF
--- a/core/renderers/block_rendering_rewrite/block_render_draw.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw.js
@@ -101,7 +101,7 @@ Blockly.blockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
  * @private
  */
 Blockly.blockRendering.Drawer.prototype.hideHiddenIcons_ = function() {
-  for (var i = 0, iconInfo; iconInfo = this.info_.hiddenIcons[i]; i++) {
+  for (var i = 0, iconInfo; (iconInfo = this.info_.hiddenIcons[i]); i++) {
     iconInfo.icon.iconGroup_.setAttribute('display', 'none');
   }
 };
@@ -145,7 +145,7 @@ Blockly.blockRendering.Drawer.prototype.drawTop_ = function() {
   this.positionPreviousConnection_();
   this.outlinePath_ +=
       Blockly.utils.svgPaths.moveBy(topRow.xPos, this.info_.startY);
-  for (var i = 0, elem; elem = elements[i]; i++) {
+  for (var i = 0, elem; (elem = elements[i]); i++) {
     if (elem.type == 'round corner') {
       this.outlinePath_ +=
           Blockly.blockRendering.constants.OUTSIDE_CORNERS.topLeft;
@@ -262,8 +262,7 @@ Blockly.blockRendering.Drawer.prototype.drawBottom_ = function() {
   this.outlinePath_ +=
     Blockly.utils.svgPaths.lineOnAxis('v', bottomRow.height - bottomRow.overhangY);
 
-  for (var i = elems.length - 1; i >= 0; i--) {
-    var elem = elems[i];
+  for (var i = elems.length - 1, elem; (elem = elems[i]); i--) {
     if (elem.isNextConnection()) {
       this.outlinePath_ += bottomRow.notchShape.pathRight;
     } else if (elem.isSquareCorner()) {
@@ -308,8 +307,8 @@ Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
  * @private
  */
 Blockly.blockRendering.Drawer.prototype.drawInternals_ = function() {
-  for (var i = 0, row; row = this.info_.rows[i]; i++) {
-    for (var j = 0, elem; elem = row.elements[j]; j++) {
+  for (var i = 0, row; (row = this.info_.rows[i]); i++) {
+    for (var j = 0, elem; (elem = row.elements[j]); j++) {
       if (elem.isInlineInput()) {
         this.drawInlineInput_(elem);
       } else if (elem.isIcon() || elem.isField()) {

--- a/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_debug.js
@@ -76,7 +76,7 @@ Blockly.blockRendering.Debug = function() {
  * @package
  */
 Blockly.blockRendering.Debug.prototype.clearElems = function() {
-  for (var i = 0, elem; elem = this.debugElements_[i]; i++) {
+  for (var i = 0, elem; (elem = this.debugElements_[i]); i++) {
     Blockly.utils.dom.removeNode(elem);
   }
 
@@ -258,7 +258,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, 
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY, isRtl) {
-  for (var i = 0, elem; elem = row.elements[i]; i++) {
+  for (var i = 0, elem; (elem = row.elements[i]); i++) {
     if (elem.isSpacer()) {
       this.drawSpacerElem(elem, row.height, isRtl);
     } else {
@@ -325,7 +325,7 @@ Blockly.blockRendering.Debug.prototype.drawDebug = function(block, info) {
   this.randomColour_ = '#' + Math.floor(Math.random() * 16777215).toString(16);
 
   var cursorY = 0;
-  for (var i = 0, row; row = info.rows[i]; i++) {
+  for (var i = 0, row; (row = info.rows[i]); i++) {
     if (row.type == 'between-row spacer') {
       this.drawSpacerRow(row, cursorY, info.RTL);
     } else {

--- a/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
+++ b/core/renderers/block_rendering_rewrite/block_render_draw_highlight.js
@@ -81,7 +81,7 @@ Blockly.blockRendering.Highlighter = function(info, pathObject) {
 Blockly.blockRendering.Highlighter.prototype.drawTopCorner = function(row) {
   this.steps_.push(
       Blockly.utils.svgPaths.moveBy(row.xPos, this.info_.startY));
-  for (var i = 0, elem; elem = row.elements[i]; i++) {
+  for (var i = 0, elem; (elem = row.elements[i]); i++) {
     if (elem.type == 'square corner') {
       this.steps_.push(Blockly.blockRendering.highlightConstants.START_POINT);
     } else if (elem.type == 'round corner') {

--- a/core/renderers/block_rendering_rewrite/block_render_info.js
+++ b/core/renderers/block_rendering_rewrite/block_render_info.js
@@ -177,7 +177,7 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
   // Icons always go on the first row, before anything else.
   var icons = this.block_.getIcons();
   if (icons.length) {
-    for (var i = 0, icon; icon = icons[i]; i++) {
+    for (var i = 0, icon; (icon = icons[i]); i++) {
       var iconInfo = new Blockly.blockRendering.Icon(icon);
       if (this.isCollapsed && icon.collapseHidden) {
         this.hiddenIcons.push(iconInfo);
@@ -190,7 +190,7 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
   var lastInput = undefined;
   // Loop across all of the inputs on the block, creating objects for anything
   // that needs to be rendered and breaking the block up into visual rows.
-  for (var i = 0, input; input = this.block_.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.block_.inputList[i]); i++) {
     if (!input.isVisible()) {
       continue;
     }
@@ -201,7 +201,7 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
     }
 
     // All of the fields in an input go on the same row.
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       activeRow.elements.push(new Blockly.blockRendering.Field(field, input));
     }
     this.addInput_(input, activeRow);
@@ -275,7 +275,7 @@ Blockly.blockRendering.RenderInfo.prototype.shouldStartNewRow_ = function(input,
  * @private
  */
 Blockly.blockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
-  for (var i = 0, row; row = this.rows[i]; i++) {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
     var oldElems = row.elements;
     row.elements = [];
     // No spacing needed before the corner on the top row or the bottom row.
@@ -449,7 +449,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
   var widestStatementRowFields = 0;
   var blockWidth = 0;
   var widestRowWithConnectedBlocks = 0;
-  for (var i = 0, row; row = this.rows[i]; i++) {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
     row.measure();
     blockWidth = Math.max(blockWidth, row.width);
     if (row.hasStatement) {
@@ -466,7 +466,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
 
   this.width = blockWidth;
 
-  for (var i = 0, row; row = this.rows[i]; i++) {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
     if (row.hasStatement) {
       row.statementEdge = this.statementEdge;
     }
@@ -488,7 +488,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
  * @private
  */
 Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
-  for (var i = 0, row; row = this.rows[i]; i++) {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
     if (!row.hasInlineInput) {
       if (row.hasStatement) {
         var statementInput = row.getLastInput();
@@ -663,7 +663,7 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
   // accesses and sets properties that already exist on the objects.
   var widestRowWithConnectedBlocks = 0;
   var yCursor = 0;
-  for (var i = 0, row; row = this.rows[i]; i++) {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
     row.yPos = yCursor;
     row.xPos = this.startX;
     yCursor += row.height;
@@ -680,7 +680,7 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
       yCursor += diff;
     }
     var xCursor = row.xPos;
-    for (var j = 0, elem; elem = row.elements[j]; j++) {
+    for (var j = 0, elem; (elem = row.elements[j]); j++) {
       elem.xPos = xCursor;
       elem.centerline = this.getElemCenterline_(row, elem);
       xCursor += elem.width;

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -170,8 +170,7 @@ Blockly.blockRendering.Row.prototype.measure = function() {
  * @package
  */
 Blockly.blockRendering.Row.prototype.getLastInput = function() {
-  for (var i = this.elements.length - 1; i >= 0; i--) {
-    var elem = this.elements[i];
+  for (var i = this.elements.length - 1, elem; (elem = this.elements[i]); i--) {
     if (elem.isSpacer()) {
       continue;
     }
@@ -191,7 +190,7 @@ Blockly.blockRendering.Row.prototype.getLastInput = function() {
  * @package
  */
 Blockly.blockRendering.Row.prototype.getFirstSpacer = function() {
-  for (var i = 0, elem; elem = this.elements[i]; i++) {
+  for (var i = 0, elem; (elem = this.elements[i]); i++) {
     if (elem.isSpacer) {
       return /** @type {Blockly.blockRendering.InRowSpacer} */ (elem);
     }
@@ -206,7 +205,7 @@ Blockly.blockRendering.Row.prototype.getFirstSpacer = function() {
  * @package
  */
 Blockly.blockRendering.Row.prototype.getLastSpacer = function() {
-  for (var i = this.elements.length - 1, elem; elem = this.elements[i]; i--) {
+  for (var i = this.elements.length - 1, elem; (elem = this.elements[i]); i--) {
     if (elem.isSpacer) {
       return /** @type {Blockly.blockRendering.InRowSpacer} */ (elem);
     }
@@ -303,8 +302,7 @@ Blockly.blockRendering.TopRow.prototype.populate = function(block) {
 Blockly.blockRendering.TopRow.prototype.measure = function() {
   this.width = this.minWidth;
   this.height = this.minHeight;
-  for (var e = 0; e < this.elements.length; e++) {
-    var elem = this.elements[e];
+  for (var e = 0, elem; (elem = this.elements[e]); e++) {
     this.width += elem.width;
     if (!(elem.isSpacer())) {
       if (elem.type == 'hat') {
@@ -403,8 +401,7 @@ Blockly.blockRendering.BottomRow.prototype.populate = function(block) {
 Blockly.blockRendering.BottomRow.prototype.measure = function() {
   this.width = this.minWidth;
   this.height = this.minHeight;
-  for (var e = 0; e < this.elements.length; e++) {
-    var elem = this.elements[e];
+  for (var e = 0, elem; (elem = this.elements[e]); e++) {
     this.width += elem.width;
     if (!(elem.isSpacer())) {
       if (elem.type == 'next connection') {
@@ -463,8 +460,7 @@ Blockly.blockRendering.InputRow.prototype.measure = function() {
   this.width = this.minWidth;
   this.height = this.minHeight;
   var connectedBlockWidths = 0;
-  for (var e = 0; e < this.elements.length; e++) {
-    var elem = this.elements[e];
+  for (var e = 0, elem; (elem = this.elements[e]); e++) {
     this.width += elem.width;
     if (elem.isInput) {
       if (elem.type == 'statement input') {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Updating instances of for loops in renderers/ to use assignment in for loop condition with parenthesis where appropriate.

### Reason for Changes

The case for using assignment inside of a condition is because, as long as array elements are not expected to evaluate to false, it simplifies code and in some cases produces more efficient code (like in node arrays where .length call is O(n) operation).

However, some debuggers and IDEs flag assignment inside a condition as a warning, asking if you meant a test for equality (==) and mistyled it as assignment (=). Adding a set of parenthesis around the assignment should prevent this case from being flagged as a warning.

### Test Coverage

Tested locally in playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
