### PR TITLE
Enable eslint rule spaced-comment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,10 +69,11 @@
         "no-console": ["off"],
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
         "operator-linebreak": ["error", "after"],
-        "spaced-comment": ["warn", "always", {
+        "spaced-comment": ["error", "always", {
             "block": {
                 "balanced": true
-            }
+            },
+            "exceptions": ["*"]
         }]
     },
     "env": {

--- a/core/block.js
+++ b/core/block.js
@@ -1433,7 +1433,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
   // Makes styles backward compatible with old way of defining hat style.
   if (json['style'] && json['style'].hat) {
     this.hat = json['style'].hat;
-    //Must set to null so it doesn't error when checking for style and colour.
+    // Must set to null so it doesn't error when checking for style and colour.
     json['style'] = null;
   }
 

--- a/core/block_events.js
+++ b/core/block_events.js
@@ -40,7 +40,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.xml');
 // TODO: Fix recursive dependency.
-//goog.require('Blockly.Xml');
+// goog.require('Blockly.Xml');
 
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -151,7 +151,7 @@ Blockly.Bubble.unbindDragEvents_ = function() {
  * @param {!Event} e Mouse up event.
  * @private
  */
-Blockly.Bubble.bubbleMouseUp_ = function(/*e*/) {
+Blockly.Bubble.bubbleMouseUp_ = function(/* e */) {
   Blockly.Touch.clearTouchIdentifier();
   Blockly.Bubble.unbindDragEvents_();
 };

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -245,8 +245,6 @@ Blockly.InsertionMarkerManager.prototype.update = function(dxy, deleteArea) {
   }
 };
 
-/**** Begin initialization functions ****/
-
 /**
  * Create an insertion marker that represents the given block.
  * @param {!Blockly.BlockSvg} sourceBlock The block that the insertion marker
@@ -311,9 +309,6 @@ Blockly.InsertionMarkerManager.prototype.initAvailableConnections_ = function() 
   }
   return available;
 };
-
-/**** End initialization functions ****/
-
 
 /**
  * Whether the previews (insertion marker and replacement marker) should be
@@ -474,8 +469,6 @@ Blockly.InsertionMarkerManager.prototype.shouldDelete_ = function(candidate,
   return wouldDelete && !wouldConnect;
 };
 
-/**** Begin preview visibility functions ****/
-
 /**
  * Show an insertion marker or replacement highlighting during a drag, if
  * needed.
@@ -576,10 +569,6 @@ Blockly.InsertionMarkerManager.prototype.hidePreview_ = function() {
   }
 };
 
-/**** End preview visibility functions ****/
-
-/**** Begin block highlighting functions ****/
-
 /**
  * Add highlighting showing which block will be replaced.
  */
@@ -612,10 +601,6 @@ Blockly.InsertionMarkerManager.prototype.unhighlightBlock_ = function() {
   this.highlightedBlock_ = null;
   this.highlightingBlock_ = false;
 };
-
-/**** End block highlighting functions ****/
-
-/**** Begin insertion marker display functions ****/
 
 /**
  * Disconnect the insertion marker block in a manner that returns the stack to
@@ -699,8 +684,6 @@ Blockly.InsertionMarkerManager.prototype.connectMarker_ = function() {
   imConn.connect(closest);
   this.markerConnection_ = imConn;
 };
-
-/**** End insertion marker display functions ****/
 
 /**
  * Get a list of the insertion markers that currently exist.  Drags have 0, 1,

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -378,7 +378,7 @@ Blockly.ASTNode.prototype.findPrevForField_ = function() {
       }
       fieldIdx--;
     }
-    //Reset the fieldIdx to the length of the field row of the previous input
+    // Reset the fieldIdx to the length of the field row of the previous input.
     if (i - 1 >= 0) {
       fieldIdx = block.inputList[i - 1].fieldRow.length - 1;
     }

--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -201,9 +201,9 @@ Blockly.CursorSvg.prototype.setParent_ = function(newParent) {
   this.parent_ = newParent;
 };
 
-/**************************/
-/**** Display          ****/
-/**************************/
+/**************************
+ * Display
+ **************************/
 
 /**
  * Show the cursor as a combination of the previous connection and block,
@@ -345,9 +345,9 @@ Blockly.CursorSvg.prototype.showCurrent_ = function() {
   this.currentCursorSvg.style.display = '';
 };
 
-/**************************/
-/**** Position         ****/
-/**************************/
+/**************************
+ * Position
+ **************************/
 
 /**
  * Position the cursor for a block.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -167,7 +167,7 @@ Blockly.Toolbox.prototype.init = function() {
           Blockly.hideChaff(true);
         }
         Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
-      }, /*opt_noCaptureIdentifier*/ false, /*opt_noPreventDefault*/ true);
+      }, /* opt_noCaptureIdentifier */ false, /* opt_noPreventDefault */ true);
   var workspaceOptions = {
     disabledPatternId: workspace.options.disabledPatternId,
     parentWorkspace: workspace,

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -128,13 +128,13 @@ Blockly.TouchGesture.prototype.doStart = function(e) {
 Blockly.TouchGesture.prototype.bindMouseEvents = function(e) {
   this.onStartWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mousedown', null, this.handleStart.bind(this),
-      /*opt_noCaptureIdentifier*/ true);
+      /* opt_noCaptureIdentifier */ true);
   this.onMoveWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mousemove', null, this.handleMove.bind(this),
-      /*opt_noCaptureIdentifier*/ true);
+      /* opt_noCaptureIdentifier */ true);
   this.onUpWrapper_ = Blockly.bindEventWithChecks_(
       document, 'mouseup', null, this.handleUp.bind(this),
-      /*opt_noCaptureIdentifier*/ true);
+      /* opt_noCaptureIdentifier */ true);
 
   e.preventDefault();
   e.stopPropagation();

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -256,7 +256,6 @@ Blockly.WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
  * @private
  */
 Blockly.WorkspaceCommentSvg.prototype.resizeMouseDown_ = function(e) {
-  //this.promote_();
   this.unbindDragEvents_();
   if (Blockly.utils.isRightButton(e)) {
     // No right-click.
@@ -334,7 +333,7 @@ Blockly.WorkspaceCommentSvg.prototype.unbindDragEvents_ = function() {
  * @param {!Event} e Mouse up event.
  * @private
  */
-Blockly.WorkspaceCommentSvg.prototype.resizeMouseUp_ = function(/*e*/) {
+Blockly.WorkspaceCommentSvg.prototype.resizeMouseUp_ = function(/* e */) {
   Blockly.Touch.clearTouchIdentifier();
   this.unbindDragEvents_();
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -27,7 +27,7 @@
 goog.provide('Blockly.WorkspaceSvg');
 
 // TODO(scr): Fix circular dependencies
-//goog.require('Blockly.BlockSvg');
+// goog.require('Blockly.BlockSvg');
 goog.require('Blockly.blockRendering');
 goog.require('Blockly.ConnectionDB');
 goog.require('Blockly.constants');

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -288,11 +288,11 @@ suite('Connections', function() {
         var blockD = this.workspace.newBlock('row_block');
 
         blockB.setShadow(true);
-        var shadowStatement = Blockly.Xml.blockToDom(blockB, true /*noid*/);
+        var shadowStatement = Blockly.Xml.blockToDom(blockB, true /* noid */);
         blockB.setShadow(false);
 
         blockD.setShadow(true);
-        var shadowValue = Blockly.Xml.blockToDom(blockD, true /*noid*/);
+        var shadowValue = Blockly.Xml.blockToDom(blockD, true /* noid */);
         blockD.setShadow(false);
 
         var connection = blockA.getInput('STATEMENT').connection;

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -45,7 +45,7 @@ suite('Abstract Fields', function() {
     FieldFalseTrue.prototype.EDITABLE = false;
     FieldFalseTrue.prototype.SERIALIZABLE = true;
 
-    /* Test Backwards Compatibility*/
+    /* Test Backwards Compatibility */
     test('Editable Default(true), Serializable Default(false)', function() {
       // An old default field should be serialized.
       var field = new FieldDefault();

--- a/tests/mocha/xml_procedures_test.js
+++ b/tests/mocha/xml_procedures_test.js
@@ -217,8 +217,8 @@ suite('Procedures XML', function() {
           chai.assert.isEmpty(block.arguments_);
           // TODO: argumentVarModels_ is undefined for call_return, but
           //  defined for call_noreturn. Make it defined for both.
-          /*chai.assert.isArray(block.argumentVarModels_);
-          chai.assert.isEmpty(block.argumentVarModels_);*/
+          /* chai.assert.isArray(block.argumentVarModels_);
+          chai.assert.isEmpty(block.argumentVarModels_); */
         });
       });
       // TODO: I couldn't get this test (of creating a definition) to work
@@ -239,8 +239,8 @@ suite('Procedures XML', function() {
           chai.assert.isEmpty(block.arguments_);
           // TODO: argumentVarModels_ is undefined for call_return, but
           //  defined for call_noreturn. Make it defined for both.
-          /*chai.assert.isArray(block.argumentVarModels_);
-          chai.assert.isEmpty(block.argumentVarModels_);*/
+          /* chai.assert.isArray(block.argumentVarModels_);
+          chai.assert.isEmpty(block.argumentVarModels_); */
           chai.assert.equal(this.workspace.getAllBlocks().count, 2);
         });
       });


### PR DESCRIPTION
Fix up all remaining violations and turn the rule on.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Turns on another rule so we don't have to manually check it.

### Proposed Changes

Only comment changes.  Here's the rule: https://eslint.org/docs/rules/spaced-comment

This was already a warn; now it's an error.
