### PR TITLE
Remove BEFORE/AFTER statement input spacer measurable

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -628,6 +628,9 @@ Blockly.blockRendering.RenderInfo.prototype.makeSpacerRow_ = function(prev, next
   if (prev.hasStatement) {
     spacer.followsStatement = true;
   }
+  if (next.hasStatement) {
+    spacer.precedesStatement = true;
+  }
   return spacer;
 };
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -104,12 +104,17 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
+  this.TOP_ROW_PRECEDES_STATEMENT_MIN_HEIGHT = this.LARGE_PADDING;
+
+  /**
+   * @override
+   */
   this.BOTTOM_ROW_MIN_HEIGHT = this.GRID_UNIT;
 
   /**
    * @override
    */
-  this.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 7 * this.GRID_UNIT;
+  this.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 6 * this.GRID_UNIT;
 
   /**
    * @override

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -98,18 +98,18 @@ Blockly.zelos.Drawer.prototype.drawOutline_ = function() {
  * @protected
  */
 Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
-  if (row.precedesStatement) {
-    var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
+  if (row.precedesStatement || row.followsStatement) {
+    var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight;
+    var remainingHeight = row.height -
+        (row.precedesStatement ? cornerHeight : 0);
     this.outlinePath_ +=
+        (row.followsStatement ?
+            this.constants_.INSIDE_CORNERS.pathBottomRight : '') +
         (remainingHeight > 0 ?
-            Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + remainingHeight) : '') +
-        this.constants_.INSIDE_CORNERS.pathTopRight;
-  } else if (row.followsStatement) {
-    var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
-    this.outlinePath_ +=
-        this.constants_.INSIDE_CORNERS.pathBottomRight +
-        (remainingHeight > 0 ?
-            Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height) : '');
+            Blockly.utils.svgPaths
+                .lineOnAxis('V', row.yPos + remainingHeight) : '') +
+        (row.precedesStatement ?
+            this.constants_.INSIDE_CORNERS.pathTopRight : '');
   } else {
     this.outlinePath_ +=
         Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -98,13 +98,13 @@ Blockly.zelos.Drawer.prototype.drawOutline_ = function() {
  * @protected
  */
 Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
-  if (row.type & Blockly.blockRendering.Types.getType('BEFORE_STATEMENT_SPACER_ROW')) {
+  if (row.precedesStatement) {
     var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
     this.outlinePath_ +=
         (remainingHeight > 0 ?
             Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + remainingHeight) : '') +
         this.constants_.INSIDE_CORNERS.pathTopRight;
-  } else if (row.type & Blockly.blockRendering.Types.getType('AFTER_STATEMENT_SPACER_ROW')) {
+  } else if (row.followsStatement) {
     var remainingHeight = row.height - this.constants_.INSIDE_CORNERS.rightWidth;
     this.outlinePath_ +=
         this.constants_.INSIDE_CORNERS.pathBottomRight +

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -178,6 +178,20 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
 };
 
 /**
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
+  var width = this.width - this.startX;
+  if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
+    return Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH);
+  }
+  if (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement) {
+    return Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH);
+  }
+  return width;
+};
+
+/**
  * Modify the given row to add the given amount of padding around its fields.
  * The exact location of the padding is based on the alignment property of the
  * last input in the field.

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -42,8 +42,6 @@ goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
-goog.require('Blockly.zelos.AfterStatementSpacerRow');
-goog.require('Blockly.zelos.BeforeStatementSpacerRow');
 goog.require('Blockly.zelos.BottomRow');
 goog.require('Blockly.zelos.RightConnectionShape');
 goog.require('Blockly.zelos.TopRow');
@@ -147,35 +145,6 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.zelos.RenderInfo.prototype.makeSpacerRow_ = function(prev, next) {
-  var height = this.getSpacerRowHeight_(prev, next);
-  var width = this.getSpacerRowWidth_(prev, next);
-  if (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement) {
-    var spacer =
-        new Blockly.zelos.BeforeStatementSpacerRow(
-            this.constants_,
-            Math.max(height, this.constants_.INSIDE_CORNERS.rightHeight || 0),
-            Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH));
-  } else if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
-    var spacer =
-        new Blockly.zelos.AfterStatementSpacerRow(
-            this.constants_,
-            Math.max(height, this.constants_.INSIDE_CORNERS.rightHeight || 0),
-            Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH));
-  } else {
-    var spacer = new Blockly.blockRendering.SpacerRow(
-        this.constants_, height, width);
-  }
-  if (prev.hasStatement) {
-    spacer.followsStatement = true;
-  }
-  return spacer;
-};
-
-
-/**
- * @override
- */
 Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
     prev, next) {
   // If we have an empty block add a spacer to increase the height.
@@ -189,6 +158,15 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
       return this.constants_.SMALL_PADDING;
     }
     return this.constants_.NO_PADDING;
+  }
+  if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
+    return Math.max(this.constants_.MEDIUM_PADDING,
+        Math.max(this.constants_.NOTCH_HEIGHT,
+            this.constants_.NOTCH_HEIGHT.rightHeight || 0));
+  }
+  if (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement) {
+    return Math.max(this.constants_.MEDIUM_PADDING,
+        this.constants_.NOTCH_HEIGHT.rightHeight || 0);
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     if (!this.outputConnection) {

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -159,14 +159,17 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
     }
     return this.constants_.NO_PADDING;
   }
