### PR TITLE
Prevent dataset IDs from being renamed

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -115,7 +115,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
 
   // Expose this block's ID on its top-level SVG group.
   if (this.svgGroup_.dataset) {
-    this.svgGroup_.dataset.id = this.id;
+    this.svgGroup_.dataset['id'] = this.id;
   }
 
   /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -288,7 +288,7 @@ Blockly.Bubble.prototype.getSvgRoot = function() {
  */
 Blockly.Bubble.prototype.setSvgId = function(id) {
   if (this.bubbleGroup_.dataset) {
-    this.bubbleGroup_.dataset.blockId = id;
+    this.bubbleGroup_.dataset['blockId'] = id;
   }
 };
 


### PR DESCRIPTION
The JS Compiler would rename ‘id’ and ‘blockId’ to something random.  Normally that would be fine, but if it ended up with a ‘$’ in the name, then that becomes an illegal HTML property name and Blockly crashes.

A bug that’s been lurking in Blockly for years and randomly surfaced on a recent compile.