### PR TITLE
Misc cleanup

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -234,13 +234,10 @@ Blockly.FlyoutButton.prototype.dispose = function() {
   }
   if (this.svgGroup_) {
     Blockly.utils.dom.removeNode(this.svgGroup_);
-    this.svgGroup_ = null;
   }
   if (this.svgText_) {
     this.workspace_.getThemeManager().unsubscribe(this.svgText_);
   }
-  this.workspace_ = null;
-  this.targetWorkspace_ = null;
 };
 
 /**

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -48,7 +48,7 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, xml, isLabel) {
   this.workspace_ = workspace;
 
   /**
-   * @type {!Blockly.Workspace}
+   * @type {!Blockly.WorkspaceSvg}
    * @private
    */
   this.targetWorkspace_ = targetWorkspace;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -947,9 +947,9 @@ Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
   while (element) {
     if (element.tagName == 'svg') {
       this.cachedParentSvg_ = element;
-      return /** @type {!SVGElement} */ (element);
+      return element;
     }
-    element = element.parentNode;
+    element = /** @type {!SVGElement} */ (element.parentNode);
   }
   return null;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -921,7 +921,7 @@ Blockly.WorkspaceSvg.prototype.updateScreenCalculationsIfScrolled =
 
 /**
  * Get the SVG element that forms the drawing surface.
- * @return {!Element} SVG element.
+ * @return {!SVGElement} SVG element.
  */
 Blockly.WorkspaceSvg.prototype.getCanvas = function() {
   return this.svgBlockCanvas_;
@@ -937,7 +937,7 @@ Blockly.WorkspaceSvg.prototype.getBubbleCanvas = function() {
 
 /**
  * Get the SVG element that contains this workspace.
- * @return {Element} SVG element.
+ * @return {SVGElement} SVG element.
  */
 Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
   if (this.cachedParentSvg_) {
@@ -947,7 +947,7 @@ Blockly.WorkspaceSvg.prototype.getParentSvg = function() {
   while (element) {
     if (element.tagName == 'svg') {
       this.cachedParentSvg_ = element;
-      return element;
+      return /** @type {!SVGElement} */ (element);
     }
     element = element.parentNode;
   }

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -31,10 +31,14 @@ goog.require('Blockly.utils.dom');
 
 /**
  * Class for a zoom controls.
- * @param {!Blockly.Workspace} workspace The workspace to sit in.
+ * @param {!Blockly.WorkspaceSVG} workspace The workspace to sit in.
  * @constructor
  */
 Blockly.ZoomControls = function(workspace) {
+  /**
+   * @type {!Blockly.WorkspaceSvg}
+   * @private
+   */
   this.workspace_ = workspace;
 };
 
@@ -128,9 +132,7 @@ Blockly.ZoomControls.prototype.init = function(verticalSpacing) {
 Blockly.ZoomControls.prototype.dispose = function() {
   if (this.svgGroup_) {
     Blockly.utils.dom.removeNode(this.svgGroup_);
-    this.svgGroup_ = null;
   }
-  this.workspace_ = null;
 };
 
 /**


### PR DESCRIPTION
Fix some annotations and remove setting things to null in dispose for flyout buttons.

I played around with the memory tab in chrome dev tools to make sure this wasn't retaining anything extra as a result.

There are some event listeners attached to the dom nodes but they don't keep anything else alive, and no one else references them, so they disappear with the nodes.