### PR TITLE
STRICT is no longer supported by Closure Compiler

### DIFF
--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -83,7 +83,7 @@ COMPILATION_COMMAND="java -jar $COMPILER --js='$BLOCKLY_ROOT/tests/compile/main.
   --compilation_level ADVANCED_OPTIMIZATIONS \
   --language_in ECMASCRIPT5_STRICT \
   --language_out ECMASCRIPT5_STRICT \
-  --dependency_mode=STRICT --entry_point=Main \
+  --dependency_mode=PRUNE --entry_point=Main \
   --js_output_file $BLOCKLY_ROOT/tests/compile/main_compressed.js"
 echo "$COMPILATION_COMMAND"
 $COMPILATION_COMMAND


### PR DESCRIPTION
Apparently 'PRUNE' is the new option, but it's undocumented.  More info:
https://github.com/google/blockly-games/issues/176
