### PR TITLE
Return focus to the workspace

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -636,6 +636,8 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
   }
   Blockly.DropDownDiv.clearContent();
   Blockly.DropDownDiv.owner_ = null;
+
+  Blockly.getMainWorkspace().markFocused();
 };
 
 /**

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -97,6 +97,8 @@ Blockly.WidgetDiv.hide = function() {
     Blockly.WidgetDiv.dispose_ = null;
     Blockly.WidgetDiv.DIV.innerHTML = '';
   }
+
+  Blockly.getMainWorkspace().markFocused();
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Last remaining focus work. 

### Proposed Changes

Return focus to the workspace after hiding a widget or dropdown div.

### Reason for Changes

Keeping focus in Blockly.

### Test Coverage

Tested playground and multiplayground with keyboard nav. 
Fields, context menu, and dropdown div.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
