### PR TITLE
Fixed block cleanup

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -878,9 +878,7 @@ Blockly.WorkspaceSvg.prototype.resizeContents = function() {
     return;
   }
   if (this.scrollbar) {
-    var metrics = this.getMetrics();
-    this.scrollbar.hScroll.resizeContentHorizontal(metrics);
-    this.scrollbar.vScroll.resizeContentVertical(metrics);
+    this.scrollbar.resize();
   }
   this.updateInverseScreenCTM();
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#3248 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Reverts a change made by #2247 (it was just meant for efficiency).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
It broke things, because `onScroll_` was no longer getting called.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

#### Bounds resizing
1. Attempted to drag a block outside of the workspace bounds.
2. Observed how scrollbars resized to show the block.

#### Cleanup blocks
1. Moved blocks to high x-coordinates.
2. Cleaned up blocks.
3. Observed how blocks were still in view.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
We could also add a call to `this.centerOnBlock(topBlocks[0]);` at the end of `workspace.cleanUp` if you want @NeilFraser .
