### PR TITLE
restart cursor animation on cursor move

### DIFF
--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -511,6 +511,12 @@ Blockly.CursorSvg.prototype.draw = function(curNode) {
   } else if (curNode.getType() === Blockly.ASTNode.types.STACK) {
     this.showWithStack_(curNode);
   }
+
+  // Ensures the cursor will be visible immediately after the move.
+  var animate = this.currentCursorSvg.childNodes[0];
+  if (animate !== undefined) {
+    animate.beginElement && animate.beginElement();
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide) *mostly*
  - [ ] I have not confirmed that this works in IE11. It's possible that SMIL animations for SVG don't work at all on IE11.
  - [ ] I have not run eslint

## The details
### Resolves

Resolves #3225 in which movement of the accessibility cursor appears delayed for movement which occurs while the cursor is not visible.

### Proposed Changes

Adds a check for an animate (in a way that assumes animate is the only type of child the cursor ever has) element in the current cursor and calls `beginElement()` on it if found to restart the animation.

### Reason for Changes

Before patch
![fixhighlight](https://user-images.githubusercontent.com/458879/66718078-8c854e00-ed94-11e9-984d-ca0815c1e752.gif)

With patch applied
![fixedhighlight](https://user-images.githubusercontent.com/458879/66718082-8ee7a800-ed94-11e9-943a-0b22b492a7df.gif)

### Test Coverage

No automated tests changed or added.

Manually tested on:
* Desktop Chrome
* Desktop Firefox

### Documentation

No doc updates

### Additional Information

I discussed this in person with Abby at the Blockly Summit Hackathon on Oct 11.