### PR TITLE
[zelos] Left/right aligned dummy inputs

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -233,6 +233,47 @@ Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
 };
 
 /**
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.addInput_ = function(input, activeRow) {
+  // If we have two dummy inputs on the same row, one aligned left and the other
+  // right, keep track of the right aligned dummy input so we can add padding
+  // later.
+  if (input.type == Blockly.DUMMY_INPUT && activeRow.hasDummyInput &&
+      activeRow.align == Blockly.ALIGN_LEFT &&
+      input.align == Blockly.ALIGN_RIGHT) {
+    activeRow.rightAlignedDummyInput = input;
+  }
+  Blockly.zelos.RenderInfo.superClass_.addInput_.call(this, input, activeRow);
+};
+
+/**
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.addAlignmentPadding_ = function(row,
+    missingSpace) {
+  if (row.rightAlignedDummyInput) {
+    var alignmentDivider;
+    for (var i = 0, elem; (elem = row.elements[i]); i++) {
+      if (Blockly.blockRendering.Types.isSpacer(elem)) {
+        alignmentDivider = elem;
+      }
+      if (Blockly.blockRendering.Types.isField(elem) &&
+        elem.parentInput == row.rightAlignedDummyInput) {
+        break;
+      }
+    }
+    if (alignmentDivider) {
+      alignmentDivider.width += missingSpace;
+      row.width += missingSpace;
+      return;
+    }
+  }
+  Blockly.zelos.RenderInfo.superClass_.addAlignmentPadding_.call(this, row,
+      missingSpace);
+};
+
+/**
  * Adjust the x position of fields to bump all non-label fields in the first row
  * past the notch position.  This must be called before ``computeBounds`` is
  * called.


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Deal with the case where we have two dummy inputs on the same row, one with left alignment and the other with right.

Zelos rendering specific fix. We keep track of the right aligned dummy input and add the missing space when adding alignment padding.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested with pxt-blockly's controls_if block.

<img width="382" alt="Screen Shot 2020-01-03 at 1 28 51 PM" src="https://user-images.githubusercontent.com/16690124/71751405-48a06300-2e30-11ea-94ff-823fe24b597b.png">
<img width="382" alt="Screen Shot 2020-01-03 at 1 28 38 PM" src="https://user-images.githubusercontent.com/16690124/71751406-4938f980-2e30-11ea-975c-bb5e822846cd.png">


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
