### PR TITLE
Only log about a missing event group if we actually did something

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -311,7 +311,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
             object.moveBy(deltaX, deltaY);
           }
           if (e) {
-            if (!e.group) {
+            if (!e.group && object) {
               console.log('WARNING: Moved object in bounds but there was no' +
                   ' event group. This may break undo.');
             }


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Spurious warning.

### Proposed Changes
Only warn about a bad move if we actually moved the object.

### Reason for Changes
As it is the warning is actionable but wrong, which is not a good state.

### Test Coverage
Tested in the fixed playground.
