### PR TITLE
Fix compiler warnings related to fields.

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -839,7 +839,7 @@ Blockly.Blocks['lists_split'] = {
         if (inputBlock.isShadow()) {
           inputBlock.dispose();
         } else {
-          this.bumpNeighbours_();
+          this.bumpNeighbours();
         }
       }
     }

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -574,7 +574,7 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
           this.getInput('B').connection.connect(prevB.outputConnection);
         }
       }
-      this.bumpNeighbours_();
+      this.bumpNeighbours();
       Blockly.Events.setGroup(false);
     }
     this.prevBlocks_[0] = this.getInputTargetBlock('A');
@@ -626,10 +626,10 @@ Blockly.Constants.Logic.LOGIC_TERNARY_ONCHANGE_MIXIN = {
           Blockly.Events.setGroup(e.group);
           if (parentConnection === this.prevParentConnection_) {
             this.unplug();
-            parentConnection.getSourceBlock().bumpNeighbours_();
+            parentConnection.getSourceBlock().bumpNeighbours();
           } else {
             block.unplug();
-            block.bumpNeighbours_();
+            block.bumpNeighbours();
           }
           Blockly.Events.setGroup(false);
         }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -253,7 +253,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
           if (this.statementConnection_) {
             var stackBlock = stackConnection.targetBlock();
             stackBlock.unplug();
-            stackBlock.bumpNeighbours_();
+            stackBlock.bumpNeighbours();
           }
           this.setStatements_(false);
         }
@@ -752,7 +752,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
             paramIds.indexOf(this.quarkIds_[i]) == -1) {
           // This connection should no longer be attached to this block.
           connection.disconnect();
-          connection.getSourceBlock().bumpNeighbours_();
+          connection.getSourceBlock().bumpNeighbours();
         }
       }
     }

