### PR TITLE
Adding check for pushing last row with only empty dummy input.

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -245,7 +245,7 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
         new Blockly.blockRendering.JaggedEdge(this.constants_));
   }
 
-  if (activeRow.elements.length) {
+  if (activeRow.elements.length || activeRow.hasDummyInput) {
     this.rows.push(activeRow);
   }
   this.populateBottomRow_();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Addresses one of the concerns in #2933 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds check so that last row is pushed if it has a dummy input, even if there are no elements.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Rows with dummy inputs are not considered empty so the row should have been pushed.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

