### PR TITLE
Fix Blockly.utils.global when wrapped in a module.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@ blockly_node_javascript_en.js
 gulpfile.js
 /msg/*
 /core/css.js
+/core/utils/global.js
 /tests/blocks/*
 /tests/compile/*
 /tests/jsunit/*

--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -33,6 +33,22 @@ goog.provide('Blockly.utils.global');
 
 /**
  * Reference to the global object.
+ *
+ * More info on this implementation here:
+ * https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI/edit
  */
-Blockly.utils.global = this || self;
-
+Blockly.utils.global = function() {
+  if (typeof globalThis === 'object') {
+    return globalThis;
+  }
+  if (typeof self === 'object') {
+    return self;
+  }
+  if (typeof window === 'object') {
+    return window;
+  }
+  if (typeof global === 'object') {
+    return global;
+  }
+  return this;
+}();

--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -38,9 +38,6 @@ goog.provide('Blockly.utils.global');
  * https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI/edit
  */
 Blockly.utils.global = function() {
-  if (typeof globalThis === 'object') {
-    return globalThis;
-  }
   if (typeof self === 'object') {
     return self;
   }

--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -19,7 +19,7 @@
  */
 
 /**
- * @fileoverview Core utility methods for Blockly
+ * @fileoverview Provides a reference to the global object.
  * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -509,8 +509,6 @@ function packageCommonJS(namespace, dependencies) {
  */
 gulp.task('package-blockly', function() {
   return gulp.src('blockly_compressed.js')
-    .pipe(gulp.insert.prepend(`
-    var self = this;`))
     .pipe(packageUMD('Blockly', []))
     .pipe(gulp.rename('blockly.js'))
     .pipe(gulp.dest(packageDistribution));
@@ -524,9 +522,8 @@ gulp.task('package-blockly', function() {
 gulp.task('package-blockly-node', function() {
   // Override textToDomDocument, providing a Node.js alternative to DOMParser.
   return gulp.src('blockly_compressed.js')
-    .pipe(gulp.insert.wrap(`
-    var self = global;`,
-      `if (typeof DOMParser !== 'function') {
+    .pipe(gulp.insert.append(`
+      if (typeof DOMParser !== 'function') {
         var JSDOM = require('jsdom').JSDOM;
         var window = (new JSDOM()).window;
         var document = window.document;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3032
An any bugs that arise from Blockly.utils.global not pointing to the global object.

### Proposed Changes

The previous logic in Blockly.utils.global was referencing ``this`` and falling back onto ``self`` if this didn't exist. When Blockly is wrapped in a UMD module, ``this`` references the function scope of the module. 

``self`` points to window in browsers and web-workers. Not generally implemented outside of browsers.
``window`` points to the window object. Not generally implemented outside of in-page browsers.
``global`` points to the global object in Node. Not implemented outside of Node.

I left out ``globalThis`` as it's not widely implemented outside of V8.

### Reason for Changes

### Test Coverage

Tested Blockly samples, webpack, react and node.

Tested on:
* Desktop Chrome
* Desktop Firefox

### Additional Information

This closure library doc has further context on implementation: 
https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI/edit#
