### PR TITLE
Removing deprecated renderMode reference in playground.

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -71,8 +71,6 @@
 var workspace = null;
 
 function start() {
-  // TODO (#2702): Choose an API for picking the renderer.
-  Blockly.renderMode = 'compatibility';
   setBackgroundColour();
 
   // Parse the URL arguments.

--- a/tests/screenshot/playground_new.html
+++ b/tests/screenshot/playground_new.html
@@ -35,12 +35,6 @@ limitations under the License.
 <script src="../../blocks/procedures.js"></script>
 <script src="../blocks/test_blocks.js"></script>
 
-<script>
-  function start() {
-    // TODO (#2702): Choose an API for picking the renderer.
-    Blockly.renderMode = 'compatibility';
-  }
-</script>
 <style>
 html, body {
   height: 100%;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Removes deprecated renderMode reference in playground and removing TODO since #2702 has been resolved.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Renderer is no longer set using renderMode.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
