### PR TITLE
Fix #3228 by only using the dark path offset in Geras.

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -309,7 +309,7 @@ Blockly.blockRendering.RenderInfo.prototype.populateBottomRow_ = function() {
   if (followsStatement) {
     this.bottomRow.minHeight = this.constants_.LARGE_PADDING;
   } else {
-    this.bottomRow.minHeight = this.constants_.MEDIUM_PADDING - 1;
+    this.bottomRow.minHeight = this.constants_.MEDIUM_PADDING;
   }
 
   var leftSquareCorner = this.bottomRow.hasLeftSquareCorner(this.block_);

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -76,6 +76,28 @@ Blockly.geras.RenderInfo.prototype.getRenderer = function() {
 /**
  * @override
  */
+Blockly.geras.RenderInfo.prototype.populateBottomRow_ = function() {
+  Blockly.geras.RenderInfo.superClass_.populateBottomRow_.call(this);
+
+  var followsStatement =
+      this.block_.inputList.length &&
+      this.block_.inputList[this.block_.inputList.length - 1]
+          .type == Blockly.NEXT_STATEMENT;
+
+  // The minimum height of the bottom row is smaller in Geras than in other
+  // renderers, because the dark path adds a pixel.
+  // If one of the row's elements has a greater height this will be overwritten
+  // in the compute pass.
+  if (!followsStatement) {
+    this.bottomRow.minHeight =
+        this.constants_.MEDIUM_PADDING - this.constants_.DARK_PATH_OFFSET;
+  }
+
+};
+
+/**
+ * @override
+ */
 Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
   // Non-dummy inputs have visual representations onscreen.
   if (this.isInline && input.type == Blockly.INPUT_VALUE) {

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -154,7 +154,8 @@ Blockly.blockRendering.ExternalValueInput = function(constants, input) {
     this.height = this.shape.height;
   } else {
     this.height =
-        this.connectedBlockHeight - 2 * this.constants_.TAB_OFFSET_FROM_TOP;
+        this.connectedBlockHeight - this.constants_.TAB_OFFSET_FROM_TOP -
+        this.constants_.MEDIUM_PADDING;
   }
   this.width = this.shape.width +
       this.constants_.EXTERNAL_VALUE_INPUT_PADDING;


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3228 

### Proposed Changes

Only use the dark path offset in bottom row height in Geras

### Reason for Changes

Height of the connected block includes the dark path, but height while laying out this block doesn't.

### Test Coverage
Checked Geras, Thrasos, and Minimalist.  Test cases included a concatenation of not blocks and of ternary blocks.

### Documentation
None

### Additional Information

