### PR TITLE
Treat a statement input as the end of the statement row.

### DIFF
--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -183,7 +183,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   }
 
   // Spacing between a non-input and the end of the row.
-  if (!Blockly.blockRendering.Types.isInput(prev) && !next) {
+  if (!Blockly.blockRendering.Types.isInput(prev) && (!next ||
+      Blockly.blockRendering.Types.isStatementInput(next))) {
     // Between an editable field and the end of the row.
     if (Blockly.blockRendering.Types.isField(prev) && prev.isEditable) {
       return this.constants_.MEDIUM_PADDING;

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -182,7 +182,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
     return this.constants_.LARGE_PADDING;
   }
 
-  // Spacing between a non-input and the end of the row.
+  // Spacing between a non-input and the end of the row or a statement input.
   if (!Blockly.blockRendering.Types.isInput(prev) && (!next ||
       Blockly.blockRendering.Types.isStatementInput(next))) {
     // Between an editable field and the end of the row.


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Treat the space before a statement input as the end of a statement input row reducing the spacing of an editable field to match spec: 

<img width="136" alt="Screen Shot 2020-01-10 at 1 46 47 PM" src="https://user-images.githubusercontent.com/16690124/72188708-d5f33280-33af-11ea-8028-4e0cf29a9fcd.png">

### Reason for Changes

Geras rendering.

### Test Coverage

Tested with the blocks factory.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
