### PR TITLE
Adjust zelos spacing constants

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -84,6 +84,11 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
+  this.MIN_BLOCK_WIDTH = 2 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
   this.MIN_BLOCK_HEIGHT = 12 * this.GRID_UNIT;
 
   /**
@@ -115,7 +120,7 @@ Blockly.zelos.ConstantProvider = function() {
    * Minimum statement input spacer width.
    * @type {number}
    */
-  this.STATEMENT_INPUT_SPACER_MIN_WIDTH = 34.5 * this.GRID_UNIT;
+  this.STATEMENT_INPUT_SPACER_MIN_WIDTH = 40 * this.GRID_UNIT;
 
   /**
    * @override

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -191,9 +191,15 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
   }
   // Top and bottom rows act as a spacer so we don't need any extra padding.
   if ((Blockly.blockRendering.Types.isTopRow(prev))) {
+    if (!prev.hasPreviousConnection && !this.outputConnection) {
+      return this.constants_.SMALL_PADDING;
+    }
     return this.constants_.NO_PADDING;
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
+    if (!this.outputConnection) {
+      return this.constants_.SMALL_PADDING;
+    }
     return this.constants_.NO_PADDING;
   }
   return this.constants_.MEDIUM_PADDING;


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Minor adjustments to the zelos spacing constants: 
- min width
- statement input min width

Add a small padding after top row and before bottom row in some situations to make it so the top and bottom rows are identical in height and the block content is centered vertically.

Before: 
<img width="709" alt="Screen Shot 2019-12-05 at 10 42 58 AM" src="https://user-images.githubusercontent.com/16690124/70263803-0827c980-174c-11ea-8811-96ddfe4a6d16.png">

After:
<img width="588" alt="Screen Shot 2019-12-05 at 10 39 15 AM" src="https://user-images.githubusercontent.com/16690124/70263669-c0a13d80-174b-11ea-9365-72edb484c69c.png">

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in zelos rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
