### PR TITLE
[zelos] Statement inputs minimum widths.

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -184,9 +184,9 @@ Blockly.blockRendering.RenderInfo.prototype.getRenderer = function() {
 Blockly.blockRendering.RenderInfo.prototype.measure = function() {
   this.createRows_();
   this.addElemSpacing_();
+  this.addRowSpacing_();
   this.computeBounds_();
   this.alignRowElements_();
-  this.addRowSpacing_();
   this.finalize_();
 };
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -115,7 +115,7 @@ Blockly.zelos.ConstantProvider = function() {
    * Minimum statement input spacer width.
    * @type {number}
    */
-  this.STATEMENT_INPUT_SPACER_MIN_WIDTH = 30 * this.GRID_UNIT;
+  this.STATEMENT_INPUT_SPACER_MIN_WIDTH = 34.5 * this.GRID_UNIT;
 
   /**
    * @override

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -120,6 +120,12 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       return this.constants_.NO_PADDING;
     }
   }
+  if (!prev) {
+    // Statement input padding.
+    if (next && Blockly.blockRendering.Types.isStatementInput(next)) {
+      return this.constants_.STATEMENT_INPUT_PADDING_LEFT;
+    }
+  }
   // Spacing between a rounded corner and a previous or next connection.
   if (prev && Blockly.blockRendering.Types.isLeftRoundedCorner(prev) && next) {
     if (Blockly.blockRendering.Types.isPreviousConnection(next) ||
@@ -141,13 +147,13 @@ Blockly.zelos.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
         new Blockly.zelos.BeforeStatementSpacerRow(
             this.constants_,
             Math.max(height, this.constants_.INSIDE_CORNERS.rightHeight || 0),
-            width);
+            Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH));
   } else if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
     var spacer =
         new Blockly.zelos.AfterStatementSpacerRow(
             this.constants_,
             Math.max(height, this.constants_.INSIDE_CORNERS.rightHeight || 0),
-            width);
+            Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH));
   } else {
     var spacer = new Blockly.blockRendering.SpacerRow(
         this.constants_, height, width);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes
Statement inputs have minimum widths in zelos.
Add min width constants to statement input before / after spacers.
Add row spacing before computing bounds.

### Reason for Changes

Zelos rendering.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

![Screen Shot 2019-11-22 at 1 33 56 PM](https://user-images.githubusercontent.com/16690124/69462018-c13ddb00-0d2c-11ea-9155-98f2cb67c189.png)
