### PR TITLE
Restore require variables to blockly.js

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -27,18 +27,19 @@
  */
 goog.provide('Blockly');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');
+goog.require('Blockly.inject');
 goog.require('Blockly.navigation');
 goog.require('Blockly.Procedures');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
-goog.require('Blockly.WidgetDiv');
-goog.require('Blockly.WorkspaceSvg');
-goog.require('Blockly.constants');
-goog.require('Blockly.inject');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.colour');
+goog.require('Blockly.Variables');
+goog.require('Blockly.WidgetDiv');
+goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
 


### PR DESCRIPTION
Variables and Xml are circular dependencies.  Both need to be declared in blockly.js

Maybe they can be sorted out later, but for now things are broken since nobody in core currently requires variables anywhere.

Also alphabetize (not asciibetize) the requires in blockly.js.