### PR TITLE
Remove references to dark path offset; fix highlights while dragging

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -216,14 +216,14 @@ Blockly.RenderedConnection.prototype.highlight = function() {
     var yLen = 5;
     steps = Blockly.utils.svgPaths.moveBy(0, -yLen) +
         Blockly.utils.svgPaths.lineOnAxis('v', yLen) +
-        Blockly.blockRendering.constants.PUZZLE_TAB.pathDown +
+        Blockly.blockRendering.getConstants().PUZZLE_TAB.pathDown +
         Blockly.utils.svgPaths.lineOnAxis('v', yLen);
   } else {
     var xLen = 5;
     // Horizontal line, notch, horizontal line.
     steps = Blockly.utils.svgPaths.moveBy(-xLen, 0) +
         Blockly.utils.svgPaths.lineOnAxis('h', xLen) +
-        Blockly.blockRendering.constants.NOTCH.pathLeft +
+        Blockly.blockRendering.getConstants().NOTCH.pathLeft +
         Blockly.utils.svgPaths.lineOnAxis('h', xLen);
   }
   var xy = this.sourceBlock_.getRelativeToSurfaceXY();

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -43,7 +43,7 @@ Blockly.blockRendering.useDebugger = false;
  */
 Blockly.blockRendering.init = function() {
   // TODO (#2702): Pick an API for choosing a renderer.
-  Blockly.blockRendering.renderer = new Blockly.geras.Renderer();
+  Blockly.blockRendering.renderer = new Blockly.thrasos.Renderer();
   Blockly.blockRendering.renderer.init();
 };
 

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -43,7 +43,7 @@ Blockly.blockRendering.useDebugger = false;
  */
 Blockly.blockRendering.init = function() {
   // TODO (#2702): Pick an API for choosing a renderer.
-  Blockly.blockRendering.renderer = new Blockly.thrasos.Renderer();
+  Blockly.blockRendering.renderer = new Blockly.geras.Renderer();
   Blockly.blockRendering.renderer.init();
 };
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -190,28 +190,15 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       return this.constants_.NO_PADDING;
     }
     // Spacing between a square corner and a previous or next connection
-    if (Blockly.blockRendering.Types.isPreviousConnection(next)) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+        Blockly.blockRendering.Types.isNextConnection(next)) {
       return next.notchOffset;
-    } else if (Blockly.blockRendering.Types.isNextConnection(next)) {
-      // Next connections are shifted slightly to the left (in both LTR and RTL)
-      // to make the dark path under the previous connection show through.
-      var offset = (this.RTL ? 1 : -1) *
-          this.constants_.DARK_PATH_OFFSET / 2;
-      return next.notchOffset + offset;
     }
   }
 
   // Spacing between a rounded corner and a previous or next connection.
   if (Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
-    if (Blockly.blockRendering.Types.isPreviousConnection(next)) {
-      return next.notchOffset - this.constants_.CORNER_RADIUS;
-    } else if (Blockly.blockRendering.Types.isNextConnection(next)) {
-      // Next connections are shifted slightly to the left (in both LTR and RTL)
-      // to make the dark path under the previous connection show through.
-      var offset = (this.RTL ? 1 : -1) *
-          this.constants_.DARK_PATH_OFFSET / 2;
-      return next.notchOffset - this.constants_.CORNER_RADIUS + offset;
-    }
+    return next.notchOffset - this.constants_.CORNER_RADIUS;
   }
 
   // Spacing between two fields of the same editability.

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -194,27 +194,17 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       return this.constants_.NO_PADDING;
     }
     // Spacing between a square corner and a previous or next connection
-    if (Blockly.blockRendering.Types.isPreviousConnection(next)) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+        Blockly.blockRendering.Types.isNextConnection(next)) {
       return next.notchOffset;
-    } else if (Blockly.blockRendering.Types.isNextConnection(next)) {
-      // Next connections are shifted slightly to the left (in both LTR and RTL)
-      // to make the dark path under the previous connection show through.
-      var offset = (this.RTL ? 1 : -1) *
-          this.constants_.DARK_PATH_OFFSET / 2;
-      return next.notchOffset + offset;
     }
   }
 
   // Spacing between a rounded corner and a previous or next connection.
   if (Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
-    if (Blockly.blockRendering.Types.isPreviousConnection(next)) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+        Blockly.blockRendering.Types.isNextConnection(next)) {
       return next.notchOffset - this.constants_.CORNER_RADIUS;
-    } else if (Blockly.blockRendering.Types.isNextConnection(next)) {
-      // Next connections are shifted slightly to the left (in both LTR and RTL)
-      // to make the dark path under the previous connection show through.
-      var offset = (this.RTL ? 1 : -1) *
-          this.constants_.DARK_PATH_OFFSET / 2;
-      return next.notchOffset - this.constants_.CORNER_RADIUS + offset;
     }
   }
 


### PR DESCRIPTION


## The basics


- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #2956 
### Proposed Changes

Remove most references to dark path offset outside of geras.

It's still being used for inline inputs in thrasos, and in the root drawer.  thrasos may need to set it to zero, or (preferred) the root drawer needs to not refer to it at all (all references can be in info instead).

### Reason for Changes

Cleanup


