### PR TITLE
Get rid of unnecessary nulls in block dragger, insertion marker manag…

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -100,14 +100,10 @@ Blockly.BlockDragger = function(block, workspace) {
  * @package
  */
 Blockly.BlockDragger.prototype.dispose = function() {
-  this.draggingBlock_ = null;
-  this.workspace_ = null;
-  this.startWorkspace_ = null;
   this.dragIconData_.length = 0;
 
   if (this.draggedConnectionManager_) {
     this.draggedConnectionManager_.dispose();
-    this.draggedConnectionManager_ = null;
   }
 };
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -250,24 +250,14 @@ Blockly.Gesture.prototype.dispose = function() {
     Blockly.unbindEvent_(this.onUpWrapper_);
   }
 
-
-  this.startField_ = null;
-  this.startBlock_ = null;
-  this.targetBlock_ = null;
-  this.startWorkspace_ = null;
-  this.flyout_ = null;
-
   if (this.blockDragger_) {
     this.blockDragger_.dispose();
-    this.blockDragger_ = null;
   }
   if (this.workspaceDragger_) {
     this.workspaceDragger_.dispose();
-    this.workspaceDragger_ = null;
   }
   if (this.bubbleDragger_) {
     this.bubbleDragger_.dispose();
-    this.bubbleDragger_ = null;
   }
 };
 

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -146,27 +146,19 @@ Blockly.InsertionMarkerManager = function(block) {
  * @package
  */
 Blockly.InsertionMarkerManager.prototype.dispose = function() {
-  this.topBlock_ = null;
-  this.workspace_ = null;
   this.availableConnections_.length = 0;
-  this.closestConnection_ = null;
-  this.localConnection_ = null;
 
   Blockly.Events.disable();
   try {
     if (this.firstMarker_) {
       this.firstMarker_.dispose();
-      this.firstMarker_ = null;
     }
     if (this.lastMarker_) {
       this.lastMarker_.dispose();
-      this.lastMarker_ = null;
     }
   } finally {
     Blockly.Events.enable();
   }
-
-  this.highlightedBlock_ = null;
 };
 
 /**


### PR DESCRIPTION
…er, and gesture dispose functions.



## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on #2152

### Proposed Changes

Stop setting some properties to null in the dispose functions for the block dragger, insertion marker manager, and gesture classes.

### Reason for Changes

Garbage collector can handle it just fine.


### Test Coverage
Tested in the playground:
- refresh
- load a single block from xml
- force run the garbage collector from chrome dev tools
- take a heap snapshot
- drag the block around
- force run the garbage collector
- take a heap snapshot
- look at detached nodes in the second snapshot, and compare sizes of first and second snapshots (should be the same or almost the same)

