### PR TITLE
Bug Fix - Issue #3386 - Warning Bubble Dragging

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -677,5 +677,9 @@ Blockly.Css.CONTENT = [
     'width: 0;',
     'height: 0;',
   '}',
+
+  '.blocklyNoPointerEvents {',
+    'pointer-events: none;',
+  '}',
   /* eslint-enable indent */
 ];

--- a/core/warning.js
+++ b/core/warning.js
@@ -103,9 +103,9 @@ Blockly.Warning.textToDom_ = function(text) {
         'tspan',
         {
           'class': 'blocklyDraggable',
-          'dy': '1em', 
+          'dy': '1em',
           'x': Blockly.Bubble.BORDER_WIDTH
-        }, 
+        },
         paragraph);
     var textNode = document.createTextNode(lines[i]);
     tspanElement.appendChild(textNode);
@@ -179,7 +179,7 @@ Blockly.Warning.prototype.disposeBubble = function() {
 Blockly.Warning.prototype.makeBubbleDraggable_ = function() {
   if (!this.block_.workspace.options.readOnly) {
     Blockly.bindEventWithChecks_(
-      this.paragraphElement_, 'mousedown', this, this.bubbleMouseDown_);
+        this.paragraphElement_, 'mousedown', this, this.bubbleMouseDown_);
   }
 };
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -156,7 +156,7 @@ Blockly.Warning.prototype.createBubble = function() {
     }
   }
   this.applyColour();
-  this.makeBubbleDraggable_();
+  this.makeParagrahDraggable_();
 };
 
 /**
@@ -173,24 +173,24 @@ Blockly.Warning.prototype.disposeBubble = function() {
 };
 
 /**
- * Make the warning bubble draggable
+ * Allow the bubble to be dragged from the warning paragraph
  * @private
  */
-Blockly.Warning.prototype.makeBubbleDraggable_ = function() {
+Blockly.Warning.prototype.makeParagrahDraggable_ = function() {
   if (!this.block_.workspace.options.readOnly) {
     Blockly.bindEventWithChecks_(
-        this.paragraphElement_, 'mousedown', this, this.bubbleMouseDown_);
+        this.paragraphElement_, 'mousedown', this, this.paragraphMouseDown_);
   }
 };
 
 /**
- * Handle a mouse-down on a warning bubble.
+ * Handle a mouse-down event on the warning paragraph.
  * @param {!Event} e Mouse down event.
  * @private
  */
