### PR TITLE
Fixed comment ownership.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -25,7 +25,6 @@
 'use strict';
 
 goog.provide('Blockly.Block');
-goog.provide('Blockly.Block.CommentModel');
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Connection');
@@ -135,6 +134,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    * @deprecated August 2019. Use getCommentText or getCommentIcon instead.
    */
   this.comment = null;
+
   /**
    * A model of the comment attached to this block.
    * @type {!Blockly.Block.CommentModel}
@@ -221,7 +221,6 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 };
 
 /**
- * A model of a comment.
  * @typedef {{
  *            text:?string,
  *            pinned:boolean

--- a/core/block.js
+++ b/core/block.js
@@ -223,7 +223,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 /**
  * @typedef {{
  *            text:?string,
- *            pinned:boolean
+ *            pinned:boolean,
  *            size:Blockly.utils.Size
  *          }}
  */

--- a/core/block.js
+++ b/core/block.js
@@ -134,20 +134,9 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    * @deprecated August 2019. Use getCommentText or getCommentIcon instead.
    */
   this.comment = null;
-
-  // TODO: There may be a better place for this typedef, or it could simply
-  //  be removed.
-  /**
-   * A model of a comment.
-   * @typedef {Object} TextBubbleModel
-   * @property {?string} text - The text of the comment.
-   * @property {boolean} pinned - Whether the comment is open or not.
-   * @property {Blockly.utils.Size} size - The height and width of the bubble.
-   */
-
   /**
    * A model of the comment attached to this block.
-   * @type {TextBubbleModel}
+   * @type {!Blockly.Block.CommentModel}
    * @package
    */
   this.commentModel = {
@@ -229,6 +218,18 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     this.setOnChange(this.onchange);
   }
 };
+
+/**
+
+/**
+ * A model of a comment.
+ * @typedef {{
+ *            text:?string,
+ *            pinned:boolean
+ *            size:Blockly.utils.Size
+ *          }}
+ */
+Blockly.Block.CommentModel;
 
 /**
  * Optional text data that round-trips between blocks and XML.

--- a/core/block.js
+++ b/core/block.js
@@ -25,6 +25,7 @@
 'use strict';
 
 goog.provide('Blockly.Block');
+goog.provide('Blockly.Block.CommentModel');
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Connection');
@@ -218,8 +219,6 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     this.setOnChange(this.onchange);
   }
 };
-
-/**
 
 /**
  * A model of a comment.

--- a/core/block.js
+++ b/core/block.js
@@ -128,8 +128,33 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    */
   this.collapsed_ = false;
 
-  /** @type {string|Blockly.Comment} */
+  /**
+   * A string/Blockly.Comment representing the comment attached to this block.
+   * @type {string|Blockly.Comment}
+   * @deprecated August 2019. Use getCommentText or getCommentIcon instead.
+   */
   this.comment = null;
+
+  // TODO: There may be a better place for this typedef, or it could simply
+  //  be removed.
+  /**
+   * A model of a comment.
+   * @typedef {Object} TextBubbleModel
+   * @property {?string} text - The text of the comment.
+   * @property {boolean} pinned - Whether the comment is open or not.
+   * @property {Blockly.utils.Size} size - The height and width of the bubble.
+   */
+
+  /**
+   * A model of the comment attached to this block.
+   * @type {TextBubbleModel}
+   * @package
+   */
+  this.commentModel = {
+    text: null,
+    pinned: false,
+    size: new Blockly.utils.Size(160, 80)
+  };
 
   /**
    * The block's position in workspace units.  (0, 0) is at the workspace's
@@ -1795,11 +1820,13 @@ Blockly.Block.prototype.getCommentText = function() {
  * @param {?string} text The text, or null to delete.
  */
 Blockly.Block.prototype.setCommentText = function(text) {
-  if (this.comment != text) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this, 'comment', null, this.comment, text || ''));
-    this.comment = text;
+  if (this.commentModel.text == text) {
+    return;
   }
+  Blockly.Events.fire(new Blockly.Events.BlockChange(
+      this, 'comment', null, this.commentModel.text, text || ''));
+  this.commentModel.text = text;
+  this.comment = text;  // For backwards compatibility.
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -40,7 +40,6 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.utils.string');
-goog.require('Blockly.Warning');
 goog.require('Blockly.Workspace');
 
 

