### PR TITLE
Rename input connection to connectionModel

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -179,7 +179,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
 
   if (Blockly.blockRendering.Types.isInput(elem) &&
       Blockly.blockRendering.Debug.config.connections) {
-    this.drawConnection(elem.model);
+    this.drawConnection(elem.connectionModel);
   }
 };
 

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -179,7 +179,7 @@ Blockly.blockRendering.Debug.prototype.drawRenderedElem = function(elem, isRtl) 
 
   if (Blockly.blockRendering.Types.isInput(elem) &&
       Blockly.blockRendering.Debug.config.connections) {
-    this.drawConnection(elem.connection);
+    this.drawConnection(elem.model);
   }
 };
 

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -390,13 +390,13 @@ Blockly.blockRendering.Drawer.prototype.drawInlineInput_ = function(input) {
 Blockly.blockRendering.Drawer.prototype.positionInlineInputConnection_ = function(input) {
   var yPos = input.centerline - input.height / 2;
   // Move the connection.
-  if (input.connection) {
+  if (input.connectionModel) {
     // xPos already contains info about startX
     var connX = input.xPos + input.connectionWidth + input.connectionOffsetX;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX,
+    input.connectionModel.setOffsetInBlock(connX,
         yPos + input.connectionOffsetY);
   }
 };
@@ -410,12 +410,12 @@ Blockly.blockRendering.Drawer.prototype.positionInlineInputConnection_ = functio
  */
 Blockly.blockRendering.Drawer.prototype.positionStatementInputConnection_ = function(row) {
   var input = row.getLastInput();
-  if (input.connection) {
+  if (input.connectionModel) {
     var connX = row.xPos + row.statementEdge + input.notchOffset;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX, row.yPos);
+    input.connectionModel.setOffsetInBlock(connX, row.yPos);
   }
 };
 
@@ -428,12 +428,12 @@ Blockly.blockRendering.Drawer.prototype.positionStatementInputConnection_ = func
  */
 Blockly.blockRendering.Drawer.prototype.positionExternalValueConnection_ = function(row) {
   var input = row.getLastInput();
-  if (input.connection) {
+  if (input.connectionModel) {
     var connX = row.xPos + row.width;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX, row.yPos);
+    input.connectionModel.setOffsetInBlock(connX, row.yPos);
   }
 };
 

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -151,14 +151,14 @@ Blockly.geras.Drawer.prototype.drawInlineInput_ = function(input) {
 Blockly.geras.Drawer.prototype.positionInlineInputConnection_ = function(input) {
   var yPos = input.centerline - input.height / 2;
   // Move the connection.
-  if (input.connection) {
+  if (input.connectionModel) {
     // xPos already contains info about startX
     var connX = input.xPos + input.connectionWidth +
         this.constants_.DARK_PATH_OFFSET;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(
+    input.connectionModel.setOffsetInBlock(
         connX, yPos + input.connectionOffsetY +
         this.constants_.DARK_PATH_OFFSET);
   }
@@ -169,14 +169,14 @@ Blockly.geras.Drawer.prototype.positionInlineInputConnection_ = function(input) 
  */
 Blockly.geras.Drawer.prototype.positionStatementInputConnection_ = function(row) {
   var input = row.getLastInput();
-  if (input.connection) {
+  if (input.connectionModel) {
     var connX = row.xPos + row.statementEdge + input.notchOffset;
     if (this.info_.RTL) {
       connX *= -1;
     } else {
       connX += this.constants_.DARK_PATH_OFFSET;
     }
-    input.connection.setOffsetInBlock(connX,
+    input.connectionModel.setOffsetInBlock(connX,
         row.yPos + this.constants_.DARK_PATH_OFFSET);
   }
 };
@@ -186,13 +186,13 @@ Blockly.geras.Drawer.prototype.positionStatementInputConnection_ = function(row)
  */
 Blockly.geras.Drawer.prototype.positionExternalValueConnection_ = function(row) {
   var input = row.getLastInput();
-  if (input.connection) {
+  if (input.connectionModel) {
     var connX = row.xPos + row.width +
         this.constants_.DARK_PATH_OFFSET;
     if (this.info_.RTL) {
       connX *= -1;
     }
-    input.connection.setOffsetInBlock(connX, row.yPos);
+    input.connectionModel.setOffsetInBlock(connX, row.yPos);
   }
 };
 

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -61,10 +61,6 @@ Blockly.blockRendering.InputConnection = function(constants, input) {
     this.connectedBlockHeight = 0;
   }
 
-  // TODO (#3186): change references to connectionModel, since that's on
-  // Connection.
-  this.connection =
-    /** @type {!Blockly.RenderedConnection} */ (input.connection);
   this.connectionOffsetX = 0;
   this.connectionOffsetY = 0;
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3186

### Proposed Changes

Rename references to an input measurable's connection property to connectionModel and remove that property.

### Reason for Changes

Cleanup.

### Test Coverage

Tested geras and zelos in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
