### PR TITLE
Fix scrolled text input widgetdiv positioning.

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -377,16 +377,16 @@ Blockly.DropDownDiv.show = function(owner, rtl, primaryX, primaryY,
  * @private
  */
 Blockly.DropDownDiv.getBoundsInfo_ = function() {
-  var boundPosition = Blockly.DropDownDiv.boundsElement_
-      .getBoundingClientRect();
+  var boundPosition = Blockly.utils.style.getPageOffset(
+      Blockly.DropDownDiv.boundsElement_);
   var boundSize = Blockly.utils.style.getSize(
       Blockly.DropDownDiv.boundsElement_);
 
   return {
-    left: boundPosition.left,
-    right: boundPosition.left + boundSize.width,
-    top: boundPosition.top,
-    bottom: boundPosition.top + boundSize.height,
+    left: boundPosition.x,
+    right: boundPosition.x + boundSize.width,
+    top: boundPosition.y,
+    bottom: boundPosition.y + boundSize.height,
     width: boundSize.width,
     height: boundSize.height
   };

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -378,9 +378,9 @@ Blockly.DropDownDiv.show = function(owner, rtl, primaryX, primaryY,
  */
 Blockly.DropDownDiv.getBoundsInfo_ = function() {
   var boundPosition = Blockly.utils.style.getPageOffset(
-      Blockly.DropDownDiv.boundsElement_);
+      /** @type {!Element} */ (Blockly.DropDownDiv.boundsElement_));
   var boundSize = Blockly.utils.style.getSize(
-      Blockly.DropDownDiv.boundsElement_);
+      /** @type {!Element} */ (Blockly.DropDownDiv.boundsElement_));
 
   return {
     left: boundPosition.x,

--- a/core/field.js
+++ b/core/field.js
@@ -698,9 +698,10 @@ Blockly.Field.prototype.getScaledBBox = function() {
       scaledHeight += 1 * scale;
     }
   } else {
-    var xy = this.borderRect_.getBoundingClientRect();
-    var scaledWidth = xy.width;
-    var scaledHeight = xy.height;
+    var bBox = this.borderRect_.getBoundingClientRect();
+    var xy = Blockly.utils.style.getPageOffset(this.borderRect_);
+    var scaledWidth = bBox.width;
+    var scaledHeight = bBox.height;
   }
   return {
     top: xy.y,


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3532

### Proposed Changes

Take into account page scroll with field scaled bbox calculation.

### Reason for Changes

Fix scrolled text input widgetdiv positioning.

### Test Coverage
Tested playground and multi playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
