### PR TITLE
Remove deprectaed use of Blockly.Procedures.NAME_TYPE

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -394,7 +394,7 @@ Blockly.Generator.prototype.FUNCTION_NAME_PLACEHOLDER_ = '{leCUI8hutHZI4480Dc}';
 Blockly.Generator.prototype.provideFunction_ = function(desiredName, code) {
   if (!this.definitions_[desiredName]) {
     var functionName = this.variableDB_.getDistinctName(desiredName,
-        Blockly.Procedures.NAME_TYPE);
+        Blockly.PROCEDURE_CATEGORY_NAME);
     this.functionNames_[desiredName] = functionName;
     var codeText = code.join('\n').replace(
         this.FUNCTION_NAME_PLACEHOLDER_REGEXP_, functionName);

--- a/generators/dart/procedures.js
+++ b/generators/dart/procedures.js
@@ -29,7 +29,7 @@ goog.require('Blockly.Dart');
 Blockly.Dart['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   var funcName = Blockly.Dart.variableDB_.getName(block.getFieldValue('NAME'),
-      Blockly.Procedures.NAME_TYPE);
+      Blockly.PROCEDURE_CATEGORY_NAME);
   var xfix1 = '';
   if (Blockly.Dart.STATEMENT_PREFIX) {
     xfix1 += Blockly.Dart.injectId(Blockly.Dart.STATEMENT_PREFIX, block);
@@ -78,7 +78,7 @@ Blockly.Dart['procedures_defnoreturn'] = Blockly.Dart['procedures_defreturn'];
 Blockly.Dart['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   var funcName = Blockly.Dart.variableDB_.getName(block.getFieldValue('NAME'),
-      Blockly.Procedures.NAME_TYPE);
+      Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
   for (var i = 0; i < block.arguments_.length; i++) {
     args[i] = Blockly.Dart.valueToCode(block, 'ARG' + i,

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -29,7 +29,7 @@ goog.require('Blockly.JavaScript');
 Blockly.JavaScript['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   var funcName = Blockly.JavaScript.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var xfix1 = '';
   if (Blockly.JavaScript.STATEMENT_PREFIX) {
     xfix1 += Blockly.JavaScript.injectId(Blockly.JavaScript.STATEMENT_PREFIX,
@@ -80,7 +80,7 @@ Blockly.JavaScript['procedures_defnoreturn'] =
 Blockly.JavaScript['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   var funcName = Blockly.JavaScript.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
   for (var i = 0; i < block.arguments_.length; i++) {
     args[i] = Blockly.JavaScript.valueToCode(block, 'ARG' + i,

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -29,7 +29,7 @@ goog.require('Blockly.Lua');
 Blockly.Lua['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   var funcName = Blockly.Lua.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var xfix1 = '';
   if (Blockly.Lua.STATEMENT_PREFIX) {
     xfix1 += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_PREFIX, block);
@@ -80,7 +80,7 @@ Blockly.Lua['procedures_defnoreturn'] =
 Blockly.Lua['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   var funcName = Blockly.Lua.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
   for (var i = 0; i < block.arguments_.length; i++) {
     args[i] = Blockly.Lua.valueToCode(block, 'ARG' + i,

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -50,7 +50,7 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
       Blockly.PHP.INDENT + 'global ' + globals.join(', ') + ';\n' : '';
 
   var funcName = Blockly.PHP.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var xfix1 = '';
   if (Blockly.PHP.STATEMENT_PREFIX) {
     xfix1 += Blockly.PHP.injectId(Blockly.PHP.STATEMENT_PREFIX, block);
@@ -99,7 +99,7 @@ Blockly.PHP['procedures_defnoreturn'] =
 Blockly.PHP['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   var funcName = Blockly.PHP.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
   for (var i = 0; i < block.arguments_.length; i++) {
     args[i] = Blockly.PHP.valueToCode(block, 'ARG' + i,

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -51,7 +51,7 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   globals = globals.length ?
       Blockly.Python.INDENT + 'global ' + globals.join(', ') + '\n' : '';
   var funcName = Blockly.Python.variableDB_.getName(
-      block.getFieldValue('NAME'), Blockly.Procedures.NAME_TYPE);
+      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var xfix1 = '';
   if (Blockly.Python.STATEMENT_PREFIX) {
     xfix1 += Blockly.Python.injectId(Blockly.Python.STATEMENT_PREFIX, block);
@@ -102,7 +102,7 @@ Blockly.Python['procedures_defnoreturn'] =
 Blockly.Python['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   var funcName = Blockly.Python.variableDB_.getName(block.getFieldValue('NAME'),
-      Blockly.Procedures.NAME_TYPE);
+      Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
   for (var i = 0; i < block.arguments_.length; i++) {
     args[i] = Blockly.Python.valueToCode(block, 'ARG' + i,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Blockly.Procedures.NAME_TYPE is marked as deprecated so just removing it from use in our code.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
