### PR TITLE
Dynamic output shapes

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -273,14 +273,14 @@ Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
   if (outputConnection) {
     var tabBottom = outputConnection.connectionOffsetY +
         outputConnection.height;
-    var connectionPath = (typeof outputConnection.shape.pathUp == "function") ?
+    var pathUp = (typeof outputConnection.shape.pathUp == "function") ?
         outputConnection.shape.pathUp(outputConnection.height) :
         outputConnection.shape.pathUp;
 
     // Draw a line up to the bottom of the tab.
     this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V', tabBottom) +
-        connectionPath;
+        pathUp;
   }
   // Close off the path.  This draws a vertical line up to the start of the
   // block's path, which may be either a rounded or a sharp corner.

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -182,9 +182,13 @@ Blockly.blockRendering.Drawer.prototype.drawValueInput_ = function(row) {
   var input = row.getLastInput();
   this.positionExternalValueConnection_(row);
 
+  var pathDown = (typeof input.shape.pathDown == "function") ?
+      input.shape.pathDown(input.height) :
+      input.shape.pathDown;
+
   this.outlinePath_ +=
       Blockly.utils.svgPaths.lineOnAxis('H', input.xPos + input.width) +
-      input.shape.pathDown +
+      pathDown +
       Blockly.utils.svgPaths.lineOnAxis('v', row.height - input.connectionHeight);
 };
 
