### PR TITLE
[zelos] Vertical tight nesting

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -94,14 +94,20 @@ Blockly.blockRendering.Debug.prototype.drawSpacerRow = function(row, cursorY, is
     return;
   }
 
+  var height = Math.abs(row.height);
+  var isNegativeSpacing = row.height < 0;
+  if (isNegativeSpacing) {
+    cursorY -= height;
+  }
+
   this.debugElements_.push(Blockly.utils.dom.createSvgElement('rect',
       {
         'class': 'rowSpacerRect blockRenderDebug',
         'x': isRtl ? -(row.xPos + row.width) : row.xPos,
         'y': cursorY,
         'width': row.width,
-        'height': row.height,
-        'stroke': 'blue',
+        'height': height,
+        'stroke': isNegativeSpacing ? 'black' : 'blue',
         'fill': 'blue',
         'fill-opacity': '0.5',
         'stroke-width': '1px'

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -291,12 +291,13 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
 };
 
 /**
- * Finalize alignment of elements on the block.  In particular, reduce the
- * implicit spacing created by the left and right output connection shapes by
- * adding setting negative spacing onto the leftmost and rightmost spacers.
+ * Finalize horizontal alignment of elements on the block.  In particular,
+ * reduce the implicit spacing created by the left and right output connection
+ * shapes by adding setting negative spacing onto the leftmost and rightmost
+ * spacers.
  * @protected
  */
-Blockly.zelos.RenderInfo.prototype.finalizeAlignment_ = function() {
+Blockly.zelos.RenderInfo.prototype.finalizeHorizontalAlignment_ = function() {
   if (!this.outputConnection) {
     return;
   }
@@ -380,10 +381,45 @@ Blockly.zelos.RenderInfo.prototype.getNegativeSpacing_ = function(elem) {
 };
 
 /**
+ * Finalize vertical alignment of rows on a block.  In particular, reduce the
+ * implicit spacing when a non-shadow block is connected to any of an input
+ * row's inline inputs.
+ * @protected
+ */
+Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
+  if (this.outputConnection) {
+    return;
+  }
+  for (var i = 2; i < this.rows.length - 1; i += 2) {
+    var prevSpacer = this.rows[i - 1];
+    var row = this.rows[i];
+    var nextSpacer = this.rows[i + 1];
+    
+    if (Blockly.blockRendering.Types.isInputRow(row)) {
+      // Determine if the input row has non-shadow connected blocks.
+      var hasNonShadowConnectedBlocks = false;
+      for (var j = 0, elem; (elem = row.elements[j]); j++) {
+        if (Blockly.blockRendering.Types.isInlineInput(elem) &&
+            elem.connectedBlock && !elem.connectedBlock.isShadow()) {
+          hasNonShadowConnectedBlocks = true;
+          break;
+        }
+      }
+      if (hasNonShadowConnectedBlocks) {
+        // Reduce the previous and next spacer's height.
+        prevSpacer.height -= this.constants_.GRID_UNIT;
+        nextSpacer.height -= this.constants_.GRID_UNIT;
+      }
+    }
+  }
+};
+
+/**
  * @override
  */
 Blockly.zelos.RenderInfo.prototype.finalize_ = function() {
   this.finalizeOutputConnection_();
-  this.finalizeAlignment_();
+  this.finalizeHorizontalAlignment_();
+  this.finalizeVerticalAlignment_();
   Blockly.zelos.RenderInfo.superClass_.finalize_.call(this);
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3495

### Proposed Changes

Reduce the vertical spacing for spacers before and after an input row if it contains non-shadow connected blocks.
Added debugger support for displaying negatively spaced row spacers.

### Reason for Changes

Zelos rendering

### Test Coverage

Tested in zelos playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information


![Screen Shot 2019-12-06 at 5 13 06 PM](https://user-images.githubusercontent.com/16690124/70366762-98e6ce00-184e-11ea-82a1-a5405d5a51c6.png)


![Screen Shot 2019-12-06 at 5 31 19 PM](https://user-images.githubusercontent.com/16690124/70366760-98e6ce00-184e-11ea-91a0-aa2fbedc5711.png)

![Screen Shot 2019-12-06 at 5 35 27 PM](https://user-images.githubusercontent.com/16690124/70366784-cfbce400-184e-11ea-88ee-e732b1eb3ec0.png)


![Screen Shot 2019-12-06 at 5 13 13 PM](https://user-images.githubusercontent.com/16690124/70366761-98e6ce00-184e-11ea-9f93-74684fc37e4e.png)
