### PR TITLE
Fix width on dummy row.

### DIFF
--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -228,15 +228,16 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
  */
 Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   var elems = row.elements;
+  var firstSpacer = row.getFirstSpacer();
+  var lastSpacer = row.getLastSpacer();
+  if (row.hasExternalInput || row.hasStatement) {
+    // Get the spacer right before the input socket.
+    lastSpacer = elems[elems.length - 3];
+    row.widthWithConnectedBlocks += missingSpace;
+  }
+
   var input = row.getLastInput();
   if (input) {
-    var firstSpacer = row.getFirstSpacer();
-    var lastSpacer = row.getLastSpacer();
-    if (row.hasExternalInput || row.hasStatement) {
-      // Get the spacer right before the input socket.
-      lastSpacer = elems[elems.length - 3];
-      row.widthWithConnectedBlocks += missingSpace;
-    }
     // Decide where the extra padding goes.
     if (input.align == Blockly.ALIGN_LEFT) {
       // Add padding to the end of the row.
@@ -249,12 +250,11 @@ Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingS
       // Add padding at the beginning of the row.
       firstSpacer.width += missingSpace;
     }
-    row.width += missingSpace;
-    // Top and bottom rows are always left aligned.
-  } else if (row.type == 'top row' || row.type == 'bottom row') {
-    row.getLastSpacer().width += missingSpace;
-    row.width += missingSpace;
+  } else {
+    // Default to left-aligning if there's no input to say where to align.
+    lastSpacer.width += missingSpace;
   }
+  row.width += missingSpace;
 };
 
 /**

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -227,14 +227,17 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
  * @override
  */
 Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
+  var elems = row.elements;
+  var firstSpacer = row.getFirstSpacer();
+  var lastSpacer = row.getLastSpacer();
+  if (row.hasExternalInput || row.hasStatement) {
+    // Get the spacer right before the input socket.
+    lastSpacer = elems[elems.length - 3];
+    row.widthWithConnectedBlocks += missingSpace;
+  }
+
   var input = row.getLastInput();
   if (input) {
-    var firstSpacer = row.getFirstSpacer();
-    var lastSpacer = row.getLastSpacer();
-    if (row.hasExternalInput || row.hasStatement) {
-      // Get the spacer right before the input socket.
-      row.widthWithConnectedBlocks += missingSpace;
-    }
     // Decide where the extra padding goes.
     if (input.align == Blockly.ALIGN_LEFT) {
       // Add padding to the end of the row.
@@ -247,12 +250,11 @@ Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missin
       // Add padding at the beginning of the row.
       firstSpacer.width += missingSpace;
     }
-    row.width += missingSpace;
-    // Top and bottom rows are always left aligned.
-  } else if (row.type == 'top row' || row.type == 'bottom row') {
-    row.getLastSpacer().width += missingSpace;
-    row.width += missingSpace;
+  } else {
+    // Default to left-aligning if there's no input to say where to align.
+    lastSpacer.width += missingSpace;
   }
+  row.width += missingSpace;
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Padding was never added on rows with only dummy inputs.

### Proposed Changes

New:
![image](https://user-images.githubusercontent.com/13686399/64057184-b79e4000-cb4e-11e9-9b34-984b2f61cc7e.png)

Old:
![image](https://user-images.githubusercontent.com/13686399/64057190-c553c580-cb4e-11e9-927f-679eab5e1b18.png)

### Additional information
If a row has only a dummy input it will always align left, even if the dummy input actually said to align right.  This seems subpar, although it probably matches the old behaviour.
I didn't actually create a Measurable for a dummy input, since it's never drawn, but that means we don't have a way to find the Blockly.Input that owns this row's fields, and that means we can't tell which way to align stuff.
That's similar to this problem: https://github.com/google/blockly/issues/338

That makes me wonder if I need an Input measurable for dummy inputs.