### PR TITLE
Look up notch height from the current renderer

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1807,7 +1807,9 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
   var nextBlock = this.getNextBlock();
   if (nextBlock) {
     var nextHeightWidth = nextBlock.getHeightWidth();
-    height += nextHeightWidth.height - 4;  // Height of tab.
+    var workspace = /** @type {!Blockly.WorkspaceSvg} */ (this.workspace);
+    var tabHeight = workspace.getRenderer().getConstants().NOTCH_HEIGHT;
+    height += nextHeightWidth.height - tabHeight;
     width = Math.max(width, nextHeightWidth.width);
   }
   return {height: height, width: width};


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves https://github.com/google/blockly/issues/2951

Previously we'd assume the tab height would always be 4:

https://github.com/google/blockly/blob/4efa0dad1f2c882234759d3ba7ecd0ebd95a4c77/core/block_render_svg.js#L304

Use the constant instead, so it'll work with renderers that have different tab heights. Fixed with lots of help from @samelhusseini!

### Before

![image](https://user-images.githubusercontent.com/413693/66686719-33eb6f00-ec35-11e9-85df-125c0df4d658.png)

### After

![image](https://user-images.githubusercontent.com/413693/66686678-1a4a2780-ec35-11e9-8f0c-1991c8dad9dd.png)