### PR TITLE
Fix jsdoc. @return instead of @returns

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -528,7 +528,7 @@ Blockly.FieldTextInput.prototype.getText_ = function() {
  * than the field's value. This should be coupled with an override of
  * `getValueFromEditorText_`.
  * @param {*} value The value stored in this field.
- * @returns {string} The text to show on the html input.
+ * @return {string} The text to show on the html input.
  * @protected
  */
 Blockly.FieldTextInput.prototype.getEditorText_ = function(value) {
@@ -542,7 +542,7 @@ Blockly.FieldTextInput.prototype.getEditorText_ = function(value) {
  * than the field's value. This should be coupled with an override of
  * `getEditorText_`.
  * @param {string} text Text received from the html input.
- * @returns {*} The value to store.
+ * @return {*} The value to store.
  * @protected
  */
 Blockly.FieldTextInput.prototype.getValueFromEditorText_ = function(text) {

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -280,7 +280,7 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
 /**
  * Returns whether or not the top row has a left square corner.
  * @param {!Blockly.BlockSvg} block The block whose top row this represents.
- * @returns {boolean} Whether or not the top row has a left square corner.
+ * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
   var hasHat = block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT;
@@ -372,7 +372,7 @@ Blockly.utils.object.inherits(Blockly.blockRendering.BottomRow,
 /**
  * Returns whether or not the bottom row has a left square corner.
  * @param {!Blockly.BlockSvg} block The block whose bottom row this represents.
- * @returns {boolean} Whether or not the bottom row has a left square corner.
+ * @return {boolean} Whether or not the bottom row has a left square corner.
  */
 Blockly.blockRendering.BottomRow.prototype.hasLeftSquareCorner = function(
     block) {

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -70,7 +70,7 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
 /**
  * Returns whether or not the top row has a right square corner.
  * @param {!Blockly.BlockSvg} block The block whose top row this represents.
- * @returns {boolean} Whether or not the top row has a left square corner.
+ * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
   // Render a round corner unless the block has an output connection.
@@ -112,7 +112,7 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
 /**
  * Returns whether or not the bottom row has a right square corner.
  * @param {!Blockly.BlockSvg} block The block whose bottom row this represents.
- * @returns {boolean} Whether or not the bottom row has a left square corner.
+ * @return {boolean} Whether or not the bottom row has a left square corner.
  */
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
   // Render a round corner unless the block has an output connection.

--- a/demos/custom-fields/pitch/field_pitch.js
+++ b/demos/custom-fields/pitch/field_pitch.js
@@ -173,7 +173,7 @@ CustomFields.FieldPitch.prototype.getText_ = function() {
 /**
  * Transform the provided value into a text to show in the HTML input.
  * @param {*} value The value stored in this field.
- * @returns {string} The text to show on the HTML input.
+ * @return {string} The text to show on the HTML input.
  */
 CustomFields.FieldPitch.prototype.getEditorText_ = function(value) {
   return this.valueToNote(value);
@@ -183,7 +183,7 @@ CustomFields.FieldPitch.prototype.getEditorText_ = function(value) {
  * Transform the text received from the HTML input (note) into a value
  * to store in this field.
  * @param {string} text Text received from the HTML input.
- * @returns {*} The value to store.
+ * @return {*} The value to store.
  */
 CustomFields.FieldPitch.prototype.getValueFromEditorText_ = function(text) {
   return this.noteToValue(text);


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Clean up.

### Proposed Changes

Fix jsdoc. @return instead of @returns

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
