### PR TITLE
Code cleanup, drop some CSS.

### DIFF
--- a/core/block_events.js
+++ b/core/block_events.js
@@ -39,6 +39,8 @@ goog.require('Blockly.Events.Abstract');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.xml');
+// TODO: Fix recursive dependency.
+//goog.require('Blockly.Xml');
 
 
 /**

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -31,7 +31,6 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.CommentMove');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
-goog.require('Blockly.WorkspaceCommentSvg');
 
 
 /**

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -57,13 +57,11 @@ Blockly.utils.object.inherits(Blockly.Menu, Blockly.Component);
  */
 Blockly.Menu.prototype.createDom = function() {
   var element = document.createElement('div');
-  element.setAttribute('id', this.getId());
+  element.id = this.getId();
   this.setElementInternal(element);
 
   // Set class
-  element.setAttribute('class', 'goog-menu goog-menu-vertical');
-  element.setAttribute('style', 'user-select: none;');
-
+  element.className = 'goog-menu goog-menu-vertical blocklyNonSelectable';
   element.tabIndex = 0;
 
   // Initialize ARIA role.

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -74,14 +74,14 @@ Blockly.utils.object.inherits(Blockly.MenuItem, Blockly.Component);
  */
 Blockly.MenuItem.prototype.createDom = function() {
   var element = document.createElement('div');
-  element.setAttribute('id', this.getId());
+  element.id = this.getId();
   this.setElementInternal(element);
 
   // Set class and style
-  element.setAttribute('class', 'goog-menuitem goog-option ' +
+  element.className = 'goog-menuitem goog-option ' +
       (!this.enabled_ ? 'goog-menuitem-disabled ' : '') +
       (this.checked_ ? 'goog-option-selected ' : '') +
-      (this.isRightToLeft() ? 'goog-menuitem-rtl ' : ''));
+      (this.isRightToLeft() ? 'goog-menuitem-rtl ' : '');
 
   var content = this.getContentWrapperDom();
   element.appendChild(content);
@@ -111,7 +111,7 @@ Blockly.MenuItem.prototype.getCheckboxDom = function() {
     return null;
   }
   var menuItemCheckbox = document.createElement('div');
-  menuItemCheckbox.setAttribute('class', 'goog-menuitem-checkbox');
+  menuItemCheckbox.className = 'goog-menuitem-checkbox';
   return menuItemCheckbox;
 };
 
@@ -133,7 +133,7 @@ Blockly.MenuItem.prototype.getContentDom = function() {
  */
 Blockly.MenuItem.prototype.getContentWrapperDom = function() {
   var contentWrapper = document.createElement('div');
-  contentWrapper.setAttribute('class', 'goog-menuitem-content');
+  contentWrapper.className = 'goog-menuitem-content';
   return contentWrapper;
 };
 

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -606,7 +606,7 @@ Blockly.tree.BaseNode.prototype.toDom = function() {
   var nonEmptyAndExpanded = this.getExpanded() && this.hasChildren();
 
   var children = document.createElement('div');
-  children.setAttribute('style', this.getLineStyle());
+  children.style = this.getLineStyle();
 
   if (nonEmptyAndExpanded) {
     // children
@@ -614,7 +614,7 @@ Blockly.tree.BaseNode.prototype.toDom = function() {
   }
 
   var node = document.createElement('div');
-  node.setAttribute('id', this.getId());
+  node.id = this.getId();
 
   node.appendChild(this.getRowDom());
   node.appendChild(children);
@@ -639,8 +639,8 @@ Blockly.tree.BaseNode.prototype.getRowDom = function() {
       this.getPixelIndent_() + 'px';
 
   var row = document.createElement('div');
-  row.setAttribute('class', this.getRowClassName());
-  row.setAttribute('style', style);
+  row.className = this.getRowClassName();
+  row.style = style;
 
   row.appendChild(this.getIconDom());
   row.appendChild(this.getLabelDom());
@@ -666,7 +666,7 @@ Blockly.tree.BaseNode.prototype.getRowClassName = function() {
  */
 Blockly.tree.BaseNode.prototype.getLabelDom = function() {
   var label = document.createElement('span');
-  label.setAttribute('class', this.config_.cssItemLabel || '');
+  label.className = this.config_.cssItemLabel || '';
   label.textContent = this.getText();
   return label;
 };
@@ -677,8 +677,8 @@ Blockly.tree.BaseNode.prototype.getLabelDom = function() {
  */
 Blockly.tree.BaseNode.prototype.getIconDom = function() {
   var icon = document.createElement('span');
-  icon.setAttribute('style', 'display: inline-block;');
-  icon.setAttribute('class', this.getCalculatedIconClass());
+  icon.style.display = 'inline-block';
+  icon.className = this.getCalculatedIconClass();
   return icon;
 };
 
@@ -706,7 +706,7 @@ Blockly.tree.BaseNode.prototype.getLineStyle = function() {
  */
 Blockly.tree.BaseNode.prototype.getBackgroundPosition = function() {
   return (this.isLastSibling() ? '-100' : (this.getDepth() - 1) *
-                  this.config_.indentWidth) + 'px 0';
+      this.config_.indentWidth) + 'px 0';
 };
 
 /**

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -40,6 +40,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.uiMenu');
 goog.require('Blockly.utils.userAgent');
+goog.require('Blockly.WorkspaceCommentSvg');
 goog.require('Blockly.Xml');
 
 

--- a/core/css.js
+++ b/core/css.js
@@ -131,7 +131,7 @@ Blockly.Css.CONTENT = [
     'height: 100%;',
     'position: relative;',
     'overflow: hidden;', /* So blocks in drag surface disappear at edges */
-    'touch-action: none',
+    'touch-action: none;',
   '}',
 
   '.blocklyNonSelectable {',
@@ -192,7 +192,6 @@ Blockly.Css.CONTENT = [
     'border: 1px solid;',
     'border-radius: 2px;',
     'padding: 4px;',
-    '-webkit-user-select: none;',
     'box-shadow: 0px 0px 3px 1px rgba(0,0,0,.3);',
   '}',
 
@@ -572,10 +571,6 @@ Blockly.Css.CONTENT = [
     'fill-opacity: .8;',
   '}',
 
-  '.blocklyTransparentBackground {',
-    'opacity: 0;',
-  '}',
-
   '.blocklyMainWorkspaceScrollbar {',
     'z-index: 20;',
   '}',
@@ -663,7 +658,7 @@ Blockly.Css.CONTENT = [
     'padding: 0 !important;',
   '}',
 
-  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem, ',
+  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem,',
   '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem {',
     /* 28px on the left for icon or checkbox. */
     'padding-left: 28px;',
@@ -671,7 +666,7 @@ Blockly.Css.CONTENT = [
 
   /* BiDi override for the resting state. */
   /* #noflip */
-  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl, ',
+  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl,',
   '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl {',
      /* Flip left/right padding for BiDi. */
     'padding-left: 5px;',
@@ -696,9 +691,6 @@ Blockly.Css.CONTENT = [
     'overflow-x: visible;',
     'overflow-y: auto;',
     'position: absolute;',
-    'user-select: none;',
-    '-ms-user-select: none;',
-    '-webkit-user-select: none;',
     'z-index: 70;', /* so blocks go under toolbox when dragging */
     '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
   '}',
@@ -913,7 +905,7 @@ Blockly.Css.CONTENT = [
    * rely solely on the BiDi flipping by the CSS compiler.  That's why we're
    * not adding the #noflip to .goog-menuitem.
    */
-  '.blocklyWidgetDiv .goog-menuitem, ',
+  '.blocklyWidgetDiv .goog-menuitem,',
   '.blocklyDropDownDiv .goog-menuitem {',
     'color: #000;',
     'font: normal 13px Arial, sans-serif;',
@@ -930,22 +922,14 @@ Blockly.Css.CONTENT = [
   /* If a menu doesn't have checkable items or items with icons,
    * remove padding.
    */
-  '.blocklyWidgetDiv .goog-menu-nocheckbox .goog-menuitem, ',
-  '.blocklyWidgetDiv .goog-menu-noicon .goog-menuitem, ',
-  '.blocklyDropDownDiv .goog-menu-nocheckbox .goog-menuitem, ',
-  '.blocklyDropDownDiv .goog-menu-noicon .goog-menuitem { ',
+  '.blocklyWidgetDiv .goog-menu-nocheckbox .goog-menuitem,',
+  '.blocklyWidgetDiv .goog-menu-noicon .goog-menuitem,',
+  '.blocklyDropDownDiv .goog-menu-nocheckbox .goog-menuitem,',
+  '.blocklyDropDownDiv .goog-menu-noicon .goog-menuitem {',
     'padding-left: 12px;',
   '}',
 
-  /* If a menu doesn't have items with shortcuts, leave just enough room for
-   * submenu arrows, if they are rendered.
-   */
-  '.blocklyWidgetDiv .goog-menu-noaccel .goog-menuitem, ',
-  '.blocklyDropDownDiv .goog-menu-noaccel .goog-menuitem {',
-    'padding-right: 20px;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-menuitem-content, ',
+  '.blocklyWidgetDiv .goog-menuitem-content,',
   '.blocklyDropDownDiv .goog-menuitem-content {',
     'font: normal 13px Arial, sans-serif;',
   '}',
@@ -959,39 +943,37 @@ Blockly.Css.CONTENT = [
   '}',
 
   /* State: disabled. */
-  '.blocklyWidgetDiv .goog-menuitem-disabled, ',
+  '.blocklyWidgetDiv .goog-menuitem-disabled,',
   '.blocklyDropDownDiv .goog-menuitem-disabled {',
     'cursor: inherit;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-accel, ',
-  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-content, ',
-  '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-accel, ',
+  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-content,',
   '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-content {',
     'color: #ccc !important;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-icon, ',
+  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-icon,',
   '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-icon {',
     'opacity: .3;',
     'filter: alpha(opacity=30);',
   '}',
 
   /* State: hover. */
-  '.blocklyWidgetDiv .goog-menuitem-highlight, ',
+  '.blocklyWidgetDiv .goog-menuitem-highlight,',
   '.blocklyWidgetDiv .goog-menuitem-hover {',
     'background-color: #f1f3f4;',
   '}',
 
-  '.blocklyDropDownDiv .goog-menuitem-highlight, ',
+  '.blocklyDropDownDiv .goog-menuitem-highlight,',
   '.blocklyDropDownDiv .goog-menuitem-hover {',
     'background-color: rgba(0,0,0,.2);',
   '}',
 
   /* State: selected/checked. */
-  '.blocklyWidgetDiv .goog-menuitem-checkbox, ',
-  '.blocklyWidgetDiv .goog-menuitem-icon, ',
-  '.blocklyDropDownDiv .goog-menuitem-checkbox, ',
+  '.blocklyWidgetDiv .goog-menuitem-checkbox,',
+  '.blocklyWidgetDiv .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-menuitem-icon {',
     'background-repeat: no-repeat;',
     'height: 16px;',
@@ -1004,69 +986,32 @@ Blockly.Css.CONTENT = [
 
   /* BiDi override for the selected/checked state. */
   /* #noflip */
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox, ',
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon, ',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox, ',
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
      /* Flip left/right positioning. */
     'left: auto;',
     'right: 6px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox, ',
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon, ',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox, ',
+  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
+  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
     'position: static;', /* Scroll with the menu. */
     'float: left;',
     'margin-left: -24px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox, ',
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon, ',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox, ',
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
+  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
+  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
     'float: right;',
     'margin-right: -24px;',
   '}',
 
-
-  /* Keyboard shortcut ("accelerator") style. */
-  '.blocklyWidgetDiv .goog-menuitem-accel, ',
-  '.blocklyDropDownDiv .goog-menuitem-accel {',
-    'color: #999;',
-     /* Keyboard shortcuts are untranslated; always left-to-right. */
-     /* #noflip */
-    'direction: ltr;',
-    'left: auto;',
-    'padding: 0 6px;',
-    'position: absolute;',
-    'right: 0;',
-    'text-align: right;',
-  '}',
-
-  /* BiDi override for shortcut style. */
-  /* #noflip */
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-accel, ',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-accel {',
-     /* Flip left/right positioning and text alignment. */
-    'left: 0;',
-    'right: auto;',
-    'text-align: left;',
-  '}',
-
-  /* Mnemonic styles. */
-  '.blocklyWidgetDiv .goog-menuitem-mnemonic-hint, ',
-  '.blocklyDropDownDiv .goog-menuitem-mnemonic-hint {',
-    'text-decoration: underline;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-menuitem-mnemonic-separator, ',
-  '.blocklyDropDownDiv .goog-menuitem-mnemonic-separator {',
-    'color: #999;',
-    'font-size: 12px;',
-    'padding-left: 4px;',
-  '}',
 
   /* Copied from: goog/css/menuseparator.css */
   /*
@@ -1082,7 +1027,7 @@ Blockly.Css.CONTENT = [
    * @author attila@google.com (Attila Bodis)
    */
 
-  '.blocklyWidgetDiv .goog-menuseparator, ',
+  '.blocklyWidgetDiv .goog-menuseparator,',
   '.blocklyDropDownDiv .goog-menuseparator {',
     'border-top: 1px solid #ccc;',
     'margin: 4px 0;',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -291,9 +291,9 @@ Blockly.DropDownDiv.show = function(owner, primaryX, primaryY,
   if (metrics.arrowVisible) {
     Blockly.DropDownDiv.arrow_.style.display = '';
     Blockly.DropDownDiv.arrow_.style.transform = 'translate(' +
-      metrics.arrowX + 'px,' + metrics.arrowY + 'px) rotate(45deg)'; // rotate(45deg)
+        metrics.arrowX + 'px,' + metrics.arrowY + 'px) rotate(45deg)';
     Blockly.DropDownDiv.arrow_.setAttribute('class', metrics.arrowAtTop ?
-      'blocklyDropDownArrow arrowTop' : 'blocklyDropDownArrow arrowBottom');
+        'blocklyDropDownArrow arrowTop' : 'blocklyDropDownArrow arrowBottom');
   } else {
     Blockly.DropDownDiv.arrow_.style.display = 'none';
   }

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -233,14 +233,12 @@ Blockly.FieldMultilineInput.prototype.widgetCreate_ = function() {
   var scale = this.workspace_.scale;
 
   var htmlInput = /** @type {HTMLTextAreaElement} */ (document.createElement('textarea'));
-  htmlInput.setAttribute('class', 'blocklyHtmlInput blocklyHtmlTextAreaInput');
+  htmlInput.className = 'blocklyHtmlInput blocklyHtmlTextAreaInput';
   htmlInput.setAttribute('spellcheck', this.spellcheck_);
-  var fontSize =
-      (Blockly.FieldTextInput.FONTSIZE * scale) + 'pt';
+  var fontSize = (Blockly.FieldTextInput.FONTSIZE * scale) + 'pt';
   div.style.fontSize = fontSize;
   htmlInput.style.fontSize = fontSize;
-  var borderRadius =
-      (Blockly.FieldTextInput.BORDERRADIUS * scale) + 'px';
+  var borderRadius = (Blockly.FieldTextInput.BORDERRADIUS * scale) + 'px';
   htmlInput.style.borderRadius = borderRadius;
   var padding = Blockly.Field.DEFAULT_TEXT_OFFSET * scale;
   htmlInput.style.paddingLeft = padding + 'px';

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -152,7 +152,7 @@ Blockly.Toolbox.prototype.init = function() {
    * @type {Element}
    */
   this.HtmlDiv = document.createElement('div');
-  this.HtmlDiv.className = 'blocklyToolboxDiv';
+  this.HtmlDiv.className = 'blocklyToolboxDiv blocklyNonSelectable';
   this.HtmlDiv.setAttribute('dir', workspace.RTL ? 'RTL' : 'LTR');
   svg.parentNode.insertBefore(this.HtmlDiv, svg);
 

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -32,7 +32,6 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Msg');
 goog.require('Blockly.utils.xml');
 goog.require('Blockly.VariableModel');
-goog.require('Blockly.Xml');
 
 
 Blockly.VariablesDynamic.onCreateVariableButtonClick_String = function(button) {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -32,8 +32,6 @@
  */
 goog.provide('Blockly.WidgetDiv');
 
-goog.require('Blockly.Css');
-
 goog.require('Blockly.utils.style');
 
 

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -29,7 +29,6 @@ goog.provide('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
-goog.require('Blockly.WorkspaceCommentSvg');
 
 
 /**

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -37,6 +37,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WorkspaceComment');
+goog.require('Blockly.WorkspaceCommentSvg.render');
 
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -51,7 +51,6 @@ goog.require('Blockly.Workspace');
 goog.require('Blockly.WorkspaceAudio');
 goog.require('Blockly.WorkspaceComment');
 goog.require('Blockly.WorkspaceCommentSvg');
-goog.require('Blockly.WorkspaceCommentSvg.render');
 goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.Xml');
 

--- a/core/ws_comment_events.js
+++ b/core/ws_comment_events.js
@@ -35,7 +35,8 @@ goog.require('Blockly.Events.Abstract');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.xml');
-goog.require('Blockly.Xml');
+// TODO: Fix recursive dependency.
+// goog.require('Blockly.Xml');
 
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -38,6 +38,8 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.global');
 goog.require('Blockly.utils.xml');
+goog.require('Blockly.WorkspaceComment');
+goog.require('Blockly.WorkspaceCommentSvg');
 
 
 /**

--- a/demos/custom-fields/turtle/field_turtle.js
+++ b/demos/custom-fields/turtle/field_turtle.js
@@ -411,7 +411,7 @@ CustomFields.FieldTurtle.prototype.dropdownCreate_ = function() {
   };
 
   var widget = document.createElement('div');
-  widget.className = 'customFieldsTurtleWidget';
+  widget.className = 'customFieldsTurtleWidget blocklyNonSelectable';
 
   var table = document.createElement('div');
   table.className = 'table';


### PR DESCRIPTION
Random improvements to require statements.

Removal of some obviously dead CSS.

.blocklyDropDownDiv no longer suppresses text selection (see comment in PR).

This PR drops the compiled size by 4 KB, which is larger than I was expecting.
