### PR TITLE
Fix block colours in advanced compilation

### DIFF
--- a/core/theme.js
+++ b/core/theme.js
@@ -170,18 +170,18 @@ Blockly.Theme.validatedBlockStyle = function(blockStyle) {
 
   // Validate required properties.
   var parsedColour = Blockly.utils.colour.parseBlockColour(
-      valid.colourPrimary || '#000');
+      valid['colourPrimary'] || '#000');
   valid.colourPrimary = parsedColour.hex;
-  valid.colourSecondary = valid.colourSecondary ?
-      Blockly.utils.colour.parseBlockColour(valid.colourSecondary).hex :
+  valid.colourSecondary = valid['colourSecondary'] ?
+      Blockly.utils.colour.parseBlockColour(valid['colourSecondary']).hex :
       Blockly.utils.colour.blend('#fff', valid.colourPrimary, 0.6) ||
       valid.colourPrimary;
   valid.colourTertiary = valid.colourTertiary ?
-      Blockly.utils.colour.parseBlockColour(valid.colourTertiary).hex :
+      Blockly.utils.colour.parseBlockColour(valid['colourTertiary']).hex :
       Blockly.utils.colour.blend('#fff', valid.colourPrimary, 0.3) ||
       valid.colourPrimary;
 
-  valid.hat = valid.hat || '';
+  valid.hat = valid['hat'] || '';
   return valid;
 };
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3382

### Proposed Changes

Access the theme object properties with bracket notation so advanced compilation doesn't rename them.

@rachel-fenichel FYI

### Reason for Changes

Fixes colours in advanced compilation.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
