### PR TITLE
Fix bugs with apply colour

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -972,10 +972,6 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
  * @package
  */
 Blockly.BlockSvg.prototype.applyColour = function() {
-  if (!this.rendered) {
-    // Non-rendered blocks don't have colour.
-    return;
-  }
   this.pathObject.applyColour(this);
 
   var icons = this.getIcons();

--- a/core/field.js
+++ b/core/field.js
@@ -673,10 +673,34 @@ Blockly.Field.prototype.getSize = function() {
  * @package
  */
 Blockly.Field.prototype.getScaledBBox = function() {
-  var bBox = this.borderRect_.getBBox();
-  var xy = this.getAbsoluteXY_();
-  var scaledWidth = bBox.width * this.sourceBlock_.workspace.scale;
-  var scaledHeight = bBox.height * this.sourceBlock_.workspace.scale;
+  if (!this.borderRect_) {
+    // Browsers are inconsistent in what they return for a bounding box.
+    // - Webkit / Blink: fill-box / object bounding box
+    // - Gecko / Triden / EdgeHTML: stroke-box
+    var bBox = this.sourceBlock_.getHeightWidth();
+    var scale = this.sourceBlock_.workspace.scale;
+    var xy = this.getAbsoluteXY_();
+    var scaledWidth = bBox.width * scale;
+    var scaledHeight = bBox.height * scale;
+
+    if (Blockly.utils.userAgent.GECKO) {
+      xy.x += 1.5 * scale;
+      xy.y += 1.5 * scale;
+      scaledWidth += 1 * scale;
+      scaledHeight += 1 * scale;
+    } else {
+      if (!Blockly.utils.userAgent.EDGE && !Blockly.utils.userAgent.IE) {
+        xy.x -= 0.5 * scale;
+        xy.y -= 0.5 * scale;
+      }
+      scaledWidth += 1 * scale;
+      scaledHeight += 1 * scale;
+    }
+  } else {
+    var xy = this.borderRect_.getBoundingClientRect();
+    var scaledWidth = xy.width;
+    var scaledHeight = xy.height;
+  }
   return {
     top: xy.y,
     bottom: xy.y + scaledHeight,

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -199,7 +199,9 @@ Blockly.FieldColour.prototype.initView = function() {
  */
 Blockly.FieldColour.prototype.applyColour = function() {
   if (!this.constants_.FIELD_COLOUR_FULL_BLOCK) {
-    this.borderRect_.style.fill = this.getValue();
+    if (this.borderRect_) {
+      this.borderRect_.style.fill = this.getValue();
+    }
   } else {
     this.sourceBlock_.pathObject.svgPath.setAttribute('fill', this.getValue());
     this.sourceBlock_.pathObject.svgPath.setAttribute('stroke', '#fff');

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -635,44 +635,4 @@ Blockly.FieldTextInput.prototype.getValueFromEditorText_ = function(text) {
   return text;
 };
 
-/**
- * @override
- */
-Blockly.FieldTextInput.prototype.getScaledBBox = function() {
-  if (!this.borderRect_) {
-    // Browsers are inconsistent in what they return for a bounding box.
-    // - Webkit / Blink: fill-box / object bounding box
-    // - Gecko / Triden / EdgeHTML: stroke-box
-    var bBox = this.sourceBlock_.getHeightWidth();
-    var scale = this.sourceBlock_.workspace.scale;
-    var xy = this.getAbsoluteXY_();
-    var scaledWidth = bBox.width * scale;
-    var scaledHeight = bBox.height * scale;
-
-    if (Blockly.utils.userAgent.GECKO) {
-      xy.x += 1.5 * scale;
-      xy.y += 1.5 * scale;
-      scaledWidth += 1 * scale;
-      scaledHeight += 1 * scale;
-    } else {
-      if (!Blockly.utils.userAgent.EDGE && !Blockly.utils.userAgent.IE) {
-        xy.x -= 0.5 * scale;
-        xy.y -= 0.5 * scale;
-      }
-      scaledWidth += 1 * scale;
-      scaledHeight += 1 * scale;
-    }
-  } else {
-    var xy = this.borderRect_.getBoundingClientRect();
-    var scaledWidth = xy.width;
-    var scaledHeight = xy.height;
-  }
-  return {
-    top: xy.y,
-    bottom: xy.y + scaledHeight,
-    left: xy.x,
-    right: xy.x + scaledWidth
-  };
-};
-
 Blockly.fieldRegistry.register('field_input', Blockly.FieldTextInput);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/commit/2a8e7d9ac8ba31ef9111ec2f576d678df485ddd9 introduced a couple of bugs: 
- Clicking on a zelos colour field throws an exception
- Opening a mutator dialog doesn't colour the blocks inside the mutator.

### Proposed Changes

Always apply colour. Check if field is rendered before applying colour in a field. Move getScaledBbox calculation into field.js

### Reason for Changes

Fix rendering bugs.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
