### PR TITLE
Make statement inputs store their actual width.

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -209,7 +209,7 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
       innerTopLeftCorner +
       Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
       this.constants_.INSIDE_CORNERS.pathBottom +
-      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width)
+      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width);
 
   this.positionStatementInputConnection_(row);
 };

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -194,7 +194,7 @@ Blockly.blockRendering.Drawer.prototype.drawValueInput_ = function(row) {
 Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   var input = row.getLastInput();
   // Where to start drawing the notch, which is on the right side in LTR.
-  var x = input.xPos + input.width;
+  var x = input.xPos + input.notchOffset + input.shape.width;
 
   var innerTopLeftCorner =
       input.shape.pathRight +
@@ -208,7 +208,8 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
   this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('H', x) +
       innerTopLeftCorner +
       Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
-      this.constants_.INSIDE_CORNERS.pathBottom;
+      this.constants_.INSIDE_CORNERS.pathBottom +
+      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width)
 
   this.positionStatementInputConnection_(row);
 };
@@ -222,7 +223,6 @@ Blockly.blockRendering.Drawer.prototype.drawStatementInput_ = function(row) {
  */
 Blockly.blockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
   this.outlinePath_ +=
-      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width) +
       Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);
 };
 

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -375,16 +375,15 @@ Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
     // TODO (#2921): this still doesn't handle the row having an inline input.
     if (!row.hasInlineInput) {
       if (row.hasStatement) {
-        var statementInput = row.getLastInput();
-        var currentWidth = row.width - statementInput.width;
-        var desiredWidth = this.statementEdge - this.startX;
+        this.alignStatementRow_(
+            /** @type {Blockly.RenderedConnection} */ (row));
       } else {
         var currentWidth = row.width;
         var desiredWidth = this.width - this.startX;
-      }
-      var missingSpace = desiredWidth - currentWidth;
-      if (missingSpace) {
-        this.addAlignmentPadding_(row, missingSpace);
+        var missingSpace = desiredWidth - currentWidth;
+        if (missingSpace) {
+          this.addAlignmentPadding_(row, missingSpace);
+        }
       }
     }
   }
@@ -405,6 +404,31 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
     lastSpacer.width += missingSpace;
     row.width += missingSpace;
   }
+};
+
+/**
+ * Align the elements of a statement row based on computed bounds.
+ * Unlike other types of rows, statement rows add space in multiple places.
+ * @param {!Blockly.blockRendering.InputRow} row The statement row to resize.
+ * @protected
+ */
+Blockly.blockRendering.RenderInfo.prototype.alignStatementRow_ = function(row) {
+  var statementInput = row.getLastInput();
+  var currentWidth = row.width - statementInput.width;
+  var desiredWidth = this.statementEdge - this.startX;
+  // Add padding before the statement input.
+  var missingSpace = desiredWidth - currentWidth;
+  if (missingSpace) {
+    this.addAlignmentPadding_(row, missingSpace);
+  }
+  // Also widen the statement input to reach to the right side of the
+  // block. Note that this does not add padding.
+  currentWidth = row.width;
+  desiredWidth = this.width - this.startX;
+  statementInput.width += (desiredWidth - currentWidth);
+  row.width += (desiredWidth - currentWidth);
+  row.widthWithConnectedBlocks = Math.max(row.width,
+      this.statementEdge + row.connectedBlockWidths);
 };
 
 /**

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -427,6 +427,13 @@ Blockly.blockRendering.SpacerRow.prototype.measure = function() {
 Blockly.blockRendering.InputRow = function() {
   Blockly.blockRendering.InputRow.superClass_.constructor.call(this);
   this.type = 'input row';
+
+  /**
+   * The total width of all blocks connected to this row.
+   * @type {number}
+   * @package
+   */
+  this.connectedBlockWidths = 0;
 };
 goog.inherits(Blockly.blockRendering.InputRow,
     Blockly.blockRendering.Row);
@@ -453,6 +460,7 @@ Blockly.blockRendering.InputRow.prototype.measure = function() {
       this.height = Math.max(this.height, elem.height);
     }
   }
+  this.connectedBlockWidths = connectedBlockWidths;
   this.widthWithConnectedBlocks = this.width + connectedBlockWidths;
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2821
### Proposed Changes

Statement inputs now extend to the right side of the block:
![image](https://user-images.githubusercontent.com/13686399/64056345-7a827f80-cb47-11e9-8301-adec83b53ff7.png)

Note that the width of a statement input does not go past the width of a block:
![image](https://user-images.githubusercontent.com/13686399/64056358-8f5f1300-cb47-11e9-86b5-810438549bf5.png)

But the bounding boxes of the rows-with-children and blocks-with-children are correct:
![image](https://user-images.githubusercontent.com/13686399/64056373-adc50e80-cb47-11e9-8bcf-6703443344af.png)

### Reason for Changes

Now the statement input can be responsible for drawing its bottom out to the right side, and that means Sam can add rounded corners on the statement input.

### Test Coverage
Looked at it in all three renderers, and in geras in RTL, and it looked reasonable.
Checked that block bounds with connected blocks are still right.