### PR TITLE
Fixed adding a variable field programmatically when it has a following field.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -147,11 +147,8 @@ Blockly.FieldVariable.prototype.initModel = function() {
       this.sourceBlock_.workspace, null,
       this.defaultVariableName, this.defaultType_);
 
-  // Don't fire a change event for this setValue.  It would have null as the
-  // old value, which is not valid.
-  Blockly.Events.disable();
-  this.setValue(variable.getId());
-  Blockly.Events.enable();
+  // Don't call setValue because we don't want to cause a rerender.
+  this.doValueUpdate_(variable.getId());
 };
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -374,6 +374,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     var oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
     // Allow the source block to rebuild itself.
     block.compose(this.rootBlock_);
+    block.initSvg();
     block.render();
     var newMutationDom = block.mutationToDom();
     var newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -372,15 +372,9 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     var block = this.block_;
     var oldMutationDom = block.mutationToDom();
     var oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
-    // Switch off rendering while the source block is rebuilt.
-    var savedRendered = block.rendered;
-    block.rendered = false;
     // Allow the source block to rebuild itself.
     block.compose(this.rootBlock_);
-    // Restore rendering and show the changes.
-    block.rendered = savedRendered;
-    // Mutation may have added some elements that need initializing.
-    block.initSvg();
+    block.render();
     var newMutationDom = block.mutationToDom();
     var newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
     if (oldMutation != newMutation) {
@@ -393,9 +387,6 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
         block.bumpNeighbours();
         Blockly.Events.setGroup(false);
       }, Blockly.BUMP_DELAY);
-    }
-    if (block.rendered) {
-      block.render();
     }
 
     if (oldMutation != newMutation &&


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #3458 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1) Changes the mutator to no longer "disable" rendering.
2) Changes the variable field to call doValueUpdate_ directly instead of calling setValue.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
So the problem wasn't exactly what I thought it was. The problem was that mutators set the block's `rendered` [property to false](https://github.com/google/blockly/blob/ba6dfd812552e0823ed75f3dc5133a267cc6fbc9/core/mutator.js#L351), which meant the [fields were not getting initialized](https://github.com/google/blockly/blob/ba6dfd812552e0823ed75f3dc5133a267cc6fbc9/core/input.js#L116) when they were appended. Then mutator would then [call initSvg](https://github.com/google/blockly/blob/ba6dfd812552e0823ed75f3dc5133a267cc6fbc9/core/mutator.js#L357), which would eventually call the variable field's initMethod, which would force a rerender. This rerender would cause an error to be thrown because the renderer would try to render the fields following the variable field, which had not been initialized.

So 1) Makes it so that fields are properly initialized when they are appended during `compose`.
And 2) Makes it so variable fields no longer cause unnecessary render calls.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Could not reproduce #3458.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

### Documentation

Nada

### Additional Information

<!-- Anything else we should know? -->
Whoever reviews this, please check my thinking! I don't think changing mutators like this will break things, but I would really appreciate a second opinion.

Also @MatzElectronics
