### PR TITLE
Disconnect child block always for block.dispose(/* healStack */ true)

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -417,7 +417,7 @@ Blockly.Block.prototype.unplugFromRow_ = function(opt_healStack) {
   if (childConnection.checkType_(parentConnection)) {
     parentConnection.connect(childConnection);
   } else {
-    childConnection.bumpAwayFrom_(parentConnection);
+    childConnection.onFailedConnect(parentConnection);
   }
 };
 

--- a/core/block.js
+++ b/core/block.js
@@ -413,9 +413,11 @@ Blockly.Block.prototype.unplugFromRow_ = function(opt_healStack) {
   var childConnection = thisConnection.targetConnection;
   // Disconnect the child block.
   childConnection.disconnect();
-  // Move the child to the parent, if possible.
+  // Connect child to the parent if possible, otherwise bump away.
   if (childConnection.checkType_(parentConnection)) {
     parentConnection.connect(childConnection);
+  } else {
+    childConnection.bumpAwayFrom_(parentConnection);
   }
 };
 

--- a/core/block.js
+++ b/core/block.js
@@ -466,7 +466,6 @@ Blockly.Block.prototype.unplugFromStack_ = function(opt_healStack) {
     // Disconnect the next statement.
     var nextTarget = this.nextConnection.targetConnection;
     nextTarget.disconnect();
-    // TODO (#1994): Check types before unplugging.
     if (previousTarget && previousTarget.checkType_(nextTarget)) {
       // Attach the next statement to the previous statement.
       previousTarget.connect(nextTarget);

--- a/core/block.js
+++ b/core/block.js
@@ -410,11 +410,11 @@ Blockly.Block.prototype.unplugFromRow_ = function(opt_healStack) {
     return;
   }
 
-  // Only disconnect the child if it's possible to move it to the parent.
   var childConnection = thisConnection.targetConnection;
+  // Disconnect the child block.
+  childConnection.disconnect();
+  // Move the child to the parent, if possible.
   if (childConnection.checkType_(parentConnection)) {
-    // Disconnect the child block.
-    childConnection.disconnect();
     parentConnection.connect(childConnection);
   }
 };

--- a/core/connection.js
+++ b/core/connection.js
@@ -212,9 +212,9 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
           if (orphanBlock.workspace && !orphanBlock.getParent()) {
             Blockly.Events.setGroup(group);
             if (orphanBlock.outputConnection) {
-              orphanBlock.outputConnection.bumpAwayFrom_(parentConnection);
+              orphanBlock.outputConnection.onFailedConnect(parentConnection);
             } else if (orphanBlock.previousConnection) {
-              orphanBlock.previousConnection.bumpAwayFrom_(parentConnection);
+              orphanBlock.previousConnection.onFailedConnect(parentConnection);
             }
             Blockly.Events.setGroup(false);
           }
@@ -454,6 +454,16 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
   }
 
   return true;
