### PR TITLE
Remove closure dependency from tests

### DIFF
--- a/tests/blocks/index.html
+++ b/tests/blocks/index.html
@@ -13,9 +13,16 @@
     <script src="../../blocks/procedures.js"></script>
     <script src="../../blocks/text.js"></script>
     <script src="../../blocks/variables.js"></script>
-    <script>goog.require('goog.testing.jsunit');</script>
   </head>
   <body>
+    <script src="https://unpkg.com/chai/chai.js"></script>
+    <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
+    <script src="https://unpkg.com/sinon/pkg/sinon.js"></script>
+
+    <script src="../mocha/test_helpers.js"></script>
+
     <script src="logic_ternary_test.js"></script>
+
+    <script src="../jsunit/mocha_jsunit_test_runner.js"></script>
   </body>
 </html>

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -23,9 +23,6 @@
  * @author fenichel@google.com (Rachel Fenichel)
  */
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
-
 'use strict';
 
 var workspace;
@@ -58,14 +55,15 @@ function undefineTestBlocks() {
 
 function blockTest_setUp() {
   defineTestBlocks();
-  mockControl_ = new goog.testing.MockControl();
   workspace = new Blockly.Workspace();
 }
 
 function blockTest_tearDown() {
   undefineTestBlocks();
   workspace.dispose();
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
 }
 
 function assertUnpluggedNoheal(blocks) {
@@ -268,10 +266,10 @@ function test_set_style() {
         "colourPrimary": "#ffffff",
         "colourSecondary": "#aabbcc",
         "colourTertiary": "#ddeeff"
-      }
+      };
     }
   };
-  setUpMockMethod(mockControl_, Blockly, 'getTheme', null, [styleStub]);
+  mockControl_ = setUpMockMethod(Blockly, 'getTheme', null, [styleStub]);
   var blockA = workspace.newBlock('row_block');
   blockA.setStyle('styleOne');
 
@@ -289,11 +287,11 @@ function test_set_style_throw_exception() {
       return null;
     }
   };
