### PR TITLE
[zelos] Full field colour

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -970,7 +970,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
  */
 Blockly.BlockSvg.prototype.applyColour = function() {
   if (!this.isEnabled() || !this.rendered) {
-    // Disabled blocks don't have colour.
+    // Disabled blocks and non-rendered blocks don't have colour.
     return;
   }
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -969,7 +969,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
  * @package
  */
 Blockly.BlockSvg.prototype.applyColour = function() {
-  if (!this.isEnabled()) {
+  if (!this.isEnabled() || !this.rendered) {
     // Disabled blocks don't have colour.
     return;
   }

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -186,9 +186,24 @@ Blockly.FieldColour.prototype.initView = function() {
   this.size_ = new Blockly.utils.Size(
       this.constants_.FIELD_COLOUR_DEFAULT_WIDTH,
       this.constants_.FIELD_COLOUR_DEFAULT_HEIGHT);
-  this.createBorderRect_();
-  this.borderRect_.style['fillOpacity'] = '1';
-  this.borderRect_.style.fill = this.value_;
+  if (!this.constants_.FIELD_COLOUR_FULL_BLOCK) {
+    this.createBorderRect_();
+    this.borderRect_.style['fillOpacity'] = '1';
+  } else {
+    this.clickTarget_ = this.sourceBlock_.getSvgRoot();
+  }
+};
+
+/**
+ * @override
+ */
+Blockly.FieldColour.prototype.applyColour = function() {
+  if (!this.constants_.FIELD_COLOUR_FULL_BLOCK) {
+    this.borderRect_.style.fill = this.getValue();
+  } else {
+    this.sourceBlock_.pathObject.svgPath.setAttribute('fill', this.getValue());
+    this.sourceBlock_.pathObject.svgPath.setAttribute('stroke', '#fff');
+  }
 };
 
 /**
@@ -214,6 +229,9 @@ Blockly.FieldColour.prototype.doValueUpdate_ = function(newValue) {
   this.value_ = newValue;
   if (this.borderRect_) {
     this.borderRect_.style.fill = newValue;
+  } else if (this.sourceBlock_) {
+    this.sourceBlock_.pathObject.svgPath.setAttribute('fill', newValue);
+    this.sourceBlock_.pathObject.svgPath.setAttribute('stroke', '#fff');
   }
 };
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -233,6 +233,13 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.FIELD_DROPDOWN_SVG_ARROW = false;
 
   /**
+   * Whether or not the colour field should display its colour value on the
+   * entire block.
+   * @type {boolean}
+   */
+  this.FIELD_COLOUR_FULL_BLOCK = false;
+
+  /**
    * A colour field's default width.
    * @type {number}
    */

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -215,6 +215,21 @@ Blockly.zelos.ConstantProvider = function() {
     'dBMS40MywxLjQzLDAsMCwxLDYuMzYsNy43OVoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=';
 
   /**
+   * @override
+   */
+  this.FIELD_COLOUR_FULL_BLOCK = true;
+
+  /**
+   * @override
+   */
+  this.FIELD_COLOUR_DEFAULT_WIDTH = 2 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.FIELD_COLOUR_DEFAULT_HEIGHT = 4 * this.GRID_UNIT;
+
+  /**
    * The ID of the highlight glow filter, or the empty string if no filter is
    * set.
    * @type {string}


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Full colour fields.

### Proposed Changes

Add support in field_colour for full colour fields. Add constants option set in the renderer to determine whether to add a border Rect or whether to use the source block's svgPath to set the current colour value.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested geras and zelos in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

![Screen Shot 2019-11-22 at 12 59 56 PM](https://user-images.githubusercontent.com/16690124/69460205-67d3ad00-0d28-11ea-9f71-855074b39587.png)
![Screen Shot 2019-11-22 at 12 59 55 PM](https://user-images.githubusercontent.com/16690124/69460206-67d3ad00-0d28-11ea-979a-0dddaeaf2f3c.png)

