### PR TITLE
Add a build debug npm script for convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 blockly_node_javascript_en.js
 node_modules
 npm-debug.log
+build-debug.log
 .DS_Store
 .settings
 .project

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "gulp build",
+    "build:debug": "gulp build-core --verbose > build-debug.log 2>&1",
     "lint": "eslint .",
     "package": "gulp package",
     "prepare": "gulp blockly_node_javascript_en",


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes
Conviniently run: 
```
npm run build:debug
```
and look at ``build-debug.log`` for the closure compiler output with warnings.

``build-debug.log`` ignored from git.

### Reason for Changes

Useful for both internal and external developers to easily check their changes against the closure compiler. 

