### PR TITLE
Start hat support in zelos.

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -194,13 +194,13 @@ Blockly.blockRendering.ConstantProvider = function() {
 
   /**
    * Height of the top hat.
-   * @private
+   * @type {number}
    */
   this.START_HAT_HEIGHT = 15;
 
   /**
    * Width of the top hat.
-   * @private
+   * @type {number}
    */
   this.START_HAT_WIDTH = 100;
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -190,6 +190,16 @@ Blockly.zelos.ConstantProvider = function() {
   this.JAGGED_TEETH_WIDTH = 0;
 
   /**
+   * @override
+   */
+  this.START_HAT_HEIGHT = 22;
+
+  /**
+   * @override
+   */
+  this.START_HAT_WIDTH = 96;
+
+  /**
    * @enum {number}
    * @override
    */
@@ -421,6 +431,27 @@ Blockly.zelos.ConstantProvider.prototype.dispose = function() {
   if (this.highlightGlowFilter_) {
     Blockly.utils.dom.removeNode(this.highlightGlowFilter_);
   }
+};
+
+/**
+ * @override
+ */
+Blockly.zelos.ConstantProvider.prototype.makeStartHat = function() {
+  var height = this.START_HAT_HEIGHT;
+  var width = this.START_HAT_WIDTH;
+
+  var mainPath =
+      Blockly.utils.svgPaths.curve('c',
+          [
+            Blockly.utils.svgPaths.point(25, -height),
+            Blockly.utils.svgPaths.point(71, -height),
+            Blockly.utils.svgPaths.point(width, 0)
+          ]);
+  return {
+    height: height,
+    width: width,
+    path: mainPath
+  };
 };
 
 /**

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -181,6 +181,11 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       return next.notchOffset - this.constants_.CORNER_RADIUS;
     }
   }
+  // Spacing between a square corner and a hat.
+  if (prev && Blockly.blockRendering.Types.isLeftSquareCorner(prev) && next &&
+      Blockly.blockRendering.Types.isHat(next)) {
+    return this.constants_.NO_PADDING;
+  }
   return this.constants_.MEDIUM_PADDING;
 };
 

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -62,7 +62,10 @@ Blockly.zelos.TopRow.prototype.endsWithElemSpacer = function() {
  * @override
  */
 Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
-  return !!block.outputConnection;
+  var hasHat = (typeof block.hat !== 'undefined' ?
+      block.hat === 'cap' : this.constants_.ADD_START_HATS) &&
+      !block.outputConnection && !block.previousConnection;
+  return !!block.outputConnection || hasHat;
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Override start hat constants in zelos to rendering of: 

<img width="546" alt="Screen Shot 2020-01-13 at 11 03 08 AM" src="https://user-images.githubusercontent.com/16690124/72283831-73d73f00-35f4-11ea-9e8e-3bf1f9406bb2.png">


### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
