### PR TITLE
Fix Capitalization Error

### DIFF
--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -490,7 +490,7 @@ FactoryUtils.getFieldsJs_ = function(block) {
           var width = Number(block.getFieldValue('WIDTH'));
           var height = Number(block.getFieldValue('HEIGHT'));
           var alt = JSON.stringify(block.getFieldValue('ALT'));
-          var flipRtl = Json.stringify(block.getFieldValue('FLIP_RTL'));
+          var flipRtl = JSON.stringify(block.getFieldValue('FLIP_RTL'));
           fields.push('new Blockly.FieldImage(' +
               src + ', ' + width + ', ' + height +
               ', { alt: ' + alt + ', flipRtl: ' + flipRtl + ' })');


### PR DESCRIPTION
## The basics

Fixing JSON.parse misspelling.  It causing the Blockly Block factory to break.  Minor fix.  I pull from master branch because I thought you might want to release this soon.

<img width="1440" alt="Screen Shot 2019-10-14 at 10 56 19 PM" src="https://user-images.githubusercontent.com/9620015/66803908-e3df0780-eed5-11e9-8aec-6ef0c8b8cbe4.png">


- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

