### PR TITLE
Break CSS into modules.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@
 blockly_node_javascript_en.js
 gulpfile.js
 /msg/*
-/core/css.js
 /core/utils/global.js
 /tests/blocks/*
 /tests/compile/*
@@ -15,7 +14,6 @@ gulpfile.js
 /tests/workspace_svg/*
 /generators/*
 /demos/*
-/accessible/*
 /appengine/*
 /externs/*
 /closure/*

--- a/core/block.js
+++ b/core/block.js
@@ -1432,7 +1432,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
   // Makes styles backward compatible with old way of defining hat style.
   if (json['style'] && json['style'].hat) {
     this.hat = json['style'].hat;
-    //Must set to null so it doesn't error when checking for style and colour.
+    // Must set to null so it doesn't error when checking for style and colour.
     json['style'] = null;
   }
 

--- a/core/css.js
+++ b/core/css.js
@@ -105,7 +105,7 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
 /**
  * Set the cursor to be displayed when over something draggable.
  * See See https://github.com/google/blockly/issues/981 for context.
- * @param {Blockly.Css.Cursor} cursor Enum.
+ * @param {Blockly.Css.Cursor} _cursor Enum.
  * @deprecated April 2017.
  */
 Blockly.Css.setCursor = function(_cursor) {
@@ -520,7 +520,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   /* Edge and IE introduce a close icon when the input value is longer than a
-     certain length. This affects our sizing calcutations of the text input.
+     certain length. This affects our sizing calculations of the text input.
      Hiding the close icon to avoid that. */
   '.blocklyHtmlInput::-ms-clear {',
     'display: none;',

--- a/core/css.js
+++ b/core/css.js
@@ -92,7 +92,7 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
     return;
   }
   // Strip off any trailing slash (either Unix or Windows).
-  var mediaPath = pathToMedia.replace(/[\\\/]$/, '');
+  var mediaPath = pathToMedia.replace(/[\\/]$/, '');
   text = text.replace(/<<<PATH>>>/g, mediaPath);
 
   // Inject CSS tag at start of head.
@@ -108,7 +108,7 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
  * @param {Blockly.Css.Cursor} cursor Enum.
  * @deprecated April 2017.
  */
