### PR TITLE
Use row height for spacer height.

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -126,15 +126,14 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
   if (isRtl) {
     xPos = -(xPos + elem.width);
   }
-  var debugRenderedHeight = Math.min(elem.height, rowHeight);
-  var yPos = elem.centerline - debugRenderedHeight / 2;
+  var yPos = elem.centerline - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'elemSpacerRect blockRenderDebug',
         'x': xPos,
         'y': yPos,
         'width': elem.width,
-        'height': debugRenderedHeight,
+        'height': elem.height,
         'stroke': 'pink',
         'fill': 'pink',
         'fill-opacity': '0.5',

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -625,6 +625,26 @@ Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row,
 };
 
 /**
+ * Record final position information on elements on the given row, for use in
+ * drawing.  At minimum this records xPos and centerline on each element.
+ * @param {!Blockly.blockRendering.Row} row The row containing the elements.
+ * @private
+ */
+Blockly.blockRendering.RenderInfo.prototype.recordElemPositions_ = function(
+    row) {
+  var xCursor = row.xPos;
+  for (var j = 0, elem; (elem = row.elements[j]); j++) {
+    // Now that row heights are finalized, make spacers use the row height.
+    if (Blockly.blockRendering.Types.isSpacer(elem)) {
+      elem.height = row.height;
+    }
+    elem.xPos = xCursor;
+    elem.centerline = this.getElemCenterline_(row, elem);
+    xCursor += elem.width;
+  }
+};
+
+/**
  * Make any final changes to the rendering information object.  In particular,
  * store the y position of each row, and record the height of the full block.
  * @protected
@@ -642,12 +662,7 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
 
     widestRowWithConnectedBlocks =
         Math.max(widestRowWithConnectedBlocks, row.widthWithConnectedBlocks);
-    var xCursor = row.xPos;
-    for (var j = 0, elem; (elem = row.elements[j]); j++) {
-      elem.xPos = xCursor;
-      elem.centerline = this.getElemCenterline_(row, elem);
-      xCursor += elem.width;
-    }
+    this.recordElemPositions_(row);
   }
 
   this.widthWithChildren = widestRowWithConnectedBlocks + this.startX;

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -309,6 +309,9 @@ Blockly.geras.RenderInfo.prototype.getSpacerRowHeight_ = function(prev, next) {
  * @override
  */
 Blockly.geras.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
+  if (Blockly.blockRendering.Types.isSpacer(elem)) {
+    return row.yPos + elem.height / 2;
+  }
   if (Blockly.blockRendering.Types.isBottomRow(row)) {
     var baseline = row.yPos + row.height - row.descenderHeight;
     if (Blockly.blockRendering.Types.isNextConnection(elem)) {
@@ -363,12 +366,7 @@ Blockly.geras.RenderInfo.prototype.finalize_ = function() {
       this.bottomRow.height += diff;
       yCursor += diff;
     }
-    var xCursor = row.xPos;
-    for (var j = 0, elem; (elem = row.elements[j]); j++) {
-      elem.xPos = xCursor;
-      elem.centerline = this.getElemCenterline_(row, elem);
-      xCursor += elem.width;
-    }
+    this.recordElemPositions_(row);
   }
   this.bottomRow.baseline = yCursor - this.bottomRow.descenderHeight;
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -270,6 +270,9 @@ Blockly.thrasos.RenderInfo.prototype.getSpacerRowHeight_ = function(
  * @override
  */
 Blockly.thrasos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
+  if (Blockly.blockRendering.Types.isSpacer(elem)) {
+    return row.yPos + elem.height / 2;
+  }
   if (Blockly.blockRendering.Types.isBottomRow(row)) {
     var baseline = row.yPos + row.height - row.descenderHeight;
     if (Blockly.blockRendering.Types.isNextConnection(elem)) {
@@ -320,12 +323,7 @@ Blockly.thrasos.RenderInfo.prototype.finalize_ = function() {
       this.bottomRow.height += diff;
       yCursor += diff;
     }
-    var xCursor = row.xPos;
-    for (var j = 0, elem; (elem = row.elements[j]); j++) {
-      elem.xPos = xCursor;
-      elem.centerline = this.getElemCenterline_(row, elem);
-      xCursor += elem.width;
-    }
+    this.recordElemPositions_(row);
   }
 
   this.bottomRow.baseline = yCursor - this.bottomRow.descenderHeight;

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -333,8 +333,10 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
 /**
  * @override
  */
-Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row,
-    elem) {
+Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
+  if (Blockly.blockRendering.Types.isSpacer(elem)) {
+    return row.yPos + elem.height / 2;
+  }
   if (Blockly.blockRendering.Types.isBottomRow(row)) {
     var baseline = row.yPos + row.height - row.descenderHeight;
     if (Blockly.blockRendering.Types.isNextConnection(elem)) {
@@ -398,12 +400,7 @@ Blockly.zelos.RenderInfo.prototype.finalize_ = function() {
 
     widestRowWithConnectedBlocks =
         Math.max(widestRowWithConnectedBlocks, row.widthWithConnectedBlocks);
-    var xCursor = row.xPos;
-    for (var j = 0, elem; (elem = row.elements[j]); j++) {
-      elem.xPos = xCursor;
-      elem.centerline = this.getElemCenterline_(row, elem);
-      xCursor += elem.width;
-    }
+    this.recordElemPositions_(row);
   }
 
   this.widthWithChildren = widestRowWithConnectedBlocks + this.startX;


### PR DESCRIPTION
Use row height for spacer height, instead of spacers being the default height all the time.

This fixes an issue with debug rendering showing spacers in the row place.

Pull the corresponding code up into the base renderer for code reuse.