### PR TITLE
Fix moving cursor when block mutates

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -323,11 +323,6 @@ Blockly.Block.prototype.dispose = function(healStack) {
     this.workspace.removeChangeListener(this.onchangeWrapper_);
   }
 
-  if (this.workspace.keyboardAccessibilityMode) {
-    // No-op if this is called from the block_svg class.
-    Blockly.navigation.moveCursorOnBlockDelete(this);
-  }
-
   this.unplug(healStack);
   if (Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.BlockDelete(this));

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -376,6 +376,10 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     block.compose(this.rootBlock_);
     block.initSvg();
     block.render();
+
+    if (Blockly.getMainWorkspace().keyboardAccessibilityMode) {
+      Blockly.navigation.moveCursorOnBlockMutation(block);
+    }
     var newMutationDom = block.mutationToDom();
     var newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
     if (oldMutation != newMutation) {
@@ -390,10 +394,6 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
       }, Blockly.BUMP_DELAY);
     }
 
-    if (oldMutation != newMutation &&
-        this.workspace_.keyboardAccessibilityMode) {
-      Blockly.navigation.moveCursorOnBlockMutation(block);
-    }
     // Don't update the bubble until the drag has ended, to avoid moving blocks
     // under the cursor.
     if (!this.workspace_.isDragging()) {

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -23,8 +23,6 @@
 
 goog.provide('Blockly.Workspace');
 
-goog.require('Blockly.Cursor');
-goog.require('Blockly.Marker');
 goog.require('Blockly.Events');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
@@ -111,13 +109,6 @@ Blockly.Workspace = function(opt_options) {
    * @private
    */
   this.potentialVariableMap_ = null;
-
-  /**
-   * True if keyboard accessibility mode is on, false otherwise.
-   * @type {boolean}
-   * @package
-   */
-  this.keyboardAccessibilityMode = false;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -155,6 +155,13 @@ Blockly.WorkspaceSvg = function(options,
 
   this.themeManager_.subscribeWorkspace(this);
   this.renderer_.getConstants().refreshTheme(this.getTheme());
+
+  /**
+   * True if keyboard accessibility mode is on, false otherwise.
+   * @type {boolean}
+   * @package
+   */
+  this.keyboardAccessibilityMode = false;
 };
 Blockly.utils.object.inherits(Blockly.WorkspaceSvg, Blockly.Workspace);
 

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -90,8 +90,8 @@ suite('Gesture', function() {
     };
     var ws = Blockly.inject('blocklyDiv', {});
     var gesture = new Blockly.Gesture(this.e, ws);
-    assertFalse(Blockly.getMainWorkspace().keyboardAccessibilityMode);
+    assertFalse(ws.keyboardAccessibilityMode);
     gesture.doWorkspaceClick_(event);
-    assertTrue(Blockly.getMainWorkspace().keyboardAccessibilityMode);
+    assertTrue(ws.keyboardAccessibilityMode);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3507.

### Proposed Changes
1. We recently removed the cursor and marker from a workspace so removed references to keyboardAccessibilityMode.
2. Use Blockly.getMainWorkspace().keyboardAccessibilityMode instead of the mutators workspace since the mutators workspace doesn't get updated when keyboardAccessibilityMode is toggled on and off for the main workspace.
3. Move the check for moving the cursor to after we re-render the block. Re rendering the block creates new inputs which causes the cursors reference to the input to no longer exists and we get an error.
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
