### PR TITLE
Fix warnings related to gestures and drag.

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -238,7 +238,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
 
   var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
   var newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
-  this.draggingBlock_.moveOffDragSurface_(newLoc);
+  this.draggingBlock_.moveOffDragSurface(newLoc);
 
   var deleted = this.maybeDeleteBlock_();
   if (!deleted) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -520,9 +520,9 @@ Blockly.BlockSvg.prototype.moveTo = function(xy) {
  * Does nothing if useDragSurface_ is false.
  * @param {!Blockly.utils.Coordinate} newXY The position the block should take on
  *     on the workspace canvas, in workspace coordinates.
- * @private
+ * @package
  */
-Blockly.BlockSvg.prototype.moveOffDragSurface_ = function(newXY) {
+Blockly.BlockSvg.prototype.moveOffDragSurface = function(newXY) {
   if (!this.useDragSurface_) {
     return;
   }
@@ -868,9 +868,9 @@ Blockly.BlockSvg.prototype.generateContextMenu = function() {
 /**
  * Show the context menu for this block.
  * @param {!Event} e Mouse event.
- * @private
+ * @package
  */
-Blockly.BlockSvg.prototype.showContextMenu_ = function(e) {
+Blockly.BlockSvg.prototype.showContextMenu = function(e) {
   var menuOptions = this.generateContextMenu();
 
   if (menuOptions && menuOptions.length) {

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -306,9 +306,9 @@ Blockly.Bubble.prototype.bubbleMouseDown_ = function(e) {
 /**
  * Show the context menu for this bubble.
  * @param {!Event} _e Mouse event.
- * @private
+ * @package
  */
-Blockly.Bubble.prototype.showContextMenu_ = function(_e) {
+Blockly.Bubble.prototype.showContextMenu = function(_e) {
   // NOP on bubbles, but used by the bubble dragger to pass events to
   // workspace comments.
 };

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -117,7 +117,7 @@ Blockly.Gesture = function(e, creatorWorkspace) {
    * to the gesture, which will need to be cleared at deletion.
    * This may be different from the start workspace.  For instance, a flyout is
    * a workspace, but its parent workspace manages gestures for it.
-   * @type {Blockly.WorkspaceSvg}
+   * @type {!Blockly.WorkspaceSvg}
    * @private
    */
   this.creatorWorkspace_ = creatorWorkspace;
@@ -288,7 +288,7 @@ Blockly.Gesture.prototype.updateFromEvent_ = function(e) {
  */
 Blockly.Gesture.prototype.updateDragDelta_ = function(currentXY) {
   this.currentDragDeltaXY_ = Blockly.utils.Coordinate.difference(currentXY,
-      this.mouseDownXY_);
+      /** @type {!Blockly.utils.Coordinate} */ (this.mouseDownXY_));
 
   if (!this.hasExceededDragRadius_) {
     var currentDragDelta = Blockly.utils.Coordinate.magnitude(
@@ -404,7 +404,8 @@ Blockly.Gesture.prototype.updateIsDraggingWorkspace_ = function() {
   if (this.flyout_) {
     this.workspaceDragger_ = new Blockly.FlyoutDragger(this.flyout_);
   } else {
-    this.workspaceDragger_ = new Blockly.WorkspaceDragger(this.startWorkspace_);
+    this.workspaceDragger_ = new Blockly.WorkspaceDragger(
+        /** @type {!Blockly.WorkspaceSvg} */ (this.startWorkspace_));
   }
 
   this.isDraggingWorkspace_ = true;
@@ -441,8 +442,9 @@ Blockly.Gesture.prototype.updateIsDragging_ = function() {
  * @private
  */
 Blockly.Gesture.prototype.startDraggingBlock_ = function() {
-  this.blockDragger_ = new Blockly.BlockDragger(this.targetBlock_,
-      this.startWorkspace_);
+  this.blockDragger_ = new Blockly.BlockDragger(
+      /** @type {!Blockly.BlockSvg} */ (this.targetBlock_),
+      /** @type {!Blockly.WorkspaceSvg} */ (this.startWorkspace_));
   this.blockDragger_.startBlockDrag(this.currentDragDeltaXY_, this.healStack_);
   this.blockDragger_.dragBlock(this.mostRecentEvent_,
       this.currentDragDeltaXY_);
@@ -454,8 +456,9 @@ Blockly.Gesture.prototype.startDraggingBlock_ = function() {
  */
 // TODO (fenichel): Possibly combine this and startDraggingBlock_.
 Blockly.Gesture.prototype.startDraggingBubble_ = function() {
-  this.bubbleDragger_ = new Blockly.BubbleDragger(this.startBubble_,
-      this.startWorkspace_);
+  this.bubbleDragger_ = new Blockly.BubbleDragger(
+      /** @type {!Blockly.Bubble} */ (this.startBubble_),
+      /** @type {!Blockly.WorkspaceSvg} */ (this.startWorkspace_));
   this.bubbleDragger_.startBubbleDrag();
   this.bubbleDragger_.dragBubble(this.mostRecentEvent_,
       this.currentDragDeltaXY_);
@@ -625,12 +628,12 @@ Blockly.Gesture.prototype.handleRightClick = function(e) {
   if (this.targetBlock_) {
     this.bringBlockToFront_();
     Blockly.hideChaff(!!this.flyout_);
-    this.targetBlock_.showContextMenu_(e);
+    this.targetBlock_.showContextMenu(e);
   } else if (this.startBubble_) {
-    this.startBubble_.showContextMenu_(e);
+    this.startBubble_.showContextMenu(e);
   } else if (this.startWorkspace_ && !this.flyout_) {
     Blockly.hideChaff();
-    this.startWorkspace_.showContextMenu_(e);
+    this.startWorkspace_.showContextMenu(e);
   }
 
   // TODO: Handle right-click on a bubble.
@@ -643,7 +646,7 @@ Blockly.Gesture.prototype.handleRightClick = function(e) {
 /**
  * Handle a mousedown/touchstart event on a workspace.
  * @param {!Event} e A mouse down or touch start event.
- * @param {!Blockly.Workspace} ws The workspace the event hit.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace the event hit.
  * @package
  */
 Blockly.Gesture.prototype.handleWsStart = function(e, ws) {

--- a/core/icon.js
+++ b/core/icon.js
@@ -174,8 +174,8 @@ Blockly.Icon.prototype.computeIconLocation = function() {
 
 /**
  * Returns the center of the block's icon relative to the surface.
- * @return {!Blockly.utils.Coordinate} Object with x and y properties in workspace
- *     coordinates.
+ * @return {Blockly.utils.Coordinate} Object with x and y properties in
+ *     workspace coordinates.
  */
 Blockly.Icon.prototype.getIconLocation = function() {
   return this.iconXY_;

--- a/core/icon.js
+++ b/core/icon.js
@@ -174,8 +174,8 @@ Blockly.Icon.prototype.computeIconLocation = function() {
 
 /**
  * Returns the center of the block's icon relative to the surface.
- * @return {Blockly.utils.Coordinate} Object with x and y properties in
- *     workspace coordinates.
+ * @return {!Blockly.utils.Coordinate} Object with x and y properties in workspace
+ *     coordinates.
  */
 Blockly.Icon.prototype.getIconLocation = function() {
   return this.iconXY_;

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -235,8 +235,10 @@ Blockly.TouchGesture.prototype.handleTouchStart = function(e) {
   var pointers = Object.keys(this.cachedPoints_);
   // If two pointers are down, check for pinch gestures
   if (pointers.length == 2) {
-    var point0 = this.cachedPoints_[pointers[0]];
-    var point1 = this.cachedPoints_[pointers[1]];
+    var point0 = /** @type {!Blockly.utils.Coordinate} */ (
+      this.cachedPoints_[pointers[0]]);
+    var point1 = /** @type {!Blockly.utils.Coordinate} */ (
+      this.cachedPoints_[pointers[1]]);
     this.startDistance_ = Blockly.utils.Coordinate.distance(point0, point1);
     this.isMultiTouch_ = true;
     e.preventDefault();
@@ -258,8 +260,10 @@ Blockly.TouchGesture.prototype.handleTouchMove = function(e) {
   // If two pointers are down, check for pinch gestures
   if (pointers.length == 2) {
     // Calculate the distance between the two pointers
-    var point0 = this.cachedPoints_[pointers[0]];
-    var point1 = this.cachedPoints_[pointers[1]];
+    var point0 = /** @type {!Blockly.utils.Coordinate} */ (
+      this.cachedPoints_[pointers[0]]);
+    var point1 = /** @type {!Blockly.utils.Coordinate} */ (
+      this.cachedPoints_[pointers[1]]);
     var moveDistance = Blockly.utils.Coordinate.distance(point0, point1);
     var startDistance = this.startDistance_;
     var scale = this.touchScale_ = moveDistance / startDistance;

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -170,9 +170,9 @@ Blockly.WorkspaceCommentSvg.prototype.pathMouseDown_ = function(e) {
 /**
  * Show the context menu for this workspace comment.
  * @param {!Event} e Mouse event.
- * @private
+ * @package
  */
-Blockly.WorkspaceCommentSvg.prototype.showContextMenu_ = function(e) {
+Blockly.WorkspaceCommentSvg.prototype.showContextMenu = function(e) {
   if (this.workspace.options.readOnly) {
     return;
   }
@@ -368,7 +368,7 @@ Blockly.WorkspaceCommentSvg.prototype.moveToDragSurface_ = function() {
  *     on the workspace canvas, in workspace coordinates.
  * @private
  */
-Blockly.WorkspaceCommentSvg.prototype.moveOffDragSurface_ = function(newXY) {
+Blockly.WorkspaceCommentSvg.prototype.moveOffDragSurface = function(newXY) {
   if (!this.useDragSurface_) {
     return;
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1579,9 +1579,9 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function() {
 /**
  * Show the context menu for the workspace.
  * @param {!Event} e Mouse event.
- * @private
+ * @package
  */
-Blockly.WorkspaceSvg.prototype.showContextMenu_ = function(e) {
+Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
   if (this.options.readOnly || this.isFlyout) {
     return;
   }


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes 17 compiler warnings.

### Proposed Changes

Visibility: 
Renamed block.``moveOffDragSurface_`` to ``moveOffDragSurface`` and made it package.
Renamed block/comment/workspace .``showContextMenu_`` to ``showContextMenu`` and made it package.

Cast gesture. startWorkspace_, startBubble_, targetBlock_ to each of their none null types where they're called after a start drag that sets them.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
