### PR TITLE
Highlight input shape in Zelos

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1730,28 +1730,6 @@ Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
 };
 
 /**
- * Determine whether or not to highlight a connection.
- * @param {Blockly.Connection} conn The connection on the input to determine
- *     whether or not to highlight.
- * @return {boolean} Whether or not to highlight the connection.
- * @package
- */
-Blockly.BlockSvg.prototype.shouldHighlightConnection = function(conn) {
-  return this.workspace.getRenderer().shouldHighlightConnection(conn);
-};
-
-/**
- * Determine whether or not to insert a dragged block into a stack.
- * @param {!Blockly.Block} block The target block.
- * @param {!Blockly.Connection} conn The closest connection.
- * @return {boolean} True if we should insert the dragged block into the stack.
- * @package
- */
-Blockly.BlockSvg.prototype.shouldInsertDraggedBlock = function(block, conn) {
-  return this.workspace.getRenderer().shouldInsertDraggedBlock(block, conn);
-};
-
-/**
  * Visual effect to show that if the dragging block is dropped it will connect
  * to this input.
  * @param {Blockly.Connection} conn The connection on the input to highlight.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1739,3 +1739,25 @@ Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
 Blockly.BlockSvg.prototype.shouldHighlightConnection = function(conn) {
   return this.workspace.getRenderer().shouldHighlightConnection(conn);
 };
+
+/**
+ * Determine whether or not to insert a dragged block into a stack.
+ * @param {Blockly.Block} block The target block.
+ * @param {Blockly.Connection} conn The closest connection.
+ * @return {boolean} True if we should insert the dragged block into the stack.
+ * @package
+ */
+Blockly.BlockSvg.prototype.shouldInsertDraggedBlock = function(block, conn) {
+  return this.workspace.getRenderer().shouldInsertDraggedBlock(block, conn);
+};
+
+/**
+ * Visual effect to show that if the dragging block is dropped it will connect
+ * to this input.
+ * @param {Blockly.Connection} conn The connection on the input to highlight.
+ * @param {boolean} add True if highlighting should be added.
+ * @package
+ */
+Blockly.BlockSvg.prototype.highlightShapeForInput = function(conn, add) {
+  this.pathObject.updateShapeForInputHighlight(conn, add);
+};

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1742,8 +1742,8 @@ Blockly.BlockSvg.prototype.shouldHighlightConnection = function(conn) {
 
 /**
  * Determine whether or not to insert a dragged block into a stack.
- * @param {Blockly.Block} block The target block.
- * @param {Blockly.Connection} conn The closest connection.
+ * @param {!Blockly.Block} block The target block.
+ * @param {!Blockly.Connection} conn The closest connection.
  * @return {boolean} True if we should insert the dragged block into the stack.
  * @package
  */

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -409,7 +409,7 @@ Blockly.InsertionMarkerManager.prototype.shouldReplace_ = function() {
   if (local.type == Blockly.OUTPUT_VALUE) {
     // Insert the dragged block into the stack if possible.
     if (closest &&
-        local.getSourceBlock()
+        this.workspace_.getRenderer()
             .shouldInsertDraggedBlock(this.topBlock_, closest)) {
       return false; // Insert.
     }
@@ -505,8 +505,8 @@ Blockly.InsertionMarkerManager.prototype.showPreview_ = function() {
   }
   // Also highlight the actual connection, as a nod to previous behaviour.
   if (this.closestConnection_ && this.closestConnection_.targetBlock() &&
-      this.closestConnection_.targetBlock()
-          .shouldHighlightConnection(this.closestConnection_)) {
+    this.workspace_.getRenderer()
+        .shouldHighlightConnection(this.closestConnection_)) {
     this.closestConnection_.highlight();
   }
 };
@@ -551,7 +551,7 @@ Blockly.InsertionMarkerManager.prototype.maybeHidePreview_ = function(candidate)
  */
 Blockly.InsertionMarkerManager.prototype.hidePreview_ = function() {
   if (this.closestConnection_ && this.closestConnection_.targetBlock() &&
-      this.closestConnection_.targetBlock()
+      this.workspace_.getRenderer()
           .shouldHighlightConnection(this.closestConnection_)) {
     this.closestConnection_.unhighlight();
   }

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -408,9 +408,8 @@ Blockly.InsertionMarkerManager.prototype.shouldReplace_ = function() {
   // Dragging a block over an existing block in an input.
   if (local.type == Blockly.OUTPUT_VALUE) {
     // Insert the dragged block into the stack if possible.
-    if (!closest.isConnected() ||
-      Blockly.Connection.lastConnectionInRow(this.topBlock_,
-          closest.targetConnection.getSourceBlock())) {
+    if (local.getSourceBlock().shouldInsertDraggedBlock(this.topBlock_,
+        closest)) {
       return false; // Insert.
     }
     // Otherwise replace the existing block and bump it out.
@@ -574,8 +573,7 @@ Blockly.InsertionMarkerManager.prototype.highlightBlock_ = function() {
     closest.targetBlock().highlightForReplacement(true);
   } else if (local.type == Blockly.OUTPUT_VALUE) {
     this.highlightedBlock_ = closest.getSourceBlock();
-    // TODO: Bring this back for zelos rendering.
-    // closest.getSourceBlock().highlightShapeForInput(closest, true);
+    closest.getSourceBlock().highlightShapeForInput(closest, true);
   }
   this.highlightingBlock_ = true;
 };
@@ -589,8 +587,7 @@ Blockly.InsertionMarkerManager.prototype.unhighlightBlock_ = function() {
   // If there's no block in place, but we're still connecting to a value input,
   // then we must have been highlighting an input shape.
   if (closest.type == Blockly.INPUT_VALUE && !closest.isConnected()) {
-    // TODO: Bring this back for zelos rendering.
-    // this.highlightedBlock_.highlightShapeForInput(closest, false);
+    this.highlightedBlock_.highlightShapeForInput(closest, false);
   } else {
     this.highlightedBlock_.highlightForReplacement(false);
   }

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -408,8 +408,9 @@ Blockly.InsertionMarkerManager.prototype.shouldReplace_ = function() {
   // Dragging a block over an existing block in an input.
   if (local.type == Blockly.OUTPUT_VALUE) {
     // Insert the dragged block into the stack if possible.
-    if (local.getSourceBlock().shouldInsertDraggedBlock(this.topBlock_,
-        closest)) {
+    if (closest &&
+        local.getSourceBlock()
+            .shouldInsertDraggedBlock(this.topBlock_, closest)) {
       return false; // Insert.
     }
     // Otherwise replace the existing block and bump it out.

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -505,8 +505,8 @@ Blockly.InsertionMarkerManager.prototype.showPreview_ = function() {
   }
   // Also highlight the actual connection, as a nod to previous behaviour.
   if (this.closestConnection_ && this.closestConnection_.targetBlock() &&
-    this.workspace_.getRenderer()
-        .shouldHighlightConnection(this.closestConnection_)) {
+      this.workspace_.getRenderer()
+          .shouldHighlightConnection(this.closestConnection_)) {
     this.closestConnection_.highlight();
   }
 };

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -265,3 +265,16 @@ Blockly.blockRendering.PathObject.prototype.updateReplacementHighlight =
     /* eslint-disable indent */
   this.setClass_('blocklyReplaceable', enable);
 }; /* eslint-enable indent */
+
+/**
+ * Add or remove styling that shows that if the dragging block is dropped, this
+ * block will be connected to the input.
+ * @param {Blockly.Connection} _conn The connection on the input to highlight.
+ * @param {boolean} _enable True if styling should be added.
+ * @package
+ */
+Blockly.blockRendering.PathObject.prototype.updateShapeForInputHighlight =
+    function(_conn, _enable) {
+    /* eslint-disable indent */
+  // NOP
+}; /* eslint-enable indent */

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -154,8 +154,8 @@ Blockly.blockRendering.Renderer.prototype.shouldHighlightConnection =
 
 /**
  * Determine whether or not to insert a dragged block into a stack.
- * @param {Blockly.Block} block The target block.
- * @param {Blockly.Connection} conn The closest connection.
+ * @param {!Blockly.Block} block The target block.
+ * @param {!Blockly.Connection} conn The closest connection.
  * @return {boolean} True if we should insert the dragged block into the stack.
  * @package
  */
@@ -163,7 +163,7 @@ Blockly.blockRendering.Renderer.prototype.shouldInsertDraggedBlock =
     function(block, conn) {
     /* eslint-disable indent */
   return !conn.isConnected() ||
-    Blockly.Connection.lastConnectionInRow(block,
+    !!Blockly.Connection.lastConnectionInRow(block,
         conn.targetConnection.getSourceBlock());
 }; /* eslint-enable indent */
 

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -153,6 +153,21 @@ Blockly.blockRendering.Renderer.prototype.shouldHighlightConnection =
 }; /* eslint-enable indent */
 
 /**
+ * Determine whether or not to insert a dragged block into a stack.
+ * @param {Blockly.Block} block The target block.
+ * @param {Blockly.Connection} conn The closest connection.
+ * @return {boolean} True if we should insert the dragged block into the stack.
+ * @package
+ */
+Blockly.blockRendering.Renderer.prototype.shouldInsertDraggedBlock =
+    function(block, conn) {
+    /* eslint-disable indent */
+  return !conn.isConnected() ||
+    Blockly.Connection.lastConnectionInRow(block,
+        conn.targetConnection.getSourceBlock());
+}; /* eslint-enable indent */
+
+/**
  * Render the block.
  * @param {!Blockly.BlockSvg} block The block to render.
  * @package

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -132,6 +132,24 @@ Blockly.zelos.PathObject.prototype.updateReplacementHighlight = function(
 };
 
 /**
+ * @override
+ */
+Blockly.zelos.PathObject.prototype.updateShapeForInputHighlight = function(
+    conn, enable) {
+  var name = conn.getParentInput().name;
+  var outlinePath = this.getOutlinePath_(name);
+  if (!outlinePath) {
+    return;
+  }
+  if (enable) {
+    outlinePath.setAttribute('filter',
+        'url(#' + this.constants_.replacementGlowFilterId + ')');
+  } else {
+    outlinePath.removeAttribute('filter');
+  }
+};
+
+/**
  * Method that's called when the drawer is about to draw the block.
  * @package
  */

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -98,4 +98,12 @@ Blockly.zelos.Renderer.prototype.shouldHighlightConnection = function(conn) {
   return conn.type != Blockly.INPUT_VALUE && conn.type !== Blockly.OUTPUT_VALUE;
 };
 
+/**
+ * @override
+ */
+Blockly.zelos.Renderer.prototype.shouldInsertDraggedBlock = function(_block,
+    _conn) {
+  return false;
+};
+
 Blockly.blockRendering.register('zelos', Blockly.zelos.Renderer);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Highlight input shape in zelos.

### Proposed Changes

Highlight input shape on drag in Zelos.

Add a method on the block and the renderer that determines whether or not to insert a dragged block into a stack. We could consider moving these into an object that defines how the insertion marker does its work if we get more of these.

### Reason for Changes

![Screen Shot 2019-11-14 at 11 27 09 AM](https://user-images.githubusercontent.com/16690124/68889426-be5e3d00-06d1-11ea-8c73-f13573e5ee87.png)


### Test Coverage
Tested geras and zelos in playground.
Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
