### PR TITLE
Adding checks for whether to add elem spacer on row ends

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -30,6 +30,7 @@ goog.require('Blockly.blockRendering.BottomRow');
 goog.require('Blockly.blockRendering.ExternalValueInput');
 goog.require('Blockly.blockRendering.Hat');
 goog.require('Blockly.blockRendering.InlineInput');
+goog.require('Blockly.blockRendering.InRowSpacer');
 goog.require('Blockly.blockRendering.InputRow');
 goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.NextConnection');
@@ -395,17 +396,23 @@ Blockly.blockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
     var oldElems = row.elements;
     row.elements = [];
     // No spacing needed before the corner on the top row or the bottom row.
-    if (!Blockly.blockRendering.Types.isTopRow(row) &&
-        !Blockly.blockRendering.Types.isBottomRow(row)) {
+    if (row.startsWithElemSpacer()) {
       // There's a spacer before the first element in the row.
       row.elements.push(new Blockly.blockRendering.InRowSpacer(
           this.constants_, this.getInRowSpacing_(null, oldElems[0])));
     }
-    for (var e = 0; e < oldElems.length; e++) {
+    for (var e = 0; e < oldElems.length - 1; e++) {
       row.elements.push(oldElems[e]);
       var spacing = this.getInRowSpacing_(oldElems[e], oldElems[e + 1]);
       row.elements.push(
           new Blockly.blockRendering.InRowSpacer(this.constants_, spacing));
+    }
+    row.elements.push(oldElems[oldElems.length - 1]);
+    if (row.endsWithElemSpacer()) {
+      // There's a spacer after the last element in the row.
+      row.elements.push(new Blockly.blockRendering.InRowSpacer(
+          this.constants_,
+          this.getInRowSpacing_(oldElems[oldElems.length - 1], null)));
     }
   }
 };

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -227,8 +227,6 @@ Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingS
   var firstSpacer = row.getFirstSpacer();
   var lastSpacer = row.getLastSpacer();
   if (row.hasExternalInput || row.hasStatement) {
-    // Get the spacer right before the input socket.
-    lastSpacer = elems[elems.length - 3];
     row.widthWithConnectedBlocks += missingSpace;
   }
 

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -223,7 +223,6 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
  * @override
  */
 Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
