### PR TITLE
Fix dummy input alignment. Fix for #3330

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -374,8 +374,8 @@ Blockly.blockRendering.RenderInfo.prototype.addInput_ = function(input, activeRo
         new Blockly.blockRendering.ExternalValueInput(this.constants_, input));
     activeRow.hasExternalInput = true;
   } else if (input.type == Blockly.DUMMY_INPUT) {
-    // Dummy inputs have no visual representation, but the information is still
-    // important.
+    activeRow.elements.push(
+        new Blockly.blockRendering.DummyInput(this.constants_, input));
     activeRow.hasDummyInput = true;
   }
 };

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -113,8 +113,8 @@ Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
         new Blockly.blockRendering.ExternalValueInput(this.constants_, input));
     activeRow.hasExternalInput = true;
   } else if (input.type == Blockly.DUMMY_INPUT) {
-    // Dummy inputs have no visual representation, but the information is still
-    // important.
+    activeRow.elements.push(
+        new Blockly.blockRendering.DummyInput(this.constants_, input));
     activeRow.hasDummyInput = true;
   }
 };

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -71,6 +71,27 @@ Blockly.utils.object.inherits(Blockly.blockRendering.InputConnection,
     Blockly.blockRendering.Connection);
 
 /**
+ * An object containing information about the space a dummy input takes up
+ * during rendering
+ * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering
+ *     constants provider.
+ * @param {!Blockly.Input} input The inline input to measure and store
+ *     information for.
+ * @package
+ * @constructor
+ * @extends {Blockly.blockRendering.Measurable}
+ */
+Blockly.blockRendering.DummyInput = function(constants, input) {
+  Blockly.blockRendering.DummyInput.superClass_.constructor.call(this,
+      constants);
+  this.type |= Blockly.blockRendering.Types.INPUT;
+  this.input = input;
+  this.align = input.align;
+};
+Blockly.utils.object.inherits(Blockly.blockRendering.DummyInput,
+    Blockly.blockRendering.Measurable);
+
+/**
  * An object containing information about the space an inline input takes up
  * during rendering
  * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3330

### Proposed Changes

Wrap dummy inputs in a measurable so that it can be aligned appropriately by ``addAlignmentPadding_``.

### Reason for Changes

Fix rendering.

### Test Coverage

Tested with the following block in the block factory: 
```
{
  "type": "test",
  "message0": "s %1 some %2 s %3 ss %4",
  "args0": [
    {
      "type": "input_dummy",
      "align": "RIGHT"
    },
    {
      "type": "input_statement",
      "name": "NAME",
      "align": "RIGHT"
    },
    {
      "type": "input_statement",
      "name": "NAME",
      "align": "RIGHT"
    },
    {
      "type": "input_value",
      "name": "NAME",
      "align": "RIGHT"
    }
  ],
  "colour": 230,
  "tooltip": "",
  "helpUrl": ""
}
```


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@rachel-fenichel FYI.