### PR TITLE
Ws cursor move

### DIFF
--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -25,6 +25,7 @@
 goog.provide('Blockly.BasicCursor');
 
 goog.require('Blockly.ASTNode');
+goog.require('Blockly.Cursor');
 
 
 /**

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -161,6 +161,14 @@ Blockly.user.keyMap.createDefaultKeyMap = function() {
   var map = {};
   var controlK = Blockly.user.keyMap.createSerializedKey(
       Blockly.utils.KeyCodes.K, [Blockly.user.keyMap.modifierKeys.CONTROL]);
+  var shiftW = Blockly.user.keyMap.createSerializedKey(
+      Blockly.utils.KeyCodes.W, [Blockly.user.keyMap.modifierKeys.SHIFT]);
+  var shiftA = Blockly.user.keyMap.createSerializedKey(
+      Blockly.utils.KeyCodes.A, [Blockly.user.keyMap.modifierKeys.SHIFT]);
+  var shiftS = Blockly.user.keyMap.createSerializedKey(
+      Blockly.utils.KeyCodes.S, [Blockly.user.keyMap.modifierKeys.SHIFT]);
+  var shiftD = Blockly.user.keyMap.createSerializedKey(
+      Blockly.utils.KeyCodes.D, [Blockly.user.keyMap.modifierKeys.SHIFT]);
 
   map[Blockly.utils.KeyCodes.W] = Blockly.navigation.ACTION_PREVIOUS;
   map[Blockly.utils.KeyCodes.A] = Blockly.navigation.ACTION_OUT;
@@ -173,5 +181,9 @@ Blockly.user.keyMap.createDefaultKeyMap = function() {
   map[Blockly.utils.KeyCodes.E] = Blockly.navigation.ACTION_EXIT;
   map[Blockly.utils.KeyCodes.ESC] = Blockly.navigation.ACTION_EXIT;
   map[controlK] = Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV;
+  map[shiftW] = Blockly.navigation.ACTION_MOVE_WS_UP;
+  map[shiftA] = Blockly.navigation.ACTION_MOVE_WS_LEFT;
+  map[shiftS] = Blockly.navigation.ACTION_MOVE_WS_DOWN;
+  map[shiftD] = Blockly.navigation.ACTION_MOVE_WS_RIGHT;
   return map;
 };

--- a/core/keyboard_nav/key_map.js
+++ b/core/keyboard_nav/key_map.js
@@ -181,9 +181,9 @@ Blockly.user.keyMap.createDefaultKeyMap = function() {
   map[Blockly.utils.KeyCodes.E] = Blockly.navigation.ACTION_EXIT;
   map[Blockly.utils.KeyCodes.ESC] = Blockly.navigation.ACTION_EXIT;
   map[controlK] = Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV;
-  map[shiftW] = Blockly.navigation.ACTION_MOVE_WS_UP;
-  map[shiftA] = Blockly.navigation.ACTION_MOVE_WS_LEFT;
-  map[shiftS] = Blockly.navigation.ACTION_MOVE_WS_DOWN;
-  map[shiftD] = Blockly.navigation.ACTION_MOVE_WS_RIGHT;
+  map[shiftW] = Blockly.navigation.ACTION_MOVE_WS_CURSOR_UP;
+  map[shiftA] = Blockly.navigation.ACTION_MOVE_WS_CURSOR_LEFT;
+  map[shiftS] = Blockly.navigation.ACTION_MOVE_WS_CURSOR_DOWN;
+  map[shiftD] = Blockly.navigation.ACTION_MOVE_WS_CURSOR_RIGHT;
   return map;
 };

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -66,6 +66,7 @@ Blockly.navigation.STATE_TOOLBOX = 3;
 /**
  * The distance to move the cursor on the workspace.
  * @type {number}
+ * @const
  */
 Blockly.navigation.WS_MOVE_DISTANCE = 40;
 
@@ -93,10 +94,10 @@ Blockly.navigation.actionNames = {
   TOOLBOX: 'toolbox',
   EXIT: 'exit',
   TOGGLE_KEYBOARD_NAV: 'toggle_keyboard_nav',
-  MOVE_WS_UP: 'move_ws_up',
-  MOVE_WS_DOWN: 'move_ws_down',
-  MOVE_WS_LEFT: 'move_ws_left',
-  MOVE_WS_RIGHT: 'move_ws_right'
+  MOVE_WS_CURSOR_UP: 'move_ws_cursor_up',
+  MOVE_WS_CURSOR_DOWN: 'move_ws_cursor_down',
+  MOVE_WS_CURSOR_LEFT: 'move_ws_cursor_left',
+  MOVE_WS_CURSOR_RIGHT: 'move_ws_cursor_right'
 };
 
 /**
@@ -885,8 +886,8 @@ Blockly.navigation.toolboxOnAction_ = function(action) {
 
 /**
  * Move the workspace cursor in the given direction.
- * @param {number} xDirection -1 to move cursor left 1 to move cursor right.
- * @param {number} yDirection -1 to move cursor up 1 to move cursor down.
+ * @param {number} xDirection -1 to move cursor left. 1 to move cursor right.
+ * @param {number} yDirection -1 to move cursor up. 1 to move cursor down.
  * @return {boolean} True if the current node is a workspace, false otherwise.
  * @private
  */
