### PR TITLE
Fix inserting into middle of stack from flyout

### DIFF
--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -492,17 +492,17 @@ Blockly.navigation.connect_ = function(movingConnection, destConnection) {
 Blockly.navigation.insertBlock = function(block, destConnection) {
   switch (destConnection.type) {
     case Blockly.PREVIOUS_STATEMENT:
-      if (Blockly.navigation.moveAndConnect_(block.nextConnection, destConnection)) {
+      if (Blockly.navigation.connect_(block.nextConnection, destConnection)) {
         return true;
       }
       break;
     case Blockly.NEXT_STATEMENT:
-      if (Blockly.navigation.moveAndConnect_(block.previousConnection, destConnection)) {
+      if (Blockly.navigation.connect_(block.previousConnection, destConnection)) {
         return true;
       }
       break;
     case Blockly.INPUT_VALUE:
-      if (Blockly.navigation.moveAndConnect_(block.outputConnection, destConnection)) {
+      if (Blockly.navigation.connect_(block.outputConnection, destConnection)) {
         return true;
       }
       break;
@@ -510,7 +510,7 @@ Blockly.navigation.insertBlock = function(block, destConnection) {
       for (var i = 0; i < block.inputList.length; i++) {
         var inputConnection = block.inputList[i].connection;
         if (inputConnection.type === Blockly.INPUT_VALUE &&
-            Blockly.navigation.moveAndConnect_(inputConnection, destConnection)) {
+            Blockly.navigation.connect_(inputConnection, destConnection)) {
           return true;
         }
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
When inserting a block from the flyout into the middle of a stack the block was not being added correctly.
### Proposed Changes
In insert block use the connect_ method instead of moveAndConnect_. The connect_ method does more logic for checking which connection to check, while the moveAndConnect_ method just connects whatever connections it is given.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
