### PR TITLE
Detect undefined elements in the debugger

### DIFF
--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -282,7 +282,12 @@ Blockly.blockRendering.Debug.prototype.drawRenderedRow = function(row, cursorY, 
  * @package
  */
 Blockly.blockRendering.Debug.prototype.drawRowWithElements = function(row, cursorY, isRtl) {
-  for (var i = 0, elem; (elem = row.elements[i]); i++) {
+  for (var i = 0, l = row.elements.length; i < l; i++) {
+    var elem = row.elements[i];
+    if (!elem) {
+      console.warn('A row has an undefined or null element.', row, elem);
+      continue;
+    }
     if (Blockly.blockRendering.Types.isSpacer(elem)) {
       this.drawSpacerElem(
           /** @type {!Blockly.blockRendering.InRowSpacer} */ (elem),

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -435,6 +435,9 @@ Blockly.blockRendering.RenderInfo.prototype.addElemSpacing_ = function() {
       row.elements.push(new Blockly.blockRendering.InRowSpacer(
           this.constants_, this.getInRowSpacing_(null, oldElems[0])));
     }
+    if (!oldElems.length) {
+      continue;
+    }
     for (var e = 0; e < oldElems.length - 1; e++) {
       row.elements.push(oldElems[e]);
       var spacing = this.getInRowSpacing_(oldElems[e], oldElems[e + 1]);

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -143,6 +143,9 @@ Blockly.geras.RenderInfo.prototype.addElemSpacing_ = function() {
       row.elements.push(new Blockly.blockRendering.InRowSpacer(
           this.constants_, this.getInRowSpacing_(null, oldElems[0])));
     }
+    if (!oldElems.length) {
+      continue;
+    }
     for (var e = 0; e < oldElems.length - 1; e++) {
       row.elements.push(oldElems[e]);
       var spacing = this.getInRowSpacing_(oldElems[e], oldElems[e + 1]);


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Detect undefined elements in the debugger.
Don't add multiple spacers when there are no elements in a row (only one for alignment)

### Reason for Changes

Rendering.

### Test Coverage

Tested with an empty dummy input.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
