### PR TITLE
Remove Firefox workaround for widgetdiv positioning

### DIFF
--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -87,11 +87,7 @@ Blockly.WidgetDiv.show = function(newOwner, rtl, dispose) {
   Blockly.WidgetDiv.hide();
   Blockly.WidgetDiv.owner_ = newOwner;
   Blockly.WidgetDiv.dispose_ = dispose;
-  // Temporarily move the widget to the top of the screen so that it does not
-  // cause a scrollbar jump in Firefox when displayed.
-  var xy = Blockly.utils.style.getViewportPageOffset();
   var div = Blockly.WidgetDiv.DIV;
-  div.style.top = xy.y + 'px';
   div.style.direction = rtl ? 'rtl' : 'ltr';
   div.style.display = 'block';
   Blockly.WidgetDiv.rendererClassName_ =


### PR DESCRIPTION
# The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/1327

### Proposed Changes

Remove workaround for Firefox as: 
- Fix was over 4 years ago
- No longer repro original issue on dropdowns
- Aside from the context menu, dropdown fields have moved to the dropdown div.


### Reason for Changes

Code cleanup / performance.

### Test Coverage

Tested on Chrome and Firefox on Mac.
Both RTL and LTR modes.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
