### PR TITLE
Fix #3191

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -531,6 +531,9 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
   if (lastSpacer) {
     lastSpacer.width += missingSpace;
     row.width += missingSpace;
+    if (row.hasExternalInput || row.hasStatement) {
+      row.widthWithConnectedBlocks += missingSpace;
+    }
   }
 };
 


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3191
### Proposed Changes

Updates the width with connected blocks as well as the row width if adding alignment padding.

### Reason for Changes

Geras was doing this but the base renderer wasn't, and it needs to.

### Test Coverage
Tested with a similar stack of blocks to the original bug report:
![image](https://user-images.githubusercontent.com/13686399/67248265-bc79c480-f418-11e9-88f0-294f1bcf4e45.png)

### Documentation

None.
