### PR TITLE
Remove special case for spacer after statement

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -372,6 +372,7 @@ Blockly.blockRendering.RenderInfo.prototype.computeBounds_ = function() {
  */
 Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
   for (var i = 0, row; (row = this.rows[i]); i++) {
+    // TODO (#2921): this still doesn't handle the row having an inline input.
     if (!row.hasInlineInput) {
       if (row.hasStatement) {
         var statementInput = row.getLastInput();
@@ -440,20 +441,14 @@ Blockly.blockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next
 };
 
 /**
- * Calculate the width of a spacer row.  Almost all spacers will be the full
- * width of the block, but there are some exceptions (e.g. the small spacer row
- * after a statement input)
- * @param {Blockly.blockRendering.Row} prev The row before the spacer.
- * @param {Blockly.blockRendering.Row} next The row after the spacer.
+ * Calculate the width of a spacer row.
+ * @param {Blockly.blockRendering.Row} _prev The row before the spacer.
+ * @param {Blockly.blockRendering.Row} _next The row after the spacer.
  * @return {number} The desired width of the spacer row between these two rows.
  * @protected
  */
-Blockly.blockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
-  // The width of the spacer before the bottom row should be the same as the
-  // bottom row.
-  if (next.type == 'bottom row' && next.hasFixedWidth) {
-    return next.width;
-  }
+Blockly.blockRendering.RenderInfo.prototype.getSpacerRowWidth_ = function(
+    _prev, _next) {
   return this.width - this.startX;
 };
 

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -226,31 +226,6 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.geras.RenderInfo.prototype.alignRowElements_ = function() {
-  for (var i = 0, row; (row = this.rows[i]); i++) {
-    if (!row.hasInlineInput) {
-      if (row.hasStatement) {
-        var statementInput = row.getLastInput();
-        var currentWidth = row.width - statementInput.width;
-        var desiredWidth = this.statementEdge - this.startX;
-      } else {
-        var currentWidth = row.width;
-        var desiredWidth = this.width - this.startX;
-      }
-      if (row.type == 'bottom row' && row.hasFixedWidth) {
-        desiredWidth = this.constants_.MAX_BOTTOM_WIDTH;
-      }
-      var missingSpace = desiredWidth - currentWidth;
-      if (missingSpace) {
-        this.addAlignmentPadding_(row, missingSpace);
-      }
-    }
-  }
-};
-
-/**
- * @override
- */
 Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   var elems = row.elements;
   var input = row.getLastInput();
@@ -280,18 +255,6 @@ Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingS
     row.getLastSpacer().width += missingSpace;
     row.width += missingSpace;
   }
-};
-
-/**
- * @override
- */
-Blockly.geras.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
-  // The width of the spacer before the bottom row should be the same as the
-  // bottom row.
-  if (next.type == 'bottom row' && next.hasFixedWidth) {
-    return next.width;
-  }
-  return this.width - this.startX;
 };
 
 /**

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -166,13 +166,8 @@ Blockly.blockRendering.Row.prototype.measure = function() {
  */
 Blockly.blockRendering.Row.prototype.getLastInput = function() {
   for (var i = this.elements.length - 1, elem; (elem = this.elements[i]); i--) {
-    if (elem.isSpacer()) {
-      continue;
-    }
     if (elem.isInput) {
       return /** @type {Blockly.blockRendering.InputConnection} */ (elem);
-    } else if (elem.isField()) {
-      return /** @type {Blockly.blockRendering.InputConnection} */ (elem.parentInput);
     }
   }
   return null;
@@ -341,12 +336,6 @@ Blockly.blockRendering.BottomRow = function() {
    * @type {number}
    */
   this.overhangY = 0;
-
-  /**
-   * True if the width of this row does not depend on its contents.
-   * @type {boolean}
-   */
-  this.hasFixedWidth = false;
 };
 goog.inherits(Blockly.blockRendering.BottomRow, Blockly.blockRendering.Row);
 
@@ -361,7 +350,6 @@ Blockly.blockRendering.BottomRow.prototype.populate = function(block) {
   var followsStatement =
       block.inputList.length &&
       block.inputList[block.inputList.length - 1].type == Blockly.NEXT_STATEMENT;
-  this.hasFixedWidth = followsStatement && block.getInputsInline();
 
   // This is the minimum height for the row. If one of its elements has a greater
   // height it will be overwritten in the compute pass.

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -226,31 +226,6 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.thrasos.RenderInfo.prototype.alignRowElements_ = function() {
-  for (var i = 0, row; (row = this.rows[i]); i++) {
-    if (!row.hasInlineInput) {
-      if (row.hasStatement) {
-        var statementInput = row.getLastInput();
-        var currentWidth = row.width - statementInput.width;
-        var desiredWidth = this.statementEdge - this.startX;
-      } else {
-        var currentWidth = row.width;
-        var desiredWidth = this.width - this.startX;
-      }
-      if (row.type == 'bottom row' && row.hasFixedWidth) {
-        desiredWidth = this.constants_.MAX_BOTTOM_WIDTH;
-      }
-      var missingSpace = desiredWidth - currentWidth;
-      if (missingSpace) {
-        this.addAlignmentPadding_(row, missingSpace);
-      }
-    }
-  }
-};
-
-/**
- * @override
- */
 Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   var input = row.getLastInput();
   if (input) {
@@ -278,18 +253,6 @@ Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missin
     row.getLastSpacer().width += missingSpace;
     row.width += missingSpace;
   }
-};
-
-/**
- * @override
- */
-Blockly.thrasos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
-  // The width of the spacer before the bottom row should be the same as the
-  // bottom row.
-  if (next.type == 'bottom row' && next.hasFixedWidth) {
-    return next.width;
-  }
-  return this.width - this.startX;
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Removes a special case I didn't want.

### Proposed Changes

The bottoms of statement inputs should go to the right edge of the block, whether or not the block has inline inputs.

### Reason for Changes

Old behaviour fell out of old rendering, but we don't need to retain it.

### Test Coverage
Checked all three renderers in the playground.

Old:
![image](https://user-images.githubusercontent.com/13686399/63979854-c7465780-ca6e-11e9-9464-ab187a9c9b5a.png)

New:
![image](https://user-images.githubusercontent.com/13686399/63979865-ce6d6580-ca6e-11e9-8c6f-62577eef98b4.png)

