### PR TITLE
Move highlightForReplacement into the path object as well.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1756,11 +1756,5 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
  * @package
  */
 Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
-  if (add) {
-    Blockly.utils.dom.addClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyReplaceable');
-  } else {
-    Blockly.utils.dom.removeClass(/** @type {!Element} */ (this.svgGroup_),
-        'blocklyReplaceable');
-  }
+  this.pathObject.updateReplacementHighlight(add);
 };

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -119,4 +119,4 @@ Blockly.blockRendering.IPathObject.prototype.updateMovable;
  * @param {boolean} enable True if styling should be added.
  * @package
  */
-Blockly.blockRendering.PathObject.prototype.updateReplacementHighlight;
+Blockly.blockRendering.IPathObject.prototype.updateReplacementHighlight;

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -111,3 +111,12 @@ Blockly.blockRendering.IPathObject.prototype.updateInsertionMarker;
  * @package
  */
 Blockly.blockRendering.IPathObject.prototype.updateMovable;
+
+/**
+ * Add or remove styling that shows that if the dragging block is dropped, this
+ * block will be replaced.  If a shadow block, it will disappear.  Otherwise it
+ * will bump.
+ * @param {boolean} enable True if styling should be added.
+ * @package
+ */
+Blockly.blockRendering.PathObject.prototype.updateReplacementHighlight;

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -221,3 +221,15 @@ Blockly.blockRendering.PathObject.prototype.updateMovable = function(enable) {
   this.setClass_('blocklyDraggable', enable);
 };
 
+/**
+ * Add or remove styling that shows that if the dragging block is dropped, this
+ * block will be replaced.  If a shadow block, it will disappear.  Otherwise it
+ * will bump.
+ * @param {boolean} enable True if styling should be added.
+ * @package
+ */
+Blockly.blockRendering.PathObject.prototype.updateReplacementHighlight =
+    function(enable) {
+    /* eslint-disable indent */
+  this.setClass_('blocklyReplaceable', enable);
+}; /* eslint-enable indent */


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
### Proposed Changes

Move highlightForReplacement into the path object so that it can use setClass.

### Reason for Changes

Renderers should be able to make decisions about what it looks like to highlight a block for replacement.

### Test Coverage
Checked in the playground.