### PR TITLE
Fix testblocks in IE11

### DIFF
--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -360,11 +360,10 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "text": "default"
       }
     ],
-    "style": "math_blocks",
+    "style": "textInput",
     "tooltip": "",
     "helpUrl": "",
-    "output": "String",
-    "style": "textInput"
+    "output": "String"
   },
   {
     "type": "test_fields_multilinetext",


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

IE 11 doesn't allow the same property to be set on an object twice in strict mode.

### Reason for Changes

Fix testing in IE11

### Test Coverage

Tested in IE11

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
