### PR TITLE
[zelos] Add extra offset for statement input to account for right corner width

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -139,6 +139,13 @@ Blockly.blockRendering.ConstantProvider = function() {
    */
   this.NOTCH_OFFSET_LEFT = 15;
 
+  /**
+   * Additional offset added to the statement input's width to account for the
+   * notch.
+   * @type {number}
+   */
+  this.STATEMENT_INPUT_NOTCH_OFFSET = this.NOTCH_OFFSET_LEFT;
+
   this.STATEMENT_BOTTOM_SPACER = 0;
   this.STATEMENT_INPUT_PADDING_LEFT = 20;
 

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -132,7 +132,7 @@ Blockly.blockRendering.StatementInput = function(constants, input) {
     this.height =
         this.connectedBlockHeight + this.constants_.STATEMENT_BOTTOM_SPACER;
   }
-  this.width = this.constants_.NOTCH_OFFSET_LEFT + this.shape.width;
+  this.width = this.constants_.STATEMENT_INPUT_NOTCH_OFFSET + this.shape.width;
 };
 Blockly.utils.object.inherits(Blockly.blockRendering.StatementInput,
     Blockly.blockRendering.InputConnection);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -80,6 +80,11 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.NOTCH_OFFSET_LEFT = 3 * this.GRID_UNIT;
+  
+  /**
+   * @override
+   */
+  this.STATEMENT_INPUT_NOTCH_OFFSET = this.NOTCH_OFFSET_LEFT;
 
   /**
    * @override
@@ -373,6 +378,8 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
   Blockly.zelos.ConstantProvider.superClass_.init.call(this);
   this.HEXAGONAL = this.makeHexagonal();
   this.ROUNDED = this.makeRounded();
+
+  this.STATEMENT_INPUT_NOTCH_OFFSET += this.INNER_CORNERS.rightWidth;
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -379,7 +379,7 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
   this.HEXAGONAL = this.makeHexagonal();
   this.ROUNDED = this.makeRounded();
 
-  this.STATEMENT_INPUT_NOTCH_OFFSET += this.INNER_CORNERS.rightWidth;
+  this.STATEMENT_INPUT_NOTCH_OFFSET += this.INSIDE_CORNERS.rightWidth;
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<img width="175" alt="Screen Shot 2019-12-11 at 1 36 33 pm" src="https://user-images.githubusercontent.com/16690124/70662581-660c5380-1c1b-11ea-9a28-1699239cc99f.png">

### Proposed Changes

Add additional offset to the statement input in zelos to account for the right corner width.

### Reason for Changes
Zelos rendering.

### Test Coverage

Tested in developer tools.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="151" alt="Screen Shot 2019-12-11 at 1 36 10 pm" src="https://user-images.githubusercontent.com/16690124/70662687-9d7b0000-1c1b-11ea-8fcc-640799a5e526.png">

