### PR TITLE
Accept lowercase alignment

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1678,7 +1678,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
         if (element['align']) {
           var align = !!element['align'] && element['align'].toUpperCase();
           var alignment = alignmentLookup[align];
-          if (alignment != null) {
+          if (alignment != undefined) {
             input.setAlign(alignment);
           } else {
             console.warn(warningPrefix + 'Illegal align value: ',

--- a/core/block.js
+++ b/core/block.js
@@ -1454,7 +1454,7 @@ Blockly.Block.prototype.jsonInit = function(json) {
   var i = 0;
   while (json['message' + i] !== undefined) {
     this.interpolate_(json['message' + i], json['args' + i] || [],
-        json['lastDummyAlign' + i]);
+        json['lastDummyAlign' + i], warningPrefix);
     i++;
   }
 
@@ -1578,9 +1578,11 @@ Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
  * @param {!Array} args Array of arguments to be interpolated.
  * @param {string|undefined} lastDummyAlign If a dummy input is added at the
  *     end, how should it be aligned?
+ * @param {string} warningPrefix Warning prefix string identifying block.
  * @private
  */
-Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
+Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
+    warningPrefix) {
   var tokens = Blockly.utils.tokenizeInterpolation(message);
   // Interpolate the arguments.  Build a list of elements.
   var indexDup = [];
@@ -1626,7 +1628,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
     'LEFT': Blockly.ALIGN_LEFT,
     'RIGHT': Blockly.ALIGN_RIGHT,
     'CENTRE': Blockly.ALIGN_CENTRE,
-    'CENTRE': Blockly.ALIGN_CENTRE
+    'CENTER': Blockly.ALIGN_CENTRE
   };
   // Populate block with inputs and fields.
   var fieldStack = [];
@@ -1674,8 +1676,14 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
           input.setCheck(element['check']);
         }
         if (element['align']) {
-          var alignment = !!element['align'] && element['align'].toUpperCase();
-          input.setAlign(alignmentLookup[alignment]);
+          var align = !!element['align'] && element['align'].toUpperCase();
+          var alignment = alignmentLookup[align];
+          if (alignment != null) {
+            input.setAlign(alignment);
+          } else {
+            console.warn(warningPrefix + 'Illegal align value: ',
+                element['align']);
+          }
         }
         for (var j = 0; j < fieldStack.length; j++) {
           input.appendField(fieldStack[j][0], fieldStack[j][1]);

--- a/core/block.js
+++ b/core/block.js
@@ -1625,6 +1625,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
   var alignmentLookup = {
     'LEFT': Blockly.ALIGN_LEFT,
     'RIGHT': Blockly.ALIGN_RIGHT,
+    'CENTRE': Blockly.ALIGN_CENTRE,
     'CENTRE': Blockly.ALIGN_CENTRE
   };
   // Populate block with inputs and fields.
@@ -1673,7 +1674,8 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign) {
           input.setCheck(element['check']);
         }
         if (element['align']) {
-          input.setAlign(alignmentLookup[element['align']]);
+          var alignment = !!element['align'] && element['align'].toUpperCase();
+          input.setAlign(alignmentLookup[alignment]);
         }
         for (var j = 0; j < fieldStack.length; j++) {
           input.appendField(fieldStack[j][0], fieldStack[j][1]);

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -380,7 +380,9 @@ Blockly.blockRendering.RenderInfo.prototype.addInput_ = function(input, activeRo
         this.constants_.DUMMY_INPUT_MIN_HEIGHT);
     activeRow.hasDummyInput = true;
   }
-  activeRow.align = input.align;
+  if (activeRow.align == null) {
+    activeRow.align = input.align;
+  }
 };
 
 /**

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -119,7 +119,9 @@ Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
         this.constants_.DUMMY_INPUT_MIN_HEIGHT);
     activeRow.hasDummyInput = true;
   }
-  activeRow.align = input.align;
+  if (activeRow.align == null) {
+    activeRow.align = input.align;
+  }
 };
 
 /**

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -158,7 +158,7 @@ Blockly.blockRendering.Row = function(constants) {
   /**
    * Alignment of the row.
    * @package
-   * @type {number}
+   * @type {?number}
    */
   this.align = null;
 };

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -154,6 +154,13 @@ Blockly.blockRendering.Row = function(constants) {
   this.constants_ = constants;
 
   this.notchOffset = this.constants_.NOTCH_OFFSET_LEFT;
+
+  /**
+   * Alignment of the row.
+   * @package
+   * @type {number}
+   */
+  this.align = null;
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

We weren't accepting lowercase alignment values in block config.

### Proposed Changes

Accept lowercase version of LEFT, RIGHT, and CENTRE.
Accept alternate spelling of CENTER.
The first input decides the alignment.
Add input type information on the row.

### Reason for Changes

More flexibility in what we author.

### Test Coverage

This block now looks like it was authored (with a right aligned value input)
![Screen Shot 2019-10-28 at 5 13 02 PM](https://user-images.githubusercontent.com/16690124/67727318-388a8400-f9a6-11e9-9d09-46840d0c3f0c.png)

Tested on:
* Desktop Chrome
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
