### PR TITLE
Fix 6 warnings related to rendering.

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -250,6 +250,28 @@ goog.require = function(namespace) {
   return null;
 };
 
+/**
+ * Requires a symbol for its type information. This is an indication to the
+ * compiler that the symbol may appear in type annotations, yet it is not
+ * referenced at runtime.
+ *
+ * When called within a goog.module or ES6 module file, the return value may be
+ * assigned to or destructured into a variable, but it may not be otherwise used
+ * in code outside of a type annotation.
+ *
+ * Note that all calls to goog.requireType will be stripped by the compiler.
+ *
+ * @param {string} namespace Namespace (as was given in goog.provide,
+ *     goog.module, or goog.declareModuleId) in the form
+ *     "goog.package.part".
+ * @return {?}
+ */
+goog.requireType = function(namespace) {
+  // Return an empty object so that single-level destructuring of the return
+  // value doesn't crash at runtime when using the debug loader. Multi-level
+  // destructuring isn't supported.
+  return {};
+};
 
 /**
  * Path for included scripts.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -100,6 +100,13 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   /** @type {!Blockly.WorkspaceSvg} */
   this.workspace = workspace;
 
+  /** @type {Blockly.RenderedConnection} */
+  this.outputConnection = null;
+  /** @type {Blockly.RenderedConnection} */
+  this.nextConnection = null;
+  /** @type {Blockly.RenderedConnection} */
+  this.previousConnection = null;
+
   /**
    * Whether to move the block to the drag surface when it is dragged.
    * True if it should move, false if it should be translated directly.
@@ -238,6 +245,13 @@ Blockly.BlockSvg.prototype.decompose;
  * @type {?function(!Blockly.BlockSvg)}
  */
 Blockly.BlockSvg.prototype.compose;
+
+/**
+ * An property used internally to reference the block's rendering debugger.
+ * @type {?Blockly.blockRendering.Debug}
+ * @package
+ */
+Blockly.BlockSvg.prototype.renderingDebugger;
 
 /**
  * Create and initialize the SVG representation of the block.

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -42,6 +42,7 @@ Blockly.blockRendering.Debug = function() {
   /**
    * An array of SVG elements that have been created by this object.
    * @type {Array.<!SVGElement>}
+   * @private
    */
   this.debugElements_ = [];
 
@@ -49,6 +50,7 @@ Blockly.blockRendering.Debug = function() {
    * The SVG root of the block that is being rendered.  Debug elements will
    * be attached to this root.
    * @type {SVGElement}
+   * @private
    */
   this.svgRoot_ = null;
 };
@@ -178,6 +180,8 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
  * share the same colours, as do previous and next.  When positioned correctly
  * a connected pair will look like a bullseye.
  * @param {Blockly.RenderedConnection} conn The connection to circle.
+ * @suppress {visibility} Suppress visibility of conn.offsetInBlock_ since this
+ *     is a debug module.
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawConnection = function(conn) {
@@ -273,7 +277,7 @@ Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, curso
   for (var i = 0, elem; (elem = row.elements[i]); i++) {
     if (Blockly.blockRendering.Types.isSpacer(elem)) {
       this.drawSpacerElem(
-          /** @type {Blockly.blockRendering.InRowSpacer} */ (elem),
+          /** @type {!Blockly.blockRendering.InRowSpacer} */ (elem),
           row.height, isRtl);
     } else {
       this.drawRenderedElem(elem, isRtl);

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -654,7 +654,7 @@ Blockly.blockRendering.RenderInfo.prototype.getElemCenterline_ = function(row,
  * Record final position information on elements on the given row, for use in
  * drawing.  At minimum this records xPos and centerline on each element.
  * @param {!Blockly.blockRendering.Row} row The row containing the elements.
- * @private
+ * @protected
  */
 Blockly.blockRendering.RenderInfo.prototype.recordElemPositions_ = function(
     row) {

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -32,7 +32,6 @@ goog.require('Blockly.utils.dom');
  * An interface for a block's path object.
  * @param {!SVGElement} _root The root SVG element.
  * @interface
- * @package
  */
 Blockly.blockRendering.IPathObject = function(_root) {};
 

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -30,6 +30,8 @@ goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.blockRendering.RenderInfo');
 goog.require('Blockly.CursorSvg');
 
+goog.requireType('Blockly.blockRendering.Debug');
+
 
 /**
  * The base class for a block renderer.
@@ -89,6 +91,7 @@ Blockly.blockRendering.Renderer.prototype.makeDrawer_ = function(block, info) {
 /**
  * Create a new instance of the renderer's debugger.
  * @return {!Blockly.blockRendering.Debug} The renderer debugger.
+ * @suppress {strictModuleDepCheck} Debug renderer only included in playground.
  * @protected
  */
 Blockly.blockRendering.Renderer.prototype.makeDebugger_ = function() {

--- a/core/renderers/geras/measurables/inputs.js
+++ b/core/renderers/geras/measurables/inputs.js
@@ -37,7 +37,7 @@ goog.require('Blockly.utils.object');
  *     information for.
  * @package
  * @constructor
- * @extends {Blockly.blockRendering.InputConnection}
+ * @extends {Blockly.blockRendering.InlineInput}
  */
 Blockly.geras.InlineInput = function(constants, input) {
   Blockly.geras.InlineInput.superClass_.constructor.call(
@@ -62,7 +62,7 @@ Blockly.utils.object.inherits(Blockly.geras.InlineInput,
  *     information for.
  * @package
  * @constructor
- * @extends {Blockly.blockRendering.InputConnection}
+ * @extends {Blockly.blockRendering.StatementInput}
  */
 Blockly.geras.StatementInput = function(constants, input) {
   Blockly.geras.StatementInput.superClass_.constructor.call(

--- a/core/renderers/measurables/connections.js
+++ b/core/renderers/measurables/connections.js
@@ -36,7 +36,7 @@ goog.require('Blockly.utils.object');
  * the block.
  * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering
  *   constants provider.
- * @param {Blockly.RenderedConnection} connectionModel The connection object on
+ * @param {!Blockly.RenderedConnection} connectionModel The connection object on
  *     the block that this represents.
  * @package
  * @constructor

--- a/core/renderers/measurables/types.js
+++ b/core/renderers/measurables/types.js
@@ -28,7 +28,6 @@ goog.provide('Blockly.blockRendering.Types');
 /**
  * Types of rendering elements.
  * @enum {number}
- * @package
  */
 Blockly.blockRendering.Types = {
   NONE: 0, // None


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix 6 compiler warnings.

### Proposed Changes

Suppress module not found with Blockly.blockRendering.Debug as it's only included in the playground.
Add requireType. Allows us to require type information from another file without including that file in the dependency tree.
Interfaces and Enum cannot be @package.

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
