### PR TITLE
Enter accessibility

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -216,9 +216,7 @@ Blockly.onKeyDown_ = function(e) {
 
   if (mainWorkspace.options.readOnly) {
     // When in read only mode handle key actions for keyboard navigation.
-    if (Blockly.keyboardAccessibilityMode) {
-      Blockly.navigation.onKeyPress(e);
-    }
+    Blockly.navigation.onKeyPress(e);
     return;
   }
 
@@ -227,8 +225,7 @@ Blockly.onKeyDown_ = function(e) {
     // Pressing esc closes the context menu.
     Blockly.hideChaff();
     Blockly.navigation.onBlocklyAction(Blockly.navigation.ACTION_EXIT);
-  } else if (Blockly.keyboardAccessibilityMode &&
-      Blockly.navigation.onKeyPress(e)) {
+  } else if (Blockly.navigation.onKeyPress(e)) {
     // If the keyboard or field handled the key press return.
     return;
   } else if (e.keyCode == Blockly.utils.KeyCodes.BACKSPACE ||

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -500,8 +500,8 @@ Blockly.Gesture.prototype.doStart = function(e) {
   if (this.targetBlock_) {
     if (!this.targetBlock_.isInFlyout && e.shiftKey) {
       Blockly.navigation.enableKeyboardAccessibility();
-      var ws = this.creatorWorkspace_;
-      ws.cursor.setLocation(Blockly.navigation.getTopNode(this.targetBlock_));
+      this.creatorWorkspace_.cursor.setLocation(
+          Blockly.navigation.getTopNode(this.targetBlock_));
     } else {
       this.targetBlock_.select();
     }

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -498,9 +498,12 @@ Blockly.Gesture.prototype.doStart = function(e) {
   Blockly.Tooltip.block();
 
   if (this.targetBlock_) {
-    this.targetBlock_.select();
     if (!this.targetBlock_.isInFlyout && e.shiftKey) {
       Blockly.navigation.enableKeyboardAccessibility();
+      var ws = this.creatorWorkspace_;
+      ws.cursor.setLocation(Blockly.navigation.getTopNode(this.targetBlock_));
+    } else {
+      this.targetBlock_.select();
     }
   }
 
@@ -760,7 +763,6 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
  * @private
  */
 Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
-  Blockly.navigation.disableKeyboardAccessibility();
   var ws = this.creatorWorkspace_;
   if (e.shiftKey) {
     Blockly.navigation.enableKeyboardAccessibility();

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -125,6 +125,25 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
 };
 
 /**
+ * Create the serialized code that will be used in the key map.
+ * @param {!string} keyCode Code for the key to use
+ * @param {!Array<string>} modifiers List of modifiers.
+ * @return {string} The serialized key code for the given modifiers and key.
+ */
+Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
+  var key = '';
+  for (var i = 0, keyName; keyName = modifiers[i]; i++) {
+    if (Blockly.user.keyMap.modifierKeys.indexOf(keyName) > -1) {
+      key += keyName;
+    } else {
+      throw Error(keyName + ' is not a valid modifier key.');
+    }
+  }
+  key += keyCode;
+  return key;
+};
+
+/**
  * Creates the default key map.
  * @return {!Object<string,Blockly.Action>} An object holding the default key
  *     to action mapping.
@@ -141,5 +160,6 @@ Blockly.user.keyMap.createDefaultKeyMap = function() {
   map[Blockly.utils.KeyCodes.T] = Blockly.navigation.ACTION_TOOLBOX;
   map[Blockly.utils.KeyCodes.E] = Blockly.navigation.ACTION_EXIT;
   map[Blockly.utils.KeyCodes.ESC] = Blockly.navigation.ACTION_EXIT;
+  map[Blockly.user.keyMap.createSerializeKey(Blockly.utils.KeyCodes.K, ['Control'])] = Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV;
   return map;
 };

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -125,9 +125,10 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
 };
 
 /**
- * Create the serialized code that will be used in the key map.
- * @param {!string} keyCode Code for the key to use
- * @param {!Array<string>} modifiers List of modifiers.
+ * Create the serialized key code that will be used in the key map.
+ * @param {!number} keyCode Number code representing the key.
+ * @param {!Array<string>} modifiers List of modifiers to be used with the key.
+ *     All valid modifiers can be found in the Blockly.user.keyMap.modifiers list.
  * @return {string} The serialized key code for the given modifiers and key.
  */
 Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
@@ -150,6 +151,8 @@ Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
  */
 Blockly.user.keyMap.createDefaultKeyMap = function() {
   var map = {};
+  var controlK = Blockly.user.keyMap.createSerializeKey(Blockly.utils.KeyCodes.K, ['Control']);
+
   map[Blockly.utils.KeyCodes.W] = Blockly.navigation.ACTION_PREVIOUS;
   map[Blockly.utils.KeyCodes.A] = Blockly.navigation.ACTION_OUT;
   map[Blockly.utils.KeyCodes.S] = Blockly.navigation.ACTION_NEXT;
@@ -160,6 +163,6 @@ Blockly.user.keyMap.createDefaultKeyMap = function() {
   map[Blockly.utils.KeyCodes.T] = Blockly.navigation.ACTION_TOOLBOX;
   map[Blockly.utils.KeyCodes.E] = Blockly.navigation.ACTION_EXIT;
   map[Blockly.utils.KeyCodes.ESC] = Blockly.navigation.ACTION_EXIT;
-  map[Blockly.user.keyMap.createSerializeKey(Blockly.utils.KeyCodes.K, ['Control'])] = Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV;
+  map[controlK] = Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV;
   return map;
 };

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -136,7 +136,7 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
  *     All valid modifiers can be found in the Blockly.user.keyMap.modifierKeys.
  * @return {string} The serialized key code for the given modifiers and key.
  */
-Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
+Blockly.user.keyMap.createSerializedKey = function(keyCode, modifiers) {
   var key = '';
   var validModifiers = Object.values(Blockly.user.keyMap.modifierKeys);
   for (var i = 0, keyName; keyName = modifiers[i]; i++) {
@@ -157,7 +157,7 @@ Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
  */
 Blockly.user.keyMap.createDefaultKeyMap = function() {
   var map = {};
-  var controlK = Blockly.user.keyMap.createSerializeKey(
+  var controlK = Blockly.user.keyMap.createSerializedKey(
       Blockly.utils.KeyCodes.K, [Blockly.user.keyMap.modifierKeys.CONTROL]);
 
   map[Blockly.utils.KeyCodes.W] = Blockly.navigation.ACTION_PREVIOUS;

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -37,10 +37,15 @@ goog.require('Blockly.utils.KeyCodes');
 Blockly.user.keyMap.map_ = {};
 
 /**
- * List of modifier keys checked when serializing the key event.
- * @type {Array<string>}
+ * Object holding valid modifiers.
+ * @enum {string}
  */
-Blockly.user.keyMap.modifierKeys = ['Shift', 'Control', 'Alt', 'Meta'];
+Blockly.user.keyMap.modifierKeys = {
+  SHIFT: 'Shift',
+  CONTROL: 'Control',
+  ALT: 'Alt',
+  META: 'Meta'
+};
 
 /**
  * Update the key map to contain the new action.
@@ -113,9 +118,9 @@ Blockly.user.keyMap.getKeyByAction = function(action) {
  * @return {!string} A string containing the serialized key event.
  */
 Blockly.user.keyMap.serializeKeyEvent = function(e) {
-  var modifierKeys = Blockly.user.keyMap.modifierKeys;
+  var modifiers = Object.values(Blockly.user.keyMap.modifierKeys);
   var key = '';
-  for (var i = 0, keyName; keyName = modifierKeys[i]; i++) {
+  for (var i = 0, keyName; keyName = modifiers[i]; i++) {
     if (e.getModifierState(keyName)) {
       key += keyName;
     }
@@ -128,13 +133,14 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
  * Create the serialized key code that will be used in the key map.
  * @param {!number} keyCode Number code representing the key.
  * @param {!Array<string>} modifiers List of modifiers to be used with the key.
- *     All valid modifiers can be found in the Blockly.user.keyMap.modifiers list.
+ *     All valid modifiers can be found in the Blockly.user.keyMap.modifierKeys.
  * @return {string} The serialized key code for the given modifiers and key.
  */
 Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
   var key = '';
+  var validModifiers = Object.values(Blockly.user.keyMap.modifierKeys);
   for (var i = 0, keyName; keyName = modifiers[i]; i++) {
-    if (Blockly.user.keyMap.modifierKeys.indexOf(keyName) > -1) {
+    if (validModifiers.indexOf(keyName) > -1) {
       key += keyName;
     } else {
       throw Error(keyName + ' is not a valid modifier key.');
@@ -151,7 +157,8 @@ Blockly.user.keyMap.createSerializeKey = function(keyCode, modifiers) {
  */
 Blockly.user.keyMap.createDefaultKeyMap = function() {
   var map = {};
-  var controlK = Blockly.user.keyMap.createSerializeKey(Blockly.utils.KeyCodes.K, ['Control']);
+  var controlK = Blockly.user.keyMap.createSerializeKey(
+      Blockly.utils.KeyCodes.K, [Blockly.user.keyMap.modifierKeys.CONTROL]);
 
   map[Blockly.utils.KeyCodes.W] = Blockly.navigation.ACTION_PREVIOUS;
   map[Blockly.utils.KeyCodes.A] = Blockly.navigation.ACTION_OUT;

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -870,7 +870,7 @@ Blockly.navigation.onKeyPress = function(e) {
         actionHandled = Blockly.navigation.onBlocklyAction(action);
       }
     // If not in accessibility mode only hanlde turning on keyboard navigation.
-    } else if (action.name == Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
+    } else if (action.name === Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
       Blockly.navigation.enableKeyboardAccessibility();
       actionHandled = true;
     }
@@ -886,7 +886,7 @@ Blockly.navigation.onKeyPress = function(e) {
  * @package
  */
 Blockly.navigation.onBlocklyAction = function(action) {
-  if (action.name == Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
+  if (action.name === Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
     Blockly.navigation.disableKeyboardAccessibility();
     return true;
   } else if (Blockly.navigation.currentState_ === Blockly.navigation.STATE_WS) {
@@ -1125,6 +1125,7 @@ Blockly.navigation.ACTION_EXIT = new Blockly.Action(
 
 /**
  * The action to toggle keyboard navigation mode on and off.
+ * @type {!Blockly.Action}
  */
 Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV = new Blockly.Action(
     Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV, 'Turns on and off keyboard navigation.');

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -154,7 +154,7 @@ Blockly.navigation.removeMark = function() {
  *     block.
  * @package
  */
-Blockly.navigation.getTopNode_ = function(block) {
+Blockly.navigation.getTopNode = function(block) {
   var prevConnection = block.previousConnection;
   var outConnection = block.outputConnection;
   var topConnection = prevConnection ? prevConnection : outConnection;
@@ -391,7 +391,7 @@ Blockly.navigation.insertFromFlyout = function() {
   }
 
   Blockly.navigation.focusWorkspace();
-  Blockly.navigation.cursor_.setLocation(Blockly.navigation.getTopNode_(newBlock));
+  Blockly.navigation.cursor_.setLocation(Blockly.navigation.getTopNode(newBlock));
   Blockly.navigation.removeMark();
 };
 
@@ -725,9 +725,8 @@ Blockly.navigation.disconnectBlocks = function() {
 /*************************/
 
 /**
- * Sets the cursor to the previous or output connection of the selected block
- * on the workspace.
- * If no block is selected, places the cursor at a fixed point on the workspace.
+ * Finds where the cursor should go on the workspace. This is either the top
+ * block or a set position on the workspace.
  */
 Blockly.navigation.focusWorkspace = function() {
   var cursor = Blockly.navigation.cursor_;
@@ -736,11 +735,8 @@ Blockly.navigation.focusWorkspace = function() {
 
   Blockly.navigation.resetFlyout(reset);
   Blockly.navigation.currentState_ = Blockly.navigation.STATE_WS;
-  if (Blockly.selected) {
-    cursor.setLocation(Blockly.navigation.getTopNode_(Blockly.selected));
-    Blockly.selected.unselect();
-  } else if (topBlocks.length > 0) {
-    cursor.setLocation(Blockly.navigation.getTopNode_(topBlocks[0]));
+  if (topBlocks.length > 0) {
+    cursor.setLocation(Blockly.navigation.getTopNode(topBlocks[0]));
   } else {
     var ws = cursor.workspace_;
     // TODO: Find the center of the visible workspace.
@@ -859,7 +855,7 @@ Blockly.navigation.onKeyPress = function(e) {
   var curNode = Blockly.navigation.cursor_.getCurNode();
   var readOnly = Blockly.getMainWorkspace().options.readOnly;
   var actionHandled = false;
-  console.log(key);
+
   if (action) {
     if (Blockly.keyboardAccessibilityMode) {
       if (!readOnly) {
@@ -873,7 +869,7 @@ Blockly.navigation.onKeyPress = function(e) {
       } else if (Blockly.navigation.READONLY_ACTION_LIST.indexOf(action) > -1) {
         actionHandled = Blockly.navigation.onBlocklyAction(action);
       }
-    // If not in accessibility mode only hanlde enable keyboard action.
+    // If not in accessibility mode only hanlde turning on keyboard navigation.
     } else if (action.name == Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
       Blockly.navigation.enableKeyboardAccessibility();
     }
@@ -1127,7 +1123,7 @@ Blockly.navigation.ACTION_EXIT = new Blockly.Action(
     Blockly.navigation.actionNames.EXIT, 'Close the current modal, such as a toolbox or field editor.');
 
 /**
- * The action to enable keyboard navigation mode.
+ * The action to toggle keyboard navigation mode on and off.
  */
 Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV = new Blockly.Action(
     Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV, 'Turns on and off keyboard navigation.');

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -872,6 +872,7 @@ Blockly.navigation.onKeyPress = function(e) {
     // If not in accessibility mode only hanlde turning on keyboard navigation.
     } else if (action.name == Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
       Blockly.navigation.enableKeyboardAccessibility();
+      actionHandled = true;
     }
   }
   return actionHandled;

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -370,6 +370,37 @@ suite('Navigation', function() {
       field.onBlocklyAction.restore();
       Blockly.navigation.onBlocklyAction.restore();
     });
+
+    test('Toggle Action Off', function() {
+      var cursor = new Blockly.Cursor();
+      Blockly.navigation.setCursor(cursor);
+      this.mockEvent.keyCode = 'Control75';
+      sinon.spy(Blockly.navigation, 'onBlocklyAction');
+      Blockly.keyboardAccessibilityMode = true;
+
+      var isHandled = Blockly.navigation.onKeyPress(this.mockEvent);
+      chai.assert.isTrue(isHandled);
+      chai.assert.isTrue(Blockly.navigation.onBlocklyAction.calledOnce);
+      chai.assert.isFalse(Blockly.keyboardAccessibilityMode);
+      Blockly.navigation.onBlocklyAction.restore();
+    });
+
+    test('Toggle Action On', function() {
+      var cursor = new Blockly.Cursor();
+      Blockly.navigation.setCursor(cursor);
+      this.workspace = Blockly.inject('blocklyDiv', {readOnly: false});
+      this.mockEvent.keyCode = 'Control75';
+      sinon.stub(Blockly.navigation, 'focusWorkspace');
+      Blockly.keyboardAccessibilityMode = false;
+
+      var isHandled = Blockly.navigation.onKeyPress(this.mockEvent);
+      chai.assert.isTrue(isHandled);
+      chai.assert.isTrue(Blockly.navigation.focusWorkspace.calledOnce);
+      chai.assert.isTrue(Blockly.keyboardAccessibilityMode);
+      Blockly.navigation.focusWorkspace.restore();
+      this.workspace.dispose();
+    });
+
     suite('Test key press in read only mode', function() {
       setup(function() {
         Blockly.defineBlocksWithJsonArray([{

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -347,6 +347,14 @@ function toggleRenderingDebug(state) {
   }
 }
 
+function toggleAccessibilityMode(state) {
+  if (state) {
+    Blockly.navigation.enableKeyboardAccessibility();
+  } else {
+    Blockly.navigation.disableKeyboardAccessibility();
+  }
+}
+
 function logger(e) {
   console.log(e);
 }
@@ -515,6 +523,12 @@ h1 {
     Block rendering debug: &nbsp;
     <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
   </p>
+
+  <p>
+    Enable Accessibility Mode: &nbsp;
+    <input type="checkbox" onclick="toggleAccessibilityMode(this.checked)" id="accessibilityModeCheck">
+  </p>
+
 
   <!-- The next three blocks of XML are sample toolboxes for testing basic
   configurations.  For more information on building toolboxes, see https://developers.google.com/blockly/guides/configure/web/toolbox -->


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
The only way to get into keyboard accessibility mode used to be by shift clicking on the workspace.

### Proposed Changes
1. Add a checkbox on the playground for inserting into keyboard navigation mode.
2. Add an action for toggling keyboard navigation. Currently mapped to hitting control k
3. Clicking on the workspace no longer takes us out of keyboard navigation. Instead keyboard navigation is turned off by hitting control k once keyboard navigation is on.

### Reason for Changes
Shift clicking wasn't a very accessible way to turn on keyboard navigation.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
