### PR TITLE
Label Field Config

### DIFF
--- a/core/field_label.js
+++ b/core/field_label.js
@@ -53,16 +53,16 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
 
   /**
    * The html class name to use for this field.
-   * @type {string}
+   * @type {?string}
    * @private
    */
-  this.class_ = '';
+  this.class_ = null;
 
   Blockly.FieldLabel.superClass_.constructor.call(
       this, opt_value, null, opt_config);
 
   if (!opt_config) {  // If the config was not passed use old configuration.
-    this.class_ = opt_class || '';
+    this.class_ = opt_class || null;
   }
 
   /**
@@ -101,7 +101,7 @@ Blockly.FieldLabel.prototype.EDITABLE = false;
  */
 Blockly.FieldLabel.prototype.configure_ = function(config) {
   Blockly.FieldLabel.superClass_.configure_.call(this, config);
-  this.class_ = config['class'] || '';
+  this.class_ = config['class'] || null;
 };
 
 /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -61,7 +61,7 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
       this, opt_value, null, opt_config);
 
   if (!opt_config) {  // If the config was not passed use old configuration.
-    this.class_ = opt_class || null;
+    this.class_ = opt_class;
   }
 
   /**
@@ -100,7 +100,7 @@ Blockly.FieldLabel.prototype.EDITABLE = false;
  */
 Blockly.FieldLabel.prototype.configure_ = function(config) {
   Blockly.FieldLabel.superClass_.configure_.call(this, config);
-  this.class_ = config['class'] || null;
+  this.class_ = config['class'];
 };
 
 /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -40,22 +40,18 @@ goog.require('Blockly.utils.Size');
  * @param {string=} opt_value The initial value of the field. Should cast to a
  *    string. Defaults to an empty string if null or undefined.
  * @param {string=} opt_class Optional CSS class for the field's text.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldLabel = function(opt_value, opt_class) {
-  /**
-   * The html class name to use for this field.
-   * @type {?string}
-   * @private
-   */
-  this.class_ = opt_class || null;
-
+Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
   if (opt_value == null) {
     opt_value = '';
   }
   Blockly.FieldLabel.superClass_.constructor.call(
-      this, opt_value, null);
+      this, opt_value, null, opt_config);
 
   /**
    * The size of the area rendered by the field.
@@ -64,6 +60,13 @@ Blockly.FieldLabel = function(opt_value, opt_class) {
    * @override
    */
   this.size_ = new Blockly.utils.Size(0, Blockly.Field.TEXT_DEFAULT_HEIGHT);
+
+  /**
+   * The html class name to use for this field.
+   * @type {string}
+   * @private
+   */
+  this.class_ = opt_class || '';
 };
 Blockly.utils.object.inherits(Blockly.FieldLabel, Blockly.Field);
 
@@ -77,7 +80,7 @@ Blockly.utils.object.inherits(Blockly.FieldLabel, Blockly.Field);
  */
 Blockly.FieldLabel.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldLabel(text, options['class']);
+  return new Blockly.FieldLabel(text, null, options);
 };
 
 /**
@@ -87,6 +90,14 @@ Blockly.FieldLabel.fromJson = function(options) {
  * @const
  */
 Blockly.FieldLabel.prototype.EDITABLE = false;
+
+/**
+ * @override
+ */
+Blockly.FieldLabel.prototype.configure_ = function(config) {
+  Blockly.FieldLabel.superClass_.configure_.call(this, config);
+  this.class_ = config['class'] || '';
+};
 
 /**
  * Create block UI for this label.
@@ -112,6 +123,24 @@ Blockly.FieldLabel.prototype.doClassValidation_ = function(opt_newValue) {
     return null;
   }
   return String(opt_newValue);
+};
+
+/**
+ * Set the css class applied to the field's textElement_.
+ * @param {?string} cssClass The new css class name, or null to remove.
+ */
+Blockly.FieldLabel.prototype.setClass = function(cssClass) {
+  if (this.textElement_) {
+    // This check isn't necessary, but it's faster than letting removeClass
+    // figure it out.
+    if (this.class_) {
+      Blockly.utils.dom.removeClass(this.textElement_, this.class_);
+    }
+    if (cssClass) {
+      Blockly.utils.dom.addClass(this.textElement_, cssClass);
+    }
+  }
+  this.class_ = cssClass;
 };
 
 Blockly.fieldRegistry.register('field_label', Blockly.FieldLabel);

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -47,10 +47,6 @@ goog.require('Blockly.utils.Size');
  * @constructor
  */
 Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