@@ -902,10 +903,8 @@ Blockly.navigation.moveWSCursor_ = function(xDirection, yDirection) {
   var newX = xDirection * Blockly.navigation.WS_MOVE_DISTANCE + wsCoord.x;
   var newY = yDirection * Blockly.navigation.WS_MOVE_DISTANCE + wsCoord.y;
 
-  var newCoord = new Blockly.utils.Coordinate(newX, newY);
-  var newWSAST = Blockly.ASTNode.createWorkspaceNode(
-      Blockly.getMainWorkspace(), newCoord);
-  cursor.setCurNode(newWSAST);
+  cursor.setCurNode(Blockly.ASTNode.createWorkspaceNode(
+      Blockly.getMainWorkspace(), new Blockly.utils.Coordinate(newX, newY)));
   return true;
 };
 
@@ -929,13 +928,13 @@ Blockly.navigation.workspaceOnAction_ = function(action) {
     case Blockly.navigation.actionNames.DISCONNECT:
       Blockly.navigation.disconnectBlocks_();
       return true;
-    case Blockly.navigation.actionNames.MOVE_WS_UP:
+    case Blockly.navigation.actionNames.MOVE_WS_CURSOR_UP:
       return Blockly.navigation.moveWSCursor_(0, -1);
-    case Blockly.navigation.actionNames.MOVE_WS_DOWN:
+    case Blockly.navigation.actionNames.MOVE_WS_CURSOR_DOWN:
       return Blockly.navigation.moveWSCursor_(0, 1);
-    case Blockly.navigation.actionNames.MOVE_WS_LEFT:
+    case Blockly.navigation.actionNames.MOVE_WS_CURSOR_LEFT:
       return Blockly.navigation.moveWSCursor_(-1, 0);
-    case Blockly.navigation.actionNames.MOVE_WS_RIGHT:
+    case Blockly.navigation.actionNames.MOVE_WS_CURSOR_RIGHT:
       return Blockly.navigation.moveWSCursor_(1, 0);
     default:
       return false;
@@ -1046,33 +1045,33 @@ Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV = new Blockly.Action(
  * The action to move the cursor to the keft on a worksapce.
  * @type {!Blockly.Action}
  */
-Blockly.navigation.ACTION_MOVE_WS_LEFT = new Blockly.Action(
-    Blockly.navigation.actionNames.MOVE_WS_LEFT,
-    'Turns on and off keyboard navigation.');
+Blockly.navigation.ACTION_MOVE_WS_CURSOR_LEFT = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_CURSOR_LEFT,
+    'Move the workspace cursor to the lefts.');
 
 /**
  * The action to move the cursor to the right on a worksapce.
  * @type {!Blockly.Action}
  */
-Blockly.navigation.ACTION_MOVE_WS_RIGHT = new Blockly.Action(
-    Blockly.navigation.actionNames.MOVE_WS_RIGHT,
-    'Turns on and off keyboard navigation.');
+Blockly.navigation.ACTION_MOVE_WS_CURSOR_RIGHT = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_CURSOR_RIGHT,
+    'Move the workspace cursor to the right.');
 
 /**
  * The action to move the cursor up on a worksapce.
  * @type {!Blockly.Action}
  */
-Blockly.navigation.ACTION_MOVE_WS_UP = new Blockly.Action(
-    Blockly.navigation.actionNames.MOVE_WS_UP,
-    'Moves the cursor to the .');
+Blockly.navigation.ACTION_MOVE_WS_CURSOR_UP = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_CURSOR_UP,
+    'Move the workspace cursor up.');
 
 /**
  * The action to move the cursor down on a worksapce.
  * @type {!Blockly.Action}
  */
-Blockly.navigation.ACTION_MOVE_WS_DOWN = new Blockly.Action(
-    Blockly.navigation.actionNames.MOVE_WS_DOWN,
-    'Turns on and off keyboard navigation.');
+Blockly.navigation.ACTION_MOVE_WS_CURSOR_DOWN = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_CURSOR_DOWN,
+    'Move the workspace cursor down.');
 
 
 /**

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -45,20 +45,29 @@ Blockly.navigation.loggingCallback = null;
 /**
  * State indicating focus is currently on the flyout.
  * @type {number}
+ * @const
  */
 Blockly.navigation.STATE_FLYOUT = 1;
 
 /**
  * State indicating focus is currently on the workspace.
  * @type {number}
+ * @const
  */
 Blockly.navigation.STATE_WS = 2;
 
 /**
  * State indicating focus is currently on the toolbox.
  * @type {number}
+ * @const
  */
 Blockly.navigation.STATE_TOOLBOX = 3;
