### PR TITLE
[zelos] Statement input centreline

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -99,6 +99,11 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
+  this.EMPTY_STATEMENT_INPUT_HEIGHT = 6 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
   this.TAB_OFFSET_FROM_TOP = 0;
 
   /**

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -224,8 +224,7 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
 /**
  * @override
  */
-Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row,
-    elem) {
+Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
   if (row.hasStatement) {
     return row.yPos + this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT / 2;
   }

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -222,6 +222,18 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
 };
 
 /**
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row,
+    elem) {
+  if (row.hasStatement) {
+    return row.yPos + this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT / 2;
+  }
+  return Blockly.zelos.RenderInfo.superClass_.getElemCenterline_.call(this,
+      row, elem);
+};
+
+/**
  * Adjust the x position of fields to bump all non-label fields in the first row
  * past the notch position.  This must be called before ``computeBounds`` is
  * called.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Statement input left side text shouldn't move up/down as the statement stack changes.
<img width="262" alt="Screen Shot 2019-12-12 at 7 02 22 PM" src="https://user-images.githubusercontent.com/16690124/70766225-f4fb9780-1d11-11ea-92f7-9e0d28048973.png">

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Make statement inputs in zelos use the top row centreline.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in zelos playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="237" alt="Screen Shot 2019-12-12 at 6 59 24 PM" src="https://user-images.githubusercontent.com/16690124/70766088-89b1c580-1d11-11ea-9464-3c1df7cf3e73.png">

