### PR TITLE
Move more CSS into renderers.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -321,15 +321,6 @@ Blockly.Css.CONTENT = [
     'stroke: none',
   '}',
 
-  '.injectionDiv:not(.zelos-renderer) .blocklyReplaceable .blocklyPath {',
-    'fill-opacity: .5;',
-  '}',
-
-  '.injectionDiv:not(.zelos-renderer) .blocklyReplaceable .blocklyPathLight,',
-  '.injectionDiv:not(.zelos-renderer) .blocklyReplaceable .blocklyPathDark {',
-    'display: none;',
-  '}',
-
   '.blocklyMultilineText {',
     'font-family: monospace;',
   '}',

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -169,6 +169,7 @@ Blockly.blockRendering.Renderer.prototype.getCSS_ = function() {
     selector + ' .blocklyEditableText>rect {',
       'fill: #fff;',
       'fill-opacity: .6;',
+      'stroke: none;',
     '}',
 
     selector + ' .blocklyNonEditableText>text,',

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -180,9 +180,23 @@ Blockly.blockRendering.Renderer.prototype.getCSS_ = function() {
       'stroke: #fff;',
       'stroke-width: 2;',
     '}',
+
     selector + ' .blocklySelected>.blocklyPath {',
       'stroke: #fc3;',
       'stroke-width: 3px;',
+    '}',
+
+    selector + ' .blocklyHighlightedConnectionPath {',
+      'stroke: #fc3;',
+    '}',
+
+    selector + ' .blocklyReplaceable .blocklyPath {',
+      'fill-opacity: .5;',
+    '}',
+
+    selector + ' .blocklyReplaceable .blocklyPathLight,',
+    selector + ' .blocklyReplaceable .blocklyPathDark {',
+      'display: none;',
     '}',
     /* eslint-enable indent */
   ];

--- a/core/renderers/minimalist/renderer.js
+++ b/core/renderers/minimalist/renderer.js
@@ -32,12 +32,13 @@ goog.require('Blockly.minimalist.RenderInfo');
 
 /**
  * The minimalist renderer.
+ * @param {string} name The renderer name.
  * @package
  * @constructor
  * @extends {Blockly.blockRendering.Renderer}
  */
-Blockly.minimalist.Renderer = function() {
-  Blockly.minimalist.Renderer.superClass_.constructor.call(this);
+Blockly.minimalist.Renderer = function(name) {
+  Blockly.minimalist.Renderer.superClass_.constructor.call(this, name);
 };
 Blockly.utils.object.inherits(Blockly.minimalist.Renderer,
     Blockly.blockRendering.Renderer);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -516,7 +516,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
   // Color the highlight
   Blockly.utils.dom.createSvgElement('feFlood',
       {
-        'flood-color': '#FFF200', // TODO: configure colour in theme.
+        'flood-color': '#fff200', // TODO: configure colour in theme.
         'flood-opacity': 1,
         'result': 'outColor'
       },
@@ -558,7 +558,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
   // Color the highlight
   Blockly.utils.dom.createSvgElement('feFlood',
       {
-        'flood-color': '#FFF200', // TODO: configure colour in theme.
+        'flood-color': '#fff200', // TODO: configure colour in theme.
         'flood-opacity': 1,
         'result': 'outColor'
       },

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -139,6 +139,16 @@ Blockly.zelos.Renderer.prototype.getCSS_ = function() {
       'font-weight: ' + constants.FIELD_TEXT_FONTWEIGHT + ';',
     '}',
 
+    selector + ' .blocklyEditableText:not(.editing):hover>rect ,',
+    selector + ' .blocklyEditableText:not(.editing):hover>.blocklyPath {',
+      'stroke: #fff;',
+      'stroke-width: 2;',
+    '}',
+
+    selector + ' .blocklyHighlightedConnectionPath {',
+      'stroke: #fff200;',
+    '}',
+
     selector + ' .blocklyDropdownText {',
       'fill: #fff !important;',
     '}',


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Move blocklyReplaceable CSS into the common renderer.
Bring back hover stroke for zelos renderer.

### Reason for Changes

Rendering.

### Test Coverage

Tested geras and zelos renderer in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