-  var elems = row.elements;
   var firstSpacer = row.getFirstSpacer();
   var lastSpacer = row.getLastSpacer();
   if (row.hasExternalInput || row.hasStatement) {

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -185,6 +185,22 @@ Blockly.blockRendering.Row.prototype.getLastInput = function() {
 };
 
 /**
+ * Determines whether this row should start with an element spacer.
+ * @return {boolean} Whether the row should start with a spacer.
+ */
+Blockly.blockRendering.Row.prototype.startsWithElemSpacer = function() {
+  return true;
+};
+
+/**
+ * Determines whether this row should end with an element spacer.
+ * @return {boolean} Whether the row should end with a spacer.
+ */
+Blockly.blockRendering.Row.prototype.endsWithElemSpacer = function() {
+  return true;
+};
+
+/**
  * Convenience method to get the first spacer element on this row.
  * @return {Blockly.blockRendering.InRowSpacer} The first spacer element on
  *   this row.
@@ -301,6 +317,13 @@ Blockly.blockRendering.TopRow.prototype.measure = function() {
 };
 
 /**
+ * @override
+ */
+Blockly.blockRendering.TopRow.prototype.startsWithElemSpacer = function() {
+  return false;
+};
+
+/**
  * An object containing information about what elements are in the bottom row of
  * a block as well as spacing information for the top row.
  * Elements in a bottom row can consist of corners, spacers and next
@@ -382,6 +405,14 @@ Blockly.blockRendering.BottomRow.prototype.measure = function() {
   this.descenderHeight = descenderHeight;
   this.widthWithConnectedBlocks = this.width;
 };
+
+/**
+ * @override
+ */
+Blockly.blockRendering.BottomRow.prototype.startsWithElemSpacer = function() {
+  return false;
+};
+
 /**
  * An object containing information about a spacer between two rows.
  * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering
@@ -465,21 +496,6 @@ Blockly.blockRendering.InputRow.prototype.measure = function() {
 /**
  * @override
  */
-Blockly.blockRendering.InputRow.prototype.getLastSpacer = function() {
-  // Adding spacing after the input connection would look weird.  Find the
-  // before the last input connection and add it there instead.
-  if (this.hasExternalInput || this.hasStatement) {
-    var elems = this.elements;
-    for (var i = elems.length - 1, elem; (elem = elems[i]); i--) {
-      if (Blockly.blockRendering.Types.isSpacer(elem)) {
-        continue;
-      }
-      if (Blockly.blockRendering.Types.isInput(elem)) {
-        var spacer = elems[i - 1];
-        return /** @type {Blockly.blockRendering.InRowSpacer} */ (spacer);
-      }
-    }
-
-  }
-  return Blockly.blockRendering.InputRow.superClass_.getLastSpacer.call(this);
+Blockly.blockRendering.InputRow.prototype.endsWithElemSpacer = function() {
+  return !this.hasExternalInput && !this.hasStatement;
 };

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -187,6 +187,7 @@ Blockly.blockRendering.Row.prototype.getLastInput = function() {
 /**
  * Determines whether this row should start with an element spacer.
  * @return {boolean} Whether the row should start with a spacer.
+ * @package
  */
 Blockly.blockRendering.Row.prototype.startsWithElemSpacer = function() {
   return true;
@@ -195,6 +196,7 @@ Blockly.blockRendering.Row.prototype.startsWithElemSpacer = function() {
 /**
  * Determines whether this row should end with an element spacer.
  * @return {boolean} Whether the row should end with a spacer.
+ * @package
  */
 Blockly.blockRendering.Row.prototype.endsWithElemSpacer = function() {
   return true;

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -210,7 +210,6 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
  * @override
  */
 Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
-  var elems = row.elements;
   var firstSpacer = row.getFirstSpacer();
   var lastSpacer = row.getLastSpacer();
   if (row.hasExternalInput || row.hasStatement) {

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -214,8 +214,6 @@ Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missin
   var firstSpacer = row.getFirstSpacer();
   var lastSpacer = row.getLastSpacer();
   if (row.hasExternalInput || row.hasStatement) {
-    // Get the spacer right before the input socket.
-    lastSpacer = elems[elems.length - 3];
     row.widthWithConnectedBlocks += missingSpace;
   }
 

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -363,11 +363,6 @@ Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row,
 Blockly.zelos.RenderInfo.prototype.addAlignmentPadding_ = function(row,
     missingSpace) {
   var lastSpacer = row.getLastSpacer();
-  // Skip the right corner element on the top and bottom row, so we don't have
-  // any spacing after the right corner element.
-  if (Blockly.blockRendering.Types.isTopOrBottomRow(row)) {
-    lastSpacer = row.elements[row.elements.length - 3];
-  }
   if (lastSpacer) {
     lastSpacer.width += missingSpace;
     row.width += missingSpace;

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -56,6 +56,13 @@ Blockly.utils.object.inherits(Blockly.zelos.TopRow,
     Blockly.blockRendering.TopRow);
 
 /**
+ * @override
+ */
+Blockly.zelos.TopRow.prototype.endsWithElemSpacer = function() {
+  return false;
+};
+
+/**
  * Render a round corner unless the block has an output connection.
  * @override
  */
@@ -89,6 +96,13 @@ Blockly.zelos.BottomRow = function(constants) {
 };
 Blockly.utils.object.inherits(Blockly.zelos.BottomRow,
     Blockly.blockRendering.BottomRow);
+
+/**
+ * @override
+ */
+Blockly.zelos.BottomRow.prototype.endsWithElemSpacer = function() {
+  return false;
+};
 
 /**
  * Render a round corner unless the block has an output connection.


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2964 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds functions to row to check whether spacer element should be added to start or end of row and removing adjustments in other places of code that assume that the last spacer is not the correct one.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

In certain cases, like with statement input, external input, and end of top/bottom row (zelos), the last spacer in the row is not actually a spacer that we want to modify and instead get the second to last spacer of that row. Not adding a spacer to the ends in some cases simplifies logic.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on playground by checking that flyout blocks in different categories render correctly (especially for cases for statement input and external input) with all 3 renderer types.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
