### PR TITLE
Handle blockly actions on the dropdown fields.

### DIFF
--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -292,9 +292,10 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
 /**
  * Highlights the next highlightable item (or the first if nothing is currently
  * highlighted).
- * @protected
+ * @package
  */
 Blockly.Menu.prototype.highlightNext = function() {
+  this.unhighlightCurrent();
   this.highlightHelper(function(index, max) {
     return (index + 1) % max;
   }, this.highlightedIndex_);
@@ -303,9 +304,10 @@ Blockly.Menu.prototype.highlightNext = function() {
 /**
  * Highlights the previous highlightable item (or the last if nothing is
  * currently highlighted).
- * @protected
+ * @package
  */
 Blockly.Menu.prototype.highlightPrevious = function() {
+  this.unhighlightCurrent();
   this.highlightHelper(function(index, max) {
     index--;
     return index < 0 ? max - 1 : index;
@@ -465,12 +467,10 @@ Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
       break;
 
     case Blockly.utils.KeyCodes.UP:
-      this.unhighlightCurrent();
       this.highlightPrevious();
       break;
 
     case Blockly.utils.KeyCodes.DOWN:
-      this.unhighlightCurrent();
       this.highlightNext();
       break;
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -34,6 +34,7 @@ goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.Menu');
 goog.require('Blockly.MenuItem');
+goog.require('Blockly.navigation');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -641,4 +641,24 @@ Blockly.FieldDropdown.validateOptions_ = function(options) {
   }
 };
 
+/**
+ * Handles the given action.
+ * This is only triggered when keyboard accessibility mode is enabled.
+ * @param {!Blockly.Action} action The action to be handled.
+ * @return {boolean} True if the field handled the action, false otherwise.
+ * @package
+ */
+Blockly.FieldDropdown.prototype.onBlocklyAction = function(action) {
+  if (this.menu_) {
+    if (action === Blockly.navigation.ACTION_PREVIOUS) {
+      this.menu_.highlightPrevious();
+      return true;
+    } else if (action === Blockly.navigation.ACTION_NEXT) {
+      this.menu_.highlightNext();
+      return true;
+    }
+  }
+  return Blockly.FieldDropdown.superClass_.onBlocklyAction.call(this, action);
+};
+
 Blockly.fieldRegistry.register('field_dropdown', Blockly.FieldDropdown);


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Handle blockly actions on the dropdown fields. Move up and down with actions mapped to PREVIOUS and NEXT in Blockly navigation.

### Reason for Changes

Field dropdown support for Blockly actions.

### Test Coverage
Playground.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
