### PR TITLE
Move the theme manager into WorkspaceSvg

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -26,8 +26,6 @@ goog.provide('Blockly.Workspace');
 goog.require('Blockly.Cursor');
 goog.require('Blockly.MarkerCursor');
 goog.require('Blockly.Events');
-goog.require('Blockly.ThemeManager');
-goog.require('Blockly.Themes.Classic');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
 goog.require('Blockly.VariableMap');
@@ -129,17 +127,6 @@ Blockly.Workspace = function(opt_options) {
   this.marker_ = new Blockly.MarkerCursor();
 
   /**
-   * Object in charge of storing and updating the workspace theme.
-   * @type {!Blockly.ThemeManager}
-   * @protected
-   */
-  this.themeManager_ = this.options.parentWorkspace ?
-      this.options.parentWorkspace.getThemeManager() :
-      new Blockly.ThemeManager(this.options.theme || Blockly.Themes.Classic);
-
-  this.themeManager_.subscribeWorkspace(this);
-
-  /**
    * True if keyboard accessibility mode is on, false otherwise.
    * @type {boolean}
    * @package
@@ -208,61 +195,6 @@ Blockly.Workspace.prototype.getMarker = function() {
 };
 
 /**
- * Get the workspace theme object.
- * @return {!Blockly.Theme} The workspace theme object.
- */
-Blockly.Workspace.prototype.getTheme = function() {
-  return this.themeManager_.getTheme();
-};
-
-/**
- * Set the workspace theme object.
- * If no theme is passed, default to the `Blockly.Themes.Classic` theme.
- * @param {Blockly.Theme} theme The workspace theme object.
- */
-Blockly.Workspace.prototype.setTheme = function(theme) {
-  if (!theme) {
-    theme = /** @type {!Blockly.Theme} */ (Blockly.Themes.Classic);
-  }
-  this.themeManager_.setTheme(theme);
-};
-
-/**
- * Refresh all blocks on the workspace after a theme update.
- * @package
- */
-Blockly.Workspace.prototype.refreshTheme = function() {
-  // Update all blocks in workspace that have a style name.
-  this.updateBlockStyles_(this.getAllBlocks(false).filter(
-      function(block) {
-        return block.getStyleName() !== undefined;
-      }
-  ));
-
-  var event = new Blockly.Events.Ui(null, 'theme', null, null);
-  event.workspaceId = this.id;
-  Blockly.Events.fire(event);
-};
-
-/**
- * Updates all the blocks with new style.
- * @param {!Array.<!Blockly.Block>} blocks List of blocks to update the style
- *     on.
- * @private
- */
-Blockly.Workspace.prototype.updateBlockStyles_ = function(blocks) {
-  for (var i = 0, block; (block = blocks[i]); i++) {
-    var blockStyleName = block.getStyleName();
-    if (blockStyleName) {
-      block.setStyle(blockStyleName);
-      if (block.mutator) {
-        block.mutator.updateBlockStyle();
-      }
-    }
-  }
-};
-
-/**
  * Dispose of this workspace.
  * Unlink from all DOM elements to prevent memory leaks.
  * @suppress {checkTypes}
@@ -272,15 +204,6 @@ Blockly.Workspace.prototype.dispose = function() {
   this.clear();
   // Remove from workspace database.
   delete Blockly.Workspace.WorkspaceDB_[this.id];
-
-  if (this.themeManager_) {
-    this.themeManager_.unsubscribeWorkspace(this);
-    this.themeManager_.unsubscribe(this.svgBackground_);
-    if (!this.options.parentWorkspace) {
-      this.themeManager_.dispose();
-      this.themeManager_ = null;
-    }
-  }
 };
 
 /**
@@ -910,13 +833,4 @@ Blockly.Workspace.getAll = function() {
     workspaces.push(Blockly.Workspace.WorkspaceDB_[workspaceId]);
   }
   return workspaces;
-};
-
-/**
- * Get the theme manager for this workspace.
- * @return {!Blockly.ThemeManager} The theme manager for this workspace.
- * @package
- */
-Blockly.Workspace.prototype.getThemeManager = function() {
-  return this.themeManager_;
 };

--- a/tests/jsunit/block_test.js
+++ b/tests/jsunit/block_test.js
@@ -252,21 +252,3 @@ function test_block_row_unplug_multi_inputs_child() {
     blockTest_tearDown();
   }
 }
-
-function test_set_style_throw_exception() {
-  blockTest_setUp();
-  var styleStub = {
-    getBlockStyle: function() {
-      return null;
-    }
-  };
-  mockControl_ = setUpMockMethod(workspace, 'getTheme', null, [styleStub]);
-  var blockA = workspace.newBlock('row_block');
-  try {
-    blockA.setStyle('styleOne');
-  } catch (error) {
-    assertEquals(error.message, 'Invalid style name: styleOne');
-  } finally {
-    blockTest_tearDown();
-  }
-}

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -21,11 +21,6 @@ goog.require('Blockly.Msg');
 suite('Procedures', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
-    this.workspace.setTheme(new Blockly.Theme({
-      "procedure_blocks": {
-        "colourPrimary": "290"
-      }
-    }));
 
     this.callForAllTypes = function(func, startName) {
       var typesArray = [
@@ -249,9 +244,7 @@ suite('Procedures', function() {
     });
     test('Multiple Workspaces', function() {
       this.callForAllTypes(function() {
-        var workspace = new Blockly.Workspace({
-          theme: this.workspace.getTheme()
-        });
+        var workspace = new Blockly.Workspace();
         var def2 = new Blockly.Block(workspace, this.defType);
         def2.setFieldValue('name', 'NAME');
         var caller2 = new Blockly.Block(workspace, this.callType);
@@ -293,9 +286,7 @@ suite('Procedures', function() {
     });
     test('Multiple Workspaces', function() {
       this.callForAllTypes(function() {
-        var workspace = new Blockly.Workspace({
-          theme: this.workspace.getTheme()
-        });
+        var workspace = new Blockly.Workspace();
         var def2 = new Blockly.Block(workspace, this.defType);
         def2.setFieldValue('name', 'NAME');
         var caller2 = new Blockly.Block(workspace, this.callType);

--- a/tests/mocha/xml_procedures_test.js
+++ b/tests/mocha/xml_procedures_test.js
@@ -22,11 +22,6 @@ suite('Procedures XML', function() {
   suite('Deserialization', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
-      this.workspace.setTheme(new Blockly.Theme({
-        "procedure_blocks": {
-          "colourPrimary": "290"
-        }
-      }));
 
       this.callForAllTypes = function(func) {
         var typesArray = [


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3380

### Proposed Changes

Moves the theme manager out of Workspace and into WorkspaceSvg, which also means there's no concept of a theme in headless mode.

This is originally how we would've done it but before https://github.com/google/blockly/pull/3357 we needed block styles in [Blockly.Block](https://github.com/google/blockly/pull/3357/files#diff-5148dfb78f1d110be97f1d3539fa647cR926)

### Reason for Changes

Cleaner code.

### Test Coverage

Tested playground.
Ran tests.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
