### PR TITLE
Fixed logic_compare type checks for disposed blocks

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -561,7 +561,7 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
       var prevA = this.prevBlocks_[0];
       if (prevA !== blockA) {
         blockA.unplug();
-        if (prevA && !prevA.isShadow()) {
+        if (prevA && !prevA.isDisposed() && !prevA.isShadow()) {
           // The shadow block is automatically replaced during unplug().
           this.getInput('A').connection.connect(prevA.outputConnection);
         }
@@ -569,7 +569,7 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
       var prevB = this.prevBlocks_[1];
       if (prevB !== blockB) {
         blockB.unplug();
-        if (prevB && !prevB.isShadow()) {
+        if (prevB && !prevB.isDisposed() && !prevB.isShadow()) {
           // The shadow block is automatically replaced during unplug().
           this.getInput('B').connection.connect(prevB.outputConnection);
         }

--- a/core/block.js
+++ b/core/block.js
@@ -844,6 +844,14 @@ Blockly.Block.prototype.setEditable = function(editable) {
 };
 
 /**
+ * Returns if this block has been disposed of / deleted.
+ * @return {boolean} True if this block has been disposed of / deleted.
+ */
+Blockly.Block.prototype.isDisposed = function() {
+  return this.disposed;
+};
+
+/**
  * Find the connection on this block that corresponds to the given connection
  * on the other block.
  * Used to match connections between a block and its insertion marker.


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #3392 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Adds an isDisposed() function to block.js
* Checks if the prev blocks are disposed before trying to reconnect them.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* The disposed property is package. Adding a wrapper function keeps it protected, and it keeps the API looking consistent (isShadow, isMovable, isEnabled, etc).
* Avoids connect errors.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Could not reproduce #3392

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
See note [here ](https://github.com/google/blockly/blob/ba6dfd812552e0823ed75f3dc5133a267cc6fbc9/core/connection.js#L298)about why this showed up as a "different workspaces" error.