### PR TITLE
Fix RTL bubble drag

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -797,7 +797,9 @@ Blockly.Bubble.prototype.moveDuringDrag = function(dragSurface, newLoc) {
  */
 Blockly.Bubble.prototype.getRelativeToSurfaceXY = function() {
   return new Blockly.utils.Coordinate(
-      this.anchorXY_.x + this.relativeLeft_,
+      this.workspace_.RTL ?
+        -this.relativeLeft_ + this.anchorXY_.x - this.width_ :
+        this.anchorXY_.x + this.relativeLeft_,
       this.anchorXY_.y + this.relativeTop_);
 };
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1896.

### Proposed Changes

Take into account RTL workspaces and the width of the bubble when returning the relative positioning of the bubble to the bubble dragger.

### Reason for Changes

Fixes bug.

### Test Coverage

Tested in playground in both LTR and RTL.

Tested on:
* Desktop Chrome
* Desktop Firefox
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
