### PR TITLE
Zelos horizontal tight nesting.

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -437,7 +437,7 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.FULL_BLOCK_FIELDS = false;
 
   /**
-   * Enum for shapes.
+   * Enum for connection shapes.
    * @enum {number}
    */
   this.SHAPES = {

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -435,6 +435,15 @@ Blockly.blockRendering.ConstantProvider = function() {
    * @package
    */
   this.FULL_BLOCK_FIELDS = false;
+
+  /**
+   * Enum for shapes.
+   * @enum {number}
+   */
+  this.SHAPES = {
+    PUZZLE: 1,
+    NOTCH: 2
+  };
 };
 
 /**
@@ -587,6 +596,7 @@ Blockly.blockRendering.ConstantProvider.prototype.makePuzzleTab = function() {
   var pathDown = makeMainPath(false);
 
   return {
+    type: this.SHAPES.PUZZLE,
     width: width,
     height: height,
     pathDown: pathDown,
@@ -616,6 +626,7 @@ Blockly.blockRendering.ConstantProvider.prototype.makeNotch = function() {
   var pathRight = makeMainPath(-1);
 
   return {
+    type: this.SHAPES.NOTCH,
     width: width,
     height: height,
     pathLeft: pathLeft,

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -428,8 +428,7 @@ Blockly.blockRendering.ConstantProvider = function() {
    */
   this.CURSOR_STROKE_WIDTH = 4;
 
-
-  /*
+  /**
    * Whether text input and colour fields fill up the entire source block.
    * @type {boolean}
    * @package

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -121,7 +121,8 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
     return;
   }
 
-  if (elem.width <= 0) {
+  // Don't render elements with negative spacing.
+  if (elem.width < 0) {
     return;
   }
 

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -121,6 +121,10 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
     return;
   }
 
+  if (elem.width <= 0) {
+    return;
+  }
+
   var xPos = elem.xPos;
   if (isRtl) {
     xPos = -(xPos + elem.width);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -184,19 +184,19 @@ Blockly.zelos.ConstantProvider = function() {
       0: 5 * this.GRID_UNIT, // Field in hexagon.
       1: 2 * this.GRID_UNIT, // Hexagon in hexagon.
       2: 5 * this.GRID_UNIT, // Round in hexagon.
-      3: 5 * this.GRID_UNIT // Square in hexagon.
+      3: 5 * this.GRID_UNIT  // Square in hexagon.
     },
     2: { // Outer shape: round.
       0: 3 * this.GRID_UNIT, // Field in round.
       1: 3 * this.GRID_UNIT, // Hexagon in round.
       2: 1 * this.GRID_UNIT, // Round in round.
-      3: 2 * this.GRID_UNIT // Square in round.
+      3: 2 * this.GRID_UNIT  // Square in round.
     },
     3: { // Outer shape: square.
       0: 2 * this.GRID_UNIT, // Field in square.
       1: 2 * this.GRID_UNIT, // Hexagon in square.
       2: 2 * this.GRID_UNIT, // Round in square.
-      3: 2 * this.GRID_UNIT // Square in square.
+      3: 2 * this.GRID_UNIT  // Square in square.
     }
   };
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -160,8 +160,7 @@ Blockly.zelos.ConstantProvider = function() {
   this.CURSOR_RADIUS = 5;
 
   /**
-   * Enum for shapes.
-   * @enum {number}
+   * @override
    */
   this.SHAPES = {
     HEXAGONAL: 1,
@@ -177,7 +176,7 @@ Blockly.zelos.ConstantProvider = function() {
    * When a block with the outer shape contains an input block with the inner
    * shape on its left or right edge, the block elements are aligned such that
    * the padding specified is reached.
-   * @pacakge
+   * @package
    */
   this.SHAPE_IN_SHAPE_PADDING = {
     1: { // Outer shape: hexagon.

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -160,6 +160,47 @@ Blockly.zelos.ConstantProvider = function() {
   this.CURSOR_RADIUS = 5;
 
   /**
+   * Enum for shapes.
+   * @enum {number}
+   */
+  this.SHAPES = {
+    HEXAGONAL: 1,
+    ROUND: 2,
+    SQUARE: 3,
+    PUZZLE: 4,
+    NOTCH: 5
+  };
+
+  /**
+   * Map of output/input shapes and the amount they should cause a block to be
+   * padded. Outer key is the outer shape, inner key is the inner shape.
+   * When a block with the outer shape contains an input block with the inner
+   * shape on its left or right edge, the block elements are aligned such that
+   * the padding specified is reached.
+   * @pacakge
+   */
+  this.SHAPE_IN_SHAPE_PADDING = {
+    1: { // Outer shape: hexagon.
+      0: 5 * this.GRID_UNIT, // Field in hexagon.
+      1: 2 * this.GRID_UNIT, // Hexagon in hexagon.
+      2: 5 * this.GRID_UNIT, // Round in hexagon.
+      3: 5 * this.GRID_UNIT // Square in hexagon.
+    },
+    2: { // Outer shape: round.
+      0: 2.5 * this.GRID_UNIT, // Field in round.
+      1: 3 * this.GRID_UNIT, // Hexagon in round.
+      2: 1 * this.GRID_UNIT, // Round in round.
+      3: 2 * this.GRID_UNIT // Square in round.
+    },
+    3: { // Outer shape: square.
+      0: 2 * this.GRID_UNIT, // Field in square.
+      1: 2 * this.GRID_UNIT, // Hexagon in square.
+      2: 2 * this.GRID_UNIT, // Round in square.
+      3: 2 * this.GRID_UNIT // Square in square.
+    }
+  };
+
+  /**
    * @override
    */
   this.FULL_BLOCK_FIELDS = true;
@@ -348,6 +389,7 @@ Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
   }
 
   return {
+    type: this.SHAPES.HEXAGONAL,
     isDynamic: true,
     width: function(height) {
       return height / 2;
@@ -386,6 +428,7 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
   }
 
   return {
+    type: this.SHAPES.ROUND,
     isDynamic: true,
     width: function(height) {
       return height / 2;
@@ -499,6 +542,7 @@ Blockly.zelos.ConstantProvider.prototype.makeNotch = function() {
   var pathRight = makeMainPath(-1);
 
   return {
+    type: this.SHAPES.NOTCH,
     width: width,
     height: height,
     pathLeft: pathLeft,

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -160,6 +160,7 @@ Blockly.zelos.ConstantProvider = function() {
   this.CURSOR_RADIUS = 5;
 
   /**
+   * @enum {number}
    * @override
    */
   this.SHAPES = {

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -187,7 +187,7 @@ Blockly.zelos.ConstantProvider = function() {
       3: 5 * this.GRID_UNIT // Square in hexagon.
     },
     2: { // Outer shape: round.
-      0: 2.5 * this.GRID_UNIT, // Field in round.
+      0: 3 * this.GRID_UNIT, // Field in round.
       1: 3 * this.GRID_UNIT, // Hexagon in round.
       2: 1 * this.GRID_UNIT, // Round in round.
       3: 2 * this.GRID_UNIT // Square in round.

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -68,7 +68,8 @@ Blockly.zelos.Drawer.prototype.draw = function() {
   }
   this.recordSizeOnBlock_();
   if (this.info_.outputConnection) {
-    // Store the output connection shape type for parent blocks to use.
+    // Store the output connection shape type for parent blocks to use during
+    // rendering.
     pathObject.outputShapeType = this.info_.outputConnection.shape.type;
   }
   pathObject.endDrawing();

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -68,6 +68,7 @@ Blockly.zelos.Drawer.prototype.draw = function() {
   }
   this.recordSizeOnBlock_();
   if (this.info_.outputConnection) {
+    // Store the output connection shape type for parent blocks to use.
     pathObject.outputShapeType = this.info_.outputConnection.shape.type;
   }
   pathObject.endDrawing();

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -67,6 +67,9 @@ Blockly.zelos.Drawer.prototype.draw = function() {
     this.block_.renderingDebugger.drawDebug(this.block_, this.info_);
   }
   this.recordSizeOnBlock_();
+  if (this.info_.outputConnection) {
+    pathObject.outputShapeType = this.info_.outputConnection.shape.type;
+  }
   pathObject.endDrawing();
 };
 

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -366,6 +366,11 @@ Blockly.zelos.RenderInfo.prototype.getNegativeSpacing_ = function(elem) {
     return connectionWidth -
         this.constants_.SHAPE_IN_SHAPE_PADDING[outerShape][innerShape];
   } else if (Blockly.blockRendering.Types.isField(elem)) {
+    // Special case for text inputs.
+    if (outerShape == constants.SHAPES.ROUND &&
+        elem.field instanceof Blockly.FieldTextInput) {
+      return connectionWidth - (2.75 * constants.GRID_UNIT);
+    }
     return connectionWidth -
         this.constants_.SHAPE_IN_SHAPE_PADDING[outerShape][0];
   } else if (Blockly.blockRendering.Types.isIcon(elem)) {

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -313,6 +313,8 @@ Blockly.zelos.RenderInfo.prototype.finalizeAlignment_ = function() {
     var minBlockWidth = this.constants_.MIN_BLOCK_WIDTH +
         this.outputConnection.width * 2;
     if (this.width - totalNegativeSpacing < minBlockWidth) {
+      // Maintain a minimum block width, split negative spacing between left
+      // and right edge.
       totalNegativeSpacing = this.width - minBlockWidth;
       row.getFirstSpacer().width = -totalNegativeSpacing / 2;
       row.getLastSpacer().width = -totalNegativeSpacing / 2;

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -73,8 +73,8 @@ Blockly.zelos.PathObject = function(root, constants) {
   this.remainingOutlines_ = null;
 
   /**
-   * The type of block's output connection shape.  This is updated when a block
-   * with an output connection is drawn.
+   * The type of block's output connection shape.  This is set when a block with
+   * an output connection is drawn.
    * @package
    */
   this.outputShapeType = null;

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -71,6 +71,13 @@ Blockly.zelos.PathObject = function(root, constants) {
    * @private
    */
   this.remainingOutlines_ = null;
+
+  /**
+   * The type of block's output connection shape.  This is updated when a block
+   * with an output connection is drawn.
+   * @package
+   */
+  this.outputShapeType = null;
 };
 Blockly.utils.object.inherits(Blockly.zelos.PathObject,
     Blockly.blockRendering.PathObject);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Reduce the amount of implicit spacing added by the connection shape by adding negative spacing to the first and last spacer in an output block.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested zelos rendering playground blocks.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="337" alt="Screen Shot 2019-12-05 at 6 35 18 PM" src="https://user-images.githubusercontent.com/16690124/70290868-34643a00-178e-11ea-999c-93e8561bce6e.png">

