### PR TITLE
Only add a hat if there's no output connection

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -253,10 +253,12 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
  * @package
  */
 Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
-  var hasHat = this.block_.hat ?
-      this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT;
   var hasPrevious = !!this.block_.previousConnection;
-  var hasOutputConnection = !!this.outputConnection;
+  var hasPreviousBlock = hasPrevious &&
+    !!this.block_.previousConnection.targetConnection;
+  var hasHat = (this.block_.hat ?
+    this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
+    !this.outputConnection && !hasPreviousBlock;
   var leftSquareCorner = this.topRow.hasLeftSquareCorner(this.block_);
 
   if (leftSquareCorner) {
@@ -267,7 +269,7 @@ Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
         new Blockly.blockRendering.RoundCorner(this.constants_));
   }
 
-  if (hasHat && !hasOutputConnection) {
+  if (hasHat) {
     var hat = new Blockly.blockRendering.Hat(this.constants_);
     this.topRow.elements.push(hat);
     this.topRow.capline = hat.ascenderHeight;

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -256,6 +256,7 @@ Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
   var hasHat = this.block_.hat ?
       this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT;
   var hasPrevious = !!this.block_.previousConnection;
+  var hasOutputConnection = !!this.outputConnection;
   var leftSquareCorner = this.topRow.hasLeftSquareCorner(this.block_);
 
   if (leftSquareCorner) {
@@ -266,7 +267,7 @@ Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
         new Blockly.blockRendering.RoundCorner(this.constants_));
   }
 
-  if (hasHat) {
+  if (hasHat && !hasOutputConnection) {
     var hat = new Blockly.blockRendering.Hat(this.constants_);
     this.topRow.elements.push(hat);
     this.topRow.capline = hat.ascenderHeight;

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -254,11 +254,9 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
  */
 Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
   var hasPrevious = !!this.block_.previousConnection;
-  var hasPreviousBlock = hasPrevious &&
-    !!this.block_.previousConnection.targetConnection;
   var hasHat = (this.block_.hat ?
     this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
-    !this.outputConnection && !hasPreviousBlock;
+    !this.outputConnection && !hasPrevious;
   var leftSquareCorner = this.topRow.hasLeftSquareCorner(this.block_);
 
   if (leftSquareCorner) {

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -286,7 +286,7 @@ Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
   var hasHat = (block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
     !block.outputConnection && !block.previousConnection;
   var prevBlock = block.getPreviousBlock();
-  
+
   return !!block.outputConnection ||
       hasHat || (prevBlock ? prevBlock.getNextBlock() == block : false);
 };

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -283,9 +283,9 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
  * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  var prevBlock = block.getPreviousBlock();
   var hasHat = (block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
-    !block.outputConnection && !prevBlock;
+    !block.outputConnection && !block.previousConnection;
+  var prevBlock = block.getPreviousBlock();
   
   return !!block.outputConnection ||
       hasHat || (prevBlock ? prevBlock.getNextBlock() == block : false);

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -283,9 +283,10 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
  * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  var hasHat = block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT;
   var prevBlock = block.getPreviousBlock();
-
+  var hasHat = (block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
+    !block.outputConnection && !prevBlock;
+  
   return !!block.outputConnection ||
       hasHat || (prevBlock ? prevBlock.getNextBlock() == block : false);
 };


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3279

### Proposed Changes
Only add a hat if there's no output connection

### Reason for Changes

Rendering fix.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on the playground by changing the ``Blockly.BlockSvg.START_HAT = true``

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