-Blockly.Css.setCursor = function(cursor) {
+Blockly.Css.setCursor = function(_cursor) {
   console.warn('Deprecated call to Blockly.Css.setCursor. ' +
       'See https://github.com/google/blockly/issues/981 for context');
 };
@@ -117,7 +117,7 @@ Blockly.Css.setCursor = function(cursor) {
  * Array making up the CSS content for Blockly.
  */
 Blockly.Css.CONTENT = [
-
+  /* eslint-disable indent */
   '.blocklySvg {',
     'background-color: #fff;',
     'outline: none;',
@@ -797,6 +797,6 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
     'float: right;',
     'margin-right: -24px;',
-  '}',
-  ''
-];  // eslint-disable-line indent
+  '}'
+  /* eslint-enable indent */
+];

--- a/core/css.js
+++ b/core/css.js
@@ -392,30 +392,6 @@ Blockly.Css.CONTENT = [
     'position: absolute;',
     'z-index: 20;',
   '}',
-  '.blocklyFlyoutButton {',
-    'fill: #888;',
-    'cursor: default;',
-  '}',
-
-  '.blocklyFlyoutButtonShadow {',
-    'fill: #666;',
-  '}',
-
-  '.blocklyFlyoutButton:hover {',
-    'fill: #aaa;',
-  '}',
-
-  '.blocklyFlyoutLabel {',
-    'cursor: default;',
-  '}',
-
-  '.blocklyFlyoutLabelBackground {',
-    'opacity: 0;',
-  '}',
-
-  '.blocklyFlyoutLabelText {',
-    'fill: #000;',
-  '}',
 
   /*
     Don't allow users to select text.  It gets annoying when trying to

--- a/core/css.js
+++ b/core/css.js
@@ -117,6 +117,7 @@ Blockly.Css.setCursor = function(cursor) {
  * Array making up the CSS content for Blockly.
  */
 Blockly.Css.CONTENT = [
+
   '.blocklySvg {',
     'background-color: #fff;',
     'outline: none;',
@@ -798,4 +799,4 @@ Blockly.Css.CONTENT = [
     'margin-right: -24px;',
   '}',
   ''
-];
+];  // eslint-disable-line indent

--- a/core/css.js
+++ b/core/css.js
@@ -56,11 +56,19 @@ Blockly.Css.currentCursor_ = '';
 Blockly.Css.injected_ = false;
 
 /**
- * Path to media directory, with any trailing slash removed.
- * @type {string}
- * @private
+ * Add some CSS to the blob that will be injected later.  Allows optional
+ * components such as fields and the toolbox to store separate CSS.
+ * The provided array of CSS will be destroyed by this function.
+ * @param {!Array.<string>} cssArray Array of CSS strings.
  */
-Blockly.Css.mediaPath_ = '';
+Blockly.Css.register = function(cssArray) {
+  if (Blockly.Css.injected_) {
+    throw Error('CSS already injected');
+  }
+  // Concatenate cssArray onto Blockly.Css.CONTENT.
+  Array.prototype.push.apply(Blockly.Css.CONTENT, cssArray);
+  cssArray.length = 0;  // Garbage collect provided CSS content.
+};
 
 /**
  * Inject the CSS into the DOM.  This is preferable over using a regular CSS
@@ -78,18 +86,14 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
     return;
   }
   Blockly.Css.injected_ = true;
-  // Placeholder for cursor rule.  Must be first rule (index 0).
-  var text = '.blocklyDraggable {}\n';
-  if (hasCss) {
-    text += Blockly.Css.CONTENT.join('\n');
-    Blockly.Css.CONTENT = null;  // Garbage collect 13 KB.
-    if (Blockly.FieldDate) {
-      text += Blockly.FieldDate.CSS.join('\n');
-    }
+  var text = Blockly.Css.CONTENT.join('\n');
+  Blockly.Css.CONTENT.length = 0;  // Garbage collect CSS content.
+  if (!hasCss) {
+    return;
   }
   // Strip off any trailing slash (either Unix or Windows).
-  Blockly.Css.mediaPath_ = pathToMedia.replace(/[\\\/]$/, '');
-  text = text.replace(/<<<PATH>>>/g, Blockly.Css.mediaPath_);
+  var mediaPath = pathToMedia.replace(/[\\\/]$/, '');
+  text = text.replace(/<<<PATH>>>/g, mediaPath);
 
   // Inject CSS tag at start of head.
   var cssNode = document.createElement('style');
@@ -311,16 +315,6 @@ Blockly.Css.CONTENT = [
 
   '.blocklyDragging.blocklyDraggingDelete {',
     'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
-  '}',
-
-  '.blocklyToolboxDelete {',
-    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
-  '}',
-
-  '.blocklyToolboxGrab {',
-    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
-    'cursor: grabbing;',
-    'cursor: -webkit-grabbing;',
   '}',
 
   '.blocklyDragging>.blocklyPath,',
@@ -597,18 +591,6 @@ Blockly.Css.CONTENT = [
     'fill: #bbb;',
   '}',
 
-  '.blocklyZoom>image, .blocklyZoom>svg>image {',
-    'opacity: .4;',
-  '}',
-
-  '.blocklyZoom>image:hover, .blocklyZoom>svg>image:hover {',
-    'opacity: .6;',
-  '}',
-
-  '.blocklyZoom>image:active, .blocklyZoom>svg>image:active {',
-    'opacity: .8;',
-  '}',
-
   /* Darken flyout scrollbars due to being on a grey background. */
   /* By contrast, workspace scrollbars are on a white background. */
   '.blocklyFlyout .blocklyScrollbarHandle {',
@@ -622,30 +604,6 @@ Blockly.Css.CONTENT = [
 
   '.blocklyInvalidInput {',
     'background: #faa;',
-  '}',
-
-  '.blocklyAngleCircle {',
-    'stroke: #444;',
-    'stroke-width: 1;',
-    'fill: #ddd;',
-    'fill-opacity: .8;',
-  '}',
-
-  '.blocklyAngleMarks {',
-    'stroke: #444;',
-    'stroke-width: 1;',
-  '}',
-
-  '.blocklyAngleGauge {',
-    'fill: #f88;',
-    'fill-opacity: .8;',
-  '}',
-
-  '.blocklyAngleLine {',
-    'stroke: #f00;',
-    'stroke-width: 2;',
-    'stroke-linecap: round;',
-    'pointer-events: none;',
   '}',
 
   '.blocklyContextMenu {',
@@ -683,154 +641,6 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
-  '}',
-
-  /* Category tree in Toolbox. */
-  '.blocklyToolboxDiv {',
-    'background-color: #ddd;',
-    'overflow-x: visible;',
-    'overflow-y: auto;',
-    'position: absolute;',
-    'z-index: 70;', /* so blocks go under toolbox when dragging */
-    '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
-  '}',
-
-  '.blocklyTreeRoot {',
-    'padding: 4px 0;',
-  '}',
-
-  '.blocklyTreeRoot:focus {',
-    'outline: none;',
-  '}',
-
-  '.blocklyTreeRow {',
-    'height: 22px;',
-    'line-height: 22px;',
-    'margin-bottom: 3px;',
-    'padding-right: 8px;',
-    'white-space: nowrap;',
-  '}',
-
-  '.blocklyHorizontalTree {',
-    'float: left;',
-    'margin: 1px 5px 8px 0;',
-  '}',
-
-  '.blocklyHorizontalTreeRtl {',
-    'float: right;',
-    'margin: 1px 0 8px 5px;',
-  '}',
-
-  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeRow {',
-    'margin-left: 8px;',
-  '}',
-
-  '.blocklyTreeRow:not(.blocklyTreeSelected):hover {',
-    'background-color: #e4e4e4;',
-  '}',
-
-  '.blocklyTreeSeparator {',
-    'border-bottom: solid #e5e5e5 1px;',
-    'height: 0;',
-    'margin: 5px 0;',
-  '}',
-
-  '.blocklyTreeSeparatorHorizontal {',
-    'border-right: solid #e5e5e5 1px;',
-    'width: 0;',
-    'padding: 5px 0;',
-    'margin: 0 5px;',
-  '}',
-
-  '.blocklyTreeIcon {',
-    'background-image: url(<<<PATH>>>/sprites.png);',
-    'height: 16px;',
-    'vertical-align: middle;',
-    'width: 16px;',
-  '}',
-
-  '.blocklyTreeIconClosedLtr {',
-    'background-position: -32px -1px;',
-  '}',
-
-  '.blocklyTreeIconClosedRtl {',
-    'background-position: 0 -1px;',
-  '}',
-
-  '.blocklyTreeIconOpen {',
-    'background-position: -16px -1px;',
-  '}',
-
-  '.blocklyTreeSelected>.blocklyTreeIconClosedLtr {',
-    'background-position: -32px -17px;',
-  '}',
-
-  '.blocklyTreeSelected>.blocklyTreeIconClosedRtl {',
-    'background-position: 0 -17px;',
-  '}',
-
-  '.blocklyTreeSelected>.blocklyTreeIconOpen {',
-    'background-position: -16px -17px;',
-  '}',
-
-  '.blocklyTreeIconNone,',
-  '.blocklyTreeSelected>.blocklyTreeIconNone {',
-    'background-position: -48px -1px;',
-  '}',
-
-  '.blocklyTreeLabel {',
-    'cursor: default;',
-    'font-family: sans-serif;',
-    'font-size: 16px;',
-    'padding: 0 3px;',
-    'vertical-align: middle;',
-  '}',
-
-  '.blocklyToolboxDelete .blocklyTreeLabel {',
-    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
-  '}',
-
-  '.blocklyTreeSelected .blocklyTreeLabel {',
-    'color: #fff;',
-  '}',
-
-  /* Colour Picker Field */
-  '.blocklyColourTable {',
-    'border-collapse: collapse;',
-    'outline: none;',
-    'padding: 1px;',
-    'display: block;',
-  '}',
-
-  '.blocklyColourTable>tr>td {',
-    'padding: 0;',
-    'cursor: pointer;',
-    'border: .5px solid transparent;',
-    'height: 25px;',
-    'width: 25px;',
-    'box-sizing: border-box;',
-    'display: inline-block;',
-  '}',
-
-  '.blocklyColourTable>tr>td.blocklyColourHighlighted {',
-    'border-color: #eee;',
-    'position: relative;',
-    'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
-  '}',
-
-  '.blocklyColourSelected, .blocklyColourSelected:hover {',
-    'border-color: #eee !important;',
-    'outline: 1px solid #333;',
-    'position: relative;',
-  '}',
-
-  /* Multiline (Textarea) Field */
-  '.blocklyHtmlTextAreaInput {',
-    'font-family: monospace;',
-    'resize: none;',
-    'overflow: hidden;',
-    'height: 100%;',
-    'text-align: left;',
   '}',
 
   /* Copied from: goog/css/menu.css */
@@ -1011,28 +821,5 @@ Blockly.Css.CONTENT = [
     'float: right;',
     'margin-right: -24px;',
   '}',
-
-
-  /* Copied from: goog/css/menuseparator.css */
-  /*
-   * Copyright 2009 The Closure Library Authors. All Rights Reserved.
-   *
-   * Use of this source code is governed by the Apache License, Version 2.0.
-   * See the COPYING file for details.
-   */
-
-  /**
-   * Standard styling for menus created by goog.ui.MenuSeparatorRenderer.
-   *
-   * @author attila@google.com (Attila Bodis)
-   */
-
-  '.blocklyWidgetDiv .goog-menuseparator,',
-  '.blocklyDropDownDiv .goog-menuseparator {',
-    'border-top: 1px solid #ccc;',
-    'margin: 4px 0;',
-    'padding: 0;',
-  '}',
-
   ''
 ];

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.FieldAngle');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.FieldTextInput');
@@ -461,5 +462,34 @@ Blockly.FieldAngle.prototype.wrapValue_ = function(value) {
   }
   return value;
 };
+
+/**
+ * CSS for angle field.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyAngleCircle {',
+    'stroke: #444;',
+    'stroke-width: 1;',
+    'fill: #ddd;',
+    'fill-opacity: .8;',
+  '}',
+
+  '.blocklyAngleMarks {',
+    'stroke: #444;',
+    'stroke-width: 1;',
+  '}',
+
+  '.blocklyAngleGauge {',
+    'fill: #f88;',
+    'fill-opacity: .8;',
+  '}',
+
+  '.blocklyAngleLine {',
+    'stroke: #f00;',
+    'stroke-width: 2;',
+    'stroke-linecap: round;',
+    'pointer-events: none;',
+  '}'
+]);
 
 Blockly.fieldRegistry.register('field_angle', Blockly.FieldAngle);

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -490,6 +490,6 @@ Blockly.Css.register([
     'stroke-linecap: round;',
     'pointer-events: none;',
   '}'
-]);
+]);  // eslint-disable-line indent
 
 Blockly.fieldRegistry.register('field_angle', Blockly.FieldAngle);

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -467,6 +467,7 @@ Blockly.FieldAngle.prototype.wrapValue_ = function(value) {
  * CSS for angle field.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyAngleCircle {',
     'stroke: #444;',
     'stroke-width: 1;',
@@ -490,6 +491,7 @@ Blockly.Css.register([
     'stroke-linecap: round;',
     'pointer-events: none;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);
 
 Blockly.fieldRegistry.register('field_angle', Blockly.FieldAngle);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -593,6 +593,7 @@ Blockly.FieldColour.prototype.dropdownDispose_ = function() {
  * CSS for colour picker.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyColourTable {',
     'border-collapse: collapse;',
     'display: block;',
@@ -621,6 +622,7 @@ Blockly.Css.register([
     'outline: 1px solid #333;',
     'position: relative;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);
 
 Blockly.fieldRegistry.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.FieldColour');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');
@@ -587,5 +588,39 @@ Blockly.FieldColour.prototype.dropdownDispose_ = function() {
   Blockly.unbindEvent_(this.onKeyDownWrapper_);
   this.picker_ = null;
 };
+
+/**
+ * CSS for colour picker.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyColourTable {',
+    'border-collapse: collapse;',
+    'display: block;',
+    'outline: none;',
+    'padding: 1px;',
+  '}',
+
+  '.blocklyColourTable>tr>td {',
+    'border: .5px solid #888;',
+    'box-sizing: border-box;',
+    'cursor: pointer;',
+    'display: inline-block;',
+    'height: 20px;',
+    'padding: 0;',
+    'width: 20px;',
+  '}',
+
+  '.blocklyColourTable>tr>td.blocklyColourHighlighted {',
+    'border-color: #eee;',
+    'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
+    'position: relative;',
+  '}',
+
+  '.blocklyColourSelected, .blocklyColourSelected:hover {',
+    'border-color: #eee !important;',
+    'outline: 1px solid #333;',
+    'position: relative;',
+  '}'
+]);
 
 Blockly.fieldRegistry.register('field_colour', Blockly.FieldColour);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -621,6 +621,6 @@ Blockly.Css.register([
     'outline: 1px solid #333;',
     'position: relative;',
   '}'
-]);
+]);  // eslint-disable-line indent
 
 Blockly.fieldRegistry.register('field_colour', Blockly.FieldColour);

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -321,7 +321,7 @@ Blockly.Css.register([
   '.blocklyDatePicker .goog-date-picker-date:hover {',
     'background-color: rgb(218, 220, 224, .5);',
   '}'
-]);
+]);  // eslint-disable-line indent
 
 Blockly.fieldRegistry.register('field_date', Blockly.FieldDate);
 

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -265,6 +265,7 @@ Blockly.FieldDate.loadLanguage_ = function() {
  * CSS for date picker.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyDatePicker,',
   '.blocklyDatePicker th,',
   '.blocklyDatePicker td {',
@@ -321,7 +322,8 @@ Blockly.Css.register([
   '.blocklyDatePicker .goog-date-picker-date:hover {',
     'background-color: rgb(218, 220, 224, .5);',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);
 
 Blockly.fieldRegistry.register('field_date', Blockly.FieldDate);
 

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.FieldDate');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.Events');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
@@ -263,64 +264,64 @@ Blockly.FieldDate.loadLanguage_ = function() {
 /**
  * CSS for date picker.  See css.js for use.
  */
-Blockly.FieldDate.CSS = [
+Blockly.Css.register([
   '.blocklyDatePicker,',
   '.blocklyDatePicker th,',
   '.blocklyDatePicker td {',
-  '  font: 13px Arial, sans-serif;',
-  '  color: #3c4043;',
+    'font: 13px Arial, sans-serif;',
+    'color: #3c4043;',
   '}',
 
   '.blocklyDatePicker th,',
   '.blocklyDatePicker td {',
-  '  text-align: center;',
-  '  vertical-align: middle;',
+    'text-align: center;',
+    'vertical-align: middle;',
   '}',
 
   '.blocklyDatePicker .goog-date-picker-wday,',
   '.blocklyDatePicker .goog-date-picker-date {',
-  '  padding: 6px 6px;',
+    'padding: 6px 6px;',
   '}',
 
   '.blocklyDatePicker button {',
-  '  cursor: pointer;',
-  '  padding: 6px 6px;',
-  '  margin: 1px 0;',
-  '  border: 0;',
-  '  color: #3c4043;',
-  '  font-weight: bold;',
-  '  background: transparent;',
+    'cursor: pointer;',
+    'padding: 6px 6px;',
+    'margin: 1px 0;',
+    'border: 0;',
+    'color: #3c4043;',
+    'font-weight: bold;',
+    'background: transparent;',
   '}',
 
   '.blocklyDatePicker .goog-date-picker-previousMonth,',
   '.blocklyDatePicker .goog-date-picker-nextMonth {',
-  '  height: 24px;',
-  '  width: 24px;',
+    'height: 24px;',
+    'width: 24px;',
   '}',
 
   '.blocklyDatePicker .goog-date-picker-monthyear {',
-  '  font-weight: bold;',
+    'font-weight: bold;',
   '}',
 
   '.blocklyDatePicker .goog-date-picker-wday, ',
   '.blocklyDatePicker .goog-date-picker-other-month {',
-  '  color: #70757a;',
-  '  border-radius: 12px;',
+    'color: #70757a;',
+    'border-radius: 12px;',
   '}',
 
   '.blocklyDatePicker button,',
   '.blocklyDatePicker .goog-date-picker-date {',
-  '  cursor: pointer;',
-  '  background-color: rgb(218, 220, 224, 0);',
-  '  border-radius: 12px;',
-  '  transition: background-color,opacity 100ms linear;',
+    'cursor: pointer;',
+    'background-color: rgb(218, 220, 224, 0);',
+    'border-radius: 12px;',
+    'transition: background-color,opacity 100ms linear;',
   '}',
 
   '.blocklyDatePicker button:hover,',
   '.blocklyDatePicker .goog-date-picker-date:hover {',
-  '  background-color: rgb(218, 220, 224, .5);',
+    'background-color: rgb(218, 220, 224, .5);',
   '}'
-];
+]);
 
 Blockly.fieldRegistry.register('field_date', Blockly.FieldDate);
 

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -287,7 +287,7 @@ Blockly.Css.register([
     'height: 100%;',
     'text-align: left;',
   '}'
-]);
+]);  // eslint-disable-line indent
 
 
 Blockly.fieldRegistry.register('field_multilinetext', Blockly.FieldMultilineInput);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -28,6 +28,7 @@
 
 goog.provide('Blockly.FieldMultilineInput');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.FieldTextInput');
 goog.require('Blockly.utils');
