### PR TITLE
Make "Infinity" case-insensitive in number field

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -274,8 +274,8 @@ Blockly.FieldNumber.prototype.doClassValidation_ = function(opt_newValue) {
   newValue = newValue.replace(/O/ig, '0');
   // Strip out thousands separators.
   newValue = newValue.replace(/,/g, '');
-  // Ignore case of 'Infinity'
-  newValue = newValue.replace(/infinity/i, "Infinity");
+  // Ignore case of 'Infinity'.
+  newValue = newValue.replace(/infinity/i, 'Infinity');
 
   // Clean up number.
   var n = Number(newValue || 0);

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -274,6 +274,8 @@ Blockly.FieldNumber.prototype.doClassValidation_ = function(opt_newValue) {
   newValue = newValue.replace(/O/ig, '0');
   // Strip out thousands separators.
   newValue = newValue.replace(/,/g, '');
+  // Ignore case of 'Infinity'
+  newValue = newValue.replace(/infinity/i, "Infinity");
 
   // Clean up number.
   var n = Number(newValue || 0);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #3180 
### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The number field now accepts any case-variation of "Infinity".

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Firstly because #3180 requested it and I also think that it would be convenient to use "infinity" lower-case or prevent the user from accidentially capitalizing one letter.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome - Version 77.0.3865.90 (Official Build) (64-bit)
* Windows Internet Explorer 11 - Version 11.388.18362.0
 * Windows Edge - Version 44.18362.387.0

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
