### PR TITLE
Handle 0x hex values in color parsing

### DIFF
--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -89,12 +89,13 @@ Blockly.utils.colour.rgbToHex = function(r, g, b) {
 };
 
 /**
- * Converts a hex representation of a colour to RGB.
- * @param {string} hexColour Colour in '#ff0000' format.
+ * Converts a colour to RGB.
+ * @param {string} colour String representing colour in any
+ *     colour format ('#ff0000', 'red', '0xff000', etc).
  * @return {!Array.<number>} RGB representation of the colour.
  */
-Blockly.utils.colour.hexToRgb = function(hexColour) {
-  var hex = Blockly.utils.colour.parse(hexColour);
+Blockly.utils.colour.hexToRgb = function(colour) {
+  var hex = Blockly.utils.colour.parse(colour);
   if (!hex) {
     return [0, 0, 0];
   }

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -37,6 +37,7 @@ goog.require('Blockly.utils');
  * .parse('red') -> '#ff0000'
  * .parse('#f00') -> '#ff0000'
  * .parse('#ff0000') -> '#ff0000'
+ * .parse('0xff0000') -> '#ff0000'
  * .parse('rgb(255, 0, 0)') -> '#ff0000'
  * @param {string} str Colour in some CSS format.
  * @return {string|null} A string containing a hex representation of the colour,
@@ -49,7 +50,8 @@ Blockly.utils.colour.parse = function(str) {
     // e.g. 'red'
     return hex;
   }
-  hex = str[0] == '#' ? str : '#' + str;
+  hex = str.substring(0, 2) == '0x' ? '#' + str.substring(2) : str;
+  hex = hex[0] == '#' ? hex : '#' + hex;
   if (/^#[0-9a-f]{6}$/.test(hex)) {
     // e.g. '#00ff88'
     return hex;
@@ -92,7 +94,12 @@ Blockly.utils.colour.rgbToHex = function(r, g, b) {
  * @return {!Array.<number>} RGB representation of the colour.
  */
 Blockly.utils.colour.hexToRgb = function(hexColour) {
-  var rgb = parseInt(hexColour.substr(1), 16);
+  var hex = Blockly.utils.colour.parse(hexColour);
+  if (!hex) {
+    return [0, 0, 0];
+  }
+
+  var rgb = parseInt(hex.substr(1), 16);
   var r = rgb >> 16;
   var g = (rgb >> 8) & 255;
   var b = rgb & 255;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

### Resolves

Pulls https://github.com/microsoft/pxt-blockly/pull/255. (Sorry for resubmitting, I messed something up in the other one!)

### Proposed Changes

Allows Blockly.utils.colour.parse to handle "0xffffff" hex formatting. Calls "parse" in the hexToRgb to handle cases of "#fff", "0xfff" etc.

### Reason for Changes

Additional flexibility in defining colors.

### Test Coverage

Modified the classic theme with color values of "0x######" format, ran it in 

Tested on:
Desktop Chrome
Desktop Firefox
Windows Internet Explorer 11
Windows Edge

### Documentation

I updated the function description to include the supported format.