### PR TITLE
Fix value to stack width measurement

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -755,7 +755,7 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
     this.recordElemPositions_(row);
   }
   if (this.outputConnection && this.block_.nextConnection &&
-      this.block_.nextConnection.targetBlock()) {
+      this.block_.nextConnection.isConnected()) {
     // Include width of connected block in value to stack width measurement.
     widestRowWithConnectedBlocks =
         Math.max(widestRowWithConnectedBlocks,

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -754,6 +754,13 @@ Blockly.blockRendering.RenderInfo.prototype.finalize_ = function() {
         Math.max(widestRowWithConnectedBlocks, row.widthWithConnectedBlocks);
     this.recordElemPositions_(row);
   }
+  if (this.outputConnection && this.block_.nextConnection &&
+      this.block_.nextConnection.targetBlock()) {
+    // Include width of connected block in value to stack width measurement.
+    widestRowWithConnectedBlocks =
+        Math.max(widestRowWithConnectedBlocks,
+            this.block_.nextConnection.targetBlock().getHeightWidth().width);
+  }
 
   this.widthWithChildren = Math.max(this.widthWithChildren,
       widestRowWithConnectedBlocks + this.startX);

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -404,7 +404,7 @@ Blockly.geras.RenderInfo.prototype.finalize_ = function() {
     this.recordElemPositions_(row);
   }
   if (this.outputConnection && this.block_.nextConnection &&
-      this.block_.nextConnection.targetBlock()) {
+      this.block_.nextConnection.isConnected()) {
     // Include width of connected block in value to stack width measurement.
     widestRowWithConnectedBlocks =
         Math.max(widestRowWithConnectedBlocks,

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -403,6 +403,15 @@ Blockly.geras.RenderInfo.prototype.finalize_ = function() {
     }
     this.recordElemPositions_(row);
   }
+  if (this.outputConnection && this.block_.nextConnection &&
+      this.block_.nextConnection.targetBlock()) {
+    // Include width of connected block in value to stack width measurement.
+    widestRowWithConnectedBlocks =
+        Math.max(widestRowWithConnectedBlocks,
+            this.block_.nextConnection.targetBlock().getHeightWidth().width -
+            this.constants_.DARK_PATH_OFFSET);
+  }
+
   this.bottomRow.baseline = yCursor - this.bottomRow.descenderHeight;
 
   // The dark (lowlight) adds to the size of the block in both x and y.

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -330,7 +330,7 @@ Blockly.thrasos.RenderInfo.prototype.finalize_ = function() {
     this.recordElemPositions_(row);
   }
   if (this.outputConnection && this.block_.nextConnection &&
-      this.block_.nextConnection.targetBlock()) {
+      this.block_.nextConnection.isConnected()) {
     // Include width of connected block in value to stack width measurement.
     widestRowWithConnectedBlocks =
         Math.max(widestRowWithConnectedBlocks,

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -329,6 +329,13 @@ Blockly.thrasos.RenderInfo.prototype.finalize_ = function() {
     }
     this.recordElemPositions_(row);
   }
+  if (this.outputConnection && this.block_.nextConnection &&
+      this.block_.nextConnection.targetBlock()) {
+    // Include width of connected block in value to stack width measurement.
+    widestRowWithConnectedBlocks =
+        Math.max(widestRowWithConnectedBlocks,
+            this.block_.nextConnection.targetBlock().getHeightWidth().width);
+  }
 
   this.bottomRow.baseline = yCursor - this.bottomRow.descenderHeight;
   this.widthWithChildren = widestRowWithConnectedBlocks + this.startX;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3176

### Proposed Changes

Include the connected block width when computing the width with connected blocks of a value to stack block.

### Reason for Changes

Bug fix.

### Test Coverage

Tested with a value to stack block: 

![Screen Shot 2020-01-07 at 1 15 30 PM](https://user-images.githubusercontent.com/16690124/71930774-2fa9f180-3151-11ea-8c95-88050826328e.png)
![Screen Shot 2020-01-07 at 1 14 49 PM](https://user-images.githubusercontent.com/16690124/71930775-2fa9f180-3151-11ea-8791-a770ea5a9b47.png)


Tested in geras, minimalist and thrasos renderers. Zelos doesn't support value to stack blocks.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
