### PR TITLE
Inject constants CSS in createDom

### DIFF
--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -63,7 +63,6 @@ Blockly.blockRendering.Renderer = function(name) {
 Blockly.blockRendering.Renderer.prototype.init = function() {
   this.constants_ = this.makeConstants_();
   this.constants_.init();
-  this.injectCSS_(this.constants_.getCSS(this.name));
 };
 
 /**
@@ -148,26 +147,6 @@ Blockly.blockRendering.Renderer.prototype.getConstants = function() {
   return (
     /** @type {!Blockly.blockRendering.ConstantProvider} */
     (this.constants_));
-};
-
-/**
- * Get any renderer specific CSS to inject when the renderer is initialized.
- * @param {!Array.<string>} cssArray Array of CSS strings.
- * @private
- */
-Blockly.blockRendering.Renderer.prototype.injectCSS_ = function(cssArray) {
-  var cssNodeId = 'blockly-renderer-style-' + this.name;
-  if (document.getElementById(cssNodeId)) {
-    // Already injected.
-    return;
-  }
-  var text = cssArray.join('\n');
-  // Inject CSS tag at start of head.
-  var cssNode = document.createElement('style');
-  cssNode.id = cssNodeId;
-  var cssTextNode = document.createTextNode(text);
-  cssNode.appendChild(cssTextNode);
-  document.head.insertBefore(cssNode, document.head.firstChild);
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -622,15 +622,11 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
   </defs>
   */
   var defs = Blockly.utils.dom.createSvgElement('defs', {}, svg);
-  // Each filter/pattern needs a unique ID for the case of multiple Blockly
-  // instances on a page.  Browser behaviour becomes undefined otherwise.
-  // https://neil.fraser.name/news/2015/11/01/
-  var rnd = String(Math.random()).substring(2);
   // Using a dilate distorts the block shape.
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
   var highlightGlowFilter = Blockly.utils.dom.createSvgElement('filter',
       {
-        'id': 'blocklyHighlightGlowFilter' + rnd,
+        'id': 'blocklyHighlightGlowFilter' + this.randomIdentifier_,
         'height': '160%',
         'width': '180%',
         y: '-30%',
@@ -672,7 +668,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
   var replacementGlowFilter = Blockly.utils.dom.createSvgElement('filter',
       {
-        'id': 'blocklyReplacementGlowFilter' + rnd,
+        'id': 'blocklyReplacementGlowFilter' + this.randomIdentifier_,
         'height': '160%',
         'width': '180%',
         y: '-30%',
@@ -720,7 +716,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
 /**
  * @override
  */
-Blockly.zelos.ConstantProvider.prototype.getCSS = function(name) {
+Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
   var selector = '.' + name + '-renderer';
   return [
     /* eslint-disable indent */
@@ -775,6 +771,11 @@ Blockly.zelos.ConstantProvider.prototype.getCSS = function(name) {
     // Connection highlight.
     selector + ' .blocklyHighlightedConnectionPath {',
       'stroke: #fff200;',
+    '}',
+
+    // Disabled outline paths.
+    selector + ' .blocklyDisabled > .blocklyOutlinePath {',
+      'fill: url(#blocklyDisabledPattern' + this.randomIdentifier_ + ')',
     '}',
     /* eslint-enable indent */
   ];

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -121,23 +121,6 @@ Blockly.zelos.PathObject.prototype.flipRTL = function() {
 /**
  * @override
  */
-Blockly.zelos.PathObject.prototype.updateDisabled_ = function(
-    disabled) {
-  Blockly.zelos.PathObject.superClass_.updateDisabled_.call(this, disabled);
-  for (var i = 0, keys = Object.keys(this.outlines_),
-    key; (key = keys[i]); i++) {
-    if (disabled) {
-      this.outlines_[key].setAttribute('fill',
-          'url(#' + this.constants_.disabledPatternId + ')');
-    } else {
-      this.outlines_[key].setAttribute('fill', this.style.colourTertiary);
-    }
-  }
-};
-
-/**
- * @override
- */
 Blockly.zelos.PathObject.prototype.updateSelected = function(enable) {
   this.setClass_('blocklySelected', enable);
   if (enable) {
@@ -229,6 +212,7 @@ Blockly.zelos.PathObject.prototype.endDrawing = function() {
 Blockly.zelos.PathObject.prototype.setOutlinePath = function(name, pathString) {
   var outline = this.getOutlinePath_(name);
   outline.setAttribute('d', pathString);
+  outline.setAttribute('fill', this.style.colourTertiary);
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -744,7 +744,9 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   this.markerManager_.registerMarker(Blockly.navigation.MARKER_NAME,
       new Blockly.Marker());
 
-  this.getRenderer().getConstants().createDom(this.svgGroup_);
+  var constants = this.getRenderer().getConstants();
+  constants.injectCSS(this.getRenderer().name);
+  constants.createDom(this.svgGroup_);
   return this.svgGroup_;
 };
 

--- a/tests/scripts/selenium-config.js
+++ b/tests/scripts/selenium-config.js
@@ -9,7 +9,7 @@ module.exports = {
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '77.0.3865.40',
+      version: '79.0.3945.36',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes issue with setting the outline path when the parent block is disabled. 
Cleanup and a more reasonable place to inject CSS.

### Proposed Changes

Inject constants CSS in workspace createDom instead. Use a random identifier to pre-emptively set css that disabled the outline path based on the disabled pattern id. 

### Reason for Changes

Cleanup / bug fix.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
