### PR TITLE
More field dispose

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -114,6 +114,12 @@ Blockly.clipboardTypeCounts_ = null;
 Blockly.cache3dSupported_ = null;
 
 /**
+ * Blockly opaque event data.
+ * @typedef {!Array.<!Array>}
+ */
+Blockly.EventData;
+
+/**
  * Returns the dimensions of the specified SVG image.
  * @param {!Element} svg SVG image.
  * @return {!Object} Contains width and height properties.
@@ -455,7 +461,7 @@ Blockly.defineBlocksWithJsonArray = function(jsonArray) {
  *     should prevent the default handler.  False by default.  If
  *     opt_noPreventDefault is provided, opt_noCaptureIdentifier must also be
  *     provided.
- * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
+ * @return {!Blockly.EventData} Opaque data that can be passed to unbindEvent_.
  */
 Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     opt_noCaptureIdentifier, opt_noPreventDefault) {
@@ -521,7 +527,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
  * @param {string} name Event name to listen to (e.g. 'mousedown').
  * @param {Object} thisObject The value of 'this' in the function.
  * @param {!Function} func Function to call when event is triggered.
- * @return {!Array.<!Array>} Opaque data that can be passed to unbindEvent_.
+ * @return {!Blockly.EventData} Opaque data that can be passed to unbindEvent_.
  */
 Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var wrapFunc = function(e) {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -114,7 +114,8 @@ Blockly.clipboardTypeCounts_ = null;
 Blockly.cache3dSupported_ = null;
 
 /**
- * Blockly opaque event data.
+ * Blockly opaque event data used to unbind events when using
+ * `Blockly.bindEvent_` and `Blockly.bindEventWithChecks_`.
  * @typedef {!Array.<!Array>}
  */
 Blockly.EventData;

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -332,7 +332,7 @@ Blockly.Component.prototype.exitDocument = function() {
 /**
  * Disposes of the object. If the object hasn't already been disposed of, calls
  * {@link #disposeInternal}.
- * @protected
+ * @package
  */
 Blockly.Component.prototype.dispose = function() {
   if (!this.disposed_) {

--- a/core/field.js
+++ b/core/field.js
@@ -310,7 +310,7 @@ Blockly.Field.prototype.init = function() {
   if (!this.isVisible()) {
     this.fieldGroup_.style.display = 'none';
   }
-  var sourceBlockSvg = (/** @type {!Blockly.BlockSvg} **/ (this.sourceBlock_));
+  var sourceBlockSvg = /** @type {!Blockly.BlockSvg} **/ (this.sourceBlock_);
   sourceBlockSvg.getSvgRoot().appendChild(this.fieldGroup_);
   this.initView();
   this.updateEditable();

--- a/core/field.js
+++ b/core/field.js
@@ -932,7 +932,8 @@ Blockly.Field.prototype.getClickTarget_ = function() {
  * @private
  */
 Blockly.Field.prototype.getAbsoluteXY_ = function() {
-  return Blockly.utils.style.getPageOffset(this.borderRect_);
+  return Blockly.utils.style.getPageOffset(
+      /** @type {!SVGRectElement} */ (this.borderRect_));
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -222,7 +222,8 @@ Blockly.Field.prototype.clickTarget_ = null;
  * Override if the text representation of the value of this field
  * is not just a string cast of its value.
  * Return null to resort to a string cast.
- * @type {?function():?string}
+ * @return {?string} Current text. Return null to resort to a string cast.
+ * @protected
  */
 Blockly.Field.prototype.getText_;
 
@@ -230,7 +231,8 @@ Blockly.Field.prototype.getText_;
  * An optional method that can be defined to show an editor when the field is
  *     clicked. Blockly will automatically set the field as clickable if this
  *     method is defined.
- * @type {?function():void}
+ * @return {void}
+ * @protected
  */
 Blockly.Field.prototype.showEditor_;
 

--- a/core/field.js
+++ b/core/field.js
@@ -428,11 +428,6 @@ Blockly.Field.prototype.dispose = function() {
 
   Blockly.utils.dom.removeNode(this.fieldGroup_);
 
-  this.fieldGroup_ = null;
-  this.textElement_ = null;
-  this.textContent_ = null;
-  this.borderRect_ = null;
-
   this.disposed = true;
 };
 

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -97,21 +97,21 @@ Blockly.FieldAngle = function(opt_value, opt_validator, opt_config) {
   this.line_ = null;
 
   /**
-   * Wrapper click event data. 
+   * Wrapper click event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.clickWrapper_ = null;
 
   /**
-   * Surface click event data. 
+   * Surface click event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.clickSurfaceWrapper_ = null;
 
   /**
-   * Surface mouse move event data. 
+   * Surface mouse move event data.
    * @type {?Blockly.EventData}
    * @private
    */

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -83,6 +83,18 @@ Blockly.FieldAngle = function(opt_value, opt_validator, opt_config) {
 
   Blockly.FieldAngle.superClass_.constructor.call(
       this, opt_value || 0, opt_validator, opt_config);
+
+  /**
+   * The angle picker's gauge path depending on the value.
+   * @type {SVGElement}
+   */
+  this.gauge_ = null;
+
+  /**
+   * The angle picker's line drawn representing the value's angle.
+   * @type {SVGElement}
+   */
+  this.line_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
 

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -96,21 +96,21 @@ Blockly.FieldAngle = function(opt_value, opt_validator, opt_config) {
    */
   this.line_ = null;
 
-  /** 
+  /**
    * Wrapper click event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.clickWrapper_ = null;
 
-  /** 
+  /**
    * Surface click event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.clickSurfaceWrapper_ = null;
 
-  /** 
+  /**
    * Surface mouse move event data. 
    * @type {?Blockly.EventData}
    * @private

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -95,6 +95,27 @@ Blockly.FieldAngle = function(opt_value, opt_validator, opt_config) {
    * @type {SVGElement}
    */
   this.line_ = null;
+
+  /** 
+   * Wrapper click event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.clickWrapper_ = null;
+
+  /** 
+   * Surface click event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.clickSurfaceWrapper_ = null;
+
+  /** 
+   * Surface mouse move event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.moveSurfaceWrapper_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldAngle, Blockly.FieldTextInput);
 
@@ -320,9 +341,15 @@ Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
  * @private
  */
 Blockly.FieldAngle.prototype.dropdownDispose_ = function() {
-  Blockly.unbindEvent_(this.clickWrapper_);
-  Blockly.unbindEvent_(this.clickSurfaceWrapper_);
-  Blockly.unbindEvent_(this.moveSurfaceWrapper_);
+  if (this.clickWrapper_) {
+    Blockly.unbindEvent_(this.clickWrapper_);
+  }
+  if (this.clickSurfaceWrapper_) {
+    Blockly.unbindEvent_(this.clickSurfaceWrapper_);
+  }
+  if (this.moveSurfaceWrapper_) {
+    Blockly.unbindEvent_(this.moveSurfaceWrapper_);
+  }
   this.gauge_ = null;
   this.line_ = null;
 };

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -65,6 +65,55 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
    */
   this.size_ = new Blockly.utils.Size(Blockly.FieldColour.DEFAULT_WIDTH,
       Blockly.FieldColour.DEFAULT_HEIGHT);
+
+  /** 
+   * The field's colour picker element.
+   * @type {HTMLElement}
+   * @private
+   */
+  this.picker_ = null;
+
+  /**
+   * 
+   * @type {?number}
+   * @private
+   */
+  this.highlightedIndex_ = null;
+
+  /** 
+   * Mouse click event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onClickWrapper_ = null;
+
+  /** 
+   * Mouse move event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onMouseMoveWrapper_ = null;
+
+  /** 
+   * Mouse enter event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onMouseEnterWrapper_ = null;
+
+  /** 
+   * Mouse leave event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onMouseLeaveWrapper_ = null;
+
+  /** 
+   * Key down event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onKeyDownWrapper_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldColour, Blockly.Field);
 
@@ -415,7 +464,7 @@ Blockly.FieldColour.prototype.moveHighlightBy_ = function(dx, dy) {
   }
 
   // Move the highlight to the new coordinates.
-  var cell = this.picker_.childNodes[y].childNodes[x];
+  var cell = /** @type {!Element} */ (this.picker_.childNodes[y].childNodes[x]);
   var index = (y * columns) + x;
   this.setHighlightedCell_(cell, index);
 };
@@ -427,9 +476,9 @@ Blockly.FieldColour.prototype.moveHighlightBy_ = function(dx, dy) {
  */
 Blockly.FieldColour.prototype.onMouseMove_ = function(e) {
   var cell = /** @type {!Element} */ (e.target);
-  var index = cell && cell.getAttribute('data-index');
+  var index = cell && Number(cell.getAttribute('data-index'));
   if (index !== null && index !== this.highlightedIndex_) {
-    this.setHighlightedCell_(cell, Number(index));
+    this.setHighlightedCell_(cell, index);
   }
 };
 
@@ -456,7 +505,7 @@ Blockly.FieldColour.prototype.onMouseLeave_ = function() {
 
 /**
  * Returns the currently highlighted item (if any).
- * @return {Element} Highlighted item (null if none).
+ * @return {HTMLElement} Highlighted item (null if none).
  * @private
  */
 Blockly.FieldColour.prototype.getHighlighted_ = function() {
@@ -467,7 +516,7 @@ Blockly.FieldColour.prototype.getHighlighted_ = function() {
   if (!row) {
     return null;
   }
-  var col = row.childNodes[x];
+  var col = /** @type {HTMLElement} */ (row.childNodes[x]);
   return col;
 };
 
@@ -495,7 +544,7 @@ Blockly.FieldColour.prototype.setHighlightedCell_ = function(cell, index) {
 
 /**
  * Create a colour picker dropdown editor.
- * @return {!Element} The newly created colour picker.
+ * @return {!HTMLElement} The newly created colour picker.
  * @private
  */
 Blockly.FieldColour.prototype.dropdownCreate_ = function() {
@@ -566,6 +615,7 @@ Blockly.FieldColour.prototype.dropdownDispose_ = function() {
   Blockly.unbindEvent_(this.onMouseLeaveWrapper_);
   Blockly.unbindEvent_(this.onKeyDownWrapper_);
   this.picker_ = null;
+  this.highlightedIndex_ = null;
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -80,35 +80,35 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
    */
   this.highlightedIndex_ = null;
 
-  /** 
+  /**
    * Mouse click event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.onClickWrapper_ = null;
 
-  /** 
+  /**
    * Mouse move event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseMoveWrapper_ = null;
 
-  /** 
+  /**
    * Mouse enter event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseEnterWrapper_ = null;
 
-  /** 
+  /**
    * Mouse leave event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseLeaveWrapper_ = null;
 
-  /** 
+  /**
    * Key down event data. 
    * @type {?Blockly.EventData}
    * @private

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -66,7 +66,7 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
   this.size_ = new Blockly.utils.Size(Blockly.FieldColour.DEFAULT_WIDTH,
       Blockly.FieldColour.DEFAULT_HEIGHT);
 
-  /** 
+  /**
    * The field's colour picker element.
    * @type {Element}
    * @private
@@ -74,42 +74,42 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
   this.picker_ = null;
 
   /**
-   * 
+   * Index of the currently highlighted element.
    * @type {?number}
    * @private
    */
   this.highlightedIndex_ = null;
 
   /**
-   * Mouse click event data. 
+   * Mouse click event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.onClickWrapper_ = null;
 
   /**
-   * Mouse move event data. 
+   * Mouse move event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseMoveWrapper_ = null;
 
   /**
-   * Mouse enter event data. 
+   * Mouse enter event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseEnterWrapper_ = null;
 
   /**
-   * Mouse leave event data. 
+   * Mouse leave event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.onMouseLeaveWrapper_ = null;
 
   /**
-   * Key down event data. 
+   * Key down event data.
    * @type {?Blockly.EventData}
    * @private
    */

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -68,7 +68,7 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
 
   /** 
    * The field's colour picker element.
-   * @type {HTMLElement}
+   * @type {Element}
    * @private
    */
   this.picker_ = null;
@@ -209,7 +209,7 @@ Blockly.FieldColour.prototype.configure_ = function(config) {
  */
 Blockly.FieldColour.prototype.initView = function() {
   this.createBorderRect_();
-  this.borderRect_.style['fillOpacity'] = 1;
+  this.borderRect_.style['fillOpacity'] = '1';
   this.borderRect_.style.fill = this.value_;
 };
 
@@ -538,13 +538,13 @@ Blockly.FieldColour.prototype.setHighlightedCell_ = function(cell, index) {
   this.highlightedIndex_ = index;
 
   // Update accessibility roles.
-  Blockly.utils.aria.setState(this.picker_,
+  Blockly.utils.aria.setState(/** @type {!Element} */ (this.picker_),
       Blockly.utils.aria.State.ACTIVEDESCENDANT, cell.getAttribute('id'));
 };
 
 /**
  * Create a colour picker dropdown editor.
- * @return {!HTMLElement} The newly created colour picker.
+ * @return {!Element} The newly created colour picker.
  * @private
  */
 Blockly.FieldColour.prototype.dropdownCreate_ = function() {
@@ -609,11 +609,21 @@ Blockly.FieldColour.prototype.dropdownCreate_ = function() {
  * @private
  */
 Blockly.FieldColour.prototype.dropdownDispose_ = function() {
-  Blockly.unbindEvent_(this.onClickWrapper_);
-  Blockly.unbindEvent_(this.onMouseMoveWrapper_);
-  Blockly.unbindEvent_(this.onMouseEnterWrapper_);
-  Blockly.unbindEvent_(this.onMouseLeaveWrapper_);
-  Blockly.unbindEvent_(this.onKeyDownWrapper_);
+  if (this.onClickWrapper_) {
+    Blockly.unbindEvent_(this.onClickWrapper_);
+  }
+  if (this.onMouseMoveWrapper_) {
+    Blockly.unbindEvent_(this.onMouseMoveWrapper_);
+  }
+  if (this.onMouseEnterWrapper_) {
+    Blockly.unbindEvent_(this.onMouseEnterWrapper_);
+  }
+  if (this.onMouseLeaveWrapper_) {
+    Blockly.unbindEvent_(this.onMouseLeaveWrapper_);
+  }
+  if (this.onKeyDownWrapper_) {
+    Blockly.unbindEvent_(this.onKeyDownWrapper_);
+  }
   this.picker_ = null;
   this.highlightedIndex_ = null;
 };

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -92,18 +92,32 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
       this, firstTuple[1], opt_validator, opt_config);
 
   /**
-   * SVG image element if currently selected option is an image, or null.
-   * @type {SVGElement}
-   * @private
-   */
-  this.imageElement_ = null;
-
-  /**
    * A reference to the currently selected menu item.
    * @type {Blockly.MenuItem}
    * @private
    */
   this.selectedMenuItem_ = null;
+
+  /**
+   * The dropdown menu.
+   * @type {Blockly.Menu}
+   * @private
+   */
+  this.menu_ = null;
+
+  /**
+   * SVG image element if currently selected option is an image, or null.
+   * @type {SVGImageElement}
+   * @private
+   */
+  this.imageElement_ = null;
+
+  /**
+   * SVG arrow element.
+   * @type {SVGTSpanElement}
+   * @private
+   */
+  this.arrow_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldDropdown, Blockly.Field);
 
@@ -182,12 +196,15 @@ Blockly.FieldDropdown.prototype.CURSOR = 'default';
 Blockly.FieldDropdown.prototype.initView = function() {
   Blockly.FieldDropdown.superClass_.initView.call(this);
 
-  this.imageElement_ = Blockly.utils.dom.createSvgElement( 'image',
-      {
-        'y': Blockly.FieldDropdown.IMAGE_Y_OFFSET
-      }, this.fieldGroup_);
+  this.imageElement_ = /** @type {!SVGImageElement} */
+      (Blockly.utils.dom.createSvgElement('image',
+          {
+            'y': Blockly.FieldDropdown.IMAGE_Y_OFFSET
+          }, this.fieldGroup_));
 
-  this.arrow_ = Blockly.utils.dom.createSvgElement('tspan', {}, this.textElement_);
+  this.arrow_ = /** @type {!SVGTspanElement} */
+      (Blockly.utils.dom.createSvgElement('tspan',
+          {}, this.textElement_));
   this.arrow_.appendChild(document.createTextNode(
       this.sourceBlock_.RTL ?
       Blockly.FieldDropdown.ARROW_CHAR + ' ' :
@@ -228,7 +245,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
 
 /**
  * Create the dropdown editor.
- * @return {Blockly.Menu} The newly created dropdown menu.
+ * @return {!Blockly.Menu} The newly created dropdown menu.
  * @private
  */
 Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
@@ -275,6 +292,7 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
 Blockly.FieldDropdown.prototype.dropdownDispose_ = function() {
   this.menu_.dispose();
   this.menu_ = null;
+  this.selectedMenuItem_ = null;
 };
 
 /**
@@ -531,9 +549,9 @@ Blockly.FieldDropdown.prototype.renderSelectedText_ = function() {
 };
 
 /**
- * Use the `getText_` developer hook to override the field's text representation.
- * Get the selected option text. If the selected option is an image
- * we return the image alt text.
+ * Use the `getText_` developer hook to override the field's text
+ * representation.  Get the selected option text. If the selected option is an
+ * image we return the image alt text.
  * @return {?string} Selected option text.
  * @protected
  * @override
@@ -609,6 +627,17 @@ Blockly.FieldDropdown.prototype.onBlocklyAction = function(action) {
     }
   }
   return Blockly.FieldDropdown.superClass_.onBlocklyAction.call(this, action);
+};
+
+/**
+ * Dispose of all DOM objects and events belonging to this editable field.
+ * @package
+ * @override
+ */
+Blockly.FieldDropdown.prototype.dispose = function() {
+  Blockly.FieldDropdown.superClass_.dispose.call(this);
+  this.imageElement_ = null;
+  this.arrow_ = null;
 };
 
 Blockly.fieldRegistry.register('field_dropdown', Blockly.FieldDropdown);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -202,7 +202,7 @@ Blockly.FieldDropdown.prototype.initView = function() {
             'y': Blockly.FieldDropdown.IMAGE_Y_OFFSET
           }, this.fieldGroup_));
 
-  this.arrow_ = /** @type {!SVGTspanElement} */
+  this.arrow_ = /** @type {!SVGTSpanElement} */
       (Blockly.utils.dom.createSvgElement('tspan',
           {}, this.textElement_));
   this.arrow_.appendChild(document.createTextNode(
@@ -290,7 +290,9 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
  * @private
  */
 Blockly.FieldDropdown.prototype.dropdownDispose_ = function() {
-  this.menu_.dispose();
+  if (this.menu_) {
+    this.menu_.dispose();
+  }
   this.menu_ = null;
   this.selectedMenuItem_ = null;
 };
@@ -302,15 +304,16 @@ Blockly.FieldDropdown.prototype.dropdownDispose_ = function() {
  */
 Blockly.FieldDropdown.prototype.handleMenuActionEvent_ = function(menuItem) {
   Blockly.DropDownDiv.hideIfOwner(this, true);
-  this.onItemSelected(this.menu_, menuItem);
+  this.onItemSelected_(/** @type {!Blockly.Menu} */ (this.menu_), menuItem);
 };
 
 /**
  * Handle the selection of an item in the dropdown menu.
  * @param {!Blockly.Menu} menu The Menu component clicked.
  * @param {!Blockly.MenuItem} menuItem The MenuItem selected within menu.
+ * @protected
  */
-Blockly.FieldDropdown.prototype.onItemSelected = function(menu, menuItem) {
+Blockly.FieldDropdown.prototype.onItemSelected_ = function(menu, menuItem) {
   this.setValue(menuItem.getValue());
 };
 
@@ -510,7 +513,8 @@ Blockly.FieldDropdown.prototype.renderSelectedImage_ = function(imageJson) {
   this.imageElement_.setAttribute('height', imageJson.height);
   this.imageElement_.setAttribute('width', imageJson.width);
 
-  var arrowWidth = Blockly.utils.dom.getTextWidth(this.arrow_);
+  var arrowWidth = Blockly.utils.dom.getTextWidth(
+      /** @type {!SVGTSpanElement} */ (this.arrow_));
 
   var imageHeight = Number(imageJson.height);
   var imageWidth = Number(imageJson.width);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -633,15 +633,5 @@ Blockly.FieldDropdown.prototype.onBlocklyAction = function(action) {
   return Blockly.FieldDropdown.superClass_.onBlocklyAction.call(this, action);
 };
 
-/**
- * Dispose of all DOM objects and events belonging to this editable field.
- * @package
- * @override
- */
-Blockly.FieldDropdown.prototype.dispose = function() {
-  Blockly.FieldDropdown.superClass_.dispose.call(this);
-  this.imageElement_ = null;
-  this.arrow_ = null;
-};
 
 Blockly.fieldRegistry.register('field_dropdown', Blockly.FieldDropdown);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -216,7 +216,7 @@ Blockly.FieldImage.prototype.doValueUpdate_ = function(newValue) {
   this.value_ = newValue;
   if (this.imageElement_) {
     this.imageElement_.setAttributeNS(Blockly.utils.dom.XLINK_NS,
-        'xlink:href', this.value_ || '');
+        'xlink:href', String(this.value_));
   }
 };
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -256,7 +256,7 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
 
 /**
  * Set the function that is called when this image  is clicked.
- * @param {?function(!Blockly.FieldImage):void} func The function that is called
+ * @param {?function(!Blockly.FieldImage)} func The function that is called
  *    when the image is clicked, or null to remove.
  */
 Blockly.FieldImage.prototype.setOnClickHandler = function(func) {

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -275,14 +275,4 @@ Blockly.FieldImage.prototype.getText_ = function() {
   return this.altText_;
 };
 
-/**
- * Dispose of all DOM objects and events belonging to this editable field.
- * @package
- * @override
- */
-Blockly.FieldImage.prototype.dispose = function() {
-  Blockly.FieldImage.superClass_.dispose.call(this);
-  this.imageElement_ = null;
-};
-
 Blockly.fieldRegistry.register('field_image', Blockly.FieldImage);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -115,6 +115,13 @@ Blockly.FieldImage = function(src, width, height,
   if (typeof opt_onClick == 'function') {
     this.clickHandler_ = opt_onClick;
   }
+
+  /**
+   * The rendered field's image element.
+   * @type {SVGImageElement}
+   * @private
+   */
+  this.imageElement_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldImage, Blockly.Field);
 
@@ -173,14 +180,15 @@ Blockly.FieldImage.prototype.configure_ = function(config) {
  * @package
  */
 Blockly.FieldImage.prototype.initView = function() {
-  this.imageElement_ = Blockly.utils.dom.createSvgElement(
-      'image',
-      {
-        'height': this.imageHeight_ + 'px',
-        'width': this.size_.width + 'px',
-        'alt': this.altText_
-      },
-      this.fieldGroup_);
+  this.imageElement_ = /** @type {!SVGImageElement} */
+      (Blockly.utils.dom.createSvgElement(
+          'image',
+          {
+            'height': this.imageHeight_ + 'px',
+            'width': this.size_.width + 'px',
+            'alt': this.altText_
+          },
+          this.fieldGroup_));
   this.imageElement_.setAttributeNS(Blockly.utils.dom.XLINK_NS,
       'xlink:href', /** @type {string} */ (this.value_));
 };
@@ -248,7 +256,7 @@ Blockly.FieldImage.prototype.showEditor_ = function() {
 
 /**
  * Set the function that is called when this image  is clicked.
- * @param {?function(!Blockly.FieldImage)} func The function that is called
+ * @param {?function(!Blockly.FieldImage):void} func The function that is called
  *    when the image is clicked, or null to remove.
  */
 Blockly.FieldImage.prototype.setOnClickHandler = function(func) {
@@ -265,6 +273,16 @@ Blockly.FieldImage.prototype.setOnClickHandler = function(func) {
  */
 Blockly.FieldImage.prototype.getText_ = function() {
   return this.altText_;
+};
+
+/**
+ * Dispose of all DOM objects and events belonging to this editable field.
+ * @package
+ * @override
+ */
+Blockly.FieldImage.prototype.dispose = function() {
+  Blockly.FieldImage.superClass_.dispose.call(this);
+  this.imageElement_ = null;
 };
 
 Blockly.fieldRegistry.register('field_image', Blockly.FieldImage);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -175,12 +175,13 @@ Blockly.FieldMultilineInput.prototype.render_ = function() {
     } else {
       this.resizeEditor_();
     }
+    var htmlInput = /** @type {!HTMLElement} */(this.htmlInput_);
     if (!this.isTextValid_) {
-      Blockly.utils.dom.addClass(this.htmlInput_, 'blocklyInvalidInput');
-      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', true);
+      Blockly.utils.dom.addClass(htmlInput, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(htmlInput, 'invalid', true);
     } else {
-      Blockly.utils.dom.removeClass(this.htmlInput_, 'blocklyInvalidInput');
-      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', false);
+      Blockly.utils.dom.removeClass(htmlInput, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(htmlInput, 'invalid', false);
     }
   }
 };
@@ -194,7 +195,7 @@ Blockly.FieldMultilineInput.prototype.updateSize_ = function() {
   var totalWidth = 0;
   var totalHeight = 0;
   for (var i = 0; i < nodes.length; i++) {
-    var tspan = nodes[i];
+    var tspan = /** @type {!Element} */ (nodes[i]);
     var textWidth = Blockly.utils.dom.getTextWidth(tspan);
     if (textWidth > totalWidth) {
       totalWidth = textWidth;

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -283,15 +283,6 @@ Blockly.FieldMultilineInput.prototype.onHtmlInputKeyDown_ = function(e) {
 };
 
 /**
- * Dispose of all DOM objects and events belonging to this editable field.
- * @package
- */
-Blockly.FieldMultilineInput.prototype.dispose = function() {
-  Blockly.FieldMultilineInput.superClass_.dispose.call(this);
-  this.textGroup_ = null;
-};
-
-/**
  * CSS for multiline field.  See css.js for use.
  */
 Blockly.Css.register([

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -58,6 +58,13 @@ Blockly.FieldMultilineInput = function(opt_value, opt_validator, opt_config) {
   }
   Blockly.FieldMultilineInput.superClass_.constructor.call(this,
       opt_value, opt_validator, opt_config);
+
+  /**
+   * The SVG group element that will contain a text element for each text row
+   *     when initialized.
+   * @type {SVGGElement}
+   */
+  this.textGroup_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldMultilineInput,
     Blockly.FieldTextInput);
@@ -89,10 +96,11 @@ Blockly.FieldMultilineInput.fromJson = function(options) {
  */
 Blockly.FieldMultilineInput.prototype.initView = function() {
   this.createBorderRect_();
-  this.textGroup_ = Blockly.utils.dom.createSvgElement('g',
-      {
-        'class': 'blocklyEditableText',
-      }, this.fieldGroup_);
+  this.textGroup_ = /** @type {!SVGGElement} **/
+      (Blockly.utils.dom.createSvgElement('g',
+          {
+            'class': 'blocklyEditableText',
+          }, this.fieldGroup_));
 };
 
 /**
@@ -271,6 +279,15 @@ Blockly.FieldMultilineInput.prototype.onHtmlInputKeyDown_ = function(e) {
   if (e.keyCode !== Blockly.utils.KeyCodes.ENTER) {
     Blockly.FieldMultilineInput.superClass_.onHtmlInputKeyDown_.call(this, e);
   }
+};
+
+/**
+ * Dispose of all DOM objects and events belonging to this editable field.
+ * @package
+ */
+Blockly.FieldMultilineInput.prototype.dispose = function() {
+  Blockly.FieldMultilineInput.superClass_.dispose.call(this);
+  this.textGroup_ = null;
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -189,12 +189,13 @@ Blockly.FieldTextInput.prototype.render_ = function() {
     } else {
       this.resizeEditor_();
     }
+    var htmlInput = /** @type {!HTMLElement} */(this.htmlInput_);
     if (!this.isTextValid_) {
-      Blockly.utils.dom.addClass(this.htmlInput_, 'blocklyInvalidInput');
-      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', true);
+      Blockly.utils.dom.addClass(htmlInput, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(htmlInput, 'invalid', true);
     } else {
-      Blockly.utils.dom.removeClass(this.htmlInput_, 'blocklyInvalidInput');
-      Blockly.utils.aria.setState(this.htmlInput_, 'invalid', false);
+      Blockly.utils.dom.removeClass(htmlInput, 'blocklyInvalidInput');
+      Blockly.utils.aria.setState(htmlInput, 'invalid', false);
     }
   }
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -71,14 +71,14 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
    */
   this.htmlInput_ = null;
 
-  /** 
+  /**
    * Key down event data. 
    * @type {?Blockly.EventData}
    * @private
    */
   this.onKeyDownWrapper_ = null;
   
-  /** 
+  /**
    * Key input event data. 
    * @type {?Blockly.EventData}
    * @private

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -70,6 +70,20 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
    * @type {HTMLElement}
    */
   this.htmlInput_ = null;
+
+  /** 
+   * Key down event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onKeyDownWrapper_ = null;
+  
+  /** 
+   * Key input event data. 
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onKeyInputWrapper_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 
@@ -345,8 +359,12 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
  * @private
  */
 Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
-  Blockly.unbindEvent_(this.onKeyDownWrapper_);
-  Blockly.unbindEvent_(this.onKeyInputWrapper_);
+  if (this.onKeyDownWrapper_) {
+    Blockly.unbindEvent_(this.onKeyDownWrapper_);
+  }
+  if (this.onKeyInputWrapper_) {
+    Blockly.unbindEvent_(this.onKeyInputWrapper_);
+  }
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -72,14 +72,14 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   this.htmlInput_ = null;
 
   /**
-   * Key down event data. 
+   * Key down event data.
    * @type {?Blockly.EventData}
    * @private
    */
   this.onKeyDownWrapper_ = null;
   
   /**
-   * Key input event data. 
+   * Key input event data.
    * @type {?Blockly.EventData}
    * @private
    */

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -64,6 +64,12 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   }
   Blockly.FieldTextInput.superClass_.constructor.call(this,
       opt_value, opt_validator, opt_config);
+
+  /**
+   * The HTML input element.
+   * @type {HTMLElement}
+   */
+  this.htmlInput_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -440,8 +440,9 @@ Blockly.FieldVariable.dropdownCreate = function() {
  * In the rename case, prompt the user for a new name.
  * @param {!Blockly.Menu} menu The Menu component clicked.
  * @param {!Blockly.MenuItem} menuItem The MenuItem selected within menu.
+ * @protected
  */
-Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
+Blockly.FieldVariable.prototype.onItemSelected_ = function(menu, menuItem) {
   var id = menuItem.getValue();
   // Handle special cases.
   if (this.sourceBlock_ && this.sourceBlock_.workspace) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Memory leaks with fields when closing fields, but also when disposing of fields.

### Proposed Changes

Dispose of references to all elements created as part of the render pass in field ``dispose``. Dispose of all references to elements created in widget/dropdown create methods in widget/dropdown dispose.

### Reason for Changes

Plugging leaks

### Test Coverage

Tested using chrome perf tools.
Creating and disposing fields + opening / closing fields.

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@BeksOmega FYI
