### PR TITLE
Fix slight offset in statement input connection X location.

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -394,8 +394,9 @@ Blockly.blockRendering.Drawer.prototype.positionStatementInputConnection_ = func
     var connX = row.xPos + row.statementEdge + input.notchOffset;
     if (this.info_.RTL) {
       connX *= -1;
+    } else {
+      connX += this.constants_.DARK_PATH_OFFSET;
     }
-    connX += this.constants_.DARK_PATH_OFFSET;
     input.connection.setOffsetInBlock(connX,
         row.yPos + this.constants_.DARK_PATH_OFFSET);
   }

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -395,7 +395,7 @@ Blockly.blockRendering.Drawer.prototype.positionStatementInputConnection_ = func
     if (this.info_.RTL) {
       connX *= -1;
     }
-    connX += 0.5;
+    connX += this.constants_.DARK_PATH_OFFSET;
     input.connection.setOffsetInBlock(connX,
         row.yPos + this.constants_.DARK_PATH_OFFSET);
   }
@@ -443,7 +443,8 @@ Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
   if (bottomRow.connection) {
     var connInfo = bottomRow.connection;
     var x = connInfo.xPos; // Already contains info about startX
-    var connX = (this.info_.RTL ? -x : x) + 0.5;
+    var connX = (this.info_.RTL ? -x : x) +
+        (this.constants_.DARK_PATH_OFFSET / 2);
     connInfo.connectionModel.setOffsetInBlock(
         connX, (connInfo.centerline - connInfo.height / 2) +
             this.constants_.DARK_PATH_OFFSET);

--- a/core/renderers/geras/highlight_constants.js
+++ b/core/renderers/geras/highlight_constants.js
@@ -134,6 +134,7 @@ Blockly.geras.HighlightConstantProvider.prototype.makeInsideCorner = function() 
               distance45outside + offset));
 
   return {
+    width: radius + offset,
     height: radius,
     pathTop: function(rtl) {
       return rtl ? pathTopRtl : '';

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -144,11 +144,15 @@ Blockly.geras.Highlighter.prototype.drawStatementInput = function(row) {
         Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos) +
         this.insideCornerPaths_.pathTop(this.RTL_) +
         Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
-        this.insideCornerPaths_.pathBottom(this.RTL_);
+        this.insideCornerPaths_.pathBottom(this.RTL_) +
+        Blockly.utils.svgPaths.lineTo(
+          row.width - input.xPos - this.insideCornerPaths_.width, 0);
   } else {
     steps =
         Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos + row.height) +
-        this.insideCornerPaths_.pathBottom(this.RTL_);
+        this.insideCornerPaths_.pathBottom(this.RTL_) +
+        Blockly.utils.svgPaths.lineTo(
+          row.width - input.xPos - this.insideCornerPaths_.width, 0);
   }
   this.steps_.push(steps);
 };

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -146,13 +146,13 @@ Blockly.geras.Highlighter.prototype.drawStatementInput = function(row) {
         Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
         this.insideCornerPaths_.pathBottom(this.RTL_) +
         Blockly.utils.svgPaths.lineTo(
-          row.width - input.xPos - this.insideCornerPaths_.width, 0);
+            row.width - input.xPos - this.insideCornerPaths_.width, 0);
   } else {
     steps =
         Blockly.utils.svgPaths.moveTo(input.xPos, row.yPos + row.height) +
         this.insideCornerPaths_.pathBottom(this.RTL_) +
         Blockly.utils.svgPaths.lineTo(
-          row.width - input.xPos - this.insideCornerPaths_.width, 0);
+            row.width - input.xPos - this.insideCornerPaths_.width, 0);
   }
   this.steps_.push(steps);
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2952

### Proposed Changes

Add additional X coordinate space when positioning the statement input. Enough for the dark path and the light path (so it matches the original renderer). 

Use the DARK_PATH_OFFSET constants instead of 0.5 when positioning the statement input on the Y axis.

### Reason for Changes

Match original renderer.

