### PR TITLE
Fix #1714

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -389,10 +389,6 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   }
   var newBlockIds = [];  // A list of block IDs added by this call.
   Blockly.utils.dom.startTextWidthCache();
-  // Safari 7.1.3 is known to provide node lists with extra references to
-  // children beyond the lists' length.  Trust the length, do not use the
-  // looping pattern of checking the index for an object.
-  var childCount = xml.childNodes.length;
   var existingGroup = Blockly.Events.getGroup();
   if (!existingGroup) {
     Blockly.Events.setGroup(true);
@@ -404,8 +400,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   }
   var variablesFirst = true;
   try {
-    for (var i = 0; i < childCount; i++) {
-      var xmlChild = xml.childNodes[i];
+    for (var i = 0, xmlChild; xmlChild = xml.childNodes[i]; i++) {
       var name = xmlChild.nodeName.toLowerCase();
       if (name == 'block' ||
           (name == 'shadow' && !Blockly.Events.recordUndo)) {


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1714 
### Proposed Changes

Get rid of code that handles a Safari 7 bug.

### Reason for Changes

Bug has since been fixed.

### Test Coverage
Tested serialization and deserialization in the playground in chrome, but not safai.

Neil confirmed that the bug was no longer present in Safari 11.