### PR TITLE
Fix full text input fields with label fields

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -154,10 +154,8 @@ Blockly.FieldTextInput.prototype.initView = function() {
 
     // Count the number of fields, excluding text fields
     for (var i = 0, input; (input = this.sourceBlock_.inputList[i]); i++) {
-      for (var j = 0, field; (field = input.fieldRow[j]); j++) {
-        if (!(field instanceof Blockly.FieldLabel)) {
-          nFields ++;
-        }
+      for (var j = 0; (input.fieldRow[j]); j++) {
+        nFields ++;
       }
       if (input.connection) {
         nConnections++;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes blocks that have a text input field and only label fields.

### Proposed Changes

Count all fields when deciding whether or not a full text field should be used.
@rachel-fenichel any idea why we weren't including label fields?

### Reason for Changes

Before: 
![Screen Shot 2019-12-06 at 10 59 17 AM](https://user-images.githubusercontent.com/16690124/70348549-c2d0ce00-1817-11ea-865a-9caa26095ecc.png)

After: 
![Screen Shot 2019-12-06 at 10 59 52 AM](https://user-images.githubusercontent.com/16690124/70348557-c6fceb80-1817-11ea-8a3d-750825e38768.png)

### Test Coverage

Tested test blocks playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
