### PR TITLE
Add dark path offset in geras info.

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -92,10 +92,8 @@ Blockly.blockRendering.Drawer.prototype.draw = function() {
 Blockly.blockRendering.Drawer.prototype.recordSizeOnBlock_ = function() {
   // This is used when the block is reporting its size to anyone else.
   // The dark path adds to the size of the block in both X and Y.
-  this.block_.height = this.info_.height +
-      this.constants_.DARK_PATH_OFFSET;
-  this.block_.width = this.info_.widthWithChildren +
-      this.constants_.DARK_PATH_OFFSET;
+  this.block_.height = this.info_.height;
+  this.block_.width = this.info_.widthWithChildren;
 };
 
 /**

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -73,18 +73,6 @@ Blockly.geras.Drawer.prototype.draw = function() {
 /**
  * @override
  */
-Blockly.geras.Drawer.prototype.recordSizeOnBlock_ = function() {
-  // This is used when the block is reporting its size to anyone else.
-  // The dark path adds to the size of the block in both X and Y.
-  this.block_.height = this.info_.height +
-      this.constants_.DARK_PATH_OFFSET;
-  this.block_.width = this.info_.widthWithChildren +
-      this.constants_.DARK_PATH_OFFSET;
-};
-
-/**
- * @override
- */
 Blockly.geras.Drawer.prototype.drawTop_ = function() {
   this.highlighter_.drawTopCorner(this.info_.topRow);
   this.highlighter_.drawRightSideRow(this.info_.topRow);

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -211,7 +211,7 @@ Blockly.geras.Highlighter.prototype.drawLeft = function() {
       this.steps_ += Blockly.utils.svgPaths.moveTo(this.info_.startX, tabBottom);
     } else {
       var left = this.info_.startX + this.highlightOffset_;
-      var bottom = this.info_.height - this.highlightOffset_;
+      var bottom = this.info_.bottomRow.baseline - this.highlightOffset_;
       this.steps_ += Blockly.utils.svgPaths.moveTo(left, bottom);
       this.steps_ += Blockly.utils.svgPaths.lineOnAxis('V', tabBottom);
     }

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -359,8 +359,10 @@ Blockly.geras.RenderInfo.prototype.finalize_ = function() {
   }
   this.bottomRow.baseline = yCursor - this.bottomRow.descenderHeight;
 
-  this.widthWithChildren = widestRowWithConnectedBlocks + this.startX;
-
-  this.height = yCursor;
+  // The dark (lowlight) adds to the size of the block in both x and y.
+  this.widthWithChildren = widestRowWithConnectedBlocks +
+      this.startX + this.constants_.DARK_PATH_OFFSET;
+  this.width += this.constants_.DARK_PATH_OFFSET;
+  this.height = yCursor + this.constants_.DARK_PATH_OFFSET;
   this.startY = this.topRow.capline;
 };


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Toward #2956

### Proposed Changes

Add the dark path offset to the block height, width, and width with children in geras info, instead of in the drawer.

### Reason for Changes

Height should be accurate at the end of the measure pass.

Adding the baseline property on the bottom row made this possible.