-  setUpMockMethod(mockControl_, Blockly, 'getTheme', null, [styleStub]);
+  mockControl_ = setUpMockMethod(Blockly, 'getTheme', null, [styleStub]);
   var blockA = workspace.newBlock('row_block');
   try {
     blockA.setStyle('styleOne');
-  } catch(error) {
+  } catch (error) {
     assertEquals(error.message, 'Invalid style name: styleOne');
   } finally {
     blockTest_tearDown();

--- a/tests/jsunit/event_test.js
+++ b/tests/jsunit/event_test.js
@@ -24,15 +24,11 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
-
 var mockControl_;
 var workspace;
 
 function eventTest_setUp() {
   workspace = new Blockly.Workspace();
-  mockControl_ = new goog.testing.MockControl();
 }
 
 function eventTest_setUpWithMockBlocks() {
@@ -58,7 +54,9 @@ function eventTest_setUpWithMockBlocks() {
 function eventTest_tearDown() {
   delete Blockly.Blocks['field_variable_test_block'];
   delete Blockly.Blocks['simple_test_block'];
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
   workspace.dispose();
 }
 
@@ -69,7 +67,7 @@ function eventTest_tearDownWithMockBlocks() {
 
 function test_block_base_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, '1');
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, '1');
   try {
     var block = createSimpleTestBlock(workspace);
 
@@ -85,7 +83,7 @@ function test_block_base_constructor() {
 
 function test_var_base_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, '1');
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, '1');
   try {
     var variable = workspace.createVariable('name1', 'type1', 'id1');
 
@@ -149,7 +147,7 @@ function createSimpleTestBlock(workspace) {
 
 function test_create_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     var block = createSimpleTestBlock(workspace);
 
@@ -163,7 +161,7 @@ function test_create_constructor() {
 function test_blockCreate_constructor() {
   // expect that blockCreate behaves the same as create.
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     var block = createSimpleTestBlock(workspace);
 
@@ -176,7 +174,7 @@ function test_blockCreate_constructor() {
 
 function test_delete_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     var block = createSimpleTestBlock(workspace);
     var event = new Blockly.Events.Delete(block);
@@ -188,7 +186,7 @@ function test_delete_constructor() {
 
 function test_blockDelete_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     var block = createSimpleTestBlock(workspace);
     block.setCommentText('test comment');
@@ -201,7 +199,7 @@ function test_blockDelete_constructor() {
 
 function test_change_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     Blockly.Events.disable();
     var block = new Blockly.Block(workspace, 'field_variable_test_block');
@@ -217,7 +215,7 @@ function test_change_constructor() {
 
 function test_blockChange_constructor() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     Blockly.Events.disable();
     var block = new Blockly.Block(workspace, 'field_variable_test_block');
@@ -235,7 +233,7 @@ function test_blockChange_constructor() {
 function test_move_constructorCoordinate() {
   // Expect the oldCoordinate to be set.
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     var block1 = createSimpleTestBlock(workspace);
     var coordinate = new Blockly.utils.Coordinate(3, 4);
@@ -252,7 +250,7 @@ function test_move_constructorCoordinate() {
 function test_move_constructoroldParentId() {
   // Expect the oldParentId to be set but not the oldCoordinate to be set.
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     var block1 = createSimpleTestBlock(workspace);
     var block2 = createSimpleTestBlock(workspace);
@@ -271,7 +269,7 @@ function test_move_constructoroldParentId() {
 function test_blockMove_constructorCoordinate() {
   // Expect the oldCoordinate to be set.
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     var block1 = createSimpleTestBlock(workspace);
     var coordinate = new Blockly.utils.Coordinate(3, 4);
@@ -288,7 +286,7 @@ function test_blockMove_constructorCoordinate() {
 function test_blockMove_constructoroldParentId() {
   // Expect the oldParentId to be set but not the oldCoordinate to be set.
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     var block1 = createSimpleTestBlock(workspace);
     var block2 = createSimpleTestBlock(workspace);
@@ -327,7 +325,7 @@ function test_uiEvent_constructor_null() {
 
 function test_uiEvent_constructor_block() {
   eventTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
   try {
     var block1 = createSimpleTestBlock(workspace);
     Blockly.Events.setGroup('testGroup');
@@ -718,7 +716,7 @@ function test_events_newblock_newvar() {
   temporary_fireEvent.firedEvents_ = [];
   // Expect three calls to genUid: one to set the block's ID, one for the event
   // group's id, and one for the variable's ID.
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2', '3']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2', '3']);
   try {
     var block = workspace.newBlock('field_variable_test_block');
 

--- a/tests/jsunit/index.html
+++ b/tests/jsunit/index.html
@@ -9,9 +9,13 @@
     <script src="../../generators/lua.js"></script>
     <script src="../../generators/php.js"></script>
     <script src="../../generators/python.js"></script>
-    <script>goog.require('goog.testing.jsunit');</script>
   </head>
   <body>
+    <script src="https://unpkg.com/chai/chai.js"></script>
+    <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
+    <script src="https://unpkg.com/sinon/pkg/sinon.js"></script>
+    <script src="../mocha/test_helpers.js"></script>
+
     <script src="test_utilities.js"></script>
     <script src="block_test.js"></script>
     <script src="connection_db_test.js"></script>
@@ -37,5 +41,7 @@
     <script src="workspace_test.js"></script>
     <script src="workspace_undo_redo_test.js"></script>
     <script src="xml_test.js"></script>
+
+    <script src="mocha_jsunit_test_runner.js"></script>
   </body>
 </html>

--- a/tests/jsunit/mocha_jsunit_test_runner.js
+++ b/tests/jsunit/mocha_jsunit_test_runner.js
@@ -44,7 +44,7 @@ document.head.appendChild(mochaCss);
 
 /**
  * Begin by discovering all of the test methods, test methods are any
- * method on the window object that begins with the prefix `test_`
+ * function on the window object that begins with the prefix `test`
  */
 var allMethods = Object.getOwnPropertyNames(window);
 var allTests = [];
@@ -71,6 +71,7 @@ for (var i = 0, method; i < allTests.length, method = allTests[i]; i++) {
   }
   suites[suiteName].push(method);
 }
+
 
 /**
  * Setup chai fail method

--- a/tests/jsunit/mocha_jsunit_test_runner.js
+++ b/tests/jsunit/mocha_jsunit_test_runner.js
@@ -76,7 +76,6 @@ for (var i = 0, method; i < allTests.length, method = allTests[i]; i++) {
 /**
  * Setup chai fail method
  */
-
 function fail() {
   chai.fail();
 }

--- a/tests/jsunit/mocha_jsunit_test_runner.js
+++ b/tests/jsunit/mocha_jsunit_test_runner.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Blockly Tests
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A mocha test runner that mimics the behaviour of
+ *    goog.testing.junit
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+'use strict';
+
+
+/**
+ * Setup mocha
+ */
+mocha.setup({
+  ui: 'tdd'
+});
+// Add mocha div
+var mochaDiv = document.createElement('div');
+mochaDiv.id = 'mocha';
+document.body.appendChild(mochaDiv);
+var mochaCss = document.createElement('link');
+mochaCss.setAttribute('href', 'https://unpkg.com/mocha@5.2.0/mocha.css');
+mochaCss.setAttribute('rel', 'stylesheet');
+document.head.appendChild(mochaCss);
+
+
+/**
+ * Begin by discovering all of the test methods, test methods are any
+ * method on the window object that begins with the prefix `test_`
+ */
+var allMethods = Object.getOwnPropertyNames(window);
+var allTests = [];
+for (var i = 0, method; i < allMethods.length, method = allMethods[i]; i++) {
+  if (method.indexOf('test') === 0 && method !== 'test' &&
+    typeof window[method] === 'function') {
+    allTests.push(method);
+  }
+}
+
+
+/**
+ * Split test methods into various suites by grouping them based on the
+ * test name. Tests the begin with the same prefix are grouped together
+ * into a suite.
+ */
+var suites = {};
+for (var i = 0, method; i < allTests.length, method = allTests[i]; i++) {
+  var testName = method.substr(5);
+  var underscore = testName.indexOf('_');
+  var suiteName = underscore > -1 ? testName.substr(0, underscore) : 'test';
+  if (!suites.hasOwnProperty(suiteName)) {
+    suites[suiteName] = [];
+  }
+  suites[suiteName].push(method);
+}
+
+/**
+ * Setup chai fail method
+ */
+
+function fail() {
+  chai.fail();
+}
+
+
+/**
+ * Wrap all unit tests into mocha test cases. Slot them into the different
+ * suite groups that we found.
+ */
+suite('jsunit tests', function() {
+  for (var i = 0, suiteKeys = Object.keys(suites), suiteName;
+    i < suiteKeys.length, suiteName = suiteKeys[i]; i++) {
+    suite(suiteName, function() {
+      for (var j = 0, tests = suites[suiteName], method;
+        j < tests.length, method = tests[j]; j++) {
+        test(method, function() {
+          window[this.test.title]();
+        });
+      }
+    });
+  }
+});
+
+
+/**
+ * Create a div for failure results, and run the mocha tests.
+ */
+var failureDiv = document.createElement('div');
+failureDiv.id = 'failureCount';
+failureDiv.style = 'display:none';
+failureDiv.setAttribute('tests_failed', 'unset');
+document.body.appendChild(failureDiv);
+mocha.run(function(failures) {
+  failureDiv.setAttribute('tests_failed', failures);
+});

--- a/tests/jsunit/run_jsunit_tests_in_browser.js
+++ b/tests/jsunit/run_jsunit_tests_in_browser.js
@@ -44,19 +44,18 @@ async function runJsUnitTestsInBrowser() {
   console.log('Initialized.\nLoading url: ' + url);
   await browser.url(url);
 
-  const elem = await browser.$('#closureTestRunnerLog')
-  const result = await elem.getHTML();
+  await browser.waitUntil(async () => {
+    var elem = await browser.$('#failureCount');
+    var text = await elem.getAttribute('tests_failed');
+    return text != 'unset';
+  }, 6000);
 
-  // call js to parse html
-  var regex = /[\d]+\spassed,\s([\d]+)\sfailed./i;
-  var numOfFailure = regex.exec(result)[1];
-  var regex2 = /Unit Tests for Blockly .*]/;
-  var testStatus = regex2.exec(result)[0];
+  const elem = await browser.$('#failureCount');
+  const numOfFailure = await elem.getAttribute('tests_failed');
+
   console.log('============Blockly Unit Test Summary=================');
-  console.log(testStatus);
-  var regex3 = /\d+ passed,\s\d+ failed/;
-  var detail = regex3.exec(result)[0];
-  console.log(detail);
+  console.log(numOfFailure);
+  console.log(numOfFailure + ' tests failed');
   console.log('============Blockly Unit Test Summary=================');
   if (parseInt(numOfFailure) !== 0) {
     await browser.deleteSession();

--- a/tests/jsunit/test_utilities.js
+++ b/tests/jsunit/test_utilities.js
@@ -24,18 +24,12 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-
 
 /**
  * The normal blockly event fire function.  We sometimes override this.  This
  * handle lets us reset after an override.
  */
 var savedFireFunc = Blockly.Events.fire;
-
-// Asserts must be disabled or else errors can't be shown when running on
-// file:// URLs.
-goog.asserts.ENABLE_ASSERTS = false;
 
 /**
  * A helper function to replace Blockly.Events.fire in tests.
@@ -61,26 +55,23 @@ function isEqualArrays(array1, array2) {
 }
 
 /**
- * Creates a controlled MethodMock. Sets the expected return values and
- *     the parameters if any exist. Sets the method to replay.
- * @param {!goog.testing.MockControl} mockControl Object that holds a set
- *    of mocks for this test.
+ * Creates a new method stub. Sets the expected return values and
+ *     the parameters if any exist.
  * @param {!Object} scope The scope of the method to be mocked out.
  * @param {!string} funcName The name of the function we're going to mock.
  * @param {Array<Object>} parameters The parameters to call the mock with.
  * @param {Array<!Object>} return_values The values to return when called.
- * @return {!goog.testing.MockInterface} The mocked method.
+ * @return {!sinon.SinonStub} The stub method.
  */
-function setUpMockMethod(mockControl, scope, funcName, parameters,
-	return_values) {
-  var mockMethod = mockControl.createMethodMock(scope, funcName);
+function setUpMockMethod(scope, funcName, parameters, return_values) {
+  var stub = sinon.stub(scope, funcName);
   if (return_values) {
     for (var i = 0, return_value; return_value = return_values[i]; i++) {
       if (parameters && i < parameters.length) {
-        mockMethod(parameters[i]).$returns(return_value);
+        stub(parameters[i]).returns(return_value);
       }
       else {
-        mockMethod().$returns(return_value);
+        stub.onCall(i).returns(return_value);
       }
     }
   }
@@ -88,11 +79,10 @@ function setUpMockMethod(mockControl, scope, funcName, parameters,
   // recording specific method calls.
   else if (parameters) {
     for (var i = 0; i < parameters.length; i++) {
-      mockMethod(parameters[i]);
+      stub(parameters[i]);
     }
   }
-  mockMethod.$replay();
-  return mockMethod;
+  return stub;
 }
 
 /**

--- a/tests/jsunit/theme_test.js
+++ b/tests/jsunit/theme_test.js
@@ -129,7 +129,7 @@ function test_setTheme() {
   };
   blockA.styleName_ = 'styleOne';
 
-  setUpMockMethod(mockControl_, Blockly, 'getMainWorkspace', null, [workspace]);
+  var mockControl_ = setUpMockMethod(Blockly, 'getMainWorkspace', null, [workspace]);
 
   Blockly.setTheme(blockStyles);
 
@@ -145,6 +145,8 @@ function test_setTheme() {
   assertEquals(Blockly.Events.FIRE_QUEUE_.pop().element, 'theme');
 
   undefineThemeTestBlocks();
+
+  mockControl_.restore();
 }
 
 function stringifyAndCompare(val1, val2) {

--- a/tests/jsunit/variable_map_test.js
+++ b/tests/jsunit/variable_map_test.js
@@ -24,9 +24,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
-
 var variable_map;
 var mockControl_;
 var workspace;
@@ -34,12 +31,13 @@ var workspace;
 function variableMapTest_setUp() {
   workspace = new Blockly.Workspace();
   variable_map = new Blockly.VariableMap(workspace);
-  mockControl_ = new goog.testing.MockControl();
 }
 
 function variableMapTest_tearDown() {
   workspace.dispose();
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
   variable_map = null;
 }
 
@@ -153,7 +151,7 @@ function test_createVariableNullAndUndefinedType() {
 
 function test_createVariableNullId() {
   variableMapTest_setUp();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     variable_map.createVariable('name1', 'type1', null);
     checkVariableValues(variable_map, 'name1', 'type1', '1');
@@ -164,7 +162,7 @@ function test_createVariableNullId() {
 
 function test_createVariableUndefinedId() {
   variableMapTest_setUp();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '2']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '2']);
   try {
     variable_map.createVariable('name1', 'type1', undefined);
     checkVariableValues(variable_map, 'name1', 'type1', '1');

--- a/tests/jsunit/variables_test.js
+++ b/tests/jsunit/variables_test.js
@@ -24,8 +24,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-
 function variablesTest_setUp() {
   defineGetVarBlock();
   var workspace = new Blockly.Workspace();

--- a/tests/jsunit/widget_div_test.js
+++ b/tests/jsunit/widget_div_test.js
@@ -19,7 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
 
 function widgetdiv_testHelper_makeBBox(left, top, width, height) {
   return {

--- a/tests/jsunit/workspace_comment_test.js
+++ b/tests/jsunit/workspace_comment_test.js
@@ -19,8 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-
 var workspace;
 
 function workspaceCommentTest_setUp() {

--- a/tests/jsunit/workspace_test.js
+++ b/tests/jsunit/workspace_test.js
@@ -19,8 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
 
 var workspace;
 var mockControl_;
@@ -28,12 +26,13 @@ var mockControl_;
 function workspaceTest_setUp() {
   defineGetVarBlock();
   workspace = new Blockly.Workspace();
-  mockControl_ = new goog.testing.MockControl();
 }
 
 function workspaceTest_tearDown() {
   undefineGetVarBlock();
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
   workspace.dispose();
 }
 
@@ -186,7 +185,7 @@ function test_clear_Trivial() {
   workspaceTest_setUp();
   workspace.createVariable('name1', 'type1', 'id1');
   workspace.createVariable('name2', 'type2', 'id2');
-  setUpMockMethod(mockControl_, Blockly.Events, 'setGroup', [true, false],
+  mockControl_ = setUpMockMethod(Blockly.Events, 'setGroup', [true, false],
     null);
 
   try {
@@ -202,7 +201,7 @@ function test_clear_Trivial() {
 
 function test_clear_NoVariables() {
   workspaceTest_setUp();
-  setUpMockMethod(mockControl_, Blockly.Events, 'setGroup', [true, false],
+  mockControl_ = setUpMockMethod(Blockly.Events, 'setGroup', [true, false],
     null);
 
   try {

--- a/tests/jsunit/workspace_undo_redo_test.js
+++ b/tests/jsunit/workspace_undo_redo_test.js
@@ -24,11 +24,6 @@
  */
 'use strict';
 
-goog.require('goog.events.EventHandler');
-goog.require('goog.testing');
-goog.require('goog.testing.events');
-goog.require('goog.testing.MockControl');
-
 
 var workspace;
 var mockControl_;
@@ -45,13 +40,14 @@ function temporary_fireEvent(event) {
 function undoRedoTest_setUp() {
   defineGetVarBlock();
   workspace = new Blockly.Workspace();
-  mockControl_ = new goog.testing.MockControl();
   Blockly.Events.fire = temporary_fireEvent;
 }
 
 function undoRedoTest_tearDown() {
   undefineGetVarBlock();
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
   workspace.dispose();
   Blockly.Events.fire = savedFireFunc;
 }

--- a/tests/jsunit/xml_test.js
+++ b/tests/jsunit/xml_test.js
@@ -19,9 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
-
 var mockControl_;
 var workspace;
 var XML_TEXT = ['<xml xmlns="https://developers.google.com/blockly/xml">',
@@ -53,7 +50,6 @@ var XML_TEXT = ['<xml xmlns="https://developers.google.com/blockly/xml">',
 
 function xmlTest_setUp() {
   workspace = new Blockly.Workspace();
-  mockControl_ = new goog.testing.MockControl();
 }
 
 function xmlTest_setUpWithMockBlocks() {
@@ -72,7 +68,9 @@ function xmlTest_setUpWithMockBlocks() {
 }
 
 function xmlTest_tearDown() {
-  mockControl_.$tearDown();
+  if (mockControl_) {
+    mockControl_.restore();
+  }
   workspace.dispose();
 }
 
@@ -138,7 +136,7 @@ function test_domToText() {
 function test_domToWorkspace_BackwardCompatibility() {
   // Expect that workspace still loads without serialized variables.
   xmlTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '1']);
   try {
     var dom = Blockly.Xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
@@ -298,7 +296,7 @@ function test_blockToDom_fieldToDom_trivial() {
 
 function test_blockToDom_fieldToDom_defaultCase() {
   xmlTest_setUpWithMockBlocks();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1', '1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1', '1']);
   try {
     workspace.createVariable('name1');
 
@@ -338,7 +336,7 @@ function test_blockToDom_fieldToDom_notAFieldVariable() {
 
 function test_variablesToDom_oneVariable() {
   xmlTest_setUp();
-  setUpMockMethod(mockControl_, Blockly.utils, 'genUid', null, ['1']);
+  mockControl_ = setUpMockMethod(Blockly.utils, 'genUid', null, ['1']);
 
   workspace.createVariable('name1');
   var resultDom = Blockly.Xml.variablesToDom(workspace.getAllVariables());

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -1,4 +1,5 @@
-/* exported assertEquals, assertTrue, assertFalse, assertNull, assertNotNull,
+/* exported assertEquals, assertNotEquals, assertArrayEquals, assertTrue, assertFalse,
+   assertNull, assertNotNull, assertNotNullNorUndefined, assert,
    isEqualArrays, assertUndefined, assertNotUndefined,
    defineRowBlock, defineStackBlock */
 function _argumentsIncludeComments(expectedNumberOfNonCommentArgs, args) {
@@ -34,6 +35,17 @@ function assertEquals() {
   var var2 = _nonCommentArg(2, 2, arguments);
   var comment = _commentArg(2, arguments);
   chai.assert.equal(var1, var2, comment);
+}
+
+/**
+ * Converts from JSUnit assertNotEquals to chai.assert.notEquals.
+ */
+function assertNotEquals() {
+  _validateArguments(2, arguments);
+  var var1 = _nonCommentArg(1, 2, arguments);
+  var var2 = _nonCommentArg(2, 2, arguments);
+  var comment = _commentArg(2, arguments);
+  chai.assert.notEqual(var1, var2, comment);
 }
 
 /**
@@ -82,6 +94,14 @@ function assertNotNull() {
   chai.assert.isNotNull(val, commentArg);
 }
 
+function assertNotNullNorUndefined() {
+  assertNotNull(arguments);
+}
+
+function assert() {
+  chai.assert(arguments);
+}
+
 /**
  * Check that two arrays have the same content.
  * @param {!Array.<string>} array1 The first array.
@@ -106,6 +126,13 @@ function assertNotUndefined() {
   var commentArg = _commentArg(1, arguments);
   var val = _nonCommentArg(1, 1, arguments);
   chai.assert.isDefined(val, commentArg);
+}
+
+function assertArrayEquals() {
+  _validateArguments(2, arguments);
+  var var1 = _nonCommentArg(1, 2, arguments);
+  var var2 = _nonCommentArg(2, 2, arguments);
+  isEqualArrays(var1, var2);
 }
 
 function defineStackBlock() {

--- a/tests/workspace_svg/event_svg_test.js
+++ b/tests/workspace_svg/event_svg_test.js
@@ -19,8 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
 
 function eventSvg_setUpMockBlocks() {
   // TODO: Replace with defineGetVarBlock();

--- a/tests/workspace_svg/index.html
+++ b/tests/workspace_svg/index.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>Blockly Workspace SVG testing</title>
 <script src="../../blockly_uncompressed.js"></script>
-<script>goog.require('goog.testing.jsunit');</script>
 <script src="../../msg/messages.js"></script>
 <script src="../../blocks/logic.js"></script>
 <script src="../../blocks/loops.js"></script>
@@ -51,12 +50,20 @@ h1 {
   <div id="blocklyDiv"></div>
 
   <h1>Blockly Workspace testing</h1>
+
+  <script src="https://unpkg.com/chai/chai.js"></script>
+  <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
+  <script src="https://unpkg.com/sinon/pkg/sinon.js"></script>
+  <script src="../mocha/test_helpers.js"></script>
+  
   <script src="../jsunit/test_utilities.js"></script>
   <script src="workspace_svg_test.js"></script>
   <script src="procedure_svg_test.js"></script>
   <!-- TODO (#1960): Uncomment once comment deletion is fixed. -->
   <!--<script src="event_svg_test.js"></script>-->
-
+  
+  <script src="../jsunit/mocha_jsunit_test_runner.js"></script>
+  
   <xml xmlns="https://developers.google.com/blockly/xml" id="toolbox-simple" style="display: none">
     <block type="controls_ifelse"></block>
     <block type="logic_compare"></block>

--- a/tests/workspace_svg/procedure_svg_test.js
+++ b/tests/workspace_svg/procedure_svg_test.js
@@ -19,9 +19,6 @@
  */
 'use strict';
 
-goog.require('goog.testing');
-goog.require('goog.testing.MockControl');
-
 var savedFireFunc = Blockly.Events.fire;
 var workspace;
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2734

Short term plan for https://github.com/google/blockly/issues/2870
Ideally long term we should convert all these into mocha tests and remove jsunit, but for now I've wrapped jsunit tests into mocha tests.

### Proposed Changes

Remove goog.testing dependency and wrap jsunit tests into mocha tests using mocha as the test runner instead of goog.testing.jsunit.

Instead of goog.testing.mockControl, using sinon for stubs / mocks (which was already being used in the mocha tests)

### Reason for Changes

Removing closure dependency from tests
