### PR TITLE
Add flag to navigate to all fields

### DIFF
--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -83,6 +83,12 @@ Blockly.ASTNode.types = {
 };
 
 /**
+ * True to navigate to all fields. False to only navigate to clickable fields.
+ * @type {boolean}
+ */
+Blockly.ASTNode.NAVIGATE_ALL_FIELDS = false;
+
+/**
  * The default y offset to use when moving the cursor from a stack to the
  * workspace.
  * @type {number}
@@ -272,7 +278,7 @@ Blockly.ASTNode.prototype.findNextForInput_ = function() {
   for (var i = curIdx + 1, input; (input = block.inputList[i]); i++) {
     var fieldRow = input.fieldRow;
     for (var j = 0, field; (field = fieldRow[j]); j++) {
-      if (field.EDITABLE) {
+      if (field.isClickable() || Blockly.ASTNode.NAVIGATE_ALL_FIELDS) {
         return Blockly.ASTNode.createFieldNode(field);
       }
     }
@@ -300,7 +306,7 @@ Blockly.ASTNode.prototype.findNextForField_ = function() {
   for (var i = curIdx, newInput; (newInput = block.inputList[i]); i++) {
     var fieldRow = newInput.fieldRow;
     while (fieldIdx < fieldRow.length) {
-      if (fieldRow[fieldIdx].EDITABLE) {
+      if (fieldRow[fieldIdx].isClickable() || Blockly.ASTNode.NAVIGATE_ALL_FIELDS) {
         return Blockly.ASTNode.createFieldNode(fieldRow[fieldIdx]);
       }
       fieldIdx++;
@@ -331,7 +337,7 @@ Blockly.ASTNode.prototype.findPrevForInput_ = function() {
     }
     var fieldRow = input.fieldRow;
     for (var j = fieldRow.length - 1, field; (field = fieldRow[j]); j--) {
-      if (field.EDITABLE) {
+      if (field.isClickable() || Blockly.ASTNode.NAVIGATE_ALL_FIELDS) {
         return Blockly.ASTNode.createFieldNode(field);
       }
     }
@@ -358,7 +364,7 @@ Blockly.ASTNode.prototype.findPrevForField_ = function() {
     }
     var fieldRow = input.fieldRow;
     while (fieldIdx > -1) {
-      if (fieldRow[fieldIdx].EDITABLE) {
+      if (fieldRow[fieldIdx].isClickable() || Blockly.ASTNode.NAVIGATE_ALL_FIELDS) {
         return Blockly.ASTNode.createFieldNode(fieldRow[fieldIdx]);
       }
       fieldIdx--;
@@ -462,7 +468,7 @@ Blockly.ASTNode.prototype.findFirstFieldOrInput_ = function(block) {
   for (var i = 0, input; (input = inputs[i]); i++) {
     var fieldRow = input.fieldRow;
     for (var j = 0, field; (field = fieldRow[j]); j++) {
-      if (field.EDITABLE) {
+      if (field.isClickable() || Blockly.ASTNode.NAVIGATE_ALL_FIELDS) {
         return Blockly.ASTNode.createFieldNode(field);
       }
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3339.
And adds support for #3344
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Use isClickable() instead of EDITABLE when navigating around the AST. 
Add a flag on ASTNode to support going through all fields or only going through clickable fields.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