-Blockly.Warning.prototype.bubbleMouseDown_ = function(e) {
+Blockly.Warning.prototype.paragraphMouseDown_ = function(e) {
   var gesture = this.block_.workspace.getGesture(e);
-  if (gesture && this.bubble_ !== null) {
+  if (gesture) {
     gesture.handleBubbleStart(e, this.bubble_);
   }
 };

--- a/core/warning.js
+++ b/core/warning.js
@@ -118,6 +118,7 @@ Blockly.Warning.textToDom_ = function(text) {
  * @param {boolean} visible True if the bubble should be visible.
  */
 Blockly.Warning.prototype.setVisible = function(visible) {
+  console.log(Blockly.Warning.prototype);
   if (visible == this.isVisible()) {
     return;
   }
@@ -156,7 +157,12 @@ Blockly.Warning.prototype.createBubble = function() {
     }
   }
   this.applyColour();
-  this.makeParagrahDraggable_();
+
+  // Allow the bubble to be dragged from the warning paragraph
+  if (!this.block_.workspace.options.readOnly) {
+    Blockly.bindEventWithChecks_(
+        this.paragraphElement_, 'mousedown', this, this.paragraphMouseDown_);
+  }
 };
 
 /**
@@ -170,17 +176,6 @@ Blockly.Warning.prototype.disposeBubble = function() {
   this.bubble_ = null;
   this.body_ = null;
   this.paragraphElement_ = null;
-};
-
-/**
- * Allow the bubble to be dragged from the warning paragraph
- * @private
- */
-Blockly.Warning.prototype.makeParagrahDraggable_ = function() {
-  if (!this.block_.workspace.options.readOnly) {
-    Blockly.bindEventWithChecks_(
-        this.paragraphElement_, 'mousedown', this, this.paragraphMouseDown_);
-  }
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -118,7 +118,6 @@ Blockly.Warning.textToDom_ = function(text) {
  * @param {boolean} visible True if the bubble should be visible.
  */
 Blockly.Warning.prototype.setVisible = function(visible) {
-  console.log(Blockly.Warning.prototype);
   if (visible == this.isVisible()) {
     return;
   }

--- a/core/warning.js
+++ b/core/warning.js
@@ -99,8 +99,14 @@ Blockly.Warning.textToDom_ = function(text) {
       );
   var lines = text.split('\n');
   for (var i = 0; i < lines.length; i++) {
-    var tspanElement = Blockly.utils.dom.createSvgElement('tspan',
-        {'dy': '1em', 'x': Blockly.Bubble.BORDER_WIDTH}, paragraph);
+    var tspanElement = Blockly.utils.dom.createSvgElement(
+        'tspan',
+        {
+          'class': 'blocklyDraggable',
+          'dy': '1em', 
+          'x': Blockly.Bubble.BORDER_WIDTH
+        }, 
+        paragraph);
     var textNode = document.createTextNode(lines[i]);
     tspanElement.appendChild(textNode);
   }
@@ -150,6 +156,7 @@ Blockly.Warning.prototype.createBubble = function() {
     }
   }
   this.applyColour();
+  this.makeBubbleDraggable_();
 };
 
 /**
@@ -163,6 +170,29 @@ Blockly.Warning.prototype.disposeBubble = function() {
   this.bubble_ = null;
   this.body_ = null;
   this.paragraphElement_ = null;
+};
+
+/**
+ * Make the warning bubble draggable
+ * @private
+ */
+Blockly.Warning.prototype.makeBubbleDraggable_ = function() {
+  if (!this.block_.workspace.options.readOnly) {
+    Blockly.bindEventWithChecks_(
+      this.paragraphElement_, 'mousedown', this, this.bubbleMouseDown_);
+  }
+};
+
+/**
+ * Handle a mouse-down on a warning bubble.
+ * @param {!Event} e Mouse down event.
+ * @private
+ */
+Blockly.Warning.prototype.bubbleMouseDown_ = function(e) {
+  var gesture = this.block_.workspace.getGesture(e);
+  if (gesture && this.bubble_ !== null) {
+    gesture.handleBubbleStart(e, this.bubble_);
+  }
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -92,21 +92,15 @@ Blockly.Warning.textToDom_ = function(text) {
       (Blockly.utils.dom.createSvgElement(
           'text',
           {
-            'class': 'blocklyText blocklyBubbleText',
+            'class': 'blocklyText blocklyBubbleText blocklyNoPointerEvents',
             'y': Blockly.Bubble.BORDER_WIDTH
           },
           null)
       );
   var lines = text.split('\n');
   for (var i = 0; i < lines.length; i++) {
-    var tspanElement = Blockly.utils.dom.createSvgElement(
-        'tspan',
-        {
-          'class': 'blocklyDraggable',
-          'dy': '1em',
-          'x': Blockly.Bubble.BORDER_WIDTH
-        },
-        paragraph);
+    var tspanElement = Blockly.utils.dom.createSvgElement('tspan',
+        {'dy': '1em', 'x': Blockly.Bubble.BORDER_WIDTH}, paragraph);
     var textNode = document.createTextNode(lines[i]);
     tspanElement.appendChild(textNode);
   }
@@ -156,12 +150,6 @@ Blockly.Warning.prototype.createBubble = function() {
     }
   }
   this.applyColour();
-
-  // Allow the bubble to be dragged from the warning paragraph
-  if (!this.block_.workspace.options.readOnly) {
-    Blockly.bindEventWithChecks_(
-        this.paragraphElement_, 'mousedown', this, this.paragraphMouseDown_);
-  }
 };
 
 /**
@@ -175,18 +163,6 @@ Blockly.Warning.prototype.disposeBubble = function() {
   this.bubble_ = null;
   this.body_ = null;
   this.paragraphElement_ = null;
-};
-
-/**
- * Handle a mouse-down event on the warning paragraph.
- * @param {!Event} e Mouse down event.
- * @private
- */
-Blockly.Warning.prototype.paragraphMouseDown_ = function(e) {
-  var gesture = this.block_.workspace.getGesture(e);
-  if (gesture && this.bubble_ !== null) {
-    gesture.handleBubbleStart(e, this.bubble_);
-  }
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -190,7 +190,7 @@ Blockly.Warning.prototype.makeParagrahDraggable_ = function() {
  */
 Blockly.Warning.prototype.paragraphMouseDown_ = function(e) {
   var gesture = this.block_.workspace.getGesture(e);
-  if (gesture) {
+  if (gesture && this.bubble_ !== null) {
     gesture.handleBubbleStart(e, this.bubble_);
   }
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3386 

### Proposed Changes
This PR adds a mouse down event handler for the warning text elements.

### Reason for Changes

This fixes the bug in #3386 

### Test Coverage
Tested on:
Desktop Chrome
Desktop Firefox
Desktop Safari
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

### Documentation
No new documentation is required

### Additional Information
This logic is very similar to handling mouse down events for dragging in the Bubble Class.

Functionality after the code changes:
![Alt Text](https://user-images.githubusercontent.com/15016463/69843433-78f35100-1235-11ea-8163-a3cf40a5fc04.gif)

