### PR TITLE
Add output shape on a block. Add squared shape.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -127,6 +127,12 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.collapsed_ = false;
 
   /**
+   * @type {?number}
+   * @protected
+   */
+  this.outputShape_ = null;
+
+  /**
    * A string representing the comment attached to this block.
    * @type {string|Blockly.Comment}
    * @deprecated August 2019. Use getCommentText instead.
@@ -1200,6 +1206,22 @@ Blockly.Block.prototype.getInputsInline = function() {
 };
 
 /**
+ * Set the block's output shape.
+ * @param {?number} outputShape Value representing an output shape.
+ */
+Blockly.Block.prototype.setOutputShape = function(outputShape) {
+  this.outputShape_ = outputShape;
+};
+
+/**
+ * Get the block's output shape.
+ * @return {?number} Value representing output shape if one exists.
+ */
+Blockly.Block.prototype.getOutputShape = function() {
+  return this.outputShape_;
+};
+
+/**
  * Set whether the block is disabled or not.
  * @param {boolean} disabled True if disabled.
  * @deprecated May 2019
@@ -1380,6 +1402,9 @@ Blockly.Block.prototype.jsonInit = function(json) {
   // Set output and previous/next connections.
   if (json['output'] !== undefined) {
     this.setOutput(true, json['output']);
+  }
+  if (json['outputShape'] !== undefined) {
+    this.setOutputShape(json['outputShape']);
   }
   if (json['previousStatement'] !== undefined) {
     this.setPreviousStatement(true, json['previousStatement']);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -408,6 +408,7 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
   Blockly.zelos.ConstantProvider.superClass_.init.call(this);
   this.HEXAGONAL = this.makeHexagonal();
   this.ROUNDED = this.makeRounded();
+  this.SQUARED = this.makeSquared();
 
   this.STATEMENT_INPUT_NOTCH_OFFSET += this.INSIDE_CORNERS.rightWidth;
 };
@@ -516,14 +517,76 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
 };
 
 /**
+ * @return {!Object} An object containing sizing and path information about
+ *     a squared shape for connections.
+ * @package
+ */
+Blockly.zelos.ConstantProvider.prototype.makeSquared = function() {
+  var radius = this.CORNER_RADIUS;
+
+  // The 'up' and 'down' versions of the paths are the same, but the Y sign
+  // flips.  Forward and back are the signs to use to move the cursor in the
+  // direction that the path is being drawn.
+  function makeMainPath(height, up, right) {
+    var innerHeight = height - radius * 2;
+    return Blockly.utils.svgPaths.arc('a', '0 0,1', radius,
+        Blockly.utils.svgPaths.point((up ? -1 : 1) * radius, (up ? -1 : 1) * radius)) +
+      Blockly.utils.svgPaths.lineOnAxis('v', (right ? 1 : -1) * innerHeight) +
+      Blockly.utils.svgPaths.arc('a', '0 0,1', radius,
+          Blockly.utils.svgPaths.point((up ? 1 : -1) * radius, (up ? -1 : 1) * radius));
+  }
+
+  return {
+    type: this.SHAPES.SQUARE,
+    isDynamic: true,
+    width: function(_height) {
+      return radius;
+    },
+    height: function(height) {
+      return height;
+    },
+    connectionOffsetY: function(connectionHeight) {
+      return connectionHeight / 2;
+    },
+    connectionOffsetX: function(connectionWidth) {
+      return - connectionWidth;
+    },
+    pathDown: function(height) {
+      return makeMainPath(height, false, false);
+    },
+    pathUp: function(height) {
+      return makeMainPath(height, true, false);
+    },
+    pathRightDown: function(height) {
+      return makeMainPath(height, false, true);
+    },
+    pathRightUp: function(height) {
+      return makeMainPath(height, false, true);
+    },
+  };
+};
+
+/**
  * @override
  */
 Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
     connection) {
   var checks = connection.getCheck();
+  if (!checks && connection.targetConnection) {
+    checks = connection.targetConnection.getCheck();
+  }
   switch (connection.type) {
     case Blockly.INPUT_VALUE:
     case Blockly.OUTPUT_VALUE:
+      var outputShape = connection.getSourceBlock().getOutputShape();
+      // If the block has an ouput shape set, use that instead.
+      if (outputShape != null) {
+        switch (outputShape) {
+          case this.SHAPES.HEXAGONAL: return this.HEXAGONAL;
+          case this.SHAPES.ROUNDED: return this.ROUNDED;
+          case this.SHAPES.SQUARE: return this.SQUARED;
+        }
+      }
       // Includes doesn't work in IE.
       if (checks && checks.indexOf('Boolean') != -1) {
         return this.HEXAGONAL;

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -533,10 +533,10 @@ Blockly.zelos.ConstantProvider.prototype.makeSquared = function() {
 
   // The main path for the squared connection shape is made out of two corners
   // and a single line in-between (a and v). These are defined in relative
-  // positions and require the hight of the block.
+  // positions and require the height of the block.
   // The 'left' and 'right' versions of the paths are the same, but the Y sign
   // flips.  The 'up' and 'down' versions of the path determine where the corner
-  // point is placed and in-turn how the direction of the corners.
+  // point is placed and in-turn the direction of the corners.
   function makeMainPath(height, up, right) {
     var innerHeight = height - radius * 2;
     return Blockly.utils.svgPaths.arc('a', '0 0,1', radius,

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -424,14 +424,17 @@ Blockly.zelos.ConstantProvider.prototype.dispose = function() {
 };
 
 /**
+ * Create sizing and path information about a hexagonal shape.
  * @return {!Object} An object containing sizing and path information about
  *     a hexagonal shape for connections.
  * @package
  */
 Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
+  // The main path for the hexagonal connection shape is made out of two lines.
+  // The lines are defined with relative positons and require the block height.
   // The 'up' and 'down' versions of the paths are the same, but the Y sign
-  // flips.  Forward and back are the signs to use to move the cursor in the
-  // direction that the path is being drawn.
+  // flips.  The 'left' and 'right' versions of the path are also the same, but
+  // the X sign flips.
   function makeMainPath(height, up, right) {
     var width = height / 2;
     var forward = up ? -1 : 1;
@@ -472,14 +475,17 @@ Blockly.zelos.ConstantProvider.prototype.makeHexagonal = function() {
 };
 
 /**
+ * Create sizing and path information about a rounded shape.
  * @return {!Object} An object containing sizing and path information about
  *     a rounded shape for connections.
  * @package
  */
 Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
+  // The main path for the rounded connection shape is made out of a single arc.
+  // The arc is defined with relative positions and requires the block height.
   // The 'up' and 'down' versions of the paths are the same, but the Y sign
-  // flips.  Forward and back are the signs to use to move the cursor in the
-  // direction that the path is being drawn.
+  // flips.  The 'up' and 'right' versions of the path flip the sweep-flag
+  // which moves the arc at negative angles.
   function makeMainPath(height, up, right) {
     var edgeWidth = height / 2;
     return Blockly.utils.svgPaths.arc('a', '0 0 ' + (up || right ? 1 : 0), edgeWidth,
@@ -517,6 +523,7 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
 };
 
 /**
+ * Create sizing and path information about a squared shape.
  * @return {!Object} An object containing sizing and path information about
  *     a squared shape for connections.
  * @package
@@ -524,9 +531,12 @@ Blockly.zelos.ConstantProvider.prototype.makeRounded = function() {
 Blockly.zelos.ConstantProvider.prototype.makeSquared = function() {
   var radius = this.CORNER_RADIUS;
 
-  // The 'up' and 'down' versions of the paths are the same, but the Y sign
-  // flips.  Forward and back are the signs to use to move the cursor in the
-  // direction that the path is being drawn.
+  // The main path for the squared connection shape is made out of two corners
+  // and a single line in-between (a and v). These are defined in relative
+  // positions and require the hight of the block.
+  // The 'left' and 'right' versions of the paths are the same, but the Y sign
+  // flips.  The 'up' and 'down' versions of the path determine where the corner
+  // point is placed and in-turn how the direction of the corners.
   function makeMainPath(height, up, right) {
     var innerHeight = height - radius * 2;
     return Blockly.utils.svgPaths.arc('a', '0 0,1', radius,

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -583,7 +583,7 @@ Blockly.zelos.ConstantProvider.prototype.shapeFor = function(
       if (outputShape != null) {
         switch (outputShape) {
           case this.SHAPES.HEXAGONAL: return this.HEXAGONAL;
-          case this.SHAPES.ROUNDED: return this.ROUNDED;
+          case this.SHAPES.ROUND: return this.ROUNDED;
           case this.SHAPES.SQUARE: return this.SQUARED;
         }
       }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3414

### Proposed Changes

Add ouput shape property on a block and parse from json.
Add implementation for a square shape in zelos. 
Use a block's output shape if one exists when deciding on what shape to use.

### Reason for Changes

Zelos rendering. 

### Test Coverage

Tested with pxt-blockly blocks in zelos rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
