### PR TITLE
added readOnly property to workspaceComment

### DIFF
--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -99,7 +99,7 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
    * @type {boolean}
    * @private
    */
-  this.readOnly_ = false;
+  this.editable_ = true;
 
   /**
    * @protected
@@ -236,22 +236,20 @@ Blockly.WorkspaceComment.prototype.setMovable = function(movable) {
 };
 
 /**
- * Get whether this comment is readOnly or not.
- * @return {boolean} True if readOnly.
- * @package
+ * Get whether this comment is editable or not.
+ * @return {boolean} True if editable.
  */
-Blockly.WorkspaceComment.prototype.isReadOnly = function() {
-  return this.readOnly_ ||
-      (this.workspace && this.workspace.options.readOnly);
+Blockly.WorkspaceComment.prototype.isEditable = function() {
+  return this.editable_ &&
+      !(this.workspace && this.workspace.options.readOnly);
 };
 
 /**
- * Set whether this comment is readOnly or not.
- * @param {boolean} readOnly True if readOnly.
- * @package
+ * Set whether this comment is editable or not.
+ * @param {boolean} editable True if editable.
  */
-Blockly.WorkspaceComment.prototype.setReadOnly = function(readOnly) {
-  this.readOnly_ = readOnly;
+Blockly.WorkspaceComment.prototype.setEditable = function(editable) {
+  this.editable_ = editable;
 };
 
 /**

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -96,6 +96,12 @@ Blockly.WorkspaceComment = function(workspace, content, height, width, opt_id) {
   this.movable_ = true;
 
   /**
+   * @type {boolean}
+   * @private
+   */
+  this.readOnly_ = false;
+
+  /**
    * @protected
    * @type {string}
    */
@@ -227,6 +233,25 @@ Blockly.WorkspaceComment.prototype.isMovable = function() {
  */
 Blockly.WorkspaceComment.prototype.setMovable = function(movable) {
   this.movable_ = movable;
+};
+
+/**
+ * Get whether this comment is readOnly or not.
+ * @return {boolean} True if readOnly.
+ * @package
+ */
+Blockly.WorkspaceComment.prototype.isReadOnly = function() {
+  return this.readOnly_ ||
+      (this.workspace && this.workspace.options.readOnly);
+};
+
+/**
+ * Set whether this comment is readOnly or not.
+ * @param {boolean} readOnly True if readOnly.
+ * @package
+ */
+Blockly.WorkspaceComment.prototype.setReadOnly = function(readOnly) {
+  this.readOnly_ = readOnly;
 };
 
 /**

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -160,7 +160,7 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   var textarea = document.createElementNS(Blockly.utils.dom.HTML_NS, 'textarea');
   textarea.className = 'blocklyCommentTextarea';
   textarea.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
-  textarea.readOnly = this.isReadOnly();
+  textarea.readOnly = !this.isEditable();
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.foreignObject_.appendChild(body);

--- a/core/workspace_comment_render_svg.js
+++ b/core/workspace_comment_render_svg.js
@@ -160,6 +160,7 @@ Blockly.WorkspaceCommentSvg.prototype.createEditor_ = function() {
   var textarea = document.createElementNS(Blockly.utils.dom.HTML_NS, 'textarea');
   textarea.className = 'blocklyCommentTextarea';
   textarea.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
+  textarea.readOnly = this.isReadOnly();
   body.appendChild(textarea);
   this.textarea_ = textarea;
   this.foreignObject_.appendChild(body);

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -484,14 +484,14 @@ Blockly.WorkspaceCommentSvg.prototype.setMovable = function(movable) {
 };
 
 /**
- * Set whether this comment is readOnly or not.
- * @param {boolean} readOnly True if readOnly.
+ * Set whether this comment is editable or not.
+ * @param {boolean} editable True if editable.
  * @package
  */
-Blockly.WorkspaceCommentSvg.prototype.setReadOnly = function(readOnly) {
-  Blockly.WorkspaceCommentSvg.superClass_.setReadOnly.call(this, readOnly);
+Blockly.WorkspaceCommentSvg.prototype.setEditable = function(editable) {
+  Blockly.WorkspaceCommentSvg.superClass_.setEditable.call(this, editable);
   if (this.textarea_) {
-    this.textarea_.readOnly = readOnly;
+    this.textarea_.readOnly = !editable;
   }
 };
 

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -484,6 +484,18 @@ Blockly.WorkspaceCommentSvg.prototype.setMovable = function(movable) {
 };
 
 /**
+ * Set whether this comment is readOnly or not.
+ * @param {boolean} readOnly True if readOnly.
+ * @package
+ */
+Blockly.WorkspaceCommentSvg.prototype.setReadOnly = function(readOnly) {
+  Blockly.WorkspaceCommentSvg.superClass_.setReadOnly.call(this, readOnly);
+  if (this.textarea_) {
+    this.textarea_.readOnly = readOnly;
+  }
+};
+
+/**
  * Recursively adds or removes the dragging class to this node and its children.
  * @param {boolean} adding True if adding, false if removing.
  * @package

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -486,7 +486,6 @@ Blockly.WorkspaceCommentSvg.prototype.setMovable = function(movable) {
 /**
  * Set whether this comment is editable or not.
  * @param {boolean} editable True if editable.
- * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.setEditable = function(editable) {
   Blockly.WorkspaceCommentSvg.superClass_.setEditable.call(this, editable);


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

This PR adds the option to set the workspace comment readonly.

### Reason for Changes

requested in #1476 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
Desktop Firefox
Desktop Opera
Windows Edge

* Smartphone:
  * Device: iPhone 7 Plus
  * OS: iOS 13.1.3
  * Browser: Safari
  * Version 13

### Documentation

Documentation has to be updated in the following since this is a new feature:
https://developers.google.com/blockly/reference/js/Blockly.WorkspaceComment
https://developers.google.com/blockly/reference/js/Blockly.WorkspaceCommentSvg