### PR TITLE
Fix warnings in blocks/

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -162,9 +162,9 @@ Blockly.Blocks['lists_create_with'] = {
   },
   /**
    * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.WorkspaceSvg} workspace Mutator's workspace.
+   * @return {!Blockly.BlockSvg} Root block in mutator.
+   * @this {Blockly.BlockSvg}
    */
   decompose: function(workspace) {
     var containerBlock = workspace.newBlock('lists_create_with_container');
@@ -173,7 +173,8 @@ Blockly.Blocks['lists_create_with'] = {
     for (var i = 0; i < this.itemCount_; i++) {
       var itemBlock = workspace.newBlock('lists_create_with_item');
       itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
+      connection.connect(
+          /** @type {!Blockly.Connection} */ (itemBlock.previousConnection));
       connection = itemBlock.nextConnection;
     }
     return containerBlock;
@@ -314,7 +315,7 @@ Blockly.Blocks['lists_indexOf'] = {
 Blockly.Blocks['lists_getIndex'] = {
   /**
    * Block for getting element at index.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Lists.GetIndexBlock}
    */
   init: function() {
     var MODE =
@@ -412,7 +413,7 @@ Blockly.Blocks['lists_getIndex'] = {
    * Create XML to represent whether the block is a statement or a value.
    * Also represent whether there is an 'AT' input.
    * @return {Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Lists.GetIndexBlock}
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
@@ -425,7 +426,7 @@ Blockly.Blocks['lists_getIndex'] = {
   /**
    * Parse XML to restore the 'AT' input.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Lists.GetIndexBlock}
    */
   domToMutation: function(xmlElement) {
     // Note: Until January 2013 this block did not have mutations,
@@ -440,12 +441,12 @@ Blockly.Blocks['lists_getIndex'] = {
    * @param {boolean} newStatement True if the block should be a statement.
    *     False if the block should be a value.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Lists.GetIndexBlock}
    */
   updateStatement_: function(newStatement) {
     var oldStatement = !this.outputConnection;
     if (newStatement != oldStatement) {
-      this.unplug(true, true);
+      this.unplug(true);
       if (newStatement) {
         this.setOutput(false);
         this.setPreviousStatement(true);
@@ -461,7 +462,7 @@ Blockly.Blocks['lists_getIndex'] = {
    * Create or delete an input for the numeric index.
    * @param {boolean} isAt True if the input should exist.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Lists.GetIndexBlock}
    */
   updateAt_: function(isAt) {
     // Destroy old 'AT' and 'ORDINAL' inputs.
@@ -837,7 +838,7 @@ Blockly.Blocks['lists_split'] = {
       if (inputBlock) {
         inputConnection.disconnect();
         if (inputBlock.isShadow()) {
-          inputBlock.dispose();
+          inputBlock.dispose(false);
         } else {
           this.bumpNeighbours();
         }
@@ -858,7 +859,7 @@ Blockly.Blocks['lists_split'] = {
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
-    container.setAttribute('mode', this.getFieldValue('MODE'));
+    container.setAttribute('mode', String(this.getFieldValue('MODE')));
     return container;
   },
   /**
@@ -870,3 +871,20 @@ Blockly.Blocks['lists_split'] = {
     this.updateType_(xmlElement.getAttribute('mode'));
   }
 };
+
+
+/**
+ * @extends {Blockly.BlockSvg}
+ * @constructor
+ */
+Blockly.Constants.Lists.GetIndexBlock = function() {};
+/**
+ * @type {?function(boolean)}
+ * @private
+ */
+Blockly.Constants.Lists.GetIndexBlock.prototype.updateAt_;
+/**
+ * @type {?function(boolean)}
+ * @private
+ */
+Blockly.Constants.Lists.GetIndexBlock.prototype.updateStatement_;

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -315,7 +315,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   /**
    * Create XML to represent the number of else-if and else inputs.
    * @return {Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   mutationToDom: function() {
     if (!this.elseifCount_ && !this.elseCount_) {
@@ -333,7 +333,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   /**
    * Parse XML to restore the else-if and else inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   domToMutation: function(xmlElement) {
     this.elseifCount_ = parseInt(xmlElement.getAttribute('elseif'), 10) || 0;
@@ -342,9 +342,9 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   },
   /**
    * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.WorkspaceSvg} workspace Mutator's workspace.
+   * @return {!Blockly.BlockSvg} Root block in mutator.
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   decompose: function(workspace) {
     var containerBlock = workspace.newBlock('controls_if_if');
@@ -353,20 +353,22 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
     for (var i = 1; i <= this.elseifCount_; i++) {
       var elseifBlock = workspace.newBlock('controls_if_elseif');
       elseifBlock.initSvg();
-      connection.connect(elseifBlock.previousConnection);
+      connection.connect(
+          /** @type {!Blockly.Connection} */ (elseifBlock.previousConnection));
       connection = elseifBlock.nextConnection;
     }
     if (this.elseCount_) {
       var elseBlock = workspace.newBlock('controls_if_else');
       elseBlock.initSvg();
-      connection.connect(elseBlock.previousConnection);
+      connection.connect(
+          /** @type {!Blockly.Connection} */ (elseBlock.previousConnection));
     }
     return containerBlock;
   },
   /**
    * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.BlockSvg} containerBlock Root block in mutator.
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   compose: function(containerBlock) {
     var clauseBlock = containerBlock.nextConnection.targetBlock();
@@ -401,7 +403,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   /**
    * Store pointers to any connected child blocks.
    * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   saveConnections: function(containerBlock) {
     var clauseBlock = containerBlock.nextConnection.targetBlock();
@@ -431,7 +433,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   },
   /**
    * Reconstructs the block with all child blocks attached.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Logic.IfBlock}
    */
   rebuildShape_: function() {
     var valueConnections = [null];
@@ -451,11 +453,11 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
     }
     this.updateShape_();
     this.reconnectChildBlocks_(valueConnections, statementConnections,
-        elseStatementConnection);
+        /** @type {?Blockly.RenderedConnection} */ (elseStatementConnection));
   },
   /**
    * Modify this block to have the correct number of inputs.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Logic.IfBlock}
    * @private
    */
   updateShape_: function() {
@@ -503,7 +505,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
 };
 
 Blockly.Extensions.registerMutator('controls_if_mutator',
-    Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN, null,
+    Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN, undefined,
     ['controls_if_elseif', 'controls_if_else']);
 /**
  * "controls_if" extension function. Adds mutator, shape updating methods, and
@@ -554,7 +556,8 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
     var blockB = this.getInputTargetBlock('B');
     // Disconnect blocks that existed prior to this change if they don't match.
     if (blockA && blockB &&
-        !blockA.outputConnection.checkType(blockB.outputConnection)) {
+        !blockA.outputConnection.checkType(
+            /** @type {!Blockly.Connection} */ (blockB.outputConnection))) {
       // Mismatch between two inputs.  Revert the block connections,
       // bumping away the newly connected block(s).
       Blockly.Events.setGroup(e.group);
@@ -641,3 +644,26 @@ Blockly.Constants.Logic.LOGIC_TERNARY_ONCHANGE_MIXIN = {
 
 Blockly.Extensions.registerMixin('logic_ternary',
     Blockly.Constants.Logic.LOGIC_TERNARY_ONCHANGE_MIXIN);
+
+
+/**
+ * @extends {Blockly.BlockSvg}
+ * @constructor
+ */
+Blockly.Constants.Logic.IfBlock = function() {};
+/**
+ * @type {?function()}
+ * @private
+ */
+Blockly.Constants.Logic.IfBlock.prototype.updateShape_;
+/**
+ * @type {?function()}
+ * @private
+ */
+Blockly.Constants.Logic.IfBlock.prototype.rebuildShape_;
+/**
+ * @type {?function(!Array.<?Blockly.RenderedConnection>,
+ * !Array.<?Blockly.RenderedConnection>,?Blockly.RenderedConnection)}
+ * @private
+ */
+Blockly.Constants.Logic.IfBlock.prototype.reconnectChildBlocks_;

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -294,7 +294,6 @@ Blockly.Extensions.register('controls_forEach_tooltip',
  * is contained in a loop. Otherwise a warning is added to the block.
  * @mixin
  * @augments Blockly.Block
- * @package
  * @readonly
  */
 Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
@@ -319,7 +318,7 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
 
   /**
    * Is the given block enclosed (at any level) by a loop?
-   * @param {!Blockly.Block} block Current block.
+   * @param {Blockly.Block} block Current block.
    * @return {Blockly.Block} The nearest surrounding loop, or null if none.
    */
   getSurroundLoop: function(block) {

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -547,7 +547,7 @@ Blockly.Constants.Math.LIST_MODES_MUTATOR_MIXIN = {
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
-    container.setAttribute('op', this.getFieldValue('OP'));
+    container.setAttribute('op', String(this.getFieldValue('OP')));
     return container;
   },
   /**

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -35,7 +35,7 @@ goog.require('Blockly.Mutator');
 Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Block for defining a procedure with no return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   init: function() {
     var nameField = new Blockly.FieldTextInput('',
@@ -63,7 +63,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Add or remove the statement block from this function definition.
    * @param {boolean} hasStatements True if a statement block is needed.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   setStatements_: function(hasStatements) {
     if (this.hasStatements_ === hasStatements) {
@@ -83,7 +83,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Update the display of parameters for this procedure definition block.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   updateParams_: function() {
 
@@ -107,12 +107,13 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @param {boolean=} opt_paramIds If true include the IDs of the parameter
    *     quarks.  Used by Blockly.Procedures.mutateCallers for reconnection.
    * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   mutationToDom: function(opt_paramIds) {
     var container = Blockly.utils.xml.createElement('mutation');
     if (opt_paramIds) {
-      container.setAttribute('name', this.getFieldValue('NAME'));
+      container.setAttribute('name',
+          /** @type {string} */ (this.getFieldValue('NAME')));
     }
     for (var i = 0; i < this.argumentVarModels_.length; i++) {
       var parameter = Blockly.utils.xml.createElement('arg');
@@ -134,7 +135,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Parse XML to restore the argument inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   domToMutation: function(xmlElement) {
     this.arguments_ = [];
@@ -161,9 +162,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   },
   /**
    * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.WorkspaceSvg} workspace Mutator's workspace.
+   * @return {!Blockly.BlockSvg} Root block in mutator.
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   decompose: function(workspace) {
     /*
@@ -210,12 +211,12 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 
     // Initialize procedure's callers with blank IDs.
     Blockly.Procedures.mutateCallers(this);
-    return containerBlock;
+    return /** @type {!Blockly.BlockSvg} */ (containerBlock);
   },
   /**
    * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.BlockSvg} containerBlock Root block in mutator.
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   compose: function(containerBlock) {
     // Parameter list.
@@ -224,7 +225,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     this.argumentVarModels_ = [];
     var paramBlock = containerBlock.getInputTargetBlock('STACK');
     while (paramBlock) {
-      var varName = paramBlock.getFieldValue('NAME');
+      var varName = /** @type {string} */ (paramBlock.getFieldValue('NAME'));
       this.arguments_.push(varName);
       var variable = this.workspace.getVariable(varName, '');
       this.argumentVarModels_.push(variable);
@@ -266,7 +267,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    *     - the name of the defined procedure,
    *     - a list of all its arguments,
    *     - that it DOES NOT have a return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   getProcedureDef: function() {
     return [this.getFieldValue('NAME'), this.arguments_, false];
@@ -274,7 +275,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Return all variables referenced by this block.
    * @return {!Array.<string>} List of variable names.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   getVars: function() {
     return this.arguments_;
@@ -282,7 +283,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Return all variables referenced by this block.
    * @return {!Array.<!Blockly.VariableModel>} List of variable models.
-   * @this {Blockly.Block}
+   * @package
+   * @override
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   getVarModels: function() {
     return this.argumentVarModels_;
@@ -295,7 +298,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    *     with an updated name.  Guaranteed to be the same type as the old
    *     variable.
    * @override
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   renameVarById: function(oldId, newId) {
     var oldVariable = this.workspace.getVariableById(oldId);
@@ -325,7 +328,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @param {!Blockly.VariableModel} variable The variable being renamed.
    * @package
    * @override
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   updateVarName: function(variable) {
     var newName = variable.name;
@@ -347,7 +350,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @param {string} oldName The old display name of the argument.
    * @param {string} newName The new display name of the argument.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   displayRenamedVar_: function(oldName, newName) {
     this.updateParams_();
@@ -365,7 +368,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   /**
    * Add custom menu options to this block's context menu.
    * @param {!Array} options List of menu options to add to.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   customContextMenu: function(options) {
     if (this.isInFlyout) {
@@ -373,7 +376,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     }
     // Add option to create caller.
     var option = {enabled: true};
-    var name = this.getFieldValue('NAME');
+    var name = /** @type {string} */ (this.getFieldValue('NAME'));
     option.text = Blockly.Msg['PROCEDURES_CREATE_DO'].replace('%1', name);
     var xmlMutation = Blockly.utils.xml.createElement('mutation');
     xmlMutation.setAttribute('name', name);
@@ -412,7 +415,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 Blockly.Blocks['procedures_defreturn'] = {
   /**
    * Block for defining a procedure with a return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   init: function() {
     var nameField = new Blockly.FieldTextInput('',
@@ -452,7 +455,7 @@ Blockly.Blocks['procedures_defreturn'] = {
    *     - the name of the defined procedure,
    *     - a list of all its arguments,
    *     - that it DOES have a return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureDefBlock}
    */
   getProcedureDef: function() {
     return [this.getFieldValue('NAME'), this.arguments_, true];
@@ -469,7 +472,7 @@ Blockly.Blocks['procedures_defreturn'] = {
 Blockly.Blocks['procedures_mutatorcontainer'] = {
   /**
    * Mutator block for procedure container.
-   * @this {Blockly.Block}
+   * @this {Blockly.Procedures.ProcedureBlock}
    */
   init: function() {
     this.appendDummyInput()
@@ -489,7 +492,7 @@ Blockly.Blocks['procedures_mutatorcontainer'] = {
    * This will create & delete variables and in dialogs workspace to ensure
    * that when a new block is dragged out it will have a unique parameter name.
    * @param {!Blockly.Events.Abstract} event Change event.
-   * @this {Blockly.Block}
+   * @this {Blockly.Procedures.ProcedureBlock}
    */
   onchange: function(event) {
     if (!this.workspace || this.workspace.isFlyout ||
@@ -523,7 +526,7 @@ Blockly.Blocks['procedures_mutatorcontainer'] = {
     if (!block.getField('NAME')) {
       return;
     }
-    var varName = block.getFieldValue('NAME');
+    var varName = /** @type {string} */ (block.getFieldValue('NAME'));
     var variable = this.workspace.getVariable(varName);
 
     if (!variable) {
@@ -552,7 +555,9 @@ Blockly.Blocks['procedures_mutatorcontainer'] = {
 Blockly.Blocks['procedures_mutatorarg'] = {
   /**
    * Mutator block for procedure argument.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureMutatorBlock}
+   * @suppress {visibility} Suppress visibility until we address the showEditor
+   * override hack below.
    */
   init: function() {
     var field = new Blockly.FieldTextInput('x', this.validator_);
@@ -591,7 +596,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
    * @param {string} varName User-supplied name.
    * @return {?string} Valid name, or null if a name was not specified.
    * @private
-   * @this Blockly.FieldTextInput
+   * @this {Blockly.FieldTextInput}
    */
   validator_: function(varName) {
     var sourceBlock = this.getSourceBlock();
@@ -631,7 +636,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
    * variable name.
    * @param {string} newText The new variable name.
    * @private
-   * @this Blockly.FieldTextInput
+   * @this {Blockly.FieldTextInput}
    */
   deleteIntermediateVars_: function(newText) {
     var outerWs = Blockly.Mutator.findParentWs(this.getSourceBlock().workspace);
@@ -650,7 +655,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
 Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Block for calling a procedure with no return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   init: function() {
     this.appendDummyInput('TOPROW')
@@ -670,7 +675,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Returns the name of the procedure this block calls.
    * @return {string} Procedure name.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   getProcedureCall: function() {
     // The NAME field is guaranteed to exist, null will never be returned.
@@ -681,7 +686,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * If the name matches this block's procedure, rename it.
    * @param {string} oldName Previous name of procedure.
    * @param {string} newName Renamed procedure.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   renameProcedure: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getProcedureCall())) {
@@ -699,7 +704,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    *     parameter through the life of a mutator, regardless of param renaming),
    *     e.g. ['piua', 'f8b_', 'oi.o'].
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   setProcedureParameters_: function(paramNames, paramIds) {
     // Data structures:
@@ -790,7 +795,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Modify this block to have the correct number of arguments.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   updateShape_: function() {
     for (var i = 0; i < this.arguments_.length; i++) {
@@ -837,7 +842,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Create XML to represent the (non-editable) name and arguments.
    * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
@@ -852,7 +857,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Parse XML to restore the (non-editable) name and parameters.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   domToMutation: function(xmlElement) {
     var name = xmlElement.getAttribute('name');
@@ -870,7 +875,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Return all variables referenced by this block.
    * @return {!Array.<!Blockly.VariableModel>} List of variable models.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   getVarModels: function() {
     return this.argumentVarModels_;
@@ -879,7 +884,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * Procedure calls cannot exist without the corresponding procedure
    * definition.  Enforce this link whenever an event is fired.
    * @param {!Blockly.Events.Abstract} event Change event.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   onchange: function(event) {
     if (!this.workspace || this.workspace.isFlyout) {
@@ -971,7 +976,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   /**
    * Add menu option to find the definition block for this call.
    * @param {!Array} options List of menu options to add to.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   customContextMenu: function(options) {
     if (!this.workspace.isMovable()) {
@@ -999,7 +1004,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
 Blockly.Blocks['procedures_callreturn'] = {
   /**
    * Block for calling a procedure with a return value.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureCallBlock}
    */
   init: function() {
     this.appendDummyInput('TOPROW')
@@ -1031,7 +1036,7 @@ Blockly.Blocks['procedures_callreturn'] = {
 Blockly.Blocks['procedures_ifreturn'] = {
   /**
    * Block for conditionally returning a value from a procedure.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureIfReturnBlock}
    */
   init: function() {
     this.appendValueInput('CONDITION')
@@ -1050,7 +1055,7 @@ Blockly.Blocks['procedures_ifreturn'] = {
   /**
    * Create XML to represent whether this block has a return value.
    * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureIfReturnBlock}
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
@@ -1060,7 +1065,7 @@ Blockly.Blocks['procedures_ifreturn'] = {
   /**
    * Parse XML to restore whether this block has a return value.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureIfReturnBlock}
    */
   domToMutation: function(xmlElement) {
     var value = xmlElement.getAttribute('value');
@@ -1075,7 +1080,7 @@ Blockly.Blocks['procedures_ifreturn'] = {
    * Called whenever anything on the workspace changes.
    * Add warning if this flow block is not nested inside a loop.
    * @param {!Blockly.Events.Abstract} _e Change event.
-   * @this {Blockly.Block}
+   * @this {Blockly.Blocks.procedures.ProcedureIfReturnBlock}
    */
   onchange: function(_e) {
     if (!this.workspace.isDragging || this.workspace.isDragging()) {
@@ -1123,3 +1128,77 @@ Blockly.Blocks['procedures_ifreturn'] = {
    */
   FUNCTION_TYPES: ['procedures_defnoreturn', 'procedures_defreturn']
 };
+
+
+/**
+ * @extends {Blockly.Procedures.ProcedureBlock}
+ * @constructor
+ */
+Blockly.Blocks.procedures.ProcedureDefBlock = function() {};
+/**
+ * @type {?function(boolean)}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureDefBlock.prototype.setStatements_;
+/**
+ * @type {?function()}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureDefBlock.prototype.updateParams_;
+/**
+ * @type {?function(string,string)}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureDefBlock.prototype.displayRenamedVar_;
+/**
+ * @type {string}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureDefBlock.prototype.callType_;
+
+/**
+ * @extends {Blockly.Procedures.ProcedureBlock}
+ * @constructor
+ */
+Blockly.Blocks.procedures.ProcedureMutatorBlock = function() {};
+/**
+ * @type {?function(string):?string}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureMutatorBlock.prototype.validator_;
+/**
+ * @type {?function(string)}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureMutatorBlock.prototype.deleteIntermediateVars_;
+
+/**
+ * @extends {Blockly.Procedures.ProcedureBlock}
+ * @constructor
+ */
+Blockly.Blocks.procedures.ProcedureCallBlock = function() {};
+/**
+ * @type {?function()}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureCallBlock.prototype.updateShape_;
+/**
+ * @type {?function(!Array.<string>,!Array.<string>)}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureCallBlock.prototype.setProcedureParameters_;
+/**
+ * @type {string}
+ * @private
+ */
+Blockly.Blocks.procedures.ProcedureCallBlock.prototype.defType_;
+
+/**
+ * @extends {Blockly.Procedures.ProcedureBlock}
+ * @constructor
+ */
+Blockly.Blocks.procedures.ProcedureIfReturnBlock = function() {};
+/**
+ * @type {!Array.<string>}
+ */
+Blockly.Blocks.procedures.ProcedureIfReturnBlock.prototype.FUNCTION_TYPES;

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -240,7 +240,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
 Blockly.Blocks['text_getSubstring'] = {
   /**
    * Block for getting substring.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.SubstringBlock}
    */
   init: function() {
     this['WHERE_OPTIONS_1'] = [
@@ -273,7 +273,7 @@ Blockly.Blocks['text_getSubstring'] = {
   /**
    * Create XML to represent whether there are 'AT' inputs.
    * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.SubstringBlock}
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
@@ -286,7 +286,7 @@ Blockly.Blocks['text_getSubstring'] = {
   /**
    * Parse XML to restore the 'AT' inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.SubstringBlock}
    */
   domToMutation: function(xmlElement) {
     var isAt1 = (xmlElement.getAttribute('at1') == 'true');
@@ -300,7 +300,7 @@ Blockly.Blocks['text_getSubstring'] = {
    * @param {number} n Specify first or second input (1 or 2).
    * @param {boolean} isAt True if the input should exist.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.SubstringBlock}
    */
   updateAt_: function(n, isAt) {
     // Create or delete an input for the numeric index.
@@ -418,7 +418,7 @@ Blockly.Blocks['text_print'] = {
 Blockly.Blocks['text_prompt_ext'] = {
   /**
    * Block for prompt function (external message).
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.PromptBlock}
    */
   init: function() {
     var TYPES = [
@@ -445,7 +445,7 @@ Blockly.Blocks['text_prompt_ext'] = {
    * Modify this block to have the correct output type.
    * @param {string} newOp Either 'TEXT' or 'NUMBER'.
    * @private
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.PromptBlock}
    */
   updateType_: function(newOp) {
     this.outputConnection.setCheck(newOp == 'NUMBER' ? 'Number' : 'String');
@@ -453,17 +453,18 @@ Blockly.Blocks['text_prompt_ext'] = {
   /**
    * Create XML to represent the output type.
    * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.PromptBlock}
    */
   mutationToDom: function() {
     var container = Blockly.utils.xml.createElement('mutation');
-    container.setAttribute('type', this.getFieldValue('TYPE'));
+    container.setAttribute('type',
+        /** @type {string} */ (this.getFieldValue('TYPE')));
     return container;
   },
   /**
    * Parse XML to restore the output type.
    * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.PromptBlock}
    */
   domToMutation: function(xmlElement) {
     this.updateType_(xmlElement.getAttribute('type'));
@@ -474,7 +475,7 @@ Blockly.Blocks['text_prompt'] = {
   /**
    * Block for prompt function (internal message).
    * The 'text_prompt_ext' block is preferred as it is more flexible.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.PromptBlock}
    */
   init: function() {
     this.mixin(Blockly.Constants.Text.QUOTE_IMAGE_MIXIN);
@@ -635,7 +636,7 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
   /**
    * Inserts appropriate quote images before and after the named field.
    * @param {string} fieldName The name of the field to wrap with quotes.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.QuoteBlock}
    */
   quoteField_: function(fieldName) {
     for (var i = 0, input; input = this.inputList[i]; i++) {
@@ -656,7 +657,7 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
    * @param {boolean} open If the image should be open quote (“ in LTR).
    *                       Otherwise, a closing quote is used (” in LTR).
    * @return {!Blockly.FieldImage} The new field.
-   * @this {Blockly.Block}
+   * @this {Blockly.Constants.Text.QuoteBlock}
    */
   newQuote_: function(open) {
     var isLeft = this.RTL ? !open : open;
@@ -673,7 +674,7 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
 
 /**
  * Wraps TEXT field with images of double quote characters.
- * @this {Blockly.Block}
+ * @this {Blockly.Constants.Text.QuoteBlock}
  */
 Blockly.Constants.Text.TEXT_QUOTES_EXTENSION = function() {
   this.mixin(Blockly.Constants.Text.QUOTE_IMAGE_MIXIN);
@@ -708,9 +709,9 @@ Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN = {
   },
   /**
    * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.WorkspaceSvg} workspace Mutator's workspace.
+   * @return {!Blockly.BlockSvg} Root block in mutator.
+   * @this {Blockly.BlockSvg}
    */
   decompose: function(workspace) {
     var containerBlock = workspace.newBlock('text_create_join_container');
@@ -719,15 +720,16 @@ Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN = {
     for (var i = 0; i < this.itemCount_; i++) {
       var itemBlock = workspace.newBlock('text_create_join_item');
       itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
+      connection.connect(
+          /** @type {!Blockly.Connection} */ (itemBlock.previousConnection));
       connection = itemBlock.nextConnection;
     }
     return containerBlock;
   },
   /**
    * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
+   * @param {!Blockly.BlockSvg} containerBlock Root block in mutator.
+   * @this {Blockly.BlockSvg}
    */
   compose: function(containerBlock) {
     var itemBlock = containerBlock.getInputTargetBlock('STACK');
@@ -931,3 +933,60 @@ Blockly.Extensions.registerMutator('text_join_mutator',
 Blockly.Extensions.registerMutator('text_charAt_mutator',
     Blockly.Constants.Text.TEXT_CHARAT_MUTATOR_MIXIN,
     Blockly.Constants.Text.TEXT_CHARAT_EXTENSION);
+
+
+/**
+ * @extends {Blockly.BlockSvg}
+ * @constructor
+ */
+Blockly.Constants.Text.SubstringBlock = function() {};
+/**
+ * @type {?function(number,boolean)}
+ * @private
+ */
+Blockly.Constants.Text.SubstringBlock.prototype.updateAt_;
+
+/**
+ * @extends {Blockly.Constants.Text.QuoteBlock}
+ * @constructor
+ */
+Blockly.Constants.Text.PromptBlock = function() {};
+/**
+ * @type {?function(string)}
+ * @private
+ */
+Blockly.Constants.Text.PromptBlock.prototype.updateType_;
+
+/**
+ * @extends {Blockly.BlockSvg}
+ * @constructor
+ */
+Blockly.Constants.Text.QuoteBlock = function() {};
+/**
+ * @type {string}
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.QUOTE_IMAGE_LEFT_DATAURI;
+/**
+ * @type {string}
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.QUOTE_IMAGE_RIGHT_DATAURI;
+/**
+ * @type {number}
+ * @const
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.QUOTE_IMAGE_WIDTH;
+/**
+ * @type {number}
+ * @const
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.QUOTE_IMAGE_HEIGHT;
+/**
+ * @type {?function(string)}
+ * @private
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.quoteField_;
+/**
+ * @type {?function(boolean):!Blockly.FieldImage}
+ * @private
+ */
+Blockly.Constants.Text.QuoteBlock.prototype.newQuote_;

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -124,13 +124,13 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
     } else {
       if (this.type == 'variables_get' || this.type == 'variables_get_reporter') {
         var renameOption = {
-          text: Blockly.Msg.RENAME_VARIABLE,
+          text: Blockly.Msg['RENAME_VARIABLE'],
           enabled: true,
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
-          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          text: Blockly.Msg['DELETE_VARIABLE'].replace('%1', name),
           enabled: true,
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
         };

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -99,7 +99,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     if (!this.isInFlyout) {
       var opposite_type;
       var contextMenuMsg;
-      var id = this.getFieldValue('VAR');
+      var id = /** @type {string} */ (this.getFieldValue('VAR'));
       var variableModel = this.workspace.getVariableById(id);
       var varType = variableModel.type;
       if (this.type == 'variables_get_dynamic') {
@@ -126,13 +126,13 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       if (this.type == 'variables_get_dynamic' ||
        this.type == 'variables_get_reporter_dynamic') {
         var renameOption = {
-          text: Blockly.Msg.RENAME_VARIABLE,
+          text: Blockly.Msg['RENAME_VARIABLE'],
           enabled: true,
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
-          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          text: Blockly.Msg['DELETE_VARIABLE'].replace('%1', name),
           enabled: true,
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
         };
@@ -148,7 +148,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
    * @this {Blockly.Block}
    */
   onchange: function(_e) {
-    var id = this.getFieldValue('VAR');
+    var id = /** @type {string} */ (this.getFieldValue('VAR'));
     var variableModel = Blockly.Variables.getVariable(this.workspace, id);
     if (this.type == 'variables_get_dynamic') {
       this.outputConnection.setCheck(variableModel.type);

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -48,13 +48,22 @@ Blockly.Procedures.NAME_TYPE = Blockly.PROCEDURE_CATEGORY_NAME;
 
 /**
  * Procedure block type.
- * @typedef {{
- *    getProcedureCall: function():string,
- *    renameProcedure: function(string,string),
- *    getProcedureDef: function():!Array
- * }}
+ * @extends {Blockly.BlockSvg}
+ * @constructor
  */
-Blockly.Procedures.ProcedureBlock;
+Blockly.Procedures.ProcedureBlock = function() {};
+/**
+ * @type {?function():string}
+ */
+Blockly.Procedures.ProcedureBlock.prototype.getProcedureCall;
+/**
+ * @type {?function(string,string)}
+ */
+Blockly.Procedures.ProcedureBlock.prototype.renameProcedure;
+/**
+ * @type {?function():!Array}
+ */
+Blockly.Procedures.ProcedureBlock.prototype.getProcedureDef;
 
 /**
  * Find all user-created procedure definitions in a workspace.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix warnings in blocks/

### Proposed Changes

Adds interfaces for the Blocks defined in blocks/ and references those. 
@rachel-fenichel this is what I was talking to you about the other day, let me know your thoughts.

Pros of having blocks type checked: 
- We know when we use a package API in our blocks

Cons: 
- It's ugly

### Reason for Changes

Warnings in blocks.
