### PR TITLE
Changed variable field to use configuration

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -67,7 +67,8 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
   /**
    * An array of options for a dropdown list,
    * or a function which generates these options.
-   * @type {(!Array.<!Array>|!Function)}
+   * @type {(!Array.<!Array>|
+   *    !function(this:Blockly.FieldDropdown): !Array.<!Array>)}
    * @protected
    */
   this.menuGenerator_ = menuGenerator;

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -75,7 +75,7 @@ Blockly.FieldVariable = function(varName, opt_validator, opt_variableTypes,
    * The initial variable name passed to this field's constructor, or an
    * empty string if a name wasn't provided. Used to create the initial
    * variable.
-   * @type {!string}
+   * @type {string}
    */
   this.defaultVariableName = varName || '';
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -90,7 +90,9 @@ Blockly.FieldVariable = function(varName, opt_validator, opt_variableTypes,
   opt_config && this.configure_(opt_config);
   opt_validator && this.setValidator(opt_validator);
 
-  this.setTypes_(opt_variableTypes, opt_defaultType);
+  if (!opt_config) {  // Only do one kind of configuration or the other.
+    this.setTypes_(opt_variableTypes, opt_defaultType);
+  }
 };
 Blockly.utils.object.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 
@@ -105,10 +107,8 @@ Blockly.utils.object.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
  */
 Blockly.FieldVariable.fromJson = function(options) {
   var varName = Blockly.utils.replaceMessageReferences(options['variable']);
-  var variableTypes = options['variableTypes'];
-  var defaultType = options['defaultType'];
   return new Blockly.FieldVariable(
-      varName, undefined, variableTypes, defaultType, options);
+      varName, undefined, undefined, undefined, options);
 };
 
 /**
@@ -125,6 +125,16 @@ Blockly.FieldVariable.prototype.workspace_ = null;
  * @const
  */
 Blockly.FieldVariable.prototype.SERIALIZABLE = true;
+
+/**
+ * Configure the field based on the given map of options.
+ * @param {!Object} config A map of options to configure the field based on.
+ * @protected
+ */
+Blockly.FieldVariable.prototype.configure_ = function(config) {
+  Blockly.FieldVariable.superClass_.configure_.call(this, config);
+  this.setTypes_(config['variableTypes'], config['defaultType']);
+};
 
 /**
  * Initialize the model for this field if it has not already been initialized.

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -42,7 +42,7 @@ goog.require('Blockly.Xml');
 
 /**
  * Class for a variable's dropdown field.
- * @param {?string} varname The default name for the variable.  If null,
+ * @param {?string} varName The default name for the variable.  If null,
  *     a unique variable name will be generated.
  * @param {Function=} opt_validator A function that is called to validate
  *    changes to the field's value. Takes in a variable ID  & returns a
@@ -51,19 +51,33 @@ goog.require('Blockly.Xml');
  *     to include in the dropdown.
  * @param {string=} opt_defaultType The type of variable to create if this
  *     field's value is not explicitly set.  Defaults to ''.
+ * @param {Object=} opt_config A map of options used to configure the field.
+ *    See the [field creation documentation]{@link https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/variable#creation}
+ *    for a list of properties this parameter supports.
  * @extends {Blockly.FieldDropdown}
  * @constructor
  */
