### PR TITLE
Adding checkboxes for debug rendering options to playground.

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -54,24 +54,20 @@ Blockly.blockRendering.Debug = function() {
    * @type {SVGElement}
    */
   this.svgRoot_ = null;
-
-  /**
-   * @type {Object} Configuration object containing booleans to enable and
-   *     disable debug rendering of specific rendering components.
-   */
-  this.config_ = Blockly.blockRendering.Debug.getDebugConfig();
 };
 
-Blockly.blockRendering.Debug.getDebugConfig = function() {
-  return {
-    // rowSpacers: true,
-    // elemSpacers: true,
-    // rows: true,
-    elems: true,
-    // connections: true,
-    blockBounds: true,
-    // connectedBlockBounds: true
-  };
+/**
+ * @type {!Object.<string, boolean>} Configuration object containing booleans
+ *    to enable and disable debug rendering of specific rendering components.
+ */
+Blockly.blockRendering.Debug.config = {
+  rowSpacers: true,
+  elemSpacers: true,
+  rows: true,
+  elems: true,
+  connections: true,
+  blockBounds: true,
+  connectedBlockBounds: true
 };
 
 /**
@@ -94,7 +90,7 @@ Blockly.blockRendering.Debug.prototype.clearElems = function() {
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, isRtl) {
-  if (!this.config_.rowSpacers) {
+  if (!Blockly.blockRendering.Debug.config.rowSpacers) {
     return;
   }
 
@@ -121,7 +117,7 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, is
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight, isRtl) {
-  if (!this.config_.elemSpacers) {
+  if (!Blockly.blockRendering.Debug.config.elemSpacers) {
     return;
   }
 
@@ -153,7 +149,7 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) {
-  if (this.config_.elems) {
+  if (Blockly.blockRendering.Debug.config.elems) {
     var xPos = elem.xPos;
     if (isRtl) {
       xPos = -(xPos + elem.width);
@@ -174,7 +170,8 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
   }
 
 
-  if (Blockly.blockRendering.Types.isInput(elem) && this.config_.connections) {
+  if (Blockly.blockRendering.Types.isInput(elem) &&
+      Blockly.blockRendering.Debug.config.connections) {
     this.drawConnection(elem.connection);
   }
 };
@@ -187,7 +184,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
-  if (!this.config_.connections) {
+  if (!Blockly.blockRendering.Debug.config.connections) {
     return;
   }
 
@@ -231,7 +228,7 @@ Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, isRtl) {
-  if (!this.config_.rows) {
+  if (!Blockly.blockRendering.Debug.config.rows) {
     return;
   }
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
@@ -251,7 +248,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, 
     return;
   }
 
-  if (this.config_.connectedBlockBounds) {
+  if (Blockly.blockRendering.Debug.config.connectedBlockBounds) {
     this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
         {
           'class': 'connectedBlockWidth blockRenderDebug',
@@ -293,7 +290,7 @@ Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, curso
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawBoundingBox = function(info) {
-  if (!this.config_.blockBounds) {
+  if (!Blockly.blockRendering.Debug.config.blockBounds) {
     return;
   }
   // Bounding box without children.
@@ -313,7 +310,7 @@ Blockly.blockRendering.Debug.prototype.drawBoundingBox = function(info) {
       },
       this.svgRoot_));
 
-  if (this.config_.connectedBlockBounds) {
+  if (Blockly.blockRendering.Debug.config.connectedBlockBounds) {
     // Bounding box with children.
     xPos = info.RTL ? -info.widthWithChildren : 0;
     this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -57,8 +57,9 @@ Blockly.blockRendering.Debug = function() {
 };
 
 /**
- * @type {!Object.<string, boolean>} Configuration object containing booleans
- *    to enable and disable debug rendering of specific rendering components.
+ * Configuration object containing booleans to enable and disable debug
+ * rendering of specific rendering components.
+ * @type {!Object.<string, boolean>}
  */
 Blockly.blockRendering.Debug.config = {
   rowSpacers: true,

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -293,7 +293,8 @@ function updateRenderDebugOptions(e) {
 function addRenderDebugOptionsCheckboxes() {
   var renderDebugConfig = Blockly.blockRendering.Debug.config;
   var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
-  Object.keys(renderDebugConfig).forEach(function(optionName) {
+  var optionNames = Object.keys(renderDebugConfig);
+  for (var i = 0, optionName; (optionName = optionNames[i]); i++) {
     var optionCheckId = 'RenderDebug' + optionName + 'Check';
     var optionLabel = document.createElement('label');
     optionLabel.setAttribute('htmlFor', optionCheckId);
@@ -307,7 +308,7 @@ function addRenderDebugOptionsCheckboxes() {
     optionLi.appendChild(optionLabel);
     optionLi.appendChild(optionCheck);
     renderDebugOptionsListEl.appendChild(optionLi);
-  });
+  }
 }
 
 function changeTheme() {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -297,7 +297,7 @@ function addRenderDebugOptionsCheckboxes() {
   for (var i = 0, optionName; (optionName = optionNames[i]); i++) {
     var optionCheckId = 'RenderDebug' + optionName + 'Check';
     var optionLabel = document.createElement('label');
-    optionLabel.setAttribute('htmlFor', optionCheckId);
+    optionLabel.setAttribute('for', optionCheckId);
     optionLabel.textContent = optionName;
     var optionCheck = document.createElement('input');
     optionCheck.setAttribute('type', 'checkbox');

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -267,53 +267,47 @@ function addToolboxButtonCallbacks() {
 
 function setRenderDebugOptionCheckboxState(overrideOptions) {
   Blockly.blockRendering.Debug.config = overrideOptions || {};
-  if(!overrideOptions) return;
+  if (!overrideOptions) {
+    return;
+  }
   var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
   var renderDebugOptionInputs =
-      renderDebugOptionsListEl.getElementsByTagName('INPUT');
-  for (var optionInput of renderDebugOptionInputs) {
-    var optionId = optionInput.getAttribute('id');
-    var checkboxMatch = optionId.match('^RenderDebug(.*)Check$');
-    if (!checkboxMatch) continue;
-    var optionName = checkboxMatch[1];
+      renderDebugOptionsListEl.getElementsByTagName('input');
+  for (var i = 0, optionInput;
+      (optionInput = renderDebugOptionInputs[i]); i++) {
+    var optionName = optionInput.getAttribute('data-optionName');
     optionInput.checked = !!overrideOptions[optionName];
   }
 }
 
-function updateRenderDebugOptions() {
-  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
-  var renderDebugOptionInputs =
-      renderDebugOptionsListEl.getElementsByTagName('INPUT');
-  var debugOptions = {};
-  for (var optionInput of renderDebugOptionInputs) {
-    var optionId = optionInput.getAttribute('id');
-    var checkboxMatch = optionId.match('^RenderDebug(.*)Check$');
-    if (!checkboxMatch) continue;
-    var optionName = checkboxMatch[1];
-    debugOptions[optionName] = optionInput.checked;
-  }
-  Blockly.blockRendering.Debug.config = debugOptions;
+function updateRenderDebugOptions(e) {
+  var target = e.target;
+  var optionName = target.getAttribute('data-optionName');
+  var config = Blockly.blockRendering.Debug.config;
+  config[optionName] = !!target.checked;
   sessionStorage.setItem(
-      'blockRenderDebugOptions',JSON.stringify(debugOptions));
+      'blockRenderDebugOptions', JSON.stringify(config));
+  workspace.render();
 }
 
 function addRenderDebugOptionsCheckboxes() {
   var renderDebugConfig = Blockly.blockRendering.Debug.config;
   var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
-  for (var optionName in renderDebugConfig) {
+  Object.keys(renderDebugConfig).forEach(function(optionName) {
     var optionCheckId = 'RenderDebug' + optionName + 'Check';
-    var optionLabel = document.createElement('LABEL');
+    var optionLabel = document.createElement('label');
     optionLabel.setAttribute('htmlFor', optionCheckId);
-    optionLabel.innerHTML = optionName;
-    var optionCheck = document.createElement('INPUT');
+    optionLabel.textContent = optionName;
+    var optionCheck = document.createElement('input');
     optionCheck.setAttribute('type', 'checkbox');
     optionCheck.setAttribute('id', optionCheckId);
+    optionCheck.setAttribute('data-optionName', optionName);
     optionCheck.onclick = updateRenderDebugOptions;
     var optionLi = document.createElement('li');
     optionLi.appendChild(optionLabel);
     optionLi.appendChild(optionCheck);
     renderDebugOptionsListEl.appendChild(optionLi);
-  }
+  });
 }
 
 function changeTheme() {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -134,6 +134,7 @@ function start() {
           }
       });
   addToolboxButtonCallbacks();
+  addRenderDebugOptionsCheckboxes();
   // Restore previously displayed text.
   if (sessionStorage) {
     var text = sessionStorage.getItem('textarea');
@@ -146,6 +147,10 @@ function start() {
     // Restore render debug state.
     var renderDebugState = sessionStorage.getItem('blockRenderDebug');
     toggleRenderingDebug(Boolean(Number(renderDebugState)));
+    // Restore render debug options state.
+    var renderDebugOptionsState =
+        JSON.parse(sessionStorage.getItem('blockRenderDebugOptions'));
+    setRenderDebugOptionCheckboxState(renderDebugOptionsState);
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);
@@ -260,6 +265,57 @@ function addToolboxButtonCallbacks() {
       'removeDynamicOption', Blockly.TestBlocks.removeDynamicDropdownOption_);
 }
 
+function setRenderDebugOptionCheckboxState(overrideOptions) {
+  Blockly.blockRendering.Debug.config = overrideOptions || {};
+  if(!overrideOptions) return;
+  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
+  var renderDebugOptionInputs =
+      renderDebugOptionsListEl.getElementsByTagName('INPUT');
+  for (var optionInput of renderDebugOptionInputs) {
+    var optionId = optionInput.getAttribute('id');
+    var checkboxMatch = optionId.match('^RenderDebug(.*)Check$');
+    if (!checkboxMatch) continue;
+    var optionName = checkboxMatch[1];
+    optionInput.checked = !!overrideOptions[optionName];
+  }
+}
+
+function updateRenderDebugOptions() {
+  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
+  var renderDebugOptionInputs =
+      renderDebugOptionsListEl.getElementsByTagName('INPUT');
+  var debugOptions = {};
+  for (var optionInput of renderDebugOptionInputs) {
+    var optionId = optionInput.getAttribute('id');
+    var checkboxMatch = optionId.match('^RenderDebug(.*)Check$');
+    if (!checkboxMatch) continue;
+    var optionName = checkboxMatch[1];
+    debugOptions[optionName] = optionInput.checked;
+  }
+  Blockly.blockRendering.Debug.config = debugOptions;
+  sessionStorage.setItem(
+      'blockRenderDebugOptions',JSON.stringify(debugOptions));
+}
+
+function addRenderDebugOptionsCheckboxes() {
+  var renderDebugConfig = Blockly.blockRendering.Debug.config;
+  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
+  for (var optionName in renderDebugConfig) {
+    var optionCheckId = 'RenderDebug' + optionName + 'Check';
+    var optionLabel = document.createElement('LABEL');
+    optionLabel.setAttribute('htmlFor', optionCheckId);
+    optionLabel.innerHTML = optionName;
+    var optionCheck = document.createElement('INPUT');
+    optionCheck.setAttribute('type', 'checkbox');
+    optionCheck.setAttribute('id', optionCheckId);
+    optionCheck.onclick = updateRenderDebugOptions;
+    var optionLi = document.createElement('li');
+    optionLi.appendChild(optionLabel);
+    optionLi.appendChild(optionCheck);
+    renderDebugOptionsListEl.appendChild(optionLi);
+  }
+}
+
 function changeTheme() {
   var theme = document.getElementById('themeChanger');
   if (theme.value === "modern") {
@@ -352,9 +408,11 @@ function toggleRenderingDebug(state) {
   if (state) {
     document.getElementById('blocklyDiv').className = 'renderingDebug';
     Blockly.blockRendering.startDebugger();
+    document.getElementById('renderDebugOptions').style.display = 'block';
   } else {
     document.getElementById('blocklyDiv').className = '';
     Blockly.blockRendering.stopDebugger();
+    document.getElementById('renderDebugOptions').style.display = 'none';
   }
 }
 
@@ -434,39 +492,46 @@ var spaghettiXml = [
 </script>
 
 <style>
-html, body {
-  height: 100%;
-}
-body {
-  background-color: #fff;
-  font-family: sans-serif;
-  overflow: hidden;
-}
-h1 {
-  font-weight: normal;
-  font-size: 140%;
-}
-#blocklyDiv {
-  float: right;
-  height: 95%;
-  width: 70%;
-}
-#importExport {
-  font-family: monospace;
-}
+  html, body {
+    height: 100%;
+  }
+  body {
+    background-color: #fff;
+    font-family: sans-serif;
+    overflow: hidden;
+  }
+  h1 {
+    font-weight: normal;
+    font-size: 140%;
+  }
+  #blocklyDiv {
+    float: right;
+    height: 95%;
+    width: 70%;
+  }
+  #importExport {
+    font-family: monospace;
+  }
 
-.ioLabel>.blocklyFlyoutLabelText {
-  font-style: italic;
-}
+  .ioLabel>.blocklyFlyoutLabelText {
+    font-style: italic;
+  }
 
-#blocklyDiv.renderingDebug .blockRenderDebug {
-  display: block;
-}
+  #blocklyDiv.renderingDebug .blockRenderDebug {
+    display: block;
+  }
 
-.blockRenderDebug {
-  display: none;
-}
+  .playgroundToggleOptions {
+    list-style: none;
+    padding: 0;
+  }
+  .playgroundToggleOptions li {
+    margin-top: 1em;
+  }
 
+  .blockRenderDebug {
+    display: none;
+  }
 </style>
 </head>
 <body onload="start()">
@@ -530,20 +595,21 @@ h1 {
     <input type="button" value="Airstrike!" onclick="airstrike(100)">
     <input type="button" value="Spaghetti!" onclick="spaghetti(8)">
   </p>
-  <p>
-    Log events: &nbsp;
-    <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
-  </p>
-
-  <p>
-    Block rendering debug: &nbsp;
-    <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
-  </p>
-
-  <p>
-    Enable Accessibility Mode: &nbsp;
-    <input type="checkbox" onclick="toggleAccessibilityMode(this.checked)" id="accessibilityModeCheck">
-  </p>
+  <ul class="playgroundToggleOptions">
+    <li>
+      <label for="logCheck">Log events:</label>
+      <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
+    </li>
+    <li>
+      <label for="blockRenderDebugCheck">Enable block rendering debug:</label>
+      <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
+      <ul id="renderDebugOptions"></ul>
+    </li>
+    <li>
+      <label for="accessibilityModeCheck">Enable Accessibility Mode:</label>
+      <input type="checkbox" onclick="toggleAccessibilityMode(this.checked)" id="accessibilityModeCheck">
+    </li>
+  </ul>
 
 
   <!-- The next three blocks of XML are sample toolboxes for testing basic


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2904 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds checkboxes to playground for toggling debug rendering options that are dynamically generated (based on defined config object on debugger) and hidden when debug rendering is disabled. The debug rendering options persist in session storage and changing any debug render option triggers re-render.
In this change, the debug config object is changed to be shared across all debuggers, rather than each instance of the debug renderer for each block storing its own object. This simplified logic, but no longer allows for different instances of the debug renderer to have different options (which is expected to be a rare case).

#### Debug rendering disabled
![debugDisabled](https://user-images.githubusercontent.com/6621618/64897335-ec72c280-d637-11e9-8bf5-f77c8654b925.png)

#### Debug rendering enabled with options
![debugEnabled](https://user-images.githubusercontent.com/6621618/64897361-fd233880-d637-11e9-84a1-1ec5eed97ed1.png)

### Reason for Changes

Improves debugging experience.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on playground and checked without session storage for options and with options saved.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->