### PR TITLE
Add a playground helper to toggle start hats

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -439,6 +439,11 @@ function configureContextMenu(menuOptions) {
   menuOptions.push(screenshotOption);
 }
 
+function toggleStartHats() {
+  Blockly.BlockSvg.START_HAT = !Blockly.BlockSvg.START_HAT;
+  workspace.render();
+}
+
 function logger(e) {
   console.log(e);
 }
@@ -607,6 +612,10 @@ var spaghettiXml = [
       onchange="taChange();" onkeyup="taChange()"></textarea>
   </p>
 
+  <p>
+    Rendering: &nbsp;
+    <input type="button" value="Toggle hats" onclick="toggleStartHats()">
+  </p>
   <p>
     Stress test: &nbsp;
     <input type="button" value="Airstrike!" onclick="airstrike(100)">


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Make it easier to catch issues like: https://github.com/google/blockly/issues/3279 during testing.

### Proposed Changes

Add a button in the playground to toggle start hats.
Open to other suggestions of surfacing this in the playground.

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
