### PR TITLE
Fix base renderer not respecting the connection's overhangY property

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -467,14 +467,20 @@ Blockly.blockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(
 /**
  * Calculate the centerline of an element in a rendered row.
  * @param {Blockly.blockRendering.Row} row The row containing the element.
- * @param {Blockly.blockRendering.Measurable} _elem The element to place.
+ * @param {Blockly.blockRendering.Measurable} elem The element to place.
  * @return {number} The desired centerline of the given element, as an offset
  *     from the top left of the block.
  * @protected
  */
 Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row,
-    _elem) {
-  return row.yPos + row.height / 2;
+    elem) {
+  var result = row.yPos;
+  if (elem.isNextConnection()) {
+    result += (row.height - row.overhangY + elem.height / 2);
+  } else {
+    result += (row.height / 2);
+  }
+  return result;
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2941

### Proposed Changes

Have the base renderer deal with a next connection's overhangY property. 
