### PR TITLE
[zelos rendering] Checkbox field constants

### DIFF
--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -60,9 +60,6 @@ Blockly.FieldCheckbox = function(opt_value, opt_validator, opt_config) {
   }
   Blockly.FieldCheckbox.superClass_.constructor.call(
       this, opt_value, opt_validator, opt_config);
-
-  this.size_.width = Blockly.FieldCheckbox.WIDTH;
-
 };
 Blockly.utils.object.inherits(Blockly.FieldCheckbox, Blockly.Field);
 
@@ -76,13 +73,6 @@ Blockly.utils.object.inherits(Blockly.FieldCheckbox, Blockly.Field);
 Blockly.FieldCheckbox.fromJson = function(options) {
   return new Blockly.FieldCheckbox(options['checked'], undefined, options);
 };
-
-/**
- * The width of a checkbox field.
- * @type {number}
- * @const
- */
-Blockly.FieldCheckbox.WIDTH = 15;
 
 /**
  * Default character for the checkmark.
@@ -129,6 +119,7 @@ Blockly.FieldCheckbox.prototype.configure_ = function(config) {
  * @package
  */
 Blockly.FieldCheckbox.prototype.initView = function() {
+  this.size_.width = this.constants_.FIELD_CHECKBOX_DEFAULT_WIDTH;
   Blockly.FieldCheckbox.superClass_.initView.call(this);
 
   this.textElement_.setAttribute('x', this.constants_.FIELD_CHECKBOX_X_OFFSET);

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -354,6 +354,12 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.FIELD_CHECKBOX_Y_OFFSET = 14;
 
   /**
+   * A checkbox field's default width.
+   * @type {number}
+   */
+  this.FIELD_CHECKBOX_DEFAULT_WIDTH = 15;
+
+  /**
    * The ID of the emboss filter, or the empty string if no filter is set.
    * @type {string}
    * @package

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -319,6 +319,21 @@ Blockly.zelos.ConstantProvider = function() {
   this.FIELD_COLOUR_DEFAULT_HEIGHT = 4 * this.GRID_UNIT;
 
   /**
+   * @override
+   */
+  this.FIELD_CHECKBOX_X_OFFSET = this.FIELD_BORDER_RECT_X_PADDING - 3;
+
+  /**
+   * @override
+   */
+  this.FIELD_CHECKBOX_Y_OFFSET = 22;
+
+  /**
+   * @override
+   */
+  this.FIELD_CHECKBOX_DEFAULT_WIDTH = 6 * this.GRID_UNIT;
+
+  /**
    * The ID of the highlight glow filter, or the empty string if no filter is
    * set.
    * @type {string}


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Override zelos field constants for the checkbox field. Make the checkbox field width a constants.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
