### PR TITLE
fix: Fixed insertion preview logic. And fixed markers not handling typed statements.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -626,6 +626,33 @@ Blockly.Block.prototype.getFirstStatementConnection = function() {
   return null;
 };
 
+Blockly.Block.prototype.getLastConnectionInRow = function() {
+  var block = this;
+  while (block.inputList.length == 1 &&
+      block.inputList[0].type == Blockly.INPUT_VALUE) {
+    var connection = block.inputList[0].connection;
+    var newBlock = connection.targetBlock();
+    if (!newBlock || newBlock.isShadow()) {
+      return connection;
+    }
+    block = newBlock;
+  }
+  return null;
+};
+
+Blockly.Block.prototype.getLastConnectionInStack = function() {
+  var block = this;
+  while (block.nextConnection) {
+    var connection = block.nextConnection;
+    var newBlock = connection.targetBlock();
+    if (!newBlock || newBlock.isShadow()) {
+      return connection;
+    }
+    block = newBlock;
+  }
+  return null;
+};
+
 /**
  * Return the top-most block in this block's tree.
  * This will return itself if this block is at the top level.

--- a/core/block.js
+++ b/core/block.js
@@ -626,33 +626,6 @@ Blockly.Block.prototype.getFirstStatementConnection = function() {
   return null;
 };
 
-Blockly.Block.prototype.getLastConnectionInRow = function() {
-  var block = this;
-  while (block.inputList.length == 1 &&
-      block.inputList[0].type == Blockly.INPUT_VALUE) {
-    var connection = block.inputList[0].connection;
-    var newBlock = connection.targetBlock();
-    if (!newBlock || newBlock.isShadow()) {
-      return connection;
-    }
-    block = newBlock;
-  }
-  return null;
-};
-
-Blockly.Block.prototype.getLastConnectionInStack = function() {
-  var block = this;
-  while (block.nextConnection) {
-    var connection = block.nextConnection;
-    var newBlock = connection.targetBlock();
-    if (!newBlock || newBlock.isShadow()) {
-      return connection;
-    }
-    block = newBlock;
-  }
-  return null;
-};
-
 /**
  * Return the top-most block in this block's tree.
  * This will return itself if this block is at the top level.

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1730,8 +1730,8 @@ Blockly.BlockSvg.prototype.getHeightWidth = function() {
  * @param {boolean} add True if highlighting should be added.
  * @package
  */
