### PR TITLE
Revert calling dropdown hide order

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -263,7 +263,7 @@ Blockly.DropDownDiv.showPositionedByBlock = function(field, block,
  */
 Blockly.DropDownDiv.showPositionedByField = function(field,
     opt_onHide, opt_secondaryYOffset) {
-  var position = field.fieldGroup_.getBoundingClientRect();
+  var position = field.getSvgRoot().getBoundingClientRect();
   // If we can fit it, render below the block.
   var primaryX = position.left + position.width / 2;
   var primaryY = position.bottom;
@@ -574,11 +574,11 @@ Blockly.DropDownDiv.hide = function() {
   Blockly.DropDownDiv.animateOutTimer_ =
       setTimeout(function() {
         Blockly.DropDownDiv.hideWithoutAnimation();
-        if (Blockly.DropDownDiv.onHide_) {
-          Blockly.DropDownDiv.onHide_();
-          Blockly.DropDownDiv.onHide_ = null;
-        }
       }, Blockly.DropDownDiv.ANIMATION_TIME * 1000);
+  if (Blockly.DropDownDiv.onHide_) {
+    Blockly.DropDownDiv.onHide_();
+    Blockly.DropDownDiv.onHide_ = null;
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Revert calling dropdown hide.

### Proposed Changes

Reverted the order in which we call onHide when we're animating. This way each field is able to dispose of their dropdown by unbinding event listeners even before the animation is complete.

### Reason for Changes

Avoid dropdown double click issues when animating. 

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

Fix warning while I'm at it.