### PR TITLE
Fix warnings related to insertion markers.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1613,6 +1613,35 @@ Blockly.BlockSvg.prototype.getConnections_ = function(all) {
 };
 
 /**
+ * Walks down a stack of blocks and finds the last next connection on the stack.
+ * @return {Blockly.RenderedConnection} The last next connection on the stack,
+ *     or null.
+ * @package
+ * @override
+ */
+Blockly.BlockSvg.prototype.lastConnectionInStack = function() {
+  return /** @type {Blockly.RenderedConnection} */ (
+    Blockly.BlockSvg.superClass_.lastConnectionInStack.call(this));
+};
+
+/**
+ * Find the connection on this block that corresponds to the given connection
+ * on the other block.
+ * Used to match connections between a block and its insertion marker.
+ * @param {!Blockly.Block} otherBlock The other block to match against.
+ * @param {!Blockly.Connection} conn The other connection to match.
+ * @return {Blockly.RenderedConnection} The matching connection on this block,
+ *     or null.
+ * @package
+ * @override
+ */
+Blockly.BlockSvg.prototype.getMatchingConnection = function(otherBlock, conn) {
+  return /** @type {Blockly.RenderedConnection} */ (
+    Blockly.BlockSvg.superClass_.getMatchingConnection.call(this,
+        otherBlock, conn));
+};
+
+/**
  * Create a connection of the specified type.
  * @param {number} type The type of the connection to create.
  * @return {!Blockly.RenderedConnection} A new connection of the specified type.
@@ -1711,6 +1740,27 @@ Blockly.BlockSvg.prototype.positionNearConnection = function(sourceConnection,
 
     this.moveBy(dx, dy);
   }
+};
+
+/**
+ * Return the parent block or null if this block is at the top level.
+ * @return {Blockly.BlockSvg} The block that holds the current block.
+ * @override
+ */
+Blockly.BlockSvg.prototype.getParent = function() {
+  return /** @type {!Blockly.BlockSvg} */ (
+    Blockly.BlockSvg.superClass_.getParent.call(this));
+};
+
+/**
+ * Return the top-most block in this block's tree.
+ * This will return itself if this block is at the top level.
+ * @return {!Blockly.BlockSvg} The root block.
+ * @override
+ */
+Blockly.BlockSvg.prototype.getRootBlock = function() {
+  return /** @type {!Blockly.BlockSvg} */ (
+    Blockly.BlockSvg.superClass_.getRootBlock.call(this));
 };
 
 /**

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -87,6 +87,26 @@ Blockly.RenderedConnection.prototype.dispose = function() {
 };
 
 /**
+ * Get the source block for this connection.
+ * @return {!Blockly.BlockSvg} The source block.
+ * @override
+ */
+Blockly.RenderedConnection.prototype.getSourceBlock = function() {
+  return /** @type {!Blockly.BlockSvg} */ (
+    Blockly.RenderedConnection.superClass_.getSourceBlock.call(this));
+};
+
+/**
+ * Returns the block that this connection connects to.
+ * @return {Blockly.BlockSvg} The connected block or null if none is connected.
+ * @override
+ */
+Blockly.RenderedConnection.prototype.targetBlock = function() {
+  return /** @type {Blockly.BlockSvg} */ (
+    Blockly.RenderedConnection.superClass_.targetBlock.call(this));
+};
+
+/**
  * Returns the distance between this connection and another connection in
  * workspace units.
  * @param {!Blockly.Connection} otherConnection The other connection to measure


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix 17 warnings related to insertion markers.

### Proposed Changes

Added ``BlockSvg.lastConnectionInStack`` and ``getMatchingConnection`` that both return ``RenderedConnection`` instead of ``Connection``.
Added ``RenderedConnection.getSourceBlock`` and ``targetBlock`` that return ``BlockSvg``'s instead of ``Block``.
Use connection.``getSourceBlock`` instead of ``sourceBlock_``.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
