### PR TITLE
Fixed bubble dispose

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -79,6 +79,13 @@ Blockly.Bubble = function(workspace, content, shape, anchorXY,
    */
   this.onMouseDownResizeWrapper_ = null;
 
+  /**
+   * Describes whether this bubble has been disposed of (nodes and event
+   * listeners removed from the page) or not.
+   * @type {boolean}
+   */
+  this.disposed = false;
+
   var angle = Blockly.Bubble.ARROW_ANGLE;
   if (this.workspace_.RTL) {
     angle = -angle;
@@ -804,6 +811,7 @@ Blockly.Bubble.prototype.dispose = function() {
   }
   Blockly.Bubble.unbindDragEvents_();
   Blockly.utils.dom.removeNode(this.bubbleGroup_);
+  this.disposed = true;
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -796,24 +796,14 @@ Blockly.Bubble.prototype.setColour = function(hexColour) {
  * Dispose of this bubble.
  */
 Blockly.Bubble.prototype.dispose = function() {
-  Blockly.Bubble.unbindDragEvents_();
-  // Dispose of and unlink the bubble.
-  Blockly.utils.dom.removeNode(this.bubbleGroup_);
   if (this.onMouseDownBubbleWrapper_) {
     Blockly.unbindEvent_(this.onMouseDownBubbleWrapper_);
-    this.onMouseDownBubbleWrapper_ = null;
   }
   if (this.onMouseDownResizeWrapper_) {
     Blockly.unbindEvent_(this.onMouseDownResizeWrapper_);
-    this.onMouseDownResizeWrapper_ = null;
   }
-  this.bubbleGroup_ = null;
-  this.bubbleArrow_ = null;
-  this.bubbleBack_ = null;
-  this.resizeGroup_ = null;
-  this.workspace_ = null;
-  this.content_ = null;
-  this.shape_ = null;
+  Blockly.Bubble.unbindDragEvents_();
+  Blockly.utils.dom.removeNode(this.bubbleGroup_);
 };
 
 /**

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -83,6 +83,7 @@ Blockly.Bubble = function(workspace, content, shape, anchorXY,
    * Describes whether this bubble has been disposed of (nodes and event
    * listeners removed from the page) or not.
    * @type {boolean}
+   * @package
    */
   this.disposed = false;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2512

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes null settings from Bubble dispose.
Adds a `disposed` property to the bubble.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Unnecessary code is sad.
It's nice to be able to know when something is disposed.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
This shouldn't change any functionality.

I tested this doing the following stress test while running a profile.
```
      function memoryStrike(n) {
        var toggleCount = 0;
        var block = /** @type Blockly.BlockSvg */Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
          '<block type="controls_if">' +
          '  <comment pinned="false" h="80" w="160">test</comment>' +
          '</block>'), workspace);
        for (var i = 0; i < 1000; i++) {
          block.commentIcon_.setVisible(true);
          block.commentIcon_.setVisible(false);
          toggleCount++;
        }
        console.log(toggleCount);
      }
```

Profiles are the same (within a margin of error):
[Profile-Orig.zip](https://github.com/google/blockly/files/3834041/Profile-Orig.zip) 91 listeners, 15161 nodes.
[Profile-New.zip](https://github.com/google/blockly/files/3834053/Profile-New.zip) 91 listeners, 15119 nodes.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This is the part I messed up in #3427! Comments were good, bubbles were bad. All sorted ε-(´o｀)ﾌ