--- a/core/block.js
+++ b/core/block.js
@@ -1812,7 +1812,7 @@ Blockly.Block.prototype.getInputTargetBlock = function(name) {
  * @return {string} Block's comment.
  */
 Blockly.Block.prototype.getCommentText = function() {
-  return this.comment || '';
+  return this.commentModel.text || '';
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -129,9 +129,9 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.collapsed_ = false;
 
   /**
-   * A string/Blockly.Comment representing the comment attached to this block.
-   * @type {string|Blockly.Comment}
-   * @deprecated August 2019. Use getCommentText or getCommentIcon instead.
+   * A string representing the comment attached to this block.
+   * @type {string}
+   * @deprecated August 2019. Use getCommentText instead.
    */
   this.comment = null;
 

--- a/core/block.js
+++ b/core/block.js
@@ -130,7 +130,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 
   /**
    * A string representing the comment attached to this block.
-   * @type {string}
+   * @type {string|Blockly.Comment}
    * @deprecated August 2019. Use getCommentText instead.
    */
   this.comment = null;

--- a/core/block.js
+++ b/core/block.js
@@ -1808,11 +1808,11 @@ Blockly.Block.prototype.getInputTargetBlock = function(name) {
 };
 
 /**
- * Returns the comment on this block (or '' if none).
+ * Returns the comment on this block (or null if there is no comment).
  * @return {string} Block's comment.
  */
 Blockly.Block.prototype.getCommentText = function() {
-  return this.commentModel.text || '';
+  return this.commentModel.text;
 };
 
 /**
@@ -1824,7 +1824,7 @@ Blockly.Block.prototype.setCommentText = function(text) {
     return;
   }
   Blockly.Events.fire(new Blockly.Events.BlockChange(
-      this, 'comment', null, this.commentModel.text, text || ''));
+      this, 'comment', null, this.commentModel.text, text));
   this.commentModel.text = text;
   this.comment = text;  // For backwards compatibility.
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1097,7 +1097,7 @@ Blockly.BlockSvg.prototype.setCommentText = function(text) {
   if (!!this.commentIcon_ == shouldHaveComment) {
     // If the comment's state of existence is correct, but the text is new
     // that means we're just updating a comment.
-    // TODO: Tell comment to update itself.
+    this.commentIcon_.updateText();
     return;
   }
   if (shouldHaveComment) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1062,9 +1062,14 @@ Blockly.BlockSvg.prototype.updateDisabled = function() {
   }
 };
 
+/**
+ * Get the comment icon attached to this block, or null if the block has no
+ * comment.
+ * @return {Blockly.Comment} The comment icon attached to this block, or null.
+ */
 Blockly.BlockSvg.prototype.getCommentIcon = function() {
   return this.commentIcon_;
-}
+};
 
 /**
  * Set this block's comment text.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -35,6 +35,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Events.BlockMove');
 goog.require('Blockly.Msg');
+goog.require('Blockly.Mutator');
 goog.require('Blockly.RenderedConnection');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
@@ -43,6 +44,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.Warning');
 
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -29,13 +29,11 @@ goog.provide('Blockly.BlockSvg');
 goog.require('Blockly.Block');
 goog.require('Blockly.blockAnimations');
 goog.require('Blockly.blockRendering.IPathObject');
-goog.require('Blockly.Comment');
 goog.require('Blockly.ContextMenu');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Events.BlockMove');
 goog.require('Blockly.Msg');
-goog.require('Blockly.Mutator');
 goog.require('Blockly.RenderedConnection');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
@@ -44,7 +42,6 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
-goog.require('Blockly.Warning');
 
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -284,8 +284,8 @@ Blockly.BlockSvg.prototype.getIcons = function() {
   if (this.mutator) {
     icons.push(this.mutator);
   }
-  if (this.comment) {
-    icons.push(this.comment);
+  if (this.commentIcon_) {
+    icons.push(this.commentIcon_);
   }
   if (this.warning) {
     icons.push(this.warning);
@@ -1079,18 +1079,9 @@ Blockly.BlockSvg.prototype.updateDisabled = function() {
   }
 };
 
-/**
- * Returns the comment on this block (or '' if none).
- * @return {string} Block's comment.
- */
-Blockly.BlockSvg.prototype.getCommentText = function() {
-  if (this.comment) {
-    var comment = this.comment.getText();
-    // Trim off trailing whitespace.
-    return comment.replace(/\s+$/, '').replace(/ +\n/g, '\n');
-  }
-  return '';
-};
+Blockly.BlockSvg.prototype.getCommentIcon = function() {
+  return this.commentIcon_;
+}
 
 /**
  * Set this block's comment text.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1076,6 +1076,9 @@ Blockly.BlockSvg.prototype.getCommentIcon = function() {
  * @param {?string} text The text, or null to delete.
  */
 Blockly.BlockSvg.prototype.setCommentText = function(text) {
+  if (!Blockly.Comment) {
+    throw Error('Missing require for Blockly.Comment');
+  }
   if (this.commentModel.text == text) {
     return;
   }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -29,6 +29,7 @@ goog.provide('Blockly.BlockSvg');
 goog.require('Blockly.Block');
 goog.require('Blockly.blockAnimations');
 goog.require('Blockly.blockRendering.IPathObject');
+goog.require('Blockly.Comment');
 goog.require('Blockly.ContextMenu');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -959,28 +959,11 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     this.warningTextDb_ = null;
   }
 
-  // If the block is rendered we need to record the event before disposing of
-  // the icons to prevent losing information.
-  // TODO (#1969): Remove event generation/firing once comments are fixed.
-  this.unplug(healStack);
-  var deleteEvent;
-  if (Blockly.Events.isEnabled()) {
-    deleteEvent = new Blockly.Events.BlockDelete(this);
+  var icons = this.getIcons();
+  for (var i = 0; i < icons.length; i++) {
+    icons[i].dispose();
   }
-  Blockly.Events.disable();
-  try {
-    var icons = this.getIcons();
-    for (var i = 0; i < icons.length; i++) {
-      icons[i].dispose();
-    }
-    // TODO (#1969): Move out of disable block once comments are fixed.
-    Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
-  } finally {
-    Blockly.Events.enable();
-  }
-  if (Blockly.Events.isEnabled() && deleteEvent) {
-    Blockly.Events.fire(deleteEvent);
-  }
+  Blockly.BlockSvg.superClass_.dispose.call(this, healStack);
 
   Blockly.utils.dom.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -42,6 +42,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.Warning');
 
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -625,10 +625,10 @@ Blockly.Bubble.prototype.moveTo = function(x, y) {
 
 /**
  * Get the dimensions of this bubble.
- * @return {!Object} Object with width and height properties.
+ * @return {!Blockly.utils.Size} The height and width of the bubble.
  */
 Blockly.Bubble.prototype.getBubbleSize = function() {
-  return {width: this.width_, height: this.height_};
+  return new Blockly.utils.Size(this.width_, this.height_);
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -657,13 +657,12 @@ Blockly.Bubble.prototype.setBubbleSize = function(width, height) {
           (height - doubleBorderWidth) + ')');
     }
   }
-  if (this.rendered_) {
-    if (this.autoLayout_) {
-      this.layoutBubble_();
-    }
-    this.positionBubble_();
-    this.renderArrow_();
+  if (this.autoLayout_) {
+    this.layoutBubble_();
   }
+  this.positionBubble_();
+  this.renderArrow_();
+
   // Allow the contents to resize.
   if (this.resizeCallback_) {
     this.resizeCallback_();

--- a/core/comment.js
+++ b/core/comment.js
@@ -52,6 +52,14 @@ Blockly.Comment = function(block) {
    */
   this.model_ = block.commentModel;
 
+  /**
+   * The model's text value at the start of an edit.
+   * Used to tell if an event should be fired at the end of an edit.
+   * @type {string}
+   * @private
+   */
+  this.cachedText_ = '';
+
   this.createIcon();
 };
 Blockly.utils.object.inherits(Blockly.Comment, Blockly.Icon);
@@ -123,16 +131,16 @@ Blockly.Comment.prototype.createEditor_ = function() {
   body.appendChild(textarea);
   this.foreignObject_.appendChild(body);
 
-  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.textareaFocus_,
+  Blockly.bindEventWithChecks_(textarea, 'mouseup', this, this.startEdit_,
       true, true);
   Blockly.bindEventWithChecks_(textarea, 'wheel', this, function(e) {
     // Don't zoom with mousewheel.
     e.stopPropagation();
   });
   Blockly.bindEventWithChecks_(textarea, 'change', this, function(_e) {
-    if (this.model_.text != textarea.value) {
+    if (this.cachedText_ != this.model_.text) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
-          this.block_, 'comment', null, this.model_.text, textarea.value));
+          this.block_, 'comment', null, this.cachedText_, this.model_.text));
     }
   });
   Blockly.bindEventWithChecks_(textarea, 'input', this, function(_e) {
@@ -222,10 +230,11 @@ Blockly.Comment.prototype.setVisible = function(visible) {
 
 /**
  * Bring the comment to the top of the stack when clicked on.
+ * Also cache the current text so it can be used to fire a change event.
  * @param {!Event} _e Mouse up event.
  * @private
  */
-Blockly.Comment.prototype.textareaFocus_ = function(_e) {
+Blockly.Comment.prototype.startEdit_ = function(_e) {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
@@ -234,6 +243,8 @@ Blockly.Comment.prototype.textareaFocus_ = function(_e) {
     // we need to reapply the focus.
     this.textarea_.focus();
   }
+
+  this.cachedText_ = this.model_.text;
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -125,8 +125,10 @@ Blockly.Comment.prototype.createEditor_ = function() {
     if (this.model_.text != textarea.value) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
           this.block_, 'comment', null, this.model_.text, textarea.value));
-      this.model_.text = textarea.value;
     }
+  });
+  Blockly.bindEventWithChecks_(textarea, 'input', this, function(_e) {
+    this.model_.text = textarea.value;
   });
   setTimeout(textarea.focus.bind(textarea), 0);
   return this.foreignObject_;
@@ -254,7 +256,7 @@ Blockly.Comment.prototype.setBubbleSize = function(width, height) {
  * @return {string} Comment text.
  */
 Blockly.Comment.prototype.getText = function() {
-  return this.textarea_ ? this.textarea_.value : this.model_.text;
+  return this.model_.text;
 };
 
 /**
@@ -274,11 +276,11 @@ Blockly.Comment.prototype.setText = function(text) {
 
 /**
  * Dispose of this comment.
+ *
+ * If you want to get the event, then this should not be called directly.
+ * Instead call block.setCommentText(null);
  */
 Blockly.Comment.prototype.dispose = function() {
-  if (Blockly.Events.isEnabled()) {
-    this.setText('');  // Fire event to delete comment.
-  }
   this.block_.comment = null;
   Blockly.Icon.prototype.dispose.call(this);
 };

--- a/core/comment.js
+++ b/core/comment.js
@@ -153,7 +153,7 @@ Blockly.Comment.prototype.updateEditable = function() {
     this.setVisible(true);
   }
   // Allow the icon to update.
-  Blockly.Icon.prototype.updateEditable.call(this);
+  Blockly.Comment.superClass_.updateEditable.call(this);
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -26,7 +26,6 @@
 
 goog.provide('Blockly.Comment');
 
-goog.require('Blockly.Block');
 goog.require('Blockly.Bubble');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');

--- a/core/comment.js
+++ b/core/comment.js
@@ -181,6 +181,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
     // MSIE does not support foreignobject; textareas are impossible.
     // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
     // Always treat comments in IE as uneditable.
+    // TODO (#2917): It would be great if this could support line breaks.
     Blockly.Warning.prototype.setVisible.call(this, visible);
     return;
   }
@@ -281,6 +282,10 @@ Blockly.Comment.prototype.setText = function(text) {
 Blockly.Comment.prototype.updateText = function() {
   if (this.textarea_) {
     this.textarea_.value = this.model_.text;
+  } else if (this.paragraphElement_) {
+    // Non-Editable mode.
+    // TODO (#2917): If 2917 gets added this will probably need to be updated.
+    this.paragraphElement_.firstChild.textContent = this.model_.text;
   }
 };
 

--- a/core/comment.js
+++ b/core/comment.js
@@ -102,7 +102,8 @@ Blockly.Comment.prototype.drawIcon_ = function(group) {
  * @private
  */
 Blockly.Comment.prototype.createEditor_ = function() {
-  /* Create the editor.  Here's the markup that will be generated:
+  /* Create the editor.  Here's the markup that will be generated in
+   * editable mode:
     <foreignObject x="8" y="8" width="164" height="164">
       <body xmlns="http://www.w3.org/1999/xhtml" class="blocklyMinimalBody">
         <textarea xmlns="http://www.w3.org/1999/xhtml"
@@ -110,7 +111,8 @@ Blockly.Comment.prototype.createEditor_ = function() {
             style="height: 164px; width: 164px;"></textarea>
       </body>
     </foreignObject>
-  */
+   * For non-editable mode see Warning.textToDom_.
+   */
 
   this.foreignObject_ = Blockly.utils.dom.createSvgElement('foreignObject',
       {'x': Blockly.Bubble.BORDER_WIDTH, 'y': Blockly.Bubble.BORDER_WIDTH},
@@ -205,7 +207,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
     // MSIE does not support foreignobject; textareas are impossible.
     // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
     // Always treat comments in IE as uneditable.
-    // TODO (#2917): It would be great if this could support line breaks.
+    // TODO (#2917): It would be great if the comment could support line breaks.
     Blockly.Warning.prototype.setVisible.call(this, visible);
     return;
   }

--- a/core/comment.js
+++ b/core/comment.js
@@ -59,7 +59,7 @@ Blockly.Comment = function(block) {
   /**
    * The model's text value at the start of an edit.
    * Used to tell if an event should be fired at the end of an edit.
-   * @type {string}
+   * @type {?string}
    * @private
    */
   this.cachedText_ = '';
@@ -258,7 +258,7 @@ Blockly.Comment.prototype.createNonEditableBubble_ = function() {
   // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
   // Always treat comments in IE as uneditable.
   // TODO (#2917): It would be great if the comment could support line breaks.
-  Blockly.Warning.prototype.createBubble.call(this, true);
+  Blockly.Warning.prototype.createBubble.call(this);
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -47,7 +47,7 @@ Blockly.Comment = function(block) {
 
   /**
    * The model for this comment.
-   * @type {Blockly.Block.CommentModel}
+   * @type {!Blockly.Block.CommentModel}
    * @private
    */
   this.model_ = block.commentModel;
@@ -226,6 +226,10 @@ Blockly.Comment.prototype.setVisible = function(visible) {
  */
 Blockly.Comment.prototype.createBubble_ = function() {
   if (!this.block_.isEditable() || Blockly.utils.userAgent.IE) {
+    // Steal the code from warnings to make an uneditable text bubble.
+    // MSIE does not support foreignobject; textareas are impossible.
+    // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
+    // Always treat comments in IE as uneditable.
     this.createNonEditableBubble_();
   } else {
     this.createEditableBubble_();
@@ -252,10 +256,6 @@ Blockly.Comment.prototype.createEditableBubble_ = function() {
  * @private
  */
 Blockly.Comment.prototype.createNonEditableBubble_ = function() {
-  // Steal the code from warnings to make an uneditable text bubble.
-  // MSIE does not support foreignobject; textareas are impossible.
-  // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
-  // Always treat comments in IE as uneditable.
   // TODO (#2917): It would be great if the comment could support line breaks.
   Blockly.Warning.prototype.createBubble.call(this);
 };
@@ -323,7 +323,7 @@ Blockly.Comment.prototype.setBubbleSize = function(width, height) {
  * @deprecated August 2019 Use block.getCommentText() instead.
  */
 Blockly.Comment.prototype.getText = function() {
-  return this.model_.text;
+  return this.model_.text || '';
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -44,27 +44,17 @@ goog.require('Blockly.utils.userAgent');
  */
 Blockly.Comment = function(block) {
   Blockly.Comment.superClass_.constructor.call(this, block);
+
+  /**
+   * The model for this comment.
+   * @type {TextBubbleModel}
+   * @private
+   */
+  this.model_ = block.commentModel;
+
   this.createIcon();
 };
 Blockly.utils.object.inherits(Blockly.Comment, Blockly.Icon);
-
-/**
- * Comment text (if bubble is not visible).
- * @private
- */
-Blockly.Comment.prototype.text_ = '';
-
-/**
- * Width of bubble.
- * @private
- */
-Blockly.Comment.prototype.width_ = 160;
-
-/**
- * Height of bubble.
- * @private
- */
-Blockly.Comment.prototype.height_ = 80;
 
 /**
  * Draw the comment icon.
@@ -132,10 +122,10 @@ Blockly.Comment.prototype.createEditor_ = function() {
     e.stopPropagation();
   });
   Blockly.bindEventWithChecks_(textarea, 'change', this, function(_e) {
-    if (this.text_ != textarea.value) {
+    if (this.model_.text != textarea.value) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
-          this.block_, 'comment', null, this.text_, textarea.value));
-      this.text_ = textarea.value;
+          this.block_, 'comment', null, this.model_.text, textarea.value));
+      this.model_.text = textarea.value;
     }
   });
   setTimeout(textarea.focus.bind(textarea), 0);
@@ -200,7 +190,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
     this.bubble_ = new Blockly.Bubble(
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
         this.createEditor_(), this.block_.svgPath_,
-        this.iconXY_, this.width_, this.height_);
+        this.iconXY_, this.model_.size.width, this.model_.size.height);
     // Expose this comment's block's ID on its top-level SVG group.
     this.bubble_.setSvgId(this.block_.id);
     this.bubble_.registerResizeEvent(this.resizeBubble_.bind(this));
@@ -241,7 +231,7 @@ Blockly.Comment.prototype.getBubbleSize = function() {
   if (this.isVisible()) {
     return this.bubble_.getBubbleSize();
   } else {
-    return {width: this.width_, height: this.height_};
+    return this.model_.size;
   }
 };
 
@@ -254,8 +244,8 @@ Blockly.Comment.prototype.setBubbleSize = function(width, height) {
   if (this.textarea_) {
     this.bubble_.setBubbleSize(width, height);
   } else {
-    this.width_ = width;
-    this.height_ = height;
+    this.model_.size.width = width;
+    this.model_.size.height = height;
   }
 };
 
@@ -264,7 +254,7 @@ Blockly.Comment.prototype.setBubbleSize = function(width, height) {
  * @return {string} Comment text.
  */
 Blockly.Comment.prototype.getText = function() {
-  return this.textarea_ ? this.textarea_.value : this.text_;
+  return this.textarea_ ? this.textarea_.value : this.model_.text;
 };
 
 /**
@@ -272,11 +262,11 @@ Blockly.Comment.prototype.getText = function() {
  * @param {string} text Comment text.
  */
 Blockly.Comment.prototype.setText = function(text) {
-  if (this.text_ != text) {
+  if (this.model_.text != text) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.block_, 'comment', null, this.text_, text));
-    this.text_ = text;
+        this.block_, 'comment', null, this.model_.text, text));
   }
+  this.model_.text = text;
   if (this.textarea_) {
     this.textarea_.value = text;
   }

--- a/core/comment.js
+++ b/core/comment.js
@@ -265,7 +265,7 @@ Blockly.Comment.prototype.createNonEditableBubble_ = function() {
  * @private
  */
 Blockly.Comment.prototype.disposeBubble_ = function() {
-  if (!this.block_.isEditable() || Blockly.utils.userAgent.IE) {
+  if (this.paragraphElement_) {
     // We're using the warning UI so we have to let it dispose.
     Blockly.Warning.prototype.disposeBubble.call(this);
     return;
@@ -320,6 +320,7 @@ Blockly.Comment.prototype.setBubbleSize = function(width, height) {
 /**
  * Returns this comment's text.
  * @return {string} Comment text.
+ * @deprecated August 2019 Use block.getCommentText() instead.
  */
 Blockly.Comment.prototype.getText = function() {
   return this.model_.text;
@@ -331,6 +332,7 @@ Blockly.Comment.prototype.getText = function() {
  * If you want to get the event, then this should not be called directly.
  * Instead call block.setCommentText();
  * @param {string} text Comment text.
+ * @deprecated August 2019 Use block.setCommentText() instead.
  */
 Blockly.Comment.prototype.setText = function(text) {
   if (this.model_.text == text) {

--- a/core/comment.js
+++ b/core/comment.js
@@ -330,8 +330,8 @@ Blockly.Comment.prototype.getText = function() {
 /**
  * Set this comment's text.
  *
- * If you want to get the event, then this should not be called directly.
- * Instead call block.setCommentText();
+ * If you want to receive a comment change event, then this should not be called
+ * directly. Instead call block.setCommentText();
  * @param {string} text Comment text.
  * @deprecated August 2019 Use block.setCommentText() instead.
  */
@@ -360,8 +360,8 @@ Blockly.Comment.prototype.updateText = function() {
 /**
  * Dispose of this comment.
  *
- * If you want to get the event, then this should not be called directly.
- * Instead call block.setCommentText(null);
+ * If you want to receive a comment "delete" event (newValue: null), then this
+ * should not be called directly. Instead call block.setCommentText(null);
  */
 Blockly.Comment.prototype.dispose = function() {
   this.block_.comment = null;

--- a/core/comment.js
+++ b/core/comment.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.Comment');
 
+goog.require('Blockly.Block');
 goog.require('Blockly.Bubble');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');

--- a/core/comment.js
+++ b/core/comment.js
@@ -47,7 +47,7 @@ Blockly.Comment = function(block) {
 
   /**
    * The model for this comment.
-   * @type {TextBubbleModel}
+   * @type {Blockly.Block.CommentModel}
    * @private
    */
   this.model_ = block.commentModel;

--- a/core/comment.js
+++ b/core/comment.js
@@ -51,6 +51,9 @@ Blockly.Comment = function(block) {
    * @private
    */
   this.model_ = block.commentModel;
+  // If someone creates the comment directly instead of calling
+  // block.setCommentText we want to make sure the text is non-null;
+  this.model_.text = this.model_.text || '';
 
   /**
    * The model's text value at the start of an edit.

--- a/core/comment.js
+++ b/core/comment.js
@@ -212,6 +212,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
   }
   Blockly.Events.fire(
       new Blockly.Events.Ui(this.block_, 'commentOpen', !visible, visible));
+  this.model_.pinned = visible;
   if (visible) {
     this.createBubble_();
   } else {

--- a/core/comment.js
+++ b/core/comment.js
@@ -187,7 +187,6 @@ Blockly.Comment.prototype.setVisible = function(visible) {
   }
   // Save the bubble stats before the visibility switch.
   var text = this.getText();
-  var size = this.getBubbleSize();
   if (visible) {
     // Create the bubble.
     this.bubble_ = new Blockly.Bubble(
@@ -207,7 +206,6 @@ Blockly.Comment.prototype.setVisible = function(visible) {
   }
   // Restore the bubble stats after the visibility switch.
   this.setText(text);
-  this.setBubbleSize(size.width, size.height);
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -261,16 +261,26 @@ Blockly.Comment.prototype.getText = function() {
 
 /**
  * Set this comment's text.
+ *
+ * If you want to get the event, then this should not be called directly.
+ * Instead call block.setCommentText();
  * @param {string} text Comment text.
  */
 Blockly.Comment.prototype.setText = function(text) {
-  if (this.model_.text != text) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.block_, 'comment', null, this.model_.text, text));
+  if (this.model_ == text) {
+    return;
   }
   this.model_.text = text;
+  this.updateText();
+};
+
+/**
+ * Update the comment's view to match the model.
+ * @package
+ */
+Blockly.Comment.prototype.updateText = function() {
   if (this.textarea_) {
-    this.textarea_.value = text;
+    this.textarea_.value = this.model_.text;
   }
 };
 

--- a/core/icon.js
+++ b/core/icon.js
@@ -26,7 +26,6 @@
 
 goog.provide('Blockly.Icon');
 
-goog.forwardDeclare('Blockly.BlockSvg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');

--- a/core/icon.js
+++ b/core/icon.js
@@ -108,6 +108,7 @@ Blockly.Icon.prototype.dispose = function() {
  * Add or remove the UI indicating if this icon may be clicked or not.
  */
 Blockly.Icon.prototype.updateEditable = function() {
+  // No-op on the base class.
 };
 
 /**

--- a/core/icon.js
+++ b/core/icon.js
@@ -26,7 +26,7 @@
 
 goog.provide('Blockly.Icon');
 
-goog.require('Blockly.BlockSvg');
+goog.forwardDeclare('Blockly.BlockSvg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');

--- a/core/icon.js
+++ b/core/icon.js
@@ -42,7 +42,7 @@ Blockly.Icon = function(block) {
   /**
    * The block this icon is attached to.
    * @type {Blockly.BlockSvg}
-   * @private
+   * @protected
    */
   this.block_ = block;
 };

--- a/core/icon.js
+++ b/core/icon.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.Icon');
 
+goog.require('Blockly.BlockSvg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
@@ -34,10 +35,15 @@ goog.require('Blockly.utils.Size');
 
 /**
  * Class for an icon.
- * @param {Blockly.Block} block The block associated with this icon.
+ * @param {Blockly.BlockSvg} block The block associated with this icon.
  * @constructor
  */
 Blockly.Icon = function(block) {
+  /**
+   * The block this icon is attached to.
+   * @type {Blockly.BlockSvg}
+   * @private
+   */
   this.block_ = block;
 };
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -183,6 +183,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
  * Add or remove the UI indicating if this icon may be clicked or not.
  */
 Blockly.Mutator.prototype.updateEditable = function() {
+  Blockly.Mutator.superClass_.updateEditable.call(this);
   if (!this.block_.isInFlyout) {
     if (this.block_.isEditable()) {
       if (this.iconGroup_) {
@@ -200,8 +201,6 @@ Blockly.Mutator.prototype.updateEditable = function() {
       }
     }
   }
-  // Default behaviour for an icon.
-  Blockly.Mutator.superClass_.updateEditable.call(this);
 };
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -297,7 +297,6 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
       };
       this.block_.workspace.addChangeListener(this.sourceListener_);
     }
-    this.resizeBubble_();
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     this.updateColour();

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -201,7 +201,7 @@ Blockly.Mutator.prototype.updateEditable = function() {
     }
   }
   // Default behaviour for an icon.
-  Blockly.Icon.prototype.updateEditable.call(this);
+  Blockly.Mutator.superClass_.updateEditable.call(this);
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -116,37 +116,55 @@ Blockly.Warning.textToDom_ = function(text) {
  */
 Blockly.Warning.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
-    // No change.
     return;
   }
   Blockly.Events.fire(
       new Blockly.Events.Ui(this.block_, 'warningOpen', !visible, visible));
   if (visible) {
-    // Create the bubble to display all warnings.
-    this.paragraphElement_ = Blockly.Warning.textToDom_(this.getText());
-    this.bubble_ = new Blockly.Bubble(
-        /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
-        this.paragraphElement_, this.block_.svgPath_, this.iconXY_, null, null);
-    // Expose this warning's block's ID on its top-level SVG group.
-    this.bubble_.setSvgId(this.block_.id);
-    if (this.block_.RTL) {
-      // Right-align the paragraph.
-      // This cannot be done until the bubble is rendered on screen.
-      var maxWidth = this.paragraphElement_.getBBox().width;
-      for (var i = 0, textElement;
-        textElement = this.paragraphElement_.childNodes[i]; i++) {
-
-        textElement.setAttribute('text-anchor', 'end');
-        textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);
-      }
-    }
-    this.updateColour();
+    this.createBubble_();
   } else {
-    // Dispose of the bubble.
-    this.bubble_.dispose();
-    this.bubble_ = null;
-    this.body_ = null;
+    this.disposeBubble_();
   }
+};
+
+/**
+ * Show the bubble.
+ * @package
+ */
+Blockly.Warning.prototype.createBubble = function() {
+  // TODO: This is package because comments steal this UI for non-editable
+  //  comments, but really this should be private.
+  this.paragraphElement_ = Blockly.Warning.textToDom_(this.getText());
+  this.bubble_ = new Blockly.Bubble(
+      /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
+      this.paragraphElement_, this.block_.svgPath_, this.iconXY_, null, null);
+  // Expose this warning's block's ID on its top-level SVG group.
+  this.bubble_.setSvgId(this.block_.id);
+  if (this.block_.RTL) {
+    // Right-align the paragraph.
+    // This cannot be done until the bubble is rendered on screen.
+    var maxWidth = this.paragraphElement_.getBBox().width;
+    for (var i = 0, textElement;
+      textElement = this.paragraphElement_.childNodes[i]; i++) {
+
+      textElement.setAttribute('text-anchor', 'end');
+      textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);
+    }
+  }
+  this.updateColour();
+};
+
+/**
+ * Dispose of the bubble and references to it.
+ * @package
+ */
+Blockly.Warning.prototype.disposeBubble = function() {
+  // TODO: This is package because comments steal this UI for non-editable
+  //  comments, but really this should be private.
+  this.bubble_.dispose();
+  this.bubble_ = null;
+  this.body_ = null;
+  this.paragraphElement_ = null;
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -121,9 +121,9 @@ Blockly.Warning.prototype.setVisible = function(visible) {
   Blockly.Events.fire(
       new Blockly.Events.Ui(this.block_, 'warningOpen', !visible, visible));
   if (visible) {
-    this.createBubble_();
+    this.createBubble();
   } else {
-    this.disposeBubble_();
+    this.disposeBubble();
   }
 };
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -132,8 +132,8 @@ Blockly.Warning.prototype.setVisible = function(visible) {
  * @package
  */
 Blockly.Warning.prototype.createBubble = function() {
-  // TODO: This is package because comments steal this UI for non-editable
-  //  comments, but really this should be private.
+  // TODO (#2943): This is package because comments steal this UI for
+  //  non-editable comments, but really this should be private.
   this.paragraphElement_ = Blockly.Warning.textToDom_(this.getText());
   this.bubble_ = new Blockly.Bubble(
       /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
@@ -159,8 +159,8 @@ Blockly.Warning.prototype.createBubble = function() {
  * @package
  */
 Blockly.Warning.prototype.disposeBubble = function() {
-  // TODO: This is package because comments steal this UI for non-editable
-  //  comments, but really this should be private.
+  // TODO (#2943): This is package because comments steal this UI for
+  //  non-editable comments, but really this should be private.
   this.bubble_.dispose();
   this.bubble_ = null;
   this.body_ = null;

--- a/core/warning.js
+++ b/core/warning.js
@@ -123,17 +123,19 @@ Blockly.Warning.prototype.setVisible = function(visible) {
       new Blockly.Events.Ui(this.block_, 'warningOpen', !visible, visible));
   if (visible) {
     // Create the bubble to display all warnings.
-    var paragraph = Blockly.Warning.textToDom_(this.getText());
+    this.paragraphElement_ = Blockly.Warning.textToDom_(this.getText());
     this.bubble_ = new Blockly.Bubble(
         /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
-        paragraph, this.block_.svgPath_, this.iconXY_, null, null);
+        this.paragraphElement_, this.block_.svgPath_, this.iconXY_, null, null);
     // Expose this warning's block's ID on its top-level SVG group.
     this.bubble_.setSvgId(this.block_.id);
     if (this.block_.RTL) {
       // Right-align the paragraph.
       // This cannot be done until the bubble is rendered on screen.
-      var maxWidth = paragraph.getBBox().width;
-      for (var i = 0, textElement; textElement = paragraph.childNodes[i]; i++) {
+      var maxWidth = this.paragraphElement_.getBBox().width;
+      for (var i = 0, textElement;
+        textElement = this.paragraphElement_.childNodes[i]; i++) {
+
         textElement.setAttribute('text-anchor', 'end');
         textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);
       }
@@ -162,7 +164,8 @@ Blockly.Warning.prototype.bodyFocus_ = function(_e) {
 
 /**
  * Set this warning's text.
- * @param {string} text Warning text (or '' to delete).
+ * @param {string} text Warning text (or '' to delete). This supports
+ *    linebreaks.
  * @param {string} id An ID for this text entry to be able to maintain
  *     multiple warnings.
  */

--- a/core/warning.js
+++ b/core/warning.js
@@ -141,9 +141,6 @@ Blockly.Warning.prototype.setVisible = function(visible) {
       }
     }
     this.updateColour();
-    // Bump the warning into the right location.
-    var size = this.bubble_.getBubbleSize();
-    this.bubble_.setBubbleSize(size.width, size.height);
   } else {
     // Dispose of the bubble.
     this.bubble_.dispose();

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -213,8 +213,9 @@ Blockly.Dart.scrub_ = function(block, code, opt_thisOnly) {
   if (!block.outputConnection || !block.outputConnection.targetConnection) {
     // Collect comment for this block.
     var comment = block.getCommentText();
-    comment = Blockly.utils.string.wrap(comment, Blockly.Dart.COMMENT_WRAP - 3);
     if (comment) {
+      comment = Blockly.utils.string.wrap(comment,
+          Blockly.Dart.COMMENT_WRAP - 3);
       if (block.getProcedureDef) {
         // Use documentation comment for function comments.
         commentCode += Blockly.Dart.prefixLines(comment + '\n', '/// ');

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -254,9 +254,9 @@ Blockly.JavaScript.scrub_ = function(block, code, opt_thisOnly) {
   if (!block.outputConnection || !block.outputConnection.targetConnection) {
     // Collect comment for this block.
     var comment = block.getCommentText();
-    comment = Blockly.utils.string.wrap(comment,
-        Blockly.JavaScript.COMMENT_WRAP - 3);
     if (comment) {
+      comment = Blockly.utils.string.wrap(comment,
+        Blockly.JavaScript.COMMENT_WRAP - 3);
       if (block.getProcedureDef) {
         // Use a comment block for function comments.
         commentCode += '/**\n' +

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -187,8 +187,9 @@ Blockly.Lua.scrub_ = function(block, code, opt_thisOnly) {
   if (!block.outputConnection || !block.outputConnection.targetConnection) {
     // Collect comment for this block.
     var comment = block.getCommentText();
-    comment = Blockly.utils.string.wrap(comment, Blockly.Lua.COMMENT_WRAP - 3);
     if (comment) {
+      comment = Blockly.utils.string.wrap(comment,
+          Blockly.Lua.COMMENT_WRAP - 3);
       commentCode += Blockly.Lua.prefixLines(comment, '-- ') + '\n';
     }
     // Collect comments for all value arguments.

--- a/generators/php.js
+++ b/generators/php.js
@@ -240,8 +240,9 @@ Blockly.PHP.scrub_ = function(block, code, opt_thisOnly) {
   if (!block.outputConnection || !block.outputConnection.targetConnection) {
     // Collect comment for this block.
     var comment = block.getCommentText();
-    comment = Blockly.utils.string.wrap(comment, Blockly.PHP.COMMENT_WRAP - 3);
     if (comment) {
+      comment = Blockly.utils.string.wrap(comment,
+          Blockly.PHP.COMMENT_WRAP - 3);
       commentCode += Blockly.PHP.prefixLines(comment, '// ') + '\n';
     }
     // Collect comments for all value arguments.

--- a/generators/python.js
+++ b/generators/python.js
@@ -268,9 +268,9 @@ Blockly.Python.scrub_ = function(block, code, opt_thisOnly) {
   if (!block.outputConnection || !block.outputConnection.targetConnection) {
     // Collect comment for this block.
     var comment = block.getCommentText();
-    comment = Blockly.utils.string.wrap(comment,
-        Blockly.Python.COMMENT_WRAP - 3);
     if (comment) {
+      comment = Blockly.utils.string.wrap(comment,
+        Blockly.Python.COMMENT_WRAP - 3);
       if (block.getProcedureDef) {
         // Use a comment block for function comments.
         commentCode += '"""' + comment + '\n"""\n';

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -425,89 +425,120 @@ suite('Blocks', function() {
           "args0": []
         },
       ]);
-      this.headlessWorkspace = this.workspace;
-      this.renderedWorkspace = Blockly.inject('blocklyDiv', {
-        comments: true,
-        scrollbars: true
-      });
-
-      this.headlessBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-          '<block type="empty_block"/>'
-      ), this.headlessWorkspace);
-      this.renderedBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-          '<block type="empty_block"/>'
-      ), this.renderedWorkspace);
       this.eventSpy = sinon.spy(Blockly.Events, 'fire');
     });
     teardown(function() {
       this.eventSpy.restore();
-      this.renderedWorkspace.dispose();
     });
     suite('Set/Get Text', function() {
-      function assertEvent(eventSpy, newValue) {
+      function assertCommentEvent(eventSpy, oldValue, newValue) {
         var calls = eventSpy.getCalls();
         var event = calls[calls.length - 1].args[0];
         chai.assert.equal(event.type, Blockly.Events.BLOCK_CHANGE);
         chai.assert.equal(event.element, 'comment');
+        chai.assert.equal(event.oldValue, oldValue);
         chai.assert.equal(event.newValue, newValue);
       }
-      test('Headless', function() {
-        this.headlessBlock.setCommentText('test text');
-        chai.assert.equal(this.headlessBlock.getCommentText(), 'test text');
-        chai.assert(this.eventSpy.calledOnce);
-        assertEvent(this.eventSpy, 'test text');
-      });
-      test('Headless Null', function() {
-        this.headlessBlock.setCommentText(null);
-        chai.assert.equal(this.headlessBlock.getCommentText(), '');
-        chai.assert(this.eventSpy.notCalled);
-      });
-      test('Headless Comment -> Null', function() {
-        this.headlessBlock.setCommentText('first text');
+      function assertNoCommentEvent(eventSpy) {
+        var calls = eventSpy.getCalls();
+        var event = calls[calls.length - 1].args[0];
+        chai.assert.notEqual(event.type, Blockly.Events.BLOCK_CHANGE);
+      }
+      suite('Headless', function() {
+        setup(function() {
+          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="empty_block"/>'
+          ), this.workspace);
+        });
+        test('Text', function() {
+          this.block.setCommentText('test text');
+          chai.assert.equal(this.block.getCommentText(), 'test text');
+          assertCommentEvent(this.eventSpy, null, 'test text');
+        });
+        test('Text Empty', function() {
+          this.block.setCommentText('');
+          chai.assert.equal(this.block.getCommentText(), '');
+          assertCommentEvent(this.eventSpy, null, '');
+        });
+        test('Text Null', function() {
+          this.block.setCommentText(null);
+          chai.assert.equal(this.block.getCommentText(), null);
+          assertNoCommentEvent(this.eventSpy);
+        });
+        test('Text -> Null', function() {
+          this.block.setCommentText('first text');
 
-        this.headlessBlock.setCommentText(null);
-        chai.assert.equal(this.headlessBlock.getCommentText(), '');
-        chai.assert(this.eventSpy.calledTwice);
-        assertEvent(this.eventSpy, '');
+          this.block.setCommentText(null);
+          chai.assert.equal(this.block.getCommentText(), null);
+          assertCommentEvent(this.eventSpy, 'first text', null);
+        });
       });
-      test('Set Text While Visible', function() {
-        this.renderedBlock.setCommentText('first text');
-        this.renderedBlock.getCommentIcon().setVisible(true);
+      suite('Rendered', function() {
+        setup(function() {
+          // Let the parent teardown take care of this.
+          this.workspace = Blockly.inject('blocklyDiv', {
+            comments: true,
+            scrollbars: true
+          });
+          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="empty_block"/>'
+          ), this.workspace);
+        });
+        test('Text', function() {
+          this.block.setCommentText('test text');
+          chai.assert.equal(this.block.getCommentText(), 'test text');
+          assertCommentEvent(this.eventSpy, null, 'test text');
+        });
+        test('Text Empty', function() {
+          this.block.setCommentText('');
+          chai.assert.equal(this.block.getCommentText(), '');
+          assertCommentEvent(this.eventSpy, null, '');
+        });
+        test('Text Null', function() {
+          this.block.setCommentText(null);
+          chai.assert.equal(this.block.getCommentText(), null);
+          assertNoCommentEvent(this.eventSpy);
+        });
+        test('Text -> Null', function() {
+          this.block.setCommentText('first text');
 
-        this.renderedBlock.setCommentText('test text');
-        chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
-        // First text set, Visible, Second text set.
-        chai.assert(this.eventSpy.calledThrice);
-        assertEvent(this.eventSpy, 'test text');
+          this.block.setCommentText(null);
+          chai.assert.equal(this.block.getCommentText(), null);
+          assertCommentEvent(this.eventSpy, 'first text', null);
+        });
+        test('Set While Visible - Editable', function() {
+          this.block.setCommentText('test1');
+          var icon = this.block.getCommentIcon();
+          icon.setVisible(true);
 
-        this.renderedBlock.getCommentIcon().setVisible(false);
-        chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
-      });
-      test('Set Text While Invisible', function() {
-        // This line is just for consistency
-        this.renderedBlock.setCommentText('first text');
+          this.block.setCommentText('test2');
+          chai.assert.equal(this.block.getCommentText(), 'test2');
+          assertCommentEvent(this.eventSpy, 'test1', 'test2');
+          chai.assert.equal(icon.textarea_.value, 'test2');
+        });
+        test('Set While Visible - NonEditable', function() {
+          this.block.setCommentText('test1');
+          var editableStub = sinon.stub(this.block, 'isEditable').returns(false);
+          var icon = this.block.getCommentIcon();
+          icon.setVisible(true);
 
-        this.renderedBlock.setCommentText('test text');
-        chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
-        chai.assert(this.eventSpy.calledTwice);
-        assertEvent(this.eventSpy, 'test text');
+          this.block.setCommentText('test2');
+          chai.assert.equal(this.block.getCommentText(), 'test2');
+          assertCommentEvent(this.eventSpy, 'test1', 'test2');
+          chai.assert.equal(icon.paragraphElement_.firstChild.textContent,
+              'test2');
 
-        this.renderedBlock.getCommentIcon().setVisible(true);
-        chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
-      });
-      test('Rendered Null', function() {
-        this.renderedBlock.setCommentText(null);
-        chai.assert.equal(this.renderedBlock.getCommentText(), '');
-        chai.assert(this.eventSpy.notCalled);
-      });
-      test('Rendered Comment -> Null', function() {
-        this.renderedBlock.setCommentText('first text');
+          editableStub.restore();
+        });
+        test('Get Text While Editing', function() {
+          this.block.setCommentText('test1');
+          var icon = this.block.getCommentIcon();
+          icon.setVisible(true);
+          icon.textarea_.value = 'test2';
+          icon.textarea_.dispatchEvent(new Event('input'));
 
-        this.renderedBlock.setCommentText(null);
-        chai.assert.equal(this.renderedBlock.getCommentText(), '');
-        chai.assert.isNull(this.renderedBlock.getCommentIcon());
-        chai.assert(this.eventSpy.calledTwice);
-        assertEvent(this.eventSpy, '');
+          chai.assert.equal(this.block.getCommentText(), 'test2');
+        });
       });
     });
   });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -428,6 +428,7 @@ suite('Blocks', function() {
       this.eventSpy = sinon.spy(Blockly.Events, 'fire');
     });
     teardown(function() {
+      delete Blockly.Blocks['empty_block'];
       this.eventSpy.restore();
     });
     suite('Set/Get Text', function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -426,7 +426,10 @@ suite('Blocks', function() {
         },
       ]);
       this.headlessWorkspace = this.workspace;
-      this.renderedWorkspace = Blockly.inject('blocklyDiv', {comments: true});
+      this.renderedWorkspace = Blockly.inject('blocklyDiv', {
+        comments: true,
+        scrollbars: true
+      });
 
       this.headlessBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
           '<block type="empty_block"/>'
@@ -469,14 +472,15 @@ suite('Blocks', function() {
       });
       test('Set Text While Visible', function() {
         this.renderedBlock.setCommentText('first text');
-        this.renderedBlock.comment.setVisible(true);
+        this.renderedBlock.getCommentIcon().setVisible(true);
 
         this.renderedBlock.setCommentText('test text');
         chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
-        chai.assert(this.eventSpy.calledTwice);
+        // First text set, Visible, Second text set.
+        chai.assert(this.eventSpy.calledThrice);
         assertEvent(this.eventSpy, 'test text');
 
-        this.renderedBlock.comment.setVisible(false);
+        this.renderedBlock.getCommentIcon().setVisible(false);
         chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
       });
       test('Set Text While Invisible', function() {
@@ -488,7 +492,7 @@ suite('Blocks', function() {
         chai.assert(this.eventSpy.calledTwice);
         assertEvent(this.eventSpy, 'test text');
 
-        this.renderedBlock.comment.setVisible(true);
+        this.renderedBlock.getCommentIcon().setVisible(true);
         chai.assert.equal(this.renderedBlock.getCommentText(), 'test text');
       });
       test('Rendered Null', function() {
@@ -501,10 +505,7 @@ suite('Blocks', function() {
 
         this.renderedBlock.setCommentText(null);
         chai.assert.equal(this.renderedBlock.getCommentText(), '');
-        chai.assert.isNull(this.renderedBlock.commentIcon_);
-        console.log(this.eventSpy.getCall(0));
-        console.log(this.eventSpy.getCall(1));
-        console.log(this.eventSpy.getCall(2));
+        chai.assert.isNull(this.renderedBlock.getCommentIcon());
         chai.assert(this.eventSpy.calledTwice);
         assertEvent(this.eventSpy, '');
       });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+suite('Comments', function() {
+  setup(function() {
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "empty_block",
+        "message0": "",
+        "args0": []
+      },
+    ]);
+
+    this.workspace = Blockly.inject('blocklyDiv', {comments: true});
+    this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        '<block type="empty_block"/>'
+    ), this.workspace);
+    this.comment = new Blockly.Comment(this.block);
+    this.comment.computeIconLocation();
+  });
+  teardown(function() {
+    this.workspace.dispose();
+  });
+  suite('Set/Get Bubble Size', function() {
+    function assertBubbleSize(comment, height, width) {
+      var size = comment.getBubbleSize();
+      chai.assert.equal(size.height, height);
+      chai.assert.equal(size.width, width);
+    }
+    function assertBubbleSizeDefault(comment) {
+      assertBubbleSize(comment, 80, 160);
+    }
+    test('Set Size While Visible', function() {
+      this.comment.setVisible(true);
+      var bubbleSizeSpy = sinon.spy(this.comment.bubble_, 'setBubbleSize');
+
+      assertBubbleSizeDefault(this.comment);
+      this.comment.setBubbleSize(100, 100);
+      assertBubbleSize(this.comment, 100, 100);
+      chai.assert(bubbleSizeSpy.calledOnce);
+
+      this.comment.setVisible(false);
+      assertBubbleSize(this.comment, 100, 100);
+
+      bubbleSizeSpy.restore();
+    });
+    test('Set Size While Invisible', function() {
+      assertBubbleSizeDefault(this.comment);
+      this.comment.setBubbleSize(100, 100);
+      assertBubbleSize(this.comment, 100, 100);
+
+      this.comment.setVisible(true);
+      assertBubbleSize(this.comment, 100, 100);
+    });
+  });
+  suite('Set/Get Text', function() {
+    test('Set Text While Visible', function() {
+      this.comment.setVisible(true);
+      var eventSpy = sinon.spy(Blockly.Events, 'fire');
+
+      chai.assert.equal(this.comment.getText(), '');
+      this.comment.setText('test text');
+      chai.assert.equal(this.comment.getText(), 'test text');
+      chai.assert(eventSpy.calledOnce);
+      var event = eventSpy.getCall(0).args[0];
+      chai.assert.equal(event.type, Blockly.Events.BLOCK_CHANGE);
+      chai.assert.equal(event.element, 'comment');
+      chai.assert.equal(event.newValue, 'test text');
+
+      this.comment.setVisible(false);
+      chai.assert.equal(this.comment.getText(), 'test text');
+
+      eventSpy.restore();
+    });
+    test('Set Text While Invisible', function() {
+      var eventSpy = sinon.spy(Blockly.Events, 'fire');
+
+      chai.assert.equal(this.comment.getText(), '');
+      this.comment.setText('test text');
+      chai.assert.equal(this.comment.getText(), 'test text');
+      chai.assert(eventSpy.calledOnce);
+      var event = eventSpy.getCall(0).args[0];
+      chai.assert.equal(event.type, Blockly.Events.BLOCK_CHANGE);
+      chai.assert.equal(event.element, 'comment');
+      chai.assert.equal(event.newValue, 'test text');
+
+      this.comment.setVisible(true);
+      chai.assert.equal(this.comment.getText(), 'test text');
+
+      eventSpy.restore();
+    });
+  });
+});

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -36,6 +36,7 @@ suite('Comments', function() {
     this.comment.computeIconLocation();
   });
   teardown(function() {
+    delete Blockly.Blocks['empty_block'];
     this.workspace.dispose();
   });
   suite('Set/Get Bubble Size', function() {

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -76,7 +76,8 @@ suite('Comments', function() {
       this.comment.setVisible(true);
       var eventSpy = sinon.spy(Blockly.Events, 'fire');
 
-      chai.assert.equal(this.comment.getText(), '');
+      // Going with initially null for now.
+      chai.assert.equal(this.comment.getText(), null);
       this.comment.setText('test text');
       chai.assert.equal(this.comment.getText(), 'test text');
       chai.assert(eventSpy.calledOnce);
@@ -93,7 +94,8 @@ suite('Comments', function() {
     test('Set Text While Invisible', function() {
       var eventSpy = sinon.spy(Blockly.Events, 'fire');
 
-      chai.assert.equal(this.comment.getText(), '');
+      // Going with initially null for now.
+      chai.assert.equal(this.comment.getText(), null);
       this.comment.setText('test text');
       chai.assert.equal(this.comment.getText(), 'test text');
       chai.assert(eventSpy.calledOnce);

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -115,4 +115,63 @@ suite('Comments', function() {
       chai.assert.equal(this.comment.getText(), 'test text');
     });
   });
+  suite('Editability', function() {
+    setup(function() {
+      this.editableStub = sinon.stub(this.block, 'isEditable').returns(true);
+    });
+    teardown(function() {
+      this.editableStub.restore();
+    });
+    function assertEditable(comment) {
+      chai.assert.isOk(comment.textarea_);
+      chai.assert.equal(comment.textarea_.value, 'test text');
+    }
+    function assertNonEditable(comment) {
+      chai.assert.isOk(comment.bubble_);
+      var displayText = comment.bubble_.content_
+          .firstChild.firstChild.nodeValue;
+      chai.assert.equal(displayText, 'test text');
+    }
+    test('Editable', function() {
+      this.comment.setText('test text');
+      this.comment.setVisible(true);
+      assertEditable(this.comment);
+    });
+    test('Non-Editable', function() {
+      this.editableStub.returns(false);
+      this.comment.setText('test text');
+      this.comment.setVisible(true);
+    });
+    test('True -> False While Open', function() {
+      this.comment.setText('test text');
+      this.comment.setVisible(true);
+      assertEditable(this.comment);
+
+      this.editableStub.returns(false);
+      this.comment.updateEditable();
+      assertNonEditable(this.comment);
+    });
+    test('False -> True While Open', function() {
+      this.editableStub.returns(false);
+      this.comment.setText('test text');
+      this.comment.setVisible(true);
+      assertNonEditable(this.comment);
+
+      this.editableStub.returns(true);
+
+      this.comment.setText('test text');
+      this.comment.updateEditable();
+      assertEditable(this.comment);
+    });
+    test('True -> False While Editing', function() {
+      this.comment.setVisible(true);
+      this.comment.textarea_.value = 'test text';
+      this.comment.textarea_.dispatchEvent(new Event('input'));
+      assertEditable(this.comment);
+
+      this.editableStub.returns(false);
+      this.comment.updateEditable();
+      assertNonEditable(this.comment);
+    });
+  });
 });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -107,5 +107,12 @@ suite('Comments', function() {
 
       eventSpy.restore();
     });
+    test('Get Text While Editing', function() {
+      this.comment.setVisible(true);
+      this.comment.textarea_.value = 'test text';
+      this.comment.textarea_.dispatchEvent(new Event('input'));
+
+      chai.assert.equal(this.comment.getText(), 'test text');
+    });
   });
 });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -28,7 +28,10 @@ suite('Comments', function() {
       },
     ]);
 
-    this.workspace = Blockly.inject('blocklyDiv', {comments: true});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      comments: true,
+      scrollbars: true
+    });
     this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
         '<block type="empty_block"/>'
     ), this.workspace);
@@ -74,40 +77,21 @@ suite('Comments', function() {
   suite('Set/Get Text', function() {
     test('Set Text While Visible', function() {
       this.comment.setVisible(true);
-      var eventSpy = sinon.spy(Blockly.Events, 'fire');
 
-      // Going with initially null for now.
-      chai.assert.equal(this.comment.getText(), null);
+      chai.assert.equal(this.comment.getText(), '');
       this.comment.setText('test text');
       chai.assert.equal(this.comment.getText(), 'test text');
-      chai.assert(eventSpy.calledOnce);
-      var event = eventSpy.getCall(0).args[0];
-      chai.assert.equal(event.type, Blockly.Events.BLOCK_CHANGE);
-      chai.assert.equal(event.element, 'comment');
-      chai.assert.equal(event.newValue, 'test text');
 
       this.comment.setVisible(false);
       chai.assert.equal(this.comment.getText(), 'test text');
-
-      eventSpy.restore();
     });
     test('Set Text While Invisible', function() {
-      var eventSpy = sinon.spy(Blockly.Events, 'fire');
-
-      // Going with initially null for now.
-      chai.assert.equal(this.comment.getText(), null);
+      chai.assert.equal(this.comment.getText(), '');
       this.comment.setText('test text');
       chai.assert.equal(this.comment.getText(), 'test text');
-      chai.assert(eventSpy.calledOnce);
-      var event = eventSpy.getCall(0).args[0];
-      chai.assert.equal(event.type, Blockly.Events.BLOCK_CHANGE);
-      chai.assert.equal(event.element, 'comment');
-      chai.assert.equal(event.newValue, 'test text');
 
       this.comment.setVisible(true);
       chai.assert.equal(this.comment.getText(), 'test text');
-
-      eventSpy.restore();
     });
     test('Get Text While Editing', function() {
       this.comment.setVisible(true);

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -26,6 +26,7 @@
 
     <script src="astnode_test.js"></script>
     <script src="block_test.js"></script>
+    <script src="comment_test.js"></script>
     <script src="connection_db_test.js"></script>
     <script src="connection_test.js"></script>
     <script src="cursor_test.js"></script>

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -501,7 +501,10 @@ suite('XML', function() {
         Blockly.Xml.domToWorkspace(renderedXml, this.headlessWorkspace);
         var headlessXml = Blockly.Xml.workspaceToDom(this.headlessWorkspace);
 
-        chai.assert.equal(renderedXml, headlessXml);
+        var renderedText = Blockly.Xml.domToText(renderedXml);
+        var headlessText = Blockly.Xml.domToText(headlessXml);
+
+        chai.assert.equal(renderedText, headlessText);
       };
     });
     teardown(function() {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -511,7 +511,7 @@ suite('XML', function() {
       this.renderedWorkspace.dispose();
       this.headlessWorkspace.dispose();
     });
-    test.skip('Comment', function() {
+    test('Comment', function() {
       Blockly.defineBlocksWithJsonArray([
         {
           "type": "empty_block",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #1969 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Moved comment icons to use a model-based system. The block holds the model of the comment, and the comment icon holds a reference to it.
* Reorganized the setVisible function.
* Changed how xml.js serializes and deserializes comments.

Some other little things:
* Removed blockSvg's getCommentText function.
* Changed bubble.getSize to return a Blockly.utils.Size object.
* Removed a rendered_ check from the bubble.
* Changed icons to properly call the parent updateEditable function.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* Fixed block disposal/delete events.
* The previous organization caused erroneous events to be fired.
* Fixed round-tripping through a headless workspace.
* This can now be handled by the headless block.
* Type specificity is good.
* This was unnecessary and causes icons to have to set the size of the bubble, even though they just passed it to the constructor.
* Code health.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests for:
* Comment Serialization (headless and rendered)
* Comment Deserialization (headless and rendered)
* Round Tripping: Rendered -> Xml -> Headless -> Xml
* Round Tripping: Headless-> Xml -> Rendered-> Xml
* GetCommentText (headless and rendered)
* SetCommentText (headless and rendered)
* Comment.setVisible
* Comment Editability
* Comment.setBubbleSize

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
I don't believe so.

### Additional Information

<!-- Anything else we should know? -->
N/A
