### PR TITLE
Moves the cursor to correct location when block is deleted

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -287,6 +287,12 @@ Blockly.Block.prototype.dispose = function(healStack) {
   if (this.onchangeWrapper_) {
     this.workspace.removeChangeListener(this.onchangeWrapper_);
   }
+
+  if (Blockly.keyboardAccessibilityMode) {
+    // No-op if this is called from the block_svg class.
+    Blockly.navigation.moveCursorOnBlockDelete(this);
+  }
+
   this.unplug(healStack);
   if (Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.BlockDelete(this));

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -907,6 +907,10 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     Blockly.ContextMenu.hide();
   }
 
+  if (Blockly.keyboardAccessibilityMode) {
+    Blockly.navigation.moveCursorOnBlockDelete(this);
+  }
+
   if (animate && this.rendered) {
     this.unplug(healStack);
     Blockly.blockAnimations.disposeUiEffect(this);

--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -138,18 +138,12 @@ Blockly.CursorSvg.prototype.setParent_ = function(newParent) {
   if (newParent == oldParent) {
     return;
   }
-
   var svgRoot = this.getSvgRoot();
 
   if (newParent) {
     newParent.appendChild(svgRoot);
+    this.parent_ = newParent;
   }
-  // If we are losing a parent, we want to move our DOM element to the
-  // root of the workspace.
-  else if (oldParent) {
-    this.workspace_.getCanvas().appendChild(svgRoot);
-  }
-  this.parent_ = newParent;
 };
 
 /**************************/

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -718,6 +718,24 @@ Blockly.navigation.moveCursorOnBlockDelete = function(deletedBlock) {
 };
 
 /**
+ * When a block that the cursor is on is mutated move the cursor to the block
+ * level.
+ * @param {!Blockly.Block} mutatedBlock The block that is being mutated.
+ * @package
+ */
+Blockly.navigation.moveCursorOnBlockMutation = function(mutatedBlock) {
+  var cursor = Blockly.navigation.cursor_;
+  if (cursor) {
+    var curNode = cursor.getCurNode();
+    var block = Blockly.navigation.getSourceBlock_(curNode);
+
+    if (block === mutatedBlock) {
+      cursor.setLocation(Blockly.ASTNode.createBlockNode(block));
+    }
+  }
+};
+
+/**
  * Handler for all the keyboard navigation events.
  * @param {Event} e The keyboard event.
  * @return {!boolean} True if the key was handled false otherwise.

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -663,6 +663,60 @@ Blockly.navigation.handleEnterForWS = function() {
 /**********************/
 
 /**
+ * Finds the source block of the location on a given node.
+ * @param {Blockly.ASTNode} node The node to find the source block on.
+ * @return {Blockly.Block} The source block of the location on the given node,
+ * or null if the node is of type workspace.
+ * @private
+ */
+Blockly.navigation.getSourceBlock_ = function(node) {
+  if (!node) {
+    return null;
+  }
+  if (node.getType() === Blockly.ASTNode.types.BLOCK) {
+    return node.getLocation();
+  } else if (node.getType() === Blockly.ASTNode.types.WORKSPACE) {
+    return null;
+  } else {
+    return node.getLocation().getSourceBlock();
+  }
+};
+
+/**
+ * Before a block is deleted move the cursor to the appropriate position.
+ * @param {!Blockly.Block} deletedBlock The block that is being deleted.
+ * @package
+ */
+Blockly.navigation.moveCursorOnBlockDelete = function(deletedBlock) {
+  var cursor = Blockly.navigation.cursor_;
+  if (cursor) {
+    var curNode = cursor.getCurNode();
+    var block = Blockly.navigation.getSourceBlock_(curNode);
+
+    if (block === deletedBlock) {
+      // If the block has a parent move the cursor to their connection point.
+      if (block.getParent()) {
+        var topConnection = block.previousConnection
+          ? block.previousConnection : block.outputConnection;
+        if (topConnection) {
+          cursor.setLocation(Blockly.ASTNode
+            .createConnectionNode(topConnection.targetConnection));
+        }
+      } else {
+        // If the block is by itself move the cursor to the workspace.
+        cursor.setLocation(Blockly.ASTNode.createWorkspaceNode(block.workspace,
+          block.getRelativeToSurfaceXY()));
+      }
+    // If the cursor is on a block whose parent is being deleted, move the
+    // cursor to the workspace.
+    } else if (deletedBlock.getChildren().indexOf(block) > -1) {
+      cursor.setLocation(Blockly.ASTNode.createWorkspaceNode(block.workspace,
+        block.getRelativeToSurfaceXY()));
+    }
+  }
+};
+
+/**
  * Handler for all the keyboard navigation events.
  * @param {Event} e The keyboard event.
  * @return {!boolean} True if the key was handled false otherwise.

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -675,7 +675,8 @@ Blockly.navigation.getSourceBlock_ = function(node) {
   }
   if (node.getType() === Blockly.ASTNode.types.BLOCK) {
     return node.getLocation();
-  } else if (node.getType() === Blockly.ASTNode.types.WORKSPACE) {
+  } else if (node.getType() === Blockly.ASTNode.types.WORKSPACE ||
+      node.getType() === Blockly.ASTNode.types.STACK) {
     return null;
   } else {
     return node.getLocation().getSourceBlock();
@@ -696,22 +697,22 @@ Blockly.navigation.moveCursorOnBlockDelete = function(deletedBlock) {
     if (block === deletedBlock) {
       // If the block has a parent move the cursor to their connection point.
       if (block.getParent()) {
-        var topConnection = block.previousConnection
-          ? block.previousConnection : block.outputConnection;
+        var topConnection = block.previousConnection ?
+          block.previousConnection : block.outputConnection;
         if (topConnection) {
-          cursor.setLocation(Blockly.ASTNode
-            .createConnectionNode(topConnection.targetConnection));
+          cursor.setLocation(
+              Blockly.ASTNode.createConnectionNode(topConnection.targetConnection));
         }
       } else {
         // If the block is by itself move the cursor to the workspace.
         cursor.setLocation(Blockly.ASTNode.createWorkspaceNode(block.workspace,
-          block.getRelativeToSurfaceXY()));
+            block.getRelativeToSurfaceXY()));
       }
     // If the cursor is on a block whose parent is being deleted, move the
     // cursor to the workspace.
     } else if (deletedBlock.getChildren().indexOf(block) > -1) {
       cursor.setLocation(Blockly.ASTNode.createWorkspaceNode(block.workspace,
-        block.getRelativeToSurfaceXY()));
+          block.getRelativeToSurfaceXY()));
     }
   }
 };

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -373,6 +373,10 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     if (block.rendered) {
       block.render();
     }
+
+    if (oldMutation != newMutation && Blockly.keyboardAccessibilityMode) {
+      Blockly.navigation.moveCursorOnBlockMutation(block);
+    }
     // Don't update the bubble until the drag has ended, to avoid moving blocks
     // under the cursor.
     if (!this.workspace_.isDragging()) {

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -94,7 +94,8 @@ suite('Navigation', function() {
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_FLYOUT);
 
-      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"), "FirstCategory-FirstBlock");
+      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"),
+          "FirstCategory-FirstBlock");
     });
 
     test('Focuses workspace from toolbox (e)', function() {
@@ -153,17 +154,20 @@ suite('Navigation', function() {
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_FLYOUT);
-      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"), "FirstCategory-FirstBlock");
+      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"),
+          "FirstCategory-FirstBlock");
     });
 
     test('Previous', function() {
       Blockly.navigation.selectNextBlockInFlyout();
-      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"), "FirstCategory-SecondBlock");
+      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"),
+          "FirstCategory-SecondBlock");
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.W;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_FLYOUT);
-      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"), "FirstCategory-FirstBlock");
+      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"),
+          "FirstCategory-FirstBlock");
     });
 
     test('Next', function() {
@@ -171,7 +175,8 @@ suite('Navigation', function() {
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_FLYOUT);
-      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"), "FirstCategory-SecondBlock");
+      chai.assert.equal(Blockly.navigation.flyoutBlock_.getFieldValue("TEXT"),
+          "FirstCategory-SecondBlock");
     });
 
     test('Out', function() {
@@ -467,14 +472,16 @@ suite('Navigation', function() {
       this.workspace.cursor.setLocation(astNode);
       // Remove the child block
       this.basicBlockB.dispose();
-      chai.assert.equal(this.workspace.cursor.getCurNode().getType(), Blockly.ASTNode.types.NEXT);
+      chai.assert.equal(this.workspace.cursor.getCurNode().getType(),
+          Blockly.ASTNode.types.NEXT);
     });
 
     test('Delete block - no parent ', function() {
       var astNode = Blockly.ASTNode.createBlockNode(this.basicBlockB);
       this.workspace.cursor.setLocation(astNode);
       this.basicBlockB.dispose();
-      chai.assert.equal(this.workspace.cursor.getCurNode().getType(), Blockly.ASTNode.types.WORKSPACE);
+      chai.assert.equal(this.workspace.cursor.getCurNode().getType(),
+          Blockly.ASTNode.types.WORKSPACE);
     });
 
     test('Delete parent block', function() {
@@ -484,7 +491,8 @@ suite('Navigation', function() {
       this.workspace.cursor.setLocation(astNode);
       // Remove the parent block
       this.basicBlockA.dispose();
-      chai.assert.equal(this.workspace.cursor.getCurNode().getType(), Blockly.ASTNode.types.WORKSPACE);
+      chai.assert.equal(this.workspace.cursor.getCurNode().getType(),
+          Blockly.ASTNode.types.WORKSPACE);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
When the cursor is on a block that is deleted the cursor will also be deleted.

### Proposed Changes
Move the cursor to the appropriate location before the block is deleted. 
The appropriate location are one of the below:
* The connection point of the deleted block and the parent 
* In the case of no parent or the parent has also been deleted to the workspace

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
