### PR TITLE
[zelos] Output connection position

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -396,7 +396,8 @@ Blockly.blockRendering.Drawer.prototype.positionInlineInputConnection_ = functio
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX, yPos + input.connectionOffsetY);
+    input.connection.setOffsetInBlock(connX + input.connectionOffsetX,
+        yPos + input.connectionOffsetY);
   }
 };
 
@@ -473,7 +474,8 @@ Blockly.blockRendering.Drawer.prototype.positionOutputConnection_ = function() {
   if (this.info_.outputConnection) {
     var x = this.info_.startX;
     var connX = this.info_.RTL ? -x : x;
-    this.block_.outputConnection.setOffsetInBlock(connX,
-        this.info_.outputConnection.connectionOffsetY);
+    this.block_.outputConnection.setOffsetInBlock(connX +
+        this.info_.outputConnection.connectionOffsetX,
+    this.info_.outputConnection.connectionOffsetY);
   }
 };

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -392,11 +392,11 @@ Blockly.blockRendering.Drawer.prototype.positionInlineInputConnection_ = functio
   // Move the connection.
   if (input.connection) {
     // xPos already contains info about startX
-    var connX = input.xPos + input.connectionWidth;
+    var connX = input.xPos + input.connectionWidth + input.connectionOffsetX;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX + input.connectionOffsetX,
+    input.connection.setOffsetInBlock(connX,
         yPos + input.connectionOffsetY);
   }
 };
@@ -472,10 +472,9 @@ Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
  */
 Blockly.blockRendering.Drawer.prototype.positionOutputConnection_ = function() {
   if (this.info_.outputConnection) {
-    var x = this.info_.startX;
+    var x = this.info_.startX + this.info_.outputConnection.connectionOffsetX;
     var connX = this.info_.RTL ? -x : x;
-    this.block_.outputConnection.setOffsetInBlock(connX +
-        this.info_.outputConnection.connectionOffsetX,
-    this.info_.outputConnection.connectionOffsetY);
+    this.block_.outputConnection.setOffsetInBlock(connX,
+        this.info_.outputConnection.connectionOffsetY);
   }
 };

--- a/core/renderers/measurables/connections.js
+++ b/core/renderers/measurables/connections.js
@@ -74,6 +74,7 @@ Blockly.blockRendering.OutputConnection = function(constants, connectionModel) {
   this.startX = this.width;
 
   this.connectionOffsetY = this.constants_.TAB_OFFSET_FROM_TOP;
+  this.connectionOffsetX = 0;
 };
 Blockly.utils.object.inherits(Blockly.blockRendering.OutputConnection,
     Blockly.blockRendering.Connection);

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -97,13 +97,18 @@ Blockly.blockRendering.InlineInput = function(constants, input) {
     this.height = this.connectedBlockHeight;
   }
 
-  this.connectionHeight = this.shape.height;
+  this.connectionHeight = !this.isDynamicShape ? this.shape.height :
+      this.shape.height(this.height);
   this.connectionWidth = !this.isDynamicShape ? this.shape.width :
-    this.shape.width(this.height);
+      this.shape.width(this.height);
   if (!this.connectedBlock) {
     this.width += this.connectionWidth * (this.isDynamicShape ? 2 : 1);
   }
-  this.connectionOffsetY = this.constants_.TAB_OFFSET_FROM_TOP;
+  this.connectionOffsetY = this.isDynamicShape ?
+      this.shape.connectionOffsetY(this.connectionHeight) :
+      this.constants_.TAB_OFFSET_FROM_TOP;
+  this.connectionOffsetX = this.isDynamicShape ?
+      this.shape.connectionOffsetX(this.connectionWidth) : 0;
 };
 Blockly.utils.object.inherits(Blockly.blockRendering.InlineInput,
     Blockly.blockRendering.InputConnection);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -424,6 +424,12 @@ Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
     height: function(height) {
       return height;
     },
+    connectionOffsetY: function(connectionHeight) {
+      return connectionHeight / 2;
+    },
+    connectionOffsetX: function(connectionWidth) {
+      return - connectionWidth;
+    },
     pathDown: function(height) {
       return makeMainPath(height, false, false);
     },
@@ -462,6 +468,12 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
     },
     height: function(height) {
       return height;
+    },
+    connectionOffsetY: function(connectionHeight) {
+      return connectionHeight / 2;
+    },
+    connectionOffsetX: function(connectionWidth) {
+      return - connectionWidth;
     },
     pathDown: function(height) {
       return makeMainPath(height, false, false);

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -284,8 +284,10 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
   this.outputConnection.height = connectionHeight;
   this.outputConnection.width = connectionWidth;
   this.outputConnection.startX = connectionWidth;
-  this.outputConnection.connectionOffsetX = -connectionWidth;
-  this.outputConnection.connectionOffsetY = connectionHeight / 2;
+  this.outputConnection.connectionOffsetY =
+      this.outputConnection.shape.connectionOffsetY(connectionHeight);
+  this.outputConnection.connectionOffsetX =
+      this.outputConnection.shape.connectionOffsetX(connectionWidth);
 
   // Adjust right side measurable.
   this.rightSide.height = connectionHeight;

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -284,6 +284,8 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
   this.outputConnection.height = connectionHeight;
   this.outputConnection.width = connectionWidth;
   this.outputConnection.startX = connectionWidth;
+  this.outputConnection.connectionOffsetX = -connectionWidth;
+  this.outputConnection.connectionOffsetY = connectionHeight / 2;
 
   // Adjust right side measurable.
   this.rightSide.height = connectionHeight;


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Zelos connection is currently positioned in the top left corner. Because the connection shape is circular / triangular, this is positioned off the block.  

### Proposed Changes

Position the connection point to the left and center of the block: 
<img width="686" alt="Screen Shot 2019-12-12 at 7 23 44 PM" src="https://user-images.githubusercontent.com/16690124/70767218-35a8e000-1d15-11ea-8b60-56d1036b0b0f.png">

Added methods on the shape for the shape developer to decide where to position it. 
@rachel-fenichel just a thought, but maybe we should make all shapes dynamic and simplify the code, in the cases where the height / width are static they would just return the static height / width not taking into account the block height that's passed in.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested geras and zelos in playground.
Tested RTL.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
