### PR TITLE
Removing leftover constant MIN_BLOCK_Y in BlockSvg.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -159,14 +159,6 @@ Blockly.BlockSvg.COLLAPSED_WARNING_ID = 'TEMP_COLLAPSED_WARNING_';
 // Leftover UI constants from block_render_svg.js.
 
 /**
- * Minimum height of a block.
- * @const
- * @package
- */
-// TODO (#3142): Remove.
-Blockly.BlockSvg.MIN_BLOCK_Y = 25;
-
-/**
  * Do blocks with no previous or output connections have a 'hat' on top?
  * @const
  * @package

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -452,8 +452,11 @@ Blockly.Bubble.prototype.layoutBubble_ = function() {
   var optimalTop = this.getOptimalRelativeTop_(metrics);
   var bbox = this.shape_.getBBox();
 
-  var topPosition = {x: optimalLeft,
-    y: -this.height_ - Blockly.BlockSvg.MIN_BLOCK_Y};
+  var topPosition = {
+    x: optimalLeft,
+    y: -this.height_ -
+        this.workspace_.getRenderer().getConstants().MIN_BLOCK_HEIGHT
+  };
   var startPosition = {x: -this.width_ - 30, y: optimalTop};
   var endPosition = {x: bbox.width, y: optimalTop};
   var bottomPosition = {x: optimalLeft, y: bbox.height};

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1655,7 +1655,8 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function() {
     block.moveBy(-xy.x, cursorY - xy.y);
     block.snapToGrid();
     cursorY = block.getRelativeToSurfaceXY().y +
-        block.getHeightWidth().height + Blockly.BlockSvg.MIN_BLOCK_Y;
+        block.getHeightWidth().height +
+        this.renderer_.getConstants().MIN_BLOCK_HEIGHT;
   }
   Blockly.Events.setGroup(false);
   this.setResizesEnabled(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3142

### Proposed Changes

Replaces usages of MIN_BLOCK_Y from BlockSvg with MIN_BLOCK_HEIGHT from constants.

### Reason for Changes

Rendering constants is source of truth for minimum block height.