### PR TITLE
Fix non-prefixed CSS

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -216,14 +216,14 @@ Blockly.Css.CONTENT = [
     'cursor: pointer;',
   '}',
 
-  '.arrowTop {',
+  '.blocklyArrowTop {',
     'border-top: 1px solid;',
     'border-left: 1px solid;',
     'border-top-left-radius: 4px;',
     'border-color: inherit;',
   '}',
 
-  '.arrowBottom {',
+  '.blocklyArrowBottom {',
     'border-bottom: 1px solid;',
     'border-right: 1px solid;',
     'border-bottom-right-radius: 4px;',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -684,7 +684,8 @@ Blockly.DropDownDiv.positionInternal_ = function(
     Blockly.DropDownDiv.arrow_.style.transform = 'translate(' +
         metrics.arrowX + 'px,' + metrics.arrowY + 'px) rotate(45deg)';
     Blockly.DropDownDiv.arrow_.setAttribute('class', metrics.arrowAtTop ?
-        'blocklyDropDownArrow arrowTop' : 'blocklyDropDownArrow arrowBottom');
+        'blocklyDropDownArrow blocklyArrowTop' :
+        'blocklyDropDownArrow blocklyArrowBottom');
   } else {
     Blockly.DropDownDiv.arrow_.style.display = 'none';
   }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3083

### Proposed Changes

Rename arrowTop and arrowBottom css classes to blocklyArrowTop and bllocklyArrowBottom.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested playground

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
