### PR TITLE
Fix 10 warnings related to visibility

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -496,7 +496,7 @@ Blockly.Block.prototype.unplugFromStack_ = function(opt_healStack) {
  * Returns all connections originating from this block.
  * @param {boolean} _all If true, return all connections even hidden ones.
  * @return {!Array.<!Blockly.Connection>} Array of connections.
- * @private
+ * @package
  */
 Blockly.Block.prototype.getConnections_ = function(_all) {
   var myConnections = [];

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -899,12 +899,12 @@ Blockly.BlockSvg.prototype.setDragging = function(adding) {
     var group = this.getSvgRoot();
     group.translate_ = '';
     group.skew_ = '';
-    Blockly.draggingConnections_ =
-        Blockly.draggingConnections_.concat(this.getConnections_(true));
+    Blockly.draggingConnections =
+        Blockly.draggingConnections.concat(this.getConnections_(true));
     Blockly.utils.dom.addClass(
         /** @type {!Element} */ (this.svgGroup_), 'blocklyDragging');
   } else {
-    Blockly.draggingConnections_ = [];
+    Blockly.draggingConnections = [];
     Blockly.utils.dom.removeClass(
         /** @type {!Element} */ (this.svgGroup_), 'blocklyDragging');
   }

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -81,9 +81,9 @@ Blockly.keyboardAccessibilityMode = false;
 /**
  * All of the connections on blocks that are currently being dragged.
  * @type {!Array.<!Blockly.Connection>}
- * @private
+ * @package
  */
-Blockly.draggingConnections_ = [];
+Blockly.draggingConnections = [];
 
 /**
  * Contents of the local clipboard.

--- a/core/connection.js
+++ b/core/connection.js
@@ -328,7 +328,7 @@ Blockly.Connection.prototype.canConnectToPrevious_ = function(candidate) {
   }
 
   // Don't let blocks try to connect to themselves or ones they nest.
-  if (Blockly.draggingConnections_.indexOf(candidate) != -1) {
+  if (Blockly.draggingConnections.indexOf(candidate) != -1) {
     return false;
   }
 
@@ -405,7 +405,7 @@ Blockly.Connection.prototype.isConnectionAllowed = function(candidate) {
   }
 
   // Don't let blocks try to connect to themselves or ones they nest.
-  if (Blockly.draggingConnections_.indexOf(candidate) != -1) {
+  if (Blockly.draggingConnections.indexOf(candidate) != -1) {
     return false;
   }
 


### PR DESCRIPTION
# The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix 10 warnings related to visibility.


### Proposed Changes

Renamed ``Blockly. draggingConnections_`` to ``Blockly. draggingConnections``.
Made ``block. getConnections_`` match the visibility of ``block_svg. getConnections_`` which is package. I'm not opposed to renaming that one to match the style guide, but block_svg.getConnections_ was changed to @package in this change: https://github.com/google/blockly/commit/98914fcf6b4fd1bcc139bece6a5afd7af8c100ae without renaming. Wondering if there's some context there @rachel-fenichel?

Otherwise, happy to rename in this PR.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
