### PR TITLE
Geras inline alignment of rows + max bottom row width

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -186,13 +186,6 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = this.LARGE_PADDING;
 
   /**
-   * The maximum width of a bottom row that follows a statement input and has
-   * inputs inline.
-   * @type {number}
-   */
-  this.MAX_BOTTOM_WIDTH = 66.5;
-
-  /**
    * Whether to add a 'hat' on top of all blocks with no previous or output
    * connections. Can be overridden by 'hat' property on Theme.BlockStyle.
    * @type {boolean}

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -191,8 +191,8 @@ Blockly.blockRendering.RenderInfo.prototype.getRenderer = function() {
 Blockly.blockRendering.RenderInfo.prototype.measure = function() {
   this.createRows_();
   this.addElemSpacing_();
-  this.addRowSpacing_();
   this.computeBounds_();
+  this.addRowSpacing_();
   this.alignRowElements_();
   this.finalize_();
 };
@@ -553,7 +553,7 @@ Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
       var currentWidth = row.width;
       var desiredWidth = this.getDesiredRowWidth_(row);
       var missingSpace = desiredWidth - currentWidth;
-      if (missingSpace) {
+      if (missingSpace > 0) {
         this.addAlignmentPadding_(row, missingSpace);
       }
     }
@@ -617,7 +617,7 @@ Blockly.blockRendering.RenderInfo.prototype.alignStatementRow_ = function(row) {
   var desiredWidth = this.statementEdge;
   // Add padding before the statement input.
   var missingSpace = desiredWidth - currentWidth;
-  if (missingSpace) {
+  if (missingSpace > 0) {
     this.addAlignmentPadding_(row, missingSpace);
   }
   // Also widen the statement input to reach to the right side of the

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -191,8 +191,8 @@ Blockly.blockRendering.RenderInfo.prototype.getRenderer = function() {
 Blockly.blockRendering.RenderInfo.prototype.measure = function() {
   this.createRows_();
   this.addElemSpacing_();
-  this.computeBounds_();
   this.addRowSpacing_();
+  this.computeBounds_();
   this.alignRowElements_();
   this.finalize_();
 };

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -551,13 +551,24 @@ Blockly.blockRendering.RenderInfo.prototype.alignRowElements_ = function() {
           /** @type {!Blockly.blockRendering.InputRow} */ (row));
     } else {
       var currentWidth = row.width;
-      var desiredWidth = this.width - this.startX;
+      var desiredWidth = this.getDesiredRowWidth_(row);
       var missingSpace = desiredWidth - currentWidth;
       if (missingSpace) {
         this.addAlignmentPadding_(row, missingSpace);
       }
     }
   }
+};
+
+/**
+ * Calculate the desired width of an input row.
+ * @param {!Blockly.blockRendering.Row} _row The input row.
+ * @return {number} The desired width of the input row.
+ * @protected
+ */
+Blockly.blockRendering.RenderInfo.prototype.getDesiredRowWidth_ = function(
+    _row) {
+  return this.width - this.startX;
 };
 
 /**
@@ -612,8 +623,7 @@ Blockly.blockRendering.RenderInfo.prototype.alignStatementRow_ = function(row) {
   // Also widen the statement input to reach to the right side of the
   // block. Note that this does not add padding.
   currentWidth = row.width;
-  var rightCornerWidth = this.constants_.INSIDE_CORNERS.rightWidth || 0;
-  desiredWidth = this.width - this.startX - rightCornerWidth;
+  desiredWidth = this.getDesiredRowWidth_(row);
   statementInput.width += (desiredWidth - currentWidth);
   statementInput.height = Math.max(statementInput.height, row.height);
   row.width += (desiredWidth - currentWidth);

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -51,7 +51,7 @@ Blockly.geras.ConstantProvider = function() {
    * inputs inline.
    * @type {number}
    */
