### PR TITLE
Add setLocale to the Blockly typescript definition file.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -369,7 +369,6 @@ gulp.task('typings', function (cb) {
   const srcs = [
     'typings/parts/blockly-header.d.ts',
     'typings/parts/blockly-interfaces.d.ts',
-    'typings/parts/goog-closure.d.ts',
     `${tmpDir}/core/**`,
     `${tmpDir}/core/components/**`,
     `${tmpDir}/core/components/tree/**`,

--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -79,13 +79,13 @@ declare module Blockly {
     viewWidth: number;
   }
 
-}
-
-declare namespace goog {
-  function require(name: string): void;
-  function provide(name: string): void;
-  function inherits(child: any, parent: any): void;
-  function isFunction(f: any): boolean;
+  /**
+   * Set the Blockly locale.
+   * Note: this method is only available in the npm release of Blockly.
+   * @param {!Object} msg An object of Blockly message strings in the desired
+   *     language.
+   */
+  function setLocale(msg: {[key: string]: string;}): void;
 }
 
 

--- a/typings/parts/blockly-interfaces.d.ts
+++ b/typings/parts/blockly-interfaces.d.ts
@@ -56,4 +56,11 @@ declare module Blockly {
     viewWidth: number;
   }
 
+  /**
+   * Set the Blockly locale.
+   * Note: this method is only available in the npm release of Blockly.
+   * @param {!Object} msg An object of Blockly message strings in the desired
+   *     language.
+   */
+  function setLocale(msg: {[key: string]: string;}): void;
 }

--- a/typings/parts/goog-closure.d.ts
+++ b/typings/parts/goog-closure.d.ts
@@ -1,6 +1,0 @@
-declare namespace goog {
-  function require(name: string): void;
-  function provide(name: string): void;
-  function inherits(child: any, parent: any): void;
-  function isFunction(f: any): boolean;
-}


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

setLocale not in typescript definitions as it's defined under ``package/``.

https://groups.google.com/forum/#!topic/blockly/UXjQnNHTixA

### Proposed Changes

Adding to the override typings.
Remove goog typings.

### Reason for Changes

Affects angular sample / anyone using the npm release and wants to update the locale.

### Test Coverage

Tested with angular sample.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