-  if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
-    return Math.max(this.constants_.MEDIUM_PADDING,
-        Math.max(this.constants_.NOTCH_HEIGHT,
-            this.constants_.NOTCH_HEIGHT.rightHeight || 0));
-  }
-  if (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement) {
-    return Math.max(this.constants_.MEDIUM_PADDING,
-        this.constants_.NOTCH_HEIGHT.rightHeight || 0);
+  var precedesStatement =
+      Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement;
+  var followsStatement =
+      Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement;
+  if (precedesStatement || followsStatement) {
+    var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight || 0;
+    var height = Math.max(this.constants_.MEDIUM_PADDING,
+        Math.max(this.constants_.NOTCH_HEIGHT, cornerHeight));
+    return precedesStatement && followsStatement ?
+        Math.max(height,
+            cornerHeight * 2 + this.constants_.DUMMY_INPUT_MIN_HEIGHT) : height;
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     if (!this.outputConnection) {

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -185,10 +185,8 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
  */
 Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
   var width = this.width - this.startX;
-  if (Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) {
-    return Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH);
-  }
-  if (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement) {
+  if ((Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement) ||
+      (Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement)) {
     return Math.max(width, this.constants_.STATEMENT_INPUT_SPACER_MIN_WIDTH);
   }
   return width;

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -24,8 +24,6 @@
 
 goog.provide('Blockly.zelos.BottomRow');
 goog.provide('Blockly.zelos.TopRow');
-goog.provide('Blockly.zelos.AfterStatementSpacerRow');
-goog.provide('Blockly.zelos.BeforeStatementSpacerRow');
 
 goog.require('Blockly.blockRendering.BottomRow');
 goog.require('Blockly.blockRendering.TopRow');
@@ -114,43 +112,3 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
   return !!block.outputConnection;
 };
-
-/**
- * An object containing information about a row spacer that comes right
- *   before a statement input.
- * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering
- *   constants provider.
- * @param {number} height The height of the spacer.
- * @param {number} width The width of the spacer.
- * @package
- * @constructor
- * @extends {Blockly.blockRendering.SpacerRow}
- */
-Blockly.zelos.BeforeStatementSpacerRow = function(constants, height, width) {
-  Blockly.zelos.BeforeStatementSpacerRow.superClass_.constructor.call(
-      this, constants, height, width);
-  this.type |=
-      Blockly.blockRendering.Types.getType('BEFORE_STATEMENT_SPACER_ROW');
-};
-Blockly.utils.object.inherits(Blockly.zelos.BeforeStatementSpacerRow,
-    Blockly.blockRendering.SpacerRow);
-
-/**
- * An object containing information about a row spacer that comes right
- *   after a statement input.
- * @param {!Blockly.blockRendering.ConstantProvider} constants The rendering
- *   constants provider.
- * @param {number} height The height of the spacer.
- * @param {number} width The width of the spacer.
- * @package
- * @constructor
- * @extends {Blockly.blockRendering.SpacerRow}
- */
-Blockly.zelos.AfterStatementSpacerRow = function(constants, height, width) {
-  Blockly.zelos.AfterStatementSpacerRow.superClass_.constructor.call(
-      this, constants, height, width);
-  this.type |=
-      Blockly.blockRendering.Types.getType('AFTER_STATEMENT_SPACER_ROW');
-};
-Blockly.utils.object.inherits(Blockly.zelos.AfterStatementSpacerRow,
-    Blockly.blockRendering.SpacerRow);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Cleanup.

### Proposed Changes

Spacer rows already have a followStatement property. Add a precedesStatement property and use that to draw the right corner before / after a statement input instead.
Remove before / after statement spacer row measurables and cleanup measurement of height / width.

### Reason for Changes

Zelos rendering / cleanup

### Test Coverage

Tested in zelos rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