-  this.MAX_INLINE_WIDTH = 30;
+  this.MAX_BOTTOM_WIDTH = 30;
 };
 Blockly.utils.object.inherits(Blockly.geras.ConstantProvider,
     Blockly.blockRendering.ConstantProvider);

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -45,6 +45,13 @@ Blockly.geras.ConstantProvider = function() {
   // The dark/shadow path in classic rendering is the same as the normal block
   // path, but translated down one and right one.
   this.DARK_PATH_OFFSET = 1;
+
+  /**
+   * The maximum width of a bottom row that follows a statement input and has
+   * inputs inline.
+   * @type {number}
+   */
+  this.MAX_INLINE_WIDTH = 30;
 };
 Blockly.utils.object.inherits(Blockly.geras.ConstantProvider,
     Blockly.blockRendering.ConstantProvider);

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -113,7 +113,10 @@ Blockly.geras.Drawer.prototype.drawStatementInput_ = function(row) {
  */
 Blockly.geras.Drawer.prototype.drawRightSideRow_ = function(row) {
   this.highlighter_.drawRightSideRow(row);
-  Blockly.geras.Drawer.superClass_.drawRightSideRow_.call(this, row);
+
+  this.outlinePath_ +=
+      Blockly.utils.svgPaths.lineOnAxis('H', row.xPos + row.width) +
+      Blockly.utils.svgPaths.lineOnAxis('V', row.yPos + row.height);
 };
 
 /**

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -168,7 +168,7 @@ Blockly.geras.Highlighter.prototype.drawStatementInput = function(row) {
 
 Blockly.geras.Highlighter.prototype.drawRightSideRow = function(row) {
   var rightEdge = row.xPos + row.width - this.highlightOffset_;
-  if (row.followsStatement) {
+  if (row.hasStatement) {
     this.steps_ += Blockly.utils.svgPaths.lineOnAxis('H', rightEdge);
   }
   if (this.RTL_) {

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -168,7 +168,7 @@ Blockly.geras.Highlighter.prototype.drawStatementInput = function(row) {
 
 Blockly.geras.Highlighter.prototype.drawRightSideRow = function(row) {
   var rightEdge = row.xPos + row.width - this.highlightOffset_;
-  if (row.hasStatement) {
+  if (row.followsStatement) {
     this.steps_ += Blockly.utils.svgPaths.lineOnAxis('H', rightEdge);
   }
   if (this.RTL_) {

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -440,7 +440,7 @@ Blockly.geras.RenderInfo.prototype.getDesiredRowWidth_ = function(
     row) {
   // Limit the width of a statement row when a block is inline.
   if (this.isInline && row.hasStatement) {
-    return this.statementEdge + this.constants_.MAX_INLINE_WIDTH + this.startX;
+    return this.statementEdge + this.constants_.MAX_BOTTOM_WIDTH + this.startX;
   }
   return Blockly.geras.RenderInfo.superClass_.getDesiredRowWidth_.call(this,
       row);

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -386,7 +386,8 @@ Blockly.geras.RenderInfo.prototype.alignRowElements_ = function() {
     return;
   }
 
-  // Walk up each row from the bottom, keeping track of the right input edge.
+  // Walk backgrounds through rows on the block, keeping track of the right
+  // input edge.
   var nextRightEdge = 0;
   var prevInput = null;
   for (var i = this.rows.length - 1, row; (row = this.rows[i]); i--) {

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -60,13 +60,6 @@ goog.require('Blockly.utils.object');
  */
 Blockly.geras.RenderInfo = function(renderer, block) {
   Blockly.geras.RenderInfo.superClass_.constructor.call(this, renderer, block);
-
-  /**
-   * Whether or not the block has a statement input.
-   * @type {boolean}
-   * @protected
-   */
-  this.hasStatementInput_ = false;
 };
 Blockly.utils.object.inherits(Blockly.geras.RenderInfo,
     Blockly.blockRendering.RenderInfo);
@@ -115,7 +108,6 @@ Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
     activeRow.elements.push(
         new Blockly.geras.StatementInput(this.constants_, input));
     activeRow.hasStatement = true;
-    this.hasStatementInput_ = true;
   } else if (input.type == Blockly.INPUT_VALUE) {
     activeRow.elements.push(
         new Blockly.blockRendering.ExternalValueInput(this.constants_, input));

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -60,6 +60,13 @@ goog.require('Blockly.utils.object');
  */
 Blockly.geras.RenderInfo = function(renderer, block) {
   Blockly.geras.RenderInfo.superClass_.constructor.call(this, renderer, block);
+
+  /**
+   * Whether or not the block has a statement input.
+   * @type {boolean}
+   * @protected
+   */
+  this.hasStatementInput_ = false;
 };
 Blockly.utils.object.inherits(Blockly.geras.RenderInfo,
     Blockly.blockRendering.RenderInfo);
@@ -108,6 +115,7 @@ Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
     activeRow.elements.push(
         new Blockly.geras.StatementInput(this.constants_, input));
     activeRow.hasStatement = true;
+    this.hasStatementInput_ = true;
   } else if (input.type == Blockly.INPUT_VALUE) {
     activeRow.elements.push(
         new Blockly.blockRendering.ExternalValueInput(this.constants_, input));
@@ -374,6 +382,19 @@ Blockly.geras.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
     result += (row.height / 2);
   }
   return result;
