### PR TITLE
Remove call to setText in playground

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8">
 <title>Blockly Playground</title>
 <script src="../blockly_uncompressed.js"></script>
@@ -237,7 +238,6 @@ function addToolboxButtonCallbacks() {
     for (var i = 0, block; block = blocks[i]; i++) {
       var imageField = block.getField('IMAGE');
       imageField.setValue(src);
-      imageField.setText(image);
     }
   };
   var addVariables = function(button) {
@@ -523,7 +523,7 @@ var spaghettiXml = [
   #blocklyDiv {
     float: right;
     height: 95%;
-    width: 70%;
+    width: 100%;
   }
   #importExport {
     font-family: monospace;

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8">
 <title>Blockly Playground</title>
 <script src="../blockly_uncompressed.js"></script>
@@ -523,7 +522,7 @@ var spaghettiXml = [
   #blocklyDiv {
     float: right;
     height: 95%;
-    width: 100%;
+    width: 70%;
   }
   #importExport {
     font-family: monospace;


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

The change image flyout button throws an error.

### Proposed Changes

We no longer need this call to setText, and setText is very much deprecated. 
Removing.
### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