-Blockly.FieldVariable = function(varname, opt_validator, opt_variableTypes,
-    opt_defaultType) {
-  // The FieldDropdown constructor would call setValue, which might create a
-  // spurious variable.  Just do the relevant parts of the constructor.
-  this.menuGenerator_ = Blockly.FieldVariable.dropdownCreate;
-  opt_validator && this.setValidator(opt_validator);
-  this.defaultVariableName = varname || '';
+Blockly.FieldVariable = function(varName, opt_validator, opt_variableTypes,
+    opt_defaultType, opt_config) {
+  // The FieldDropdown constructor expects the field's initial value to be
+  // the first entry in the menu generator, which it may or may not be.
+  // Just do the relevant parts of the constructor.
 
-  this.setTypes_(opt_variableTypes, opt_defaultType);
-  this.value_ = null;
+  /**
+   * An array of options for a dropdown list,
+   * or a function which generates these options.
+   * @type {!function(this:Blockly.FieldVariable): !Array.<!Array>}
+   * @protected
+   */
+  this.menuGenerator_ = Blockly.FieldVariable.dropdownCreate;
+
+  /**
+   * The initial variable name passed to this field's constructor, or an
+   * empty string if a name wasn't provided. Used to create the initial
+   * variable.
+   * @type {!string}
+   */
+  this.defaultVariableName = varName || '';
 
   /**
    * The size of the area rendered by the field.
@@ -72,6 +86,11 @@ Blockly.FieldVariable = function(varname, opt_validator, opt_variableTypes,
    * @override
    */
   this.size_ = new Blockly.utils.Size(0, Blockly.BlockSvg.MIN_BLOCK_Y);
+
+  opt_config && this.configure_(opt_config);
+  opt_validator && this.setValidator(opt_validator);
+
+  this.setTypes_(opt_variableTypes, opt_defaultType);
 };
 Blockly.utils.object.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
 
@@ -85,10 +104,11 @@ Blockly.utils.object.inherits(Blockly.FieldVariable, Blockly.FieldDropdown);
  * @nocollapse
  */
 Blockly.FieldVariable.fromJson = function(options) {
-  var varname = Blockly.utils.replaceMessageReferences(options['variable']);
+  var varName = Blockly.utils.replaceMessageReferences(options['variable']);
   var variableTypes = options['variableTypes'];
   var defaultType = options['defaultType'];
-  return new Blockly.FieldVariable(varname, null, variableTypes, defaultType);
+  return new Blockly.FieldVariable(
+      varName, undefined, variableTypes, defaultType, options);
 };
 
 /**

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -211,6 +211,43 @@ suite('Variable Fields', function() {
       });
     });
   });
+  suite('Customizations', function() {
+    suite('Types and Default Types', function() {
+      test('JS Constructor', function() {
+        var field = new Blockly.FieldVariable(
+            'test', undefined, ['Type1'], 'Type1');
+        chai.assert.deepEqual(field.variableTypes, ['Type1']);
+        chai.assert.equal(field.defaultType_, 'Type1');
+      });
+      test('JSON Definition', function() {
+        var field = Blockly.FieldVariable.fromJson({
+          variable: 'test',
+          variableTypes: ['Type1'],
+          defaultType: 'Type1'
+        });
+        chai.assert.deepEqual(field.variableTypes, ['Type1']);
+        chai.assert.equal(field.defaultType_, 'Type1');
+      });
+      test('JS Configuration - Simple', function() {
+        var field = new Blockly.FieldVariable(
+            'test', undefined, undefined, undefined, {
+              variableTypes: ['Type1'],
+              defaultType: 'Type1'
+            });
+        chai.assert.deepEqual(field.variableTypes, ['Type1']);
+        chai.assert.equal(field.defaultType_, 'Type1');
+      });
+      test('JS Configuration - Ignore', function() {
+        var field = new Blockly.FieldVariable(
+            'test', undefined, ['Type2'], 'Type2', {
+              variableTypes: ['Type1'],
+              defaultType: 'Type1'
+            });
+        chai.assert.deepEqual(field.variableTypes, ['Type1']);
+        chai.assert.equal(field.defaultType_, 'Type1');
+      });
+    });
+  });
   suite('Get variable types', function() {
     setup(function() {
       this.workspace.createVariable('name1', 'type1');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #2722

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an opt_config option to the variable field.

I added the option to configure types using the opt_config, but I did it on a separate commit so it can be easily reverted.

The initial commit just adds an opt_config property so variables can support tooltips.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Standardization of Configuration.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests for configuring types using different methods.

And for the initial commit I manually tested setting tooltips via json.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
If you want to keep configuring types via the opt_config the variable field's [creation ](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/variable#creation)section may need updates.

### Additional Information

<!-- Anything else we should know? -->
Configuring types via opt_config is on a separate commit, so it'll be easy to revert if you don't want it.

Also: Woot! this is the last field!