### PR TITLE
Fixed disabled blocks in trashcan. Also fixed block comments.

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -497,6 +497,11 @@ Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
       node.removeAttribute('y');
       node.removeAttribute('id');
       node.removeAttribute('disabled');
+      if (node.nodeName == 'comment') {  // Future proof just in case.
+        node.removeAttribute('h');
+        node.removeAttribute('w');
+        node.removeAttribute('pinned');
+      }
     }
 
     // Try to go down the tree

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -287,11 +287,6 @@ Blockly.Trashcan.prototype.init = function(verticalSpacing) {
     Blockly.utils.dom.insertAfter(this.flyout_.createDom('svg'),
         this.workspace_.getParentSvg());
     this.flyout_.init(this.workspace_);
-    this.flyout_.isBlockCreatable_ = function() {
-      // All blocks, including disabled ones, can be dragged from the
-      // trashcan flyout.
-      return true;
-    };
   }
 
   this.verticalSpacing_ = this.MARGIN_BOTTOM_ + verticalSpacing;
@@ -501,6 +496,7 @@ Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
       node.removeAttribute('x');
       node.removeAttribute('y');
       node.removeAttribute('id');
+      node.removeAttribute('disabled');
     }
 
     // Try to go down the tree

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -102,7 +102,9 @@ suite("Trashcan", function() {
     test("No Disabled - Disabled True", function() {
       sendDeleteEvent('<block type="dummy_type"/>');
       sendDeleteEvent('<block type="dummy_type" disabled="true"/>');
-      chai.assert.equal(this.trashcan.contents_.length, 2);
+      // Disabled tags get removed because disabled blocks aren't allowed to
+      // be dragged from flyouts. See #2239 and #3243.
+      chai.assert.equal(this.trashcan.contents_.length, 1);
     });
     test("No Editable - Editable False", function() {
       sendDeleteEvent('<block type="dummy_type"/>');
@@ -244,9 +246,8 @@ suite("Trashcan", function() {
           '  <comment h="20" w="20">comment_text</comment>' +
           '</block>'
       );
-      // TODO (#2574): These blocks are treated as different, but appear
-      //  identical when the trashcan is opened.
-      chai.assert.equal(this.trashcan.contents_.length, 2);
+      // h & w tags are removed b/c the blocks appear the same.
+      chai.assert.equal(this.trashcan.contents_.length, 1);
     });
     test("Different Comment Pinned", function() {
       sendDeleteEvent(
@@ -259,9 +260,8 @@ suite("Trashcan", function() {
           '  <comment pinned="true">comment_text</comment>' +
           '</block>'
       );
-      // TODO (#2574): These blocks are treated as different, but appear
-      //  identical when the trashcan is opened.
-      chai.assert.equal(this.trashcan.contents_.length, 2);
+      // pinned tags are removed b/c the blocks appear the same.
+      chai.assert.equal(this.trashcan.contents_.length, 1);
     });
     test("No Mutator - Mutator", function() {
       sendDeleteEvent('<block type="dummy_type"/>');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #3243
Closes #2574 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Disabled tags are removed from blocks when they are added to the trashcan.
* h, w, and pinned tags are removed from block-comments when they are added to the trashcan.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* See reasoning [here](https://github.com/google/blockly/issues/2239#issuecomment-458290090). I was going to go with the alternative suggestion [here](https://github.com/google/blockly/issues/3243#issuecomment-541941991), but I believe that would allow users to get around the maxBlocks/maxInstances if disable/enable was available.
* This allowed "duplicate" blocks that looked the same to exist in the trashcan.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Modified unit tests to reflect changes.

#### Testing disableOrphans
1. Added disableOrphans listener to playground.
2. Dragged blocks onto the workspace.
3. Dragged them into the trashcan.
4. Observed how they were re-enabled in the trashcan.
5. Dragged them out of the trashcan.
6. Observed how they were re-disabled.

#### Testing maxBlocks
1. Set maxBlocks to 1.
2. Dragged a block from the toolbox to the trashcan.
3. Added a block to the workspace. This trips maxBlocks.
4. Opened the trashcan.
5. Observed how I was unable to add the block to the workspace.

#### Testing Comments
1. Followed the procedure from #2574.
2. Was not able to reproduce the issue.

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
@NeilFraser does the solution to #3243 look ok to you?
