### PR TITLE
Fix setting focus for workspace

### DIFF
--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -73,7 +73,7 @@ Blockly.Menu.prototype.createDom = function() {
 Blockly.Menu.prototype.focus = function() {
   var el = this.getElement();
   if (el) {
-    el.focus();
+    el.focus({preventScroll:true});
     Blockly.utils.dom.addClass(el, 'focused');
   }
 };

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -334,7 +334,7 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
       this, this.dropdownDispose_.bind(this));
 
   // Focus so we can start receiving keyboard events.
-  this.picker_.focus();
+  this.picker_.focus({preventScroll:true});
 };
 
 /**
@@ -487,7 +487,7 @@ Blockly.FieldColour.prototype.onMouseMove_ = function(e) {
  * @private
  */
 Blockly.FieldColour.prototype.onMouseEnter_ = function() {
-  this.picker_.focus();
+  this.picker_.focus({preventScroll:true});
 };
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -234,7 +234,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   // Focusing needs to be handled after the menu is rendered and positioned.
   // Otherwise it will cause a page scroll to get the misplaced menu in
   // view. See issue #1329.
-  this.menu_.focus({preventScroll:true});
+  this.menu_.focus();
 
   // Scroll the dropdown to show the selected menu item.
   if (this.selectedMenuItem_) {

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -234,7 +234,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   // Focusing needs to be handled after the menu is rendered and positioned.
   // Otherwise it will cause a page scroll to get the misplaced menu in
   // view. See issue #1329.
-  this.menu_.focus();
+  this.menu_.focus({preventScroll:true});
 
   // Scroll the dropdown to show the selected menu item.
   if (this.selectedMenuItem_) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -269,7 +269,7 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
   this.isBeingEdited_ = true;
 
   if (!quietInput) {
-    this.htmlInput_.focus();
+    this.htmlInput_.focus({preventScroll:true});
     this.htmlInput_.select();
   }
 };
@@ -349,6 +349,10 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
   this.onKeyInputWrapper_ =
       Blockly.bindEventWithChecks_(
           htmlInput, 'input', this, this.onHtmlInputChange_);
+
+  this.onBlurInputWrapper_ =
+      Blockly.bindEventWithChecks_(
+          htmlInput, 'blur', this, this.onHtmlInputBlur_);
 };
 
 /**
@@ -361,6 +365,9 @@ Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
   }
   if (this.onKeyInputWrapper_) {
     Blockly.unbindEvent_(this.onKeyInputWrapper_);
+  }
+  if (this.onBlurInputWrapper_) {
+    Blockly.unbindEvent_(this.onBlurInputWrapper_);
   }
 };
 
@@ -404,6 +411,16 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
     this.forceRerender();
     Blockly.Events.setGroup(false);
   }
+};
+
+/**
+ * Handle blur for the editor.
+ * @param {!Event} _e Focus event.
+ * @protected
+ */
+Blockly.FieldTextInput.prototype.onHtmlInputBlur_ = function(_e) {
+  Blockly.WidgetDiv.hide();
+  Blockly.DropDownDiv.hideWithoutAnimation();
 };
 
 /**

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -483,12 +483,14 @@ Blockly.Gesture.prototype.doStart = function(e) {
     // dragged, the block was moved, the parent workspace zoomed, etc.
     this.startWorkspace_.resize();
   }
-  this.startWorkspace_.markFocused();
-  this.mostRecentEvent_ = e;
 
   // Hide chaff also hides the flyout, so don't do it if the click is in a
   // flyout.
   Blockly.hideChaff(!!this.flyout_);
+
+  this.startWorkspace_.markFocused();
+  this.mostRecentEvent_ = e;
+
   Blockly.Tooltip.block();
 
   if (this.targetBlock_) {

--- a/core/inject.js
+++ b/core/inject.js
@@ -78,16 +78,14 @@ Blockly.inject = function(container, opt_options) {
   Blockly.user.keyMap.setKeyMap(options.keyMap);
 
   Blockly.init_(workspace);
+
+  // Keep focus on the first workspace so entering keyboard navigation looks correct.
   Blockly.mainWorkspace = workspace;
 
   Blockly.svgResize(workspace);
 
-  subContainer.addEventListener('focus', function() {
+  subContainer.addEventListener('focusin', function() {
     Blockly.mainWorkspace = workspace;
-  });
-
-  subContainer.addEventListener('blur', function() {
-    Blockly.mainWorkspace = null;
   });
 
   return workspace;
@@ -127,7 +125,8 @@ Blockly.createDom_ = function(container, options) {
     'xmlns:html': Blockly.utils.dom.HTML_NS,
     'xmlns:xlink': Blockly.utils.dom.XLINK_NS,
     'version': '1.1',
-    'class': 'blocklySvg'
+    'class': 'blocklySvg',
+    'tabindex': '0'
   }, container);
   /*
   <defs>
@@ -183,7 +182,6 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);
-  Blockly.mainWorkspace = mainWorkspace;
 
   if (!options.readOnly && !mainWorkspace.isMovable()) {
     // Helper function for the workspaceChanged callback.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1874,7 +1874,7 @@ Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
   }
   try {
     // Focus the workspace SVG - this is for Chrome and Firefox.
-    this.getParentSvg().focus();
+    this.getParentSvg().focus({preventScroll:true});
   } catch (e) {
     // IE and Edge do not support focus on SVG elements. When that fails
     // above, get the injectionDiv (the workspace's parent) and focus that
@@ -1886,7 +1886,7 @@ Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
     } catch (e) {
       // setActive support was discontinued in Edge so when that fails, call
       // focus instead.
-      this.getParentSvg().parentNode.focus();
+      this.getParentSvg().parentNode.focus({preventScroll:true});
     }
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3364.

### Proposed Changes
1. Use focusin and don't set the mainWorkspace on focusout
2. Add prevent scroll to focus 
3. hideChaff before marking workspace 
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
