### PR TITLE
Fix #2811

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -557,8 +557,10 @@ Blockly.Field.prototype.updateColour = function() {
  * @protected
  */
 Blockly.Field.prototype.render_ = function() {
-  this.textContent_.nodeValue = this.getDisplayText_();
-  this.updateSize_();
+  if (this.textContent_) {
+    this.textContent_.nodeValue = this.getDisplayText_();
+    this.updateSize_();
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2811

### Proposed Changes

The problem here is that ``FieldColour`` and ``FieldImage`` override the initView method and don't create a textContent_ element. Both of these fields never set the isDirty_ flag and thus so far forceRerender hasn't been called.

However, in cases where the workspace is hidden when a block is imported. Fields are re-renderered when visible.
Since FieldColour and FieldImage don't override render_, that causes a crash. We could override render in these methods, but I think a simpler less intrusive change is to just check for the existance of textContent_ in render.

### Reason for Changes

Fix bug.

### Test Coverage

Tested in playground by following repro steps.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
