### PR TITLE
Remove dead code from ast node

### DIFF
--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -243,33 +243,6 @@ Blockly.ASTNode.prototype.isConnection = function() {
 };
 
 /**
- * Get either the previous editable field, or get the first editable field for
- * the given input.
- * @param {!(Blockly.Field|Blockly.Connection)} location The current location of
- *     the cursor, which must be a field or connection.
- * @param {!Blockly.Input} parentInput The parentInput of the field.
- * @param {boolean=} opt_last If true find the last editable field otherwise get
- *     the previous field.
- * @return {Blockly.ASTNode} The AST node holding the previous or last field or
- *     null if no previous field exists.
- * @private
- */
-Blockly.ASTNode.prototype.findPreviousEditableField_ = function(location,
-    parentInput, opt_last) {
-  var fieldRow = parentInput.fieldRow;
-  var fieldIdx = fieldRow.indexOf(location);
-  var previousField = null;
-  var startIdx = (opt_last ? fieldRow.length : fieldIdx) - 1;
-  for (var i = startIdx, field; field = fieldRow[i]; i--) {
-    if (field.EDITABLE) {
-      previousField = field;
-      return Blockly.ASTNode.createFieldNode(previousField);
-    }
-  }
-  return null;
-};
-
-/**
  * Given an input find the next editable field or an input with a non null
  * connection in the same block. The current location must be an input
  * connection.

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -110,23 +110,6 @@ suite('ASTNode', function() {
   });
 
   suite('HelperFunctions', function() {
-    test('findPreviousEditableField_', function() {
-      var input = this.blocks.statementInput1.inputList[0];
-      var field = input.fieldRow[1];
-      var prevField = input.fieldRow[0];
-      var node = Blockly.ASTNode.createFieldNode(prevField);
-      var editableField = node.findPreviousEditableField_(field, input);
-      assertEquals(editableField.getLocation(), prevField);
-    });
-
-    test('findPreviousEditableFieldLast_', function() {
-      var input = this.blocks.statementInput1.inputList[0];
-      var field = input.fieldRow[0];
-      var node = Blockly.ASTNode.createFieldNode(field);
-      var editableField = node.findPreviousEditableField_(field, input, true);
-      assertEquals(editableField.getLocation(), input.fieldRow[1]);
-    });
-
     test('findNextForInput_', function() {
       var input = this.blocks.statementInput1.inputList[0];
       var input2 = this.blocks.statementInput1.inputList[1];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes
Remove findPreviousEditableField_ from ast node. 

### Reason for Changes
It wasn't being used anywhere.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
