### PR TITLE
Bound element position based on height of the row

### DIFF
--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -330,7 +330,8 @@ Blockly.geras.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
   if (Blockly.blockRendering.Types.isField(elem) ||
       Blockly.blockRendering.Types.isIcon(elem)) {
     result += (elem.height / 2);
-    if (row.hasInlineInput || row.hasStatement) {
+    if ((row.hasInlineInput || row.hasStatement) &&
+        elem.height > row.height + this.constants_.TALL_INPUT_FIELD_OFFSET_Y) {
       result += this.constants_.TALL_INPUT_FIELD_OFFSET_Y;
     }
   } else if (Blockly.blockRendering.Types.isInlineInput(elem)) {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3098, which is the case when the field next to an inline input us taller than the inline input itself.