@@ -274,5 +275,19 @@ Blockly.FieldMultilineInput.prototype.onHtmlInputKeyDown_ = function(e) {
     Blockly.FieldMultilineInput.superClass_.onHtmlInputKeyDown_.call(this, e);
   }
 };
+
+/**
+ * CSS for multiline field.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyHtmlTextAreaInput {',
+    'font-family: monospace;',
+    'resize: none;',
+    'overflow: hidden;',
+    'height: 100%;',
+    'text-align: left;',
+  '}'
+]);
+
 
 Blockly.fieldRegistry.register('field_multilinetext', Blockly.FieldMultilineInput);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -280,6 +280,7 @@ Blockly.FieldMultilineInput.prototype.onHtmlInputKeyDown_ = function(e) {
  * CSS for multiline field.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyHtmlTextAreaInput {',
     'font-family: monospace;',
     'resize: none;',
@@ -287,7 +288,8 @@ Blockly.Css.register([
     'height: 100%;',
     'text-align: left;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);
 
 
 Blockly.fieldRegistry.register('field_multilinetext', Blockly.FieldMultilineInput);

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -288,4 +288,4 @@ Blockly.Css.register([
   '.blocklyFlyoutLabelText {',
     'fill: #000;',
   '}'
-]);
+]);  // eslint-disable-line indent

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -264,6 +264,7 @@ Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
  * CSS for buttons and labels.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyFlyoutButton {',
     'fill: #888;',
     'cursor: default;',
@@ -288,4 +289,5 @@ Blockly.Css.register([
   '.blocklyFlyoutLabelText {',
     'fill: #000;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.FlyoutButton');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
@@ -258,3 +259,33 @@ Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
     this.targetWorkspace_.getButtonCallback(this.callbackKey_)(this);
   }
 };
+
+/**
+ * CSS for buttons and labels.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyFlyoutButton {',
+    'fill: #888;',
+    'cursor: default;',
+  '}',
+
+  '.blocklyFlyoutButtonShadow {',
+    'fill: #666;',
+  '}',
+
+  '.blocklyFlyoutButton:hover {',
+    'fill: #aaa;',
+  '}',
+
+  '.blocklyFlyoutLabel {',
+    'cursor: default;',
+  '}',
+
+  '.blocklyFlyoutLabelBackground {',
+    'opacity: 0;',
+  '}',
+
+  '.blocklyFlyoutLabelText {',
+    'fill: #000;',
+  '}'
+]);

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -378,7 +378,7 @@ Blockly.ASTNode.prototype.findPrevForField_ = function() {
       }
       fieldIdx--;
     }
-    //Reset the fieldIdx to the length of the field row of the previous input
+    // Reset the fieldIdx to the length of the field row of the previous input.
     if (i - 1 >= 0) {
       fieldIdx = block.inputList[i - 1].fieldRow.length - 1;
     }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.Toolbox');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.navigation');
@@ -709,3 +710,127 @@ Blockly.Toolbox.TreeSeparator = function(config) {
 };
 Blockly.utils.object.inherits(Blockly.Toolbox.TreeSeparator,
     Blockly.tree.TreeNode);
+
+/**
+ * CSS for Toolbox.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyToolboxDelete {',
+    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
+  '}',
+
+  '.blocklyToolboxGrab {',
+    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
+    'cursor: grabbing;',
+    'cursor: -webkit-grabbing;',
+  '}',
+
+  /* Category tree in Toolbox. */
+  '.blocklyToolboxDiv {',
+    'background-color: #ddd;',
+    'overflow-x: visible;',
+    'overflow-y: auto;',
+    'position: absolute;',
+    'z-index: 70;', /* so blocks go under toolbox when dragging */
+    '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
+  '}',
+
+  '.blocklyTreeRoot {',
+    'padding: 4px 0;',
+  '}',
+
+  '.blocklyTreeRoot:focus {',
+    'outline: none;',
+  '}',
+
+  '.blocklyTreeRow {',
+    'height: 22px;',
+    'line-height: 22px;',
+    'margin-bottom: 3px;',
+    'padding-right: 8px;',
+    'white-space: nowrap;',
+  '}',
+
+  '.blocklyHorizontalTree {',
+    'float: left;',
+    'margin: 1px 5px 8px 0;',
+  '}',
+
+  '.blocklyHorizontalTreeRtl {',
+    'float: right;',
+    'margin: 1px 0 8px 5px;',
+  '}',
+
+  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeRow {',
+    'margin-left: 8px;',
+  '}',
+
+  '.blocklyTreeRow:not(.blocklyTreeSelected):hover {',
+    'background-color: #e4e4e4;',
+  '}',
+
+  '.blocklyTreeSeparator {',
+    'border-bottom: solid #e5e5e5 1px;',
+    'height: 0;',
+    'margin: 5px 0;',
+  '}',
+
+  '.blocklyTreeSeparatorHorizontal {',
+    'border-right: solid #e5e5e5 1px;',
+    'width: 0;',
+    'padding: 5px 0;',
+    'margin: 0 5px;',
+  '}',
+
+  '.blocklyTreeIcon {',
+    'background-image: url(<<<PATH>>>/sprites.png);',
+    'height: 16px;',
+    'vertical-align: middle;',
+    'width: 16px;',
+  '}',
+
+  '.blocklyTreeIconClosedLtr {',
+    'background-position: -32px -1px;',
+  '}',
+
+  '.blocklyTreeIconClosedRtl {',
+    'background-position: 0 -1px;',
+  '}',
+
+  '.blocklyTreeIconOpen {',
+    'background-position: -16px -1px;',
+  '}',
+
+  '.blocklyTreeSelected>.blocklyTreeIconClosedLtr {',
+    'background-position: -32px -17px;',
+  '}',
+
+  '.blocklyTreeSelected>.blocklyTreeIconClosedRtl {',
+    'background-position: 0 -17px;',
+  '}',
+
+  '.blocklyTreeSelected>.blocklyTreeIconOpen {',
+    'background-position: -16px -17px;',
+  '}',
+
+  '.blocklyTreeIconNone,',
+  '.blocklyTreeSelected>.blocklyTreeIconNone {',
+    'background-position: -48px -1px;',
+  '}',
+
+  '.blocklyTreeLabel {',
+    'cursor: default;',
+    'font-family: sans-serif;',
+    'font-size: 16px;',
+    'padding: 0 3px;',
+    'vertical-align: middle;',
+  '}',
+
+  '.blocklyToolboxDelete .blocklyTreeLabel {',
+    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
+  '}',
+
+  '.blocklyTreeSelected .blocklyTreeLabel {',
+    'color: #fff;',
+  '}'
+]);

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -833,4 +833,4 @@ Blockly.Css.register([
   '.blocklyTreeSelected .blocklyTreeLabel {',
     'color: #fff;',
   '}'
-]);
+]);  // eslint-disable-line indent

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -715,6 +715,7 @@ Blockly.utils.object.inherits(Blockly.Toolbox.TreeSeparator,
  * CSS for Toolbox.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyToolboxDelete {',
     'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
   '}',
@@ -833,4 +834,5 @@ Blockly.Css.register([
   '.blocklyTreeSelected .blocklyTreeLabel {',
     'color: #fff;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -353,4 +353,4 @@ Blockly.Css.register([
   '.blocklyZoom>image:active, .blocklyZoom>svg>image:active {',
     'opacity: .8;',
   '}'
-]);
+]);  // eslint-disable-line indent

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -26,6 +26,7 @@
 
 goog.provide('Blockly.ZoomControls');
 
