### PR TITLE
Fix dropdown field alignment in zelos in IE / Edge

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -635,7 +635,9 @@ Blockly.FieldDropdown.prototype.renderSelectedText_ = function() {
   this.textElement_.setAttribute('y', halfHeight);
   if (!this.constants_.FIELD_TEXT_BASELINE_CENTER) {
     this.textElement_.setAttribute('dy',
-        this.constants_.FIELD_TEXT_BASELINE_Y - halfHeight);
+        this.constants_.FIELD_TEXT_BASELINE_Y -
+        this.constants_.FIELD_TEXT_HEIGHT / 2 +
+        this.constants_.FIELD_TEXT_Y_OFFSET);
   }
 };
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Fix dropdown field alignment in zelos when baseline is not centered and the border rect height is greater than the text height. (in IE / Edge). 

Fix is to only take into account text height when calculating dy.

### Reason for Changes

Fixes in IE / Edge:
<img width="301" alt="Screen Shot 2020-01-02 at 12 54 11 PM" src="https://user-images.githubusercontent.com/16690124/71692672-71a4f300-2d5f-11ea-9dd7-ad1a7992d441.png">

### Test Coverage

Tested in playground in Edge / IE and on Chrome with no baseline center in zelos.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
