### PR TITLE
Add an RLM after Flyout button text for RTL languages

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -152,7 +152,6 @@ Blockly.FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-
   var text = Blockly.utils.replaceMessageReferences(this.text_);
   if (this.workspace_.RTL) {
     // Force text to be RTL by adding an RLM.

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -152,7 +152,13 @@ Blockly.FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-  svgText.textContent = Blockly.utils.replaceMessageReferences(this.text_);
+
+  var text = Blockly.utils.replaceMessageReferences(this.text_);
+  if (this.workspace_.RTL) {
+    // Force text to be RTL by adding an RLM.
+    text += '\u200F';
+  }
+  svgText.textContent = text;
   if (this.isLabel_) {
     this.svgText_ = svgText;
     this.workspace_.getThemeManager().subscribe(this.svgText_, 'flyoutText', 'fill');


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1928

### Proposed Changes

The SVG is LTR, add an RLM after flyout button texts for RTL languages to switch the text direction.

### Reason for Changes

Fix bug.

### Test Coverage

Tested in the playground with the ar.js lang.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Fixed
<img width="282" alt="Screen Shot 2019-10-29 at 11 24 35 pm" src="https://user-images.githubusercontent.com/16690124/67834122-cf893600-faa3-11e9-9aaa-4df17209dde8.png">
<img width="313" alt="Screen Shot 2019-10-29 at 11 30 38 pm" src="https://user-images.githubusercontent.com/16690124/67834258-2a229200-faa4-11e9-8453-fe9f4d798d20.png">

