### PR TITLE
Add dragStart and dragEnd UI events

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -195,7 +195,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
 Blockly.BlockDragger.prototype.fireDragStartEvent_ = function() {
   var event = new Blockly.Events.Ui(this.draggingBlock_, 'dragStart',
       null, this.draggingBlock_.getDescendants(false));
-  Blockly.Events.fire(event)
+  Blockly.Events.fire(event);
 };
 
 /**

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -189,7 +189,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
 };
 
 /**
- * Fire a ui event at the start of a block drag.
+ * Fire a UI event at the start of a block drag.
  * @private
  */
 Blockly.BlockDragger.prototype.fireDragStartEvent_ = function() {
@@ -266,7 +266,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
 };
 
 /**
- * Fire a ui event at the end of a block drag.
+ * Fire a UI event at the end of a block drag.
  * @private
  */
 Blockly.BlockDragger.prototype.fireDragEndEvent_ = function() {

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -26,6 +26,7 @@ goog.provide('Blockly.BlockDragger');
 goog.require('Blockly.blockAnimations');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockMove');
+goog.require('Blockly.Events.Ui');
 goog.require('Blockly.InsertionMarkerManager');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
@@ -147,6 +148,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
   if (!Blockly.Events.getGroup()) {
     Blockly.Events.setGroup(true);
   }
+  this.fireDragStartEvent_();
 
   // Mutators don't have the same type of z-ordering as the normal workspace
   // during a drag.  They have to rely on the order of the blocks in the SVG.
@@ -187,6 +189,16 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
 };
 
 /**
+ * Fire a ui event at the start of a block drag.
+ * @private
+ */
+Blockly.BlockDragger.prototype.fireDragStartEvent_ = function() {
+  var event = new Blockly.Events.Ui(this.draggingBlock_, 'dragStart',
+      null, this.draggingBlock_.getDescendants(false));
+  Blockly.Events.fire(event)
+};
+
+/**
  * Execute a step of block dragging, based on the given event.  Update the
  * display accordingly.
  * @param {!Event} e The most recent move event.
@@ -218,7 +230,8 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   // Make sure internal state is fresh.
   this.dragBlock(e, currentDragDeltaXY);
   this.dragIconData_ = [];
-
+  this.fireDragEndEvent_();
+  
   Blockly.utils.dom.stopTextWidthCache();
 
   Blockly.blockAnimations.disconnectUiStop();
@@ -250,6 +263,16 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
     toolbox.removeStyle(style);
   }
   Blockly.Events.setGroup(false);
+};
+
+/**
+ * Fire a ui event at the end of a block drag.
+ * @private
+ */
+Blockly.BlockDragger.prototype.fireDragEndEvent_ = function() {
+  var event = new Blockly.Events.Ui(this.draggingBlock_, 'dragStop',
+      this.draggingBlock_.getDescendants(false), null);
+  Blockly.Events.fire(event);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I branched from develop
- [x ] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Addresses #3216, creating UI events for the start and end of a drag.

### Proposed Changes
Creates UI events "dragStart" and "dragEnd" which are fired at the start and end of a drag respectively.
"dragStart"

### Reason for Changes
Provide support for updating the UI in response to a block being dragged.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

The Events document needs to be updated to include "dragStart" and "dragEnd" to the list of valid element values.

### Additional Information

<!-- Anything else we should know? -->
