### PR TITLE
Make bumpNeighbours public.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -539,7 +539,6 @@ Blockly.Block.prototype.lastConnectionInStack = function() {
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
- * @package
  */
 Blockly.Block.prototype.bumpNeighbours = function() {
   console.warn('Not expected to reach Block.bumpNeighbours function. ' +

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1566,7 +1566,6 @@ Blockly.BlockSvg.prototype.makeConnection_ = function(type) {
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
- * @package
  */
 Blockly.BlockSvg.prototype.bumpNeighbours = function() {
   if (!this.workspace) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/3152

### Proposed Changes

Turns out @package is more restrictively. Making ``bumpNeighbours`` public since it's used in blocks.
This is a bit lame, because what we really want is @package. A way to say this is okay to be used within our codebase but not outside, but blocks falls in a different directory, so we can't use @package. 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
