### PR TITLE
[zelos] Update constants to use grid unit, add dummy shadow min height

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -127,6 +127,12 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.DUMMY_INPUT_MIN_HEIGHT = this.TAB_HEIGHT;
 
   /**
+   * The minimum height of a dummy input row in a shadow block.
+   * @type {number}
+   */
+  this.DUMMY_INPUT_SHADOW_MIN_HEIGHT = this.TAB_HEIGHT;
+
+  /**
    * Rounded corner radius.
    * @type {number}
    */

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -386,6 +386,8 @@ Blockly.blockRendering.RenderInfo.prototype.addInput_ = function(input, activeRo
     // Dummy inputs have no visual representation, but the information is still
     // important.
     activeRow.minHeight = Math.max(activeRow.minHeight,
+        input.getSourceBlock() && input.getSourceBlock().isShadow() ?
+        this.constants_.DUMMY_INPUT_SHADOW_MIN_HEIGHT :
         this.constants_.DUMMY_INPUT_MIN_HEIGHT);
     activeRow.hasDummyInput = true;
   }

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -150,7 +150,12 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
-  this.DUMMY_INPUT_MIN_HEIGHT = 6 * this.GRID_UNIT;
+  this.DUMMY_INPUT_MIN_HEIGHT = 8 * this.GRID_UNIT;
+
+  /**
+   * @override
+   */
+  this.DUMMY_INPUT_SHADOW_MIN_HEIGHT = 6 * this.GRID_UNIT;
 
   /**
    * @override
@@ -218,7 +223,7 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
-  this.FIELD_TEXT_FONTSIZE = 12;
+  this.FIELD_TEXT_FONTSIZE = 3 * this.GRID_UNIT;
 
   /**
    * @override
@@ -283,7 +288,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @type {number}
    * @const
    */
-  this.FIELD_DROPDOWN_SVG_ARROW_SIZE = 12;
+  this.FIELD_DROPDOWN_SVG_ARROW_SIZE = 3 * this.GRID_UNIT;
 
   /**
    * A dropdown field's SVG arrow datauri.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Use GRID_UNIT for all constants.
Zelos has different minimum height for dummy inputs whether they're in a shadow block or not. 

### Proposed Changes

Update zelos constants to use GRID UNIT.
Zelos has different minimum height for dummy inputs whether they're in a shadow block or not. Add new constant for shadow dummy min height.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
