### PR TITLE
Fixes error from connecting a neseted input to its parent

### DIFF
--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -451,6 +451,24 @@ suite('Navigation', function() {
         "message0": "",
         "previousStatement": null,
         "nextStatement": null,
+      },
+      {
+        "type": "inline_block",
+        "message0": "%1 %2",
+        "args0": [
+          {
+            "type": "input_value",
+            "name": "NAME"
+          },
+          {
+            "type": "input_value",
+            "name": "NAME"
+          }
+        ],
+        "inputsInline": true,
+        "output": null,
+        "tooltip": "",
+        "helpUrl": ""
       }]);
 
       var toolbox = document.getElementById('toolbox-categories');
@@ -461,14 +479,22 @@ suite('Navigation', function() {
       var basicBlock3 = this.workspace.newBlock('basic_block');
       var basicBlock4 = this.workspace.newBlock('basic_block');
 
+      var inlineBlock1 = this.workspace.newBlock('inline_block');
+      var inlineBlock2 = this.workspace.newBlock('inline_block');
+
       this.basicBlock = basicBlock;
       this.basicBlock2 = basicBlock2;
       this.basicBlock3 = basicBlock3;
       this.basicBlock4 = basicBlock4;
 
+      this.inlineBlock1 = inlineBlock1;
+      this.inlineBlock2 = inlineBlock2;
+
       this.basicBlock.nextConnection.connect(this.basicBlock2.previousConnection);
 
       this.basicBlock3.nextConnection.connect(this.basicBlock4.previousConnection);
+
+      this.inlineBlock1.inputList[0].connection.connect(this.inlineBlock2.outputConnection);
     });
 
     teardown(function() {
@@ -516,6 +542,16 @@ suite('Navigation', function() {
 
       chai.assert.equal(this.basicBlock3.previousConnection.targetBlock(), this.basicBlock2);
     });
+
+    test('Try to connect input that is descendant of output', function() {
+      var markedLocation = this.inlineBlock2.inputList[0].connection;
+      var cursorLocation = this.inlineBlock1.outputConnection;
+
+      Blockly.navigation.connect(cursorLocation, markedLocation);
+
+      chai.assert.equal(this.inlineBlock2.outputConnection.targetBlock(), this.inlineBlock1);
+    });
+
 
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
<img width="371" alt="Screen Shot 2019-08-27 at 1 35 44 PM" src="https://user-images.githubusercontent.com/23059043/63806063-9a0f7300-c8cf-11e9-8de5-fe5c96fdf935.png">
Trying to connect the above scenario was throwing an error in block.setParent because we can not set the parent's svgRoot a one of its children.

### Proposed Changes
Checks this case before trying to connect the two connections.
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
