### PR TITLE
Remove firefox flyout positioning workaround

### DIFF
--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -333,30 +333,6 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
     var width = flyoutRect.width;
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, left + width);
   } else {  // Right
-    // Firefox sometimes reports the wrong value for the client rect.
-    // See https://github.com/google/blockly/issues/1425 and
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1066435
-    if (Blockly.utils.userAgent.GECKO &&
-        this.targetWorkspace_ && this.targetWorkspace_.isMutator) {
-      // The position of the left side of the mutator workspace in pixels
-      // relative to the window origin.
-      var targetWsLeftPixels =
-          this.targetWorkspace_.svgGroup_.getBoundingClientRect().x;
-      // The client rect is in pixels relative to the window origin.  When the
-      // browser gets the wrong value it reports that the flyout left is the
-      // same as the mutator workspace left.
-      // We know that in a mutator workspace with the flyout on the right, the
-      // visible area of the workspace should be more than ten pixels wide.  If
-      // the browser reports that the flyout is within ten pixels of the left
-      // side of the workspace, ignore it and manually calculate the value.
-      if (Math.abs(targetWsLeftPixels - left) < 10) {
-        // If we're in a mutator, its scale is always 1, purely because of some
-        // oddities in our rendering optimizations.  The actual scale is the
-        // same as the scale on the parent workspace.
-        var scale = this.targetWorkspace_.options.parentWorkspace.scale;
-        left += this.leftEdge_ * scale;
-      }
-    }
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, left, BIG_NUM);
   }
 };


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Originally introduced in: https://github.com/google/blockly/commit/29571e91e25248dfb854203d5cb4c50ef82c2f0a
The workaround was unintentionally broken by https://github.com/google/blockly/pull/2311

The root Firefox bug ([1066435](https://bugzilla.mozilla.org/show_bug.cgi?id=1066435)) has been fixed, so removing.

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Remove firefox flyout positioning workaround code.

### Reason for Changes

Workaround broken, cleaning up.

### Test Coverage

Tested on:
* Desktop Firefox 69.

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
