### PR TITLE
[zelos] Limit vertical tightnesting

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -400,7 +400,8 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
       var hasNonShadowConnectedBlocks = false;
       for (var j = 0, elem; (elem = row.elements[j]); j++) {
         if (Blockly.blockRendering.Types.isInlineInput(elem) &&
-            elem.connectedBlock && !elem.connectedBlock.isShadow()) {
+            elem.connectedBlock && !elem.connectedBlock.isShadow() &&
+            elem.connectedBlock.getHeightWidth().height >= 40) {
           hasNonShadowConnectedBlocks = true;
           break;
         }

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -398,10 +398,12 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
     if (Blockly.blockRendering.Types.isInputRow(row)) {
       // Determine if the input row has non-shadow connected blocks.
       var hasNonShadowConnectedBlocks = false;
+      var MIN_VERTICAL_TIGHTNESTING_HEIGHT = 40;
       for (var j = 0, elem; (elem = row.elements[j]); j++) {
         if (Blockly.blockRendering.Types.isInlineInput(elem) &&
             elem.connectedBlock && !elem.connectedBlock.isShadow() &&
-            elem.connectedBlock.getHeightWidth().height >= 40) {
+            elem.connectedBlock.getHeightWidth().height >=
+                MIN_VERTICAL_TIGHTNESTING_HEIGHT) {
           hasNonShadowConnectedBlocks = true;
           break;
         }

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -104,6 +104,12 @@ Blockly.zelos.PathObject.prototype.applyColour = function(block) {
   if (block.isShadow() && block.getParent()) {
     this.svgPath.setAttribute('stroke', block.getParent().style.colourTertiary);
   }
+
+  // Apply colour to outlines.
+  for (var i = 0, keys = Object.keys(this.outlines_),
+    key; (key = keys[i]); i++) {
+    this.outlines_[key].setAttribute('fill', this.style.colourTertiary);
+  }
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Limit vertical tight nesting to blocks with a certain height: 

Tight nesting:
![Screen Shot 2019-12-10 at 3 40 57 PM](https://user-images.githubusercontent.com/16690124/70578768-8f69a880-1b63-11ea-8bb3-e314e86e4a04.png)

No tight nesting:
![Screen Shot 2019-12-10 at 3 40 46 PM](https://user-images.githubusercontent.com/16690124/70578773-92fd2f80-1b63-11ea-8224-37ebf52a1b9f.png)

Also, re-add code to apply colour on input outlines, as the theme changes.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested zelos in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
