### PR TITLE
Move of render contant START_HAT into ConstantProvider.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -156,16 +156,6 @@ Blockly.BlockSvg.INLINE = -1;
  */
 Blockly.BlockSvg.COLLAPSED_WARNING_ID = 'TEMP_COLLAPSED_WARNING_';
 
-// Leftover UI constants from block_render_svg.js.
-
-/**
- * Do blocks with no previous or output connections have a 'hat' on top?
- * @const
- * @package
- */
-// TODO (#3142): Remove.
-Blockly.BlockSvg.START_HAT = false;
-
 /**
  * An optional method called when a mutator dialog is first opened.
  * This function must create and initialize a top-level block for the mutator

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -38,6 +38,13 @@ goog.require('Blockly.utils.userAgent');
 Blockly.blockRendering.ConstantProvider = function() {
 
   /**
+   * Whether to add a 'hat' on top of all blocks with no previous or output
+   * connections. Can be overridden by 'hat' property on Theme.BlockStyle.
+   * @type {boolean}
+   */
+  this.ADD_START_HATS = false;
+
+  /**
    * The size of an empty spacer.
    * @type {number}
    */

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -38,13 +38,6 @@ goog.require('Blockly.utils.userAgent');
 Blockly.blockRendering.ConstantProvider = function() {
 
   /**
-   * Whether to add a 'hat' on top of all blocks with no previous or output
-   * connections. Can be overridden by 'hat' property on Theme.BlockStyle.
-   * @type {boolean}
-   */
-  this.ADD_START_HATS = false;
-
-  /**
    * The size of an empty spacer.
    * @type {number}
    */
@@ -198,6 +191,13 @@ Blockly.blockRendering.ConstantProvider = function() {
    * @type {number}
    */
   this.MAX_BOTTOM_WIDTH = 66.5;
+
+  /**
+   * Whether to add a 'hat' on top of all blocks with no previous or output
+   * connections. Can be overridden by 'hat' property on Theme.BlockStyle.
+   * @type {boolean}
+   */
+  this.ADD_START_HATS = false;
 
   /**
    * Height of the top hat.

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -262,8 +262,8 @@ Blockly.blockRendering.RenderInfo.prototype.createRows_ = function() {
  */
 Blockly.blockRendering.RenderInfo.prototype.populateTopRow_ = function() {
   var hasPrevious = !!this.block_.previousConnection;
-  var hasHat = (this.block_.hat ?
-    this.block_.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
+  var hasHat = (typeof this.block_.hat !== 'undefined' ?
+    this.block_.hat === 'cap' : this.constants_.ADD_START_HATS) &&
     !this.outputConnection && !hasPrevious;
   var leftSquareCorner = this.topRow.hasLeftSquareCorner(this.block_);
 

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -290,7 +290,7 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
  * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  var hasHat = (typeof this.block_.hat !== 'undefined' ?
+  var hasHat = (typeof block.hat !== 'undefined' ?
       block.hat === 'cap' : this.constants_.ADD_START_HATS) &&
       !block.outputConnection && !block.previousConnection;
   var prevBlock = block.getPreviousBlock();

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -290,8 +290,9 @@ Blockly.utils.object.inherits(Blockly.blockRendering.TopRow,
  * @return {boolean} Whether or not the top row has a left square corner.
  */
 Blockly.blockRendering.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  var hasHat = (block.hat ? block.hat === 'cap' : Blockly.BlockSvg.START_HAT) &&
-    !block.outputConnection && !block.previousConnection;
+  var hasHat = (typeof this.block_.hat !== 'undefined' ?
+      block.hat === 'cap' : this.constants_.ADD_START_HATS) &&
+      !block.outputConnection && !block.previousConnection;
   var prevBlock = block.getPreviousBlock();
 
   return !!block.outputConnection ||


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3142

### Proposed Changes

Moves START_HAT constant into rendering ConstantProvider and renames it to ADD_START_HATS to resolve conflict of pre-existing constant START_HAT (that defines start hat path).

### Reason for Changes

START_HAT constant was leftover UI constant from block_render_svg.