### PR TITLE
Text Field Config

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -54,10 +54,6 @@ goog.require('Blockly.utils.userAgent');
  * @constructor
  */
 Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
-  if (opt_value == null) {
-    opt_value = '';
-  }
-
   /**
    * Allow browser to spellcheck this field.
    * @type {boolean}
@@ -65,6 +61,9 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
    */
   this.spellcheck_ = true;
 
+  if (opt_value == null) {
+    opt_value = '';
+  }
   Blockly.FieldTextInput.superClass_.constructor.call(this,
       opt_value, opt_validator, opt_config);
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -57,8 +57,6 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   if (opt_value == null) {
     opt_value = '';
   }
-  Blockly.FieldTextInput.superClass_.constructor.call(this,
-      opt_value, opt_validator, opt_config);
 
   /**
    * Allow browser to spellcheck this field.
@@ -66,6 +64,9 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
    * @private
    */
   this.spellcheck_ = true;
+
+  Blockly.FieldTextInput.superClass_.constructor.call(this,
+      opt_value, opt_validator, opt_config);
 };
 Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -59,6 +59,13 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   }
   Blockly.FieldTextInput.superClass_.constructor.call(this,
       opt_value, opt_validator, opt_config);
+
+  /**
+   * Allow browser to spellcheck this field.
+   * @type {boolean}
+   * @private
+   */
+  this.spellcheck_ = true;
 };
 Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 
@@ -73,11 +80,7 @@ Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
  */
 Blockly.FieldTextInput.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  var field = new Blockly.FieldTextInput(text);
-  if (typeof options['spellcheck'] === 'boolean') {
-    field.setSpellcheck(options['spellcheck']);
-  }
-  return field;
+  return new Blockly.FieldTextInput(text, null, options);
 };
 
 /**
@@ -105,10 +108,14 @@ Blockly.FieldTextInput.BORDERRADIUS = 4;
 Blockly.FieldTextInput.prototype.CURSOR = 'text';
 
 /**
- * Allow browser to spellcheck this field.
- * @protected
+ * @override
  */
-Blockly.FieldTextInput.prototype.spellcheck_ = true;
+Blockly.FieldTextInput.prototype.configure_ = function(config) {
+  Blockly.FieldTextInput.superClass_.configure_.call(this, config);
+  if (typeof config['spellcheck'] == 'boolean') {
+    this.spellcheck_ = config['spellcheck'];
+  }
+};
 
 /**
  * Ensure that the input value casts to a valid string.
@@ -194,7 +201,13 @@ Blockly.FieldTextInput.prototype.render_ = function() {
  * @param {boolean} check True if checked.
  */
 Blockly.FieldTextInput.prototype.setSpellcheck = function(check) {
+  if (check == this.spellcheck_) {
+    return;
+  }
   this.spellcheck_ = check;
+  if (this.htmlInput_) {
+    this.htmlInput_.setAttribute('spellcheck', this.spellcheck_);
+  }
 };
 
 /**

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -222,4 +222,65 @@ suite('Text Input Fields', function() {
       });
     });
   });
+  suite('Customization', function() {
+    suite('Spellcheck', function() {
+      setup(function() {
+        this.prepField = function(field) {
+          field.sourceBlock_ = {
+            workspace: {
+              scale: 1
+            }
+          };
+          Blockly.WidgetDiv.DIV = document.createElement('div');
+          this.stub = sinon.stub(field, 'resizeEditor_');
+        };
+
+        this.assertSpellcheck = function(field, value) {
+          this.prepField(field);
+          field.showEditor_();
+          chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'),
+              value.toString());
+        };
+      });
+      teardown(function() {
+        if (this.stub) {
+          this.stub.restore();
+        }
+      });
+      test('Default', function() {
+        var field = new Blockly.FieldTextInput('test');
+        field.initValue();
+        this.assertSpellcheck(field, true);
+      });
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldTextInput('test', null, {
+          spellcheck: false
+        });
+        field.initValue();
+        this.assertSpellcheck(field, false);
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldTextInput.fromJson({
+          text: 'test',
+          spellcheck: false
+        });
+        field.initValue();
+        this.assertSpellcheck(field, false);
+      });
+      test('setSpellcheck Editor Hidden', function() {
+        var field = new Blockly.FieldTextInput('test');
+        field.initValue();
+        field.setSpellcheck(false);
+        this.assertSpellcheck(field, false);
+      });
+      test('setSpellcheck Editor Shown', function() {
+        var field = new Blockly.FieldTextInput('test');
+        field.initValue();
+        this.prepField(field);
+        field.showEditor_();
+        field.setSpellcheck(false);
+        chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'), 'false');
+      });
+    });
+  });
 });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -249,14 +249,12 @@ suite('Text Input Fields', function() {
       });
       test('Default', function() {
         var field = new Blockly.FieldTextInput('test');
-        field.initValue();
         this.assertSpellcheck(field, true);
       });
       test('JS Constructor', function() {
         var field = new Blockly.FieldTextInput('test', null, {
           spellcheck: false
         });
-        field.initValue();
         this.assertSpellcheck(field, false);
       });
       test('JSON Definition', function() {
@@ -264,18 +262,15 @@ suite('Text Input Fields', function() {
           text: 'test',
           spellcheck: false
         });
-        field.initValue();
         this.assertSpellcheck(field, false);
       });
       test('setSpellcheck Editor Hidden', function() {
         var field = new Blockly.FieldTextInput('test');
-        field.initValue();
         field.setSpellcheck(false);
         this.assertSpellcheck(field, false);
       });
       test('setSpellcheck Editor Shown', function() {
         var field = new Blockly.FieldTextInput('test');
-        field.initValue();
         this.prepField(field);
         field.showEditor_();
         field.setSpellcheck(false);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config parameter to the text input field constructor. Accepts spellcheck.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for setting the spellcheck. JS, Json, programmatic, etc.

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Updates [here](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#creation). And info about .spellcheck_ parameter should probably be removed [here](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#customization).

### Additional Information

<!-- Anything else we should know? -->
Dependent on #2915 Will rebase once merged.
