### PR TITLE
gitignore the .idea directory which contains jetbrains artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build-debug.log
 .DS_Store
 .settings
 .project
+.idea
 *.gz
 *.pyc
 *.komodoproject


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/3475

### Proposed Changes

Add `.idea` to `.gitignore`

### Reason for Changes

So that the `.idea` directory isn't accidentally committed/to make it easier for people who just JetBrains products to contribute to the repository.