### PR TITLE
Fix 6 warnings related to generators.

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -375,6 +375,28 @@ Blockly.Generator.prototype.addReservedWords = function(words) {
 Blockly.Generator.prototype.FUNCTION_NAME_PLACEHOLDER_ = '{leCUI8hutHZI4480Dc}';
 
 /**
+ * A dictionary of definitions to be printed before the code.
+ * @type {Object}
+ * @protected
+ */
+Blockly.Generator.prototype.definitions_;
+
+/**
+ * A dictionary mapping desired function names in definitions_ to actual
+ * function names (to avoid collisions with user functions).
+ * @type {Object}
+ * @protected
+ */
+Blockly.Generator.prototype.functionNames_;
+
+/**
+ * A database of variable names.
+ * @type {Blockly.Names}
+ * @protected
+ */
+Blockly.Generator.prototype.variableDB_;
+
+/**
  * Define a function to be included in the generated code.
  * The first time this is called with a given desiredName, the code is
  * saved and an actual name is generated.  Subsequent calls with the
@@ -394,7 +416,7 @@ Blockly.Generator.prototype.FUNCTION_NAME_PLACEHOLDER_ = '{leCUI8hutHZI4480Dc}';
 Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
   if (!this.definitions_[desiredName]) {
     var functionName = this.variableDB_.getDistinctName(desiredName,
-        Blockly.Procedures.NAME_TYPE);
+        Blockly.PROCEDURE_CATEGORY_NAME);
     this.functionNames_[desiredName] = functionName;
     var codeText = code.join('\n').replace(
         this.FUNCTION_NAME_PLACEHOLDER_REGEXP_, functionName);


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

6 compiler warnings.

### Proposed Changes

Blockly.Procedures.NAME_TYPE is deprecated. Using Blockly.PROCEDURE_CATEGORY_NAME instead.
Add type information for properties defined in each of the generators.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
