### PR TITLE
Image Field Config

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -165,7 +165,7 @@ Blockly.FieldImage.prototype.EDITABLE = false;
  * rendered. Image fields are statically sized, and only need to be
  * rendered at initialization.
  * @type {boolean}
- * @private
+ * @protected
  */
 Blockly.FieldImage.prototype.isDirty_ = false;
 
@@ -194,12 +194,12 @@ Blockly.FieldImage.prototype.initView = function() {
       },
       this.fieldGroup_);
   this.imageElement_.setAttributeNS(Blockly.utils.dom.XLINK_NS,
-      'xlink:href', this.value_);
+      'xlink:href', /** @type {string} */ (this.value_));
 };
 
 /**
  * Ensure that the input value (the source URL) is a string.
- * @param {string=} opt_newValue The input value.
+ * @param {*=} opt_newValue The input value.
  * @return {?string} A string, or null if invalid.
  * @protected
  */

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -56,12 +56,13 @@ Blockly.FieldImage = function(src, width, height,
   if (!src) {
     throw Error('Src value of an image field is required');
   }
-  if (isNaN(height) || isNaN(width)) {
+  src = Blockly.utils.replaceMessageReferences(src);
+  var imageHeight = Number(Blockly.utils.replaceMessageReferences(height));
+  var imageWidth = Number(Blockly.utils.replaceMessageReferences(width));
+  if (isNaN(imageHeight) || isNaN(imageWidth)) {
     throw Error('Height and width values of an image field must cast to' +
       ' numbers.');
   }
-  var imageHeight = Number(height);
-  var imageWidth = Number(width);
   if (imageHeight <= 0 || imageWidth <= 0) {
     throw Error('Height and width values of an image field must be greater' +
       ' than 0.');
@@ -87,7 +88,7 @@ Blockly.FieldImage = function(src, width, height,
 
   if (!opt_config) {  // If the config wasn't passed, do old configuration.
     this.flipRtl_ = !!opt_flipRtl;
-    this.altText_ = opt_alt || '';
+    this.altText_ = Blockly.utils.replaceMessageReferences(opt_alt) || '';
   }
 
   // Initialize other properties.
@@ -130,15 +131,9 @@ Blockly.utils.object.inherits(Blockly.FieldImage, Blockly.Field);
  * @nocollapse
  */
 Blockly.FieldImage.fromJson = function(options) {
-  var src = Blockly.utils.replaceMessageReferences(options['src']);
-  var width = Number(Blockly.utils.replaceMessageReferences(
-      options['width']));
-  var height = Number(Blockly.utils.replaceMessageReferences(
-      options['height']));
-  var alt = Blockly.utils.replaceMessageReferences(options['alt']);
-  var flipRtl = !!options['flipRtl'];
-  return new Blockly.FieldImage(src, width, height,
-      alt, null, flipRtl, options);
+  return new Blockly.FieldImage(
+      options['src'], options['width'], options['height'],
+      null, null, null, options);
 };
 
 /**
@@ -174,7 +169,7 @@ Blockly.FieldImage.prototype.isDirty_ = false;
 Blockly.FieldImage.prototype.configure_ = function(config) {
   Blockly.FieldImage.superClass_.configure_.call(this, config);
   this.flipRtl_ = !!config['flipRtl'];
-  this.altText_ = config['alt'] || '';
+  this.altText_ = Blockly.utils.replaceMessageReferences(config['alt']) || '';
 };
 
 /**

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -52,7 +52,7 @@ goog.require('Blockly.utils.Size');
  */
 Blockly.FieldImage = function(src, width, height,
     opt_alt, opt_onClick, opt_flipRtl, opt_config) {
-  /* Return early. */
+  // Return early.
   if (!src) {
     throw Error('Src value of an image field is required');
   }
@@ -67,7 +67,7 @@ Blockly.FieldImage = function(src, width, height,
       ' than 0.');
   }
 
-  /* Initialize configurable properties. */
+  // Initialize configurable properties.
   /**
    * Whether to flip this image in RTL.
    * @type {boolean}
@@ -85,7 +85,7 @@ Blockly.FieldImage = function(src, width, height,
   Blockly.FieldImage.superClass_.constructor.call(
       this, src || '', null, opt_config);
 
-  /* Give constructor parameters priority. */
+  // Give constructor parameters priority.
   if (opt_flipRtl != null) {
     this.flipRtl_ = !!opt_flipRtl;
   }
@@ -93,7 +93,7 @@ Blockly.FieldImage = function(src, width, height,
     this.altText_ = opt_alt;
   }
 
-  /* Initialize other properties. */
+  // Initialize other properties.
   /**
    * The size of the area rendered by the field.
    * @type {Blockly.utils.Size}

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -85,12 +85,9 @@ Blockly.FieldImage = function(src, width, height,
   Blockly.FieldImage.superClass_.constructor.call(
       this, src || '', null, opt_config);
 
-  // Give constructor parameters priority.
-  if (opt_flipRtl != null) {
+  if (!opt_config) {  // If the config wasn't passed, do old configuration.
     this.flipRtl_ = !!opt_flipRtl;
-  }
-  if (opt_alt != null) {
-    this.altText_ = opt_alt;
+    this.altText_ = opt_alt || '';
   }
 
   // Initialize other properties.

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -493,8 +493,10 @@ FactoryUtils.getFieldsJs_ = function(block) {
           var width = Number(block.getFieldValue('WIDTH'));
           var height = Number(block.getFieldValue('HEIGHT'));
           var alt = JSON.stringify(block.getFieldValue('ALT'));
+          var flipRtl = Json.stringify(block.getFieldValue('FLIP_RTL'));
           fields.push('new Blockly.FieldImage(' +
-              src + ', ' + width + ', ' + height + ', ' + alt + ')');
+              src + ', ' + width + ', ' + height +
+              ', { alt: ' + alt + ', flipRtl: ' + flipRtl + ' })');
           break;
       }
     }

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -196,11 +196,23 @@ suite('Image Fields', function() {
         });
         chai.assert.equal(field.altText_, 'alt');
       });
-      test('JS Configuration - Override', function() {
+      test('JS Configuration - Ignore', function() {
         var field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
-          alt: 'otherAlt'
+          alt: 'configAlt'
         });
-        chai.assert.equal(field.altText_, 'alt');
+        chai.assert.equal(field.altText_, 'configAlt');
+      });
+      test('JS Configuration - Ignore - \'\'', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, '', null, null, {
+          alt: 'configAlt'
+        });
+        chai.assert.equal(field.altText_, 'configAlt');
+      });
+      test('JS Configuration - Ignore - Config \'\'', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
+          alt: ''
+        });
+        chai.assert.equal(field.altText_, '');
       });
     });
     suite('Flip RTL', function() {
@@ -223,9 +235,15 @@ suite('Image Fields', function() {
         });
         chai.assert.isTrue(field.getFlipRtl());
       });
-      test('JS Configuration - Override', function() {
+      test('JS Configuration - Ignore - True', function() {
         var field = new Blockly.FieldImage('src', 10, 10, null, null, true, {
           flipRtl: false
+        });
+        chai.assert.isFalse(field.getFlipRtl());
+      });
+      test('JS Configuration - Ignore - False', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, null, false, {
+          flipRtl: true
         });
         chai.assert.isTrue(field.getFlipRtl());
       });

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -51,9 +51,6 @@ suite('Image Fields', function() {
         new Blockly.FieldImage('src', 'bad', 'bad');
       });
     });
-    // Note: passing invalid an src path doesn't need to throw errors
-    // because the developer can see they did it incorrectly when they view
-    // the block.
     test('With Alt', function() {
       var imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
       assertValue(imageField, 'src', 'alt');
@@ -131,27 +128,106 @@ suite('Image Fields', function() {
       assertValue(this.imageField, 'newSrc', 'alt');
     });
   });
-  suite('setAlt', function() {
-    suite('Alt', function() {
+  suite('Customizations', function() {
+    suite('On Click Handler', function() {
       setup(function() {
-        this.imageField = new Blockly.FieldImage('src', 1, 1, 'alt');
+        this.onClick = function() {
+          console.log('on click');
+        };
+      });
+      teardown(function() {
+        delete this.onClick;
+      });
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
+        chai.assert.equal(field.clickHandler_, this.onClick);
+      });
+      test('setOnClickHandler', function() {
+        var field = new Blockly.FieldImage('src', 10, 10);
+        field.setOnClickHandler(this.onClick);
+        chai.assert.equal(field.clickHandler_, this.onClick);
+      });
+      test('Remove Click Handler', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
+        field.setOnClickHandler(null);
+        chai.assert.equal(field.clickHandler_, null);
+      });
+    });
+    suite('Alt', function() {
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, 'alt');
+        chai.assert.equal(field.altText_, 'alt');
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: 10,
+          height: 10,
+          alt: 'alt'
+        });
+        chai.assert.equal(field.altText_, 'alt');
       });
       test('Deprecated - setText', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, 'alt');
         chai.assert.throws(function() {
-          this.imageField.setText('newAlt');
+          field.setText('newAlt');
         });
       });
-      test('Null', function() {
-        this.imageField.setAlt(null);
-        assertValue(this.imageField, 'src', '');
+      suite('SetAlt', function() {
+        setup(function() {
+          this.imageField = new Blockly.FieldImage('src', 10, 10, 'alt');
+        });
+        test('Null', function() {
+          this.imageField.setAlt(null);
+          assertValue(this.imageField, 'src', '');
+        });
+        test('Empty String', function() {
+          this.imageField.setAlt('');
+          assertValue(this.imageField, 'src', '');
+        });
+        test('Good Alt', function() {
+          this.imageField.setAlt('newAlt');
+          assertValue(this.imageField, 'src', 'newAlt');
+        });
       });
-      test('Empty String', function() {
-        this.imageField.setAlt('');
-        assertValue(this.imageField, 'src', '');
+      test('JS Configuration - Simple', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
+          alt: 'alt'
+        });
+        chai.assert.equal(field.altText_, 'alt');
       });
-      test('Good Alt', function() {
-        this.imageField.setAlt('newAlt');
-        assertValue(this.imageField, 'src', 'newAlt');
+      test('JS Configuration - Override', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
+          alt: 'otherAlt'
+        });
+        chai.assert.equal(field.altText_, 'alt');
+      });
+    });
+    suite('Flip RTL', function() {
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, null, true);
+        chai.assert.isTrue(field.getFlipRtl());
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldImage.fromJson({
+          src: 'src',
+          width: 10,
+          height: 10,
+          flipRtl: true
+        });
+        chai.assert.isTrue(field.getFlipRtl());
+      });
+      test('JS Configuration - Simple', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
+          flipRtl: true
+        });
+        chai.assert.isTrue(field.getFlipRtl());
+      });
+      test('JS Configuration - Override', function() {
+        var field = new Blockly.FieldImage('src', 10, 10, null, null, true, {
+          flipRtl: false
+        });
+        chai.assert.isTrue(field.getFlipRtl());
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config option that can be passed to the image field constructor. Supports flipRtl, alt, and tooltip.

Also fixed block factory.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

Working is good!

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for:
 * onClick handler
 * Alt
 * FlipRtl

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Updates [here ](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/image#creation)and [here](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/image#click_handler).

### Additional Information

<!-- Anything else we should know? -->
Dependent on #2915 Will rebase once merged.
