### PR TITLE
[zelos] Jagged teeth

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -673,9 +673,9 @@ Blockly.blockRendering.ConstantProvider.prototype.makeJaggedTeeth = function() {
   var mainPath =
       Blockly.utils.svgPaths.line(
           [
-            Blockly.utils.svgPaths.point(6, 3),
-            Blockly.utils.svgPaths.point(-12, 6),
-            Blockly.utils.svgPaths.point(6, 3)
+            Blockly.utils.svgPaths.point(width, height / 4),
+            Blockly.utils.svgPaths.point(-width * 2, height / 2),
+            Blockly.utils.svgPaths.point(width, height / 4)
           ]);
   return {
     height: height,

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -225,13 +225,13 @@ Blockly.blockRendering.ConstantProvider = function() {
 
   /**
    * Height of SVG path for jagged teeth at the end of collapsed blocks.
-   * @const
+   * @type {number}
    */
   this.JAGGED_TEETH_HEIGHT = 12;
 
   /**
    * Width of SVG path for jagged teeth at the end of collapsed blocks.
-   * @const
+   * @type {number}
    */
   this.JAGGED_TEETH_WIDTH = 6;
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -170,6 +170,16 @@ Blockly.zelos.ConstantProvider = function() {
   this.CURSOR_RADIUS = 5;
 
   /**
+   * @override
+   */
+  this.JAGGED_TEETH_HEIGHT = 0;
+
+  /**
+   * @override
+   */
+  this.JAGGED_TEETH_WIDTH = 0;
+
+  /**
    * @enum {number}
    * @override
    */


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Jagged teeth not using the constants provided.
Zelos doesn't use jagged teeth.

### Proposed Changes

Update jagged teeth code to use height / width constants.
Remove use in zelos.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="420" alt="Screen Shot 2019-12-12 at 7 07 12 PM" src="https://user-images.githubusercontent.com/16690124/70766516-ca5e0e80-1d12-11ea-99ff-9e86b178cf10.png">

