### PR TITLE
Mark fields as dirty when the workspace becomes visible.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -541,6 +541,16 @@ Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
 };
 
 /**
+ * Notify every input on this block to mark its fields as dirty.
+ * A dirty field is a field that needs to be re-rendererd.
+ */
+Blockly.BlockSvg.prototype.markDirty = function() {
+  for (var i = 0, input; input = this.inputList[i]; i++) {
+    input.markDirty();
+  }
+};
+
+/**
  * Set whether the block is collapsed or not.
  * @param {boolean} collapsed True if collapsed.
  */

--- a/core/field.js
+++ b/core/field.js
@@ -707,7 +707,7 @@ Blockly.Field.prototype.markDirty = function() {
  * @package
  */
 Blockly.Field.prototype.forceRerender = function() {
-  this.markDirty();
+  this.isDirty_ = true;
   if (this.sourceBlock_ && this.sourceBlock_.rendered) {
     this.sourceBlock_.render();
     this.sourceBlock_.bumpNeighbours_();

--- a/core/field.js
+++ b/core/field.js
@@ -695,8 +695,19 @@ Blockly.Field.prototype.setText = function(_newText) {
  * already been recorded.
  * @package
  */
-Blockly.Field.prototype.forceRerender = function() {
+Blockly.Field.prototype.markDirty = function() {
   this.isDirty_ = true;
+};
+
+/**
+ * Force a rerender of the block that this field is installed on, which will
+ * rerender this field and adjust for any sizing changes.
+ * Other fields on the same block will not rerender, because their sizes have
+ * already been recorded.
+ * @package
+ */
+Blockly.Field.prototype.forceRerender = function() {
+  this.markDirty();
   if (this.sourceBlock_ && this.sourceBlock_.rendered) {
     this.sourceBlock_.render();
     this.sourceBlock_.bumpNeighbours_();

--- a/core/input.js
+++ b/core/input.js
@@ -207,6 +207,16 @@ Blockly.Input.prototype.setVisible = function(visible) {
 };
 
 /**
+ * Mark all fields on this input as dirty.
+ * @package
+ */
+Blockly.Input.prototype.markDirty = function() {
+  for (var y = 0, field; field = this.fieldRow[y]; y++) {
+    field.markDirty();
+  }
+};
+
+/**
  * Change a connection's compatibility.
  * @param {string|Array.<string>|null} check Compatible value type or
  *     list of value types.  Null if all types are compatible.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1080,7 +1080,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
   }
   if (isVisible) {
     var blocks = this.getAllBlocks(false);
-    // Tell each block on the workspace to mark it's fields as dirty.
+    // Tell each block on the workspace to mark its fields as dirty.
     for (var i = blocks.length - 1; i >= 0; i--) {
       blocks[i].markDirty();
     }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1079,6 +1079,12 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
     this.toolbox_.HtmlDiv.style.display = isVisible ? 'block' : 'none';
   }
   if (isVisible) {
+    var blocks = this.getAllBlocks(false);
+    // Tell each block on the workspace to mark it's fields as dirty.
+    for (var i = blocks.length - 1; i >= 0; i--) {
+      blocks[i].markDirty();
+    }
+
     this.render();
     if (this.toolbox_) {
       this.toolbox_.position();


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/2811

### Proposed Changes

When a workspace re-gains visibility. It's possible some fields may have been imported while the workspace was not visible. We'll need to re-compute the field size. This PR goes through all blocks on the workspace and marks their fields as dirty. The next time render is called, the field's sizes are re-computed.

A previous attempt at this https://github.com/google/blockly/pull/3041 breaks collapsed mode.

### Reason for Changes

### Test Coverage
Tested playground, tested adding blocks onto the workspace when the workspace is not visible. 
Also tested that this works with collapsed blocks.

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@BeksOmega FYI
