### PR TITLE
Normalize to one spelling of color/colour.

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -107,18 +107,18 @@ Blockly.DropDownDiv.PADDING_Y = 16;
 Blockly.DropDownDiv.ANIMATION_TIME = 0.25;
 
 /**
- * The default dropdown div border color.
+ * The default dropdown div border colour.
  * @type {string}
  * @const
  */
-Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOR = '#dadce0';
+Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR = '#dadce0';
 
 /**
- * The default dropdown div color.
+ * The default dropdown div colour.
  * @type {string}
  * @const
  */
-Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOR = '#fff';
+Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR = '#fff';
 
 /**
  * Timer for animation out, to be cleared if we need to immediately hide
@@ -145,8 +145,8 @@ Blockly.DropDownDiv.createDom = function() {
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOR;
-  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOR;
+  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR;
+  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR;
   document.body.appendChild(div);
   Blockly.DropDownDiv.DIV_ = div;
 
@@ -626,8 +626,8 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
   div.style.top = '';
   div.style.opacity = 0;
   div.style.display = 'none';
-  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOR;
-  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOR;
+  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR;
+  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR;
 
   if (Blockly.DropDownDiv.onHide_) {
     Blockly.DropDownDiv.onHide_();
@@ -663,7 +663,7 @@ Blockly.DropDownDiv.positionInternal_ = function(
   } else {
     Blockly.DropDownDiv.arrow_.style.display = 'none';
   }
-  
+
   var initialX = Math.floor(metrics.initialX);
   var initialY = Math.floor(metrics.initialY);
   var finalX = Math.floor(metrics.finalX);

--- a/core/keyboard_nav/cursor_svg.js
+++ b/core/keyboard_nav/cursor_svg.js
@@ -119,18 +119,18 @@ Blockly.CursorSvg.BLOCK_PADDING = 2;
 Blockly.CursorSvg.HEIGHT_MULTIPLIER = 3 / 4;
 
 /**
- * Cursor color.
+ * Cursor colour.
  * @type {string}
  * @const
  */
-Blockly.CursorSvg.CURSOR_COLOR = '#cc0a0a';
+Blockly.CursorSvg.CURSOR_COLOUR = '#cc0a0a';
 
 /**
- * Immovable marker color.
+ * Immovable marker colour.
  * @type {string}
  * @const
  */
-Blockly.CursorSvg.MARKER_COLOR = '#4286f4';
+Blockly.CursorSvg.MARKER_COLOUR = '#4286f4';
 
 /**
  * The name of the CSS class for a cursor.
@@ -534,8 +534,8 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
   </g>
   */
 
-  var colour = this.isMarker_ ? Blockly.CursorSvg.MARKER_COLOR :
-      Blockly.CursorSvg.CURSOR_COLOR;
+  var colour = this.isMarker_ ? Blockly.CursorSvg.MARKER_COLOUR :
+      Blockly.CursorSvg.CURSOR_COLOUR;
   this.cursorSvg_ = Blockly.utils.dom.createSvgElement('g',
       {
         'width': Blockly.CursorSvg.CURSOR_WIDTH,
@@ -599,7 +599,7 @@ Blockly.CursorSvg.prototype.createCursorSvg_ = function() {
       'attributeType': 'XML',
       'attributeName': 'fill',
       'dur': '1s',
-      'values': Blockly.CursorSvg.CURSOR_COLOR + ';transparent;transparent;',
+      'values': Blockly.CursorSvg.CURSOR_COLOUR + ';transparent;transparent;',
       'repeatCount': 'indefinite'
     };
     Blockly.utils.dom.createSvgElement('animate', properties,

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -175,7 +175,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
 
 /**
  * Draw a circle at the location of the given connection.  Inputs and outputs
- * share the same colors, as do previous and next.  When positioned correctly
+ * share the same colours, as do previous and next.  When positioned correctly
  * a connected pair will look like a bullseye.
  * @param {Blockly.RenderedConnection} conn The connection to circle.
  * @package

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -88,11 +88,11 @@ Blockly.utils.colour.rgbToHex = function(r, g, b) {
 
 /**
  * Converts a hex representation of a colour to RGB.
- * @param {string} hexColor Colour in '#ff0000' format.
+ * @param {string} hexColour Colour in '#ff0000' format.
  * @return {!Array.<number>} RGB representation of the colour.
  */
-Blockly.utils.colour.hexToRgb = function(hexColor) {
-  var rgb = parseInt(hexColor.substr(1), 16);
+Blockly.utils.colour.hexToRgb = function(hexColour) {
+  var rgb = parseInt(hexColour.substr(1), 16);
   var r = rgb >> 16;
   var g = (rgb >> 8) & 255;
   var b = rgb & 255;


### PR DESCRIPTION
Over the past month a couple of instances of "color" appeared in our codebase.  I don't actually care about how people spell this word, but consistency and predictability is important.  It isn't good if 90% of our API uses one spelling, and 10% uses a different spelling.

I assume this choice was unintentional.