### PR TITLE
Fix flickering in zelos selection highlight.

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -585,13 +585,13 @@ Blockly.Flyout.prototype.addBlockListeners_ = function(root, block, rect) {
       this.blockMouseDown_(block)));
   this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
       this.blockMouseDown_(block)));
-  this.listeners_.push(Blockly.bindEvent_(root, 'mouseover', block,
+  this.listeners_.push(Blockly.bindEvent_(root, 'mouseenter', block,
       block.addSelect));
-  this.listeners_.push(Blockly.bindEvent_(root, 'mouseout', block,
+  this.listeners_.push(Blockly.bindEvent_(root, 'mouseleave', block,
       block.removeSelect));
-  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseover', block,
+  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseenter', block,
       block.addSelect));
-  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseout', block,
+  this.listeners_.push(Blockly.bindEvent_(rect, 'mouseleave', block,
       block.removeSelect));
 };
 

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -103,12 +103,14 @@ Blockly.zelos.PathObject.prototype.flipRTL = function() {
 Blockly.zelos.PathObject.prototype.updateSelected = function(enable) {
   this.setClass_('blocklySelected', enable);
   if (enable) {
-    this.svgPathSelected_ =
-      /** @type {!SVGElement} */ (this.svgPath.cloneNode(true));
-    this.svgPathSelected_.setAttribute('fill', 'none');
-    this.svgPathSelected_.setAttribute('filter',
-        'url(#' + this.constants_.highlightGlowFilterId + ')');
-    this.svgRoot.appendChild(this.svgPathSelected_);
+    if (!this.svgPathSelected_) {
+      this.svgPathSelected_ =
+        /** @type {!SVGElement} */ (this.svgPath.cloneNode(true));
+      this.svgPathSelected_.setAttribute('fill', 'none');
+      this.svgPathSelected_.setAttribute('filter',
+          'url(#' + this.constants_.highlightGlowFilterId + ')');
+      this.svgRoot.appendChild(this.svgPathSelected_);
+    }
   } else {
     if (this.svgPathSelected_) {
       this.svgRoot.removeChild(this.svgPathSelected_);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes flickering in zelos selection highlight. 

![zelos_flickering](https://user-images.githubusercontent.com/16690124/68988604-e1324380-07ee-11ea-9064-5d8f53b71d15.gif)

### Proposed Changes

The zelos highlight uses two elements, the path object and the selected path object, mouse moves in between them trigger a mousemove event. Instead use ``mouseenter`` / ``mouseleave`` which is agnostic of moves inside of the root element. 

[This](https://www.w3schools.com/jquery/tryit.asp?filename=tryjquery_event_mouseenter_mouseover) is a good demonstration of the difference between the two events.

### Reason for Changes

Fix zelos flyout selection highlight.

### Test Coverage

Tested in playground.

Tested on:
* Desktop Chrome
* Desktop Safari
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
