### PR TITLE
Changed multiline field to use new configuration

### DIFF
--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -26,7 +26,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.FieldMultilineCode');
+goog.provide('Blockly.FieldMultilineInput');
 
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.FieldTextInput');

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -26,7 +26,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.FieldMultilineInput');
+goog.provide('Blockly.FieldMultilineCode');
 
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.FieldTextInput');
@@ -46,15 +46,20 @@ goog.require('Blockly.utils.userAgent');
  *     to validate any constraints on what the user entered.  Takes the new
  *     text as an argument and returns either the accepted text, a replacement
  *     text, or null to abort the change.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.FieldTextInput}
  * @constructor
  */
-Blockly.FieldMultilineInput = function(opt_value, opt_validator) {
-  if (opt_value === null) {
+Blockly.FieldMultilineInput = function(opt_value, opt_validator, opt_config) {
+  // TODO: Once this field is documented the opt_config link should point to its
+  //  creation documentation, rather than the text input field's.
+  if (opt_value == null) {
     opt_value = '';
   }
   Blockly.FieldMultilineInput.superClass_.constructor.call(this,
-      opt_value, opt_validator);
+      opt_value, opt_validator, opt_config);
 };
 Blockly.utils.object.inherits(Blockly.FieldMultilineInput,
     Blockly.FieldTextInput);
@@ -70,19 +75,14 @@ Blockly.FieldMultilineInput.LINE_HEIGHT = 20;
 /**
  * Construct a FieldMultilineInput from a JSON arg object,
  * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (text, class, and
- *                          spellcheck).
+ * @param {!Object} options A JSON object with options (text, and spellcheck).
  * @return {!Blockly.FieldMultilineInput} The new field instance.
  * @package
  * @nocollapse
  */
 Blockly.FieldMultilineInput.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  var field = new Blockly.FieldMultilineInput(text);
-  if (typeof options['spellcheck'] === 'boolean') {
-    field.setSpellcheck(options['spellcheck']);
-  }
-  return field;
+  return new Blockly.FieldMultilineInput(text, null, options);
 };
 
 /**

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -82,7 +82,7 @@ Blockly.FieldMultilineInput.LINE_HEIGHT = 20;
  */
 Blockly.FieldMultilineInput.fromJson = function(options) {
   var text = Blockly.utils.replaceMessageReferences(options['text']);
-  return new Blockly.FieldMultilineInput(text, null, options);
+  return new Blockly.FieldMultilineInput(text, undefined, options);
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -73,8 +73,7 @@ Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 /**
  * Construct a FieldTextInput from a JSON arg object,
  * dereferencing any string table references.
- * @param {!Object} options A JSON object with options (text, class, and
- *                          spellcheck).
+ * @param {!Object} options A JSON object with options (text, and spellcheck).
  * @return {!Blockly.FieldTextInput} The new field instance.
  * @package
  * @nocollapse

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -273,6 +273,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": ""
   },
   {
+    "type": "test_fields_multilinetext",
+    "message0": "code %1",
+    "args0": [
+      {
+        "type": "field_multilinetext",
+        "name": "CODE",
+        "text": "default1\ndefault2"
+      }
+    ],
+    "style": "math_blocks",
+    "tooltip": "test tooltip"
+  },
+  {
     "type": "test_fields_checkbox",
     "message0": "checkbox %1",
     "args0": [

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1435,6 +1435,7 @@ var spaghettiXml = [
         <block type="test_fields_colour"></block>
         <block type="test_fields_colour_options"></block>
         <block type="test_fields_text_input"></block>
+        <block type="test_fields_multilinetext"></block>
         <block type="test_fields_variable"></block>
         <button text="randomize label text" callbackKey="randomizeLabelText"></button>
         <sep gap="12"></sep>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2722 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Gives the multinline input field an opt_config parameter.

Also I fixed a little text input doc bug.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

Currently the field doesn't have any of its own config options, but now it can support tooltips and spellcheck correctly.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
I didn't add any configuration tests because this field doesn't have any options of its own, but I did add a test block, and everything seems to be working.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
When the multiline input field gets written up, its creation section should include info about its config properties.

### Additional Information

<!-- Anything else we should know? -->
N/A