-  if (opt_value == null) {
-    opt_value = '';
-  }  // Else it gets cast to a string (e.g. false -> 'false').
-
   /**
    * The html class name to use for this field.
    * @type {?string}
@@ -58,6 +54,9 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
    */
   this.class_ = null;
 
+  if (opt_value == null) {
+    opt_value = '';
+  }
   Blockly.FieldLabel.superClass_.constructor.call(
       this, opt_value, null, opt_config);
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -56,14 +56,13 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
    * @type {string}
    * @private
    */
-  this.class_ = opt_class || '';
+  this.class_ = '';
 
   Blockly.FieldLabel.superClass_.constructor.call(
       this, opt_value, null, opt_config);
 
-  // Give constructor parameters priority.
-  if (opt_class != null) {
-    this.class_ = opt_class;
+  if (!opt_config) {  // If the config was not passed use old configuration.
+    this.class_ = opt_class || '';
   }
 
   /**

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -49,9 +49,22 @@ goog.require('Blockly.utils.Size');
 Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
   if (opt_value == null) {
     opt_value = '';
-  }
+  }  // Else it gets cast to a string (e.g. false -> 'false').
+
+  /**
+   * The html class name to use for this field.
+   * @type {string}
+   * @private
+   */
+  this.class_ = opt_class || '';
+
   Blockly.FieldLabel.superClass_.constructor.call(
       this, opt_value, null, opt_config);
+
+  // Give constructor parameters priority.
+  if (opt_class != null) {
+    this.class_ = opt_class;
+  }
 
   /**
    * The size of the area rendered by the field.
@@ -60,13 +73,6 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
    * @override
    */
   this.size_ = new Blockly.utils.Size(0, Blockly.Field.TEXT_DEFAULT_HEIGHT);
-
-  /**
-   * The html class name to use for this field.
-   * @type {string}
-   * @private
-   */
-  this.class_ = opt_class || '';
 };
 Blockly.utils.object.inherits(Blockly.FieldLabel, Blockly.Field);
 

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -38,13 +38,16 @@ goog.require('Blockly.utils.object');
  * @param {*} opt_value The initial value of the field. Should cast to a
  *    string. Defaults to an empty string if null or undefined.
  * @param {string=} opt_class Optional CSS class for the field's text.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label-serializable#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.FieldLabel}
  * @constructor
  *
  */
