### PR TITLE
Give bottom row a fixed with after statement inputs

### DIFF
--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -191,9 +191,9 @@ Blockly.blockRendering.RenderInfo.prototype.getRenderer = function() {
 Blockly.blockRendering.RenderInfo.prototype.measure = function() {
   this.createRows_();
   this.addElemSpacing_();
-  this.addRowSpacing_();
   this.computeBounds_();
   this.alignRowElements_();
+  this.addRowSpacing_();
   this.finalize_();
 };
 

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -105,7 +105,25 @@ Blockly.geras.Drawer.prototype.drawValueInput_ = function(row) {
 Blockly.geras.Drawer.prototype.drawStatementInput_ = function(row) {
   this.highlighter_.drawStatementInput(row);
 
-  Blockly.geras.Drawer.superClass_.drawStatementInput_.call(this, row);
+  var input = row.getLastInput();
+  // Where to start drawing the notch, which is on the right side in LTR.
+  var x = input.xPos + input.notchOffset + input.shape.width;
+
+  var innerTopLeftCorner =
+      input.shape.pathRight +
+      Blockly.utils.svgPaths.lineOnAxis('h',
+          -(input.notchOffset - this.constants_.INSIDE_CORNERS.width)) +
+      this.constants_.INSIDE_CORNERS.pathTop;
+
+  var innerHeight =
+      row.height - (2 * this.constants_.INSIDE_CORNERS.height);
+
+  this.outlinePath_ += Blockly.utils.svgPaths.lineOnAxis('H', x) +
+      innerTopLeftCorner +
+      Blockly.utils.svgPaths.lineOnAxis('v', innerHeight) +
+      this.constants_.INSIDE_CORNERS.pathBottom;
+
+  this.positionStatementInputConnection_(row);
 };
 
 /**
@@ -113,7 +131,9 @@ Blockly.geras.Drawer.prototype.drawStatementInput_ = function(row) {
  */
 Blockly.geras.Drawer.prototype.drawRightSideRow_ = function(row) {
   this.highlighter_.drawRightSideRow(row);
-  Blockly.geras.Drawer.superClass_.drawRightSideRow_.call(this, row);
+  this.outlinePath_ +=
+      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width) +
+      Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);
 };
 
 /**

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -83,7 +83,7 @@ Blockly.geras.RenderInfo.prototype.populateBottomRow_ = function() {
       this.block_.inputList.length &&
       this.block_.inputList[this.block_.inputList.length - 1]
           .type == Blockly.NEXT_STATEMENT;
-  this.bottomRow.hasFixedWidth = followsStatement && this.block_.getInputsInline();
+  this.bottomRow.hasFixedWidth = !!followsStatement && this.block_.getInputsInline();
 
   // The minimum height of the bottom row is smaller in Geras than in other
   // renderers, because the dark path adds a pixel.

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -83,6 +83,7 @@ Blockly.geras.RenderInfo.prototype.populateBottomRow_ = function() {
       this.block_.inputList.length &&
       this.block_.inputList[this.block_.inputList.length - 1]
           .type == Blockly.NEXT_STATEMENT;
+  this.bottomRow.hasFixedWidth = followsStatement && this.block_.getInputsInline();
 
   // The minimum height of the bottom row is smaller in Geras than in other
   // renderers, because the dark path adds a pixel.
@@ -337,6 +338,41 @@ Blockly.geras.RenderInfo.prototype.getSpacerRowHeight_ = function(prev, next) {
     return this.constants_.LARGE_PADDING;
   }
   return this.constants_.MEDIUM_PADDING;
+};
+
+/**
+ * @override
+ */
+Blockly.geras.RenderInfo.prototype.alignRowElements_ = function() {
+  for (var i = 0, row; (row = this.rows[i]); i++) {
+    if (row.hasStatement) {
+      var statementInput = row.getLastInput();
+      var currentWidth = row.width - statementInput.width;
+      var desiredWidth = this.statementEdge - this.startX;
+    } else {
+      var currentWidth = row.width;
+      var desiredWidth = this.width - this.startX;
+      if (Blockly.blockRendering.Types.isBottomRow(row) && row.hasFixedWidth) {
+        desiredWidth = this.constants_.MAX_BOTTOM_WIDTH;
+      }
+    }
+    var missingSpace = desiredWidth - currentWidth;
+    if (missingSpace) {
+      this.addAlignmentPadding_(row, missingSpace);
+    }
+  }
+};
+
+/**
+ * @override
+ */
+Blockly.geras.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
+  // The width of the spacer before the bottom row should be the same as the
+  // bottom row.
+  if (Blockly.blockRendering.Types.isBottomRow(next) && next.hasFixedWidth) {
+    return next.width;
+  }
+  return this.width - this.startX;
 };
 
 /**

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -390,6 +390,12 @@ Blockly.blockRendering.BottomRow = function(constants) {
    * @type {number}
    */
   this.baseline = 0;
+
+  /**
+   * True if the width of this row does not depend on its contents.
+   * @type {boolean}
+   */
+  this.hasFixedWidth = false;
 };
 Blockly.utils.object.inherits(Blockly.blockRendering.BottomRow,
     Blockly.blockRendering.Row);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3367

### Proposed Changes
geras/Info.js
Override alignRowElements_ and getSpacerRowWidth_ for geras so that it can check if it is the bottom row and the bottom row has a fixed width.

geras/drawer.js
Moves drawing the horizontal 'lineOnAxis('H', row.xPos + row.width)' from drawStatementInput to drawRightSideRow.

I had to move addRowSpacing_ back to below alignRowElement because I needed the bottom rows width to get the correct width of the spacer. This was originally changed in #3463 for zelos, however zelos now overrides the measure function so it can have a different order. 

### Reason for Changes



### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
