### PR TITLE
[zelos] Bug fix in centerline alignment of statement inputs

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -224,7 +224,7 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
  * @override
  */
 Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
-  if (row.hasStatement) {
+  if (row.hasStatement && !Blockly.blockRendering.Types.isSpacer(elem)) {
     return row.yPos + this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT / 2;
   }
   return Blockly.zelos.RenderInfo.superClass_.getElemCenterline_.call(this,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<img width="275" alt="Screen Shot 2020-01-10 at 4 23 27 PM" src="https://user-images.githubusercontent.com/16690124/72195337-a0a60f00-33c6-11ea-95ca-71fcb59c4635.png">

### Proposed Changes

Zelos statement input centerline alignment currently centers spacers but they shouldn't. This fixes that.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
