### PR TITLE
[zelos] Bump / tight nest for all rows that are preceded and followed by a notch

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -247,7 +247,7 @@ Blockly.zelos.RenderInfo.prototype.adjustXPosition_ = function() {
     var row = this.rows[i];
     var nextSpacer = this.rows[i + 1];
     var hasPrevNotch = i == 2 ?
-        !!this.topRow.hasPreviousConnection : prevSpacer.followsStatement;
+        !!this.topRow.hasPreviousConnection : !!prevSpacer.followsStatement;
     var hasNextNotch = i + 2 >= this.rows.length - 1 ?
         !!this.bottomRow.hasNextConnection : !!nextSpacer.precedesStatement;
 

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -239,31 +239,41 @@ Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
  * @protected
  */
 Blockly.zelos.RenderInfo.prototype.adjustXPosition_ = function() {
-  if (!this.topRow.hasPreviousConnection) {
-    return;
-  }
-  var minXPos = this.constants_.NOTCH_OFFSET_LEFT +
+  var notchTotalWidth = this.constants_.NOTCH_OFFSET_LEFT +
       this.constants_.NOTCH_WIDTH;
-  for (var i = 0, row; (row = this.rows[i]); i++) {
-    if (Blockly.blockRendering.Types.isInputRow(row)) {
+  var minXPos = notchTotalWidth;
+  for (var i = 2; i < this.rows.length - 1; i += 2) {
+    var prevSpacer = this.rows[i - 1];
+    var row = this.rows[i];
+    var nextSpacer = this.rows[i + 1];
+    var hasPrevNotch = i == 2 ?
+        !!this.topRow.hasPreviousConnection : prevSpacer.followsStatement;
+    var hasNextNotch = i + 2 >= this.rows.length - 1 ?
+        !!this.bottomRow.hasNextConnection : !!nextSpacer.precedesStatement;
+
+    if (Blockly.blockRendering.Types.isInputRow(row) && row.hasStatement) {
+      row.measure();
+      minXPos = row.width - row.getLastInput().width + notchTotalWidth;
+    } else if (hasPrevNotch && (i == 2 || hasNextNotch) &&
+        Blockly.blockRendering.Types.isInputRow(row) && !row.hasStatement) {
       var xCursor = row.xPos;
-      var prevSpacer = null;
+      var prevInRowSpacer = null;
       for (var j = 0, elem; (elem = row.elements[j]); j++) {
         if (Blockly.blockRendering.Types.isSpacer(elem)) {
-          prevSpacer = elem;
+          prevInRowSpacer = elem;
         }
-        if (prevSpacer && (Blockly.blockRendering.Types.isField(elem) ||
+        if (prevInRowSpacer && (Blockly.blockRendering.Types.isField(elem) ||
             Blockly.blockRendering.Types.isInput(elem))) {
           if (xCursor < minXPos &&
               !(Blockly.blockRendering.Types.isField(elem) &&
-              elem.field instanceof Blockly.FieldLabel)) {
+              (elem.field instanceof Blockly.FieldLabel ||
+              elem.field instanceof Blockly.FieldImage))) {
             var difference = minXPos - xCursor;
-            prevSpacer.width += difference;
+            prevInRowSpacer.width += difference;
           }
         }
         xCursor += elem.width;
       }
-      return;
     }
   }
 };
@@ -430,8 +440,15 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
     var prevSpacer = this.rows[i - 1];
     var row = this.rows[i];
     var nextSpacer = this.rows[i + 1];
+
+    var hasPrevNotch = i == 2 ?
+        !!this.topRow.hasPreviousConnection : !!prevSpacer.followsStatement;
+    var hasNextNotch = i + 2 >= this.rows.length - 1 ?
+        !!this.bottomRow.hasNextConnection : !!nextSpacer.precedesStatement;
     
-    if (Blockly.blockRendering.Types.isInputRow(row)) {
+    // Apply tight-nesting if we have both a prev and next notch.
+    if (hasPrevNotch && hasNextNotch &&
+        Blockly.blockRendering.Types.isInputRow(row)) {
       // Determine if the input row has non-shadow connected blocks.
       var hasNonShadowConnectedBlocks = false;
       var MIN_VERTICAL_TIGHTNESTING_HEIGHT = 40;
@@ -449,6 +466,9 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
         prevSpacer.height -= this.constants_.GRID_UNIT;
         nextSpacer.height -= this.constants_.GRID_UNIT;
       }
+    } else if (hasPrevNotch && !hasNextNotch) {
+      // Add a small padding so the notch doesn't interfere with inputs/fields.
+      prevSpacer.height += this.constants_.SMALL_PADDING;
     }
   }
 };

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -246,6 +246,7 @@ Blockly.zelos.RenderInfo.prototype.adjustXPosition_ = function() {
     var prevSpacer = this.rows[i - 1];
     var row = this.rows[i];
     var nextSpacer = this.rows[i + 1];
+
     var hasPrevNotch = i == 2 ?
         !!this.topRow.hasPreviousConnection : !!prevSpacer.followsStatement;
     var hasNextNotch = i + 2 >= this.rows.length - 1 ?

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -242,6 +242,9 @@ Blockly.zelos.RenderInfo.prototype.adjustXPosition_ = function() {
   var notchTotalWidth = this.constants_.NOTCH_OFFSET_LEFT +
       this.constants_.NOTCH_WIDTH;
   var minXPos = notchTotalWidth;
+  // Run through every input row on the block and only apply bump logic to the
+  // first input row (if the block has prev connection) and every input row that
+  // has a prev and next notch.
   for (var i = 2; i < this.rows.length - 1; i += 2) {
     var prevSpacer = this.rows[i - 1];
     var row = this.rows[i];
@@ -437,6 +440,8 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
   if (this.outputConnection) {
     return;
   }
+  // Run through every input row on the block and only apply tight nesting logic
+  // to input rows that have a prev and next notch.
   for (var i = 2; i < this.rows.length - 1; i += 2) {
     var prevSpacer = this.rows[i - 1];
     var row = this.rows[i];


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Instead of only applying the bump X logic (for bumping inputs past the notch horizontally), apply this logic for every row that has a notch before it and after it (with the exception of the first row where we always apply the bump).
When bumping horizontally, unless we're bumping the first row, use the prev statement row's left width to determine the full extent to which to bump the next row, ie: making sure we always bump past the notch on every row.
We use this same logic to determine whether we should tightly nest vertically.

Add small padding after a notch so the notch doesn't clash with inputs / fields.

### Reason for Changes

Zelos rendering.

### Test Coverage

<img width="265" alt="Screen Shot 2020-01-02 at 2 30 31 PM" src="https://user-images.githubusercontent.com/16690124/71751951-20b1ff00-2e32-11ea-9981-0ac9372def1e.png">

<img width="235" alt="Screen Shot 2020-01-03 at 2 06 28 PM" src="https://user-images.githubusercontent.com/16690124/71751987-42ab8180-2e32-11ea-8f1a-cec028f82cc7.png">

![Uploading Screen Shot 2020-01-03 at 2.06.58 PM.png…]()

Tested in zelos rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