-Blockly.FieldLabelSerializable = function(opt_value, opt_class) {
-  Blockly.FieldLabelSerializable.superClass_.constructor.call(this, opt_value,
-      opt_class);
+Blockly.FieldLabelSerializable = function(opt_value, opt_class, opt_config) {
+  Blockly.FieldLabelSerializable.superClass_.constructor.call(
+      this, opt_value, opt_class, opt_config);
 };
 Blockly.utils.object.inherits(Blockly.FieldLabelSerializable,
     Blockly.FieldLabel);
@@ -59,7 +62,7 @@ Blockly.utils.object.inherits(Blockly.FieldLabelSerializable,
  */
 Blockly.FieldLabelSerializable.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldLabelSerializable(text, options['class']);
+  return new Blockly.FieldLabelSerializable(text, null, options);
 };
 
 /**

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -29,7 +29,6 @@ suite('Label Serializable Fields', function() {
     assertValue(labelField, '');
   }
   function assertClass(labelField, cssClass) {
-    labelField.initValue();
     labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
     labelField.initView();
     chai.assert.isTrue(Blockly.utils.dom.hasClass(
@@ -192,10 +191,10 @@ suite('Label Serializable Fields', function() {
       assertClass(field, 'testClass');
     });
     test('JS Configuration - Override', function() {
-      var field = new Blockly.FieldLabelSerializable('text', 'oldClass', {
-        class: 'testClass'
+      var field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
+        class: 'configClass'
       });
-      assertClass(field, 'testClass');
+      assertClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -28,6 +28,13 @@ suite('Label Serializable Fields', function() {
   function assertValueDefault(labelField) {
     assertValue(labelField, '');
   }
+  function assertClass(labelField, cssClass) {
+    labelField.initValue();
+    labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+    labelField.initView();
+    chai.assert.isTrue(Blockly.utils.dom.hasClass(
+        labelField.textElement_, cssClass));
+  }
   suite('Constructor', function() {
     test('Empty', function() {
       var labelField = new Blockly.FieldLabelSerializable();
@@ -164,6 +171,55 @@ suite('Label Serializable Fields', function() {
       test('Boolean False', function() {
         this.labelField.setValue(false);
         assertValue(this.labelField, 'false');
+      });
+    });
+  });
+  suite('Customizations', function() {
+    test('JS Constructor', function() {
+      var field = new Blockly.FieldLabelSerializable('text', 'testClass');
+      assertClass(field, 'testClass');
+    });
+    test('JSON Definition', function() {
+      var field = Blockly.FieldLabelSerializable.fromJson({
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    test('JS Configuration - Simple', function() {
+      var field = new Blockly.FieldLabelSerializable('text', null, {
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    test('JS Configuration - Override', function() {
+      var field = new Blockly.FieldLabelSerializable('text', 'oldClass', {
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    suite('setClass', function() {
+      test('setClass', function() {
+        var field = new Blockly.FieldLabelSerializable();
+        field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+        field.initView();
+        field.setClass('testClass');
+        // Don't call assertClass b/c we don't want to re-initialize.
+        chai.assert.isTrue(Blockly.utils.dom.hasClass(
+            field.textElement_, 'testClass'));
+      });
+      test('setClass Before Initialization', function() {
+        var field = new Blockly.FieldLabelSerializable();
+        field.setClass('testClass');
+        assertClass(field, 'testClass');
+      });
+      test('Remove Class', function() {
+        var field = new Blockly.FieldLabelSerializable('text', null, {
+          class: 'testClass'
+        });
+        assertClass(field, 'testClass');
+        field.setClass(null);
+        chai.assert.isFalse(Blockly.utils.dom.hasClass(
+            field.textElement_, 'testClass'));
       });
     });
   });

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -28,10 +28,16 @@ suite('Label Serializable Fields', function() {
   function assertValueDefault(labelField) {
     assertValue(labelField, '');
   }
-  function assertClass(labelField, cssClass) {
+  function assertHasClass(labelField, cssClass) {
     labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
     labelField.initView();
     chai.assert.isTrue(Blockly.utils.dom.hasClass(
+        labelField.textElement_, cssClass));
+  }
+  function assertDoesNotHaveClass(labelField, cssClass) {
+    labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+    labelField.initView();
+    chai.assert.isFalse(Blockly.utils.dom.hasClass(
         labelField.textElement_, cssClass));
   }
   suite('Constructor', function() {
@@ -176,25 +182,38 @@ suite('Label Serializable Fields', function() {
   suite('Customizations', function() {
     test('JS Constructor', function() {
       var field = new Blockly.FieldLabelSerializable('text', 'testClass');
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
     test('JSON Definition', function() {
       var field = Blockly.FieldLabelSerializable.fromJson({
         class: 'testClass'
       });
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Simple', function() {
       var field = new Blockly.FieldLabelSerializable('text', null, {
         class: 'testClass'
       });
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
-    test('JS Configuration - Override', function() {
+    test('JS Configuration - Ignore', function() {
       var field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
         class: 'configClass'
       });
-      assertClass(field, 'paramClass');
+      assertDoesNotHaveClass(field, 'paramClass');
+      assertHasClass(field, 'configClass');
+    });
+    test('JS Configuration - Ignore - \'\'', function() {
+      var field = new Blockly.FieldLabelSerializable('text', '', {
+        class: 'configClass'
+      });
+      assertHasClass(field, 'configClass');
+    });
+    test('JS Configuration - Ignore - Config \'\'', function() {
+      var field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
+        class: ''
+      });
+      assertDoesNotHaveClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {
@@ -202,20 +221,20 @@ suite('Label Serializable Fields', function() {
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
         field.initView();
         field.setClass('testClass');
-        // Don't call assertClass b/c we don't want to re-initialize.
+        // Don't call assertHasClass b/c we don't want to re-initialize.
         chai.assert.isTrue(Blockly.utils.dom.hasClass(
             field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
         var field = new Blockly.FieldLabelSerializable();
         field.setClass('testClass');
-        assertClass(field, 'testClass');
+        assertHasClass(field, 'testClass');
       });
       test('Remove Class', function() {
         var field = new Blockly.FieldLabelSerializable('text', null, {
           class: 'testClass'
         });
-        assertClass(field, 'testClass');
+        assertHasClass(field, 'testClass');
         field.setClass(null);
         chai.assert.isFalse(Blockly.utils.dom.hasClass(
             field.textElement_, 'testClass'));

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -28,10 +28,16 @@ suite('Label Fields', function() {
   function assertValueDefault(labelField) {
     assertValue(labelField, '');
   }
-  function assertClass(labelField, cssClass) {
+  function assertHasClass(labelField, cssClass) {
     labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
     labelField.initView();
     chai.assert.isTrue(Blockly.utils.dom.hasClass(
+        labelField.textElement_, cssClass));
+  }
+  function assertDoesNotHaveClass(labelField, cssClass) {
+    labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+    labelField.initView();
+    chai.assert.isFalse(Blockly.utils.dom.hasClass(
         labelField.textElement_, cssClass));
   }
   suite('Constructor', function() {
@@ -165,25 +171,38 @@ suite('Label Fields', function() {
   suite('Customizations', function() {
     test('JS Constructor', function() {
       var field = new Blockly.FieldLabel('text', 'testClass');
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
     test('JSON Definition', function() {
       var field = Blockly.FieldLabel.fromJson({
         class: 'testClass'
       });
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Simple', function() {
       var field = new Blockly.FieldLabel('text', null, {
         class: 'testClass'
       });
-      assertClass(field, 'testClass');
+      assertHasClass(field, 'testClass');
     });
-    test('JS Configuration - Override', function() {
+    test('JS Configuration - Ignore', function() {
       var field = new Blockly.FieldLabel('text', 'paramClass', {
         class: 'configClass'
       });
-      assertClass(field, 'paramClass');
+      assertDoesNotHaveClass(field, 'paramClass');
+      assertHasClass(field, 'configClass');
+    });
+    test('JS Configuration - Ignore - \'\'', function() {
+      var field = new Blockly.FieldLabel('text', '', {
+        class: 'configClass'
+      });
+      assertHasClass(field, 'configClass');
+    });
+    test('JS Configuration - Ignore - Config \'\'', function() {
+      var field = new Blockly.FieldLabel('text', 'paramClass', {
+        class: ''
+      });
+      assertDoesNotHaveClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {
@@ -191,20 +210,20 @@ suite('Label Fields', function() {
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
         field.initView();
         field.setClass('testClass');
-        // Don't call assertClass b/c we don't want to re-initialize.
+        // Don't call assertHasClass b/c we don't want to re-initialize.
         chai.assert.isTrue(Blockly.utils.dom.hasClass(
             field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
         var field = new Blockly.FieldLabel();
         field.setClass('testClass');
-        assertClass(field, 'testClass');
+        assertHasClass(field, 'testClass');
       });
       test('Remove Class', function() {
         var field = new Blockly.FieldLabel('text', null, {
           class: 'testClass'
         });
-        assertClass(field, 'testClass');
+        assertHasClass(field, 'testClass');
         field.setClass(null);
         chai.assert.isFalse(Blockly.utils.dom.hasClass(
             field.textElement_, 'testClass'));

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -28,6 +28,13 @@ suite('Label Fields', function() {
   function assertValueDefault(labelField) {
     assertValue(labelField, '');
   }
+  function assertClass(labelField, cssClass) {
+    labelField.initValue();
+    labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+    labelField.initView();
+    chai.assert.isTrue(Blockly.utils.dom.hasClass(
+        labelField.textElement_, cssClass));
+  }
   suite('Constructor', function() {
     test('Empty', function() {
       var labelField = new Blockly.FieldLabel();
@@ -153,6 +160,56 @@ suite('Label Fields', function() {
       test('Boolean False', function() {
         this.labelField.setValue(false);
         assertValue(this.labelField, 'false');
+      });
+    });
+  });
+  suite('Customizations', function() {
+    test('JS Constructor', function() {
+      var field = new Blockly.FieldLabel('text', 'testClass');
+      assertClass(field, 'testClass');
+    });
+    test('JSON Definition', function() {
+      var field = Blockly.FieldLabel.fromJson({
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    test('JS Configuration - Simple', function() {
+      var field = new Blockly.FieldLabel('text', null, {
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    test('JS Configuration - Override', function() {
+      var field = new Blockly.FieldLabel('text', 'oldClass', {
+        class: 'testClass'
+      });
+      assertClass(field, 'testClass');
+    });
+    suite('setClass', function() {
+      test('setClass', function() {
+        var field = new Blockly.FieldLabel();
+        field.initValue();
+        field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
+        field.initView();
+        field.setClass('testClass');
+        // Don't call assertClass b/c we don't want to re-initialize.
+        chai.assert.isTrue(Blockly.utils.dom.hasClass(
+            field.textElement_, 'testClass'));
+      });
+      test('setClass Before Initialization', function() {
+        var field = new Blockly.FieldLabel();
+        field.setClass('testClass');
+        assertClass(field, 'testClass');
+      });
+      test('Remove Class', function() {
+        var field = new Blockly.FieldLabel('text', null, {
+          class: 'testClass'
+        });
+        assertClass(field, 'testClass');
+        field.setClass(null);
+        chai.assert.isFalse(Blockly.utils.dom.hasClass(
+            field.textElement_, 'testClass'));
       });
     });
   });

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -29,7 +29,6 @@ suite('Label Fields', function() {
     assertValue(labelField, '');
   }
   function assertClass(labelField, cssClass) {
-    labelField.initValue();
     labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
     labelField.initView();
     chai.assert.isTrue(Blockly.utils.dom.hasClass(
@@ -181,15 +180,14 @@ suite('Label Fields', function() {
       assertClass(field, 'testClass');
     });
     test('JS Configuration - Override', function() {
-      var field = new Blockly.FieldLabel('text', 'oldClass', {
-        class: 'testClass'
+      var field = new Blockly.FieldLabel('text', 'paramClass', {
+        class: 'configClass'
       });
-      assertClass(field, 'testClass');
+      assertClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {
         var field = new Blockly.FieldLabel();
-        field.initValue();
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
         field.initView();
         field.setClass('testClass');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config parameter to the label field and serializable label field constructors. It accepts class and tooltip.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for setting the class via js constructor, json, programmatic, etc. Tests run on label field and serializable label field.


<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Updates [here ](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label#creation)and [here](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label-serializable#creation).

Label fields also need a customization section, since setClass is now a thing.

### Additional Information

<!-- Anything else we should know? -->
Dependent on #2915 Will rebase once merged.