### PR TITLE
Make XML format extensible

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -393,7 +393,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
       var xmlChild = xml.childNodes[i];
       var name = xmlChild.nodeName.toLowerCase();
       var handler = Blockly.Xml.tagMap_[name] ||
-        Blockly.Xml.unrecognizedTagType;
+           Blockly.Xml.unrecognizedTagType;
       handler(workspace, xmlChild, state);
     }
   } finally {
@@ -450,24 +450,23 @@ Blockly.Xml.serializers_ = [];
 
 /**
  * The function to handle unrecognized tags when parsing an XML document.
- * @param {!Blockly.Workspace} workspace the Blockly workspace
- * @param {!Element} xmlChild the XML element being parsed
- * @param {!Blockly.Xml.ParserState} _state parse state information (not used
+ * @param {!Blockly.Workspace} workspace The Blockly workspace.
+ * @param {!Element} xmlChild The XML element being parsed.
+ * @param {!Blockly.Xml.ParserState} _state Parser state information (not used
  *     in this implementation, but may be used by projects that provide a
  *     different behavior.
  * @public
  */
 Blockly.Xml.unrecognizedTagType = function(workspace, xmlChild, _state) {
-  if (xmlChild.nodeName.toLowerCase() != '#text' &&
-      xmlChild.nodeName.toLowerCase() != '#comment') {
-    Blockly.Xml.onError('Unrecognized tag ' + xmlChild.nodeName.toLowerCase() +
-      ' in XML');
+  var name = xmlChild.nodeName.toLowerCase();
+  if (name != '#text' && name != '#comment') {
+    Blockly.Xml.onError('Unrecognized tag ' + name + ' in XML');
   }
 };
 
 /**
  * Shared state used by different tag parsers.
- * @param {!Blockly.Workspace} workspace the target workspace for parsing
+ * @param {!Blockly.Workspace} workspace The target workspace for parsing.
  * @constructor
  */
 Blockly.Xml.ParserState = function(workspace) {
@@ -488,7 +487,7 @@ Blockly.Xml.ParserState = function(workspace) {
  * @param {!function(!Element, !Blockly.Workspace, boolean=)} save A
  *     function to serialize a workspace into the given tag.
  * @param {boolean=} opt_force Force registering the handler even if it
- *     will overwrite an existing handler
+ *     will overwrite an existing handler.
  */
 Blockly.Xml.registerTopLevelTag = function(tagName, load, save, opt_force) {
   if (tagName in Blockly.Xml.tagMap_ && !opt_force) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

This is based on work I did at the hackathon in 2018 (yes, yes I know it's late). I'm motivated to add it sooner rather than later though due to some features we want to put into App Inventor that will require new top level elements in the XML.

### Proposed Changes

This PR makes it so that one can register tags to be parsed, and can register serialization functions to serialize different parts of the workspace. This change also implements #3025.

### Reason for Changes

In App Inventor, we store additional versioning metadata in the XML file that is used to determine when to upgrade from one version of the language to the next. Similarly, we are looking to add new features (such as folders), that might not be part of core Blockly, but still need to be serialized/deserialized preferably without modifying core.

### Test Coverage

Ran the npm tests to confirm that nothing broke when parsing/serializing workspaces. Also tested with airstrike in the playground.

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

There is now a `registerTopLevelTag` method that takes:

* `tagName` (e.g., `'block'`)
* a `load` function that will be called with the XML element, workspace, and a state
* a `save` function that will be called with the workspace, XML root
* an optional boolean `opt_force`, that will overwrite any previously registered save/load for the given `tagName`. This could be used, for example, to overwrite the default handling of `<block>` from outside of core.

### Additional Information

I'm putting this up for PR because I'd like to get some feedback from the team. Mainly:

1. API design: What are your thoughts on the `registerTopLevelTag` design?
2. Code org: I've placed registration of the existing core tags close to domToWorkspace, which is where the original code was located. However, these are executable statements and probably should be moved to the end of the file instead. What's your preference here?
3. Code org: For workspace comments, since @samelhusseini made them optional, do we want to have registration of the 'comment' tag occur in either Blockly.WorkspaceComment or Blockly.WorkspaceCommentSvg namespaces? Right now there's this check in the parser if the class is defined, but the logic of registering the tag could be moved into the file itself so it simply wouldn't register for parsing unless the supporting requires were also somewhere in the Blockly setup.
4. Depending on the decision for \#2, do we want to do the same for other tag types? The downside being that if one day there are multiple parsers (e.g., XML and JSON), the parsing has now been coupled to the type rather than the parser, whereas right now each parser needs to be aware of each type in the system.
5.  onError and onWarning are public as I'm expecting that in App Inventor we'll provide our own implementations, but I can change the scope if desired.