### PR TITLE
Suppress workspace comment compiler errors.

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -300,6 +300,8 @@ Blockly.ContextMenu.blockCommentOption = function(block) {
  *     right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
+ * @suppress {checkTypes} Suppress checks while workspace comments are not
+ *     bundled in.
  */
 Blockly.ContextMenu.commentDeleteOption = function(comment) {
   var deleteOption = {
@@ -320,6 +322,8 @@ Blockly.ContextMenu.commentDeleteOption = function(comment) {
  *     right-click originated.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
+ * @suppress {checkTypes} Suppress checks while workspace comments are not
+ *     bundled in.
  */
 Blockly.ContextMenu.commentDuplicateOption = function(comment) {
   var duplicateOption = {
@@ -339,6 +343,8 @@ Blockly.ContextMenu.commentDuplicateOption = function(comment) {
  * @param {!Event} e The right-click mouse event.
  * @return {!Object} A menu option, containing text, enabled, and a callback.
  * @package
+ * @suppress {strictModuleDepCheck,checkTypes} Suppress checks while workspace
+ *     comments are not bundled in.
  */
 Blockly.ContextMenu.workspaceCommentOption = function(ws, e) {
   if (!Blockly.WorkspaceCommentSvg) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1261,6 +1261,8 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
  * Paste the provided comment onto the workspace.
  * @param {!Element} xmlComment XML workspace comment element.
  * @private
+ * @suppress {checkTypes} Suppress checks while workspace comments are not
+ *     bundled in.
  */
 Blockly.WorkspaceSvg.prototype.pasteWorkspaceComment_ = function(xmlComment) {
   Blockly.Events.disable();

--- a/core/xml.js
+++ b/core/xml.js
@@ -371,6 +371,8 @@ Blockly.Xml.clearWorkspaceAndLoadFromXml = function(xml, workspace) {
  * @param {!Element} xml XML DOM.
  * @param {!Blockly.Workspace} workspace The workspace.
  * @return {!Array.<string>} An array containing new block IDs.
+ * @suppress {strictModuleDepCheck} Suppress module check while workspace
+ *     comments are not bundled in.
  */
 Blockly.Xml.domToWorkspace = function(xml, workspace) {
   if (xml instanceof Blockly.Workspace) {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Suppress compiler errors related to workspace comments as it's complaining about not finding the module. (Since it's not bundled in). 
Added a TODO issue to remove these suppress tags when we bundle workspace comments back in.
https://github.com/google/blockly/issues/3302

### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
