### PR TITLE
Fix up more zelos spacing

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -82,8 +82,29 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.STATEMENT_INPUT_PADDING_LEFT = 20;
   this.BETWEEN_STATEMENT_PADDING_Y = 4;
 
-  // The minimum height of the bottom row following a statement input.
-  this.AFTER_STATEMENT_BOTTOM_ROW_MIN_HEIGHT = this.LARGE_PADDING;
+  /**
+   * The top row's minimum height.
+   * @type {number}
+   */
+  this.TOP_ROW_MIN_HEIGHT = this.MEDIUM_PADDING;
+
+  /**
+   * The top row's minimum height if it precedes a statement.
+   * @type {number}
+   */
+  this.TOP_ROW_PRECEDES_STATEMENT_MIN_HEIGHT = this.LARGE_PADDING;
+
+  /**
+   * The bottom row's minimum height.
+   * @type {number}
+   */
+  this.BOTTOM_ROW_MIN_HEIGHT = this.MEDIUM_PADDING;
+
+  /**
+   * The bottom row's minimum height if it follows a statement input.
+   * @type {number}
+   */
+  this.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = this.LARGE_PADDING;
 
   // This is the max width of a bottom row that follows a statement input and
   // has inputs inline.

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -286,9 +286,10 @@ Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
   // This is the minimum height for the row. If one of its elements has a
   // greater height it will be overwritten in the compute pass.
   if (precedesStatement && !this.block_.isCollapsed()) {
-    this.topRow.minHeight = this.constants_.LARGE_PADDING;
+    this.topRow.minHeight =
+        this.constants_.TOP_ROW_PRECEDES_STATEMENT_MIN_HEIGHT;
   } else {
-    this.topRow.minHeight = this.constants_.MEDIUM_PADDING;
+    this.topRow.minHeight = this.constants_.TOP_ROW_MIN_HEIGHT;
   }
 
   var rightSquareCorner = this.topRow.hasRightSquareCorner(this.block_);
@@ -318,9 +319,9 @@ Blockly.blockRendering.RenderInfo.prototype.populateBottomRow_ = function() {
   // greater height it will be overwritten in the compute pass.
   if (followsStatement) {
     this.bottomRow.minHeight =
-      this.constants_.AFTER_STATEMENT_BOTTOM_ROW_MIN_HEIGHT;
+      this.constants_.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT;
   } else {
-    this.bottomRow.minHeight = this.constants_.MEDIUM_PADDING;
+    this.bottomRow.minHeight = this.constants_.BOTTOM_ROW_MIN_HEIGHT;
   }
 
   var leftSquareCorner = this.bottomRow.hasLeftSquareCorner(this.block_);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -94,6 +94,21 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
+  this.TOP_ROW_MIN_HEIGHT = this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.BOTTOM_ROW_MIN_HEIGHT = this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 7 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
   this.STATEMENT_BOTTOM_SPACER = -this.NOTCH_HEIGHT;
 
   /**
@@ -106,11 +121,6 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.STATEMENT_INPUT_PADDING_LEFT = 4 * this.GRID_UNIT;
-
-  /**
-   * @override
-   */
-  this.AFTER_STATEMENT_BOTTOM_ROW_MIN_HEIGHT = 7 * this.GRID_UNIT;
 
   /**
    * @override

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -120,12 +120,14 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       return this.constants_.NO_PADDING;
     }
   }
-  // Between inputs and the end of the row.
-  if (prev && Blockly.blockRendering.Types.isInput(prev) && !next) {
-    return this.constants_.MEDIUM_PADDING;
+  // Spacing between a rounded corner and a previous or next connection.
+  if (prev && Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
+    if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
+      Blockly.blockRendering.Types.isNextConnection(next)) {
+      return next.notchOffset - this.constants_.CORNER_RADIUS;
+    }
   }
-  return Blockly.zelos.RenderInfo.superClass_.getInRowSpacing_.call(
-      this, prev, next);
+  return this.constants_.MEDIUM_PADDING;
 };
 
 /**

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -112,6 +112,25 @@ Blockly.zelos.RenderInfo.prototype.computeBounds_ = function() {
 /**
  * @override
  */
+Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
+  if (!prev || !next) {
+    // No need for padding at the beginning or end of the row if the
+    // output shape is dynamic.
+    if (this.outputConnection && this.outputConnection.isDynamicShape) {
+      return this.constants_.NO_PADDING;
+    }
+  }
+  // Between inputs and the end of the row.
+  if (prev && Blockly.blockRendering.Types.isInput(prev) && !next) {
+    return this.constants_.MEDIUM_PADDING;
+  }
+  return Blockly.zelos.RenderInfo.superClass_.getInRowSpacing_.call(
+      this, prev, next);
+};
+
+/**
+ * @override
+ */
 Blockly.zelos.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
   var height = this.getSpacerRowHeight_(prev, next);
   var width = this.getSpacerRowWidth_(prev, next);

--- a/tests/rendering/zelos/zelos.html
+++ b/tests/rendering/zelos/zelos.html
@@ -32,9 +32,6 @@
   <script>
     goog.require('Blockly.blockRendering.Debug');
     goog.require('Blockly.zelos.Renderer');
-    Blockly.Field.FONTSIZE = 12;
-    Blockly.Field.FONTWEIGHT = 'bold';
-    Blockly.Field.FONTFAMILY = 'Helvetica Neue';
     // Blockly.blockRendering.startDebugger();
     var blocklyDiv = document.getElementById('blocklyDiv');
     var workspace;
@@ -63,6 +60,10 @@
           startScale: 2,
         }
       });
+      var constants = workspace.getRenderer().getConstants();
+      constants.FIELD_TEXT_FONTSIZE = 12;
+      constants.FIELD_TEXT_FONTWEIGHT = 'bold';
+      constants.FIELD_TEXT_FONTFAMILY = 'Helvetica Neue';
 
       try {
         Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Zelos spacing.

### Proposed Changes

Add constants for top row and bottom row min spacing. Override in zelos.
Bring back in row spacing override for output connections, and pretty much always use medium spacing for everything else.
Fix zelos playground.

### Reason for Changes

Zelos rendering. 

![Screen Shot 2019-11-14 at 3 38 34 PM](https://user-images.githubusercontent.com/16690124/68905213-3f7afb80-06f5-11ea-89dc-a296ed5717b9.png)


### Test Coverage

Tested zelos and geras in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
