### PR TITLE
Make alignment common renderer behaviour

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -560,14 +560,28 @@ Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
  */
 Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
     missingSpace) {
+  var firstSpacer = row.getFirstSpacer();
   var lastSpacer = row.getLastSpacer();
-  if (lastSpacer) {
-    lastSpacer.width += missingSpace;
-    row.width += missingSpace;
-    if (row.hasExternalInput || row.hasStatement) {
-      row.widthWithConnectedBlocks += missingSpace;
-    }
+  if (row.hasExternalInput || row.hasStatement) {
+    row.widthWithConnectedBlocks += missingSpace;
   }
+  
+  // Decide where the extra padding goes.
+  if (row.align == Blockly.ALIGN_LEFT) {
+    // Add padding to the end of the row.
+    lastSpacer.width += missingSpace;
+  } else if (row.align == Blockly.ALIGN_CENTRE) {
+    // Split the padding between the beginning and end of the row.
+    firstSpacer.width += missingSpace / 2;
+    lastSpacer.width += missingSpace / 2;
+  } else if (row.align == Blockly.ALIGN_RIGHT) {
+    // Add padding at the beginning of the row.
+    firstSpacer.width += missingSpace;
+  } else {
+    // Default to left-aligning.
+    lastSpacer.width += missingSpace;
+  }
+  row.width += missingSpace;
 };
 
 /**

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -310,34 +310,6 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.geras.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
-  var firstSpacer = row.getFirstSpacer();
-  var lastSpacer = row.getLastSpacer();
-  if (row.hasExternalInput || row.hasStatement) {
-    row.widthWithConnectedBlocks += missingSpace;
-  }
-
-  // Decide where the extra padding goes.
-  if (row.align == Blockly.ALIGN_LEFT) {
-    // Add padding to the end of the row.
-    lastSpacer.width += missingSpace;
-  } else if (row.align == Blockly.ALIGN_CENTRE) {
-    // Split the padding between the beginning and end of the row.
-    firstSpacer.width += missingSpace / 2;
-    lastSpacer.width += missingSpace / 2;
-  } else if (row.align == Blockly.ALIGN_RIGHT) {
-    // Add padding at the beginning of the row.
-    firstSpacer.width += missingSpace;
-  } else {
-    // Default to left-aligning.
-    lastSpacer.width += missingSpace;
-  }
-  row.width += missingSpace;
-};
-
-/**
- * @override
- */
 Blockly.geras.RenderInfo.prototype.getSpacerRowHeight_ = function(prev, next) {
   // If we have an empty block add a spacer to increase the height.
   if (Blockly.blockRendering.Types.isTopRow(prev) &&

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -243,34 +243,6 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.thrasos.RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
-  var firstSpacer = row.getFirstSpacer();
-  var lastSpacer = row.getLastSpacer();
-  if (row.hasExternalInput || row.hasStatement) {
-    row.widthWithConnectedBlocks += missingSpace;
-  }
-  
-  // Decide where the extra padding goes.
-  if (row.align == Blockly.ALIGN_LEFT) {
-    // Add padding to the end of the row.
-    lastSpacer.width += missingSpace;
-  } else if (row.align == Blockly.ALIGN_CENTRE) {
-    // Split the padding between the beginning and end of the row.
-    firstSpacer.width += missingSpace / 2;
-    lastSpacer.width += missingSpace / 2;
-  } else if (row.align == Blockly.ALIGN_RIGHT) {
-    // Add padding at the beginning of the row.
-    firstSpacer.width += missingSpace;
-  } else {
-    // Default to left-aligning.
-    lastSpacer.width += missingSpace;
-  }
-  row.width += missingSpace;
-};
-
-/**
- * @override
- */
 Blockly.thrasos.RenderInfo.prototype.getSpacerRowHeight_ = function(
     prev, next) {
   // If we have an empty block add a spacer to increase the height.

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -200,23 +200,6 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
 };
 
 /**
- * Modify the given row to add the given amount of padding around its fields.
- * The exact location of the padding is based on the alignment property of the
- * last input in the field.
- * @param {Blockly.blockRendering.Row} row The row to add padding to.
- * @param {number} missingSpace How much padding to add.
- * @protected
- */
-Blockly.zelos.RenderInfo.prototype.addAlignmentPadding_ = function(row,
-    missingSpace) {
-  var lastSpacer = row.getLastSpacer();
-  if (lastSpacer) {
-    lastSpacer.width += missingSpace;
-    row.width += missingSpace;
-  }
-};
-
-/**
  * Adjust the x position of fields to bump all non-label fields in the first row
  * past the notch position.  This must be called before ``computeBounds`` is
  * called.

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -149,7 +149,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   },
   {
     "type": "test_align_dummy_right",
-    "message0": "text %1 long text %2",
+    "message0": "text right %1 long text right %2",
     "args0": [
       {
         "type": "input_dummy",
@@ -164,7 +164,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   },
   {
     "type": "test_align_all",
-    "message0": "text %1 long text %2 text %3 much longer text",
+    "message0": "text %1 long text left %2 text centre %3 much longer text right",
     "args0": [
       {
         "type": "input_dummy",
@@ -183,7 +183,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   },
   {
     "type": "test_align_with_external_input",
-    "message0": "text %1 long text %2 text %3 much longer text %4",
+    "message0": "text right %1 long text centre %2 text left %3 much longer text %4",
     "args0": [
       {
         "type": "input_dummy",


### PR DESCRIPTION
# The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3361

### Proposed Changes

Rather than it just being in geras and thrasos. Make alignment common to all renderers.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested geras and zelos in playground (with test blocks).

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
