### PR TITLE
No Edge/IE close input icon

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -547,6 +547,13 @@ Blockly.Css.CONTENT = [
     'text-align: center;',
   '}',
 
+  /* Edge and IE introduce a close icon when the input is longer than certain
+     size. This close icon shifts the text in the input field and that messes
+     with our sizing calculations. Hiding the close icon. */
+  '.blocklyHtmlInput::-ms-clear {',
+    'display: none;',
+  '}',
+
   '.blocklyMainBackground {',
     'stroke-width: 1;',
     'stroke: #c6c6c6;',  /* Equates to #ddd due to border being off-pixel. */


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Edge and IE introduce a close icon to clear an input when its longer than a certain length. see screenshot. This messes with the sizing calculations we do as we base it on the size of the text.

![Screen Shot 2019-08-23 at 7 12 59 PM](https://user-images.githubusercontent.com/16690124/63631273-0b061080-c5da-11e9-94e6-89af7d98210d.png)

### Proposed Changes

Hide the ms close icon that Edge / IE introduce.

### Reason for Changes

Correct sizing of input fields.

### Test Coverage


Tested on:
* Edge 18
* IE 11


