### PR TITLE
Make Blockly options an interface

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -34,12 +34,14 @@ goog.require('Blockly.WidgetDiv');
 
 /**
  * Class for a flyout.
- * @param {!Object} workspaceOptions Dictionary of options for the workspace.
+ * @param {!Blockly.Options} workspaceOptions Dictionary of options for the
+ *     workspace.
  * @extends {Blockly.Flyout}
  * @constructor
  */
 Blockly.HorizontalFlyout = function(workspaceOptions) {
-  workspaceOptions.getMetrics = this.getMetrics_.bind(this);
+  workspaceOptions.getMetrics = /** @type {function():!Object} */ (
+    this.getMetrics_.bind(this));
   workspaceOptions.setMetrics = this.setMetrics_.bind(this);
 
   Blockly.HorizontalFlyout.superClass_.constructor.call(this, workspaceOptions);

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -35,12 +35,14 @@ goog.require('Blockly.WidgetDiv');
 
 /**
  * Class for a flyout.
- * @param {!Object} workspaceOptions Dictionary of options for the workspace.
+ * @param {!Blockly.Options} workspaceOptions Dictionary of options for the
+ *     workspace.
  * @extends {Blockly.Flyout}
  * @constructor
  */
 Blockly.VerticalFlyout = function(workspaceOptions) {
-  workspaceOptions.getMetrics = this.getMetrics_.bind(this);
+workspaceOptions.getMetrics = /** @type {function():!Object} */ (
+  this.getMetrics_.bind(this));
   workspaceOptions.setMetrics = this.setMetrics_.bind(this);
 
   Blockly.VerticalFlyout.superClass_.constructor.call(this, workspaceOptions);

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -41,8 +41,8 @@ goog.require('Blockly.WidgetDiv');
  * @constructor
  */
 Blockly.VerticalFlyout = function(workspaceOptions) {
-workspaceOptions.getMetrics = /** @type {function():!Object} */ (
-  this.getMetrics_.bind(this));
+  workspaceOptions.getMetrics = /** @type {function():!Object} */ (
+    this.getMetrics_.bind(this));
   workspaceOptions.setMetrics = this.setMetrics_.bind(this);
 
   Blockly.VerticalFlyout.superClass_.constructor.call(this, workspaceOptions);

--- a/core/inject.js
+++ b/core/inject.js
@@ -43,8 +43,7 @@ goog.require('Blockly.WorkspaceSvg');
  * Inject a Blockly editor into the specified container element (usually a div).
  * @param {Element|string} container Containing element, or its ID,
  *     or a CSS selector.
- * @param {Blockly.WorkspaceOptions=} opt_options Optional dictionary of
- *     options.
+ * @param {Blockly.BlocklyOptions=} opt_options Optional dictionary of options.
  * @return {!Blockly.WorkspaceSvg} Newly created main workspace.
  */
 Blockly.inject = function(container, opt_options) {
@@ -59,7 +58,7 @@ Blockly.inject = function(container, opt_options) {
     throw Error('Error: container is not in current document.');
   }
   var options = new Blockly.Options(opt_options ||
-    (/** @type {!Blockly.WorkspaceOptions} */ ({})));
+    (/** @type {!Blockly.BlocklyOptions} */ ({})));
   var subContainer = document.createElement('div');
   subContainer.className = 'injectionDiv';
   container.appendChild(subContainer);

--- a/core/inject.js
+++ b/core/inject.js
@@ -43,7 +43,8 @@ goog.require('Blockly.WorkspaceSvg');
  * Inject a Blockly editor into the specified container element (usually a div).
  * @param {Element|string} container Containing element, or its ID,
  *     or a CSS selector.
- * @param {Object=} opt_options Optional dictionary of options.
+ * @param {Blockly.WorkspaceOptions=} opt_options Optional dictionary of
+ *     options.
  * @return {!Blockly.WorkspaceSvg} Newly created main workspace.
  */
 Blockly.inject = function(container, opt_options) {
@@ -57,7 +58,8 @@ Blockly.inject = function(container, opt_options) {
   if (!container || !Blockly.utils.dom.containsNode(document, container)) {
     throw Error('Error: container is not in current document.');
   }
-  var options = new Blockly.Options(opt_options || {});
+  var options = new Blockly.Options(opt_options ||
+    (/** @type {!Blockly.WorkspaceOptions} */ ({})));
   var subContainer = document.createElement('div');
   subContainer.className = 'injectionDiv';
   container.appendChild(subContainer);

--- a/core/options.js
+++ b/core/options.js
@@ -30,8 +30,8 @@ goog.require('Blockly.Xml');
 /**
  * Parse the user-specified options, using reasonable defaults where behaviour
  * is unspecified.
- * @param {!Object} options Dictionary of options.  Specification:
- *   https://developers.google.com/blockly/guides/get-started/web#configuration
+ * @param {!Blockly.WorkspaceOptions} options Dictionary of options.
+ *     Specification: https://developers.google.com/blockly/guides/get-started/web#configuration
  * @constructor
  */
 Blockly.Options = function(options) {
@@ -147,6 +147,13 @@ Blockly.Options = function(options) {
 };
 
 /**
+ * Blockly workspace options.
+ * This list is further extended in `typings/blockly-interfaces.d.ts`.
+ * @interface
+ */
+Blockly.WorkspaceOptions = function() {};
+
+/**
  * The parent of the current workspace, or null if there is no parent workspace.
  * @type {Blockly.Workspace}
  */
@@ -154,6 +161,8 @@ Blockly.Options.prototype.parentWorkspace = null;
 
 /**
  * If set, sets the translation of the workspace to match the scrollbars.
+ * @param {!Object} xyRatio Contains an x and/or y property which is a float
+ *     between 0 and 1 specifying the degree of scrolling.
  * @return {void}
  */
 Blockly.Options.prototype.setMetrics;

--- a/core/options.js
+++ b/core/options.js
@@ -30,7 +30,7 @@ goog.require('Blockly.Xml');
 /**
  * Parse the user-specified options, using reasonable defaults where behaviour
  * is unspecified.
- * @param {!Blockly.WorkspaceOptions} options Dictionary of options.
+ * @param {!Blockly.BlocklyOptions} options Dictionary of options.
  *     Specification: https://developers.google.com/blockly/guides/get-started/web#configuration
  * @constructor
  */
@@ -147,11 +147,11 @@ Blockly.Options = function(options) {
 };
 
 /**
- * Blockly workspace options.
- * This list is further extended in `typings/blockly-interfaces.d.ts`.
+ * Blockly options.
+ * This interface is further described in `typings/blockly-interfaces.d.ts`.
  * @interface
  */
-Blockly.WorkspaceOptions = function() {};
+Blockly.BlocklyOptions = function() {};
 
 /**
  * The parent of the current workspace, or null if there is no parent workspace.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -178,7 +178,7 @@ Blockly.Toolbox.prototype.init = function() {
         }
         Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
       }, /* opt_noCaptureIdentifier */ false, /* opt_noPreventDefault */ true);
-  var workspaceOptions = {
+  var workspaceOptions = /** @type {!Blockly.Options} */ ({
     disabledPatternId: workspace.options.disabledPatternId,
     parentWorkspace: workspace,
     RTL: workspace.RTL,
@@ -186,7 +186,7 @@ Blockly.Toolbox.prototype.init = function() {
     horizontalLayout: workspace.horizontalLayout,
     toolboxPosition: workspace.options.toolboxPosition,
     renderer: workspace.options.renderer
-  };
+  });
   if (workspace.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -60,14 +60,14 @@ Blockly.Trashcan = function(workspace) {
     return;
   }
   // Create flyout options.
-  var flyoutWorkspaceOptions = {
+  var flyoutWorkspaceOptions = /** @type {!Blockly.Options} */ ({
     scrollbars: true,
     disabledPatternId: this.workspace_.options.disabledPatternId,
     parentWorkspace: this.workspace_,
     RTL: this.workspace_.RTL,
     oneBasedIndex: this.workspace_.options.oneBasedIndex,
     renderer: this.workspace_.options.renderer
-  };
+  });
   // Create vertical or horizontal flyout.
   if (this.workspace_.horizontalLayout) {
     flyoutWorkspaceOptions.toolboxPosition =

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -62,7 +62,7 @@ Blockly.WorkspaceSvg = function(options,
   /** @type {function():!Object} */
   this.getMetrics =
       options.getMetrics || Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_;
-  /** @type {function(!Object)} */
+  /** @type {function(!Object):void} */
   this.setMetrics =
       options.setMetrics || Blockly.WorkspaceSvg.setTopLevelWorkspaceMetrics_;
 
@@ -804,7 +804,7 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
-  var workspaceOptions = {
+  var workspaceOptions = /** @type {!Blockly.Options} */ ({
     disabledPatternId: this.options.disabledPatternId,
     parentWorkspace: this,
     RTL: this.RTL,
@@ -812,7 +812,7 @@ Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
     horizontalLayout: this.horizontalLayout,
     toolboxPosition: this.options.toolboxPosition,
     renderer: this.options.renderer
-  };
+  });
   if (this.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Partial fix for https://github.com/google/blockly/issues/2937

### Proposed Changes

Make Blockly options an interface that can be extended in the Typescript typings. This makes the closure compiler happy with the type given to ``Blockly.Options`` but also allows us to extend the type to include the full list of options. 

I would prefer to just define the options interface in closure (using @typedef) but unfortunately closure doesn't support optional properties and all the properties are optional.

This solution makes it so that you can do something like ``Blockly.inject(div, {
... options
});`` and not have to cast options to Blockly.BlocklyOptions.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran ``npm run typings`` and tested with the Angular sample (TypeScript).

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
