### PR TITLE
Statement input height

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -590,6 +590,7 @@ Blockly.blockRendering.RenderInfo.prototype.alignStatementRow_ = function(row) {
   var rightCornerWidth = this.constants_.INSIDE_CORNERS.rightWidth || 0;
   desiredWidth = this.width - this.startX - rightCornerWidth;
   statementInput.width += (desiredWidth - currentWidth);
+  statementInput.height = Math.max(statementInput.height, row.height);
   row.width += (desiredWidth - currentWidth);
   row.widthWithConnectedBlocks = Math.max(row.width,
       this.statementEdge + row.connectedBlockWidths);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Set statement input height to be the max of the default statement input height and the row height.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

![Screen Shot 2019-11-12 at 3 52 46 PM](https://user-images.githubusercontent.com/16690124/68720629-bf259080-0564-11ea-8d9b-7eabc8a359f2.png)


