### PR TITLE
Add Object values helper method to fix IE

### DIFF
--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -28,6 +28,7 @@
 goog.provide('Blockly.user.keyMap');
 
 goog.require('Blockly.utils.KeyCodes');
+goog.require('Blockly.utils.object');
 
 
 /**
@@ -118,7 +119,7 @@ Blockly.user.keyMap.getKeyByAction = function(action) {
  * @return {!string} A string containing the serialized key event.
  */
 Blockly.user.keyMap.serializeKeyEvent = function(e) {
-  var modifiers = Object.values(Blockly.user.keyMap.modifierKeys);
+  var modifiers = Blockly.utils.object.values(Blockly.user.keyMap.modifierKeys);
   var key = '';
   for (var i = 0, keyName; keyName = modifiers[i]; i++) {
     if (e.getModifierState(keyName)) {
@@ -138,7 +139,7 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
  */
 Blockly.user.keyMap.createSerializedKey = function(keyCode, modifiers) {
   var key = '';
-  var validModifiers = Object.values(Blockly.user.keyMap.modifierKeys);
+  var validModifiers = Blockly.utils.object.values(Blockly.user.keyMap.modifierKeys);
   for (var i = 0, keyName; keyName = modifiers[i]; i++) {
     if (validModifiers.indexOf(keyName) > -1) {
       key += keyName;

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -50,3 +50,18 @@ Blockly.utils.object.mixin = function(target, source) {
     target[x] = source[x];
   }
 };
+
+/**
+ * Returns an array of a given object's own enumerable property values.
+ * @param {!Object} obj Object containing values.
+ * @return {!Array} Array of values.
+ */
+Blockly.utils.object.values = function(obj) {
+  if (Object.values) {
+    return Object.values(obj);
+  }
+  // Fallback for IE.
+  return Object.keys(obj).map(function(e) {
+    return obj[e];
+  });
+};


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/2999

### Proposed Changes

Add an Object.values helper method in the object utils to have a fallback option for IE.

### Reason for Changes

No Object.values in IE.

### Test Coverage

Tested on:
* Desktop Chrome 
* IE 11

