### PR TITLE
Merge toolbox navigation 

### DIFF
--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -1206,7 +1206,7 @@ Blockly.tree.BaseNode.prototype.selectParent = function() {
  * Expand the current node if it's not already expanded, or select the
  * child node.
  * @return {boolean} True if the action has been handled, false otherwise.
- * @protected
+ * @package
  */
 Blockly.tree.BaseNode.prototype.selectChild = function() {
   if (this.hasChildren()) {

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -1127,43 +1127,22 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
       if (e.altKey) {
         break;
       }
-      if (this.hasChildren()) {
-        if (!this.getExpanded()) {
-          this.setExpanded(true);
-        } else {
-          this.getFirstChild().select();
-        }
-      }
+      handled = this.selectChild();
       break;
 
     case Blockly.utils.KeyCodes.LEFT:
       if (e.altKey) {
         break;
       }
-      if (this.hasChildren() && this.getExpanded() && this.isUserCollapsible_) {
-        this.setExpanded(false);
-      } else {
-        var parent = this.getParent();
-        var tree = this.getTree();
-        // don't go to root if hidden
-        if (parent && (parent != tree)) {
-          parent.select();
-        }
-      }
+      handled = this.selectParent();
       break;
 
     case Blockly.utils.KeyCodes.DOWN:
-      var nextNode = this.getNextShownNode();
-      if (nextNode) {
-        nextNode.select();
-      }
+      handled = this.selectNext();
       break;
 
     case Blockly.utils.KeyCodes.UP:
-      var previousNode = this.getPreviousShownNode();
-      if (previousNode) {
-        previousNode.select();
-      }
+      handled = this.selectPrevious();
       break;
 
     default:
@@ -1175,6 +1154,70 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
   }
 
   return handled;
+};
+
+
+/**
+ * Select the next node.
+ * @return {boolean} True if the field handled the action, false otherwise.
+ * @package
+ */
+Blockly.tree.BaseNode.prototype.selectNext = function() {
+  var nextNode = this.getNextShownNode();
+  if (nextNode) {
+    nextNode.select();
+  }
+  return true;
+};
+
+/**
+ * Select the previous node.
+ * @return {boolean} True if the field handled the action, false otherwise.
+ * @package
+ */
+Blockly.tree.BaseNode.prototype.selectPrevious = function() {
+  var previousNode = this.getPreviousShownNode();
+  if (previousNode) {
+    previousNode.select();
+  }
+  return true;
+};
+
+/**
+ * Select the parent node or collapse the current node.
+ * @return {boolean} True if the field handled the action, false otherwise.
+ * @package
+ */
+Blockly.tree.BaseNode.prototype.selectParent = function() {
+  if (this.hasChildren() && this.getExpanded() && this.isUserCollapsible_) {
+    this.setExpanded(false);
+  } else {
+    var parent = this.getParent();
+    var tree = this.getTree();
+    // don't go to root if hidden
+    if (parent && (parent != tree)) {
+      parent.select();
+    }
+  }
+  return true;
+};
+
+/**
+ * Expand the current node if it's not already expanded, or select the
+ * child node.
+ * @return {boolean} True if the field handled the action, false otherwise.
+ * @protected
+ */
+Blockly.tree.BaseNode.prototype.selectChild = function() {
+  if (this.hasChildren()) {
+    if (!this.getExpanded()) {
+      this.setExpanded(true);
+    } else {
+      this.getFirstChild().select();
+    }
+    return true;
+  }
+  return false;
 };
 
 /**

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -1159,7 +1159,7 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
 
 /**
  * Select the next node.
- * @return {boolean} True if the field handled the action, false otherwise.
+ * @return {boolean} True if the action has been handled, false otherwise.
  * @package
  */
 Blockly.tree.BaseNode.prototype.selectNext = function() {
@@ -1172,7 +1172,7 @@ Blockly.tree.BaseNode.prototype.selectNext = function() {
 
 /**
  * Select the previous node.
- * @return {boolean} True if the field handled the action, false otherwise.
+ * @return {boolean} True if the action has been handled, false otherwise.
  * @package
  */
 Blockly.tree.BaseNode.prototype.selectPrevious = function() {
@@ -1185,7 +1185,7 @@ Blockly.tree.BaseNode.prototype.selectPrevious = function() {
 
 /**
  * Select the parent node or collapse the current node.
- * @return {boolean} True if the field handled the action, false otherwise.
+ * @return {boolean} True if the action has been handled, false otherwise.
  * @package
  */
 Blockly.tree.BaseNode.prototype.selectParent = function() {
@@ -1205,7 +1205,7 @@ Blockly.tree.BaseNode.prototype.selectParent = function() {
 /**
  * Expand the current node if it's not already expanded, or select the
  * child node.
- * @return {boolean} True if the field handled the action, false otherwise.
+ * @return {boolean} True if the action has been handled, false otherwise.
  * @protected
  */
 Blockly.tree.BaseNode.prototype.selectChild = function() {

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -40,7 +40,7 @@ goog.require('Blockly.utils.style');
  *
  * @param {string} content The content of the node label treated as
  *     plain-text and will be HTML escaped.
- * @param {Blockly.tree.BaseNode.Config} config The configuration for the tree.
+ * @param {!Blockly.tree.BaseNode.Config} config The configuration for the tree.
  * @constructor
  * @extends {Blockly.Component}
  */
@@ -49,7 +49,7 @@ Blockly.tree.BaseNode = function(content, config) {
 
   /**
    * The configuration for the tree.
-   * @type {Blockly.tree.BaseNode.Config}
+   * @type {!Blockly.tree.BaseNode.Config}
    * @private
    */
   this.config_ = config;
@@ -488,6 +488,17 @@ Blockly.tree.BaseNode.prototype.select = function() {
 };
 
 /**
+ * Selects the first node.
+ * @protected
+ */
+Blockly.tree.BaseNode.prototype.selectFirst = function() {
+  var tree = this.getTree();
+  if (tree && this.firstChild_) {
+    tree.setSelectedItem(this.firstChild_);
+  }
+};
+
+/**
  * Called from the tree to instruct the node change its selection state.
  * @param {boolean} selected The new selection state.
  * @protected
@@ -885,7 +896,7 @@ Blockly.tree.BaseNode.prototype.getElement = function() {
 /**
  * @return {Element} The row is the div that is used to draw the node without
  *     the children.
- * @protected
+ * @package
  */
 Blockly.tree.BaseNode.prototype.getRowElement = function() {
   var el = this.getElement();
@@ -1222,7 +1233,7 @@ Blockly.tree.BaseNode.prototype.getPreviousShownNode = function() {
 };
 
 /**
- * @return {Blockly.tree.BaseNode.Config} The configuration for the tree.
+ * @return {!Blockly.tree.BaseNode.Config} The configuration for the tree.
  * @protected
  */
 Blockly.tree.BaseNode.prototype.getConfig = function() {

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -40,7 +40,7 @@ goog.require('Blockly.utils.style');
  * Similar to Closure's goog.ui.tree.TreeControl
  *
  * @param {Blockly.Toolbox} toolbox The parent toolbox for this tree.
- * @param {Blockly.tree.BaseNode.Config} config The configuration for the tree.
+ * @param {!Blockly.tree.BaseNode.Config} config The configuration for the tree.
  * @constructor
  * @extends {Blockly.tree.BaseNode}
  */

--- a/core/components/tree/treenode.js
+++ b/core/components/tree/treenode.js
@@ -39,7 +39,7 @@ goog.require('Blockly.utils.KeyCodes');
  * @param {Blockly.Toolbox} toolbox The parent toolbox for this tree.
  * @param {string} content The content of the node label treated as
  *     plain-text and will be HTML escaped.
- * @param {Blockly.tree.BaseNode.Config} config The configuration for the tree.
+ * @param {!Blockly.tree.BaseNode.Config} config The configuration for the tree.
  * @constructor
  * @extends {Blockly.tree.BaseNode}
  */

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -31,6 +31,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
+goog.require('Blockly.navigation');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.dom');

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -836,6 +836,7 @@ Blockly.navigation.toolboxOnAction_ = function(action) {
   var handled = toolbox.onBlocklyAction(action);
   if (!handled && action.name === Blockly.navigation.actionNames.IN) {
     Blockly.navigation.focusFlyout_();
+    return true;
   }
 
   return handled;

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -146,7 +146,7 @@ Blockly.navigation.focusToolbox_ = function() {
   if (!Blockly.getMainWorkspace().getMarker().getCurNode()) {
     Blockly.navigation.markAtCursor_();
   }
-  toolbox.selectFirst();
+  toolbox.selectFirstCategory();
 };
 
 /***********************/

--- a/core/theme.js
+++ b/core/theme.js
@@ -27,6 +27,20 @@ goog.provide('Blockly.Theme');
 
 
 /**
+ * Class for a theme.
+ * @param {!Object.<string, Blockly.Theme.BlockStyle>} blockStyles A map from style
+ *     names (strings) to objects with style attributes relating to blocks.
+ * @param {!Object.<string, Blockly.Theme.CategoryStyle>} categoryStyles A map from
+ *     style names (strings) to objects with style attributes relating to
+ *     categories.
+ * @constructor
+ */
+Blockly.Theme = function(blockStyles, categoryStyles) {
+  this.blockStyles_ = blockStyles;
+  this.categoryStyles_ = categoryStyles;
+};
+
+/**
  * A block style.
  * @typedef {{
   *            colourPrimary:string,
@@ -44,20 +58,6 @@ Blockly.Theme.BlockStyle;
   *          }}
   */
 Blockly.Theme.CategoryStyle;
-
-/**
- * Class for a theme.
- * @param {!Object.<string, Blockly.Theme.BlockStyle>} blockStyles A map from style
- *     names (strings) to objects with style attributes relating to blocks.
- * @param {!Object.<string, Blockly.Theme.CategoryStyle>} categoryStyles A map from
- *     style names (strings) to objects with style attributes relating to
- *     categories.
- * @constructor
- */
-Blockly.Theme = function(blockStyles, categoryStyles) {
-  this.blockStyles_ = blockStyles;
-  this.categoryStyles_ = categoryStyles;
-};
 
 /**
  * Overrides or adds all values from blockStyles to blockStyles_

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -30,6 +30,7 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Flyout');
 goog.require('Blockly.HorizontalFlyout');
+goog.require('Blockly.navigation');
 goog.require('Blockly.Touch');
 goog.require('Blockly.tree.TreeControl');
 goog.require('Blockly.tree.TreeNode');

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -683,7 +683,7 @@ Blockly.Toolbox.prototype.refreshSelection = function() {
  * Select the first toolbox category if no category is selected.
  * @package
  */
-Blockly.Toolbox.prototype.selectFirst = function() {
+Blockly.Toolbox.prototype.selectFirstCategory = function() {
   var selectedItem = this.tree_.getSelectedItem();
   if (!selectedItem) {
     this.tree_.selectFirst();

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -17,6 +17,7 @@ suite('Navigation', function() {
       }]);
       var toolbox = document.getElementById('toolbox-categories');
       this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+      Blockly.keyboardAccessibilityMode = true;
       Blockly.navigation.focusToolbox_();
       this.mockEvent = {
         getModifierState: function() {
@@ -31,7 +32,6 @@ suite('Navigation', function() {
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
-      Blockly.navigation.currentCategory_ = null;
     });
 
     test('Next', function() {
@@ -39,43 +39,45 @@ suite('Navigation', function() {
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_TOOLBOX);
-      chai.assert.equal(Blockly.navigation.currentCategory_,
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(),
           this.secondCategory_);
     });
 
     // Should be a no-op.
     test('Next at end', function() {
-      Blockly.navigation.nextCategory_();
+      this.workspace.getToolbox().tree_.getSelectedItem().selectNext();
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.S;
-      var startCategory = Blockly.navigation.currentCategory_;
+      // Go forward one so that we can go back one.
+      Blockly.navigation.onKeyPress(this.mockEvent);
+      var startCategory = this.workspace.getToolbox().tree_.getSelectedItem();
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_TOOLBOX);
-      chai.assert.equal(Blockly.navigation.currentCategory_,
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(),
           startCategory);
     });
 
     test('Previous', function() {
       // Go forward one so that we can go back one:
-      Blockly.navigation.nextCategory_();
+      this.workspace.getToolbox().tree_.getSelectedItem().selectNext();
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.W;
-      chai.assert.equal(Blockly.navigation.currentCategory_,
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(),
           this.secondCategory_);
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_TOOLBOX);
-      chai.assert.equal(Blockly.navigation.currentCategory_,
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(),
           this.firstCategory_);
     });
 
     // Should be a no-op.
     test('Previous at start', function() {
-      var startCategory = Blockly.navigation.currentCategory_;
+      var startCategory = this.workspace.getToolbox().tree_.getSelectedItem();
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.W;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_TOOLBOX);
-      chai.assert.equal(Blockly.navigation.currentCategory_,
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(),
           startCategory);
     });
 
@@ -146,7 +148,6 @@ suite('Navigation', function() {
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
-      Blockly.navigation.currentCategory_ = null;
     });
 
     // Should be a no-op
@@ -240,7 +241,6 @@ suite('Navigation', function() {
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
-      Blockly.navigation.currentCategory_ = null;
     });
 
     test('Previous', function() {
@@ -310,7 +310,7 @@ suite('Navigation', function() {
     test('Toolbox', function() {
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.T;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.equal(Blockly.navigation.currentCategory_, this.firstCategory_);
+      chai.assert.equal(this.workspace.getToolbox().tree_.getSelectedItem(), this.firstCategory_);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_TOOLBOX);
     });
@@ -485,7 +485,6 @@ suite('Navigation', function() {
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
-      Blockly.navigation.currentCategory_ = null;
     });
 
     test('Insert from flyout with a valid connection marked', function() {
@@ -592,7 +591,6 @@ suite('Navigation', function() {
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
       this.workspace.dispose();
-      Blockly.navigation.currentCategory_ = null;
     });
 
     test('Connect cursor on previous into stack', function() {

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -31,6 +31,7 @@ suite('Navigation', function() {
     var workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     if (enableKeyboardNav) {
       Blockly.navigation.enableKeyboardAccessibility();
+      Blockly.navigation.currentState_ = Blockly.navigation.STATE_WS;
     }
     return workspace;
   }
@@ -352,6 +353,7 @@ suite('Navigation', function() {
       Blockly.user.keyMap.setKeyMap(Blockly.user.keyMap.createDefaultKeyMap());
       Blockly.mainWorkspace = this.workspace;
       Blockly.keyboardAccessibilityMode = true;
+      Blockly.navigation.currentState_ = Blockly.navigation.STATE_WS;
 
       this.mockEvent = {
         getModifierState: function() {
@@ -360,7 +362,9 @@ suite('Navigation', function() {
       };
     });
     test('Action does not exist', function() {
+      var block = new Blockly.Block(this.workspace);
       var field = new Blockly.FieldDropdown([['a','b'], ['c','d']]);
+      field.setSourceBlock(block);
       sinon.spy(field, 'onBlocklyAction');
       this.workspace.getCursor().setLocation(Blockly.ASTNode.createFieldNode(field));
 
@@ -373,7 +377,9 @@ suite('Navigation', function() {
     });
 
     test('Action exists - field handles action', function() {
+      var block = new Blockly.Block(this.workspace);
       var field = new Blockly.FieldDropdown([['a','b'], ['c','d']]);
+      field.setSourceBlock(block);
       sinon.stub(field, 'onBlocklyAction').callsFake(function(){
         return true;
       });
@@ -387,7 +393,9 @@ suite('Navigation', function() {
     });
 
     test('Action exists - field does not handle action', function() {
+      var block = new Blockly.Block(this.workspace);
       var field = new Blockly.FieldDropdown([['a','b'], ['c','d']]);
+      field.setSourceBlock(block);
       sinon.spy(field, 'onBlocklyAction');
       this.workspace.getCursor().setLocation(Blockly.ASTNode.createFieldNode(field));
 
@@ -455,6 +463,8 @@ suite('Navigation', function() {
         this.workspace.setCursor(new Blockly.Cursor());
         Blockly.mainWorkspace = this.workspace;
         Blockly.keyboardAccessibilityMode = true;
+        Blockly.navigation.currentState_ = Blockly.navigation.STATE_WS;
+
         this.fieldBlock1 = this.workspace.newBlock('field_block');
         this.mockEvent = {
           getModifierState: function() {

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -1,4 +1,39 @@
+/**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2019 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Navigation tests.
+ * @author aschmiedt@google.com (Abby Schmiedt)
+ */
+'use strict';
+
+
 suite('Navigation', function() {
+  function createNavigationWorkspace(enableKeyboardNav) {
+    var toolbox = document.getElementById('toolbox-categories');
+    var workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    if (enableKeyboardNav) {
+      Blockly.navigation.enableKeyboardAccessibility();
+    }
+    return workspace;
+  }
 
   // Test that toolbox key handlers call through to the right functions and
   // transition correctly between toolbox, workspace, and flyout.
@@ -15,9 +50,7 @@ suite('Navigation', function() {
           }
         ]
       }]);
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
-      Blockly.keyboardAccessibilityMode = true;
+      this.workspace = createNavigationWorkspace(true);
       Blockly.navigation.focusToolbox_();
       this.mockEvent = {
         getModifierState: function() {
@@ -134,8 +167,7 @@ suite('Navigation', function() {
           }
         ]
       }]);
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+      this.workspace = createNavigationWorkspace(true);
       Blockly.navigation.focusToolbox_();
       Blockly.navigation.focusFlyout_();
       this.mockEvent = {
@@ -226,9 +258,7 @@ suite('Navigation', function() {
         "previousStatement": null,
         "nextStatement": null
       }]);
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
-      Blockly.navigation.enableKeyboardAccessibility();
+      this.workspace = createNavigationWorkspace(true);
       this.basicBlock = this.workspace.newBlock('basic_block');
       this.firstCategory_ = this.workspace.getToolbox().tree_.firstChild_;
       this.mockEvent = {
@@ -424,8 +454,8 @@ suite('Navigation', function() {
         this.workspace = new Blockly.Workspace({readOnly: true});
         this.workspace.setCursor(new Blockly.Cursor());
         Blockly.mainWorkspace = this.workspace;
-        this.fieldBlock1 = this.workspace.newBlock('field_block');
         Blockly.keyboardAccessibilityMode = true;
+        this.fieldBlock1 = this.workspace.newBlock('field_block');
         this.mockEvent = {
           getModifierState: function() {
             return false;
@@ -435,7 +465,6 @@ suite('Navigation', function() {
 
       teardown(function() {
         delete Blockly.Blocks['field_block'];
-        Blockly.mainWorkspace = null;
         this.workspace.dispose();
       });
 
@@ -472,8 +501,7 @@ suite('Navigation', function() {
         "nextStatement": null,
       }]);
 
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+      this.workspace = createNavigationWorkspace(true);
 
       var basicBlock = this.workspace.newBlock('basic_block');
       var basicBlock2 = this.workspace.newBlock('basic_block');
@@ -561,8 +589,7 @@ suite('Navigation', function() {
         "helpUrl": ""
       }]);
 
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+      this.workspace = createNavigationWorkspace(true);
 
       var basicBlock = this.workspace.newBlock('basic_block');
       var basicBlock2 = this.workspace.newBlock('basic_block');
@@ -653,9 +680,7 @@ suite('Navigation', function() {
         "previousStatement": null,
         "nextStatement": null,
       }]);
-      var toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
-      Blockly.navigation.enableKeyboardAccessibility();
+      this.workspace = createNavigationWorkspace(true);
       this.basicBlockA = this.workspace.newBlock('basic_block');
       this.basicBlockB = this.workspace.newBlock('basic_block');
     });

--- a/tests/mocha/xml_procedures_test.js
+++ b/tests/mocha/xml_procedures_test.js
@@ -19,7 +19,7 @@
  */
 
 goog.require('Blockly.Blocks.procedures');
-goog.require('Blockly.Msg.en');
+goog.require('Blockly.Msg');
 
 suite('Procedures XML', function() {
   suite('Deserialization', function() {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Merge both types of toolbox navigation (when in accessibility mode) and when we're not. 
The arrow keys can be used when we're not in accessibility mode and focused on the toolbox.

The logic was duplicated into Blockly.navigation. This moves it all into the one places and makes use of the same methods in base_node.js

I've also moved the handling of a blockly action on a toolbox into toolbox.js.

### Reason for Changes

The two navigation methods were tracking the selected category differently causing conflicts when using both interchangeably.

### Test Coverage

Tested playground.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
