### PR TITLE
Fix the text input field colouring in full block fields.

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -237,12 +237,12 @@ Blockly.FieldTextInput.prototype.doValueUpdate_ = function(newValue) {
  */
 Blockly.FieldTextInput.prototype.applyColour = function() {
   if (this.sourceBlock_ && this.constants_.FULL_BLOCK_FIELDS) {
-    if (this.sourceBlock_.isShadow()) {
-      this.sourceBlock_.pathObject.svgPath.setAttribute('fill', '#fff');
-    } else if (this.borderRect_) {
+    if (this.borderRect_) {
       this.borderRect_.setAttribute('stroke',
           this.sourceBlock_.style.colourTertiary);
       this.borderRect_.setAttribute('fill', '#fff');
+    } else if (this.sourceBlock_.isShadow()) {
+      this.sourceBlock_.pathObject.svgPath.setAttribute('fill', '#fff');
     }
   }
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

![Screen Shot 2019-12-05 at 5 31 53 PM](https://user-images.githubusercontent.com/16690124/70287815-252cbe80-1785-11ea-8b86-1eeec54099df.png)

### Proposed Changes

Check border Rect first.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested zelos in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

![Screen Shot 2019-12-05 at 5 29 55 PM](https://user-images.githubusercontent.com/16690124/70287838-370e6180-1785-11ea-84e7-44f4e15be7f1.png)

