### PR TITLE
Make toolbox an optional module.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -36,7 +36,6 @@ goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Generator');
 goog.require('Blockly.navigation');
 goog.require('Blockly.Procedures');
-goog.require('Blockly.Toolbox');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.WidgetDiv');

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -97,13 +97,6 @@ Blockly.Component = function() {
 
 
 /**
- * Generator for unique IDs.
- * @type {!Blockly.utils.IdGenerator}
- * @private
- */
-Blockly.Component.prototype.idGenerator_ = Blockly.utils.IdGenerator.getInstance();
-
-/**
  * The default right to left value.
  * @type {?boolean}
  * @private
@@ -171,27 +164,7 @@ Blockly.Component.setDefaultRightToLeft = function(rightToLeft) {
  * @package
  */
 Blockly.Component.prototype.getId = function() {
-  return this.id_ || (this.id_ = this.idGenerator_.getNextUniqueId());
-};
-
-/**
- * Assigns an ID to this component instance.  It is the caller's responsibility
- * to guarantee that the ID is unique.  If the component is a child of a parent
- * component, then the parent component's child index is updated to reflect the
- * new ID; this may throw an error if the parent already has a child with an ID
- * that conflicts with the new ID.
- * @param {string} id Unique component ID.
- * @protected
- */
-Blockly.Component.prototype.setId = function(id) {
-  if (this.parent_ && this.parent_.childIndex_) {
-    // Update the parent's child index.
-    delete this.parent_.childIndex_[this.id_];
-    this.parent_.childIndex_[id] = this;
-  }
-
-  // Update the component ID.
-  this.id_ = id;
+  return this.id_ || (this.id_ = Blockly.utils.IdGenerator.getNextUniqueId());
 };
 
 /**

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -690,8 +690,7 @@ Blockly.Component.prototype.forEachChild = function(f, opt_obj) {
  * @protected
  */
 Blockly.Component.prototype.indexOfChild = function(child) {
-  return (this.children_ && child) ? this.children_.indexOf(child) :
-                                     -1;
+  return (this.children_ && child) ? this.children_.indexOf(child) : -1;
 };
 
 /**

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -410,34 +410,6 @@ Blockly.Component.prototype.disposeInternal = function() {
 };
 
 /**
- * Helper function for subclasses that gets a unique id for a given fragment,
- * this can be used by components to generate unique string ids for DOM
- * elements.
- * @param {string} idFragment A partial id.
- * @return {string} Unique element id.
- * @protected
- */
-Blockly.Component.prototype.makeId = function(idFragment) {
-  return this.getId() + '.' + idFragment;
-};
-
-/**
- * Makes a collection of ids.  This is a convenience method for makeId.  The
- * object's values are the id fragments and the new values are the generated
- * ids.  The key will remain the same.
- * @param {Object} object The object that will be used to create the ids.
- * @return {!Object<string, string>} An object of id keys to generated ids.
- * @protected
- */
-Blockly.Component.prototype.makeIds = function(object) {
-  var ids = {};
-  for (var key in object) {
-    ids[key] = this.makeId(object[key]);
-  }
-  return ids;
-};
-
-/**
  * Adds the specified component as the last child of this component.  See
  * {@link Blockly.Component#addChildAt} for detailed semantics.
  *
@@ -620,22 +592,6 @@ Blockly.Component.prototype.hasChildren = function() {
  */
 Blockly.Component.prototype.getChildCount = function() {
   return this.children_ ? this.children_.length : 0;
-};
-
-/**
- * Returns an array containing the IDs of the children of this component, or an
- * empty array if the component has no children.
- * @return {!Array.<string>} Child component IDs.
- * @protected
- */
-Blockly.Component.prototype.getChildIds = function() {
-  var ids = [];
-
-  this.forEachChild(function(child) {
-    ids.push(child.getId());
-  });
-
-  return ids;
 };
 
 /**

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -267,14 +267,8 @@ Blockly.Menu.prototype.setHighlightedIndex = function(index) {
   if (child) {
     child.setHighlighted(true);
     this.highlightedIndex_ = index;
-    if (this.highlightHandler_) {
-      this.highlightHandler_(child);
-    }
   } else if (this.highlightedIndex_ > -1) {
     this.getHighlighted().setHighlighted(false);
-    if (this.highlightHandler_) {
-      this.highlightHandler_();
-    }
     this.highlightedIndex_ = -1;
   }
 
@@ -357,15 +351,6 @@ Blockly.Menu.prototype.highlightHelper = function(fn, startIndex) {
  */
 Blockly.Menu.prototype.canHighlightItem = function(item) {
   return item.isEnabled();
-};
-
-/**
- * Set the handler that's triggered when a menuitem is highlighted.
- * @param {function(?Blockly.MenuItem)} fn The handler.
- * @package
- */
-Blockly.Menu.prototype.onHighlighted = function(fn) {
-  this.highlightHandler_ = fn;
 };
 
 // Mouse events.

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -406,8 +406,7 @@ Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
  * @private
  */
 Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
-  var el = this.getElement();
-  if (el) {
+  if (this.getElement()) {
     this.blur();
     this.clearHighlighted();
   }

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -178,13 +178,7 @@ Blockly.tree.BaseNode.prototype.initAccessibility = function() {
 
     var img = this.getIconElement();
     if (img) {
-      Blockly.utils.aria.setRole(img,
-          Blockly.utils.aria.Role.PRESENTATION + '1');
-    }
-    var ei = this.getExpandIconElement();
-    if (ei) {
-      Blockly.utils.aria.setRole(ei,
-          Blockly.utils.aria.Role.PRESENTATION + '2');
+      Blockly.utils.aria.setRole(img, Blockly.utils.aria.Role.PRESENTATION);
     }
 
     var ce = this.getChildrenElement();
@@ -644,7 +638,6 @@ Blockly.tree.BaseNode.prototype.getRowDom = function() {
   row.setAttribute('class', this.getRowClassName());
   row.setAttribute('style', style);
 
-  row.appendChild(this.getExpandIconDom());
   row.appendChild(this.getIconDom());
   row.appendChild(this.getLabelDom());
 
@@ -694,14 +687,6 @@ Blockly.tree.BaseNode.prototype.getCalculatedIconClass = function() {
 };
 
 /**
- * @return {!Element} The source for the icon.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.getExpandIconDom = function() {
-  return document.createElement('span');
-};
-
-/**
  * @return {string} The line style.
  * @protected
  */
@@ -744,21 +729,12 @@ Blockly.tree.BaseNode.prototype.getRowElement = function() {
 };
 
 /**
- * @return {Element} The expanded icon element.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.getExpandIconElement = function() {
-  var el = this.getRowElement();
-  return el ? /** @type {Element} */ (el.firstChild) : null;
-};
-
-/**
  * @return {Element} The icon element.
  * @protected
  */
 Blockly.tree.BaseNode.prototype.getIconElement = function() {
   var el = this.getRowElement();
-  return el ? /** @type {Element} */ (el.childNodes[1]) : null;
+  return el ? /** @type {Element} */ (el.firstChild) : null;
 };
 
 /**
@@ -834,10 +810,6 @@ Blockly.tree.BaseNode.prototype.updateRow = function() {
  * @protected
  */
 Blockly.tree.BaseNode.prototype.updateExpandIcon = function() {
-  var img = this.getExpandIconElement();
-  if (img) {
-    img.className = this.config_.cssTreeIcon;
-  }
   var cel = this.getChildrenElement();
   if (cel) {
     cel.style.backgroundPosition = this.getBackgroundPosition();

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -607,82 +607,6 @@ Blockly.tree.BaseNode.prototype.toggle = function() {
 };
 
 /**
- * Expands the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.expand = function() {
-  this.setExpanded(true);
-};
-/**
- * Collapses the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.collapse = function() {
-  this.setExpanded(false);
-};
-
-/**
- * Collapses the children of the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.collapseChildren = function() {
-  this.forEachChild(function(child) { child.collapseAll(); });
-};
-
-/**
- * Collapses the children and the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.collapseAll = function() {
-  this.collapseChildren();
-  this.collapse();
-};
-
-/**
- * Expands the children of the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.expandChildren = function() {
-  this.forEachChild(function(child) { child.expandAll(); });
-};
-
-/**
- * Expands the children and the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.expandAll = function() {
-  this.expandChildren();
-  this.expand();
-};
-
-/**
- * Expands the parent chain of this node so that it is visible.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.reveal = function() {
-  var parent = this.getParent();
-  if (parent) {
-    parent.setExpanded(true);
-    parent.reveal();
-  }
-};
-
-/**
- * Sets whether the node will allow the user to collapse it.
- * @param {boolean} isCollapsible Whether to allow node collapse.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.setIsUserCollapsible = function(isCollapsible) {
-  this.isUserCollapsible_ = isCollapsible;
-  if (!this.isUserCollapsible_) {
-    this.expand();
-  }
-  if (this.getElement()) {
-    this.updateExpandIcon();
-  }
-};
-
-/**
  * @return {boolean} Whether the node is collapsible by user actions.
  * @protected
  */
@@ -765,7 +689,6 @@ Blockly.tree.BaseNode.prototype.getRowClassName = function() {
 Blockly.tree.BaseNode.prototype.getLabelDom = function() {
   var label = document.createElement('span');
   label.setAttribute('class', this.config_.cssItemLabel || '');
-  label.setAttribute('title', this.getToolTip() || '');
   label.textContent = this.getText();
   return label;
 };
@@ -922,15 +845,6 @@ Blockly.tree.BaseNode.prototype.getLabelElement = function() {
 };
 
 /**
- * @return {Element} The element after the label.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.getAfterLabelElement = function() {
-  var el = this.getRowElement();
-  return el ? /** @type {Element} */ (el.lastChild) : null;
-};
-
-/**
  * @return {Element} The div containing the children.
  * @protected
  */
@@ -940,36 +854,12 @@ Blockly.tree.BaseNode.prototype.getChildrenElement = function() {
 };
 
 /**
- * Sets the icon class for the node.
- * @param {string} s The icon class.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.setIconClass = function(s) {
-  this.iconClass_ = s;
-  if (this.isInDocument()) {
-    this.updateIcon_();
-  }
-};
-
-/**
  * Gets the icon class for the node.
  * @return {string} s The icon source.
  * @protected
  */
 Blockly.tree.BaseNode.prototype.getIconClass = function() {
   return this.iconClass_;
-};
-
-/**
- * Sets the icon class for when the node is expanded.
- * @param {string} s The expanded icon class.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.setExpandedIconClass = function(s) {
-  this.expandedIconClass_ = s;
-  if (this.isInDocument()) {
-    this.updateIcon_();
-  }
 };
 
 /**
@@ -998,28 +888,6 @@ Blockly.tree.BaseNode.prototype.setText = function(s) {
  */
 Blockly.tree.BaseNode.prototype.getText = function() {
   return this.content_;
-};
-
-/**
- * Sets the text of the tooltip.
- * @param {string} s The tooltip text to set.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.setToolTip = function(s) {
-  this.toolTip_ = s;
-  var el = this.getLabelElement();
-  if (el) {
-    el.title = s;
-  }
-};
-
-/**
- * Returns the text of the tooltip.
- * @return {?string} The tooltip text.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.getToolTip = function() {
-  return this.toolTip_;
 };
 
 /**
@@ -1083,24 +951,6 @@ Blockly.tree.BaseNode.prototype.onMouseDown = function(e) {
  */
 Blockly.tree.BaseNode.prototype.onClick_ = function(e) {
   e.preventDefault();
-};
-
-/**
- * Handles a double click event.
- * @param {!Event} e The browser event.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.onDoubleClick_ = function(e) {
-  var el = e.target;
-  // expand icon
-  var type = el.getAttribute('type');
-  if (type == 'expand' && this.hasChildren()) {
-    return;
-  }
-
-  if (this.isUserCollapsible_) {
-    this.toggle();
-  }
 };
 
 /**

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -122,27 +122,12 @@ Blockly.utils.object.inherits(Blockly.tree.BaseNode, Blockly.Component);
  *            indentWidth:number,
  *            cssRoot:string,
  *            cssHideRoot:string,
- *            cssItem:string,
- *            cssChildren:string,
- *            cssChildrenNoLines:string,
  *            cssTreeRow:string,
  *            cssItemLabel:string,
  *            cssTreeIcon:string,
- *            cssExpandTreeIcon:string,
- *            cssExpandTreeIconPlus:string,
- *            cssExpandTreeIconMinus:string,
- *            cssExpandTreeIconTPlus:string,
- *            cssExpandTreeIconTMinus:string,
- *            cssExpandTreeIconLPlus:string,
- *            cssExpandTreeIconLMinus:string,
- *            cssExpandTreeIconT:string,
- *            cssExpandTreeIconL:string,
- *            cssExpandTreeIconBlank:string,
  *            cssExpandedFolderIcon:string,
  *            cssCollapsedFolderIcon:string,
  *            cssFileIcon:string,
- *            cssExpandedRootIcon:string,
- *            cssCollapsedRootIcon:string,
  *            cssSelectedRow:string
  *          }}
  */
@@ -194,12 +179,12 @@ Blockly.tree.BaseNode.prototype.initAccessibility = function() {
     var img = this.getIconElement();
     if (img) {
       Blockly.utils.aria.setRole(img,
-          Blockly.utils.aria.Role.PRESENTATION);
+          Blockly.utils.aria.Role.PRESENTATION + '1');
     }
     var ei = this.getExpandIconElement();
     if (ei) {
       Blockly.utils.aria.setRole(ei,
-          Blockly.utils.aria.Role.PRESENTATION);
+          Blockly.utils.aria.Role.PRESENTATION + '2');
     }
 
     var ce = this.getChildrenElement();
@@ -620,12 +605,9 @@ Blockly.tree.BaseNode.prototype.isUserCollapsible = function() {
  * @protected
  */
 Blockly.tree.BaseNode.prototype.toDom = function() {
-  var childClass = this.config_.cssChildrenNoLines;
-
   var nonEmptyAndExpanded = this.getExpanded() && this.hasChildren();
 
   var children = document.createElement('div');
-  children.setAttribute('class', childClass || '');
   children.setAttribute('style', this.getLineStyle());
 
   if (nonEmptyAndExpanded) {
@@ -634,7 +616,6 @@ Blockly.tree.BaseNode.prototype.toDom = function() {
   }
 
   var node = document.createElement('div');
-  node.setAttribute('class', this.config_.cssItem || '');
   node.setAttribute('id', this.getId());
 
   node.appendChild(this.getRowDom());
@@ -718,59 +699,6 @@ Blockly.tree.BaseNode.prototype.getCalculatedIconClass = function() {
  */
 Blockly.tree.BaseNode.prototype.getExpandIconDom = function() {
   return document.createElement('span');
-};
-
-/**
- * @return {string} The class names of the icon used for expanding the node.
- * @protected
- */
-Blockly.tree.BaseNode.prototype.getExpandIconClass = function() {
-  var config = this.config_;
-  var sb = '';
-  sb += config.cssTreeIcon + ' ' + config.cssExpandTreeIcon + ' ';
-
-  if (this.hasChildren()) {
-    var bits = 0;
-    /*
-      Bitmap used to determine which icon to use
-      1  Plus
-      2  Minus
-      4  T Line
-      8  L Line
-    */
-
-    switch (bits) {
-      case 1:
-        sb += config.cssExpandTreeIconPlus;
-        break;
-      case 2:
-        sb += config.cssExpandTreeIconMinus;
-        break;
-      case 4:
-        sb += config.cssExpandTreeIconL;
-        break;
-      case 5:
-        sb += config.cssExpandTreeIconLPlus;
-        break;
-      case 6:
-        sb += config.cssExpandTreeIconLMinus;
-        break;
-      case 8:
-        sb += config.cssExpandTreeIconT;
-        break;
-      case 9:
-        sb += config.cssExpandTreeIconTPlus;
-        break;
-      case 10:
-        sb += config.cssExpandTreeIconTMinus;
-        break;
-      default:  // 0
-        sb += config.cssExpandTreeIconBlank;
-    }
-  } else {
-    sb += config.cssExpandTreeIconBlank;
-  }
-  return sb;
 };
 
 /**
@@ -908,7 +836,7 @@ Blockly.tree.BaseNode.prototype.updateRow = function() {
 Blockly.tree.BaseNode.prototype.updateExpandIcon = function() {
   var img = this.getExpandIconElement();
   if (img) {
-    img.className = this.getExpandIconClass();
+    img.className = this.config_.cssTreeIcon;
   }
   var cel = this.getChildrenElement();
   if (cel) {

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -138,12 +138,6 @@ Blockly.tree.TreeControl.prototype.getIconElement = function() {
 };
 
 /** @override */
-Blockly.tree.TreeControl.prototype.getExpandIconElement = function() {
-  // no expand icon for root element
-  return null;
-};
-
-/** @override */
 Blockly.tree.TreeControl.prototype.updateExpandIcon = function() {
   // no expand icon
 };

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -54,7 +54,7 @@ Blockly.tree.TreeControl = function(toolbox, config) {
   this.setSelectedInternal(true);
 
   /**
-   * Currenty selected item.
+   * Currently selected item.
    * @private {Blockly.tree.BaseNode}
    */
   this.selectedItem_ = this;
@@ -174,8 +174,6 @@ Blockly.tree.TreeControl.prototype.getCalculatedIconClass = function() {
   var config = this.getConfig();
   if (expanded && config.cssExpandedRootIcon) {
     return config.cssTreeIcon + ' ' + config.cssExpandedRootIcon;
-  } else if (!expanded && config.cssCollapsedRootIcon) {
-    return config.cssTreeIcon + ' ' + config.cssCollapsedRootIcon;
   }
   return '';
 };

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -87,16 +87,6 @@ Blockly.tree.TreeControl.prototype.getDepth = function() {
 };
 
 /**
- * Expands the parent chain of this node so that it is visible.
- * @override
- */
-Blockly.tree.TreeControl.prototype.reveal = function() {
-  // always expanded by default
-  // needs to be overriden so that we don't try to reveal our parent
-  // which is a generic component
-};
-
-/**
  * Handles focus on the tree.
  * @param {!Event} _e The browser event.
  * @private
@@ -248,38 +238,6 @@ Blockly.tree.TreeControl.prototype.onAfterSelected = function(fn) {
  */
 Blockly.tree.TreeControl.prototype.getSelectedItem = function() {
   return this.selectedItem_;
-};
-
-/**
- * Updates the lines after the tree has been drawn.
- * @private
- */
-Blockly.tree.TreeControl.prototype.updateLinesAndExpandIcons_ = function() {
-  var tree = this;
-  var showLines = false;
-  var showRootLines = false;
-
-  /**
-   * Recursively walk through all nodes and update the class names of the
-   * expand icon and the children element.
-   * @param {!Blockly.tree.BaseNode} node tree node
-   */
-  function updateShowLines(node) {
-    var childrenEl = node.getChildrenElement();
-    if (childrenEl) {
-      var hideLines = !showLines || tree == node.getParent() && !showRootLines;
-      var childClass = hideLines ? node.getConfig().cssChildrenNoLines :
-                                   node.getConfig().cssChildren;
-      childrenEl.className = childClass;
-
-      var expandIconEl = node.getExpandIconElement();
-      if (expandIconEl) {
-        expandIconEl.className = node.getExpandIconClass();
-      }
-    }
-    node.forEachChild(updateShowLines);
-  }
-  updateShowLines(this);
 };
 
 /**

--- a/core/css.js
+++ b/core/css.js
@@ -367,7 +367,7 @@ Blockly.Css.CONTENT = [
     'font-family: sans-serif;',
     'font-size: 11pt;',
   '}',
-  
+
   '.blocklyMultilineText {',
   '  font-family: monospace;',
   '}',
@@ -752,7 +752,6 @@ Blockly.Css.CONTENT = [
     'padding: 5px 0;',
     'margin: 0 5px;',
   '}',
-
 
   '.blocklyTreeIcon {',
     'background-image: url(<<<PATH>>>/sprites.png);',

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -533,7 +533,6 @@ Blockly.FieldColour.prototype.dropdownCreate_ = function() {
       Math.floor(colours.length / columns));
   Blockly.utils.aria.setState(table, 'colcount', columns);
   var row;
-  var idGenerator = Blockly.utils.IdGenerator.getInstance();
   for (var i = 0; i < colours.length; i++) {
     if (i % columns == 0) {
       row = document.createElement('tr');
@@ -544,7 +543,7 @@ Blockly.FieldColour.prototype.dropdownCreate_ = function() {
     row.appendChild(cell);
     cell.label = colours[i];  // This becomes the value, if clicked.
     cell.title = titles[i] || colours[i];
-    cell.id = idGenerator.getNextUniqueId();
+    cell.id = Blockly.utils.IdGenerator.getNextUniqueId();
     cell.setAttribute('data-index', i);
     Blockly.utils.aria.setRole(cell, Blockly.utils.aria.Role.GRIDCELL);
     Blockly.utils.aria.setState(cell,

--- a/core/requires.js
+++ b/core/requires.js
@@ -35,6 +35,9 @@ goog.require('Blockly');
 // configuration must be false, and no blocks may be loaded from XML which
 // define comments.
 goog.require('Blockly.Comment');
+// If the toolbox does not have categories and only has a simple flyout, then
+// 'Blockly.Toolbox' is not needed.
+goog.require('Blockly.Toolbox');
 // If a trashcan on the workspace isn't required, then Blockly.inject's
 // "trashcan" configuration must be false.
 goog.require('Blockly.Trashcan');

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -84,7 +84,6 @@ Blockly.Toolbox = function(workspace) {
     indentWidth: 19,
     cssRoot: 'blocklyTreeRoot',
     cssHideRoot: 'blocklyHidden',
-    cssItem: '',
     cssTreeRow: 'blocklyTreeRow',
     cssItemLabel: 'blocklyTreeLabel',
     cssTreeIcon: 'blocklyTreeIcon',

--- a/core/utils/idgenerator.js
+++ b/core/utils/idgenerator.js
@@ -30,37 +30,18 @@ goog.provide('Blockly.utils.IdGenerator');
 
 
 /**
- * Creates a new ID generator.
- * @constructor
- * @final
- */
-Blockly.utils.IdGenerator = function() {};
-
-/**
- * Get the singleton instance of Blockly.utils.IdGenerator.
- * @return {Blockly.utils.IdGenerator} singleton instance
- */
-Blockly.utils.IdGenerator.getInstance = function() {
-  if (!Blockly.utils.IdGenerator.instance_) {
-    Blockly.utils.IdGenerator.instance_ = new Blockly.utils.IdGenerator();
-  }
-  return Blockly.utils.IdGenerator.instance_;
-};
-
-/**
  * Next unique ID to use.
  * @type {number}
  * @private
  */
-Blockly.utils.IdGenerator.prototype.nextId_ = 0;
+Blockly.utils.IdGenerator.nextId_ = 0;
 
 /**
  * Gets the next unique ID.
- * The difference between this and genUid is that getNextUniqueId generates
- * IDs compatible with the HTML4 id attribute restrictions:
+ * IDs are compatible with the HTML4 id attribute restrictions:
  * Use only ASCII letters, digits, '_', '-' and '.'
  * @return {string} The next unique identifier.
  */
-Blockly.utils.IdGenerator.prototype.getNextUniqueId = function() {
-  return 'blockly:' + (this.nextId_++).toString(36);
+Blockly.utils.IdGenerator.getNextUniqueId = function() {
+  return 'blockly:' + (Blockly.utils.IdGenerator.nextId_++).toString(36);
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -656,6 +656,9 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   // Determine if there needs to be a category tree, or a simple list of
   // blocks.  This cannot be changed later, since the UI is very different.
   if (this.options.hasCategories) {
+    if (!Blockly.Toolbox) {
+      throw Error('Missing require for Blockly.Toolbox');
+    }
     this.toolbox_ = new Blockly.Toolbox(this);
   }
   if (this.grid_) {


### PR DESCRIPTION
This drops the compiled size by 25 kb if there are no categories.  Which also indicates that the toolbox itself suffers from really bad bloat.  The toolbox should not represent 1/6th of our codebase.