### PR TITLE
Fixes shift clicking on block

### DIFF
--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -118,9 +118,10 @@ Blockly.CursorSvg.prototype.getSvgRoot = function() {
  * @return {!Element} The cursor controls SVG group.
  */
 Blockly.CursorSvg.prototype.createDom = function() {
+  var className = this.isMarker_ ? 'blocklyMarker' : 'blocklyCursor';
   this.svgGroup_ =
       Blockly.utils.dom.createSvgElement('g', {
-        'class': 'blocklyCursor'
+        'class': className
       }, null);
 
   this.createCursorSvg_();
@@ -169,7 +170,6 @@ Blockly.CursorSvg.prototype.showWithCoordinates_ = function() {
  * @private
  */
 Blockly.CursorSvg.prototype.showWithBlock_ = function() {
-  //TODO: Change this from getLocation to something else
   var block = this.getCurNode().getLocation();
 
   this.currentCursorSvg = this.cursorSvgRect_;

--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -41,6 +41,8 @@ goog.require('Blockly.Cursor');
 Blockly.CursorSvg = function(workspace, opt_marker) {
   Blockly.CursorSvg.superClass_.constructor.call(this, opt_marker);
   this.workspace_ = workspace;
+  this.constants = new Blockly.blockRendering.ConstantProvider();
+  this.constants.init();
 };
 goog.inherits(Blockly.CursorSvg, Blockly.Cursor);
 
@@ -187,7 +189,7 @@ Blockly.CursorSvg.prototype.showWithInputOutput_ = function() {
       (this.getCurNode().getLocation());
   this.currentCursorSvg = this.cursorInputOutput_;
   var path = Blockly.utils.svgPaths.moveTo(0, 0) +
-      Blockly.blockRendering.constants.PUZZLE_TAB.pathDown;
+      this.constants.shapeFor(connection).pathDown;
   this.cursorInputOutput_.setAttribute('d', path);
   this.setParent_(connection.getSourceBlock().getSvgRoot());
   this.positionInputOutput_(connection);

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -146,6 +146,27 @@ Blockly.navigation.removeMark = function() {
   Blockly.navigation.marker_.hide();
 };
 
+/**
+ * Gets the top node on a block.
+ * This is either the previous connection, output connection or the block.
+ * @param {Blockly.Block} block The block to find the top most ast node on.
+ * @return {Blockly.ASTNode} The ast node holding the top most node on the
+ *     block.
+ * @package
+ */
+Blockly.navigation.getTopNode_ = function(block) {
+  var prevConnection = block.previousConnection;
+  var outConnection = block.outputConnection;
+  var topConnection = prevConnection ? prevConnection : outConnection;
+  var astNode = null;
+  if (topConnection) {
+    astNode = Blockly.ASTNode.createConnectionNode(topConnection);
+  } else {
+    astNode = Blockly.ASTNode.createBlockNode(block);
+  }
+  return astNode;
+};
+
 /************************/
 /** Toolbox Navigation **/
 /************************/
@@ -369,15 +390,8 @@ Blockly.navigation.insertFromFlyout = function() {
     Blockly.navigation.warn('Something went wrong while inserting a block from the flyout.');
   }
 
-  // Move the cursor to the right place on the inserted block.
   Blockly.navigation.focusWorkspace();
-  var prevConnection = newBlock.previousConnection;
-  var outConnection = newBlock.outputConnection;
-  var topConnection = prevConnection ? prevConnection : outConnection;
-  // TODO: This will have to be fixed when we add in a block that does not have
-  // a previous or output connection
-  var astNode = Blockly.ASTNode.createConnectionNode(topConnection);
-  Blockly.navigation.cursor_.setLocation(astNode);
+  Blockly.navigation.cursor_.setLocation(Blockly.navigation.getTopNode_(newBlock));
   Blockly.navigation.removeMark();
 };
 
@@ -694,13 +708,7 @@ Blockly.navigation.focusWorkspace = function() {
   Blockly.navigation.currentState_ = Blockly.navigation.STATE_WS;
   Blockly.navigation.enableKeyboardAccessibility();
   if (Blockly.selected) {
-    var previousConnection = Blockly.selected.previousConnection;
-    var outputConnection = Blockly.selected.outputConnection;
-    // TODO: This still needs to work with blocks that have neither previous
-    // or output connection.
-    var connection = previousConnection ? previousConnection : outputConnection;
-    var newAstNode = Blockly.ASTNode.createConnectionNode(connection);
-    cursor.setLocation(newAstNode);
+    cursor.setLocation(Blockly.navigation.getTopNode_(Blockly.selected));
     Blockly.selected.unselect();
   } else {
     var ws = cursor.workspace_;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Shift clicking on a block only worked if it had a previous or output connection.

### Proposed Changes
If there is no previous or output connection then creates a node at the block level. 

### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
