### PR TITLE
[zelos] single field text/image tight nesting

### DIFF
--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -98,10 +98,14 @@ Blockly.zelos.Drawer.prototype.drawOutline_ = function() {
  * @protected
  */
 Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
+  if (row.height <= 0) {
+    return;
+  }
   if (row.precedesStatement || row.followsStatement) {
     var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight;
     var remainingHeight = row.height -
-        (row.precedesStatement ? cornerHeight : 0);
+        (row.precedesStatement ? cornerHeight : 0) -
+        (row.followsStatement ? cornerHeight : 0);
     this.outlinePath_ +=
         (row.followsStatement ?
             this.constants_.INSIDE_CORNERS.pathBottomRight : '') +

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -497,6 +497,7 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
         Blockly.blockRendering.Types.isInputRow(row)) {
       // Determine if the input row has non-shadow connected blocks.
       var hasNonShadowConnectedBlocks = false;
+      var hasSingleTextOrImageField = null;
       var MIN_VERTICAL_TIGHTNESTING_HEIGHT = 40;
       for (var j = 0, elem; (elem = row.elements[j]); j++) {
         if (Blockly.blockRendering.Types.isInlineInput(elem) &&
@@ -505,12 +506,21 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
                 MIN_VERTICAL_TIGHTNESTING_HEIGHT) {
           hasNonShadowConnectedBlocks = true;
           break;
+        } else if (Blockly.blockRendering.Types.isField(elem) &&
+            (elem.field instanceof Blockly.FieldLabel ||
+            elem.field instanceof Blockly.FieldImage)) {
+          hasSingleTextOrImageField =
+              hasSingleTextOrImageField == null ? true : false;
         }
       }
+      // Reduce the previous and next spacer's height.
       if (hasNonShadowConnectedBlocks) {
-        // Reduce the previous and next spacer's height.
-        prevSpacer.height -= this.constants_.GRID_UNIT;
-        nextSpacer.height -= this.constants_.GRID_UNIT;
+        prevSpacer.height -= this.constants_.SMALL_PADDING;
+        nextSpacer.height -= this.constants_.SMALL_PADDING;
+      } else if (i != 2 && hasSingleTextOrImageField) {
+        prevSpacer.height -= this.constants_.SMALL_PADDING;
+        nextSpacer.height -= this.constants_.SMALL_PADDING;
+        row.height -= this.constants_.MEDIUM_PADDING;
       }
     } else if (i != 2 && hasPrevNotch && !hasNextNotch) {
       // Add a small padding so the notch doesn't interfere with inputs/fields.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Zelos rendering.

### Proposed Changes

Single field vertical tight nesting adjustment for text/image single fields: 

![Screen Shot 2020-01-07 at 11 30 42 AM](https://user-images.githubusercontent.com/16690124/71923122-29ac1480-3141-11ea-9ead-7710c0781236.png)
![Screen Shot 2020-01-07 at 11 30 36 AM](https://user-images.githubusercontent.com/16690124/71923123-29ac1480-3141-11ea-8fe8-e35b4f649961.png)

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in rendering playground with the pxt-blockly control_if block and if_else block.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
