### PR TITLE
Delete two leftover constants in block_svg.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -170,13 +170,6 @@ Blockly.BlockSvg.INLINE = -1;
 Blockly.BlockSvg.COLLAPSED_WARNING_ID = 'TEMP_COLLAPSED_WARNING_';
 
 // Leftover UI constants from block_render_svg.js.
-/**
- * Vertical space between elements.
- * @const
- * @package
- */
-// TODO (#3142): Remove.
-Blockly.BlockSvg.SEP_SPACE_Y = 10;
 
 /**
  * Minimum height of a block.
@@ -185,13 +178,6 @@ Blockly.BlockSvg.SEP_SPACE_Y = 10;
  */
 // TODO (#3142): Remove.
 Blockly.BlockSvg.MIN_BLOCK_Y = 25;
-
-/**
- * Width of horizontal puzzle tab.
- * @package
- */
-// TODO (#3142): Remove.
-Blockly.BlockSvg.TAB_WIDTH = 8;
 
 /**
  * Do blocks with no previous or output connections have a 'hat' on top?
@@ -579,25 +565,17 @@ Blockly.BlockSvg.prototype.snapToGrid = function() {
  */
 Blockly.BlockSvg.prototype.getBoundingRectangle = function() {
   var blockXY = this.getRelativeToSurfaceXY();
-  var tab = this.outputConnection ? Blockly.BlockSvg.TAB_WIDTH : 0;
   var blockBounds = this.getHeightWidth();
-  var top = blockXY.y;
-  var bottom = blockXY.y + blockBounds.height;
   var left, right;
   if (this.RTL) {
-    // Width has the tab built into it already so subtract it here.
-    left = blockXY.x - (blockBounds.width - tab);
-    // Add the width of the tab/puzzle piece knob to the x coordinate
-    // since X is the corner of the rectangle, not the whole puzzle piece.
-    right = blockXY.x + tab;
+    left = blockXY.x - blockBounds.width;
+    right = blockXY.x;
   } else {
-    // Subtract the width of the tab/puzzle piece knob to the x coordinate
-    // since X is the corner of the rectangle, not the whole puzzle piece.
-    left = blockXY.x - tab;
-    // Width has the tab built into it already so subtract it here.
-    right = blockXY.x + blockBounds.width - tab;
+    left = blockXY.x;
+    right = blockXY.x + blockBounds.width;
   }
-  return new Blockly.utils.Rect(top, bottom, left, right);
+  return new Blockly.utils.Rect(
+      blockXY.y, blockXY.y + blockBounds.height, left, right);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -476,13 +476,7 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
   // First check if we have a workspaceSvg, otherwise the blocks have no shape
   // and the position does not matter.
   if (workspace.hasOwnProperty('scale')) {
-    var savetab = Blockly.BlockSvg.TAB_WIDTH;
-    try {
-      Blockly.BlockSvg.TAB_WIDTH = 0;
-      bbox = workspace.getBlocksBoundingBox();
-    } finally {
-      Blockly.BlockSvg.TAB_WIDTH = savetab;
-    }
+    bbox = workspace.getBlocksBoundingBox();
   }
   // Load the new blocks into the workspace and get the IDs of the new blocks.
   var newBlockIds = Blockly.Xml.domToWorkspace(xml, workspace);
@@ -494,6 +488,7 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
     // Check position of the new blocks.
     var newX = Infinity;  // x of top corner
     var newY = Infinity;  // y of top corner
+    var ySeparation = 10;
     for (var i = 0; i < newBlockIds.length; i++) {
       var blockXY =
           workspace.getBlockById(newBlockIds[i]).getRelativeToSurfaceXY();
@@ -504,7 +499,7 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
         newX = blockXY.x;
       }
     }
-    offsetY = farY - newY + Blockly.BlockSvg.SEP_SPACE_Y;
+    offsetY = farY - newY + ySeparation;
     offsetX = topX - newX;
     // move the new blocks to append them at the bottom
     var width;  // Not used in LTR.


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3142 
### Proposed Changes

Remove two constants: TAB_WIDTH and SEP_SPACE_Y.

### Reason for Changes

These were leftovers from block_render_svg, but we don't need them anymore.

Vertical separation of blocks during loading does not depend on the renderer and its constants.
Tab width no longer needs to be considered separately in `getHeightWidth` because it's handled in the rendering code.

### Test Coverage
Tested in the playground.