### PR TITLE
Use zero height / width for compute canvas

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -772,6 +772,11 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
     'float: right;',
     'margin-right: -24px;',
+  '}',
+
+  '.blocklyComputeCanvas {',
+    'width: 0;',
+    'height: 0;',
   '}'
   /* eslint-enable indent */
 ];

--- a/core/css.js
+++ b/core/css.js
@@ -772,6 +772,12 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
     'float: right;',
     'margin-right: -24px;',
-  '}'
+  '}',
+
+  '.blocklyComputeCanvas {',
+    'position: absolute;',
+    'width: 0;',
+    'height: 0;',
+  '}',
   /* eslint-enable indent */
 ];

--- a/core/css.js
+++ b/core/css.js
@@ -772,11 +772,6 @@ Blockly.Css.CONTENT = [
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
     'float: right;',
     'margin-right: -24px;',
-  '}',
-
-  '.blocklyComputeCanvas {',
-    'width: 0;',
-    'height: 0;',
   '}'
   /* eslint-enable indent */
 ];

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -306,6 +306,8 @@ Blockly.utils.dom.getFastTextWidth = function(textElement,
     // Inject the canvas element used for computing text widths.
     var computeCanvas = document.createElement('canvas');
     computeCanvas.className = 'blocklyComputeCanvas';
+    computeCanvas.width = 0;
+    computeCanvas.height = 0;
     document.body.appendChild(computeCanvas);
 
     // Initialize the HTML canvas context and set the font.

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -306,8 +306,6 @@ Blockly.utils.dom.getFastTextWidth = function(textElement,
     // Inject the canvas element used for computing text widths.
     var computeCanvas = document.createElement('canvas');
     computeCanvas.className = 'blocklyComputeCanvas';
-    computeCanvas.width = 0;
-    computeCanvas.height = 0;
     document.body.appendChild(computeCanvas);
 
     // Initialize the HTML canvas context and set the font.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3368

### Proposed Changes

Use zero height / width for compute canvas and position:absolute.

### Reason for Changes

So it doesn't affect layout.

### Test Coverage

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
* Edge 18
* IE 11
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@BeksOmega 