### PR TITLE
Removes ability to enter accessibility mode using shift click

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -496,8 +496,9 @@ Blockly.Gesture.prototype.doStart = function(e) {
   Blockly.Tooltip.block();
 
   if (this.targetBlock_) {
-    if (!this.targetBlock_.isInFlyout && e.shiftKey) {
-      Blockly.navigation.enableKeyboardAccessibility();
+    if (!this.targetBlock_.isInFlyout &&
+        e.shiftKey &&
+        this.targetBlock_.workspace.keyboardAccessibilityMode) {
       this.creatorWorkspace_.getCursor().setCurNode(
           Blockly.navigation.getTopNode(this.targetBlock_));
     } else {
@@ -765,8 +766,7 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
  */
 Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   var ws = this.creatorWorkspace_;
-  if (e.shiftKey) {
-    Blockly.navigation.enableKeyboardAccessibility();
+  if (e.shiftKey && ws.keyboardAccessibilityMode) {
     var screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
     var wsCoord = Blockly.utils.screenToWsCoordinates(ws, screenCoord);
     var wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -89,9 +89,10 @@ suite('Gesture', function() {
 
     };
     var ws = Blockly.inject('blocklyDiv', {});
-    var gesture = new Blockly.Gesture(this.e, ws);
-    assertFalse(ws.keyboardAccessibilityMode);
+    ws.keyboardAccessibilityMode = true;
+    var gesture = new Blockly.Gesture(event, ws);
     gesture.doWorkspaceClick_(event);
-    assertTrue(ws.keyboardAccessibilityMode);
+    var cursor = ws.getCursor();
+    assertEquals(cursor.getCurNode().getType(), Blockly.ASTNode.types.WORKSPACE);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3412

### Proposed Changes
Shift click no longer puts a user into keyboard accessibility mode. A user can still shift click to move around the workspace once they are in keyboard accessibility mode.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
