### PR TITLE
Cleanup connection test blocks in playground

### DIFF
--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1731,7 +1731,7 @@ Blockly.Blocks['test_dropdowns_dynamic'] = {
 /**
  * An array of options for the dynamic dropdown.
  * @type {!Array<!Array>}
- * @protected
+ * @private
  */
 Blockly.TestBlocks.dynamicDropdownOptions_ = [];
 

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1731,7 +1731,7 @@ Blockly.Blocks['test_dropdowns_dynamic'] = {
 /**
  * An array of options for the dynamic dropdown.
  * @type {!Array<!Array>}
- * @package
+ * @protected
  */
 Blockly.TestBlocks.dynamicDropdownOptions_ = [];
 
@@ -1740,7 +1740,7 @@ Blockly.TestBlocks.dynamicDropdownOptions_ = [];
  * the user for an option to add.
  * @package
  */
-Blockly.TestBlocks.addDynamicDropdownOption_ = function() {
+Blockly.TestBlocks.addDynamicDropdownOption = function() {
   Blockly.prompt('Add an option?',
       'option '  + Blockly.TestBlocks.dynamicDropdownOptions_.length,
       function(text) {
@@ -1761,7 +1761,7 @@ Blockly.TestBlocks.addDynamicDropdownOption_ = function() {
  * same name.
  * @package
  */
-Blockly.TestBlocks.removeDynamicDropdownOption_ = function() {
+Blockly.TestBlocks.removeDynamicDropdownOption = function() {
   var defaultText = Blockly.TestBlocks.dynamicDropdownOptions_[0] ?
       Blockly.TestBlocks.dynamicDropdownOptions_[0][0] : '';
   Blockly.prompt('Remove an option?', defaultText, function(text) {
@@ -1795,4 +1795,98 @@ Blockly.Blocks['test_dropdowns_dynamic_random'] = {
     }
     return options;
   }
+};
+
+/**
+ * Handles "insert" button in the connection row test category. This will insert
+ * a group of test blocks connected in a row.
+ * @package
+ */
+Blockly.TestBlocks.insertConnectionRows = function(button) {
+  var workspace = button.getTargetWorkspace();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
+      '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
+      '  <block type="test_connections_row_input">\n' +
+      '    <value name="NAME">\n' +
+      '      <block type="test_connections_row_blue">\n' +
+      '        <value name="NAME">\n' +
+      '          <block type="test_connections_row_yellow">\n' +
+      '            <value name="NAME">\n' +
+      '              <block type="test_connections_row_yellow">\n' +
+      '                <value name="NAME">\n' +
+      '                  <block type="test_connections_row_red">\n' +
+      '                    <value name="NAME">\n' +
+      '                      <block type="test_connections_row_output"/>\n' +
+      '                    </value>\n' +
+      '                  </block>\n' +
+      '                </value>\n' +
+      '              </block>\n' +
+      '            </value>\n' +
+      '          </block>\n' +
+      '        </value>\n' +
+      '      </block>\n' +
+      '    </value>\n' +
+      '  </block>\n' +
+      '</xml>'
+  ), workspace)
+};
+
+/**
+ * Handles "insert" button in the connection stack test category. This will
+ * insert a group of test blocks connected in a stack.
+ * @package
+ */
+Blockly.TestBlocks.insertConnectionStacks = function(button) {
+  var workspace = button.getTargetWorkspace();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
+      '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
+      '  <block type="test_connections_stack_next">\n' +
+      '    <next>\n' +
+      '      <block type="test_connections_stack_blue">\n' +
+      '        <next>\n' +
+      '          <block type="test_connections_stack_yellow">\n' +
+      '            <next>\n' +
+      '              <block type="test_connections_stack_yellow">\n' +
+      '                <next>\n' +
+      '                  <block type="test_connections_stack_red">\n' +
+      '                    <next>\n' +
+      '                      <block type="test_connections_stack_prev"/>\n' +
+      '                    </next>\n' +
+      '                  </block>\n' +
+      '                </next>\n' +
+      '              </block>\n' +
+      '            </next>\n' +
+      '          </block>\n' +
+      '        </next>\n' +
+      '      </block>\n' +
+      '    </next>\n' +
+      '  </block>\n' +
+      '</xml>'
+  ), workspace);
+};
+
+/**
+ * Handles "insert" button in the connection statement test category. This will
+ * insert a group of test blocks connected as statements.
+ * @package
+ */
+Blockly.TestBlocks.insertConnectionStatements = function(button) {
+  var workspace = button.getTargetWorkspace();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
+      '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
+      '  <block type="test_connections_statement_blue">\n' +
+      '    <statement name="NAME">\n' +
+      '      <block type="test_connections_statement_yellow">\n' +
+      '        <statement name="NAME">\n' +
+      '          <block type="test_connections_statement_yellow">\n' +
+      '            <statement name="NAME">\n' +
+      '              <block type="test_connections_statement_red"/>\n' +
+      '            </statement>\n' +
+      '          </block>\n' +
+      '        </statement>\n' +
+      '      </block>\n' +
+      '    </statement>\n' +
+      '  </block>\n' +
+      '</xml>'
+  ), workspace);
 };

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -249,91 +249,15 @@ function addToolboxButtonCallbacks() {
     workspace.createVariable('2b', '', '2B');
     workspace.createVariable('2c', '', '2C');
   };
-  var insertConnectionRows = function(button) {
-    var workspace = button.getTargetWorkspace();
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
-            '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
-            '  <block type="test_connections_row_input">\n' +
-            '    <value name="NAME">\n' +
-            '      <block type="test_connections_row_blue">\n' +
-            '        <value name="NAME">\n' +
-            '          <block type="test_connections_row_yellow">\n' +
-            '            <value name="NAME">\n' +
-            '              <block type="test_connections_row_yellow">\n' +
-            '                <value name="NAME">\n' +
-            '                  <block type="test_connections_row_red">\n' +
-            '                    <value name="NAME">\n' +
-            '                      <block type="test_connections_row_output"/>\n' +
-            '                    </value>\n' +
-            '                  </block>\n' +
-            '                </value>\n' +
-            '              </block>\n' +
-            '            </value>\n' +
-            '          </block>\n' +
-            '        </value>\n' +
-            '      </block>\n' +
-            '    </value>\n' +
-            '  </block>\n' +
-            '</xml>'
-    ), workspace)
-  };
-  var insertConnectionStacks = function(button) {
-    var workspace = button.getTargetWorkspace();
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
-            '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
-            '  <block type="test_connections_stack_next">\n' +
-            '    <next>\n' +
-            '      <block type="test_connections_stack_blue">\n' +
-            '        <next>\n' +
-            '          <block type="test_connections_stack_yellow">\n' +
-            '            <next>\n' +
-            '              <block type="test_connections_stack_yellow">\n' +
-            '                <next>\n' +
-            '                  <block type="test_connections_stack_red">\n' +
-            '                    <next>\n' +
-            '                      <block type="test_connections_stack_prev"/>\n' +
-            '                    </next>\n' +
-            '                  </block>\n' +
-            '                </next>\n' +
-            '              </block>\n' +
-            '            </next>\n' +
-            '          </block>\n' +
-            '        </next>\n' +
-            '      </block>\n' +
-            '    </next>\n' +
-            '  </block>\n' +
-            '</xml>'
-    ), workspace);
-  };
-  var insertConnectionStatements = function(button) {
-    var workspace = button.getTargetWorkspace();
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
-            '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
-            '  <block type="test_connections_statement_blue">\n' +
-            '    <statement name="NAME">\n' +
-            '      <block type="test_connections_statement_yellow">\n' +
-            '        <statement name="NAME">\n' +
-            '          <block type="test_connections_statement_yellow">\n' +
-            '            <statement name="NAME">\n' +
-            '              <block type="test_connections_statement_red"/>\n' +
-            '            </statement>\n' +
-            '          </block>\n' +
-            '        </statement>\n' +
-            '      </block>\n' +
-            '    </statement>\n' +
-            '  </block>\n' +
-            '</xml>'
-    ), workspace);
-  };
 
   workspace.registerButtonCallback(
-    'addVariables', addVariables);
+      'addVariables', addVariables);
   workspace.registerButtonCallback(
-    'changeImage', changeImage);
+      'changeImage', changeImage);
   workspace.registerButtonCallback(
-    'addAllBlocksToWorkspace', addAllBlocksToWorkspace);
+      'addAllBlocksToWorkspace', addAllBlocksToWorkspace);
   workspace.registerButtonCallback(
-    'setInput', setInput);
+      'setInput', setInput);
   workspace.registerButtonCallback(
       'setRandomStyle', setRandomStyle);
   workspace.registerButtonCallback(
@@ -345,15 +269,16 @@ function addToolboxButtonCallbacks() {
   workspace.registerButtonCallback(
       'randomizeLabelText', randomizeLabelText);
   workspace.registerButtonCallback(
-      'addDynamicOption', Blockly.TestBlocks.addDynamicDropdownOption_);
+      'addDynamicOption', Blockly.TestBlocks.addDynamicDropdownOption);
   workspace.registerButtonCallback(
-      'removeDynamicOption', Blockly.TestBlocks.removeDynamicDropdownOption_);
+      'removeDynamicOption', Blockly.TestBlocks.removeDynamicDropdownOption);
   workspace.registerButtonCallback(
-          'insertConnectionRows', insertConnectionRows);
+      'insertConnectionRows', Blockly.TestBlocks.insertConnectionRows);
   workspace.registerButtonCallback(
-          'insertConnectionStacks', insertConnectionStacks);
+      'insertConnectionStacks', Blockly.TestBlocks.insertConnectionStacks);
   workspace.registerButtonCallback(
-          'insertConnectionStatements', insertConnectionStatements);
+      'insertConnectionStatements',
+          Blockly.TestBlocks.insertConnectionStatements);
 }
 
 function setRenderDebugOptionCheckboxState(overrideOptions) {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Cleanup. 

### Proposed Changes

Remove connection tests blocks handlers introduced in https://github.com/google/blockly/pull/3525 out of the playground and into the test_blocks.js file. 
Add jsdoc for handlers, and align properly.

### Reason for Changes

Cleanup, keep playground lean.

### Test Coverage

Tested playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
