### PR TITLE
Fix #3169

### DIFF
--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -80,10 +80,10 @@ Blockly.utils.object.inherits(Blockly.RenderedConnection, Blockly.Connection);
  * @package
  */
 Blockly.RenderedConnection.prototype.dispose = function() {
+  Blockly.RenderedConnection.superClass_.dispose.call(this);
   if (this.tracked_) {
     this.db_.removeConnection(this, this.y_);
   }
-  Blockly.RenderedConnection.superClass_.dispose.call(this);
 };
 
 /**


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3169
### Proposed Changes

Moves the superclass dispose call to the beginning of the dispose.

### Reason for Changes

Apparently having it in the other order breaks removing the connection from the DB.  I don't yet understand why and will need to dig.
@BeksOmega Sam and I also talked about style here (since I requested this change originally).  The pattern we want to go with is to call the superclass dispose first, then do the rest of the cleanup.

### Test Coverage
Tested in the playground.

### Documentation

None

### Additional Information

