### PR TITLE
Make trashcan and zoomcontrols optional modules.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -33,7 +33,6 @@ goog.require('Blockly.ContextMenu');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Events.BlockMove');
-goog.require('Blockly.Grid');
 goog.require('Blockly.Msg');
 goog.require('Blockly.RenderedConnection');
 goog.require('Blockly.Tooltip');

--- a/core/requires.js
+++ b/core/requires.js
@@ -29,6 +29,7 @@ goog.provide('Blockly.requires');
 
 // Blockly Core.
 goog.require('Blockly');
+goog.require('Blockly.Trashcan');
 // Blockly Fields.
 goog.require('Blockly.FieldAngle');
 goog.require('Blockly.FieldCheckbox');

--- a/core/requires.js
+++ b/core/requires.js
@@ -30,6 +30,7 @@ goog.provide('Blockly.requires');
 // Blockly Core.
 goog.require('Blockly');
 goog.require('Blockly.Trashcan');
+goog.require('Blockly.ZoomControls');
 // Blockly Fields.
 goog.require('Blockly.FieldAngle');
 goog.require('Blockly.FieldCheckbox');

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -41,7 +41,6 @@ goog.require('Blockly.Options');
 goog.require('Blockly.ScrollbarPair');
 goog.require('Blockly.Touch');
 goog.require('Blockly.TouchGesture');
-goog.require('Blockly.Trashcan');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
@@ -766,6 +765,9 @@ Blockly.WorkspaceSvg.prototype.newBlock = function(prototypeName, opt_id) {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.addTrashcan = function() {
+  if (!Blockly.Trashcan) {
+    throw Error('Missing require for Blockly.Trashcan');
+  }
   /** @type {Blockly.Trashcan} */
   this.trashcan = new Blockly.Trashcan(this);
   var svgTrashcan = this.trashcan.createDom();

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -54,7 +54,6 @@ goog.require('Blockly.WorkspaceCommentSvg');
 goog.require('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.Xml');
-goog.require('Blockly.ZoomControls');
 
 
 /**
@@ -779,6 +778,9 @@ Blockly.WorkspaceSvg.prototype.addTrashcan = function() {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
+  if (!Blockly.ZoomControls) {
+    throw Error('Missing require for Blockly.ZoomControls');
+  }
   /** @type {Blockly.ZoomControls} */
   this.zoomControls_ = new Blockly.ZoomControls(this);
   var svgZoomControls = this.zoomControls_.createDom();


### PR DESCRIPTION
Saves 6 KB when compiled if there is no trashcan nor zoomcontrols.