### PR TITLE
Updating behavior of register functions and adding unregister.

### DIFF
--- a/core/extensions.js
+++ b/core/extensions.js
@@ -129,7 +129,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
 };
 
 /**
- * Unregisters extension with the given name.
+ * Unregisters the extension registered with the given name.
  * @param {string} name The name of the extension to unregister.
  */
 Blockly.Extensions.unregister = function(name) {

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -129,6 +129,19 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
 };
 
 /**
+ * Unregisters extension with the given name.
+ * @param {string} name The name of the extension to unregister.
+ */
+Blockly.Extensions.unregister = function(name) {
+  if (Blockly.Extensions.ALL_[name]) {
+    Blockly.Extensions.ALL_[name] = undefined;
+  } else {
+    console.warn('No extension mapping for name "' + name +
+        '" found to unregister');
+  }
+};
+
+/**
  * Applies an extension method to a block. This should only be called during
  * block construction.
  * @param {string} name The name of the extension.

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -38,7 +38,7 @@ goog.provide('Blockly.fieldRegistry');
 Blockly.fieldRegistry.typeMap_ = {};
 
 /**
- * Registers a field type. May also override an existing field type.
+ * Registers a field type.
  * Blockly.fieldRegistry.fromJson uses this registry to
  * find the appropriate field type.
  * @param {string} type The field type name as used in the JSON definition.
@@ -64,9 +64,7 @@ Blockly.fieldRegistry.register = function(type, fieldClass) {
 };
 
 /**
- * Registers a field type. May also override an existing field type.
- * Blockly.fieldRegistry.fromJson uses this registry to
- * find the appropriate field type.
+ * Unregisters the field registered with the given type.
  * @param {string} type The field type name as used in the JSON definition.
  */
 Blockly.fieldRegistry.unregister = function(type) {

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -44,19 +44,38 @@ Blockly.fieldRegistry.typeMap_ = {};
  * @param {string} type The field type name as used in the JSON definition.
  * @param {!{fromJson: Function}} fieldClass The field class containing a
  *     fromJson function that can construct an instance of the field.
- * @throws {Error} if the type name is empty, or the fieldClass is not an
- *     object containing a fromJson function.
+ * @throws {Error} if the type name is empty, the field is already
+ *     registered, or the fieldClass is not an object containing a fromJson
+ *     function.
  */
 Blockly.fieldRegistry.register = function(type, fieldClass) {
   if ((typeof type != 'string') || (type.trim() == '')) {
     throw Error('Invalid field type "' + type + '". The type must be a' +
       ' non-empty string.');
   }
+  if (Blockly.fieldRegistry.typeMap_[type]) {
+    throw Error('Error: Field "' + type + '" is already registered.');
+  }
   if (!fieldClass || (typeof fieldClass.fromJson != 'function')) {
     throw Error('Field "' + fieldClass + '" must have a fromJson function');
   }
   type = type.toLowerCase();
   Blockly.fieldRegistry.typeMap_[type] = fieldClass;
+};
+
+/**
+ * Registers a field type. May also override an existing field type.
+ * Blockly.fieldRegistry.fromJson uses this registry to
+ * find the appropriate field type.
+ * @param {string} type The field type name as used in the JSON definition.
+ */
+Blockly.fieldRegistry.unregister = function(type) {
+  if (Blockly.fieldRegistry.typeMap_[type]) {
+    Blockly.fieldRegistry.typeMap_[type] = undefined;
+  } else {
+    console.warn('No field mapping for type "' + type +
+        '" found to unregister');
+  }
 };
 
 /**

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -62,7 +62,7 @@ Blockly.blockRendering.register = function(name, rendererClass) {
 };
 
 /**
- * Unregisters renderer with the given name.
+ * Unregisters the renderer registered with the given name.
  * @param {string} name The name of the renderer.
  */
 Blockly.blockRendering.unregister = function(name) {

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -62,6 +62,19 @@ Blockly.blockRendering.register = function(name, rendererClass) {
 };
 
 /**
+ * Unregisters renderer with the given name.
+ * @param {string} name The name of the renderer.
+ */
+Blockly.blockRendering.unregister = function(name) {
+  if (Blockly.blockRendering.rendererMap_[name]) {
+    Blockly.blockRendering.rendererMap_[name] = undefined;
+  } else {
+    console.warn('No renderer mapping for name "' + name +
+        '" found to unregister');
+  }
+};
+
+/**
  * Turn on the blocks debugger.
  * @package
  */

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -57,11 +57,11 @@ suite('Field Registry', function() {
         Blockly.fieldRegistry.register(CustomFieldType.fromJson, '');
       }, 'Invalid field type');
     });
-    // TODO (#2788): What do you want it to do if you overwrite a key?
     test('Overwrite a Key', function() {
       Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
-
-      Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
+      chai.assert.throws(function() {
+        Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
+      }, 'already registered');
     });
     test('Null Value', function() {
       chai.assert.throws(function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2788
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds unregister methods for extensions, fields, and renderers.
Changes field register to throw error if another is registered with same name.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Makes the behavior of register functions more consistent with extensions, fields, and renderer all throwing an error when something is registered with same name as existing and adding an unregister functionality for all of them.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
