### PR TITLE
[zelos] Fix breakout loop block

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -513,7 +513,7 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
         prevSpacer.height -= this.constants_.GRID_UNIT;
         nextSpacer.height -= this.constants_.GRID_UNIT;
       }
-    } else if (hasPrevNotch && !hasNextNotch) {
+    } else if (i !== 2 && hasPrevNotch && !hasNextNotch) {
       // Add a small padding so the notch doesn't interfere with inputs/fields.
       prevSpacer.height += this.constants_.SMALL_PADDING;
     }

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -513,7 +513,7 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
         prevSpacer.height -= this.constants_.GRID_UNIT;
         nextSpacer.height -= this.constants_.GRID_UNIT;
       }
-    } else if (i !== 2 && hasPrevNotch && !hasNextNotch) {
+    } else if (i != 2 && hasPrevNotch && !hasNextNotch) {
       // Add a small padding so the notch doesn't interfere with inputs/fields.
       prevSpacer.height += this.constants_.SMALL_PADDING;
     }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

We were adding an additional padding between the top row and the input row of the breakout loop block.

### Proposed Changes

Only apply small padding after notch if we have a statement input.

### Reason for Changes

Zelos rendering fixes.

### Test Coverage
Tested the breakout loop block in the playground. 

![Screen Shot 2020-01-06 at 11 28 17 AM](https://user-images.githubusercontent.com/16690124/71842942-a8d51600-3077-11ea-96dd-833338d56521.png)

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
