### PR TITLE
Base renderer next / prev notch alignment issues

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -438,6 +438,22 @@ Blockly.blockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, ne
     }
   }
 
+  // Spacing between a square corner and a previous or next connection
+  if (prev && Blockly.blockRendering.Types.isLeftSquareCorner(prev) && next) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+        Blockly.blockRendering.Types.isNextConnection(next)) {
+      return next.notchOffset;
+    }
+  }
+
+  // Spacing between a rounded corner and a previous or next connection.
+  if (prev && Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+      Blockly.blockRendering.Types.isNextConnection(next)) {
+      return next.notchOffset - this.constants_.CORNER_RADIUS;
+    }
+  }
+
   return this.constants_.MEDIUM_PADDING;
 };
 
@@ -612,16 +628,30 @@ Blockly.blockRendering.RenderInfo.prototype.getSpacerRowHeight_ = function(
  * vertically, with no special cases.  You will likely need extra logic to
  * handle (at minimum) top and bottom rows.
  * @param {!Blockly.blockRendering.Row} row The row containing the element.
- * @param {!Blockly.blockRendering.Measurable} _elem The element to place.
+ * @param {!Blockly.blockRendering.Measurable} elem The element to place.
  * @return {number} The desired centerline of the given element, as an offset
  *     from the top left of the block.
  * @protected
  */
 Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row,
-    _elem) {
-  var result = row.yPos;
-  result += (row.height / 2);
-  return result;
+    elem) {
+  if (Blockly.blockRendering.Types.isSpacer(elem)) {
+    return row.yPos + elem.height / 2;
+  }
+  if (Blockly.blockRendering.Types.isBottomRow(row)) {
+    var baseline = row.yPos + row.height - row.descenderHeight;
+    if (Blockly.blockRendering.Types.isNextConnection(elem)) {
+      return baseline + elem.height / 2;
+    }
+    return baseline - elem.height / 2;
+  }
+  if (Blockly.blockRendering.Types.isTopRow(row)) {
+    if (Blockly.blockRendering.Types.isHat(elem)) {
+      return row.capline - elem.height / 2;
+    }
+    return row.capline + elem.height / 2;
+  }
+  return row.yPos + row.height / 2;
 };
 
 /**

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -331,29 +331,6 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
 };
 
 /**
- * @override
- */
-Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
-  if (Blockly.blockRendering.Types.isSpacer(elem)) {
-    return row.yPos + elem.height / 2;
-  }
-  if (Blockly.blockRendering.Types.isBottomRow(row)) {
-    var baseline = row.yPos + row.height - row.descenderHeight;
-    if (Blockly.blockRendering.Types.isNextConnection(elem)) {
-      return baseline + elem.height / 2;
-    }
-    return baseline - elem.height / 2;
-  }
-  if (Blockly.blockRendering.Types.isTopRow(row)) {
-    if (Blockly.blockRendering.Types.isHat(elem)) {
-      return row.capline - elem.height / 2;
-    }
-    return row.capline + elem.height / 2;
-  }
-  return row.yPos + row.height / 2;
-};
-
-/**
  * Modify the given row to add the given amount of padding around its fields.
  * The exact location of the padding is based on the alignment property of the
  * last input in the field.


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves https://github.com/google/blockly/issues/3132

### Proposed Changes

Add spacing before next / previous connection notches in the base renderer to account for the notch offset. 
Take into account square corners when there is a next connection.

Move baseline alignment of rows into the base renderer to take into account top and bottom row baseline. 

### Reason for Changes

Couple of issues with the base renderer.

### Test Coverage

Tested all renderers in the playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
