### PR TITLE
Fix zelos top row spacer height when it precedes a statement row.

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -199,16 +199,9 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
       Blockly.blockRendering.Types.isBottomRow(next)) {
     return this.constants_.EMPTY_BLOCK_SPACER_HEIGHT;
   }
-  // Top and bottom rows act as a spacer so we don't need any extra padding.
-  if ((Blockly.blockRendering.Types.isTopRow(prev))) {
-    if (!prev.hasPreviousConnection && !this.outputConnection) {
-      return this.constants_.SMALL_PADDING;
-    }
-    return this.constants_.NO_PADDING;
-  }
-  var precedesStatement =
-      Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement;
   var followsStatement =
+      Blockly.blockRendering.Types.isInputRow(prev) && prev.hasStatement;
+  var precedesStatement =
       Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement;
   if (precedesStatement || followsStatement) {
     var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight || 0;
@@ -216,6 +209,13 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
         Math.max(this.constants_.NOTCH_HEIGHT, cornerHeight));
     return precedesStatement && followsStatement ?
         Math.max(height, this.constants_.DUMMY_INPUT_MIN_HEIGHT) : height;
+  }
+  // Top and bottom rows act as a spacer so we don't need any extra padding.
+  if ((Blockly.blockRendering.Types.isTopRow(prev))) {
+    if (!prev.hasPreviousConnection && !this.outputConnection) {
+      return this.constants_.SMALL_PADDING;
+    }
+    return this.constants_.NO_PADDING;
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     if (!this.outputConnection) {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix zelos top spacer height when the top row precedes a statement row.

<img width="506" alt="Screen Shot 2020-01-13 at 4 28 24 PM" src="https://user-images.githubusercontent.com/16690124/72303383-f7f3eb80-3621-11ea-8ab2-2d529f80e75c.png">


### Proposed Changes

Give preference to the followsStatement check before checking if the prev row is a top row and applying the top row check.

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground with new connection test blocks.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

