### PR TITLE
[zelos] Fix bug in tight nesting

### DIFF
--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -104,8 +104,7 @@ Blockly.zelos.Drawer.prototype.drawRightSideRow_ = function(row) {
   if (row.precedesStatement || row.followsStatement) {
     var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight;
     var remainingHeight = row.height -
-        (row.precedesStatement ? cornerHeight : 0) -
-        (row.followsStatement ? cornerHeight : 0);
+        (row.precedesStatement ? cornerHeight : 0);
     this.outlinePath_ +=
         (row.followsStatement ?
             this.constants_.INSIDE_CORNERS.pathBottomRight : '') +

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -505,12 +505,15 @@ Blockly.zelos.RenderInfo.prototype.finalizeVerticalAlignment_ = function() {
             elem.connectedBlock.getHeightWidth().height >=
                 MIN_VERTICAL_TIGHTNESTING_HEIGHT) {
           hasNonShadowConnectedBlocks = true;
+          hasSingleTextOrImageField = false;
           break;
         } else if (Blockly.blockRendering.Types.isField(elem) &&
             (elem.field instanceof Blockly.FieldLabel ||
             elem.field instanceof Blockly.FieldImage)) {
           hasSingleTextOrImageField =
               hasSingleTextOrImageField == null ? true : false;
+        } else if (!Blockly.blockRendering.Types.isSpacer(elem)) {
+          hasSingleTextOrImageField = false;
         }
       }
       // Reduce the previous and next spacer's height.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Fix bug in zelos tight nesting code causing this:
<img width="361" alt="Screen Shot 2020-01-07 at 11 28 56 pm" src="https://user-images.githubusercontent.com/16690124/71958593-83dec100-31a5-11ea-8a00-951e52853421.png">

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested all if statement blocks, both blockly's and pxt-blockly's.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
