### PR TITLE
Fix field sizing issue when workspace is hidden

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -532,6 +532,22 @@ Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
   return new Blockly.utils.Rect(top, bottom, left, right);
 };
 
+
+/**
+ * Toggles the visibility of the block.
+ * @param {boolean} isVisible True if block should be visible.
+ */
+Blockly.BlockSvg.prototype.setVisible = function(isVisible) {
+  var display = isVisible ? 'block' : 'none';
+
+  this.getSvgRoot().style.display = display;
+
+  // Show/hide the inputs.
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    input.setVisible(isVisible);
+  }
+};
+
 /**
  * Set whether the block is collapsed or not.
  * @param {boolean} collapsed True if collapsed.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1068,10 +1068,20 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
     // Currently does not support toolboxes in mutators.
     this.toolbox_.HtmlDiv.style.display = isVisible ? 'block' : 'none';
   }
+
+  // Set visibility of all blocks.
+  var blocks = this.getAllBlocks(false);
+  for (var i = blocks.length - 1; i >= 0; i--) {
+    blocks[i].setVisible(isVisible);
+  }
+
   if (isVisible) {
     this.render();
     if (this.toolbox_) {
       this.toolbox_.position();
+    }
+    if (this.scrollbar) {
+      this.scrollbar.resize();
     }
   } else {
     Blockly.hideChaff(true);

--- a/core/xml.js
+++ b/core/xml.js
@@ -541,6 +541,7 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
       topBlock.setConnectionsHidden(true);
       // Render each block.
       for (var i = blocks.length - 1; i >= 0; i--) {
+        blocks[i].setVisible(workspace.isVisible());
         blocks[i].initSvg();
       }
       for (var i = blocks.length - 1; i >= 0; i--) {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2811

### Proposed Changes

When a workspace is hidden, hide the blocks too, which in turn hides its inputs.
Vice versa when the workspace is shown. 

This makes it so that when blocks enter the workspace when it's not visible, they are not rendered. When the workspace restores visibility, they are then rendered.

For blocks that are currently on the workspace and rendered, they are merely hidden, and their visibility is restored when the workspace is set to visible. 

### Reason for Changes

Bug in field sizing when blocks enter the workspace while it's hidden. 

### Test Coverage

Hiding the playground, importing blocks and then showing it.

Tested on:
* Desktop Chrome
* Desktop Safari

### Additional Information

@BeksOmega thoughts on this solution? It's pretty similar to what you proposed in the bug.