+};
+
+/**
+ * @override
+ */
+Blockly.geras.RenderInfo.prototype.getDesiredRowWidth_ = function(
+    row) {
+  if (this.isInline && (row.hasStatement || (row == this.bottomRow &&
+      this.hasStatementInput_))) {
+    return this.constants_.MAX_BOTTOM_WIDTH + this.startX;
+  }
+  return Blockly.geras.RenderInfo.superClass_.getDesiredRowWidth_.call(this,
+      row);
 };
 
 /**

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -127,7 +127,8 @@ Blockly.geras.RenderInfo.prototype.addInput_ = function(input, activeRow) {
         this.constants_.DUMMY_INPUT_MIN_HEIGHT);
     activeRow.hasDummyInput = true;
   }
-  if (activeRow.align == null) {
+  // Ignore row alignment if inline.
+  if (!this.isInline && activeRow.align == null) {
     activeRow.align = input.align;
   }
 };

--- a/core/renderers/measurables/types.js
+++ b/core/renderers/measurables/types.js
@@ -134,7 +134,8 @@ Blockly.blockRendering.Types.isIcon = function(elem) {
 
 /**
  * Whether a measurable stores information about a spacer.
- * @param {!Blockly.blockRendering.Measurable} elem The element to check.
+ * @param {!Blockly.blockRendering.Measurable|!Blockly.blockRendering.Row} elem
+ *     The element to check.
  * @return {number} 1 if the object stores information about a spacer.
  * @package
  */

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -144,6 +144,19 @@ Blockly.zelos.RenderInfo.prototype.shouldStartNewRow_ = function(input,
   return false;
 };
 
+
+/**
+ * @override
+ */
+Blockly.zelos.RenderInfo.prototype.getDesiredRowWidth_ = function(row) {
+  if (row.hasStatement) {
+    var rightCornerWidth = this.constants_.INSIDE_CORNERS.rightWidth || 0;
+    return this.width - this.startX - rightCornerWidth;
+  }
+  return Blockly.zelos.RenderInfo.superClass_.getDesiredRowWidth_.call(this,
+      row);
+};
+
 /**
  * @override
  */


### PR DESCRIPTION
##  The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3367

### Proposed Changes

Add hook for getting desired width of a row.
Move MAX_BOTTOM_ROW constants to geras as it only applies there.
Don't take row alignment into account if inline.
Override alignRowElements_ in geras to align all rows (top, bottom, spacer) to the width of the max of the prev / next input.

### Reason for Changes

Geras rendering fix.

### Test Coverage

Tested a bunch of blocks in the blocks factory matching spec of the old renderer.

<img width="345" alt="Screen Shot 2020-01-10 at 1 15 54 PM" src="https://user-images.githubusercontent.com/16690124/72188061-426d3200-33ae-11ea-90a4-9c67b4b5ce41.png">


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