@@ -269,10 +273,14 @@ Blockly.blockRendering.Drawer.prototype.drawLeft_ = function() {
   if (outputConnection) {
     var tabBottom = outputConnection.connectionOffsetY +
         outputConnection.height;
+    var connectionPath = (typeof outputConnection.shape.pathUp == "function") ?
+        outputConnection.shape.pathUp(outputConnection.height) :
+        outputConnection.shape.pathUp;
+
     // Draw a line up to the bottom of the tab.
     this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V', tabBottom) +
-        outputConnection.shape.pathUp;
+        connectionPath;
   }
   // Close off the path.  This draws a vertical line up to the start of the
   // block's path, which may be either a rounded or a sharp corner.

--- a/core/renderers/measurables/connections.js
+++ b/core/renderers/measurables/connections.js
@@ -72,6 +72,15 @@ goog.inherits(Blockly.blockRendering.OutputConnection,
     Blockly.blockRendering.Connection);
 
 /**
+ * Whether or not the connection shape is dynamic. Dynamic shapes get their
+ * height from the block.
+ * @return {boolean} True if the connection shape is dynamic.
+ */
+Blockly.blockRendering.OutputConnection.prototype.isDynamic = function() {
+  return this.shape.isDynamic;
+};
+
+/**
  * An object containing information about the space a previous connection takes
  * up during rendering.
  * @param {Blockly.RenderedConnection} connectionModel The connection object on

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -155,6 +155,9 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
       if (checks && checks.indexOf('Number') != -1) {
         return this.CIRCLE;
       }
+      if (checks && checks.indexOf('String') != -1) {
+        return this.CIRCLE;
+      }
       return this.PUZZLE_TAB;
     case Blockly.PREVIOUS_STATEMENT:
     case Blockly.NEXT_STATEMENT:

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -91,10 +91,10 @@ Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
     height: 0,
     isDynamic: true,
     pathDown: function(height) {
-      return makeMainPath(height, false);
+      return makeMainPath(height, false, false);
     },
     pathUp: function(height) {
-      return makeMainPath(height, true);
+      return makeMainPath(height, true, false);
     },
     pathRightDown: function(height) {
       return makeMainPath(height, false, true);
@@ -125,10 +125,10 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
     height: 0,
     isDynamic: true,
     pathDown: function(height) {
-      return makeMainPath(height, false);
+      return makeMainPath(height, false, false);
     },
     pathUp: function(height) {
-      return makeMainPath(height, true);
+      return makeMainPath(height, true, false);
     },
     pathRightDown: function(height) {
       return makeMainPath(height, false, true);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -38,20 +38,23 @@ goog.require('Blockly.utils.svgPaths');
  */
 Blockly.zelos.ConstantProvider = function() {
   Blockly.zelos.ConstantProvider.superClass_.constructor.call(this);
+  
+  this.GRID_UNIT = 4;
 
-  var GRID_UNIT = 4;
+  this.CORNER_RADIUS = 1 * this.GRID_UNIT;
 
-  this.CORNER_RADIUS = 1 * GRID_UNIT;
+  this.NOTCH_WIDTH = 9 * this.GRID_UNIT;
 
-  this.NOTCH_WIDTH = 9 * GRID_UNIT;
+  this.NOTCH_HEIGHT = 2 * this.GRID_UNIT;
 
-  this.NOTCH_HEIGHT = 2 * GRID_UNIT;
+  this.NOTCH_OFFSET_LEFT = 3 * this.GRID_UNIT;
 
-  this.NOTCH_OFFSET_LEFT = 3 * GRID_UNIT;
-
-  this.MIN_BLOCK_HEIGHT = 12 * GRID_UNIT;
+  this.MIN_BLOCK_HEIGHT = 12 * this.GRID_UNIT;
 
   this.DARK_PATH_OFFSET = 0;
+
+  this.TAB_OFFSET_FROM_TOP = 0;
+
 };
 goog.inherits(Blockly.zelos.ConstantProvider,
     Blockly.blockRendering.ConstantProvider);
@@ -62,6 +65,7 @@ goog.inherits(Blockly.zelos.ConstantProvider,
 Blockly.zelos.ConstantProvider.prototype.init = function() {
   Blockly.zelos.ConstantProvider.superClass_.init.call(this);
   this.TRIANGLE = this.makeTriangle();
+  this.CIRCLE = this.makeCircle();
 };
 
 /**
@@ -70,26 +74,68 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
  * @package
  */
 Blockly.zelos.ConstantProvider.prototype.makeTriangle = function() {
-  var width = 20;
-  var height = 20;
   // The 'up' and 'down' versions of the paths are the same, but the Y sign
   // flips.  Forward and back are the signs to use to move the cursor in the
   // direction that the path is being drawn.
-  function makeMainPath(up) {
+  function makeMainPath(height, up, right) {
+    var width = height / 2;
     var forward = up ? -1 : 1;
+    var direction = right ? -1 : 1;
 
-    return Blockly.utils.svgPaths.lineTo(-width, forward * height / 2) +
-        Blockly.utils.svgPaths.lineTo(width, forward * height / 2);
+    return Blockly.utils.svgPaths.lineTo(-1 * direction * width, forward * height / 2) +
+        Blockly.utils.svgPaths.lineTo(direction * width, forward * height / 2);
   }
 
-  var pathUp = makeMainPath(true);
-  var pathDown = makeMainPath(false);
+  return {
+    width: 0,
+    height: 0,
+    isDynamic: true,
+    pathDown: function(height) {
+      return makeMainPath(height, false);
+    },
+    pathUp: function(height) {
+      return makeMainPath(height, true);
+    },
+    pathRightDown: function(height) {
+      return makeMainPath(height, false, true);
+    },
+    pathRightUp: function(height) {
+      return makeMainPath(height, false, true);
+    },
+  };
+};
+
+/**
+ * @return {!Object} An object containing sizing and path information about
+ *     a triangle shape for connections.
+ * @package
+ */
+Blockly.zelos.ConstantProvider.prototype.makeCircle = function() {
+  // The 'up' and 'down' versions of the paths are the same, but the Y sign
+  // flips.  Forward and back are the signs to use to move the cursor in the
+  // direction that the path is being drawn.
+  function makeMainPath(height, up, right) {
+    var edgeWidth = height / 2;
+    return Blockly.utils.svgPaths.arc('a', '0 0 ' + (up || right ? 1 : 0), edgeWidth,
+        Blockly.utils.svgPaths.point(0, (up ? -1 : 1) * edgeWidth * 2));
+  }
 
   return {
-    width: width,
-    height: height,
-    pathDown: pathDown,
-    pathUp: pathUp
+    width: 0,
+    height: 0,
+    isDynamic: true,
+    pathDown: function(height) {
+      return makeMainPath(height, false);
+    },
+    pathUp: function(height) {
+      return makeMainPath(height, true);
+    },
+    pathRightDown: function(height) {
+      return makeMainPath(height, false, true);
+    },
+    pathRightUp: function(height) {
+      return makeMainPath(height, false, true);
+    },
   };
 };
 
@@ -105,6 +151,9 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
       // Includes doesn't work in IE.
       if (checks && checks.indexOf('Boolean') != -1) {
         return this.TRIANGLE;
+      }
+      if (checks && checks.indexOf('Number') != -1) {
+        return this.CIRCLE;
       }
       return this.PUZZLE_TAB;
     case Blockly.PREVIOUS_STATEMENT:

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -64,16 +64,16 @@ goog.inherits(Blockly.zelos.ConstantProvider,
  */
 Blockly.zelos.ConstantProvider.prototype.init = function() {
   Blockly.zelos.ConstantProvider.superClass_.init.call(this);
-  this.TRIANGLE = this.makeTriangle();
-  this.CIRCLE = this.makeCircle();
+  this.HEXAGONAL = this.makeHexagonal();
+  this.ROUNDED = this.makeRounded();
 };
 
 /**
  * @return {!Object} An object containing sizing and path information about
- *     a triangle shape for connections.
+ *     a hexagonal shape for connections.
  * @package
  */
-Blockly.zelos.ConstantProvider.prototype.makeTriangle = function() {
+Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
   // The 'up' and 'down' versions of the paths are the same, but the Y sign
   // flips.  Forward and back are the signs to use to move the cursor in the
   // direction that the path is being drawn.
@@ -107,10 +107,10 @@ Blockly.zelos.ConstantProvider.prototype.makeTriangle = function() {
 
 /**
  * @return {!Object} An object containing sizing and path information about
- *     a triangle shape for connections.
+ *     a rounded shape for connections.
  * @package
  */
-Blockly.zelos.ConstantProvider.prototype.makeCircle = function() {
+Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
   // The 'up' and 'down' versions of the paths are the same, but the Y sign
   // flips.  Forward and back are the signs to use to move the cursor in the
   // direction that the path is being drawn.
@@ -150,13 +150,13 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
     case Blockly.OUTPUT_VALUE:
       // Includes doesn't work in IE.
       if (checks && checks.indexOf('Boolean') != -1) {
-        return this.TRIANGLE;
+        return this.HEXAGONAL;
       }
       if (checks && checks.indexOf('Number') != -1) {
-        return this.CIRCLE;
+        return this.ROUNDED;
       }
       if (checks && checks.indexOf('String') != -1) {
-        return this.CIRCLE;
+        return this.ROUNDED;
       }
       return this.PUZZLE_TAB;
     case Blockly.PREVIOUS_STATEMENT:

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -127,6 +127,10 @@ Blockly.zelos.Drawer.prototype.drawBottom_ = function() {
  * @protected
  */
 Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
+  if (this.info_.outputConnection && this.info_.outputConnection.isDynamic()) {
+    this.drawRightConnection_(row);
+    return;
+  }
   if (row.type & Blockly.blockRendering.Types.getType('BEFORE_STATEMENT_SPACER_ROW')) {
     var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
     this.outlinePath_ +=
@@ -139,19 +143,25 @@ Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
         this.constants_.INSIDE_CORNERS.pathBottomRight +
         (remainingHeight > 0 ?
             Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height) : '');
-  } else if (Blockly.blockRendering.Types.isInputRow(row) &&
-      this.info_.outputConnection &&
-      (typeof this.info_.outputConnection.shape.pathRightDown == "function")) {
-    // Draw right side of an output connection
-    this.outlinePath_ += this.info_.outputConnection.shape.pathRightDown(
-        this.info_.outputConnection.height);
   } else {
-    if (!this.info_.outputConnection ||
-        !this.info_.outputConnection.isDynamic()) {
-      // Don't draw spacers when drawing the right side of outputs.
-      this.outlinePath_ +=
-          Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);
-    }
+    this.outlinePath_ +=
+        Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);
+  }
+};
+
+/**
+ * Add steps to draw the right side of an output connection.
+ * @param {!Blockly.blockRendering.Row} row The row to draw the
+ *     side of.
+ * @protected
+ */
+Blockly.zelos.Drawer.prototype.drawRightConnection_ = function(row) {
+  // We only want to draw this once, so determine if this is the first row.
+  var index = this.info_.rows.indexOf(row);
+  if (index === 1) {
+    var height = this.info_.outputConnection.height;
+    var pathRightDown = this.info_.outputConnection.shape.pathRightDown(height);
+    this.outlinePath_ += pathRightDown;
   }
 };
 
@@ -160,7 +170,6 @@ Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
  */
 Blockly.zelos.Drawer.prototype.drawInlineInput_ = function(input) {
   // Don't draw an inline input.
-  // TODO:
   this.positionInlineInputConnection_(input);
 };
 

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -76,7 +76,7 @@ Blockly.zelos.Drawer.prototype.drawTop_ = function() {
     // No branch for a square corner because it's a no-op.
   }
   if (!this.info_.outputConnection ||
-      !this.info_.outputConnection.shape.isDynamic) {
+      !this.info_.outputConnection.isDynamic()) {
     this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
   }
 };
@@ -110,7 +110,7 @@ Blockly.zelos.Drawer.prototype.drawBottom_ = function() {
   }
 
   if (!this.info_.outputConnection ||
-      !this.info_.outputConnection.shape.isDynamic) {
+      !this.info_.outputConnection.isDynamic()) {
     this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V',
             bottomRow.baseline -
@@ -147,7 +147,7 @@ Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
         this.info_.outputConnection.height);
   } else {
     if (!this.info_.outputConnection ||
-      !this.info_.outputConnection.shape.isDynamic) {
+        !this.info_.outputConnection.isDynamic()) {
       // Don't draw spacers when drawing the right side of outputs.
       this.outlinePath_ +=
           Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -75,6 +75,7 @@ Blockly.zelos.Drawer.prototype.drawTop_ = function() {
     }
     // No branch for a square corner because it's a no-op.
   }
+
   if (!this.info_.outputConnection ||
       !this.info_.outputConnection.isDynamic()) {
     this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
@@ -113,8 +114,7 @@ Blockly.zelos.Drawer.prototype.drawBottom_ = function() {
       !this.info_.outputConnection.isDynamic()) {
     this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V',
-            bottomRow.baseline -
-            rightCornerYOffset);
+            bottomRow.baseline - rightCornerYOffset);
   }
   this.outlinePath_ += outlinePath;
 };

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -48,6 +48,21 @@ goog.inherits(Blockly.zelos.Drawer, Blockly.blockRendering.Drawer);
 
 
 /**
+ * @override
+ */
+Blockly.zelos.Drawer.prototype.drawOutline_ = function() {
+  if (this.info_.outputConnection &&
+      this.info_.outputConnection.isDynamic()) {
+    this.drawFlatTop_();
+    this.drawRightDynamicConnection_();
+    this.drawFlatBottom_();
+    this.drawLeftDynamicConnection_();
+  } else {
+    Blockly.zelos.Drawer.superClass_.drawOutline_.call(this);
+  }
+};
+
+/**
  * Add steps for the top corner of the block, taking into account
  * details such as hats and rounded corners.
  * @protected
@@ -76,10 +91,7 @@ Blockly.zelos.Drawer.prototype.drawTop_ = function() {
     // No branch for a square corner because it's a no-op.
   }
 
-  if (!this.info_.outputConnection ||
-      !this.info_.outputConnection.isDynamic()) {
-    this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
-  }
+  this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
 };
 
 
@@ -110,12 +122,9 @@ Blockly.zelos.Drawer.prototype.drawBottom_ = function() {
     }
   }
 
-  if (!this.info_.outputConnection ||
-      !this.info_.outputConnection.isDynamic()) {
-    this.outlinePath_ +=
+  this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V',
             bottomRow.baseline - rightCornerYOffset);
-  }
   this.outlinePath_ += outlinePath;
 };
 
@@ -127,10 +136,6 @@ Blockly.zelos.Drawer.prototype.drawBottom_ = function() {
  * @protected
  */
 Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
-  if (this.info_.outputConnection && this.info_.outputConnection.isDynamic()) {
-    this.drawRightConnection_(row);
-    return;
-  }
   if (row.type & Blockly.blockRendering.Types.getType('BEFORE_STATEMENT_SPACER_ROW')) {
     var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
     this.outlinePath_ +=
@@ -150,19 +155,55 @@ Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
 };
 
 /**
- * Add steps to draw the right side of an output connection.
- * @param {!Blockly.blockRendering.Row} row The row to draw the
- *     side of.
+ * Add steps to draw the right side of an output with a dynamic connection.
  * @protected
  */
-Blockly.zelos.Drawer.prototype.drawRightConnection_ = function(row) {
-  // We only want to draw this once, so determine if this is the first row.
-  var index = this.info_.rows.indexOf(row);
-  if (index === 1) {
-    var height = this.info_.outputConnection.height;
-    var pathRightDown = this.info_.outputConnection.shape.pathRightDown(height);
-    this.outlinePath_ += pathRightDown;
-  }
+Blockly.zelos.Drawer.prototype.drawRightDynamicConnection_ = function() {
+  this.outlinePath_ += this.info_.outputConnection.shape.pathRightDown(
+      this.info_.outputConnection.height);
+};
+
+/**
+ * Add steps to draw the left side of an output with a dynamic connection.
+ * @protected
+ */
+Blockly.zelos.Drawer.prototype.drawLeftDynamicConnection_ = function() {
+  this.positionOutputConnection_();
+
+  this.outlinePath_ += this.info_.outputConnection.shape.pathUp(
+      this.info_.outputConnection.height);
+
+  // Close off the path.  This draws a vertical line up to the start of the
+  // block's path, which may be either a rounded or a sharp corner.
+  this.outlinePath_ += 'z';
+};
+
+/**
+ * Add steps to draw a flat top row.
+ * @protected
+ */
+Blockly.zelos.Drawer.prototype.drawFlatTop_ = function() {
+  var topRow = this.info_.topRow;
+  this.positionPreviousConnection_();
+
+  this.outlinePath_ +=
+      Blockly.utils.svgPaths.moveBy(topRow.xPos, this.info_.startY);
+
+  this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('h', topRow.width);
+};
+
+/**
+ * Add steps to draw a flat bottom row.
+ * @protected
+ */
+Blockly.zelos.Drawer.prototype.drawFlatBottom_ = function() {
+  var bottomRow = this.info_.bottomRow;
+  this.positionNextConnection_();
+
+  this.outlinePath_ +=
+    Blockly.utils.svgPaths.lineOnAxis('V', bottomRow.baseline);
+  
+  this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('h', -bottomRow.width);
 };
 
 /**

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -90,7 +90,6 @@ Blockly.zelos.Drawer.prototype.drawTop_ = function() {
     }
     // No branch for a square corner because it's a no-op.
   }
-
   this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('v', topRow.height);
 };
 

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -172,22 +172,3 @@ Blockly.zelos.Drawer.prototype.drawInlineInput_ = function(input) {
   // Don't draw an inline input.
   this.positionInlineInputConnection_(input);
 };
-
-/**
- * @override
- */
-Blockly.zelos.Drawer.prototype.positionInlineInputConnection_ = function(input) {
-  var yPos = input.centerline - input.height / 2;
-  // Move the connection.
-  if (input.connection) {
-    // xPos already contains info about startX
-    var connX = input.xPos + input.connectionWidth +
-        this.constants_.DARK_PATH_OFFSET;
-    if (this.info_.RTL) {
-      connX *= -1;
-    }
-    input.connection.setOffsetInBlock(
-        connX, yPos + input.connectionOffsetY +
-        this.constants_.DARK_PATH_OFFSET);
-  }
-};

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -90,7 +90,7 @@ goog.inherits(Blockly.zelos.RenderInfo, Blockly.blockRendering.RenderInfo);
 Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev || !next) {
     // No need for padding at the beginning or end of the row if the
-    // output shape is dyanmic.
+    // output shape is dynamic.
     if (this.outputConnection && this.outputConnection.isDynamic()) {
       return this.constants_.NO_PADDING;
     }

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -91,7 +91,7 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev || !next) {
     // No need for padding at the beginning or end of the row if the
     // output shape is dyanmic.
-    if (this.outputConnection && this.outputConnection.shape.isDynamic) {
+    if (this.outputConnection && this.outputConnection.isDynamic()) {
       return this.constants_.NO_PADDING;
     }
   }

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -88,6 +88,13 @@ goog.inherits(Blockly.zelos.RenderInfo, Blockly.blockRendering.RenderInfo);
  * @override
  */
 Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
+  if (!prev || !next) {
+    // No need for padding at the beginning or end of the row if the
+    // output shape is dyanmic.
+    if (this.outputConnection && this.outputConnection.shape.isDynamic) {
+      return this.constants_.NO_PADDING;
+    }
+  }
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next && Blockly.blockRendering.Types.isField(next) && next.isEditable) {
@@ -328,14 +335,16 @@ Blockly.zelos.RenderInfo.prototype.finalize_ = function() {
     row.yPos = yCursor;
     yCursor += row.height;
   }
-  // // Dynamic output.
+  // Dynamic output connections depend on the height of the block. Adjust the
+  // height and width of the connection, and then adjust the startX and width of the
+  // block accordingly.
   var outputConnectionWidth = 0;
   if (this.outputConnection && !this.outputConnection.height) {
     this.outputConnection.height = yCursor;
-    outputConnectionWidth = yCursor / 2;
-    this.outputConnection.width = outputConnectionWidth;
+    outputConnectionWidth = yCursor; // Twice the width to account for the right side.
+    this.outputConnection.width = outputConnectionWidth / 2;
   }
-  this.startX += outputConnectionWidth;
+  this.startX += outputConnectionWidth / 2;
   this.width += outputConnectionWidth;
 
   var widestRowWithConnectedBlocks = 0;
@@ -349,10 +358,6 @@ Blockly.zelos.RenderInfo.prototype.finalize_ = function() {
       elem.xPos = xCursor;
       elem.centerline = this.getElemCenterline_(row, elem);
       xCursor += elem.width;
-      // if (this.isInline && Blockly.blockRendering.Types.isInlineInput(elem)) {
-      //   elem.connectionWidth = outputConnectionWidth;
-      //   elem.connectedBlockWidth += outputConnectionWidth;
-      // }
     }
   }
 

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -74,7 +74,7 @@ Blockly.zelos.TopRow.prototype.populate = function(block) {
  * @override
  */
 Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  return block.outputConnection;
+  return !!block.outputConnection;
 };
 
 /**
@@ -84,7 +84,7 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
  */
 Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
   // Render a round corner unless the block has an output connection.
-  return block.outputConnection;
+  return !!block.outputConnection;
 };
 
 /**
@@ -124,7 +124,7 @@ Blockly.zelos.BottomRow.prototype.populate = function(block) {
  * @override
  */
 Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
