### PR TITLE
Move populate for topRow and bottomRow to info

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -42,7 +42,6 @@ goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.blockRendering.SquareCorner');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
-goog.require('Blockly.BlockSvg');
 goog.require('Blockly.RenderedConnection');
 
 

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -264,48 +264,6 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
     Blockly.blockRendering.Row);
 
 /**
- * Create all non-spacer elements that belong on the top row.
- * @param {!Blockly.BlockSvg} block The block whose top row this represents.
- * @package
- */
-Blockly.blockRendering.TopRow.prototype.populate = function(block) {
-  var hasHat = block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT;
-  var hasPrevious = !!block.previousConnection;
-  var leftSquareCorner = this.hasLeftSquareCorner(block);
-
-  if (leftSquareCorner) {
-    this.elements.push(
-        new Blockly.blockRendering.SquareCorner(this.constants_));
-  } else {
-    this.elements.push(
-        new Blockly.blockRendering.RoundCorner(this.constants_));
-  }
-
-  if (hasHat) {
-    var hat = new Blockly.blockRendering.Hat(this.constants_);
-    this.elements.push(hat);
-    this.capline = hat.ascenderHeight;
-  } else if (hasPrevious) {
-    this.hasPreviousConnection = true;
-    this.connection = new Blockly.blockRendering.PreviousConnection(
-        this.constants_,
-        /** @type {Blockly.RenderedConnection} */ (block.previousConnection));
-    this.elements.push(this.connection);
-  }
-
-  var precedesStatement = block.inputList.length &&
-      block.inputList[0].type == Blockly.NEXT_STATEMENT;
-
-  // This is the minimum height for the row. If one of its elements has a
-  // greater height it will be overwritten in the compute pass.
-  if (precedesStatement && !block.isCollapsed()) {
-    this.minHeight = this.constants_.LARGE_PADDING;
-  } else {
-    this.minHeight = this.constants_.MEDIUM_PADDING;
-  }
-};
-
-/**
  * Returns whether or not the top row has a left square corner.
  * @param {!Blockly.BlockSvg} block The block whose top row this represents.
  * @returns {boolean} Whether or not the top row has a left square corner.
@@ -389,44 +347,6 @@ Blockly.blockRendering.BottomRow = function(constants) {
 };
 Blockly.utils.object.inherits(Blockly.blockRendering.BottomRow,
     Blockly.blockRendering.Row);
-
-/**
- * Create all non-spacer elements that belong on the bottom row.
- * @param {!Blockly.BlockSvg} block The block whose bottom row this represents.
- * @package
- */
-Blockly.blockRendering.BottomRow.prototype.populate = function(block) {
-  this.hasNextConnection = !!block.nextConnection;
-
-  var followsStatement =
-      block.inputList.length &&
-      block.inputList[block.inputList.length - 1].type == Blockly.NEXT_STATEMENT;
-
-  // This is the minimum height for the row. If one of its elements has a
-  // greater height it will be overwritten in the compute pass.
-  if (followsStatement) {
-    this.minHeight = this.constants_.LARGE_PADDING;
-  } else {
-    this.minHeight = this.constants_.MEDIUM_PADDING - 1;
-  }
-
-  var leftSquareCorner = this.hasLeftSquareCorner(block);
-
-  if (leftSquareCorner) {
-    this.elements.push(
-        new Blockly.blockRendering.SquareCorner(this.constants_));
-  } else {
-    this.elements.push(
-        new Blockly.blockRendering.RoundCorner(this.constants_));
-  }
-
-  if (this.hasNextConnection) {
-    this.connection = new Blockly.blockRendering.NextConnection(
-        this.constants_,
-        /** @type {Blockly.RenderedConnection} */ (block.nextConnection));
-    this.elements.push(this.connection);
-  }
-};
 
 /**
  * Returns whether or not the bottom row has a left square corner.

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -121,7 +121,7 @@ Blockly.zelos.RenderInfo.prototype.populateTopRow_ = function() {
 Blockly.zelos.RenderInfo.prototype.populateBottomRow_ = function() {
   Blockly.zelos.RenderInfo.superClass_.populateBottomRow_.call(this);
 
-  var rightSquareCorner = this.bottomRow.hasRightSquareCorner(block);
+  var rightSquareCorner = this.bottomRow.hasRightSquareCorner(this.block_);
 
   if (rightSquareCorner) {
     this.bottomRow.elements.push(

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -37,7 +37,9 @@ goog.require('Blockly.blockRendering.NextConnection');
 goog.require('Blockly.blockRendering.OutputConnection');
 goog.require('Blockly.blockRendering.PreviousConnection');
 goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.blockRendering.RoundCorner');
 goog.require('Blockly.blockRendering.Row');
+goog.require('Blockly.blockRendering.SquareCorner');
 goog.require('Blockly.blockRendering.SpacerRow');
 goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.blockRendering.TopRow');
@@ -90,6 +92,44 @@ Blockly.utils.object.inherits(Blockly.zelos.RenderInfo,
  */
 Blockly.zelos.RenderInfo.prototype.getRenderer = function() {
   return /** @type {!Blockly.zelos.Renderer} */ (this.renderer_);
+};
+
+/**
+ * Create all non-spacer elements that belong on the top row.
+ * @package
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.populateTopRow_ = function() {
+  Blockly.zelos.RenderInfo.superClass_.populateTopRow_.call(this);
+
+  var rightSquareCorner = this.topRow.hasRightSquareCorner(this.block_);
+
+  if (rightSquareCorner) {
+    this.topRow.elements.push(
+        new Blockly.blockRendering.SquareCorner(this.constants_, 'right'));
+  } else {
+    this.topRow.elements.push(
+        new Blockly.blockRendering.RoundCorner(this.constants_, 'right'));
+  }
+};
+
+/**
+ * Create all non-spacer elements that belong on the bottom row.
+ * @package
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.populateBottomRow_ = function() {
+  Blockly.zelos.RenderInfo.superClass_.populateBottomRow_.call(this);
+
+  var rightSquareCorner = this.bottomRow.hasRightSquareCorner(block);
+
+  if (rightSquareCorner) {
+    this.bottomRow.elements.push(
+        new Blockly.blockRendering.SquareCorner(this.constants_, 'right'));
+  } else {
+    this.bottomRow.elements.push(
+        new Blockly.blockRendering.RoundCorner(this.constants_, 'right'));
+  }
 };
 
 /**

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -56,24 +56,6 @@ Blockly.utils.object.inherits(Blockly.zelos.TopRow,
     Blockly.blockRendering.TopRow);
 
 /**
- * Create all non-spacer elements that belong on the top row.
- * @param {!Blockly.BlockSvg} block The block whose top row this represents.
- * @package
- * @override
- */
-Blockly.zelos.TopRow.prototype.populate = function(block) {
-  Blockly.zelos.TopRow.superClass_.populate.call(this, block);
-
-  var rightSquareCorner = this.hasRightSquareCorner(block);
-
-  if (rightSquareCorner) {
-    this.elements.push(new Blockly.blockRendering.SquareCorner(this.constants_, 'right'));
-  } else {
-    this.elements.push(new Blockly.blockRendering.RoundCorner(this.constants_, 'right'));
-  }
-};
-
-/**
  * Render a round corner unless the block has an output connection.
  * @override
  */
@@ -107,24 +89,6 @@ Blockly.zelos.BottomRow = function(constants) {
 };
 Blockly.utils.object.inherits(Blockly.zelos.BottomRow,
     Blockly.blockRendering.BottomRow);
-
-/**
- * Create all non-spacer elements that belong on the bottom row.
- * @param {!Blockly.BlockSvg} block The block whose bottom row this represents.
- * @package
- * @override
- */
-Blockly.zelos.BottomRow.prototype.populate = function(block) {
-  Blockly.zelos.BottomRow.superClass_.populate.call(this, block);
-
-  var rightSquareCorner = this.hasRightSquareCorner(block);
-
-  if (rightSquareCorner) {
-    this.elements.push(new Blockly.blockRendering.SquareCorner(this.constants_, 'right'));
-  } else {
-    this.elements.push(new Blockly.blockRendering.RoundCorner(this.constants_, 'right'));
-  }
-};
 
 /**
  * Render a round corner unless the block has an output connection.


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2945 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Refactors populate method from Row Measurable to RenderInfo.

### Reason for Changes

Other rows are populated in RenderInfo, so moving the logic for top and bottom row seems consistent.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually on playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
