### PR TITLE
Support workspace theme option as JSON

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -23,6 +23,8 @@
 
 goog.provide('Blockly.Options');
 
+goog.require('Blockly.Theme');
+goog.require('Blockly.Themes.Classic');
 goog.require('Blockly.utils.userAgent');
 goog.require('Blockly.Xml');
 
@@ -114,7 +116,6 @@ Blockly.Options = function(options) {
   } else {
     var oneBasedIndex = !!options['oneBasedIndex'];
   }
-  var theme = options['theme'];
   var keyMap = options['keyMap'] || Blockly.user.keyMap.createDefaultKeyMap();
 
   var renderer = options['renderer'] || 'geras';
@@ -141,7 +142,7 @@ Blockly.Options = function(options) {
   this.gridOptions = Blockly.Options.parseGridOptions_(options);
   this.zoomOptions = Blockly.Options.parseZoomOptions_(options);
   this.toolboxPosition = toolboxPosition;
-  this.theme = theme;
+  this.theme = Blockly.Options.parseThemeOptions_(options);
   this.keyMap = keyMap;
   this.renderer = renderer;
 };
@@ -271,6 +272,22 @@ Blockly.Options.parseGridOptions_ = function(options) {
   gridOptions.length = Number(grid['length']) || 1;
   gridOptions.snap = gridOptions.spacing > 0 && !!grid['snap'];
   return gridOptions;
+};
+
+/**
+ * Parse the user-specified theme options, using the classic theme as a default.
+ *   https://developers.google.com/blockly/guides/configure/web/themes
+ * @param {!Object} options Dictionary of options.
+ * @return {!Blockly.Theme} A Blockly Theme.
+ * @private
+ */
+Blockly.Options.parseThemeOptions_ = function(options) {
+  var theme = options['theme'] || Blockly.Themes.Classic;
+  if (theme instanceof Blockly.Theme) {
+    return /** @type {!Blockly.Theme} */ (theme);
+  }
+  return new Blockly.Theme(
+      theme['blockStyles'], theme['categoryStyles'], theme['componentStyles']);
 };
 
 /**

--- a/core/theme.js
+++ b/core/theme.js
@@ -203,6 +203,15 @@ Blockly.Theme.prototype.setCategoryStyle = function(categoryStyleName,
 };
 
 /**
+ * Gets a map of all the category style names.
+ * @return {!Object.<string, Blockly.Theme.CategoryStyle>} Map of category
+ *     styles.
+ */
+Blockly.Theme.prototype.getAllCategoryStyles = function() {
+  return this.categoryStyles_;
+};
+
+/**
  * Gets the style for a given Blockly UI component.  If the style value is a
  * string, we attempt to find the value of any named references.
  * @param {string} componentName The name of the component.

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -27,6 +27,7 @@ goog.require('Blockly.Cursor');
 goog.require('Blockly.MarkerCursor');
 goog.require('Blockly.Events');
 goog.require('Blockly.ThemeManager');
+goog.require('Blockly.Themes.Classic');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
 goog.require('Blockly.VariableMap');
@@ -134,7 +135,7 @@ Blockly.Workspace = function(opt_options) {
    */
   this.themeManager_ = this.options.parentWorkspace ?
       this.options.parentWorkspace.getThemeManager() :
-      new Blockly.ThemeManager(this.options.theme);
+      new Blockly.ThemeManager(this.options.theme || Blockly.Themes.Classic);
   
   this.themeManager_.subscribeWorkspace(this);
 

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -27,7 +27,6 @@ goog.require('Blockly.Cursor');
 goog.require('Blockly.MarkerCursor');
 goog.require('Blockly.Events');
 goog.require('Blockly.ThemeManager');
-goog.require('Blockly.Themes.Classic');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
 goog.require('Blockly.VariableMap');
@@ -135,7 +134,7 @@ Blockly.Workspace = function(opt_options) {
    */
   this.themeManager_ = this.options.parentWorkspace ?
       this.options.parentWorkspace.getThemeManager() :
-      new Blockly.ThemeManager(this.options.theme || Blockly.Themes.Classic);
+      new Blockly.ThemeManager(this.options.theme);
   
   this.themeManager_.subscribeWorkspace(this);
 

--- a/typings/parts/blockly-interfaces.d.ts
+++ b/typings/parts/blockly-interfaces.d.ts
@@ -16,7 +16,7 @@ declare module Blockly {
     css?: boolean;
     oneBasedIndex?: boolean;
     media?: string;
-    theme?: Blockly.BlocklyTheme;
+    theme?: Blockly.Theme | BlocklyThemeOptions;
     move?: {
       scrollbars?: boolean;
       drag?: boolean;
@@ -38,9 +38,10 @@ declare module Blockly {
     };
   }
 
-  interface BlocklyTheme {
-    defaultBlockStyles?: {[blocks: string]: Blockly.Theme.BlockStyle;};
+  interface BlocklyThemeOptions {
+    blockStyles?: {[blocks: string]: Blockly.Theme.BlockStyle;};
     categoryStyles?: {[category: string]: Blockly.Theme.CategoryStyle;};
+    componentStyles?: {[component: string]: any;};
   }
 
   interface Metrics {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Support passing in a theme in workspace options as JSON, rather than having to pass in a Theme Object.
Updated typings.

### Reason for Changes

Most of our other configuration is in JSON. It's serializable and easier for developers to work with.

### Test Coverage

Tested playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
