### PR TITLE
Changed text input field to new configuration paradigm

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -117,7 +117,7 @@ Blockly.FieldTextInput.prototype.configure_ = function(opt_config) {
     return;
   }
   if (typeof opt_config['spellcheck'] == 'boolean') {
-    this.setSpellcheck(opt_config['spellcheck']);
+    this.spellcheck_ = opt_config['spellcheck'];
   }
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -116,10 +116,7 @@ Blockly.FieldTextInput.prototype.configure_ = function(opt_config) {
   if (!opt_config) {
     return;
   }
-  if (typeof opt_config == 'boolean') {
-    // opt_config used to be spellcheck.
-    this.setSpellcheck(opt_config);
-  } else if (typeof opt_config['spellcheck'] == 'boolean') {
+  if (typeof opt_config['spellcheck'] == 'boolean') {
     this.setSpellcheck(opt_config['spellcheck']);
   }
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -46,16 +46,20 @@ goog.require('Blockly.utils.userAgent');
  * @param {Function=} opt_validator A function that is called to validate
  *    changes to the field's value. Takes in a string & returns a validated
  *    string, or null to abort the change.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldTextInput = function(opt_value, opt_validator) {
+Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   opt_value = this.doClassValidation_(opt_value);
   if (opt_value === null) {
     opt_value = '';
   }
   Blockly.FieldTextInput.superClass_.constructor.call(this, opt_value,
       opt_validator);
+  this.configure_(opt_config);
 };
 goog.inherits(Blockly.FieldTextInput, Blockly.Field);
 
@@ -70,10 +74,7 @@ goog.inherits(Blockly.FieldTextInput, Blockly.Field);
  */
 Blockly.FieldTextInput.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  var field = new Blockly.FieldTextInput(text);
-  if (typeof options['spellcheck'] === 'boolean') {
-    field.setSpellcheck(options['spellcheck']);
-  }
+  var field = new Blockly.FieldTextInput(text, null, options);
   return field;
 };
 
@@ -105,6 +106,23 @@ Blockly.FieldTextInput.prototype.CURSOR = 'text';
  * @private
  */
 Blockly.FieldTextInput.prototype.spellcheck_ = true;
+
+/**
+ * Configure the field based on the given map of options.
+ * @param {Object} opt_config A map of options to configure the field based on.
+ * @private
+ */
+Blockly.FieldTextInput.prototype.configure_ = function(opt_config) {
+  if (!opt_config) {
+    return;
+  }
+  if (typeof opt_config == 'boolean') {
+    // opt_config used to be spellcheck.
+    this.setSpellcheck(opt_config);
+  } else if (typeof opt_config['spellcheck'] == 'boolean') {
+    this.setSpellcheck(opt_config['spellcheck']);
+  }
+};
 
 /**
  * Ensure that the input value casts to a valid string.
@@ -191,7 +209,13 @@ Blockly.FieldTextInput.prototype.render_ = function() {
  * @param {boolean} check True if checked.
  */
 Blockly.FieldTextInput.prototype.setSpellcheck = function(check) {
+  if (check == this.spellcheck_) {
+    return;
+  }
   this.spellcheck_ = check;
+  if (this.htmlInput_) {
+    this.htmlInput_.setAttribute('spellcheck', this.spellcheck_);
+  }
 };
 
 /**

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -222,4 +222,60 @@ suite('Text Input Fields', function() {
       });
     });
   });
+  suite('Customization', function() {
+    suite('Spellcheck', function() {
+      setup(function() {
+        this.prepField = function(field) {
+          field.sourceBlock_ = {
+            workspace: {
+              scale: 1
+            }
+          };
+          Blockly.WidgetDiv.DIV = document.createElement('div');
+          this.stub = sinon.stub(field, 'resizeEditor_');
+        };
+
+        this.assertSpellcheck = function(field, value) {
+          this.prepField(field);
+          field.showEditor_();
+          chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'),
+              value.toString());
+        };
+      });
+      teardown(function() {
+        if (this.stub) {
+          this.stub.restore();
+        }
+      });
+      test('Default', function() {
+        var field = new Blockly.FieldTextInput('test');
+        this.assertSpellcheck(field, true);
+      });
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldTextInput('test', null, {
+          spellcheck: false
+        });
+        this.assertSpellcheck(field, false);
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldTextInput.fromJson({
+          text: 'test',
+          spellcheck: false
+        });
+        this.assertSpellcheck(field, false);
+      });
+      test('setSpellcheck Editor Hidden', function() {
+        var field = new Blockly.FieldTextInput('test');
+        field.setSpellcheck(false);
+        this.assertSpellcheck(field, false);
+      });
+      test('setSpellcheck Editor Shown', function() {
+        var field = new Blockly.FieldTextInput('test');
+        this.prepField(field);
+        field.showEditor_();
+        field.setSpellcheck(false);
+        chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'), 'false');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config property to the text input field, which accepts `spellcheck` as an option.

Also changed the setSpellcheck function so that it works while the editor is opened. Not sure how often this actually occures, so I can revert if you want.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

Fix possible bug.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for:
* Default spellcheck value.
* JS Constructor.
* JSON Definition.
* setSpellcheck while the editor is hidden.
* setSpellcheck while the editor is open.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
The text input field [creation ](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#creation)and [customization ](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#spellcheck)section should be updated.

### Additional Information

<!-- Anything else we should know? -->
N/A