+goog.require('Blockly.Css');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils.dom');
 
@@ -336,3 +337,20 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
     e.preventDefault();  // Stop double-clicking from selecting text.
   });
 };
+
+/**
+ * CSS for zoom controls.  See css.js for use.
+ */
+Blockly.Css.register([
+  '.blocklyZoom>image, .blocklyZoom>svg>image {',
+    'opacity: .4;',
+  '}',
+
+  '.blocklyZoom>image:hover, .blocklyZoom>svg>image:hover {',
+    'opacity: .6;',
+  '}',
+
+  '.blocklyZoom>image:active, .blocklyZoom>svg>image:active {',
+    'opacity: .8;',
+  '}'
+]);

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -342,6 +342,7 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
  * CSS for zoom controls.  See css.js for use.
  */
 Blockly.Css.register([
+  /* eslint-disable indent */
   '.blocklyZoom>image, .blocklyZoom>svg>image {',
     'opacity: .4;',
   '}',
@@ -353,4 +354,5 @@ Blockly.Css.register([
   '.blocklyZoom>image:active, .blocklyZoom>svg>image:active {',
     'opacity: .8;',
   '}'
-]);  // eslint-disable-line indent
+  /* eslint-enable indent */
+]);


### PR DESCRIPTION
Drops the compile test by 3 KB.
Remove obsolete .blocklyDraggable class stub (it used to be dynamically changed).
Remove unused menuseparator CSS.