### PR TITLE
Changed dropdown field to use new configuration

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -51,11 +51,14 @@ goog.require('Blockly.utils.userAgent');
  *    changes to the field's value. Takes in a language-neutral dropdown
  *    option & returns a validated language-neutral dropdown option, or null to
  *    abort the change.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.Field}
  * @constructor
  * @throws {TypeError} If `menuGenerator` options are incorrectly structured.
  */
-Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
+Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
   if (typeof menuGenerator != 'function') {
     Blockly.FieldDropdown.validateOptions_(menuGenerator);
   }
@@ -87,8 +90,8 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator) {
   var firstTuple = this.getOptions(false)[0];
 
   // Call parent's constructor.
-  Blockly.FieldDropdown.superClass_.constructor.call(this, firstTuple[1],
-      opt_validator);
+  Blockly.FieldDropdown.superClass_.constructor.call(
+      this, firstTuple[1], opt_validator, opt_config);
 
   /**
    * SVG image element if currently selected option is an image, or null.
@@ -125,7 +128,7 @@ Blockly.FieldDropdown.ImageProperties;
  * @nocollapse
  */
 Blockly.FieldDropdown.fromJson = function(options) {
-  return new Blockly.FieldDropdown(options['options']);
+  return new Blockly.FieldDropdown(options['options'], undefined, options);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2722

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config property to the dropdown field that accepts 'tooltip'.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I didn't add unit tests since this field doesn't have any of its own config options, but I did manually test that the tooltips passed through JSON are applied.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Not necessary. #2706 docs should cover this.

### Additional Information

<!-- Anything else we should know? -->
N/A
