### PR TITLE
[zelos] adjust height of sand-witched empty row

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -197,8 +197,7 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
     var height = Math.max(this.constants_.MEDIUM_PADDING,
         Math.max(this.constants_.NOTCH_HEIGHT, cornerHeight));
     return precedesStatement && followsStatement ?
-        Math.max(height,
-            cornerHeight * 2 + this.constants_.DUMMY_INPUT_MIN_HEIGHT) : height;
+        Math.max(height, this.constants_.DUMMY_INPUT_MIN_HEIGHT) : height;
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     if (!this.outputConnection) {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Reduce an empty row surrounded by statement inputs to match size of bottom row.

![Screen Shot 2020-01-06 at 11 14 31 AM](https://user-images.githubusercontent.com/16690124/71842210-fb153780-3075-11ea-8950-9b461ae8dbd2.png)

### Reason for Changes

Zelos rendering.

### Test Coverage
Tested in playground with controls_if block.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
