### PR TITLE
More zelos constants

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -451,6 +451,12 @@ Blockly.blockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
  * @protected
  */
 Blockly.blockRendering.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
+  if (!prev) {
+    // Statement input padding.
+    if (next && Blockly.blockRendering.Types.isStatementInput(next)) {
+      return this.constants_.STATEMENT_INPUT_PADDING_LEFT;
+    }
+  }
   // Between inputs and the end of the row.
   if (prev && Blockly.blockRendering.Types.isInput(prev) && !next) {
     if (Blockly.blockRendering.Types.isExternalInput(prev)) {

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -44,6 +44,26 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
+  this.SMALL_PADDING = this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.MEDIUM_PADDING = 2 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.MEDIUM_LARGE_PADDING = 3 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.LARGE_PADDING = 4 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
   this.CORNER_RADIUS = 1 * this.GRID_UNIT;
 
   /**
@@ -77,9 +97,20 @@ Blockly.zelos.ConstantProvider = function() {
   this.STATEMENT_BOTTOM_SPACER = -this.NOTCH_HEIGHT;
 
   /**
+   * Minimum statement input spacer width.
+   * @type {number}
+   */
+  this.STATEMENT_INPUT_SPACER_MIN_WIDTH = 30 * this.GRID_UNIT;
+
+  /**
    * @override
    */
-  this.AFTER_STATEMENT_BOTTOM_ROW_MIN_HEIGHT = this.LARGE_PADDING * 2;
+  this.STATEMENT_INPUT_PADDING_LEFT = 4 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.AFTER_STATEMENT_BOTTOM_ROW_MIN_HEIGHT = 7 * this.GRID_UNIT;
 
   /**
    * @override
@@ -90,6 +121,11 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.EMPTY_INLINE_INPUT_HEIGHT = 8 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.DUMMY_INPUT_MIN_HEIGHT = 6 * this.GRID_UNIT;
 
   /**
    * The ID of the highlight glow filter, or the empty string if no filter is

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -112,148 +112,6 @@ Blockly.zelos.RenderInfo.prototype.computeBounds_ = function() {
 /**
  * @override
  */
-Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
-  if (!prev || !next) {
-    // No need for padding at the beginning or end of the row if the
-    // output shape is dynamic.
-    if (this.outputConnection && this.outputConnection.isDynamicShape) {
-      return this.constants_.NO_PADDING;
-    }
-  }
-  if (!prev) {
-    // Between an editable field and the beginning of the row.
-    if (next && Blockly.blockRendering.Types.isField(next) && next.isEditable) {
-      return this.constants_.MEDIUM_PADDING;
-    }
-    // Inline input at the beginning of the row.
-    if (next && Blockly.blockRendering.Types.isInlineInput(next)) {
-      return this.constants_.MEDIUM_LARGE_PADDING;
-    }
-    if (next && Blockly.blockRendering.Types.isStatementInput(next)) {
-      return this.constants_.STATEMENT_INPUT_PADDING_LEFT;
-    }
-    // Anything else at the beginning of the row.
-    return this.constants_.LARGE_PADDING;
-  }
-
-  // Spacing between a non-input and the end of the row.
-  if (!Blockly.blockRendering.Types.isInput(prev) && !next) {
-    // Between an editable field and the end of the row.
-    if (Blockly.blockRendering.Types.isField(prev) && prev.isEditable) {
-      return this.constants_.MEDIUM_PADDING;
-    }
-    // Padding at the end of an icon-only row to make the block shape clearer.
-    if (Blockly.blockRendering.Types.isIcon(prev)) {
-      return (this.constants_.LARGE_PADDING * 2) + 1;
-    }
-    if (Blockly.blockRendering.Types.isHat(prev)) {
-      return this.constants_.NO_PADDING;
-    }
-    // Establish a minimum width for a block with a previous or next connection.
-    if (Blockly.blockRendering.Types.isPreviousOrNextConnection(prev)) {
-      return this.constants_.LARGE_PADDING;
-    }
-    // Between rounded corner and the end of the row.
-    if (Blockly.blockRendering.Types.isLeftRoundedCorner(prev)) {
-      return this.constants_.MIN_BLOCK_WIDTH;
-    }
-    // Between a jagged edge and the end of the row.
-    if (Blockly.blockRendering.Types.isJaggedEdge(prev)) {
-      return this.constants_.NO_PADDING;
-    }
-    // Between noneditable fields and icons and the end of the row.
-    return this.constants_.LARGE_PADDING;
-  }
-
-  // Between inputs and the end of the row.
-  if (Blockly.blockRendering.Types.isInput(prev) && !next) {
-    if (Blockly.blockRendering.Types.isExternalInput(prev)) {
-      return this.constants_.NO_PADDING;
-    } else if (Blockly.blockRendering.Types.isInlineInput(prev)) {
-      return this.constants_.LARGE_PADDING;
-    } else if (Blockly.blockRendering.Types.isStatementInput(prev)) {
-      return this.constants_.NO_PADDING;
-    }
-  }
-
-  // Spacing between a non-input and an input.
-  if (!Blockly.blockRendering.Types.isInput(prev) &&
-      next && Blockly.blockRendering.Types.isInput(next)) {
-    // Between an editable field and an input.
-    if (prev.isEditable) {
-      if (Blockly.blockRendering.Types.isInlineInput(next)) {
-        return this.constants_.MEDIUM_PADDING;
-      } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
-        return this.constants_.MEDIUM_PADDING;
-      }
-    } else {
-      if (Blockly.blockRendering.Types.isInlineInput(next)) {
-        return this.constants_.MEDIUM_LARGE_PADDING;
-      } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
-        return this.constants_.MEDIUM_LARGE_PADDING;
-      } else if (Blockly.blockRendering.Types.isStatementInput(next)) {
-        return this.constants_.LARGE_PADDING;
-      }
-    }
-    return this.constants_.LARGE_PADDING - 1;
-  }
-
-  // Spacing between an icon and an icon or field.
-  if (Blockly.blockRendering.Types.isIcon(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next)) {
-    return this.constants_.LARGE_PADDING;
-  }
-
-  // Spacing between an inline input and a field.
-  if (Blockly.blockRendering.Types.isInlineInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next)) {
-    // Editable field after inline input.
-    if (next.isEditable) {
-      return this.constants_.MEDIUM_PADDING;
-    } else {
-      // Noneditable field after inline input.
-      return this.constants_.LARGE_PADDING;
-    }
-  }
-
-  if (Blockly.blockRendering.Types.isLeftSquareCorner(prev) && next) {
-    // Spacing between a hat and a corner
-    if (Blockly.blockRendering.Types.isHat(next)) {
-      return this.constants_.NO_PADDING;
-    }
-    // Spacing between a square corner and a previous or next connection
-    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
-        Blockly.blockRendering.Types.isNextConnection(next)) {
-      return next.notchOffset;
-    }
-  }
-
-  // Spacing between a rounded corner and a previous or next connection.
-  if (Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
-    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
-        Blockly.blockRendering.Types.isNextConnection(next)) {
-      return next.notchOffset - this.constants_.CORNER_RADIUS;
-    }
-  }
-
-  // Spacing between two fields of the same editability.
-  if (!Blockly.blockRendering.Types.isInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next) &&
-      (prev.isEditable == next.isEditable)) {
-    return this.constants_.LARGE_PADDING;
-  }
-
-  // Spacing between anything and a jagged edge.
-  if (next && Blockly.blockRendering.Types.isJaggedEdge(next)) {
-    return this.constants_.LARGE_PADDING;
-  }
-
-  return this.constants_.MEDIUM_PADDING;
-};
-
-/**
- * @override
- */
 Blockly.zelos.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
   var height = this.getSpacerRowHeight_(prev, next);
   var width = this.getSpacerRowWidth_(prev, next);
@@ -291,10 +149,10 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
     return this.constants_.EMPTY_BLOCK_SPACER_HEIGHT;
   }
   // Top and bottom rows act as a spacer so we don't need any extra padding.
-  if ((Blockly.blockRendering.Types.isTopRow(prev) && !prev.hasPreviousConnection)) {
+  if ((Blockly.blockRendering.Types.isTopRow(prev))) {
     return this.constants_.NO_PADDING;
   }
-  if ((Blockly.blockRendering.Types.isBottomRow(next) && !next.hasNextConnection)) {
+  if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     return this.constants_.NO_PADDING;
   }
   return this.constants_.MEDIUM_PADDING;


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Zelos constants.

### Proposed Changes

More zelos constants.
Removing ``getInRowSpacing_`` from zelos as I don't see a need for anything more than the standard medium spacing between everything.
Also adding ``STATEMENT_INPUT_PADDING_LEFT`` to be considered by the common.
Remove top and bottom row spacers from Zelos.

### Reason for Changes

![Screen Shot 2019-11-08 at 10 49 11 AM](https://user-images.githubusercontent.com/16690124/68502510-6af17800-0215-11ea-9dc7-794e422899f8.png)

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
