### PR TITLE
Fixed scrolling the trashcan flyout with mouse

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -342,14 +342,14 @@ Blockly.hideChaff = function(opt_allowToolbox) {
   Blockly.Tooltip.hide();
   Blockly.WidgetDiv.hide();
   Blockly.DropDownDiv.hideWithoutAnimation();
-  // For now the trashcan flyout always autocloses because it overlays the
-  // trashcan UI (no trashcan to click to close it)
-  var workspace = Blockly.getMainWorkspace();
-  if (workspace.trashcan &&
-      workspace.trashcan.flyout_) {
-    workspace.trashcan.flyout_.hide();
-  }
   if (!opt_allowToolbox) {
+    var workspace = Blockly.getMainWorkspace();
+    // For now the trashcan flyout always autocloses because it overlays the
+    // trashcan UI (no trashcan to click to close it).
+    if (workspace.trashcan &&
+      workspace.trashcan.flyout_) {
+      workspace.trashcan.flyout_.hide();
+    }
     if (workspace.toolbox_ &&
         workspace.toolbox_.flyout_ &&
         workspace.toolbox_.flyout_.autoClose) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #3008 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so you can scroll the trashcan flyout with mouse/touch input.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Mobile users need to be able to scroll with mouse/touch.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Tested scrolling the trashcan flyout using mouse input on the flyout background, and on the scrollbars, for every workspace on the multiplayground.

Also tested that clicking on the workspace surface/blocks still closes the flyout, which it does.

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
How's this fix look to you @samelhusseini ?

I looked through all the hideChaff calls, and I think this is the correct behavior.
