### PR TITLE
Don't insert disabled blocks from the flyout.

### DIFF
--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -304,6 +304,7 @@ Blockly.navigation.insertFromFlyout = function() {
 
   var curBlock = Blockly.navigation.getFlyoutCursor_().getCurNode().getLocation();
   if (!curBlock.isEnabled()) {
+    Blockly.navigation.warn_('Can\'t insert a disabled block.');
     return;
   }
 

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -302,8 +302,12 @@ Blockly.navigation.insertFromFlyout = function() {
     return;
   }
 
-  var newBlock = flyout.createBlock(
-      Blockly.navigation.getFlyoutCursor_().getCurNode().getLocation());
+  var curBlock = Blockly.navigation.getFlyoutCursor_().getCurNode().getLocation();
+  if (!curBlock.isEnabled()) {
+    return;
+  }
+
+  var newBlock = flyout.createBlock(curBlock);
   // Render to get the sizing right.
   newBlock.render();
   // Connections are hidden when the block is first created.  Normally there's


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Don't insert disabled blocks from the flyout.

### Reason for Changes
Match mouse behaviour. 