+};
+
+/**
+ * Behavior after a connection attempt fails.
+ * @param {Blockly.Connection} _otherConnection Connection that this connection
+ *     failed to connect to.
+ * @package
+ */
+Blockly.Connection.prototype.onFailedConnect = function(_otherConnection) {
+  // NOP
 };
 
 /**

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -349,6 +349,18 @@ Blockly.RenderedConnection.prototype.isConnectionAllowed = function(candidate,
 };
 
 /**
+ * Behavior after a connection attempt fails.
+ * @param {Blockly.Connection} otherConnection Connection that this connection
+ *     failed to connect to.
+ * @package
+ */
+Blockly.RenderedConnection.prototype.onFailedConnect = function(
+    otherConnection) {
+  this.bumpAwayFrom_(otherConnection);
+};
+
+
+/**
  * Disconnect two blocks that are connected by this connection.
  * @param {!Blockly.Block} parentBlock The superior block.
  * @param {!Blockly.Block} childBlock The inferior block.

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -165,20 +165,7 @@ function test_block_stack_unplug_heal_bad_checks() {
     // The types don't work.
     blocks.B.unplug(true);
 
-    // Stack blocks unplug before checking whether the types match.
-    // TODO (#1994): Check types before unplugging.
-    // A has nothing connected to it.
-    assertEquals(0, blocks.A.getChildren().length);
-    // B has nothing connected to it.
-    assertEquals(0, blocks.B.getChildren().length);
-    // C has nothing connected to it.
-    assertEquals(0, blocks.C.getChildren().length);
-    // A is the top of its stack.
-    assertNull(blocks.A.getParent());
-    // B is the top of its stack.
-    assertNull(blocks.B.getParent());
-    // C is the top of its stack.
-    assertNull(blocks.C.getParent());
+    assertUnpluggedHealFailed(blocks);
   } finally {
     blockTest_tearDown();
   }

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -85,6 +85,17 @@ function assertUnpluggedHealed(blocks) {
   assertNull(blocks.B.getParent());
 }
 
+function assertUnpluggedHealFailed(blocks) {
+  // A has nothing connected to it.
+  assertEquals(0, blocks.A.getChildren().length);
+  // B has nothing connected to it.
+  assertEquals(0, blocks.B.getChildren().length);
+  // B is the top of its stack.
+  assertNull(blocks.B.getParent());
+  // C is the top of its stack.
+  assertNull(blocks.C.getParent());
+}
+
 function setUpRowBlocks() {
   var blockA = workspace.newBlock('row_block');
   var blockB = workspace.newBlock('row_block');
@@ -207,7 +218,7 @@ function test_block_row_unplug_heal_bad_checks() {
 
     // Each block has only one input, but the types don't work.
     blocks.B.unplug(true);
-    assertUnpluggedNoheal(blocks);
+    assertUnpluggedHealFailed(blocks);
   } finally {
     blockTest_tearDown();
   }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -69,6 +69,16 @@ suite('Blocks', function() {
         // B is the top of its stack.
         assertNull(blocks.B.getParent());
       }
+      function assertUnpluggedHealFailed(blocks) {
+        // A has nothing connected to it.
+        assertEquals(0, blocks.A.getChildren().length);
+        // B has nothing connected to it.
+        assertEquals(0, blocks.B.getChildren().length);
+        // B is the top of its stack.
+        assertNull(blocks.B.getParent());
+        // C is the top of its stack.
+        assertNull(blocks.C.getParent());
+      }
 
       suite('Row', function() {
         setup(function() {
@@ -106,7 +116,7 @@ suite('Blocks', function() {
 
           // Each block has only one input, but the types don't work.
           blocks.B.unplug(true);
-          assertUnpluggedNoheal(blocks);
+          assertUnpluggedHealFailed(blocks);
         });
         test('A has multiple inputs', function() {
           var blocks = this.blocks;
@@ -165,7 +175,7 @@ suite('Blocks', function() {
           this.blocks.B.unplug(true);
           assertUnpluggedHealed(this.blocks);
         });
-        test.skip('Heal with bad checks', function() {
+        test('Heal with bad checks', function() {
           var blocks = this.blocks;
           // A and C can't connect, but both can connect to B.
           blocks.A.nextConnection.setCheck('type1');
@@ -174,9 +184,7 @@ suite('Blocks', function() {
           // The types don't work.
           blocks.B.unplug(true);
 
-          // TODO (#1994): Check types before unplugging. Currently
-          //  everything disconnects, when C should stick with B
-          assertUnpluggedNoheal();
+          assertUnpluggedHealFailed(blocks);
         });
         test('C is Shadow', function() {
           var blocks = this.blocks;
@@ -206,6 +214,16 @@ suite('Blocks', function() {
         assertEquals(blocks.A, blocks.C.getParent());
         // B is disposed.
         chai.assert.isTrue(blocks.B.disposed);
+      }
+      function assertDisposedHealFailed(blocks) {
+        chai.assert.isFalse(blocks.A.disposed);
+        chai.assert.isFalse(blocks.C.disposed);
+        // A has nothing connected to it.
+        chai.assert.equal(0, blocks.A.getChildren().length);
+        // B is disposed.
+        chai.assert.isTrue(blocks.B.disposed);
+        // C is the top of its stack.
+        assertNull(blocks.C.getParent());
       }
 
       suite('Row', function() {
@@ -244,7 +262,7 @@ suite('Blocks', function() {
 
           // Each block has only one input, but the types don't work.
           blocks.B.dispose(true);
-          assertDisposedNoheal(blocks);
+          assertDisposedHealFailed(blocks);
         });
         test('A has multiple inputs', function() {
           var blocks = this.blocks;
@@ -303,7 +321,7 @@ suite('Blocks', function() {
           this.blocks.B.dispose(true);
           assertDisposedHealed(this.blocks);
         });
-        test.skip('Heal with bad checks', function() {
+        test('Heal with bad checks', function() {
           var blocks = this.blocks;
           // A and C can't connect, but both can connect to B.
           blocks.A.nextConnection.setCheck('type1');
@@ -312,9 +330,7 @@ suite('Blocks', function() {
           // The types don't work.
           blocks.B.dispose(true);
 
-          // TODO (#1994): Check types before unplugging. Current C gets
-          //  left behind when it should get disposed with B.
-          assertDisposedNoheal(blocks);
+          assertDisposedHealFailed(blocks);
         });
         test('C is Shadow', function() {
           var blocks = this.blocks;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixed #2991 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Always disconnects child block with healStack true in unplugFromRow_. Bumps child block away if it cannot be connected.

![1d1fb01e-2a02-41a9-b04a-70312608cb26](https://user-images.githubusercontent.com/6621618/65454269-9d781a80-ddf9-11e9-99d0-0658e0077671.gif)

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Desired behavior.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Blockly playground
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
