### PR TITLE
Update mutator workspace delete areas when bubble is moved.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1291,7 +1291,7 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
     this.mutator.dispose();
   }
   if (mutator) {
-    mutator.block_ = this;
+    mutator.setBlock(this);
     this.mutator = mutator;
     mutator.createIcon();
   }

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -81,6 +81,20 @@ Blockly.Bubble = function(workspace, content, shape, anchorXY,
           this.resizeGroup_, 'mousedown', this, this.resizeMouseDown_);
     }
   }
+
+  /**
+   * Method to call on resize of bubble.
+   * @type {?function()}
+   * @private
+   */
+  this.resizeCallback_ = null;
+
+  /**
+   * Method to call on move of bubble.
+   * @type {?function()}
+   * @private
+   */
+  this.moveCallback_ = null;
 };
 
 /**
@@ -122,13 +136,6 @@ Blockly.Bubble.onMouseUpWrapper_ = null;
  * @private
  */
 Blockly.Bubble.onMouseMoveWrapper_ = null;
-
-/**
- * Function to call on resize of bubble.
- * @type {Function}
- * @private
- */
-Blockly.Bubble.prototype.resizeCallback_ = null;
 
 /**
  * Stop binding to the global mouseup and mousemove events.
@@ -369,6 +376,14 @@ Blockly.Bubble.prototype.resizeMouseMove_ = function(e) {
  */
 Blockly.Bubble.prototype.registerResizeEvent = function(callback) {
   this.resizeCallback_ = callback;
+};
+
+/**
+ * Register a function as a callback event for when the bubble is moved.
+ * @param {!Function} callback The function to call on move.
+ */
+Blockly.Bubble.prototype.registerMoveEvent = function(callback) {
+  this.moveCallback_ = callback;
 };
 
 /**
@@ -618,6 +633,17 @@ Blockly.Bubble.prototype.positionBubble_ = function() {
  */
 Blockly.Bubble.prototype.moveTo = function(x, y) {
   this.bubbleGroup_.setAttribute('transform', 'translate(' + x + ',' + y + ')');
+};
+
+/**
+ * Triggers a move callback if one exists at the end of a drag.
+ * @param {boolean} adding True if adding, false if removing.
+ * @package
+ */
+Blockly.Bubble.prototype.setDragging = function(adding) {
+  if (!adding && this.moveCallback_) {
+    this.moveCallback_();
+  }
 };
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -63,6 +63,15 @@ Blockly.Mutator.prototype.workspaceWidth_ = 0;
 Blockly.Mutator.prototype.workspaceHeight_ = 0;
 
 /**
+ * Set the block this mutator is associated with.
+ * @param {Blockly.BlockSvg} block The block to associated with.
+ * @package
+ */
+Blockly.Mutator.prototype.setBlock = function(block) {
+  this.block_ = block;
+};
+
+/**
  * Draw the mutator icon.
  * @param {!Element} group The icon group.
  * @private
@@ -243,6 +252,16 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
 };
 
 /**
+ * A method handler for when the bubble is moved.
+ * @private
+ */
+Blockly.Mutator.prototype.onBubbleMove_ = function() {
+  if (this.workspace_) {
+    this.workspace_.recordDeleteAreas();
+  }
+};
+
+/**
  * Show or hide the mutator bubble.
  * @param {boolean} visible True if the bubble should be visible.
  */
@@ -261,6 +280,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
         /** @type {!Blockly.utils.Coordinate} */ (this.iconXY_), null, null);
     // Expose this mutator's block's ID on its top-level SVG group.
     this.bubble_.setSvgId(this.block_.id);
+    this.bubble_.registerMoveEvent(this.onBubbleMove_.bind(this));
     var tree = this.workspace_.options.languageTree;
     var flyout = this.workspace_.getFlyout();
     if (tree) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3354.

### Proposed Changes

Updates the mutator dialog's workspace deleteAreas when the bubble is moved.

### Reason for Changes

Fixes bug.

### Test Coverage

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
