### PR TITLE
Add parens around inline assignments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,8 +61,6 @@
         "space-infix-ops": ["error"],
         "_comment": "Blockly uses 'use strict' in files",
         "strict": ["off"],
-        "_comment": "Blockly often uses cond-assignment in loops",
-        "no-cond-assign": ["off"],
         "_comment": "Closure style allows redeclarations",
         "no-redeclare": ["off"],
         "valid-jsdoc": ["error", {"requireReturn": false}],

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -139,7 +139,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   domToMutation: function(xmlElement) {
     this.arguments_ = [];
     this.argumentVarModels_ = [];
-    for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
+    for (var i = 0, childNode; (childNode = xmlElement.childNodes[i]); i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         var varName = childNode.getAttribute('name');
         var varId = childNode.getAttribute('varid') || childNode.getAttribute('varId');
@@ -354,7 +354,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     // Update the mutator's variables if the mutator is open.
     if (this.mutator && this.mutator.isVisible()) {
       var blocks = this.mutator.workspace_.getAllBlocks(false);
-      for (var i = 0, block; block = blocks[i]; i++) {
+      for (var i = 0, block; (block = blocks[i]); i++) {
         if (block.type == 'procedures_mutatorarg' &&
             Blockly.Names.equals(oldName, block.getFieldValue('NAME'))) {
           block.setFieldValue(newName, 'NAME');
@@ -859,7 +859,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     this.renameProcedure(this.getProcedureCall(), name);
     var args = [];
     var paramIds = [];
-    for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
+    for (var i = 0, childNode; (childNode = xmlElement.childNodes[i]); i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         args.push(childNode.getAttribute('name'));
         paramIds.push(childNode.getAttribute('paramId'));

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -638,8 +638,8 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
    * @this {Blockly.Block}
    */
   quoteField_: function(fieldName) {
-    for (var i = 0, input; input = this.inputList[i]; i++) {
-      for (var j = 0, field; field = input.fieldRow[j]; j++) {
+    for (var i = 0, input; (input = this.inputList[i]); i++) {
+      for (var j = 0, field; (field = input.fieldRow[j]); j++) {
         if (fieldName == field.name) {
           input.insertFieldAt(j, this.newQuote_(true));
           input.insertFieldAt(j + 2, this.newQuote_(false));

--- a/core/block.js
+++ b/core/block.js
@@ -359,13 +359,13 @@ Blockly.Block.prototype.dispose = function(healStack) {
     }
     // Then dispose of myself.
     // Dispose of all inputs and their fields.
-    for (var i = 0, input; input = this.inputList[i]; i++) {
+    for (var i = 0, input; (input = this.inputList[i]); i++) {
       input.dispose();
     }
     this.inputList.length = 0;
     // Dispose of any remaining connections (next/previous/output).
     var connections = this.getConnections_(true);
-    for (var i = 0, connection; connection = connections[i]; i++) {
+    for (var i = 0, connection; (connection = connections[i]); i++) {
       connection.dispose();
     }
   } finally {
@@ -384,8 +384,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
  * @public
  */
 Blockly.Block.prototype.initModel = function() {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.initModel) {
         field.initModel();
       }
@@ -516,7 +516,7 @@ Blockly.Block.prototype.getConnections_ = function(_all) {
   if (this.nextConnection) {
     myConnections.push(this.nextConnection);
   }
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.connection) {
       myConnections.push(input.connection);
     }
@@ -567,7 +567,7 @@ Blockly.Block.prototype.getParent = function() {
  * @return {Blockly.Input} The input that connects to the specified block.
  */
 Blockly.Block.prototype.getInputWithBlock = function(block) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.connection && input.connection.targetBlock() == block) {
       return input;
     }
@@ -618,7 +618,7 @@ Blockly.Block.prototype.getPreviousBlock = function() {
  * @package
  */
 Blockly.Block.prototype.getFirstStatementConnection = function() {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.connection && input.connection.type == Blockly.NEXT_STATEMENT) {
       return input.connection;
     }
@@ -669,7 +669,7 @@ Blockly.Block.prototype.getChildren = function(ordered) {
     return this.childBlocks_;
   }
   var blocks = [];
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.connection) {
       var child = input.connection.targetBlock();
       if (child) {
@@ -732,7 +732,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
 Blockly.Block.prototype.getDescendants = function(ordered) {
   var blocks = [this];
   var childBlocks = this.getChildren(ordered);
-  for (var child, i = 0; child = childBlocks[i]; i++) {
+  for (var child, i = 0; (child = childBlocks[i]); i++) {
     blocks.push.apply(blocks, child.getDescendants(ordered));
   }
   return blocks;
@@ -836,8 +836,8 @@ Blockly.Block.prototype.isEditable = function() {
  */
 Blockly.Block.prototype.setEditable = function(editable) {
   this.editable_ = editable;
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       field.updateEditable();
     }
   }
@@ -956,8 +956,8 @@ Blockly.Block.prototype.setOnChange = function(onchangeFn) {
  * @return {Blockly.Field} Named field, or null if field does not exist.
  */
 Blockly.Block.prototype.getField = function(name) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.name == name) {
         return field;
       }
@@ -973,8 +973,8 @@ Blockly.Block.prototype.getField = function(name) {
  */
 Blockly.Block.prototype.getVars = function() {
   var vars = [];
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.referencesVariables()) {
         vars.push(field.getValue());
       }
@@ -990,8 +990,8 @@ Blockly.Block.prototype.getVars = function() {
  */
 Blockly.Block.prototype.getVarModels = function() {
   var vars = [];
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.referencesVariables()) {
         var model = this.workspace.getVariableById(
             /** @type {string} */ (field.getValue()));
@@ -1013,8 +1013,8 @@ Blockly.Block.prototype.getVarModels = function() {
  * @package
  */
 Blockly.Block.prototype.updateVarName = function(variable) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.referencesVariables() &&
           variable.getId() == field.getValue()) {
         field.refreshVariableName();
@@ -1031,8 +1031,8 @@ Blockly.Block.prototype.updateVarName = function(variable) {
  *     an updated name.
  */
 Blockly.Block.prototype.renameVarById = function(oldId, newId) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       if (field.referencesVariables() &&
           oldId == field.getValue()) {
         field.setValue(newId);
@@ -1277,8 +1277,8 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
   if (this.collapsed_) {
     text.push(this.getInput('_TEMP_COLLAPSED_INPUT').fieldRow[0].getText());
   } else {
-    for (var i = 0, input; input = this.inputList[i]; i++) {
-      for (var j = 0, field; field = input.fieldRow[j]; j++) {
+    for (var i = 0, input; (input = this.inputList[i]); i++) {
+      for (var j = 0, field; (field = input.fieldRow[j]); j++) {
         text.push(field.getText());
       }
       if (input.connection) {
@@ -1573,11 +1573,9 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
               field = Blockly.fieldRegistry.fromJson(element);
 
               // Unknown field.
-              if (!field) {
-                if (element['alt']) {
-                  element = element['alt'];
-                  altRepeat = true;
-                }
+              if (!field && element['alt']) {
+                element = element['alt'];
+                altRepeat = true;
               }
           }
         }
@@ -1589,13 +1587,12 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
           input.setCheck(element['check']);
         }
         if (element['align']) {
-          var align = !!element['align'] && element['align'].toUpperCase();
-          var alignment = alignmentLookup[align];
-          if (alignment != undefined) {
-            input.setAlign(alignment);
-          } else {
+          var alignment = alignmentLookup[element['align'].toUpperCase()];
+          if (alignment === undefined) {
             console.warn(warningPrefix + 'Illegal align value: ',
                 element['align']);
+          } else {
+            input.setAlign(alignment);
           }
         }
         for (var j = 0; j < fieldStack.length; j++) {
@@ -1640,7 +1637,7 @@ Blockly.Block.prototype.moveInputBefore = function(name, refName) {
   // Find both inputs.
   var inputIndex = -1;
   var refIndex = refName ? -1 : this.inputList.length;
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.name == name) {
       inputIndex = i;
       if (refIndex != -1) {
@@ -1693,11 +1690,10 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  * Remove an input from this block.
  * @param {string} name The name of the input.
  * @param {boolean=} opt_quiet True to prevent error if input is not present.
- * @throws {Error} if the input is not present and
- *     opt_quiet is not true.
+ * @throws {Error} if the input is not present and opt_quiet is not true.
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.name == name) {
       input.dispose();
       this.inputList.splice(i, 1);
@@ -1715,7 +1711,7 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
  * @return {Blockly.Input} The input object, or null if input does not exist.
  */
 Blockly.Block.prototype.getInput = function(name) {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.name == name) {
       return input;
     }
@@ -1827,7 +1823,7 @@ Blockly.Block.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
   }
 
   // Recursively check each input block of the current block.
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (!input.connection) {
       continue;
     }

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -120,7 +120,7 @@ Blockly.BlockDragger.initIconData_ = function(block) {
   // Build a list of icons that need to be moved and where they started.
   var dragIconData = [];
   var descendants = block.getDescendants(false);
-  for (var i = 0, descendant; descendant = descendants[i]; i++) {
+  for (var i = 0, descendant; (descendant = descendants[i]); i++) {
     var icons = descendant.getIcons();
     for (var j = 0; j < icons.length; j++) {
       var data = {

--- a/core/block_events.js
+++ b/core/block_events.js
@@ -273,7 +273,7 @@ Blockly.Events.Create.prototype.run = function(forward) {
     xml.appendChild(this.xml);
     Blockly.Xml.domToWorkspace(xml, workspace);
   } else {
-    for (var i = 0, id; id = this.ids[i]; i++) {
+    for (var i = 0, id; (id = this.ids[i]); i++) {
       var block = workspace.getBlockById(id);
       if (block) {
         block.dispose(false);
@@ -349,7 +349,7 @@ Blockly.Events.Delete.prototype.fromJson = function(json) {
 Blockly.Events.Delete.prototype.run = function(forward) {
   var workspace = this.getEventWorkspace_();
   if (forward) {
-    for (var i = 0, id; id = this.ids[i]; i++) {
+    for (var i = 0, id; (id = this.ids[i]); i++) {
       var block = workspace.getBlockById(id);
       if (block) {
         block.dispose(false);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -258,7 +258,7 @@ Blockly.BlockSvg.prototype.initSvg = function() {
   if (!this.workspace.rendered) {
     throw TypeError('Workspace is headless.');
   }
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     input.init();
   }
   var icons = this.getIcons();
@@ -621,7 +621,7 @@ Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
  * A dirty field is a field that needs to be re-rendererd.
  */
 Blockly.BlockSvg.prototype.markDirty = function() {
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     input.markDirty();
   }
 };
@@ -636,7 +636,7 @@ Blockly.BlockSvg.prototype.setCollapsed = function(collapsed) {
   }
   var renderList = [];
   // Show/hide the inputs.
-  for (var i = 0, input; input = this.inputList[i]; i++) {
+  for (var i = 0, input; (input = this.inputList[i]); i++) {
     renderList.push.apply(renderList, input.setVisible(!collapsed));
   }
 
@@ -656,7 +656,7 @@ Blockly.BlockSvg.prototype.setCollapsed = function(collapsed) {
       var index = descendants.indexOf(nextBlock);
       descendants.splice(index, descendants.length - index);
     }
-    for (var i = 1, block; block = descendants[i]; i++) {
+    for (var i = 1, block; (block = descendants[i]); i++) {
       if (block.warning) {
         this.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
             Blockly.BlockSvg.COLLAPSED_WARNING_ID);
@@ -680,7 +680,7 @@ Blockly.BlockSvg.prototype.setCollapsed = function(collapsed) {
     renderList[0] = this;
   }
   if (this.rendered) {
-    for (var i = 0, block; block = renderList[i]; i++) {
+    for (var i = 0, block; (block = renderList[i]); i++) {
       block.render();
     }
     // Don't bump neighbours.
@@ -1045,8 +1045,8 @@ Blockly.BlockSvg.prototype.applyColour = function() {
     icons[i].applyColour();
   }
 
-  for (var x = 0, input; input = this.inputList[x]; x++) {
-    for (var y = 0, field; field = input.fieldRow[y]; y++) {
+  for (var x = 0, input; (input = this.inputList[x]); x++) {
+    for (var y = 0, field; (field = input.fieldRow[y]); y++) {
       field.applyColour();
     }
   }
@@ -1071,7 +1071,7 @@ Blockly.BlockSvg.prototype.updateDisabled = function() {
     }
   }
   var children = this.getChildren(false);
-  for (var i = 0, child; child = children[i]; i++) {
+  for (var i = 0, child; (child = children[i]); i++) {
     child.updateDisabled();
   }
 };
@@ -1544,7 +1544,7 @@ Blockly.BlockSvg.prototype.getConnections_ = function(all) {
       myConnections.push(this.nextConnection);
     }
     if (all || !this.collapsed_) {
-      for (var i = 0, input; input = this.inputList[i]; i++) {
+      for (var i = 0, input; (input = this.inputList[i]); i++) {
         if (input.connection) {
           myConnections.push(input.connection);
         }
@@ -1610,7 +1610,7 @@ Blockly.BlockSvg.prototype.bumpNeighbours = function() {
   }
   // Loop through every connection on this block.
   var myConnections = this.getConnections_(false);
-  for (var i = 0, connection; connection = myConnections[i]; i++) {
+  for (var i = 0, connection; (connection = myConnections[i]); i++) {
 
     // Spider down from this block bumping all sub-blocks.
     if (connection.isConnected() && connection.isSuperior()) {
@@ -1618,7 +1618,7 @@ Blockly.BlockSvg.prototype.bumpNeighbours = function() {
     }
 
     var neighbours = connection.neighbours(Blockly.SNAP_RADIUS);
-    for (var j = 0, otherConnection; otherConnection = neighbours[j]; j++) {
+    for (var j = 0, otherConnection; (otherConnection = neighbours[j]); j++) {
 
       // If both connections are connected, that's probably fine.  But if
       // either one of them is unconnected, then there could be confusion.

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -470,7 +470,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
     // Handle each touch point separately.  If the event was a mouse event, this
     // will hand back an array with one element, which we're fine handling.
     var events = Blockly.Touch.splitEventByTouches(e);
-    for (var i = 0, event; event = events[i]; i++) {
+    for (var i = 0, event; (event = events[i]); i++) {
       if (captureIdentifier && !Blockly.Touch.shouldHandleEvent(event)) {
         continue;
       }
@@ -487,7 +487,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
   var bindData = [];
   if (Blockly.utils.global['PointerEvent'] &&
       (name in Blockly.Touch.TOUCH_MAP)) {
-    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+    for (var i = 0, type; (type = Blockly.Touch.TOUCH_MAP[name][i]); i++) {
       node.addEventListener(type, wrapFunc, false);
       bindData.push([node, type, wrapFunc]);
     }
@@ -506,7 +506,7 @@ Blockly.bindEventWithChecks_ = function(node, name, thisObject, func,
           e.preventDefault();
         }
       };
-      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+      for (var i = 0, type; (type = Blockly.Touch.TOUCH_MAP[name][i]); i++) {
         node.addEventListener(type, touchWrapFunc, false);
         bindData.push([node, type, touchWrapFunc]);
       }
@@ -539,7 +539,7 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var bindData = [];
   if (Blockly.utils.global['PointerEvent'] &&
       (name in Blockly.Touch.TOUCH_MAP)) {
-    for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+    for (var i = 0, type; (type = Blockly.Touch.TOUCH_MAP[name][i]); i++) {
       node.addEventListener(type, wrapFunc, false);
       bindData.push([node, type, wrapFunc]);
     }
@@ -562,7 +562,7 @@ Blockly.bindEvent_ = function(node, name, thisObject, func) {
         // Stop the browser from scrolling/zooming the page.
         e.preventDefault();
       };
-      for (var i = 0, type; type = Blockly.Touch.TOUCH_MAP[name][i]; i++) {
+      for (var i = 0, type; (type = Blockly.Touch.TOUCH_MAP[name][i]); i++) {
         node.addEventListener(type, touchWrapFunc, false);
         bindData.push([node, type, touchWrapFunc]);
       }

--- a/core/connection.js
+++ b/core/connection.js
@@ -496,15 +496,14 @@ Blockly.Connection.singleConnection_ = function(block, orphanBlock) {
  * @param {!Blockly.Block} startBlock The block on which to start the search.
  * @param {!Blockly.Block} orphanBlock The block that is looking for a home.
  * @return {Blockly.Connection} The suitable connection point on the chain
- *    of blocks, or null.
+ *     of blocks, or null.
  * @package
  */
 Blockly.Connection.lastConnectionInRow = function(startBlock, orphanBlock) {
   var newBlock = startBlock;
   var connection;
-  while (connection = Blockly.Connection.singleConnection_(
-      /** @type {!Blockly.Block} */ (newBlock), orphanBlock)) {
-    // '=' is intentional in line above.
+  while ((connection = Blockly.Connection.singleConnection_(
+      /** @type {!Blockly.Block} */ (newBlock), orphanBlock))) {
     newBlock = connection.targetBlock();
     if (!newBlock || newBlock.isShadow()) {
       return connection;

--- a/core/connection.js
+++ b/core/connection.js
@@ -749,7 +749,7 @@ Blockly.Connection.prototype.toString = function() {
     msg = 'Next Connection of ';
   } else {
     var parentInput = null;
-    for (var i = 0, input; input = block.inputList[i]; i++) {
+    for (var i = 0, input; (input = block.inputList[i]); i++) {
       if (input.connection == this) {
         parentInput = input;
         break;

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -89,7 +89,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
   */
   var menu = new Blockly.Menu();
   menu.setRightToLeft(rtl);
-  for (var i = 0, option; option = options[i]; i++) {
+  for (var i = 0, option; (option = options[i]); i++) {
     var menuItem = new Blockly.MenuItem(option.text);
     menuItem.setRightToLeft(rtl);
     menu.addChild(menuItem, true);

--- a/core/events.js
+++ b/core/events.js
@@ -194,7 +194,7 @@ Blockly.Events.fire = function(event) {
 Blockly.Events.fireNow_ = function() {
   var queue = Blockly.Events.filter(Blockly.Events.FIRE_QUEUE_, true);
   Blockly.Events.FIRE_QUEUE_.length = 0;
-  for (var i = 0, event; event = queue[i]; i++) {
+  for (var i = 0, event; (event = queue[i]); i++) {
     if (!event.workspaceId) {
       continue;
     }
@@ -220,7 +220,7 @@ Blockly.Events.filter = function(queueIn, forward) {
   var mergedQueue = [];
   var hash = Object.create(null);
   // Merge duplicates.
-  for (var i = 0, event; event = queue[i]; i++) {
+  for (var i = 0, event; (event = queue[i]); i++) {
     if (!event.isNull()) {
       var key = [event.type, event.blockId, event.workspaceId].join(' ');
 
@@ -266,7 +266,7 @@ Blockly.Events.filter = function(queueIn, forward) {
   }
   // Move mutation events to the top of the queue.
   // Intentionally skip first event.
-  for (var i = 1, event; event = queue[i]; i++) {
+  for (var i = 1, event; (event = queue[i]); i++) {
     if (event.type == Blockly.Events.CHANGE &&
         event.element == 'mutation') {
       queue.unshift(queue.splice(i, 1)[0]);
@@ -280,7 +280,7 @@ Blockly.Events.filter = function(queueIn, forward) {
  * in the undo stack.  Called by Blockly.Workspace.clearUndo.
  */
 Blockly.Events.clearPendingUndo = function() {
-  for (var i = 0, event; event = Blockly.Events.FIRE_QUEUE_[i]; i++) {
+  for (var i = 0, event; (event = Blockly.Events.FIRE_QUEUE_[i]); i++) {
     event.recordUndo = false;
   }
 };
@@ -338,7 +338,7 @@ Blockly.Events.setGroup = function(state) {
 Blockly.Events.getDescendantIds = function(block) {
   var ids = [];
   var descendants = block.getDescendants(false);
-  for (var i = 0, descendant; descendant = descendants[i]; i++) {
+  for (var i = 0, descendant; (descendant = descendants[i]); i++) {
     ids[i] = descendant.id;
   }
   return ids;
@@ -420,7 +420,7 @@ Blockly.Events.disableOrphans = function(event) {
       var parent = block.getParent();
       if (parent && parent.isEnabled()) {
         var children = block.getDescendants(false);
-        for (var i = 0, child; child = children[i]; i++) {
+        for (var i = 0, child; (child = children[i]); i++) {
           child.setEnabled(true);
         }
       } else if ((block.outputConnection || block.previousConnection) &&

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -430,7 +430,7 @@ Blockly.FieldDropdown.prototype.getOptions = function(opt_useCache) {
 Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
   var isValueValid = false;
   var options = this.getOptions(true);
-  for (var i = 0, option; option = options[i]; i++) {
+  for (var i = 0, option; (option = options[i]); i++) {
     // Options are tuples of human-readable text and language-neutral values.
     if (option[1] == opt_newValue) {
       isValueValid = true;
@@ -457,7 +457,7 @@ Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
 Blockly.FieldDropdown.prototype.doValueUpdate_ = function(newValue) {
   Blockly.FieldDropdown.superClass_.doValueUpdate_.call(this, newValue);
   var options = this.getOptions(true);
-  for (var i = 0, option; option = options[i]; i++) {
+  for (var i = 0, option; (option = options[i]); i++) {
     if (option[1] == this.value_) {
       this.selectedIndex_ = i;
     }

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -146,7 +146,7 @@ Blockly.FieldMultilineInput.prototype.getDisplayText_ = function() {
 Blockly.FieldMultilineInput.prototype.render_ = function() {
   // Remove all text group children.
   var currentChild;
-  while (currentChild = this.textGroup_.firstChild) {
+  while ((currentChild = this.textGroup_.firstChild)) {
     this.textGroup_.removeChild(currentChild);
   }
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -422,7 +422,7 @@ Blockly.Flyout.prototype.hide = function() {
   }
   this.setVisible(false);
   // Delete all the event listeners.
-  for (var i = 0, listen; listen = this.listeners_[i]; i++) {
+  for (var i = 0, listen; (listen = this.listeners_[i]); i++) {
     Blockly.unbindEvent_(listen);
   }
   this.listeners_.length = 0;
@@ -466,7 +466,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   var gaps = [];
   this.permanentlyDisabled_.length = 0;
   var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
-  for (var i = 0, xml; xml = xmlList[i]; i++) {
+  for (var i = 0, xml; (xml = xmlList[i]); i++) {
     if (!xml.tagName) {
       continue;
     }
@@ -517,7 +517,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   // When the mouse is over the background, deselect all blocks.
   var deselectAll = function() {
     var topBlocks = this.workspace_.getTopBlocks(false);
-    for (var i = 0, block; block = topBlocks[i]; i++) {
+    for (var i = 0, block; (block = topBlocks[i]); i++) {
       block.removeSelect();
     }
   };
@@ -549,7 +549,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
 Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   // Delete any blocks from a previous showing.
   var oldBlocks = this.workspace_.getTopBlocks(false);
-  for (var i = 0, block; block = oldBlocks[i]; i++) {
+  for (var i = 0, block; (block = oldBlocks[i]); i++) {
     if (block.workspace == this.workspace_) {
       block.dispose(false, false);
     }
@@ -563,7 +563,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   }
   this.mats_.length = 0;
   // Delete any buttons from a previous showing.
-  for (var i = 0, button; button = this.buttons_[i]; i++) {
+  for (var i = 0, button; (button = this.buttons_[i]); i++) {
     button.dispose();
   }
   this.buttons_.length = 0;
@@ -756,7 +756,7 @@ Blockly.Flyout.prototype.moveRectToBlock_ = function(rect, block) {
  */
 Blockly.Flyout.prototype.filterForCapacity_ = function() {
   var blocks = this.workspace_.getTopBlocks(false);
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     if (this.permanentlyDisabled_.indexOf(block) == -1) {
       var enable = this.targetWorkspace_
           .isCapacityAvailable(Blockly.utils.getBlockTypeCounts(block));

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -259,11 +259,11 @@ Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
   var cursorX = this.RTL ? margin : margin + this.tabWidth_;
   var cursorY = margin;
 
-  for (var i = 0, item; item = contents[i]; i++) {
+  for (var i = 0, item; (item = contents[i]); i++) {
     if (item.type == 'block') {
       var block = item.block;
       var allBlocks = block.getDescendants(false);
-      for (var j = 0, child; child = allBlocks[j]; j++) {
+      for (var j = 0, child; (child = allBlocks[j]); j++) {
         // Mark blocks as being inside a flyout.  This is used to detect and
         // prevent the closure of the flyout if the user right-clicks on such a
         // block.
@@ -361,7 +361,7 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
   flyoutWidth += Blockly.Scrollbar.scrollbarThickness;
 
   if (this.width_ != flyoutWidth) {
-    for (var i = 0, block; block = blocks[i]; i++) {
+    for (var i = 0, block; (block = blocks[i]); i++) {
       if (this.RTL) {
         // With the flyoutWidth known, right-align the blocks.
         var oldX = block.getRelativeToSurfaceXY().x;

--- a/core/generator.js
+++ b/core/generator.js
@@ -101,7 +101,7 @@ Blockly.Generator.prototype.workspaceToCode = function(workspace) {
   var code = [];
   this.init(workspace);
   var blocks = workspace.getTopBlocks(true);
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     var line = this.blockToCode(block);
     if (Array.isArray(line)) {
       // Value blocks return tuples of code and operator order.

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -972,7 +972,7 @@ Blockly.Gesture.prototype.getInsertionMarkers = function() {
  */
 Blockly.Gesture.inProgress = function() {
   var workspaces = Blockly.Workspace.getAll();
-  for (var i = 0, workspace; workspace = workspaces[i]; i++) {
+  for (var i = 0, workspace; (workspace = workspaces[i]); i++) {
     if (workspace.currentGesture_) {
       return true;
     }

--- a/core/inject.js
+++ b/core/inject.js
@@ -473,7 +473,7 @@ Blockly.inject.bindDocumentEvents_ = function() {
   if (!Blockly.documentEventsBound_) {
     Blockly.bindEventWithChecks_(document, 'scroll', null, function() {
       var workspaces = Blockly.Workspace.getAll();
-      for (var i = 0, workspace; workspace = workspaces[i]; i++) {
+      for (var i = 0, workspace; (workspace = workspaces[i]); i++) {
         if (workspace.updateInverseScreenCTM) {
           workspace.updateInverseScreenCTM();
         }

--- a/core/input.js
+++ b/core/input.js
@@ -144,7 +144,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
  * @throws {Error} if the field is not present.
  */
 Blockly.Input.prototype.removeField = function(name) {
-  for (var i = 0, field; field = this.fieldRow[i]; i++) {
+  for (var i = 0, field; (field = this.fieldRow[i]); i++) {
     if (field.name === name) {
       field.dispose();
       this.fieldRow.splice(i, 1);
@@ -185,7 +185,7 @@ Blockly.Input.prototype.setVisible = function(visible) {
   this.visible_ = visible;
 
   var display = visible ? 'block' : 'none';
-  for (var y = 0, field; field = this.fieldRow[y]; y++) {
+  for (var y = 0, field; (field = this.fieldRow[y]); y++) {
     field.setVisible(visible);
   }
   if (this.connection) {
@@ -211,7 +211,7 @@ Blockly.Input.prototype.setVisible = function(visible) {
  * @package
  */
 Blockly.Input.prototype.markDirty = function() {
-  for (var y = 0, field; field = this.fieldRow[y]; y++) {
+  for (var y = 0, field; (field = this.fieldRow[y]); y++) {
     field.markDirty();
   }
 };
@@ -261,7 +261,7 @@ Blockly.Input.prototype.init = function() {
  * @suppress {checkTypes}
  */
 Blockly.Input.prototype.dispose = function() {
-  for (var i = 0, field; field = this.fieldRow[i]; i++) {
+  for (var i = 0, field; (field = this.fieldRow[i]); i++) {
     field.dispose();
   }
   if (this.connection) {

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -269,9 +269,9 @@ Blockly.ASTNode.prototype.findNextForInput_ = function() {
   var parentInput = this.location_.getParentInput();
   var block = parentInput.getSourceBlock();
   var curIdx = block.inputList.indexOf(parentInput);
-  for (var i = curIdx + 1, input; input = block.inputList[i]; i++) {
+  for (var i = curIdx + 1, input; (input = block.inputList[i]); i++) {
     var fieldRow = input.fieldRow;
-    for (var j = 0, field; field = fieldRow[j]; j++) {
+    for (var j = 0, field; (field = fieldRow[j]); j++) {
       if (field.EDITABLE) {
         return Blockly.ASTNode.createFieldNode(field);
       }
@@ -297,7 +297,7 @@ Blockly.ASTNode.prototype.findNextForField_ = function() {
   var block = location.getSourceBlock();
   var curIdx = block.inputList.indexOf(/** @type {!Blockly.Input} */ (input));
   var fieldIdx = input.fieldRow.indexOf(location) + 1;
-  for (var i = curIdx, newInput; newInput = block.inputList[i]; i++) {
+  for (var i = curIdx, newInput; (newInput = block.inputList[i]); i++) {
     var fieldRow = newInput.fieldRow;
     while (fieldIdx < fieldRow.length) {
       if (fieldRow[fieldIdx].EDITABLE) {
@@ -325,12 +325,12 @@ Blockly.ASTNode.prototype.findPrevForInput_ = function() {
   var location = this.location_.getParentInput();
   var block = location.getSourceBlock();
   var curIdx = block.inputList.indexOf(location);
-  for (var i = curIdx, input; input = block.inputList[i]; i--) {
+  for (var i = curIdx, input; (input = block.inputList[i]); i--) {
     if (input.connection && input !== location) {
       return Blockly.ASTNode.createInputNode(input);
     }
     var fieldRow = input.fieldRow;
-    for (var j = fieldRow.length - 1, field; field = fieldRow[j]; j--) {
+    for (var j = fieldRow.length - 1, field; (field = fieldRow[j]); j--) {
       if (field.EDITABLE) {
         return Blockly.ASTNode.createFieldNode(field);
       }
@@ -352,7 +352,7 @@ Blockly.ASTNode.prototype.findPrevForField_ = function() {
   var curIdx = block.inputList.indexOf(
       /** @type {!Blockly.Input} */ (parentInput));
   var fieldIdx = parentInput.fieldRow.indexOf(location) - 1;
-  for (var i = curIdx, input; input = block.inputList[i]; i--) {
+  for (var i = curIdx, input; (input = block.inputList[i]); i--) {
     if (input.connection && input !== parentInput) {
       return Blockly.ASTNode.createInputNode(input);
     }
@@ -388,7 +388,7 @@ Blockly.ASTNode.prototype.navigateBetweenStacks_ = function(forward) {
   }
   var curRoot = curLocation.getRootBlock();
   var topBlocks = curRoot.workspace.getTopBlocks(true);
-  for (var i = 0, topBlock; topBlock = topBlocks[i]; i++) {
+  for (var i = 0, topBlock; (topBlock = topBlocks[i]); i++) {
     if (curRoot.id == topBlock.id) {
       var offset = forward ? 1 : -1;
       var resultIndex = i + offset;
@@ -459,9 +459,9 @@ Blockly.ASTNode.prototype.getOutAstNodeForBlock_ = function(block) {
  */
 Blockly.ASTNode.prototype.findFirstFieldOrInput_ = function(block) {
   var inputs = block.inputList;
-  for (var i = 0, input; input = inputs[i]; i++) {
+  for (var i = 0, input; (input = inputs[i]); i++) {
     var fieldRow = input.fieldRow;
-    for (var j = 0, field; field = fieldRow[j]; j++) {
+    for (var j = 0, field; (field = fieldRow[j]); j++) {
       if (field.EDITABLE) {
         return Blockly.ASTNode.createFieldNode(field);
       }

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -104,7 +104,7 @@ Blockly.user.keyMap.getActionByKeyCode = function(keyCode) {
  */
 Blockly.user.keyMap.getKeyByAction = function(action) {
   var keys = Object.keys(Blockly.user.keyMap.map_);
-  for (var i = 0, key; key = keys[i]; i++) {
+  for (var i = 0, key; (key = keys[i]); i++) {
     if (Blockly.user.keyMap.map_[key].name === action.name) {
       return key;
     }
@@ -120,7 +120,7 @@ Blockly.user.keyMap.getKeyByAction = function(action) {
 Blockly.user.keyMap.serializeKeyEvent = function(e) {
   var modifiers = Blockly.utils.object.values(Blockly.user.keyMap.modifierKeys);
   var key = '';
-  for (var i = 0, keyName; keyName = modifiers[i]; i++) {
+  for (var i = 0, keyName; (keyName = modifiers[i]); i++) {
     if (e.getModifierState(keyName)) {
       key += keyName;
     }
@@ -139,7 +139,7 @@ Blockly.user.keyMap.serializeKeyEvent = function(e) {
 Blockly.user.keyMap.createSerializedKey = function(keyCode, modifiers) {
   var key = '';
   var validModifiers = Blockly.utils.object.values(Blockly.user.keyMap.modifierKeys);
-  for (var i = 0, keyName; keyName = modifiers[i]; i++) {
+  for (var i = 0, keyName; (keyName = modifiers[i]); i++) {
     if (validModifiers.indexOf(keyName) > -1) {
       key += keyName;
     } else {

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -39,7 +39,6 @@ Blockly.TabNavigateCursor = function() {
 };
 Blockly.utils.object.inherits(Blockly.TabNavigateCursor, Blockly.Cursor);
 
-
 /**
  * Find the next node in the pre order traversal.
  * @override
@@ -67,7 +66,7 @@ Blockly.TabNavigateCursor.prototype.prev = function() {
     return null;
   }
   var newNode = this.getPreviousNode_(curNode);
-  
+
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -153,7 +152,6 @@ Blockly.TabNavigateCursor.prototype.getRightMostChild_ = function(node) {
     newNode = newNode.next();
   }
   return this.getRightMostChild_(newNode);
-
 };
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -142,7 +142,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   // Convert the list of names into a list of XML objects for the flyout.
   if (this.quarkNames_.length) {
     var quarkXml = Blockly.utils.xml.createElement('xml');
-    for (var i = 0, quarkName; quarkName = this.quarkNames_[i]; i++) {
+    for (var i = 0, quarkName; (quarkName = this.quarkNames_[i]); i++) {
       var element = Blockly.utils.xml.createElement('block');
       element.setAttribute('type', quarkName);
       quarkXml.appendChild(element);
@@ -290,7 +290,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
 
     this.rootBlock_ = this.block_.decompose(this.workspace_);
     var blocks = this.rootBlock_.getDescendants(false);
-    for (var i = 0, child; child = blocks[i]; i++) {
+    for (var i = 0, child; (child = blocks[i]); i++) {
       child.render();
     }
     // The root block should not be dragable or deletable.
@@ -356,7 +356,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;
-    for (var b = 0, block; block = blocks[b]; b++) {
+    for (var b = 0, block; (block = blocks[b]); b++) {
       var blockXY = block.getRelativeToSurfaceXY();
       var blockHW = block.getHeightWidth();
       if (blockXY.y + blockHW.height < MARGIN) {

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -307,7 +307,7 @@ Blockly.Procedures.mutateCallers = function(defBlock) {
   var name = procedureBlock.getProcedureDef()[0];
   var xmlElement = defBlock.mutationToDom(true);
   var callers = Blockly.Procedures.getCallers(name, defBlock.workspace);
-  for (var i = 0, caller; caller = callers[i]; i++) {
+  for (var i = 0, caller; (caller = callers[i]); i++) {
     var oldMutationDom = caller.mutationToDom();
     var oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
     caller.domToMutation(xmlElement);

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -216,8 +216,8 @@ Blockly.RenderedConnection.prototype.moveBy = function(dx, dy) {
 /**
  * Move this connection to the location given by its offset within the block and
  * the location of the block's top left corner.
- * @param {!Blockly.utils.Coordinate} blockTL The location of the top left corner
- *     of the block, in workspace coordinates.
+ * @param {!Blockly.utils.Coordinate} blockTL The location of the top left
+ *     corner of the block, in workspace coordinates.
  */
 Blockly.RenderedConnection.prototype.moveToOffset = function(blockTL) {
   this.moveTo(blockTL.x + this.offsetInBlock_.x,
@@ -344,8 +344,7 @@ Blockly.RenderedConnection.prototype.setTracking = function(doTracking) {
     this.trackedState_ = Blockly.RenderedConnection.TrackedState.TRACKED;
     return;
   }
-  if (this.trackedState_ == Blockly.RenderedConnection
-      .TrackedState.TRACKED) {
+  if (this.trackedState_ == Blockly.RenderedConnection.TrackedState.TRACKED) {
     this.db_.removeConnection(this, this.y);
   }
   this.trackedState_ = Blockly.RenderedConnection.TrackedState.UNTRACKED;

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -96,7 +96,7 @@ Blockly.ThemeManager.prototype.setTheme = function(theme) {
 
   // Refresh all registered Blockly UI components.
   for (var i = 0, keys = Object.keys(this.componentDB_),
-    key; key = keys[i]; i++) {
+    key; (key = keys[i]); i++) {
     for (var j = 0, component; (component = this.componentDB_[key][j]); j++) {
       var element = component.element;
       var propertyName = component.propertyName;

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -433,7 +433,7 @@ Blockly.Toolbox.prototype.position = function() {
 Blockly.Toolbox.prototype.syncTrees_ = function(treeIn, treeOut, pathToMedia) {
   var openNode = null;
   var lastElement = null;
-  for (var i = 0, childIn; childIn = treeIn.childNodes[i]; i++) {
+  for (var i = 0, childIn; (childIn = treeIn.childNodes[i]); i++) {
     if (!childIn.tagName) {
       // Skip over text.
       continue;
@@ -574,7 +574,7 @@ Blockly.Toolbox.prototype.updateColourFromTheme_ = function(opt_tree) {
   var tree = opt_tree || this.tree_;
   if (tree) {
     var children = tree.getChildren(false);
-    for (var i = 0, child; child = children[i]; i++) {
+    for (var i = 0, child; (child = children[i]); i++) {
       if (child.styleName) {
         this.setColourFromStyle_(child.styleName, child, '');
         this.addColour_();
@@ -621,7 +621,7 @@ Blockly.Toolbox.prototype.updateSelectedItemColour_ = function(tree) {
 Blockly.Toolbox.prototype.addColour_ = function(opt_tree) {
   var tree = opt_tree || this.tree_;
   var children = tree.getChildren(false);
-  for (var i = 0, child; child = children[i]; i++) {
+  for (var i = 0, child; (child = children[i]); i++) {
     var element = child.getRowElement();
     if (element) {
       if (this.hasColours_) {

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -430,7 +430,7 @@ Blockly.Trashcan.prototype.click = function() {
   }
 
   var xml = [];
-  for (var i = 0, text; text = this.contents_[i]; i++) {
+  for (var i = 0, text; (text = this.contents_[i]); i++) {
     xml[i] = Blockly.Xml.textToDom(text);
   }
   this.flyout.show(xml);

--- a/core/utils.js
+++ b/core/utils.js
@@ -574,7 +574,7 @@ Blockly.utils.getBlockTypeCounts = function(block, opt_stripFollowing) {
       descendants.splice(index, descendants.length - index);
     }
   }
-  for (var i = 0, checkBlock; checkBlock = descendants[i]; i++) {
+  for (var i = 0, checkBlock; (checkBlock = descendants[i]); i++) {
     if (typeCountsMap[checkBlock.type]) {
       typeCountsMap[checkBlock.type]++;
     } else {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -208,7 +208,7 @@ Blockly.VariableMap.prototype.createVariable = function(name,
  */
 Blockly.VariableMap.prototype.deleteVariable = function(variable) {
   var variableList = this.variableMap_[variable.type];
-  for (var i = 0, tempVar; tempVar = variableList[i]; i++) {
+  for (var i = 0, tempVar; (tempVar = variableList[i]); i++) {
     if (tempVar.getId() == variable.getId()) {
       variableList.splice(i, 1);
       Blockly.Events.fire(new Blockly.Events.VarDelete(variable));
@@ -228,7 +228,7 @@ Blockly.VariableMap.prototype.deleteVariableById = function(id) {
     // Check whether this variable is a function parameter before deleting.
     var variableName = variable.name;
     var uses = this.getVariableUsesById(id);
-    for (var i = 0, block; block = uses[i]; i++) {
+    for (var i = 0, block; (block = uses[i]); i++) {
       if (block.type == 'procedures_defnoreturn' ||
         block.type == 'procedures_defreturn') {
         var procedureName = block.getFieldValue('NAME');
@@ -301,7 +301,7 @@ Blockly.VariableMap.prototype.getVariable = function(name, opt_type) {
   var type = opt_type || '';
   var list = this.variableMap_[type];
   if (list) {
-    for (var j = 0, variable; variable = list[j]; j++) {
+    for (var j = 0, variable; (variable = list[j]); j++) {
       if (Blockly.Names.equals(variable.name, name)) {
         return variable;
       }
@@ -320,7 +320,7 @@ Blockly.VariableMap.prototype.getVariableById = function(id) {
   var keys = Object.keys(this.variableMap_);
   for (var i = 0; i < keys.length; i++ ) {
     var key = keys[i];
-    for (var j = 0, variable; variable = this.variableMap_[key][j]; j++) {
+    for (var j = 0, variable; (variable = this.variableMap_[key][j]); j++) {
       if (variable.getId() == id) {
         return variable;
       }

--- a/core/variables.js
+++ b/core/variables.js
@@ -107,7 +107,7 @@ Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
 Blockly.Variables.allDeveloperVariables = function(workspace) {
   var blocks = workspace.getAllBlocks(false);
   var variableHash = Object.create(null);
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     var getDeveloperVariables = block.getDeveloperVariables;
     if (!getDeveloperVariables && block.getDeveloperVars) {
       // August 2018: getDeveloperVars() was deprecated and renamed
@@ -194,7 +194,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
 
     if (Blockly.Blocks['variables_get']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
-      for (var i = 0, variable; variable = variableModelList[i]; i++) {
+      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
         var block = Blockly.utils.xml.createElement('block');
         block.setAttribute('type', 'variables_get');
         block.setAttribute('gap', 8);
@@ -411,7 +411,7 @@ Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
   var allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
-  for (var i = 0, variable; variable = allVariables[i]; i++) {
+  for (var i = 0, variable; (variable = allVariables[i]); i++) {
     if (variable.name.toLowerCase() == name && variable.type != type) {
       return variable;
     }
@@ -432,7 +432,7 @@ Blockly.Variables.nameUsedWithAnyType_ = function(name, workspace) {
   var allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
-  for (var i = 0, variable; variable = allVariables[i]; i++) {
+  for (var i = 0, variable; (variable = allVariables[i]); i++) {
     if (variable.name.toLowerCase() == name) {
       return variable;
     }

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -98,7 +98,7 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
     }
     if (Blockly.Blocks['variables_get_dynamic']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
-      for (var i = 0, variable; variable = variableModelList[i]; i++) {
+      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
         var block = Blockly.utils.xml.createElement('block');
         block.setAttribute('type', 'variables_get_dynamic');
         block.setAttribute('gap', 8);

--- a/core/warning.js
+++ b/core/warning.js
@@ -143,7 +143,7 @@ Blockly.Warning.prototype.createBubble = function() {
     // This cannot be done until the bubble is rendered on screen.
     var maxWidth = this.paragraphElement_.getBBox().width;
     for (var i = 0, textElement;
-      textElement = this.paragraphElement_.childNodes[i]; i++) {
+        (textElement = this.paragraphElement_.childNodes[i]); i++) {
 
       textElement.setAttribute('text-anchor', 'end');
       textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);

--- a/core/warning.js
+++ b/core/warning.js
@@ -143,7 +143,7 @@ Blockly.Warning.prototype.createBubble = function() {
     // This cannot be done until the bubble is rendered on screen.
     var maxWidth = this.paragraphElement_.getBBox().width;
     for (var i = 0, textElement;
-        (textElement = this.paragraphElement_.childNodes[i]); i++) {
+      (textElement = this.paragraphElement_.childNodes[i]); i++) {
 
       textElement.setAttribute('text-anchor', 'end');
       textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -136,7 +136,7 @@ Blockly.Workspace = function(opt_options) {
   this.themeManager_ = this.options.parentWorkspace ?
       this.options.parentWorkspace.getThemeManager() :
       new Blockly.ThemeManager(this.options.theme || Blockly.Themes.Classic);
-  
+
   this.themeManager_.subscribeWorkspace(this);
 
   /**
@@ -251,7 +251,7 @@ Blockly.Workspace.prototype.refreshTheme = function() {
  * @private
  */
 Blockly.Workspace.prototype.updateBlockStyles_ = function(blocks) {
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     var blockStyleName = block.getStyleName();
     if (blockStyleName) {
       block.setStyle(blockStyleName);
@@ -731,13 +731,13 @@ Blockly.Workspace.prototype.undo = function(redo) {
     events.push(inputStack.pop());
   }
   // Push these popped events on the opposite stack.
-  for (var i = 0, event; event = events[i]; i++) {
+  for (var i = 0, event; (event = events[i]); i++) {
     outputStack.push(event);
   }
   events = Blockly.Events.filter(events, redo);
   Blockly.Events.recordUndo = false;
   try {
-    for (var i = 0, event; event = events[i]; i++) {
+    for (var i = 0, event; (event = events[i]); i++) {
       event.run(redo);
     }
   } finally {
@@ -788,7 +788,7 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
       this.undoStack_.shift();
     }
   }
-  for (var i = 0, func; func = this.listeners_[i]; i++) {
+  for (var i = 0, func; (func = this.listeners_[i]); i++) {
     func(event);
   }
 };
@@ -842,7 +842,7 @@ Blockly.Workspace.prototype.getCommentById = function(id) {
 Blockly.Workspace.prototype.allInputsFilled = function(
     opt_shadowBlocksAreFilled) {
   var blocks = this.getTopBlocks(false);
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     if (!block.allInputsFilled(opt_shadowBlocksAreFilled)) {
       return false;
     }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1150,7 +1150,7 @@ Blockly.WorkspaceSvg.prototype.traceOn = function() {
 Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
   if (opt_state === undefined) {
     // Unhighlight all blocks.
-    for (var i = 0, block; block = this.highlightedBlocks_[i]; i++) {
+    for (var i = 0, block; (block = this.highlightedBlocks_[i]); i++) {
       block.setHighlighted(false);
     }
     this.highlightedBlocks_.length = 0;
@@ -1220,7 +1220,7 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
       do {
         var collide = false;
         var allBlocks = this.getAllBlocks(false);
-        for (var i = 0, otherBlock; otherBlock = allBlocks[i]; i++) {
+        for (var i = 0, otherBlock; (otherBlock = allBlocks[i]); i++) {
           var otherXY = otherBlock.getRelativeToSurfaceXY();
           if (Math.abs(blockX - otherXY.x) <= 1 &&
               Math.abs(blockY - otherXY.y) <= 1) {
@@ -1231,7 +1231,7 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
         if (!collide) {
           // Check for blocks in snap range to any of its connections.
           var connections = block.getConnections_(false);
-          for (var i = 0, connection; connection = connections[i]; i++) {
+          for (var i = 0, connection; (connection = connections[i]); i++) {
             var neighbour = connection.closest(Blockly.SNAP_RADIUS,
                 new Blockly.utils.Coordinate(blockX, blockY));
             if (neighbour.connection) {
@@ -1564,7 +1564,7 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function() {
   Blockly.Events.setGroup(true);
   var topBlocks = this.getTopBlocks(true);
   var cursorY = 0;
-  for (var i = 0, block; block = topBlocks[i]; i++) {
+  for (var i = 0, block; (block = topBlocks[i]); i++) {
     if (!block.isMovable()) {
       continue;
     }

--- a/core/xml.js
+++ b/core/xml.js
@@ -51,11 +51,11 @@ Blockly.Xml.workspaceToDom = function(workspace, opt_noId) {
     xml.appendChild(variablesElement);
   }
   var comments = workspace.getTopComments(true);
-  for (var i = 0, comment; comment = comments[i]; i++) {
+  for (var i = 0, comment; (comment = comments[i]); i++) {
     xml.appendChild(comment.toXmlWithXY(opt_noId));
   }
   var blocks = workspace.getTopBlocks(true);
-  for (var i = 0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; (block = blocks[i]); i++) {
     xml.appendChild(Blockly.Xml.blockToDomWithXY(block, opt_noId));
   }
   return xml;
@@ -69,7 +69,7 @@ Blockly.Xml.workspaceToDom = function(workspace, opt_noId) {
  */
 Blockly.Xml.variablesToDom = function(variableList) {
   var variables = Blockly.utils.xml.createElement('variables');
-  for (var i = 0, variable; variable = variableList[i]; i++) {
+  for (var i = 0, variable; (variable = variableList[i]); i++) {
     var element = Blockly.utils.xml.createElement('variable');
     element.appendChild(Blockly.utils.xml.createTextNode(variable.name));
     if (variable.type) {
@@ -125,8 +125,8 @@ Blockly.Xml.fieldToDom_ = function(field) {
  * @private
  */
 Blockly.Xml.allFieldsToDom_ = function(block, element) {
-  for (var i = 0, input; input = block.inputList[i]; i++) {
-    for (var j = 0, field; field = input.fieldRow[j]; j++) {
+  for (var i = 0, input; (input = block.inputList[i]); i++) {
+    for (var j = 0, field; (field = input.fieldRow[j]); j++) {
       var fieldDom = Blockly.Xml.fieldToDom_(field);
       if (fieldDom) {
         element.appendChild(fieldDom);
@@ -178,7 +178,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
     element.appendChild(dataElement);
   }
 
-  for (var i = 0, input; input = block.inputList[i]; i++) {
+  for (var i = 0, input; (input = block.inputList[i]); i++) {
     var container;
     var empty = true;
     if (input.type == Blockly.DUMMY_INPUT) {
@@ -402,7 +402,7 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   }
   var variablesFirst = true;
   try {
-    for (var i = 0, xmlChild; xmlChild = xml.childNodes[i]; i++) {
+    for (var i = 0, xmlChild; (xmlChild = xml.childNodes[i]); i++) {
       var name = xmlChild.nodeName.toLowerCase();
       var xmlChildElement = /** @type {!Element} */ (xmlChild);
       if (name == 'block' ||
@@ -595,7 +595,7 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
  *     should be added.
  */
 Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
-  for (var i = 0, xmlChild; xmlChild = xmlVariables.childNodes[i]; i++) {
+  for (var i = 0, xmlChild; (xmlChild = xmlVariables.childNodes[i]); i++) {
     if (xmlChild.nodeType != Blockly.utils.dom.Node.ELEMENT_NODE) {
       continue;  // Skip text nodes.
     }
@@ -625,7 +625,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   block = workspace.newBlock(prototypeName, id);
 
   var blockChild = null;
-  for (var i = 0, xmlChild; xmlChild = xmlBlock.childNodes[i]; i++) {
+  for (var i = 0, xmlChild; (xmlChild = xmlBlock.childNodes[i]); i++) {
     if (xmlChild.nodeType == Blockly.utils.dom.Node.TEXT_NODE) {
       // Ignore any text at the <block> level.  It's all whitespace anyway.
       continue;
@@ -635,7 +635,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     // Find any enclosed blocks or shadows in this tag.
     var childBlockElement = null;
     var childShadowElement = null;
-    for (var j = 0, grandchild; grandchild = xmlChild.childNodes[j]; j++) {
+    for (var j = 0, grandchild; (grandchild = xmlChild.childNodes[j]); j++) {
       if (grandchild.nodeType == Blockly.utils.dom.Node.ELEMENT_NODE) {
         if (grandchild.nodeName.toLowerCase() == 'block') {
           childBlockElement = /** @type {!Element} */ (grandchild);
@@ -771,7 +771,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
   if (xmlBlock.nodeName.toLowerCase() == 'shadow') {
     // Ensure all children are also shadows.
     var children = block.getChildren(false);
-    for (var i = 0, child; child = children[i]; i++) {
+    for (var i = 0, child; (child = children[i]); i++) {
       if (!child.isShadow()) {
         throw TypeError('Shadow block not allowed non-shadow child.');
       }
@@ -807,7 +807,7 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
  * @param {!Element} xmlBlock XML block element.
  */
 Blockly.Xml.deleteNext = function(xmlBlock) {
-  for (var i = 0, child; child = xmlBlock.childNodes[i]; i++) {
+  for (var i = 0, child; (child = xmlBlock.childNodes[i]); i++) {
     if (child.nodeName.toLowerCase() == 'next') {
       xmlBlock.removeChild(child);
       break;

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -33,7 +33,7 @@ suite('Procedures', function() {
         ['procedures_defreturn', 'procedures_callreturn']
       ];
 
-      for (var i = 0, types; types = typesArray[i]; i++) {
+      for (var i = 0, types; (types = typesArray[i]); i++) {
         var context = Object.create(null);
         context.workspace = this.workspace;
         context.defType = types[0];
@@ -392,7 +392,7 @@ suite('Procedures', function() {
           // TODO: Update this for typed vars.
           var variables = this.workspace.getVariablesOfType('');
           var variableMap = this.workspace.getVariableMap();
-          for (var i = 0, variable; variable = variables[i]; i++) {
+          for (var i = 0, variable; (variable = variables[i]); i++) {
             variableMap.deleteVariable(variable);
           }
         }

--- a/tests/mocha/xml_procedures_test.js
+++ b/tests/mocha/xml_procedures_test.js
@@ -34,7 +34,7 @@ suite('Procedures XML', function() {
           ['procedures_defreturn', 'procedures_callreturn']
         ];
 
-        for (var i = 0, types; types = typesArray[i]; i++) {
+        for (var i = 0, types; (types = typesArray[i]); i++) {
           var context = Object.create(null);
           context.workspace = this.workspace;
           context.defType = types[0];

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -442,7 +442,7 @@ suite('XML', function() {
         this.workspace.createVariable('name1', '', 'id1');
         var blocksArray = Blockly.Variables.flyoutCategoryBlocks(this.workspace);
         try {
-          for (var i = 0, xml; xml = blocksArray[i]; i++) {
+          for (var i = 0, xml; (xml = blocksArray[i]); i++) {
             Blockly.Xml.domToBlock(xml, this.workspace);
           }
         } finally {
@@ -509,7 +509,7 @@ suite('XML', function() {
         var blocksArray = Blockly.VariablesDynamic
             .flyoutCategoryBlocks(this.workspace);
         try {
-          for (var i = 0, xml; xml = blocksArray[i]; i++) {
+          for (var i = 0, xml; (xml = blocksArray[i]); i++) {
             Blockly.Xml.domToBlock(xml, this.workspace);
           }
         } finally {


### PR DESCRIPTION
Most linters wag their finger at inline assignments.  This catches stuff like:
```
if (foo = 42) {
```
Historically we've had to turn this feature off, since we have a lot of loops with the following construct:
```
for (var i = 0, foo; foo = foos[i]; i++) {
```
This PR wraps these assignments in parens:
```
for (var i = 0, foo; (foo = foos[i]); i++) {
```
This is a well-established code convention in other codebases, and is the default setting on the linter.  It adds no code bloat since the compiler strips the parens out.  The benefits are 1) it enables us to catch unintentional assignments (a few of these have bitten us over the years), and 2) it makes IDEs stop harassing developers.