### PR TITLE
Using shapeFor to determine connections shape for marker_svg.

### DIFF
--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -233,7 +233,7 @@ Blockly.blockRendering.MarkerSvg.prototype.showWithField_ = function(curNode) {
  * @protected
  */
 Blockly.blockRendering.MarkerSvg.prototype.showWithInput_ = function(curNode) {
-  var connection = /** @type {Blockly.Connection} */
+  var connection = /** @type {Blockly.RenderedConnection} */
       (curNode.getLocation());
   var sourceBlock = /** @type {!Blockly.BlockSvg} */ (connection.getSourceBlock());
 
@@ -331,7 +331,7 @@ Blockly.blockRendering.MarkerSvg.prototype.positionBlock_ = function(
 /**
  * Position the marker for an input connection.
  * Displays a filled in puzzle piece.
- * @param {!Blockly.Connection} connection The connection to position marker around.
+ * @param {!Blockly.RenderedConnection} connection The connection to position marker around.
  * @private
  */
 Blockly.blockRendering.MarkerSvg.prototype.positionInput_ = function(connection) {
@@ -339,7 +339,7 @@ Blockly.blockRendering.MarkerSvg.prototype.positionInput_ = function(connection)
   var y = connection.getOffsetInBlock().y;
 
   var path = Blockly.utils.svgPaths.moveTo(0, 0) +
-      this.constants_.PUZZLE_TAB.pathDown;
+      this.constants_.shapeFor(connection).pathDown;
 
   this.markerInput_.setAttribute('d', path);
   this.markerInput_.setAttribute('transform',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3522

### Proposed Changes

Cast connections in `MarkerSvg` to `Blockly.RenderedConnection` and use `shapeFor` to determine the correct path for input.

### Reason for Changes

Renderers may change the path of the input based on the connection so using `PUZZLE_TAB` directly instead of `shapeFor` does not guarantee the correct path.
