### PR TITLE
Make finished-loading events be UI events

### DIFF
--- a/core/events.js
+++ b/core/events.js
@@ -390,6 +390,9 @@ Blockly.Events.fromJson = function(json, workspace) {
     case Blockly.Events.COMMENT_DELETE:
       event = new Blockly.Events.CommentDelete(null);
       break;
+    case Blockly.Events.FINISHED_LOADING:
+      event = new Blockly.Events.FinishedLoading(null);
+      break;
     default:
       throw Error('Unknown event type.');
   }

--- a/core/workspace_events.js
+++ b/core/workspace_events.js
@@ -24,7 +24,7 @@
 goog.provide('Blockly.Events.FinishedLoading');
 
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.Abstract');
+goog.require('Blockly.Events.Ui');
 goog.require('Blockly.utils.object');
 
 
@@ -46,7 +46,7 @@ Blockly.Events.FinishedLoading = function(workspace) {
   this.workspaceId = workspace.id;
 
   /**
-   * The event group id for the group this event belongs to. Groups define
+   * The event group ID for the group this event belongs to. Groups define
    * events that should be treated as an single action from the user's
    * perspective, and should be undone together.
    * @type {string}
@@ -57,7 +57,7 @@ Blockly.Events.FinishedLoading = function(workspace) {
   this.recordUndo = false;
 };
 Blockly.utils.object.inherits(Blockly.Events.FinishedLoading,
-    Blockly.Events.Abstract);
+    Blockly.Events.Ui);
 
 /**
  * Type of this event.

--- a/demos/mirror/index.html
+++ b/demos/mirror/index.html
@@ -65,7 +65,7 @@
     primaryWorkspace.addChangeListener(mirrorEvent);
 
     function mirrorEvent(primaryEvent) {
-      if (primaryEvent.type == Blockly.Events.UI) {
+      if (primaryEvent instanceof Blockly.Events.Ui) {
         return;  // Don't mirror UI events.
       }
       // Convert event to JSON.  This could then be transmitted across the net.


### PR DESCRIPTION
Currently the playground throws when a block is deleted and the delete is undone.