### PR TITLE
Revert "Deprecate Blockly.Constants.Colour and .Lists"

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -30,7 +30,7 @@
 'use strict';
 
 goog.provide('Blockly.Blocks.colour');  // Deprecated
-goog.provide('Blockly.Constants.Colour');  // deprecated, 2018 April 5
+goog.provide('Blockly.Constants.Colour');
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly');

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -30,7 +30,7 @@
 'use strict';
 
 goog.provide('Blockly.Blocks.lists');  // Deprecated
-goog.provide('Blockly.Constants.Lists');  // deprecated, 2018 April 5
+goog.provide('Blockly.Constants.Lists');
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly');


### PR DESCRIPTION
Reverts google/blockly#1797

We should keep a non-deprecated provide in both of these files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly/2972)
<!-- Reviewable:end -->
