### PR TITLE
Remove this.text_ and have every field handle its own properties.

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -168,7 +168,7 @@ Blockly.Field.prototype.clickTarget_ = null;
  * @return {?string} Current text. Return null to resort to a string cast.
  * @protected
  */
-Blockly.Field.prototype.hookGetText_;
+Blockly.Field.prototype.getText_;
 
 /**
  * Non-breaking space.
@@ -649,8 +649,8 @@ Blockly.Field.prototype.getDisplayText = function() {
  * @return {string} Current text.
  */
 Blockly.Field.prototype.getText = function() {
-  if (this.hookGetText_) {
-    var text = this.hookGetText_.call(this);
+  if (this.getText_) {
+    var text = this.getText_.call(this);
     if (text) {
       return String(text);
     }

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -295,12 +295,9 @@ Blockly.FieldAngle.prototype.setAngle = function(angle) {
 
   // Update value.
   var angleString = String(angle);
-  if (angleString != this.text_) {
-    this.htmlInput_.value = angle;
-    this.setValue(angle);
-    // Always render the input angle.
-    this.text_ = angleString;
-    this.forceRerender();
+  if (angleString != this.angleString_) {
+    this.angleString_ = angleString;
+    this.setEditorValue_(angle);
   }
 };
 
@@ -313,7 +310,7 @@ Blockly.FieldAngle.prototype.updateGraph_ = function() {
     return;
   }
   // Always display the input (i.e. getText) even if it is invalid.
-  var angleDegrees = Number(this.getText()) + Blockly.FieldAngle.OFFSET;
+  var angleDegrees = Number(this.getDisplayText()) + Blockly.FieldAngle.OFFSET;
   angleDegrees %= 360;
   var angleRadians = Blockly.utils.math.toRadians(angleDegrees);
   var path = ['M ', Blockly.FieldAngle.HALF, ',', Blockly.FieldAngle.HALF];

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -62,6 +62,13 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   this.trimOptions_();
   var firstTuple = this.getOptions()[0];
 
+  /**
+   * The currently selected option.
+   * @type {string|Object}
+   * @private
+   */
+  this.selectedOption_ = null;
+
   // Call parent's constructor.
   Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],
       opt_validator);
@@ -438,14 +445,7 @@ Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {
   var options = this.getOptions();
   for (var i = 0, option; option = options[i]; i++) {
     if (option[1] == this.value_) {
-      var content = option[0];
-      if (typeof content == 'object') {
-        this.imageJson_ = content;
-        this.text_ = content.alt;
-      } else {
-        this.imageJson_ = null;
-        this.text_ = content;
-      }
+      this.setSelectedValue_(option[0]);
     }
   }
 };
@@ -475,7 +475,7 @@ Blockly.FieldDropdown.prototype.render_ = function() {
   this.imageElement_.style.display = 'none';
 
   // Show correct element.
-  if (this.imageJson_) {
+  if (typeof this.selectedOption_ == 'object') {
     this.renderSelectedImage_();
   } else {
     this.renderSelectedText_();
@@ -489,16 +489,17 @@ Blockly.FieldDropdown.prototype.render_ = function() {
  * @private
  */
 Blockly.FieldDropdown.prototype.renderSelectedImage_ = function() {
+  var imageJson = this.selectedOption_;
   this.imageElement_.style.display = '';
   this.imageElement_.setAttributeNS(
-      Blockly.utils.dom.XLINK_NS, 'xlink:href', this.imageJson_.src);
-  this.imageElement_.setAttribute('height', this.imageJson_.height);
-  this.imageElement_.setAttribute('width', this.imageJson_.width);
+      Blockly.utils.dom.XLINK_NS, 'xlink:href', imageJson.src);
+  this.imageElement_.setAttribute('height', imageJson.height);
+  this.imageElement_.setAttribute('width', imageJson.width);
 
   var arrowWidth = Blockly.utils.dom.getTextWidth(this.arrow_);
 
-  var imageHeight = Number(this.imageJson_.height);
-  var imageWidth = Number(this.imageJson_.width);
+  var imageHeight = Number(imageJson.height);
+  var imageWidth = Number(imageJson.width);
 
   // Height and width include the border rect.
   this.size_.height = imageHeight + Blockly.FieldDropdown.IMAGE_Y_PADDING;
@@ -522,13 +523,35 @@ Blockly.FieldDropdown.prototype.renderSelectedImage_ = function() {
  * @private
  */
 Blockly.FieldDropdown.prototype.renderSelectedText_ = function() {
-  this.textContent_.nodeValue = this.getDisplayText_();
+  this.textContent_.nodeValue = this.getDisplayText();
   this.textElement_.setAttribute('text-anchor', 'start');
   this.textElement_.setAttribute('x', Blockly.Field.DEFAULT_TEXT_OFFSET);
   // Height and width include the border rect.
   this.size_.height = Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT;
   this.size_.width = Blockly.utils.dom.getTextWidth(this.textElement_) +
       Blockly.Field.X_PADDING;
+};
+
+/**
+ * @override
+ */
+Blockly.FieldDropdown.prototype.hookGetText_ = function() {
+  if (this.selectedOption_) {
+    if (typeof this.selectedOption_ == 'object') {
+      return this.selectedOption_['alt'];
+    }
+    return this.selectedOption_;
+  }
+  return null;
+};
+
+/**
+ * Set the selected option on this dropdown.
+ * @param {string|Object} option The option to select.
+ * @protected
+ */
+Blockly.FieldDropdown.prototype.setSelectedValue_ = function(option) {
+  this.selectedOption_ = option;
 };
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -535,7 +535,7 @@ Blockly.FieldDropdown.prototype.renderSelectedText_ = function() {
 /**
  * @override
  */
-Blockly.FieldDropdown.prototype.hookGetText_ = function() {
+Blockly.FieldDropdown.prototype.getText_ = function() {
   if (this.selectedOption_) {
     if (typeof this.selectedOption_ == 'object') {
       return this.selectedOption_['alt'];

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -445,7 +445,7 @@ Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {
   var options = this.getOptions();
   for (var i = 0, option; option = options[i]; i++) {
     if (option[1] == this.value_) {
-      this.setSelectedValue_(option[0]);
+      this.setSelectedOption_(option[0]);
     }
   }
 };
@@ -550,7 +550,7 @@ Blockly.FieldDropdown.prototype.hookGetText_ = function() {
  * @param {string|Object} option The option to select.
  * @protected
  */
-Blockly.FieldDropdown.prototype.setSelectedValue_ = function(option) {
+Blockly.FieldDropdown.prototype.setSelectedOption_ = function(option) {
   this.selectedOption_ = option;
 };
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -70,8 +70,22 @@ Blockly.FieldImage = function(src, width, height,
   this.size_ = new Blockly.utils.Size(imageWidth,
       imageHeight + Blockly.FieldImage.Y_PADDING);
 
+  /**
+   * Alt text shown on the image.
+   *
+   * @type {boolean}
+   * @private
+   */
   this.flipRtl_ = opt_flipRtl;
-  this.text_ = opt_alt || '';
+
+  /**
+   * Alt text shown on the image.
+   *
+   * @type {string}
+   * @private
+   */
+  this.altText_ = opt_alt || '';
+
   this.setValue(src || '');
 
   if (typeof opt_onClick == 'function') {
@@ -134,7 +148,7 @@ Blockly.FieldImage.prototype.initView = function() {
       {
         'height': this.imageHeight_ + 'px',
         'width': this.size_.width + 'px',
-        'alt': this.text_
+        'alt': this.altText_
       },
       this.fieldGroup_);
   this.imageElement_.setAttributeNS(Blockly.utils.dom.XLINK_NS,
@@ -178,17 +192,6 @@ Blockly.FieldImage.prototype.getFlipRtl = function() {
 /**
  * Set the alt text of this image.
  * @param {?string} alt New alt text.
- * @override
- * @deprecated 2019 setText has been deprecated for all fields. Instead use
- *    setAlt to set the alt text of the field.
- */
-Blockly.FieldImage.prototype.setText = function(alt) {
-  this.setAlt(alt);
-};
-
-/**
- * Set the alt text of this image.
- * @param {?string} alt New alt text.
  * @public
  */
 Blockly.FieldImage.prototype.setAlt = function(alt) {
@@ -196,7 +199,7 @@ Blockly.FieldImage.prototype.setAlt = function(alt) {
     // No change if null.
     return;
   }
-  this.text_ = alt;
+  this.altText_ = alt;
   if (this.imageElement_) {
     this.imageElement_.setAttribute('alt', alt || '');
   }

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -225,4 +225,11 @@ Blockly.FieldImage.prototype.setOnClickHandler = function(func) {
   this.clickHandler_ = func;
 };
 
+/**
+ * @override
+ */
+Blockly.FieldImage.prototype.hookGetText_ = function() {
+  return this.altText_;
+};
+
 Blockly.fieldRegistry.register('field_image', Blockly.FieldImage);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -228,7 +228,7 @@ Blockly.FieldImage.prototype.setOnClickHandler = function(func) {
 /**
  * @override
  */
-Blockly.FieldImage.prototype.hookGetText_ = function() {
+Blockly.FieldImage.prototype.getText_ = function() {
   return this.altText_;
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -459,7 +459,7 @@ Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
 /**
  * @override
  */
-Blockly.FieldTextInput.prototype.hookGetText_ = function() {
+Blockly.FieldTextInput.prototype.getText_ = function() {
   if (this.isBeingEdited_ && this.htmlInput_) {
     // We are currently editing, return the html input value instead.
     return this.htmlInput_.value;

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -254,7 +254,7 @@ Blockly.FieldVariable.prototype.doClassValidation_ = function(newId) {
 Blockly.FieldVariable.prototype.doValueUpdate_ = function(newId) {
   this.variable_ = Blockly.Variables.getVariable(this.workspace_, newId);
   this.value_ = newId;
-  this.text_ = this.variable_.name;
+  this.setSelectedValue_(this.variable_.name);
   this.isDirty_ = true;
 };
 
@@ -349,7 +349,7 @@ Blockly.FieldVariable.prototype.setTypes_ = function(opt_variableTypes,
  * @package
  */
 Blockly.FieldVariable.prototype.refreshVariableName = function() {
-  this.text_ = this.variable_.name;
+  this.setSelectedValue_(this.variable_.name);
   this.forceRerender();
 };
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -254,7 +254,7 @@ Blockly.FieldVariable.prototype.doClassValidation_ = function(newId) {
 Blockly.FieldVariable.prototype.doValueUpdate_ = function(newId) {
   this.variable_ = Blockly.Variables.getVariable(this.workspace_, newId);
   this.value_ = newId;
-  this.setSelectedValue_(this.variable_.name);
+  this.setSelectedOption_(this.variable_.name);
   this.isDirty_ = true;
 };
 
@@ -349,7 +349,7 @@ Blockly.FieldVariable.prototype.setTypes_ = function(opt_variableTypes,
  * @package
  */
 Blockly.FieldVariable.prototype.refreshVariableName = function() {
-  this.setSelectedValue_(this.variable_.name);
+  this.setSelectedOption_(this.variable_.name);
   this.forceRerender();
 };
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2720
https://github.com/google/blockly/pull/2796 is also a relevant PR for context.

### Proposed Changes

After doing a deep dive into how each field was using ``this.text_``. It turned out they were using it in different an inconsistent ways. It was pretty much a convenient property to dump a value in and use it later during render. Here's a summary: 
- ``field.js``: Field was storing a string cast of the value, and using it to render that on the screen (after having it pass through the getDisplayText_ converted to make it display read, converting spaces to &nbsp; and truncating). 
- ``field_dropdown.js``: Cast of the selected value, but only in the case of text dropdowns. For image dropdowns, a different property is used to store the currently selected item (imageJson). This is another hint to me, that each field is using ``this.text_`` as a convenient property to store a value in and use during render. This field inherits part of the view from ``field.js`` but diverges significantly when its an image field.
- ``field_variable.js``: In FieldVariable, the model is an object. ``this.text_`` was being used to set the currently selected variable, but unlike its parent, the selected option is a property inside of the model. 
- ``field_image.js``: Using ``this.text_`` as a convenient property to set the alt text. 
- ``field_textinput.js``: This is where things get interesting. ``this.text_`` is being used here as a way to store the current html value in the input while editing. (It also is used to store the text representation of the value (string cast) but that's taken care of by ``field.js`` and described above). The reason we need that is a little, I'll describe in the additional information section. 
- ``field_anglepicker.js``: This one does something similar to text input, but the difference here is we're unable to derive the text to display from the value. (eg: if we're typing in 4000 in the input text, setValue will convert that to 40, but we want to keep 4000 in the input text). The picker also needs a way to override what's in it's parent's html input when using the cursor. 

Here's what I'm proposing here: 
- ``FieldTextInput`` doesn't need to store any temporary values while editing. The html input has all the info we need. While we're editing, a call to getText returns the html value, otherwise it returns the string cast of the value. The field also provides the ability for subclasses to set the editor value, by calling ``setEditorValue_``, this updates the value of the field, and the html input.
- ``FieldDropdown`` adds the concept of a selected option. In the default cast, this is just a cache of the currently selected option, but ``FieldVariable`` uses it to set an explicit string.
- ``FieldImage`` use a ``this.altText_`` property instead.
- In ``Field``: 
 - getText: is basically the ``toString`` of fields. It converts a value to a string that can be displayed in various locations. I've added a developer hook: ``getText_`` as a place where developers can easily override the hook without having to call super. If it's there it's used, otherwise a string cast is used. I'm not a huge fan of this, so depending on the feedback I get, I'm happy to just have developers override getText directly and call super if they want to.
 - getDisplayText_: reads in ``getText`` and converts it to text that can be shown on the block. In most cases, developers don't need to override this.

### Reason for Changes

Reasons defined in the linked issue.

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Safari

### Documentation

Needs to be updated once this PR is finalized. 

### Additional Information

- Reason for a text span behind the input while editing: The reason we need to maintain a text span behind the input field is so that we can get the right size calculation for the html input. We use that text span to replicate the text inside of the html input in a span, and ask the browser for the size of that text which takes into account the current font size. This information is then used to size the text input correctly. If you'd like more detail on that, I'm happy to provide further details.

@BeksOmega please review! I've tried to be verbose with my reasoning, let me know if anything doesn't make sense.
