### PR TITLE
Move cursorSvg and markerSvg to pathObject

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -109,22 +109,6 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   if (this.svgGroup_.dataset) {
     this.svgGroup_.dataset['id'] = this.id;
   }
-
-  /**
-   * Holds the cursors svg element when the cursor is attached to the block.
-   * This is null if there is no cursor on the block.
-   * @type {SVGElement}
-   * @private
-   */
-  this.cursorSvg_ = null;
-
-  /**
-   * Holds the markers svg element when the marker is attached to the block.
-   * This is null if there is no marker on the block.
-   * @type {SVGElement}
-   * @private
-   */
-  this.markerSvg_ = null;
 };
 Blockly.utils.object.inherits(Blockly.BlockSvg, Blockly.Block);
 
@@ -1700,13 +1684,7 @@ Blockly.BlockSvg.prototype.updateConnectionLocations_ = function() {
  * @package
  */
 Blockly.BlockSvg.prototype.setCursorSvg = function(cursorSvg) {
-  if (!cursorSvg) {
-    this.cursorSvg_ = null;
-    return;
-  }
-
-  this.svgGroup_.appendChild(cursorSvg);
-  this.cursorSvg_ = cursorSvg;
+  this.pathObject.setCursorSvg(cursorSvg);
 };
 
 /**
@@ -1716,17 +1694,7 @@ Blockly.BlockSvg.prototype.setCursorSvg = function(cursorSvg) {
  * @package
  */
 Blockly.BlockSvg.prototype.setMarkerSvg = function(markerSvg) {
-  if (!markerSvg) {
-    this.markerSvg_ = null;
-    return;
-  }
-
-  if (this.cursorSvg_) {
-    this.svgGroup_.insertBefore(markerSvg, this.cursorSvg_);
-  } else {
-    this.svgGroup_.appendChild(markerSvg);
-  }
-  this.markerSvg_ = markerSvg;
+  this.pathObject.setMarkerSvg(markerSvg);
 };
 
 /**

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -67,6 +67,22 @@ Blockly.blockRendering.IPathObject.prototype.setStyle;
 Blockly.blockRendering.IPathObject.prototype.flipRTL;
 
 /**
+ * Add the cursor svg to this block's svg group.
+ * @param {SVGElement} cursorSvg The svg root of the cursor to be added to the
+ *     block svg group.
+ * @package
+ */
+Blockly.blockRendering.IPathObject.prototype.setCursorSvg;
+
+/**
+ * Add the marker svg to this block's svg group.
+ * @param {SVGElement} markerSvg The svg root of the marker to be added to the
+ *     block svg group.
+ * @package
+ */
+Blockly.blockRendering.IPathObject.prototype.setMarkerSvg;
+
+/**
  * Set whether the block shows a highlight or not.  Block highlighting is
  * often used to visually mark blocks currently being executed.
  * @param {boolean} highlighted True if highlighted.

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -64,6 +64,22 @@ Blockly.blockRendering.PathObject = function(root, constants) {
    * @package
    */
   this.style = Blockly.Theme.createBlockStyle('#000000');
+
+  /**
+   * Holds the cursors svg element when the cursor is attached to the block.
+   * This is null if there is no cursor on the block.
+   * @type {SVGElement}
+   * @private
+   */
+  this.cursorSvg_ = null;
+
+  /**
+   * Holds the markers svg element when the marker is attached to the block.
+   * This is null if there is no marker on the block.
+   * @type {SVGElement}
+   * @private
+   */
+  this.markerSvg_ = null;
 };
 
 /**
@@ -82,6 +98,42 @@ Blockly.blockRendering.PathObject.prototype.setPath = function(pathString) {
 Blockly.blockRendering.PathObject.prototype.flipRTL = function() {
   // Mirror the block's path.
   this.svgPath.setAttribute('transform', 'scale(-1 1)');
+};
+
+/**
+ * Add the cursor svg to this block's svg group.
+ * @param {SVGElement} cursorSvg The svg root of the cursor to be added to the
+ *     block svg group.
+ * @package
+ */
+Blockly.blockRendering.PathObject.prototype.setCursorSvg = function(cursorSvg) {
+  if (!cursorSvg) {
+    this.cursorSvg_ = null;
+    return;
+  }
+
+  this.svgRoot.appendChild(cursorSvg);
+  this.cursorSvg_ = cursorSvg;
+};
+
+/**
+ * Add the marker svg to this block's svg group.
+ * @param {SVGElement} markerSvg The svg root of the marker to be added to the
+ *     block svg group.
+ * @package
+ */
+Blockly.blockRendering.PathObject.prototype.setMarkerSvg = function(markerSvg) {
+  if (!markerSvg) {
+    this.markerSvg_ = null;
+    return;
+  }
+
+  if (this.cursorSvg_) {
+    this.svgRoot.insertBefore(markerSvg, this.cursorSvg_);
+  } else {
+    this.svgRoot.appendChild(markerSvg);
+  }
+  this.markerSvg_ = markerSvg;
 };
 
 /**


### PR DESCRIPTION


## The basics


- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Move cursor svg and marker svg into the path object.

### Reason for Changes

Moving markers and cursors into rendering generally.

### Test Coverage
Tested in playground with zelos and thrasos.