### PR TITLE
Fix gulp blocks compile build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -198,8 +198,8 @@ gulp.task('build-core', function () {
  */
 gulp.task('build-blocks', function () {
   // Add provides used throughout blocks/ in order to be compatible with the
-  // compiler.  All provides added to this list must be removed from the
-  // compiled result using the regex remove steps below.
+  // compiler.  Anything added to this list must be removed from the compiled
+  // result using the remove regex steps below.
   const provides = `
 goog.provide('Blockly');
 goog.provide('Blockly.Blocks');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,6 +197,9 @@ gulp.task('build-core', function () {
  *     blocks_compressed.js
  */
 gulp.task('build-blocks', function () {
+  // Add provides used throughout blocks/ in order to be compatible with the
+  // compiler.  All provides added to this list must be removed from the
+  // compiled result using the regex remove steps below.
   const provides = `
 goog.provide('Blockly');
 goog.provide('Blockly.Blocks');
@@ -227,6 +230,8 @@ goog.provide('Blockly.Warning');`;
     .pipe(gulp.replace(/var Blockly=\{[^;]*\};\n?/, ''))
     // Remove Blockly Fields to be compatible with Blockly.
     .pipe(gulp.replace(/Blockly\.Field[^=\(]+=\{[^;]*\};/g, ''))
+    // Remove Blockly Warning, Comment & Mutator to be compatible with Blockly.
+    .pipe(gulp.replace(/Blockly\.(Comment|Warning|Mutator)=\{[^;]*\};/g, ''))
     .pipe(prependHeader())
     .pipe(gulp.dest('./'));
 });


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/3518

### Proposed Changes

Fix gulp compile build of blocks, by ensuring all added provides are included in the remove regex.

### Reason for Changes

Fix gulp build.

### Test Coverage

Tested demos and playground with both uncompressed and compressed builds.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
