### PR TITLE
Re-rendering block in setMutator.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1123,6 +1123,11 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
     this.mutator = mutator;
     mutator.createIcon();
   }
+  if (this.rendered) {
+    this.render();
+    // Adding or removing a mutator icon will cause the block to change shape.
+    this.bumpNeighbours();
+  }
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3510

### Proposed Changes

Added call to re-render block in `setMutator`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Blocks were not re-rendering as expected after `setMutator` call.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

Tested change by:

1) Loading the following XML to the playground:

```
<xml xmlns="https://developers.google.com/blockly/xml">
  <block type="logic_compare" id="2n20(|Q%A^}6]Z-V`}5w" x="63" y="38">
    <field name="OP">EQ</field>
  </block>
  <block type="math_number" id="iTHDI?u7Ojrv{`iCKf][" x="188" y="38">
    <field name="NUM">123</field>
  </block>
</xml>
```

2. Running the following code in the console:

```
blocks = workspace.getBlocksByType('logic_compare');
for (var i = 0, block; block = blocks[i]; i++) {
  block.setMutator(new Blockly.Mutator(['logic_negate']))
}
```
3. Observing how the logic_compare block is correctly re-rendered and the unattached number block is bumped away.

4. Running the following code in the console:

```
blocks = workspace.getBlocksByType('logic_compare');
for (var i = 0, block; block = blocks[i]; i++) {
  block.setMutator(null)
}
```

5. Observing how the logic_compare block is correctly re-rendered.

