### PR TITLE
Support adjusting dropdowndiv default colours through CSS

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -176,6 +176,8 @@ Blockly.Css.CONTENT = [
     'z-index: 1000;',
     'display: none;',
     'border: 1px solid;',
+    'border-color: #dadce0;',
+    'background-color: #fff;',
     'border-radius: 2px;',
     'padding: 4px;',
     'box-shadow: 0px 0px 3px 1px rgba(0,0,0,.3);',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -100,20 +100,6 @@ Blockly.DropDownDiv.PADDING_Y = 16;
 Blockly.DropDownDiv.ANIMATION_TIME = 0.25;
 
 /**
- * The default dropdown div border colour.
- * @type {string}
- * @const
- */
-Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR = '#dadce0';
-
-/**
- * The default dropdown div colour.
- * @type {string}
- * @const
- */
-Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR = '#fff';
-
-/**
  * Timer for animation out, to be cleared if we need to immediately hide
  * without disrupting new shows.
  * @type {?number}
@@ -152,8 +138,6 @@ Blockly.DropDownDiv.createDom = function() {
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR;
-  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR;
   document.body.appendChild(div);
   /**
    * The div element.
@@ -657,8 +641,8 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
   div.style.top = '';
   div.style.opacity = 0;
   div.style.display = 'none';
-  div.style.backgroundColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_COLOUR;
-  div.style.borderColor = Blockly.DropDownDiv.DEFAULT_DROPDOWN_BORDER_COLOUR;
+  div.style.backgroundColor = '';
+  div.style.borderColor = '';
 
   if (Blockly.DropDownDiv.onHide_) {
     Blockly.DropDownDiv.onHide_();

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -130,6 +130,9 @@ Blockly.Themes.Dark.setComponentStyle('scrollbarOpacity', 0.4);
 
 /**
  * CSS for the dark theme.
+ * This registers CSS that is specific to this theme. It does so by prepending a
+ * ``.dark-theme`` selector before every CSS rule that we wish to override by
+ * this theme.
  */
 (function() {
   var selector = '.dark-theme';

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -131,10 +131,30 @@ Blockly.Themes.Dark.setComponentStyle('scrollbarOpacity', 0.4);
 /**
  * CSS for the dark theme.
  */
-Blockly.Css.register([
-  /* eslint-disable indent */
-  '.dark-theme .blocklyTreeRow:not(.blocklyTreeSelected):hover {',
-    'background-color: #2a2d2e;',
-  '}',
-  /* eslint-enable indent */
-]);
+(function() {
+  var selector = '.dark-theme';
+  Blockly.Css.register([
+    /* eslint-disable indent */
+    selector + ' .blocklyTreeRow:not(.blocklyTreeSelected):hover {',
+      'background-color: #2a2d2e;',
+    '}',
+    selector + '.blocklyWidgetDiv .goog-menu ,',
+    selector + '.blocklyDropDownDiv {',
+      'background-color: #3c3c3c;',
+    '}',
+    selector + '.blocklyDropDownDiv {',
+      'border-color: #565656;',
+    '}',
+    selector + '.blocklyWidgetDiv .goog-menuitem-content, ',
+    selector + '.blocklyDropDownDiv .goog-menuitem-content {',
+      'color: #f0f0f0;',
+    '}',
+    selector + '.blocklyWidgetDiv .goog-menuitem-disabled',
+    ' .goog-menuitem-content,',
+    selector + '.blocklyDropDownDiv .goog-menuitem-disabled',
+    ' .goog-menuitem-content {',
+      'color: #8a8a8a !important;',
+    '}',
+    /* eslint-enable indent */
+  ]);
+})();

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -135,10 +135,12 @@ Blockly.Themes.Dark.setComponentStyle('scrollbarOpacity', 0.4);
   var selector = '.dark-theme';
   Blockly.Css.register([
     /* eslint-disable indent */
+    // Toolbox hover
     selector + ' .blocklyTreeRow:not(.blocklyTreeSelected):hover {',
       'background-color: #2a2d2e;',
     '}',
-    selector + '.blocklyWidgetDiv .goog-menu ,',
+    // Dropdown and Widget div.
+    selector + '.blocklyWidgetDiv .goog-menu, ',
     selector + '.blocklyDropDownDiv {',
       'background-color: #3c3c3c;',
     '}',

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -122,6 +122,8 @@ Blockly.ThemeManager.prototype.setTheme = function(theme) {
       element.style[propertyName] = style || '';
     }
   }
+
+  Blockly.hideChaff();
 };
 
 /**

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -136,6 +136,7 @@ suite('Theme', function() {
     blockA.styleName_ = 'styleOne';
 
     var stub = sinon.stub(Blockly, "getMainWorkspace").returns(workspace);
+    var hideStub = sinon.stub(Blockly, "hideChaff");
 
     workspace.setTheme(blockStyles);
 
@@ -153,6 +154,7 @@ suite('Theme', function() {
     undefineThemeTestBlocks();
 
     stub.restore();
+    hideStub.restore();
   });
 
   suite('Validate block styles', function() {


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Support setting the dropdown theme default colours through CSS.
Update dark theme to adjust dropdown and widget div colours. 

### Reason for Changes

### Test Coverage

Multiple themes in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

![Screen Shot 2019-11-22 at 3 47 28 PM](https://user-images.githubusercontent.com/16690124/69468155-f4d63080-0d3f-11ea-9a3b-8c30bbe92478.png)
![Screen Shot 2019-11-22 at 3 47 25 PM](https://user-images.githubusercontent.com/16690124/69468156-f4d63080-0d3f-11ea-84d4-917253c4ed39.png)

