### PR TITLE
Creating cursordrawer in renderer.

### DIFF
--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -68,8 +68,7 @@ Blockly.CursorSvg = function(workspace, opt_marker) {
    * @type {Blockly.blockRendering.ConstantProvider}
    * @private
    */
-  this.constants_ = new Blockly.blockRendering.ConstantProvider();
-  this.constants_.init();
+  this.constants_ = workspace.getRenderer().getConstants();
 };
 
 /**

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -32,6 +32,7 @@ goog.require('Blockly.blockRendering.Drawer');
 goog.require('Blockly.blockRendering.IPathObject');
 goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.CursorSvg');
 
 
 /**
@@ -50,7 +51,7 @@ Blockly.blockRendering.Renderer = function() {
 };
 
 /**
- * Initialize the renderer
+ * Initialize the renderer.
  * @package
  */
 Blockly.blockRendering.Renderer.prototype.init = function() {
@@ -99,6 +100,19 @@ Blockly.blockRendering.Renderer.prototype.makeDebugger_ = function() {
 };
 
 /**
+ * Create a new instance of the renderer's cursor drawer
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace the cursor belongs to.
+ * @param {boolean=} opt_marker True if the cursor is a marker. A marker is used
+ *     to save a location and is an immovable cursor. False or undefined if the
+ *     cursor is not a marker.
+ * @return {!Blockly.CursorSvg} The cursor drawer.
+ * @package
+ */
+Blockly.blockRendering.Renderer.prototype.makeCursorDrawer = function(workspace, opt_marker) {
+  return new Blockly.CursorSvg(workspace, opt_marker);
+};
+
+/**
  * Create a new instance of a renderer path object.
  * @param {!SVGElement} root The root SVG element.
  * @return {!Blockly.blockRendering.IPathObject} The renderer path object.
@@ -133,4 +147,3 @@ Blockly.blockRendering.Renderer.prototype.render = function(block) {
   info.measure();
   this.makeDrawer_(block, info).draw();
 };
-

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -100,7 +100,7 @@ Blockly.blockRendering.Renderer.prototype.makeDebugger_ = function() {
 };
 
 /**
- * Create a new instance of the renderer's cursor drawer
+ * Create a new instance of the renderer's cursor drawer.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace the cursor belongs to.
  * @param {boolean=} opt_marker True if the cursor is a marker. A marker is used
  *     to save a location and is an immovable cursor. False or undefined if the
@@ -108,7 +108,8 @@ Blockly.blockRendering.Renderer.prototype.makeDebugger_ = function() {
  * @return {!Blockly.CursorSvg} The cursor drawer.
  * @package
  */
-Blockly.blockRendering.Renderer.prototype.makeCursorDrawer = function(workspace, opt_marker) {
+Blockly.blockRendering.Renderer.prototype.makeCursorDrawer = function(
+    workspace, opt_marker) {
   return new Blockly.CursorSvg(workspace, opt_marker);
 };
 

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -119,14 +119,14 @@ Blockly.Workspace = function(opt_options) {
 
   /**
    * The cursor used to navigate around the AST for keyboard navigation.
-   * @type {Blockly.Cursor}
+   * @type {!Blockly.Cursor}
    * @protected
    */
   this.cursor_ = new Blockly.Cursor();
 
   /**
    * The marker used to mark a location for keyboard navigation.
-   * @type {Blockly.MarkerCursor}
+   * @type {!Blockly.MarkerCursor}
    * @protected
    */
   this.marker_ = new Blockly.MarkerCursor();

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -122,24 +122,20 @@ Blockly.Workspace = function(opt_options) {
    * @type {Blockly.Cursor}
    * @protected
    */
-  this.cursor_ = null;
+  this.cursor_ = new Blockly.Cursor();
 
   /**
    * The marker used to mark a location for keyboard navigation.
    * @type {Blockly.MarkerCursor}
    * @protected
    */
-  this.marker_ = null;
+  this.marker_ = new Blockly.MarkerCursor();
 
   // Set the default theme. This is for headless workspaces. This will get
   // overwritten by the theme passed into the inject call for rendered workspaces.
   if (!Blockly.getTheme()) {
     Blockly.setTheme(Blockly.Themes.Classic);
   }
-
-  this.setCursor(new Blockly.Cursor());
-
-  this.setMarker(new Blockly.MarkerCursor());
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -139,15 +139,15 @@ Blockly.WorkspaceSvg = function(options,
     this.registerToolboxCategoryCallback(Blockly.PROCEDURE_CATEGORY_NAME,
         Blockly.Procedures.flyoutCategory);
   }
+
+  /**
+   * The block renderer used for rendering blocks on this workspace.
+   * @type {!Blockly.blockRendering.Renderer}
+   * @private
+   */
+  this.renderer_ = Blockly.blockRendering.init(this.options.renderer || 'geras');
 };
 Blockly.utils.object.inherits(Blockly.WorkspaceSvg, Blockly.Workspace);
-
-/**
- * The block renderer used for rendering blocks on this workspace.
- * @type {!Blockly.blockRendering.Renderer}
- * @private
- */
-Blockly.WorkspaceSvg.prototype.renderer_ = undefined;
 
 /**
  * A wrapper function called when a resize event occurs.
@@ -419,20 +419,17 @@ Blockly.WorkspaceSvg.prototype.inverseScreenCTMDirty_ = true;
  * @return {!Blockly.blockRendering.Renderer} The renderer attached to this workspace.
  */
 Blockly.WorkspaceSvg.prototype.getRenderer = function() {
-  if (!this.renderer_) {
-    this.renderer_ =
-        Blockly.blockRendering.init(this.options.renderer || 'geras');
-  }
   return this.renderer_;
 };
 
 /**
  * Sets the cursor for use with keyboard navigation.
+ *
  * @param {Blockly.Cursor} cursor The cursor used to move around this workspace.
  * @override
  */
 Blockly.WorkspaceSvg.prototype.setCursor = function(cursor) {
-  if (this.cursor_) {
+  if (this.cursor_ && this.cursor_.getDrawer()) {
     this.cursor_.getDrawer().dispose();
   }
   this.cursor_ = cursor;
@@ -449,7 +446,7 @@ Blockly.WorkspaceSvg.prototype.setCursor = function(cursor) {
  * @override
  */
 Blockly.WorkspaceSvg.prototype.setMarker = function(marker) {
-  if (this.marker_) {
+  if (this.marker_ && this.marker_.getDrawer()) {
     this.marker_.getDrawer().dispose();
   }
   this.marker_ = marker;
@@ -666,9 +663,11 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   }
   this.recordDeleteAreas();
 
+  this.cursor_.setDrawer(this.getRenderer().makeCursorDrawer(this, false));
   var svgCursor = this.cursor_.getDrawer().createDom();
   this.svgGroup_.appendChild(svgCursor);
 
+  this.marker_.setDrawer(this.getRenderer().makeCursorDrawer(this, true));
   var svgMarker = this.marker_.getDrawer().createDom();
   this.svgGroup_.appendChild(svgMarker);
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -139,15 +139,15 @@ Blockly.WorkspaceSvg = function(options,
     this.registerToolboxCategoryCallback(Blockly.PROCEDURE_CATEGORY_NAME,
         Blockly.Procedures.flyoutCategory);
   }
-
-  /**
-   * The block renderer used for rendering blocks on this workspace.
-   * @type {!Blockly.blockRendering.Renderer}
-   * @private
-   */
-  this.renderer_ = Blockly.blockRendering.init(this.options.renderer || 'geras');
 };
 Blockly.utils.object.inherits(Blockly.WorkspaceSvg, Blockly.Workspace);
+
+/**
+ * The block renderer used for rendering blocks on this workspace.
+ * @type {!Blockly.blockRendering.Renderer}
+ * @private
+ */
+Blockly.WorkspaceSvg.prototype.renderer_ = undefined;
 
 /**
  * A wrapper function called when a resize event occurs.
@@ -419,6 +419,10 @@ Blockly.WorkspaceSvg.prototype.inverseScreenCTMDirty_ = true;
  * @return {!Blockly.blockRendering.Renderer} The renderer attached to this workspace.
  */
 Blockly.WorkspaceSvg.prototype.getRenderer = function() {
+  if (!this.renderer_) {
+    this.renderer_ =
+        Blockly.blockRendering.init(this.options.renderer || 'geras');
+  }
   return this.renderer_;
 };
 
@@ -433,7 +437,7 @@ Blockly.WorkspaceSvg.prototype.setCursor = function(cursor) {
   }
   this.cursor_ = cursor;
   if (this.cursor_) {
-    this.cursor_.setDrawer(new Blockly.CursorSvg(this, false));
+    this.cursor_.setDrawer(this.getRenderer().makeCursorDrawer(this, false));
     this.setCursorSvg(this.cursor_.getDrawer().createDom());
   }
 };
@@ -450,7 +454,7 @@ Blockly.WorkspaceSvg.prototype.setMarker = function(marker) {
   }
   this.marker_ = marker;
   if (this.marker_) {
-    this.marker_.setDrawer(new Blockly.CursorSvg(this, true));
+    this.marker_.setDrawer(this.getRenderer().makeCursorDrawer(this, true));
     this.setMarkerSvg(this.marker_.getDrawer().createDom());
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Moves initialization of drawer for cursor to the renderer, rather than in the WorkspaceSvg constructor.
Additionally, in order to have access to the renderer when setCursor and setMarker are called, the initialization of the renderer was moved to getRenderer(), so the renderer is now initialized at the first time getRenderer is called, rather than in the WorkspaceSvg constructor. At this time, this means that the renderer is initialized at the overridden setCursor call for WorkspaceSvg (inside of the super constructor call).
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

We expect some people to customize their cursor, so moving the initialization to the renderer gives more flexibility for changing what implementation of the cursor drawer to call.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested in playground.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
