### PR TITLE
Fix blocks tests

### DIFF
--- a/tests/blocks/index.html
+++ b/tests/blocks/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Unit Tests for Blockly Blocks</title>
-    <script src="../../blockly_compressed.js"></script>
+    <script src="../../blockly_uncompressed.js"></script>
     <script src="../../msg/js/en.js"></script>  <!-- TODO: Test messages in all languages. -->
     <script src="../../blocks/colour.js"></script>
     <script src="../../blocks/lists.js"></script>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Blocks tests are broken because no goog. in blockly_compressed.

``/tests/blocks/index.html``

### Proposed Changes

Use uncompressed instead.

### Reason for Changes

Fix test

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