+
+/**
+ * The distance to move the cursor on the workspace.
+ * @type {number}
+ */
+Blockly.navigation.WS_MOVE_DISTANCE = 40;
 
 /**
  * The current state the user is in.
@@ -83,7 +92,11 @@ Blockly.navigation.actionNames = {
   DISCONNECT: 'disconnect',
   TOOLBOX: 'toolbox',
   EXIT: 'exit',
-  TOGGLE_KEYBOARD_NAV: 'toggle_keyboard_nav'
+  TOGGLE_KEYBOARD_NAV: 'toggle_keyboard_nav',
+  MOVE_WS_UP: 'move_ws_up',
+  MOVE_WS_DOWN: 'move_ws_down',
+  MOVE_WS_LEFT: 'move_ws_left',
+  MOVE_WS_RIGHT: 'move_ws_right'
 };
 
 /**
@@ -108,7 +121,6 @@ Blockly.navigation.getMarker = function() {
 /**
  * If a toolbox exists, set the navigation state to toolbox and select the first
  * category in the toolbox.
- * category.
  * @private
  */
 Blockly.navigation.focusToolbox_ = function() {
@@ -872,6 +884,32 @@ Blockly.navigation.toolboxOnAction_ = function(action) {
 };
 
 /**
+ * Move the workspace cursor in the given direction.
+ * @param {number} xDirection -1 to move cursor left 1 to move cursor right.
+ * @param {number} yDirection -1 to move cursor up 1 to move cursor down.
+ * @return {boolean} True if the current node is a workspace, false otherwise.
+ * @private
+ */
+Blockly.navigation.moveWSCursor_ = function(xDirection, yDirection) {
+  var cursor = Blockly.getMainWorkspace().getCursor();
+  var curNode = Blockly.getMainWorkspace().getCursor().getCurNode();
+
+  if (curNode.getType() !== Blockly.ASTNode.types.WORKSPACE) {
+    return false;
+  }
+
+  var wsCoord = curNode.getWsCoordinate();
+  var newX = xDirection * Blockly.navigation.WS_MOVE_DISTANCE + wsCoord.x;
+  var newY = yDirection * Blockly.navigation.WS_MOVE_DISTANCE + wsCoord.y;
+
+  var newCoord = new Blockly.utils.Coordinate(newX, newY);
+  var newWSAST = Blockly.ASTNode.createWorkspaceNode(
+      Blockly.getMainWorkspace(), newCoord);
+  cursor.setCurNode(newWSAST);
+  return true;
+};
+
+/**
  * Handles the given action for the workspace.
  * @param {!Blockly.Action} action The action to handle.
  * @return {boolean} True if the action has been handled, false otherwise.
@@ -891,6 +929,14 @@ Blockly.navigation.workspaceOnAction_ = function(action) {
     case Blockly.navigation.actionNames.DISCONNECT:
       Blockly.navigation.disconnectBlocks_();
       return true;
+    case Blockly.navigation.actionNames.MOVE_WS_UP:
+      return Blockly.navigation.moveWSCursor_(0, -1);
+    case Blockly.navigation.actionNames.MOVE_WS_DOWN:
+      return Blockly.navigation.moveWSCursor_(0, 1);
+    case Blockly.navigation.actionNames.MOVE_WS_LEFT:
+      return Blockly.navigation.moveWSCursor_(-1, 0);
+    case Blockly.navigation.actionNames.MOVE_WS_RIGHT:
+      return Blockly.navigation.moveWSCursor_(1, 0);
     default:
       return false;
   }
@@ -995,6 +1041,39 @@ Blockly.navigation.ACTION_EXIT = new Blockly.Action(
 Blockly.navigation.ACTION_TOGGLE_KEYBOARD_NAV = new Blockly.Action(
     Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV,
     'Turns on and off keyboard navigation.');
+
+/**
+ * The action to move the cursor to the keft on a worksapce.
+ * @type {!Blockly.Action}
+ */
+Blockly.navigation.ACTION_MOVE_WS_LEFT = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_LEFT,
+    'Turns on and off keyboard navigation.');
+
+/**
+ * The action to move the cursor to the right on a worksapce.
+ * @type {!Blockly.Action}
+ */
+Blockly.navigation.ACTION_MOVE_WS_RIGHT = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_RIGHT,
+    'Turns on and off keyboard navigation.');
+
+/**
+ * The action to move the cursor up on a worksapce.
+ * @type {!Blockly.Action}
+ */
+Blockly.navigation.ACTION_MOVE_WS_UP = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_UP,
+    'Moves the cursor to the .');
+
+/**
+ * The action to move the cursor down on a worksapce.
+ * @type {!Blockly.Action}
+ */
+Blockly.navigation.ACTION_MOVE_WS_DOWN = new Blockly.Action(
+    Blockly.navigation.actionNames.MOVE_WS_DOWN,
+    'Turns on and off keyboard navigation.');
+
 
 /**
  * List of actions that can be performed in read only mode.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Add ability to move around the workspace in keyboard navigation mode.

### Proposed Changes
shift + wasd keys will move a user around the workspace.
If a user hits shift + wasd when on a block or field nothing will happen. 

### Reason for Changes
Not being able to move around the workspace is no fun.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