-Blockly.BlockSvg.prototype.highlightForReplacement = function(add) {
-  this.pathObject.updateReplacementHighlight(add);
+Blockly.BlockSvg.prototype.fadeForReplacement = function(add) {
+  this.pathObject.updateReplacementFade(add);
 };
 
 /**

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -140,6 +140,11 @@ Blockly.InsertionMarkerManager = function(block) {
   this.availableConnections_ = this.initAvailableConnections_();
 };
 
+/**
+ * An enum describing different kinds of previews the InsertionMarkerManager
+ * could display.
+ * @enum {number}
+ */
 Blockly.InsertionMarkerManager.PREVIEW_TYPE = {
   INSERTION_MARKER: 0,
   INPUT_OUTLINE: 1,
@@ -537,6 +542,11 @@ Blockly.InsertionMarkerManager.prototype.hidePreview_ = function() {
   }
 };
 
+/**
+ * Shows an insertion marker connected to the appropriate blocks (based on
+ * manager state).
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.showInsertionMarker_ = function() {
   var local = this.localConnection_;
   var closest = this.closestConnection_;
@@ -568,6 +578,11 @@ Blockly.InsertionMarkerManager.prototype.showInsertionMarker_ = function() {
   this.markerConnection_ = imConn;
 };
 
+/**
+ * Disconnects and hides the current insertion marker. Should return the blocks
+ * to their original state.
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.hideInsertionMarker_ = function() {
   if (!this.markerConnection_) {
     console.log('No insertion marker connection to disconnect');
@@ -615,22 +630,39 @@ Blockly.InsertionMarkerManager.prototype.hideInsertionMarker_ = function() {
   imBlock.getSvgRoot().setAttribute('visibility', 'hidden');
 };
 
+/**
+ * Shows an outline around the input the closest connection belongs to.
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.showInsertionInputOutline_ = function() {
   var closest = this.closestConnection_;
   this.highlightedBlock_ = closest.getSourceBlock();
   this.highlightedBlock_.highlightShapeForInput(closest, true);
 };
 
+/**
+ * Hides any visible input outlines.
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.hideInsertionInputOutline_ = function() {
   this.highlightedBlock_.highlightShapeForInput(this.closestConnection_, false);
   this.highlightedBlock_ = null;
 };
 
+/**
+ * Shows a replacement fade affect on the closest connection's target block
+ * (the block that is currently connected to it).
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.showReplacementFade_ = function() {
   this.fadedBlock_ = this.closestConnection_.targetBlock();
   this.fadedBlock_.fadeForReplacement(true);
 };
 
+/**
+ * Hides/Removes any visible fade affects.
+ * @private
+ */
 Blockly.InsertionMarkerManager.prototype.hideReplacementFade_ = function() {
   this.fadedBlock_.fadeForReplacement(false);
   this.fadedBlock_ = null;

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -558,7 +558,7 @@ Blockly.InsertionMarkerManager.prototype.showInsertionMarker_ = function() {
   var imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);
 
   if (imConn == this.markerConnection_) {
-    throw Error('Made it to connectMarker_ even though the marker isn\'t ' +
+    throw Error('Made it to showInsertionMarker_ even though the marker isn\'t ' +
         'changing');
   }
 

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -469,7 +469,9 @@ Blockly.InsertionMarkerManager.prototype.showPreview_ = function() {
   var closest = this.closestConnection_;
   var renderer = this.workspace_.getRenderer();
   var method = renderer.getConnectionPreviewMethod(
-      closest, this.localConnection_, this.topBlock_);
+      /** @type {!Blockly.RenderedConnection} */ (closest),
+      /** @type {!Blockly.RenderedConnection} */ (this.localConnection_),
+      this.topBlock_);
 
   switch (method) {
     case Blockly.InsertionMarkerManager.PREVIEW_TYPE.INPUT_OUTLINE:

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -141,6 +141,12 @@ Blockly.InsertionMarkerManager = function(block) {
   this.availableConnections_ = this.initAvailableConnections_();
 };
 
+Blockly.InsertionMarkerManager.PREVIEW_TYPE = {
+  INSERTION_MARKER: 0,
+  INPUT_OUTLINE: 1,
+  REPLACEMENT_FADE: 2,
+};
+
 /**
  * Sever all links from this object.
  * @package
@@ -681,6 +687,30 @@ Blockly.InsertionMarkerManager.prototype.connectMarker_ = function() {
   }
 
   this.markerConnection_ = imConn;
+};
+
+Blockly.InsertionMarkerManager.prototype.showInsertionMarker = function() {
+
+};
+
+Blockly.InsertionMarkerManager.prototype.hideInsertionMarker = function() {
+
+};
+
+Blockly.InsertionMarkerManager.prototype.showInsertionInputOutline = function() {
+
+};
+
+Blockly.InsertionMarkerManager.prototype.hideInsertionInputOutline = function() {
+
+};
+
+Blockly.InsertionMarkerManager.prototype.showReplacementFade = function() {
+
+};
+
+Blockly.InsertionMarkerManager.prototype.hideReplacementFade = function() {
+
 };
 
 /**

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -622,7 +622,7 @@ Blockly.InsertionMarkerManager.prototype.showInsertionInputOutline_ = function()
 };
 
 Blockly.InsertionMarkerManager.prototype.hideInsertionInputOutline_ = function() {
-  this.highlightedBlock_.highlightShapeForInput(false);
+  this.highlightedBlock_.highlightShapeForInput(this.closestConnection_, false);
   this.highlightedBlock_ = null;
 };
 

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -127,4 +127,4 @@ Blockly.blockRendering.IPathObject.prototype.updateMovable;
  * @param {boolean} enable True if styling should be added.
  * @package
  */
-Blockly.blockRendering.IPathObject.prototype.updateReplacementHighlight;
+Blockly.blockRendering.IPathObject.prototype.updateReplacementFade;

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -268,7 +268,7 @@ Blockly.blockRendering.PathObject.prototype.updateMovable = function(enable) {
  * @param {boolean} enable True if styling should be added.
  * @package
  */
-Blockly.blockRendering.PathObject.prototype.updateReplacementHighlight =
+Blockly.blockRendering.PathObject.prototype.updateReplacementFade =
     function(enable) {
     /* eslint-disable indent */
   this.setClass_('blocklyReplaceable', enable);

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -177,9 +177,29 @@ Blockly.blockRendering.Renderer.prototype.shouldInsertDraggedBlock =
         conn.targetConnection.getSourceBlock());
 }; /* eslint-enable indent */
 
-Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
-    function(closest, local) {
+Blockly.blockRendering.Renderer.prototype.topHasPlaceForConnectedBlock =
+  function(topBlock, connected) {
+    // TODO: There a multitude of problems with this function
+    //  * The name is confusing, which is why I wrapped it.
+    //  * I don't think handles stack/statement blocks correctly.
+    //  * It has no unit tests associated with it.
+    //  * I'm not even sure if it has the desired behavior for this situation.
+    return !!Blockly.Connection.lastConnectionInRow(topBlock, connected);
+  };
 
+Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
+    function(closest, local, topBlock) {
+
+      if (local.type == Blockly.OUTPUT_VALUE ||
+          local.type == Blockly.PREVIOUS_STATEMENT) {
+        if (!closest.isConnected() || this.topHasPlaceForConnectedBlock(
+            topBlock, closest.targetBlock())) {
+          return Blockly.InsertionMarkerManager.PREVIEW_TYPE.INSERTION_MARKER;
+        }
+        return Blockly.InsertionMarkerManager.PREVIEW_TYPE.REPLACEMENT_FADE;
+      }
+
+      return Blockly.InsertionMarkerManager.PREVIEW_TYPE.INSERTION_MARKER;
     };
 
 /**

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -184,7 +184,8 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
         // TODO:  I don't think this function necessarily has the correct logic,
         //  but for now it is being kept for behavioral backwards-compat.
         lastConnection = Blockly.Connection
-            .lastConnectionInRow(/** @type {!Blockly.Block} **/ topBlock, orphanBlock);
+            .lastConnectionInRow(
+                /** @type {!Blockly.Block} **/ (topBlock), orphanBlock);
       } else {  // We are replacing a previous.
         orphanConnection = orphanBlock.previousConnection;
         // TODO: This lives on the block while lastConnectionInRow lives on
@@ -215,7 +216,9 @@ Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
           local.type == Blockly.PREVIOUS_STATEMENT) {
         if (!closest.isConnected() ||
             this.orphanCanConnectAtEnd(
-                topBlock, closest.targetBlock(), local.type)) {
+                topBlock,
+                /** @type {!Blockly.BlockSvg} */ (closest.targetBlock()),
+                local.type)) {
           return Blockly.InsertionMarkerManager.PREVIEW_TYPE.INSERTION_MARKER;
         }
         return Blockly.InsertionMarkerManager.PREVIEW_TYPE.REPLACEMENT_FADE;

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -187,13 +187,31 @@ Blockly.blockRendering.Renderer.prototype.topHasPlaceForConnectedBlock =
     return !!Blockly.Connection.lastConnectionInRow(topBlock, connected);
   };
 
+Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
+    function(topBlock, orphanBlock, localType) {
+      var orphanConnection = null;
+      var lastConnection = null;
+      if (localType == Blockly.OUTPUT_VALUE) {  // We are replacing an output.
+        orphanConnection = orphanBlock.outputConnection;
+        lastConnection = topBlock.getLastConnectionInRow();
+      } else {  // We are replacing a previous.
+        orphanConnection = orphanBlock.previousConnection;
+        lastConnection = topBlock.getLastConnectionInStack();
+      }
+
+      if (!lastConnection) {
+        return false;
+      }
+      return orphanConnection.checkType(lastConnection);
+    };
+
 Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
     function(closest, local, topBlock) {
-
       if (local.type == Blockly.OUTPUT_VALUE ||
           local.type == Blockly.PREVIOUS_STATEMENT) {
-        if (!closest.isConnected() || this.topHasPlaceForConnectedBlock(
-            topBlock, closest.targetBlock())) {
+        if (!closest.isConnected() ||
+            this.orphanCanConnectAtEnd(
+                topBlock, closest.targetBlock(), local.type)) {
           return Blockly.InsertionMarkerManager.PREVIEW_TYPE.INSERTION_MARKER;
         }
         return Blockly.InsertionMarkerManager.PREVIEW_TYPE.REPLACEMENT_FADE;

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -193,7 +193,10 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
       var lastConnection = null;
       if (localType == Blockly.OUTPUT_VALUE) {  // We are replacing an output.
         orphanConnection = orphanBlock.outputConnection;
-        lastConnection = topBlock.getLastConnectionInRow();
+        // I don't think this function necessarily has the correct logic, but
+        // for now it is being kept for behavioral backwards-compat.
+        lastConnection = Blockly.Connection
+            .lastConnectionInRow(topBlock, orphanBlock);
       } else {  // We are replacing a previous.
         orphanConnection = orphanBlock.previousConnection;
         lastConnection = topBlock.getLastConnectionInStack();

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -177,6 +177,11 @@ Blockly.blockRendering.Renderer.prototype.shouldInsertDraggedBlock =
         conn.targetConnection.getSourceBlock());
 }; /* eslint-enable indent */
 
+Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
+    function(closest, local) {
+
+    };
+
 /**
  * Render the block.
  * @param {!Blockly.BlockSvg} block The block to render.

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -29,6 +29,7 @@ goog.require('Blockly.blockRendering.Drawer');
 goog.require('Blockly.blockRendering.IPathObject');
 goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.InsertionMarkerManager');
 
 goog.requireType('Blockly.blockRendering.Debug');
 

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -167,9 +167,9 @@ Blockly.blockRendering.Renderer.prototype.shouldHighlightConnection =
  * block-clump. If the clump is a row the end is the last input. If the clump
  * is a stack, the end is the last next connection. If the clump is neither,
  * then this returns false.
- * @param {Blockly.BlockSvg} topBlock The top block of the block clump we want to try and
+ * @param {!Blockly.BlockSvg} topBlock The top block of the block clump we want to try and
  *     connect to.
- * @param {Blockly.BlockSvg} orphanBlock The orphan block that wants to find
+ * @param {!Blockly.BlockSvg} orphanBlock The orphan block that wants to find
  *     a home.
  * @param {number} localType The type of the connection being dragged.
  * @return {boolean} Whether there is a home for the orphan or not.
@@ -184,7 +184,7 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
         // TODO:  I don't think this function necessarily has the correct logic,
         //  but for now it is being kept for behavioral backwards-compat.
         lastConnection = Blockly.Connection
-            .lastConnectionInRow(topBlock, orphanBlock);
+            .lastConnectionInRow(/** @type {!Blockly.Block} **/ topBlock, orphanBlock);
       } else {  // We are replacing a previous.
         orphanConnection = orphanBlock.previousConnection;
         // TODO: This lives on the block while lastConnectionInRow lives on
@@ -201,11 +201,11 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
 /**
  * Chooses a connection preview method based on the available connection, the
  * current dragged connection, and the block being dragged.
- * @param {Blockly.RenderedConnection} closest The available connection.
- * @param {Blockly.RenderedConnection} local The connection currently being
+ * @param {!Blockly.RenderedConnection} closest The available connection.
+ * @param {!Blockly.RenderedConnection} local The connection currently being
  *     dragged.
- * @param {Blockly.BlockSvg} topBlock The block currently being dragged.
- * @return {Blockly.InsertionMarkerManager.PREVIEW_TYPE} The preview type
+ * @param {!Blockly.BlockSvg} topBlock The block currently being dragged.
+ * @return {!Blockly.InsertionMarkerManager.PREVIEW_TYPE} The preview type
  *     to display.
  * @package
  */

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -149,7 +149,7 @@ Blockly.zelos.PathObject.prototype.updateSelected = function(enable) {
 /**
  * @override
  */
-Blockly.zelos.PathObject.prototype.updateReplacementHighlight = function(
+Blockly.zelos.PathObject.prototype.updateReplacementFade = function(
     enable) {
   this.setClass_('blocklyReplaceable', enable);
   if (enable) {

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -25,6 +25,7 @@ goog.provide('Blockly.zelos.Renderer');
 
 goog.require('Blockly.blockRendering');
 goog.require('Blockly.blockRendering.Renderer');
+goog.require('Blockly.InsertionMarkerManager');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.zelos.ConstantProvider');
 goog.require('Blockly.zelos.Drawer');

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -124,4 +124,9 @@ Blockly.zelos.Renderer.prototype.shouldInsertDraggedBlock = function(_block,
   return false;
 };
 
+Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
+    function(closest, local) {
+
+    };
+
 Blockly.blockRendering.register('zelos', Blockly.zelos.Renderer);

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -126,7 +126,20 @@ Blockly.zelos.Renderer.prototype.shouldInsertDraggedBlock = function(_block,
 
 Blockly.zelos.Renderer.prototype.getConnectionPreviewMethod =
     function(closest, local, topBlock) {
+      if (local.type == Blockly.OUTPUT_VALUE) {
+        if (!closest.isConnected()) {
+          return Blockly.InsertionMarkerManager.PREVIEW_TYPE.INPUT_OUTLINE;
+        }
+        // TODO: Returning this is a total hack, because we don't want to show
+        //   a replacement fade, we want to show an outline affect.
+        //   Sadly zelos does not support showing an outline around filled
+        //   inputs, so we have to pretend like the connected block is getting
+        //   replaced.
+        return Blockly.InsertionMarkerManager.PREVIEW_TYPE.REPLACEMENT_FADE;
+      }
 
+      return Blockly.zelos.Renderer.superClass_
+          .getConnectionPreviewMethod(closest, local, topBlock);
     };
 
 Blockly.blockRendering.register('zelos', Blockly.zelos.Renderer);

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -124,8 +124,8 @@ Blockly.zelos.Renderer.prototype.shouldInsertDraggedBlock = function(_block,
   return false;
 };
 
-Blockly.blockRendering.Renderer.prototype.getConnectionPreviewMethod =
-    function(closest, local) {
+Blockly.zelos.Renderer.prototype.getConnectionPreviewMethod =
+    function(closest, local, topBlock) {
 
     };
 

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -119,11 +119,6 @@ Blockly.zelos.Renderer.prototype.shouldHighlightConnection = function(conn) {
 /**
  * @override
  */
-Blockly.zelos.Renderer.prototype.shouldInsertDraggedBlock = function(_block,
-    _conn) {
-  return false;
-};
-
 Blockly.zelos.Renderer.prototype.getConnectionPreviewMethod =
     function(closest, local, topBlock) {
       if (local.type == Blockly.OUTPUT_VALUE) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #2948 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Changes insertion marker manager to explicitly ask which way a valid connection should be handled. Options include:
  * Placing an insertion marker.
  * Highlighting an Input.
  * Giving a block a "faded" appearance.
* Renamed show preview and hide preview functions so that they're more clear.
* Fixed and simplfied decision logic so that markers are properly inserted into statement stacks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* Reduces duplicate logic, and makes code more readable.
* Readability!
* No need to have extra logic. Bugs are bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
It's really hard to know how to test these things, because it's hard to know what you touched, but I tried my best. I tested using the test blocks from #3525 

Blocks no longer disconnect:
![Test1](https://user-images.githubusercontent.com/25440652/71493209-e6bd7900-27f1-11ea-8489-423a24232345.gif)

Blocks can still be inserted:
![Test2](https://user-images.githubusercontent.com/25440652/71493216-ecb35a00-27f1-11ea-801f-eb0824ef8a81.gif)

Also works for C-statement blocks:
![Test3](https://user-images.githubusercontent.com/25440652/71493221-f2a93b00-27f1-11ea-9dd2-e73e7d9dfcf3.gif)
![Test4](https://user-images.githubusercontent.com/25440652/71493223-f3da6800-27f1-11ea-8d15-dd0d45952650.gif)

Row blocks work as expected:
![Test5](https://user-images.githubusercontent.com/25440652/71493228-fc32a300-27f1-11ea-838c-78059a6a7af6.gif)
![Test6](https://user-images.githubusercontent.com/25440652/71493229-fd63d000-27f1-11ea-836f-c3d492e87e4e.gif)
![Test7](https://user-images.githubusercontent.com/25440652/71493230-ff2d9380-27f1-11ea-8fad-a5c834143665.gif)
(yes this is the behavior on develop)
![Test8](https://user-images.githubusercontent.com/25440652/71493233-00f75700-27f2-11ea-93e0-6577c5262827.gif)
![Test9](https://user-images.githubusercontent.com/25440652/71493234-02c11a80-27f2-11ea-9a7d-a2589a5fec89.gif)

Doesn't break Zelos:
![Test10](https://user-images.githubusercontent.com/25440652/71493237-05bc0b00-27f2-11ea-9fc3-1b5d8afbf756.gif)
![Test11](https://user-images.githubusercontent.com/25440652/71493238-06ed3800-27f2-11ea-929e-316d43da7c79.gif)


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Honestly I don't love this solution. In general I think it would be better to tear out all of the connection logic and start from scratch.

But at least this works.

Other notes:
* If I get approval, I'll create issues for all of the TODOs and mark them with the issue numbers.
* Sorry if I'm a bit out of practice on the typings/jsdoc.
* I'll be out of town this next week, so I might be a bit slow to respond.