### PR TITLE
feat: Improved procedure arg interaction.

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -483,71 +483,6 @@ Blockly.Blocks['procedures_mutatorcontainer'] = {
     this.setTooltip(Blockly.Msg['PROCEDURES_MUTATORCONTAINER_TOOLTIP']);
     this.contextMenu = false;
   },
-
-  // TODO: Move this to a validator on the arg blocks, that way it can be
-  //  tested.
-  /**
-   * This will create & delete variables and in dialogs workspace to ensure
-   * that when a new block is dragged out it will have a unique parameter name.
-   * @param {!Blockly.Events.Abstract} event Change event.
-   * @this {Blockly.Block}
-   */
-  onchange: function(event) {
-    if (!this.workspace || this.workspace.isFlyout ||
-        (event.type != Blockly.Events.BLOCK_DELETE && event.type != Blockly.Events.BLOCK_CREATE)) {
-      return;
-    }
-    var blocks = this.workspace.getAllBlocks(false);
-    var allVariables = this.workspace.getAllVariables();
-    if (event.type == Blockly.Events.BLOCK_DELETE) {
-      var variableNamesToKeep = [];
-      for (var i = 0; i < blocks.length; i += 1) {
-        if (blocks[i].getFieldValue('NAME')) {
-          variableNamesToKeep.push(blocks[i].getFieldValue('NAME'));
-        }
-      }
-      for (var k = 0; k < allVariables.length; k += 1) {
-        if (variableNamesToKeep.indexOf(allVariables[k].name) == -1) {
-          this.workspace.deleteVariableById(allVariables[k].getId());
-        }
-      }
-      return;
-    }
-
-    if (event.type != Blockly.Events.BLOCK_CREATE) {
-      return;
-    }
-
-    var block = this.workspace.getBlockById(event.blockId);
-    // This is to handle the one none variable block
-    // Happens when all the blocks are regenerated
-    if (!block.getField('NAME')) {
-      return;
-    }
-    var varName = block.getFieldValue('NAME');
-    var variable = this.workspace.getVariable(varName);
-
-    if (!variable) {
-      // This means the parameter name is not in use and we can create the variable.
-      variable = this.workspace.createVariable(varName);
-    }
-    // If the blocks are connected we don't have to check duplicate variables
-    // This only happens if the dialog box is open
-    if (block.previousConnection.isConnected() || block.nextConnection.isConnected()) {
-      return;
-    }
-
-    for (var j = 0; j < blocks.length; j += 1) {
-      // filter block that was created
-      if (block.id != blocks[j].id && blocks[j].getFieldValue('NAME') == variable.name) {
-        // generate new name and set name field
-        varName = Blockly.Variables.generateUniqueName(this.workspace);
-        variable = this.workspace.createVariable(varName);
-        block.setFieldValue(variable.name, 'NAME');
-        return;
-      }
-    }
-  }
 };
 
 Blockly.Blocks['procedures_mutatorarg'] = {
@@ -556,7 +491,8 @@ Blockly.Blocks['procedures_mutatorarg'] = {
    * @this {Blockly.Block}
    */
   init: function() {
-    var field = new Blockly.FieldTextInput('x', this.validator_);
+    var field = new Blockly.FieldTextInput(
+        Blockly.Procedures.DEFAULT_ARG, this.validator_);
     // Hack: override showEditor to do just a little bit more work.
     // We don't have a good place to hook into the start of a text edit.
     field.oldShowEditorFn_ = field.showEditor_;
@@ -603,7 +539,9 @@ Blockly.Blocks['procedures_mutatorarg'] = {
     }
 
     // Prevents duplicate parameter names in functions
-    var blocks = sourceBlock.workspace.getAllBlocks(false);
+    var workspace = sourceBlock.workspace.targetWorkspace ||
+        sourceBlock.workspace;
+    var blocks = workspace.getAllBlocks(false);
     for (var i = 0; i < blocks.length; i++) {
       if (blocks[i].id == this.getSourceBlock().id) {
         continue;
@@ -611,6 +549,12 @@ Blockly.Blocks['procedures_mutatorarg'] = {
       if (blocks[i].getFieldValue('NAME') == varName) {
         return null;
       }
+    }
+
+    // Don't create variables for arg blocks that
+    // only exist in the mutator's flyout.
+    if (sourceBlock.isInFlyout) {
+      return varName;
     }
 
     var model = outerWs.getVariable(varName, '');
@@ -626,6 +570,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
     }
     return varName;
   },
+
   /**
    * Called when focusing away from the text field.
    * Deletes all variables that were created as the user typed their intended

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -72,6 +72,10 @@ Blockly.Mutator.prototype.setBlock = function(block) {
   this.block_ = block;
 };
 
+Blockly.Mutator.prototype.getWorkspace = function() {
+  return this.workspace_;
+};
+
 /**
  * Draw the mutator icon.
  * @param {!Element} group The icon group.

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -72,6 +72,11 @@ Blockly.Mutator.prototype.setBlock = function(block) {
   this.block_ = block;
 };
 
+/**
+ * Returns the workspace inside this mutator icon's bubble.
+ * @return {Blockly.WorkspaceSvg} The workspace inside this mutator icon's
+ *     bubble.
+ */
 Blockly.Mutator.prototype.getWorkspace = function() {
   return this.workspace_;
 };

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -46,6 +46,10 @@ goog.require('Blockly.Xml');
  */
 Blockly.Procedures.NAME_TYPE = Blockly.PROCEDURE_CATEGORY_NAME;
 
+/**
+ * The default argument for a procedures_mutatorarg block.
+ * @type {string}
+ */
 Blockly.Procedures.DEFAULT_ARG = 'x';
 
 /**
@@ -273,6 +277,13 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
   return xmlList;
 };
 
+/**
+ * Updates the procedure mutator's flyout so that the arg block is not a
+ * duplicate of another arg.
+ * @param {!Blockly.Workspace} workspace The procedure mutator's workspace. This
+ *     workspace's flyout is what is being updated.
+ * @package
+ */
 Blockly.Procedures.updateMutatorFlyout = function(workspace) {
   var usedNames = [];
   var blocks = workspace.getBlocksByType('procedures_mutatorarg');
@@ -296,6 +307,12 @@ Blockly.Procedures.updateMutatorFlyout = function(workspace) {
   workspace.updateToolbox(xml);
 };
 
+/**
+ * Listens for when a procedure mutator is opened. Then it triggers a flyout
+ * update and adds a mutator change listener to the mutator workspace.
+ * @param {!Blockly.Event} e The event that triggered this listener.
+ * @package
+ */
 Blockly.Procedures.mutatorOpenListener = function(e) {
   if (e.type != Blockly.Events.UI || e.element != 'mutatorOpen' ||
       !e.newValue) {
@@ -312,6 +329,12 @@ Blockly.Procedures.mutatorOpenListener = function(e) {
   workspace.addChangeListener(Blockly.Procedures.mutatorChangeListener);
 };
 
+/**
+ * Listens for changes in a procedure mutator and triggers flyout updates when
+ * necessary.
+ * @param {!Blockly.Event} e The event that triggered this listener.
+ * @package
+ */
 Blockly.Procedures.mutatorChangeListener = function(e) {
   if (e.type != Blockly.Events.BLOCK_CREATE &&
       e.type != Blockly.Events.BLOCK_DELETE &&

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -286,7 +286,7 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
  */
 Blockly.Procedures.updateMutatorFlyout = function(workspace) {
   var usedNames = [];
-  var blocks = workspace.getBlocksByType('procedures_mutatorarg');
+  var blocks = workspace.getBlocksByType('procedures_mutatorarg', false);
   for (var i = 0, block; (block = blocks[i]); i++) {
     usedNames.push(block.getFieldValue('NAME'));
   }
@@ -310,7 +310,7 @@ Blockly.Procedures.updateMutatorFlyout = function(workspace) {
 /**
  * Listens for when a procedure mutator is opened. Then it triggers a flyout
  * update and adds a mutator change listener to the mutator workspace.
- * @param {!Blockly.Event} e The event that triggered this listener.
+ * @param {!Blockly.Events.Abstract} e The event that triggered this listener.
  * @package
  */
 Blockly.Procedures.mutatorOpenListener = function(e) {
@@ -332,7 +332,7 @@ Blockly.Procedures.mutatorOpenListener = function(e) {
 /**
  * Listens for changes in a procedure mutator and triggers flyout updates when
  * necessary.
- * @param {!Blockly.Event} e The event that triggered this listener.
+ * @param {!Blockly.Events.Abstract} e The event that triggered this listener.
  * @package
  */
 Blockly.Procedures.mutatorChangeListener = function(e) {
@@ -341,7 +341,8 @@ Blockly.Procedures.mutatorChangeListener = function(e) {
       e.type != Blockly.Events.BLOCK_CHANGE) {
     return;
   }
-  var workspace = Blockly.Workspace.getById(e.workspaceId);
+  var workspace = /** @type {!Blockly.WorkspaceSvg} */
+      (Blockly.Workspace.getById(e.workspaceId));
   Blockly.Procedures.updateMutatorFlyout(workspace);
 };
 

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -46,6 +46,8 @@ goog.require('Blockly.Xml');
  */
 Blockly.Procedures.NAME_TYPE = Blockly.PROCEDURE_CATEGORY_NAME;
 
+Blockly.Procedures.DEFAULT_ARG = 'x';
+
 /**
  * Procedure block type.
  * @typedef {{
@@ -269,6 +271,55 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
   populateProcedures(tuple[0], 'procedures_callnoreturn');
   populateProcedures(tuple[1], 'procedures_callreturn');
   return xmlList;
+};
+
+Blockly.Procedures.updateMutatorFlyout = function(workspace) {
+  var usedNames = [];
+  var blocks = workspace.getBlocksByType('procedures_mutatorarg');
+  for (var i = 0, block; (block = blocks[i]); i++) {
+    usedNames.push(block.getFieldValue('NAME'));
+  }
+
+  var xml = Blockly.utils.xml.createElement('xml');
+  var argBlock = Blockly.utils.xml.createElement('block');
+  argBlock.setAttribute('type', 'procedures_mutatorarg');
+  var nameField = Blockly.utils.xml.createElement('field');
+  nameField.setAttribute('name', 'NAME');
+  var argValue = Blockly.Variables.generateUniqueNameFromOptions(
+      Blockly.Procedures.DEFAULT_ARG, usedNames);
+  var fieldContent = Blockly.utils.xml.createTextNode(argValue);
+
+  nameField.appendChild(fieldContent);
+  argBlock.appendChild(nameField);
+  xml.appendChild(argBlock);
+
+  workspace.updateToolbox(xml);
+};
+
+Blockly.Procedures.mutatorOpenListener = function(e) {
+  if (e.type != Blockly.Events.UI || e.element != 'mutatorOpen' ||
+      !e.newValue) {
+    return;
+  }
+  var block = Blockly.Workspace.getById(e.workspaceId)
+      .getBlockById(e.blockId);
+  var type = block.type;
+  if (type != 'procedures_defnoreturn' && type != 'procedures_defreturn') {
+    return;
+  }
+  var workspace = block.mutator.getWorkspace();
+  Blockly.Procedures.updateMutatorFlyout(workspace);
+  workspace.addChangeListener(Blockly.Procedures.mutatorChangeListener);
+};
+
+Blockly.Procedures.mutatorChangeListener = function(e) {
+  if (e.type != Blockly.Events.BLOCK_CREATE &&
+      e.type != Blockly.Events.BLOCK_DELETE &&
+      e.type != Blockly.Events.BLOCK_CHANGE) {
+    return;
+  }
+  var workspace = Blockly.Workspace.getById(e.workspaceId);
+  Blockly.Procedures.updateMutatorFlyout(workspace);
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -282,9 +282,9 @@ Blockly.Procedures.flyoutCategory = function(workspace) {
  * duplicate of another arg.
  * @param {!Blockly.Workspace} workspace The procedure mutator's workspace. This
  *     workspace's flyout is what is being updated.
- * @package
+ * @private
  */
-Blockly.Procedures.updateMutatorFlyout = function(workspace) {
+Blockly.Procedures.updateMutatorFlyout_ = function(workspace) {
   var usedNames = [];
   var blocks = workspace.getBlocksByType('procedures_mutatorarg', false);
   for (var i = 0, block; (block = blocks[i]); i++) {
@@ -326,17 +326,17 @@ Blockly.Procedures.mutatorOpenListener = function(e) {
     return;
   }
   var workspace = block.mutator.getWorkspace();
-  Blockly.Procedures.updateMutatorFlyout(workspace);
-  workspace.addChangeListener(Blockly.Procedures.mutatorChangeListener);
+  Blockly.Procedures.updateMutatorFlyout_(workspace);
+  workspace.addChangeListener(Blockly.Procedures.mutatorChangeListener_);
 };
 
 /**
  * Listens for changes in a procedure mutator and triggers flyout updates when
  * necessary.
  * @param {!Blockly.Events.Abstract} e The event that triggered this listener.
- * @package
+ * @private
  */
-Blockly.Procedures.mutatorChangeListener = function(e) {
+Blockly.Procedures.mutatorChangeListener_ = function(e) {
   if (e.type != Blockly.Events.BLOCK_CREATE &&
       e.type != Blockly.Events.BLOCK_DELETE &&
       e.type != Blockly.Events.BLOCK_CHANGE) {
@@ -345,7 +345,7 @@ Blockly.Procedures.mutatorChangeListener = function(e) {
   var workspaceId = /** @type {string} */ (e.workspaceId);
   var workspace = /** @type {!Blockly.WorkspaceSvg} */
       (Blockly.Workspace.getById(workspaceId));
-  Blockly.Procedures.updateMutatorFlyout(workspace);
+  Blockly.Procedures.updateMutatorFlyout_(workspace);
 };
 
 /**

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -318,7 +318,8 @@ Blockly.Procedures.mutatorOpenListener = function(e) {
       !e.newValue) {
     return;
   }
-  var block = Blockly.Workspace.getById(e.workspaceId)
+  var workspaceId = /** @type {string} */ (e.workspaceId);
+  var block = Blockly.Workspace.getById(workspaceId)
       .getBlockById(e.blockId);
   var type = block.type;
   if (type != 'procedures_defnoreturn' && type != 'procedures_defreturn') {
@@ -341,8 +342,9 @@ Blockly.Procedures.mutatorChangeListener = function(e) {
       e.type != Blockly.Events.BLOCK_CHANGE) {
     return;
   }
+  var workspaceId = /** @type {string} */ (e.workspaceId);
   var workspace = /** @type {!Blockly.WorkspaceSvg} */
-      (Blockly.Workspace.getById(e.workspaceId));
+      (Blockly.Workspace.getById(workspaceId));
   Blockly.Procedures.updateMutatorFlyout(workspace);
 };
 

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -391,7 +391,10 @@ Blockly.VariableMap.prototype.getAllVariables = function() {
 Blockly.VariableMap.prototype.getAllVariableNames = function() {
   var allNames = [];
   for (var key in this.variableMap_) {
-    allNames.push(this.variableMap_[key].name);
+    var variables = this.variableMap_[key];
+    for (var i = 0, variable; (variable = variables[i]); i++) {
+      allNames.push(variable.name);
+    }
   }
   return allNames;
 };

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -384,6 +384,14 @@ Blockly.VariableMap.prototype.getAllVariables = function() {
   return all_variables;
 };
 
+Blockly.VariableMap.prototype.getAllVariableNames = function() {
+  var allNames = [];
+  for (var key in this.variableMap_) {
+    allNames.push(this.variableMap_[key].name);
+  }
+  return allNames;
+};
+
 /**
  * Find all the uses of a named variable.
  * @param {string} id ID of the variable to find.

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -384,6 +384,10 @@ Blockly.VariableMap.prototype.getAllVariables = function() {
   return all_variables;
 };
 
+/**
+ * Returns all of the variable names of all types.
+ * @return {!Array<string>} All of the variable names of all types.
+ */
 Blockly.VariableMap.prototype.getAllVariableNames = function() {
   var allNames = [];
   for (var key in this.variableMap_) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -67,11 +67,11 @@ Blockly.Variables.allUsedVarModels = function(ws) {
     }
   }
   // Flatten the hash into a list.
-  var variableList = [];
+  var VariableList = [];
   for (var id in variableHash) {
-    variableList.push(variableHash[id]);
+    VariableList.push(variableHash[id]);
   }
-  return variableList;
+  return VariableList;
 };
 
 /**
@@ -206,6 +206,8 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
   return xmlList;
 };
 
+Blockly.Variables.VAR_LETTER_OPTIONS = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
+
 /**
  * Return a new variable name that is not yet being used. This will try to
  * generate single letter variable names in the range 'i' to 'z' to start with.
@@ -215,44 +217,43 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
  * @return {string} New variable name.
  */
 Blockly.Variables.generateUniqueName = function(workspace) {
-  var variableList = workspace.getAllVariables();
-  var newName = '';
-  if (variableList.length) {
-    var nameSuffix = 1;
-    var letters = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
-    var letterIndex = 0;
-    var potName = letters.charAt(letterIndex);
-    while (!newName) {
-      var inUse = false;
-      for (var i = 0; i < variableList.length; i++) {
-        if (variableList[i].name.toLowerCase() == potName) {
-          // This potential name is already used.
-          inUse = true;
-          break;
-        }
-      }
-      if (inUse) {
-        // Try the next potential name.
-        letterIndex++;
-        if (letterIndex == letters.length) {
-          // Reached the end of the character sequence so back to 'i'.
-          // a new suffix.
-          letterIndex = 0;
-          nameSuffix++;
-        }
-        potName = letters.charAt(letterIndex);
-        if (nameSuffix > 1) {
-          potName += nameSuffix;
-        }
-      } else {
-        // We can use the current potential name.
-        newName = potName;
+  Blockly.Variables.generateUniqueNameFromOptions(
+      Blockly.Variables.VAR_LETTER_OPTIONS.charAt(0),
+      workspace.getAllVariableNames()
+  );
+};
+
+Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames) {
+  if (!usedNames.length) {
+    return startChar;
+  }
+
+  var letters = Blockly.Variables.VAR_LETTER_OPTIONS;
+  var suffix = '';
+  var letterIndex = letters.indexOf(startChar);
+  var potName = startChar;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    var inUse = false;
+    for (var i = 0; i < usedNames.length; i++) {
+      if (usedNames[i].toLowerCase() == potName) {
+        inUse = true;
+        break;
       }
     }
-  } else {
-    newName = 'i';
+    if (!inUse) {
+      return potName;
+    }
+
+    letterIndex++;
+    if (letterIndex == letters.length) {
+      // Reached the end of the character sequence so back to 'i'.
+      letterIndex = 0;
+      suffix = Number(suffix) + 1;
+    }
+    potName = letters.charAt(letterIndex) + suffix;
   }
-  return newName;
 };
 
 /**

--- a/core/variables.js
+++ b/core/variables.js
@@ -67,11 +67,11 @@ Blockly.Variables.allUsedVarModels = function(ws) {
     }
   }
   // Flatten the hash into a list.
-  var VariableList = [];
+  var variableList = [];
   for (var id in variableHash) {
-    VariableList.push(variableHash[id]);
+    variableList.push(variableHash[id]);
   }
-  return VariableList;
+  return variableList;
 };
 
 /**

--- a/core/variables.js
+++ b/core/variables.js
@@ -217,12 +217,20 @@ Blockly.Variables.VAR_LETTER_OPTIONS = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
  * @return {string} New variable name.
  */
 Blockly.Variables.generateUniqueName = function(workspace) {
-  Blockly.Variables.generateUniqueNameFromOptions(
+  return Blockly.Variables.generateUniqueNameFromOptions(
       Blockly.Variables.VAR_LETTER_OPTIONS.charAt(0),
       workspace.getAllVariableNames()
   );
 };
 
+/**
+ * Returns a unique name that is not present in the usedNames array. This
+ * will try to generate single letter names in the range a -> z (skip l). It
+ * will start with the character passed to startChar.
+ * @param {string} startChar The character to start the search at.
+ * @param {!Array<string>} usedNames A list of all of the used names.
+ * @return {string} A unique name that is not present in the usedNames array.
+ */
 Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames) {
   if (!usedNames.length) {
     return startChar;

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -501,6 +501,10 @@ Blockly.Workspace.prototype.getAllVariables = function() {
   return this.variableMap_.getAllVariables();
 };
 
+/**
+ * Returns all variable names of all types.
+ * @return {!Array<string>} List of all variable names of all types.
+ */
 Blockly.Workspace.prototype.getAllVariableNames = function() {
   return this.variableMap_.getAllVariableNames();
 };

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -501,6 +501,10 @@ Blockly.Workspace.prototype.getAllVariables = function() {
   return this.variableMap_.getAllVariables();
 };
 
+Blockly.Workspace.prototype.getAllVariableNames = function() {
+  return this.variableMap_.getAllVariableNames();
+};
+
 /* End functions that are just pass-throughs to the variable map. */
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -127,6 +127,7 @@ Blockly.WorkspaceSvg = function(options,
   if (Blockly.Procedures && Blockly.Procedures.flyoutCategory) {
     this.registerToolboxCategoryCallback(Blockly.PROCEDURE_CATEGORY_NAME,
         Blockly.Procedures.flyoutCategory);
+    this.addChangeListener(Blockly.Procedures.mutatorOpenListener);
   }
 
   /**

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -398,24 +398,6 @@ suite('Procedures', function() {
             clearVariables.call(this);
           }, 'name');
         });
-        // TODO: Reenable the following two once arg name validation has been
-        //  moved to the arg blocks.
-        test.skip('Add Identical Arg', function() {
-          this.callForAllTypes(function() {
-            var args = ['x', 'x'];
-            createMutator.call(this, args);
-            assertArgs.call(this, ['x', 'i']);
-            clearVariables.call(this);
-          });
-        });
-        test.skip('Add Identical (except case) Arg', function() {
-          this.callForAllTypes(function() {
-            var args = ['x', 'X'];
-            createMutator.call(this, args);
-            assertArgs.call(this, ['x', 'i']);
-            clearVariables.call(this);
-          });
-        });
         test('Multiple Args', function() {
           this.callForAllTypes(function() {
             var args = ['arg1', 'arg2', 'arg3'];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes the prevent-duplicate-args behavior so that instead of updating the arg when the block is placed, the flyout is updated instead.

I also changed it so that it starts at whatever character you want, instead of always at 'i'.

New behavior:
![ProcedureArgs](https://user-images.githubusercontent.com/25440652/71532167-f5b23300-28a6-11ea-8d2b-f49941c8285f.gif)
Old behavior:
![ProcedureArgsOld](https://user-images.githubusercontent.com/25440652/71532171-f77bf680-28a6-11ea-9605-9c19efe22819.gif)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
... Mostly I was just bored hehe. But I do think there are a couple of nice things about the new behavior.

* The arg value changes in the flyout. This makes the behavior more clear.
* The args go in alphabetical order, instead of jumping to i. I think that's more pleasant.
* In the second behavior gif, I drag out the second arg and its value turns to "j" instead of "i". The new behavior fixes that, which I think is nice.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I don't think this really needs unit tests. It's basically just two event listeners and a unique string generator, so it should be pretty unbreakable. But if people have test recommendations I'd be happy to write them!

In addition to the behavior demo above, I'd like to show that this works after the mutator has been closed and reopened:
![ProcedureArgs2](https://user-images.githubusercontent.com/25440652/71532403-01522980-28a8-11ea-876b-14eb25c63c19.gif)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
If you guys don't like this behavior, that's cool. I was just bored and wanted something to tinker with.

Also I'll be out of town for the next week, so I may not be super quick to respond.
