### PR TITLE
Add constant for field dropdown arrow padding

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -682,7 +682,7 @@ Blockly.FieldDropdown.prototype.positionSVGArrow_ = function(x, y) {
   if (!this.svgArrow_) {
     return 0;
   }
-  var padding = this.constants_.FIELD_DROPDOWN_SVG_PADDING;
+  var padding = this.constants_.FIELD_DROPDOWN_SVG_ARROW_PADDING;
   var svgArrowSize = this.constants_.FIELD_DROPDOWN_SVG_ARROW_SIZE;
   var arrowX = this.sourceBlock_.RTL ? padding : x + padding;
   this.svgArrow_.setAttribute('transform',

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -682,7 +682,7 @@ Blockly.FieldDropdown.prototype.positionSVGArrow_ = function(x, y) {
   if (!this.svgArrow_) {
     return 0;
   }
-  var padding = this.constants_.FIELD_BORDER_RECT_X_PADDING;
+  var padding = this.constants_.FIELD_DROPDOWN_SVG_PADDING;
   var svgArrowSize = this.constants_.FIELD_DROPDOWN_SVG_ARROW_SIZE;
   var arrowX = this.sourceBlock_.RTL ? padding : x + padding;
   this.svgArrow_.setAttribute('transform',

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -340,7 +340,36 @@ Blockly.blockRendering.ConstantProvider = function() {
    * Whether or not a dropdown field uses a text or SVG arrow.
    * @type {boolean}
    */
-  this.FIELD_DROPDOWN_SVG_ARROW = false;
+  this.FIELD_DROPDOWN_SVG_ARROW = true;
+
+  /**
+   * A dropdown field's SVG arrow padding.
+   * @type {number}
+   */
+  this.FIELD_DROPDOWN_SVG_ARROW_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
+
+  /**
+   * A dropdown field's SVG arrow size.
+   * @type {number}
+   */
+  this.FIELD_DROPDOWN_SVG_ARROW_SIZE = 12;
+
+  /**
+   * A dropdown field's SVG arrow datauri.
+   * @type {string}
+   */
+  this.FIELD_DROPDOWN_SVG_ARROW_DATAURI =
+    'data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllci' +
+    'AxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMi43MSIgaG' +
+    'VpZ2h0PSI4Ljc5IiB2aWV3Qm94PSIwIDAgMTIuNzEgOC43OSI+PHRpdGxlPmRyb3Bkb3duLW' +
+    'Fycm93PC90aXRsZT48ZyBvcGFjaXR5PSIwLjEiPjxwYXRoIGQ9Ik0xMi43MSwyLjQ0QTIuND' +
+    'EsMi40MSwwLDAsMSwxMiw0LjE2TDguMDgsOC4wOGEyLjQ1LDIuNDUsMCwwLDEtMy40NSwwTD' +
+    'AuNzIsNC4xNkEyLjQyLDIuNDIsMCwwLDEsMCwyLjQ0LDIuNDgsMi40OCwwLDAsMSwuNzEuNz' +
+    'FDMSwwLjQ3LDEuNDMsMCw2LjM2LDBTMTEuNzUsMC40NiwxMiwuNzFBMi40NCwyLjQ0LDAsMC' +
+    'wxLDEyLjcxLDIuNDRaIiBmaWxsPSIjMjMxZjIwIi8+PC9nPjxwYXRoIGQ9Ik02LjM2LDcuNz' +
+    'lhMS40MywxLjQzLDAsMCwxLTEtLjQyTDEuNDIsMy40NWExLjQ0LDEuNDQsMCwwLDEsMC0yYz' +
+    'AuNTYtLjU2LDkuMzEtMC41Niw5Ljg3LDBhMS40NCwxLjQ0LDAsMCwxLDAsMkw3LjM3LDcuMz' +
+    'dBMS40MywxLjQzLDAsMCwxLDYuMzYsNy43OVoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=';
 
   /**
    * Whether or not to show a box shadow around the widget div. This is only a

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -340,7 +340,7 @@ Blockly.blockRendering.ConstantProvider = function() {
    * Whether or not a dropdown field uses a text or SVG arrow.
    * @type {boolean}
    */
-  this.FIELD_DROPDOWN_SVG_ARROW = true;
+  this.FIELD_DROPDOWN_SVG_ARROW = false;
 
   /**
    * A dropdown field's SVG arrow padding.

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -304,36 +304,9 @@ Blockly.zelos.ConstantProvider = function() {
   this.FIELD_DROPDOWN_SVG_ARROW = true;
 
   /**
-   * A dropdown field's SVG arrow padding.
-   * @type {number}
-   * @const
+   * @override
    */
   this.FIELD_DROPDOWN_SVG_ARROW_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
-
-  /**
-   * A dropdown field's SVG arrow size.
-   * @type {number}
-   * @const
-   */
-  this.FIELD_DROPDOWN_SVG_ARROW_SIZE = 3 * this.GRID_UNIT;
-
-  /**
-   * A dropdown field's SVG arrow datauri.
-   * @type {string}
-   * @const
-   */
-  this.FIELD_DROPDOWN_SVG_ARROW_DATAURI =
-    'data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllci' +
-    'AxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMi43MSIgaG' +
-    'VpZ2h0PSI4Ljc5IiB2aWV3Qm94PSIwIDAgMTIuNzEgOC43OSI+PHRpdGxlPmRyb3Bkb3duLW' +
-    'Fycm93PC90aXRsZT48ZyBvcGFjaXR5PSIwLjEiPjxwYXRoIGQ9Ik0xMi43MSwyLjQ0QTIuND' +
-    'EsMi40MSwwLDAsMSwxMiw0LjE2TDguMDgsOC4wOGEyLjQ1LDIuNDUsMCwwLDEtMy40NSwwTD' +
-    'AuNzIsNC4xNkEyLjQyLDIuNDIsMCwwLDEsMCwyLjQ0LDIuNDgsMi40OCwwLDAsMSwuNzEuNz' +
-    'FDMSwwLjQ3LDEuNDMsMCw2LjM2LDBTMTEuNzUsMC40NiwxMiwuNzFBMi40NCwyLjQ0LDAsMC' +
-    'wxLDEyLjcxLDIuNDRaIiBmaWxsPSIjMjMxZjIwIi8+PC9nPjxwYXRoIGQ9Ik02LjM2LDcuNz' +
-    'lhMS40MywxLjQzLDAsMCwxLTEtLjQyTDEuNDIsMy40NWExLjQ0LDEuNDQsMCwwLDEsMC0yYz' +
-    'AuNTYtLjU2LDkuMzEtMC41Niw5Ljg3LDBhMS40NCwxLjQ0LDAsMCwxLDAsMkw3LjM3LDcuMz' +
-    'dBMS40MywxLjQzLDAsMCwxLDYuMzYsNy43OVoiIGZpbGw9IiNmZmYiLz48L3N2Zz4=';
 
   /**
    * @override

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -308,7 +308,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @type {number}
    * @const
    */
-  this.FIELD_DROPDOWN_SVG_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
+  this.FIELD_DROPDOWN_SVG_ARROW_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
 
   /**
    * A dropdown field's SVG arrow size.

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -304,6 +304,13 @@ Blockly.zelos.ConstantProvider = function() {
   this.FIELD_DROPDOWN_SVG_ARROW = true;
 
   /**
+   * A dropdown field's SVG arrow padding.
+   * @type {number}
+   * @const
+   */
+  this.FIELD_DROPDOWN_SVG_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
+
+  /**
    * A dropdown field's SVG arrow size.
    * @type {number}
    * @const


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Add constants for field dropdown arrow padding for more control over where the arrow shows up, and so that the padding between the text and the arrow isn't necessarily the same as the padding on the edges (which is the case for scratch-blocks).

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in rendering playground: 

8 px padding around edges, 8px padding between text and arrow (pxtblockly):
<img width="292" alt="Screen Shot 2020-01-13 at 11 08 36 AM" src="https://user-images.githubusercontent.com/16690124/72284207-4212a800-35f5-11ea-83ac-e7596197bdc6.png">

11 px padding around edges, 8px padding between text and arrow (scratch-blocks):
<img width="391" alt="Screen Shot 2020-01-13 at 11 06 45 AM" src="https://user-images.githubusercontent.com/16690124/72284208-4212a800-35f5-11ea-9b8b-548341ca7a50.png">



Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
