### PR TITLE
Removed Object.assign() from turtle demo

### DIFF
--- a/demos/custom-fields/turtle/blocks.js
+++ b/demos/custom-fields/turtle/blocks.js
@@ -48,7 +48,11 @@ Blockly.Blocks['turtle_nullifier'] = {
   },
 
   validate: function(newValue) {
-    this.cachedValidatedValue_ = Object.assign({}, newValue);
+    this.cachedValidatedValue_ = {
+      turtleName: newValue.turtleName,
+      pattern: newValue.pattern,
+      hat: newValue.hat,
+    };
     if ((newValue.turtleName == 'Leonardo' && newValue.hat == 'Mask') ||
         (newValue.turtleName == 'Yertle' && newValue.hat == 'Crown') ||
         (newValue.turtleName == 'Franklin') && newValue.hat == 'Propeller') {

--- a/demos/custom-fields/turtle/field_turtle.js
+++ b/demos/custom-fields/turtle/field_turtle.js
@@ -316,16 +316,18 @@ CustomFields.FieldTurtle.prototype.renderEditor_ = function() {
 // included inside render_ (it is not called anywhere else), but it is
 // usually separated to keep code more organized.
 CustomFields.FieldTurtle.prototype.updateSize_ = function() {
-  var size = this.movableGroup_.getBBox();
+  var bbox = this.movableGroup_.getBBox();
+  var width = bbox.width;
+  var height = bbox.height;
   if (this.borderRect_) {
-    size.width += this.PADDING;
-    size.height += this.PADDING;
-    this.borderRect_.setAttribute('width', size.width);
-    this.borderRect_.setAttribute('height', size.height);
+    width += this.PADDING;
+    height += this.PADDING;
+    this.borderRect_.setAttribute('width', width);
+    this.borderRect_.setAttribute('height', height);
   }
   // Note how both the width and the height can be dynamic.
-  this.size_.width = size.width;
-  this.size_.height = size.height;
+  this.size_.width = width;
+  this.size_.height = height;
 };
 
 // Called when the field is clicked. It is usually used to show an editor,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#3153 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the Object.assign call from the turtle demo.

No longer assign to properties of the bbox (not that we were trying to change them anyway).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Doesn't work in IE.

Throws errors in IE.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested the relevant example block manually.

Tested on:
* Desktop Chrome
* Desktop Firefox 
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
* Windows Internet Explorer 11
* Windows Edge

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I figured this was just for a demo, so I went with the simple options.