-  return block.outputConnection;
+  return !!block.outputConnection;
 };
 
 /**
@@ -134,7 +134,7 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
  */
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
   // Render a round corner unless the block has an output connection.
-  return block.outputConnection;
+  return !!block.outputConnection;
 };
 
 /**

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -70,21 +70,21 @@ Blockly.zelos.TopRow.prototype.populate = function(block) {
 };
 
 /**
- * Never render a left square corner. Always round.
+ * Render a round corner unless the block has an output connection.
  * @override
  */
-Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(_block) {
-  return false;
+Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
+  return block.outputConnection;
 };
 
 /**
  * Returns whether or not the top row has a right square corner.
- * @param {!Blockly.BlockSvg} _block The block whose top row this represents.
+ * @param {!Blockly.BlockSvg} block The block whose top row this represents.
  * @returns {boolean} Whether or not the top row has a left square corner.
  */
-Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(_block) {
-  // Never render a right square corner. Always round.
-  return false;
+Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
+  // Render a round corner unless the block has an output connection.
+  return block.outputConnection;
 };
 
 /**
@@ -120,21 +120,21 @@ Blockly.zelos.BottomRow.prototype.populate = function(block) {
 };
 
 /**
- * Never render a left square corner. Always round.
+ * Render a round corner unless the block has an output connection.
  * @override
  */
-Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(_block) {
-  return false;
+Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
+  return block.outputConnection;
 };
 
 /**
  * Returns whether or not the bottom row has a right square corner.
- * @param {!Blockly.BlockSvg} _block The block whose bottom row this represents.
+ * @param {!Blockly.BlockSvg} block The block whose bottom row this represents.
  * @returns {boolean} Whether or not the bottom row has a left square corner.
  */
-Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(_block) {
-  // Never render a right square corner. Always round.
-  return false;
+Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
+  // Render a round corner unless the block has an output connection.
+  return block.outputConnection;
 };
 
 /**

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -91,6 +91,7 @@ function start() {
   match = location.search.match(/side=([^&]+)/);
   var side = match ? match[1] : 'start';
   document.forms.options.elements.side.value = side;
+  var autoimport = !!location.search.match(/autoimport=([^&]+)/);
   // Create main workspace.
   workspace = Blockly.inject('blocklyDiv',
       {
@@ -146,6 +147,9 @@ function start() {
     logEvents(false);
   }
   taChange();
+  if (autoimport) {
+    fromXml();
+  }
 }
 
 function addToolboxButtonCallbacks() {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/2977

### Proposed Changes

This is just an initial PR, there's more work to be done here, but this gets us the following:
<img width="373" alt="Screen Shot 2019-09-06 at 9 20 39 AM" src="https://user-images.githubusercontent.com/16690124/64444318-c0c86900-d088-11e9-8392-d2d57d989071.png">

We still need to figure out how this should render for external inputs. https://github.com/google/blockly/issues/2978 tracking that.
I have removed the drawing of empty inline inputs in this change but hope to tackle that in a separate change: https://github.com/google/blockly/issues/2979

### Reason for Changes

Rendering feature.

### Additional Information

<!-- Anything else we should know? -->
