### PR TITLE
Remove now unneeded requires from compile test.

### DIFF
--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -2,11 +2,6 @@ goog.provide('Main');
 // Core
 // Either require 'Blockly.requires', or just the components you use:
 goog.require('Blockly');
-goog.require('Blockly.FieldDropdown');
-goog.require('Blockly.FieldImage');
-goog.require('Blockly.FieldNumber');
-goog.require('Blockly.FieldTextInput');
-goog.require('Blockly.FieldVariable');
 goog.require('Blockly.geras.Renderer');
 // Blocks
 goog.require('Blockly.Constants.Logic');


### PR DESCRIPTION
The block files now handle the requires for these fields.