### PR TITLE
Dropdown scrolls to selected element

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -58,6 +58,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
     Blockly.FieldDropdown.validateOptions_(menuGenerator);
   }
   this.menuGenerator_ = menuGenerator;
+  this.selectedMenuItem_ = this.getOptions()[0];
 
   this.trimOptions_();
   var firstTuple = this.getOptions()[0];
@@ -179,7 +180,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
       /** @type {!Element} */ (this.menu_.getElement()), 'blocklyDropdownMenu');
 
   this.positionMenu_(this.menu_);
-
+  Blockly.utils.style.scrollIntoContainerView(this.selectedMenuItem_.getElement(), this.menu_.getElement());
   // Focusing needs to be handled after the menu is rendered and positioned.
   // Otherwise it will cause a page scroll to get the misplaced menu in
   // view. See issue #1329.
@@ -217,6 +218,7 @@ Blockly.FieldDropdown.prototype.widgetCreate_ = function() {
     menuItem.setChecked(value == this.value_);
     if (value == this.value_) {
       selectedMenuItem = menuItem;
+      this.selectedMenuItem_ = menuItem;
     }
     menuItem.onAction(this.handleMenuActionEvent_, this);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#2613

### Proposed Changes

Created a private variable to calculate the y-value to scroll the div element.

### Reason for Changes

The div would not scroll to the selected element when the dropdown opened.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

No documentation needs to be changed.

### Additional Information

