### PR TITLE
Render negative elem spacing in debugger.

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -121,14 +121,12 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
     return;
   }
 
-  // Don't render elements with negative spacing.
-  if (elem.width < 0) {
-    return;
-  }
+  var width = Math.abs(elem.width);
+  var isNegativeSpacing = elem.width < 0;
 
-  var xPos = elem.xPos;
+  var xPos = isNegativeSpacing ? elem.xPos - width : elem.xPos;
   if (isRtl) {
-    xPos = -(xPos + elem.width);
+    xPos = -(xPos + width);
   }
   var yPos = elem.centerline - elem.height / 2;
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
@@ -136,10 +134,10 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
         'class': 'elemSpacerRect blockRenderDebug',
         'x': xPos,
         'y': yPos,
-        'width': elem.width,
+        'width': width,
         'height': elem.height,
         'stroke': 'pink',
-        'fill': 'pink',
+        'fill': isNegativeSpacing ? 'black' : 'pink',
         'fill-opacity': '0.5',
         'stroke-width': '1px'
       },

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -123,7 +123,6 @@ Blockly.blockRendering.Debug.prototype.drawSpacerElem = function(elem, rowHeight
 
   var width = Math.abs(elem.width);
   var isNegativeSpacing = elem.width < 0;
-
   var xPos = isNegativeSpacing ? elem.xPos - width : elem.xPos;
   if (isRtl) {
     xPos = -(xPos + width);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Render negative elem spacing in debugger.

![Screen Shot 2019-12-06 at 11 45 45 AM](https://user-images.githubusercontent.com/16690124/70351614-2d850800-181e-11ea-86c1-2a9ade2f4fae.png)


### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