--- a/core/block.js
+++ b/core/block.js
@@ -518,11 +518,11 @@ Blockly.Block.prototype.lastConnectionInStack = function() {
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
- * @protected
+ * @package
  */
-Blockly.Block.prototype.bumpNeighbours_ = function() {
-  console.warn('Not expected to reach Block.bumpNeighbours_ function. ' +
-      'BlockSvg.bumpNeighbours_ was expected to be called instead.');
+Blockly.Block.prototype.bumpNeighbours = function() {
+  console.warn('Not expected to reach Block.bumpNeighbours function. ' +
+      'BlockSvg.bumpNeighbours was expected to be called instead.');
 };
 
 /**
@@ -1051,7 +1051,8 @@ Blockly.Block.prototype.getVarModels = function() {
   for (var i = 0, input; input = this.inputList[i]; i++) {
     for (var j = 0, field; field = input.fieldRow[j]; j++) {
       if (field.referencesVariables()) {
-        var model = this.workspace.getVariableById(field.getValue());
+        var model = this.workspace.getVariableById(
+            /** @type {string} */ (field.getValue()));
         // Check if the variable actually exists (and isn't just a potential
         // variable).
         if (model) {
@@ -1106,7 +1107,7 @@ Blockly.Block.prototype.renameVarById = function(oldId, newId) {
 Blockly.Block.prototype.getFieldValue = function(name) {
   var field = this.getField(name);
   if (field) {
-    return field.getValue();
+    return String(field.getValue());
   }
   return null;
 };

--- a/core/block.js
+++ b/core/block.js
@@ -1102,12 +1102,12 @@ Blockly.Block.prototype.renameVarById = function(oldId, newId) {
 /**
  * Returns the language-neutral value from the field of a block.
  * @param {string} name The name of the field.
- * @return {?string} Value from the field or null if field does not exist.
+ * @return {*} Value from the field or null if field does not exist.
  */
 Blockly.Block.prototype.getFieldValue = function(name) {
   var field = this.getField(name);
   if (field) {
-    return String(field.getValue());
+    return field.getValue();
   }
   return null;
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1110,7 +1110,7 @@ Blockly.BlockSvg.prototype.setCommentText = function(text) {
   if (this.rendered) {
     this.render();
     // Adding or removing a comment icon will cause the block to change shape.
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1193,7 +1193,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
   if (changedState && this.rendered) {
     this.render();
     // Adding or removing a warning icon will cause the block to change shape.
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1331,7 +1331,7 @@ Blockly.BlockSvg.prototype.setPreviousStatement = function(newBoolean,
 
   if (this.rendered) {
     this.render();
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1347,7 +1347,7 @@ Blockly.BlockSvg.prototype.setNextStatement = function(newBoolean, opt_check) {
 
   if (this.rendered) {
     this.render();
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1363,7 +1363,7 @@ Blockly.BlockSvg.prototype.setOutput = function(newBoolean, opt_check) {
 
   if (this.rendered) {
     this.render();
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1376,7 +1376,7 @@ Blockly.BlockSvg.prototype.setInputsInline = function(newBoolean) {
 
   if (this.rendered) {
     this.render();
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1393,7 +1393,7 @@ Blockly.BlockSvg.prototype.removeInput = function(name, opt_quiet) {
   if (this.rendered) {
     this.render();
     // Removing an input will cause the block to change shape.
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1410,7 +1410,7 @@ Blockly.BlockSvg.prototype.moveNumberedInputBefore = function(
   if (this.rendered) {
     this.render();
     // Moving an input will cause the block to change shape.
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
 };
 
@@ -1429,7 +1429,7 @@ Blockly.BlockSvg.prototype.appendInput_ = function(type, name) {
   if (this.rendered) {
     this.render();
     // Adding an input will cause the block to change shape.
-    this.bumpNeighbours_();
+    this.bumpNeighbours();
   }
   return input;
 };
@@ -1513,9 +1513,9 @@ Blockly.BlockSvg.prototype.makeConnection_ = function(type) {
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
- * @private
+ * @package
  */
-Blockly.BlockSvg.prototype.bumpNeighbours_ = function() {
+Blockly.BlockSvg.prototype.bumpNeighbours = function() {
   if (!this.workspace) {
     return;  // Deleted block.
   }
@@ -1532,7 +1532,7 @@ Blockly.BlockSvg.prototype.bumpNeighbours_ = function() {
 
     // Spider down from this block bumping all sub-blocks.
     if (connection.isConnected() && connection.isSuperior()) {
-      connection.targetBlock().bumpNeighbours_();
+      connection.targetBlock().bumpNeighbours();
     }
 
     var neighbours = connection.neighbours_(Blockly.SNAP_RADIUS);
@@ -1574,7 +1574,7 @@ Blockly.BlockSvg.prototype.scheduleSnapAndBump = function() {
 
   setTimeout(function() {
     Blockly.Events.setGroup(group);
-    block.bumpNeighbours_();
+    block.bumpNeighbours();
     Blockly.Events.setGroup(false);
   }, Blockly.BUMP_DELAY);
 };

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -262,7 +262,7 @@ Blockly.tree.TreeControl.prototype.exitDocument = function() {
 /**
  * Adds the event listeners to the tree.
  * @private
- * @suppress {deprecated}
+ * @suppress {deprecated} Suppress deprecated bindEvent_ call.
  */
 Blockly.tree.TreeControl.prototype.attachEvents_ = function() {
   var el = this.getElement();

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -131,7 +131,7 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
  */
 Blockly.Extensions.unregister = function(name) {
   if (Blockly.Extensions.ALL_[name]) {
-    Blockly.Extensions.ALL_[name] = undefined;
+    delete Blockly.Extensions.ALL_[name];
   } else {
     console.warn('No extension mapping for name "' + name +
         '" found to unregister');

--- a/core/field.js
+++ b/core/field.js
@@ -201,8 +201,6 @@ Blockly.Field.NBSP = '\u00A0';
  * Editable fields usually show some sort of UI indicating they are editable.
  * They will also be saved by the XML renderer.
  * @type {boolean}
- * @const
- * @default
  */
 Blockly.Field.prototype.EDITABLE = true;
 
@@ -211,8 +209,6 @@ Blockly.Field.prototype.EDITABLE = true;
  * are not. Editable fields should also be serializable. This is not the
  * case by default so that SERIALIZABLE is backwards compatible.
  * @type {boolean}
- * @const
- * @default
  */
 Blockly.Field.prototype.SERIALIZABLE = false;
 
@@ -707,7 +703,7 @@ Blockly.Field.prototype.forceRerender = function() {
   this.isDirty_ = true;
   if (this.sourceBlock_ && this.sourceBlock_.rendered) {
     this.sourceBlock_.render();
-    this.sourceBlock_.bumpNeighbours_();
+    this.sourceBlock_.bumpNeighbours();
   }
 };
 
@@ -752,7 +748,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
 
   if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.sourceBlock_, 'field', this.name, oldValue, newValue));
+        this.sourceBlock_, 'field', this.name || null, oldValue, newValue));
   }
   this.doValueUpdate_(newValue);
   if (this.isDirty_) {
@@ -797,7 +793,7 @@ Blockly.Field.prototype.getValue = function() {
  * @param {*=} opt_newValue The value to be validated.
  * @return {*} The validated value, same as input by default.
  * @protected
- * @suppress {deprecated}
+ * @suppress {deprecated} Suppress deprecated this.classValidator call.
  */
 Blockly.Field.prototype.doClassValidation_ = function(opt_newValue) {
   if (opt_newValue === null || opt_newValue === undefined) {

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -101,7 +101,6 @@ Blockly.FieldAngle.fromJson = function(options) {
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldAngle.prototype.SERIALIZABLE = true;
 
@@ -423,8 +422,9 @@ Blockly.FieldAngle.prototype.onHtmlInputKeyDown_ = function(e) {
     multiplier = 1;
   }
   if (multiplier) {
+    var value = /** @type {number} */ (this.getValue());
     this.displayMouseOrKeyboardValue_(
-        this.getValue() + (multiplier * this.round_));
+        value + (multiplier * this.round_));
     e.preventDefault();
     e.stopPropagation();
   }

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -109,7 +109,6 @@ Blockly.FieldCheckbox.CHECK_Y_OFFSET = 14;
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldCheckbox.prototype.SERIALIZABLE = true;
 
@@ -193,7 +192,7 @@ Blockly.FieldCheckbox.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of the field, and update the checkElement.
- * @param {string} newValue The new value ('TRUE' or 'FALSE') of the field.
+ * @param {*} newValue The value to be saved.
  * @protected
  */
 Blockly.FieldCheckbox.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -192,7 +192,8 @@ Blockly.FieldCheckbox.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of the field, and update the checkElement.
- * @param {*} newValue The value to be saved.
+ * @param {*} newValue The value to be saved. The default validator guarantees
+ * that this is a either 'TRUE' or 'FALSE'.
  * @protected
  */
 Blockly.FieldCheckbox.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -195,7 +195,8 @@ Blockly.FieldColour.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this colour field, and update the displayed colour.
- * @param {*} newValue The value to be saved. A colour in '#rrggbb' format.
+ * @param {*} newValue The value to be saved. The default validator guarantees
+ * that this is a colour in '#rrggbb' format.
  * @protected
  */
 Blockly.FieldColour.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -99,7 +99,6 @@ Blockly.FieldColour.DEFAULT_HEIGHT = Blockly.Field.BORDER_RECT_DEFAULT_HEIGHT;
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldColour.prototype.SERIALIZABLE = true;
 
@@ -196,7 +195,7 @@ Blockly.FieldColour.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this colour field, and update the displayed colour.
- * @param {string} newValue The new colour in '#rrggbb' format.
+ * @param {*} newValue The value to be saved. A colour in '#rrggbb' format.
  * @protected
  */
 Blockly.FieldColour.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_date.js
+++ b/core/field_date.js
@@ -70,7 +70,6 @@ Blockly.FieldDate.fromJson = function(options) {
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldDate.prototype.SERIALIZABLE = true;
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -134,7 +134,6 @@ Blockly.FieldDropdown.fromJson = function(options) {
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldDropdown.prototype.SERIALIZABLE = true;
 
@@ -479,7 +478,7 @@ Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this dropdown field.
- * @param {string} newValue The new language-neutral value.
+ * @param {*} newValue The value to be saved. A language-neutral value.
  * @protected
  */
 Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -478,7 +478,8 @@ Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this dropdown field.
- * @param {*} newValue The value to be saved. A language-neutral value.
+ * @param {*} newValue The value to be saved. The default validator guarantees
+ * that this is one of the valid dropdown options.
  * @protected
  */
 Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -200,7 +200,8 @@ Blockly.FieldImage.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this image field, and update the displayed image.
- * @param {*} newValue The value to be saved.
+ * @param {*} newValue The value to be saved. The default validator guarantees
+ * that this is a string.
  * @protected
  */
 Blockly.FieldImage.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -145,7 +145,6 @@ Blockly.FieldImage.Y_PADDING = 1;
  * Editable fields usually show some sort of UI indicating they are
  * editable. This field should not.
  * @type {boolean}
- * @const
  */
 Blockly.FieldImage.prototype.EDITABLE = false;
 
@@ -201,7 +200,7 @@ Blockly.FieldImage.prototype.doClassValidation_ = function(opt_newValue) {
 
 /**
  * Update the value of this image field, and update the displayed image.
- * @param {string} newValue The new image src.
+ * @param {*} newValue The value to be saved.
  * @protected
  */
 Blockly.FieldImage.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -58,7 +58,7 @@ Blockly.FieldLabel = function(opt_value, opt_class, opt_config) {
       this, opt_value, null, opt_config);
 
   if (!opt_config) {  // If the config was not passed use old configuration.
-    this.class_ = opt_class;
+    this.class_ = opt_class || null;
   }
 
   /**
@@ -88,7 +88,6 @@ Blockly.FieldLabel.fromJson = function(options) {
  * Editable fields usually show some sort of UI indicating they are
  * editable. This field should not.
  * @type {boolean}
- * @const
  */
 Blockly.FieldLabel.prototype.EDITABLE = false;
 

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -66,7 +66,6 @@ Blockly.FieldLabelSerializable.fromJson = function(options) {
  * Editable fields usually show some sort of UI indicating they are
  * editable. This field should not.
  * @type {boolean}
- * @public
  */
 Blockly.FieldLabelSerializable.prototype.EDITABLE = false;
 
@@ -74,7 +73,6 @@ Blockly.FieldLabelSerializable.prototype.EDITABLE = false;
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not.  This field should be serialized, but only edited programmatically.
  * @type {boolean}
- * @public
  */
 Blockly.FieldLabelSerializable.prototype.SERIALIZABLE = true;
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -102,7 +102,6 @@ Blockly.FieldNumber.fromJson = function(options) {
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldNumber.prototype.SERIALIZABLE = true;
 

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -66,7 +66,7 @@ Blockly.fieldRegistry.register = function(type, fieldClass) {
  */
 Blockly.fieldRegistry.unregister = function(type) {
   if (Blockly.fieldRegistry.typeMap_[type]) {
-    Blockly.fieldRegistry.typeMap_[type] = undefined;
+    delete Blockly.fieldRegistry.typeMap_[type];
   } else {
     console.warn('No field mapping for type "' + type +
         '" found to unregister');

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -55,7 +55,7 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   /**
    * Allow browser to spellcheck this field.
    * @type {boolean}
-   * @private
+   * @protected
    */
   this.spellcheck_ = true;
 
@@ -84,7 +84,6 @@ Blockly.FieldTextInput.fromJson = function(options) {
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}
- * @const
  */
 Blockly.FieldTextInput.prototype.SERIALIZABLE = true;
 
@@ -144,7 +143,7 @@ Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_invalidValue) {
     this.value_ = this.htmlInput_.untypedDefaultValue_;
     if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
-          this.sourceBlock_, 'field', this.name, oldValue, this.value_));
+          this.sourceBlock_, 'field', this.name || null, oldValue, this.value_));
     }
   }
 };
@@ -153,7 +152,7 @@ Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_invalidValue) {
  * Called by setValue if the text input is valid. Updates the value of the
  * field, and updates the text of the field if it is not currently being
  * edited (i.e. handled by the htmlInput_).
- * @param {string} newValue The new validated value of the field.
+ * @param {*} newValue The value to be saved.
  * @protected
  */
 Blockly.FieldTextInput.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -152,7 +152,8 @@ Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_invalidValue) {
  * Called by setValue if the text input is valid. Updates the value of the
  * field, and updates the text of the field if it is not currently being
  * edited (i.e. handled by the htmlInput_).
- * @param {*} newValue The value to be saved.
+ * @param {*} newValue The value to be saved. The default validator guarantees
+ * that this is a string.
  * @protected
  */
 Blockly.FieldTextInput.prototype.doValueUpdate_ = function(newValue) {

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -326,7 +326,7 @@ Blockly.FieldVariable.prototype.getVariableTypes_ = function() {
   var variableTypes = this.variableTypes;
   if (variableTypes === null) {
     // If variableTypes is null, return all variable types.
-    if (this.sourceBlock_.workspace) {
+    if (this.sourceBlock_ && this.sourceBlock_.workspace) {
       return this.sourceBlock_.workspace.getVariableTypes();
     }
   }
@@ -403,7 +403,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
   }
   var name = this.getText();
   var variableModelList = [];
-  if (this.sourceBlock_.workspace) {
+  if (this.sourceBlock_ && this.sourceBlock_.workspace) {
     var variableTypes = this.getVariableTypes_();
     // Get a copy of the list, so that adding rename and new variable options
     // doesn't modify the workspace's list.
@@ -444,7 +444,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
 Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
   var id = menuItem.getValue();
   // Handle special cases.
-  if (this.sourceBlock_.workspace) {
+  if (this.sourceBlock_ && this.sourceBlock_.workspace) {
     if (id == Blockly.RENAME_VARIABLE_ID) {
       // Rename variable.
       Blockly.Variables.renameVariable(

--- a/core/input.js
+++ b/core/input.js
@@ -133,7 +133,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
   if (this.sourceBlock_.rendered) {
     this.sourceBlock_.render();
     // Adding a field will cause the block to change shape.
-    this.sourceBlock_.bumpNeighbours_();
+    this.sourceBlock_.bumpNeighbours();
   }
   return index;
 };
@@ -151,7 +151,7 @@ Blockly.Input.prototype.removeField = function(name) {
       if (this.sourceBlock_.rendered) {
         this.sourceBlock_.render();
         // Removing a field will cause the block to change shape.
-        this.sourceBlock_.bumpNeighbours_();
+        this.sourceBlock_.bumpNeighbours();
       }
       return;
     }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -364,7 +364,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
       var group = Blockly.Events.getGroup();
       setTimeout(function() {
         Blockly.Events.setGroup(group);
-        block.bumpNeighbours_();
+        block.bumpNeighbours();
         Blockly.Events.setGroup(false);
       }, Blockly.BUMP_DELAY);
     }

--- a/core/names.js
+++ b/core/names.js
@@ -113,6 +113,7 @@ Blockly.Names.prototype.getNameForUserVariable_ = function(id) {
  * @param {string} type The type of entity in Blockly
  *     ('VARIABLE', 'PROCEDURE', 'BUILTIN', etc...).
  * @return {string} An entity name that is legal in the exported language.
+ * @suppress {deprecated} Suppress deprecated Blockly.Variables.NAME_TYPE.
  */
 Blockly.Names.prototype.getName = function(name, type) {
   if (type == Blockly.Variables.NAME_TYPE) {

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -495,6 +495,6 @@ Blockly.RenderedConnection.prototype.onCheckChanged_ = function() {
     var child = this.isSuperior() ? this.targetBlock() : this.sourceBlock_;
     child.unplug();
     // Bump away.
-    this.sourceBlock_.bumpNeighbours_();
+    this.sourceBlock_.bumpNeighbours();
   }
 };

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -64,7 +64,7 @@ Blockly.blockRendering.register = function(name, rendererClass) {
  */
 Blockly.blockRendering.unregister = function(name) {
   if (Blockly.blockRendering.rendererMap_[name]) {
-    Blockly.blockRendering.rendererMap_[name] = undefined;
+    delete Blockly.blockRendering.rendererMap_[name];
   } else {
     console.warn('No renderer mapping for name "' + name +
         '" found to unregister');

--- a/core/variables.js
+++ b/core/variables.js
@@ -466,7 +466,7 @@ Blockly.Variables.generateVariableFieldDom = function(variableModel) {
  * If no variable exists, creates and returns it.
  * @param {!Blockly.Workspace} workspace The workspace to search for the
  *     variable.  It may be a flyout workspace or main workspace.
- * @param {string} id The ID to use to look up or create the variable, or null.
+ * @param {?string} id The ID to use to look up or create the variable, or null.
  * @param {string=} opt_name The string to use to look up or create the
  *     variable.
  * @param {string=} opt_type The type to use to look up or create the variable.
@@ -490,7 +490,7 @@ Blockly.Variables.getOrCreateVariablePackage = function(workspace, id, opt_name,
  * Always prefers lookup by ID to lookup by name + type.
  * @param {!Blockly.Workspace} workspace The workspace to search for the
  *     variable.  It may be a flyout workspace or main workspace.
- * @param {string} id The ID to use to look up the variable, or null.
+ * @param {?string} id The ID to use to look up the variable, or null.
  * @param {string=} opt_name The string to use to look up the variable.
  *     Only used if lookup by ID fails.
  * @param {string=} opt_type The type to use to look up the variable.
@@ -531,7 +531,7 @@ Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
  * Helper function to create a variable on the given workspace.
  * @param {!Blockly.Workspace} workspace The workspace in which to create the
  * variable.  It may be a flyout workspace or main workspace.
- * @param {string} id The ID to use to create the variable, or null.
+ * @param {?string} id The ID to use to create the variable, or null.
  * @param {string=} opt_name The string to use to create the variable.
  * @param {string=} opt_type The type to use to create the variable.
  * @return {!Blockly.VariableModel} The variable corresponding to the given ID

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -31,7 +31,7 @@ suite('Inputs', function() {
     ), this.workspace);
 
     this.renderStub = sinon.stub(this.block, 'render');
-    this.bumpNeighboursStub = sinon.stub(this.block, 'bumpNeighbours_');
+    this.bumpNeighboursStub = sinon.stub(this.block, 'bumpNeighbours');
 
     this.dummy = this.block.appendDummyInput('DUMMY');
     this.value = this.block.appendValueInput('VALUE');


### PR DESCRIPTION

## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes 34 warnings related to fields.

### Proposed Changes

``bumpNeighbours`` is @package.
Fix unregister calls to delete from map rather than set to undefined.
Make ``SERIALIZABLE`` and ``EDITABLE`` not constants.
Fix ``doValueUpdate_`` parameter to be consistent with super class. 

### Reason for Changes

Compiler warnings.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
