### PR TITLE
bringToFront optimization for large workspaces

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1375,7 +1375,12 @@ Blockly.BlockSvg.prototype.bringToFront = function() {
   var block = this;
   do {
     var root = block.getSvgRoot();
-    root.parentNode.appendChild(root);
+    var parent = root.parentNode;
+    var childNodes = parent.childNodes;
+    // Avoid moving the block if it's already at the bottom.
+    if (childNodes[childNodes.length - 1] !== root) {
+      root.parentNode.appendChild(root);
+    }
     block = block.getParent();
   } while (block);
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1379,7 +1379,7 @@ Blockly.BlockSvg.prototype.bringToFront = function() {
     var childNodes = parent.childNodes;
     // Avoid moving the block if it's already at the bottom.
     if (childNodes[childNodes.length - 1] !== root) {
-      root.parentNode.appendChild(root);
+      parent.appendChild(root);
     }
     block = block.getParent();
   } while (block);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

The ``appendChild`` is causing a reflow takes much longer with larger workspaces.
Something as simple as a field click causes calls to bringToFront.

### Proposed Changes

Minor optimization to skip moving a block if it's already in the right position.

### Reason for Changes

Perf.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
