### PR TITLE
Cache dynamic dropdown options

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -433,7 +433,6 @@ Blockly.FieldDropdown.prototype.isOptionListDynamic = function() {
  *     cached options or to re-generate them.
  * @return {!Array.<!Array>} A non-empty array of option tuples:
  *     (human-readable text or image, language-neutral name).
- * @throws If generated options are incorrectly structured.
  */
 Blockly.FieldDropdown.prototype.getOptions = function(opt_useCache) {
   if (this.isOptionListDynamic()) {
@@ -599,7 +598,7 @@ Blockly.FieldDropdown.prototype.getText_ = function() {
 /**
  * Validates the data structure to be processed as an options list.
  * @param {?} options The proposed dropdown options.
- * @throws If proposed options are incorrectly structured.
+ * @throws {TypeError} If proposed options are incorrectly structured.
  * @private
  */
 Blockly.FieldDropdown.validateOptions_ = function(options) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -83,7 +83,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   this.selectedIndex_ = 0;
 
   this.trimOptions_();
-  var options = this.getOptions(true);
+  var options = this.getOptions(false);
   var firstTuple = options[0];
 
   // Call parent's constructor.
@@ -238,7 +238,7 @@ Blockly.FieldDropdown.prototype.widgetCreate_ = function() {
   menu.setRightToLeft(this.sourceBlock_.RTL);
   menu.setRole('listbox');
 
-  var options = this.getOptions(true);
+  var options = this.getOptions(false);
   this.selectedMenuItem_ = null;
   for (var i = 0; i < options.length; i++) {
     var content = options[i][0]; // Human-readable text or image.
@@ -438,7 +438,7 @@ Blockly.FieldDropdown.prototype.isOptionListDynamic = function() {
  */
 Blockly.FieldDropdown.prototype.getOptions = function(opt_useCache) {
   if (this.isOptionListDynamic()) {
-    if (!opt_useCache || !this.generatedOptions_) {
+    if (!this.generatedOptions_ || !opt_useCache) {
       this.generatedOptions_ = this.menuGenerator_.call(this);
       Blockly.FieldDropdown.validateOptions_(this.generatedOptions_);
     }
@@ -455,7 +455,7 @@ Blockly.FieldDropdown.prototype.getOptions = function(opt_useCache) {
  */
 Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
   var isValueValid = false;
-  var options = this.getOptions(false);
+  var options = this.getOptions(true);
   for (var i = 0, option; option = options[i]; i++) {
     // Options are tuples of human-readable text and language-neutral values.
     if (option[1] == opt_newValue) {
@@ -481,7 +481,7 @@ Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
  */
 Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {
   Blockly.FieldDropdown.superClass_.doValueUpdate_.call(this, newValue);
-  var options = this.getOptions(false);
+  var options = this.getOptions(true);
   for (var i = 0, option; option = options[i]; i++) {
     if (option[1] == this.value_) {
       this.selectedIndex_ = i;
@@ -514,7 +514,7 @@ Blockly.FieldDropdown.prototype.render_ = function() {
   this.imageElement_.style.display = 'none';
 
   // Show correct element.
-  var options = this.getOptions(false);
+  var options = this.getOptions(true);
   var selectedOption = this.selectedIndex_ >= 0 &&
       options[this.selectedIndex_][0];
   if (selectedOption && typeof selectedOption == 'object') {
@@ -589,7 +589,7 @@ Blockly.FieldDropdown.prototype.getText_ = function() {
   if (this.selectedIndex_ < 0) {
     return null;
   }
-  var options = this.getOptions(false);
+  var options = this.getOptions(true);
   var selectedOption = options[this.selectedIndex_][0];
   if (typeof selectedOption == 'object') {
     return selectedOption['alt'];

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -83,8 +83,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   this.selectedIndex_ = 0;
 
   this.trimOptions_();
-  var options = this.getOptions(false);
-  var firstTuple = options[0];
+  var firstTuple = this.getOptions(false)[0];
 
   // Call parent's constructor.
   Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -53,6 +53,7 @@ goog.require('Blockly.utils.userAgent');
  *    abort the change.
  * @extends {Blockly.Field}
  * @constructor
+ * @throws {TypeError} If `menuGenerator` options are incorrectly structured.
  */
 Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   if (typeof menuGenerator != 'function') {
@@ -433,6 +434,7 @@ Blockly.FieldDropdown.prototype.isOptionListDynamic = function() {
  *     cached options or to re-generate them.
  * @return {!Array.<!Array>} A non-empty array of option tuples:
  *     (human-readable text or image, language-neutral name).
+ * @throws {TypeError} If generated options are incorrectly structured.
  */
 Blockly.FieldDropdown.prototype.getOptions = function(opt_useCache) {
   if (this.isOptionListDynamic()) {

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1210,3 +1210,21 @@ Blockly.TestBlocks.removeDynamicDropdownOption_ = function() {
     }
   })
 };
+
+Blockly.Blocks['test_dropdowns_dynamic_random'] = {
+  init: function() {
+    var dropdown = new Blockly.FieldDropdown(this.dynamicOptions);
+    this.appendDummyInput()
+      .appendField('dynamic random')
+      .appendField(dropdown, 'OPTIONS');
+  },
+
+  dynamicOptions: function() {
+    var random = Math.floor(Math.random() * 10) + 1;
+    var options = [];
+    for (var i = 0; i < random; i++) {
+      options.push([String(i), String(i)]);
+    }
+    return options;
+  }
+};

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1468,6 +1468,7 @@ var spaghettiXml = [
         <block type="test_dropdowns_dynamic"></block>
         <button text="Add option" callbackKey="addDynamicOption"></button>
         <button text="Remove option" callbackKey="removeDynamicOption"></button>
+        <block type="test_dropdowns_dynamic_random"></block>
         <label text="Other"></label>
         <block type="test_dropdowns_long"></block>
         <block type="test_dropdowns_images"></block>


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2493
https://github.com/google/blockly/issues/2926

### Proposed Changes
Only generate options during inialization (as we need the first tuple) and when a use clicks on the field to open it. (ie: when the editor is shown / widget is created). 

### Reason for Changes

Be more efficient about calling a dynamic dropdown function and not break in places where we expect certain options to be available. 

### Test Coverage

Tested the playground, and added a new test dropdown block that returns a random number of items every time the generate method is called. 

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
