### PR TITLE
Setting default options in workspace constructor.

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -77,7 +77,7 @@ Blockly.inject = function(container, opt_options) {
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);
-  Blockly.user.keyMap.setKeyMap(workspace.options.keyMap);
+  Blockly.user.keyMap.setKeyMap(options.keyMap);
 
   Blockly.init_(workspace);
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -77,7 +77,7 @@ Blockly.inject = function(container, opt_options) {
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);
-  Blockly.user.keyMap.setKeyMap(options.keyMap);
+  Blockly.user.keyMap.setKeyMap(workspace.options.keyMap);
 
   Blockly.init_(workspace);
 
@@ -161,24 +161,25 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   options.parentWorkspace = null;
   var mainWorkspace =
       new Blockly.WorkspaceSvg(options, blockDragSurface, workspaceDragSurface);
-  mainWorkspace.scale = options.zoomOptions.startScale;
+  var wsOptions = mainWorkspace.options;
+  mainWorkspace.scale = wsOptions.zoomOptions.startScale;
   svg.appendChild(mainWorkspace.createDom('blocklyMainBackground'));
 
   // Set the theme name and renderer name onto the injection div.
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
-      (mainWorkspace.options.renderer || 'geras') + '-renderer');
+      (wsOptions.renderer || 'geras') + '-renderer');
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
       mainWorkspace.getTheme().name + '-theme');
 
-  if (!options.hasCategories && options.languageTree) {
+  if (!wsOptions.hasCategories && wsOptions.languageTree) {
     // Add flyout as an <svg> that is a sibling of the workspace svg.
     var flyout = mainWorkspace.addFlyout('svg');
     Blockly.utils.dom.insertAfter(flyout, svg);
   }
-  if (options.hasTrashcan) {
+  if (wsOptions.hasTrashcan) {
     mainWorkspace.addTrashcan();
   }
-  if (options.zoomOptions && options.zoomOptions.controls) {
+  if (wsOptions.zoomOptions && wsOptions.zoomOptions.controls) {
     mainWorkspace.addZoomControls();
   }
   // Register the workspace svg as a UI component.
@@ -188,7 +189,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   // A null translation will also apply the correct initial scale.
   mainWorkspace.translate(0, 0);
 
-  if (!options.readOnly && !mainWorkspace.isMovable()) {
+  if (!wsOptions.readOnly && !mainWorkspace.isMovable()) {
     // Helper function for the workspaceChanged callback.
     // TODO (#2300): Move metrics math back to the WorkspaceSvg.
     var getWorkspaceMetrics = function() {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -161,7 +161,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   } else {
     var quarkXml = null;
   }
-  var workspaceOptions =  new Blockly.Options(
+  var workspaceOptions = new Blockly.Options(
       /** @type {Blockly.BlocklyOptions} */
       ({
         // If you want to enable disabling, also remove the

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -162,7 +162,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
     var quarkXml = null;
   }
   var workspaceOptions = new Blockly.Options(
-      /** @type {Blockly.BlocklyOptions} */
+      /** @type {!Blockly.BlocklyOptions} */
       ({
         // If you want to enable disabling, also remove the
         // event filter from workspaceChanged_ .

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -161,21 +161,23 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   } else {
     var quarkXml = null;
   }
-  var workspaceOptions = new Blockly.Options({
-    // If you want to enable disabling, also remove the
-    // event filter from workspaceChanged_ .
-    disable: false,
-    languageTree: quarkXml,
-    parentWorkspace: this.block_.workspace,
-    pathToMedia: this.block_.workspace.options.pathToMedia,
-    RTL: this.block_.RTL,
-    toolboxPosition: this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
-        Blockly.TOOLBOX_AT_LEFT,
-    horizontalLayout: false,
-    getMetrics: this.getFlyoutMetrics_.bind(this),
-    setMetrics: null,
-    renderer: this.block_.workspace.options.renderer
-  });
+  var workspaceOptions =  new Blockly.Options(
+      /** @type {Blockly.BlocklyOptions} */
+      ({
+        // If you want to enable disabling, also remove the
+        // event filter from workspaceChanged_ .
+        disable: false,
+        languageTree: quarkXml,
+        parentWorkspace: this.block_.workspace,
+        pathToMedia: this.block_.workspace.options.pathToMedia,
+        RTL: this.block_.RTL,
+        toolboxPosition: this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
+            Blockly.TOOLBOX_AT_LEFT,
+        horizontalLayout: false,
+        getMetrics: this.getFlyoutMetrics_.bind(this),
+        setMetrics: null,
+        renderer: this.block_.workspace.options.renderer
+      }));
   this.workspace_ = new Blockly.WorkspaceSvg(workspaceOptions);
   this.workspace_.isMutator = true;
   this.workspace_.addChangeListener(Blockly.Events.disableOrphans);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -161,7 +161,7 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   } else {
     var quarkXml = null;
   }
-  var workspaceOptions = /** @type {!Blockly.Options} */ ({
+  var workspaceOptions = new Blockly.Options({
     // If you want to enable disabling, also remove the
     // event filter from workspaceChanged_ .
     disable: false,

--- a/core/options.js
+++ b/core/options.js
@@ -155,7 +155,7 @@ Blockly.Options = function(options) {
    * workspace.
    * @type {Blockly.Workspace}
    */
-  this.parentWorkspace = null
+  this.parentWorkspace = null;
 };
 
 /**

--- a/core/options.js
+++ b/core/options.js
@@ -87,11 +87,7 @@ Blockly.Options = function(options) {
     horizontalLayout = false;
   }
   var toolboxAtStart = options['toolboxPosition'];
-  if (toolboxAtStart === 'end') {
-    toolboxAtStart = false;
-  } else {
-    toolboxAtStart = true;
-  }
+  toolboxAtStart = toolboxAtStart !== 'end';
 
   if (horizontalLayout) {
     var toolboxPosition = toolboxAtStart ?

--- a/core/options.js
+++ b/core/options.js
@@ -146,7 +146,7 @@ Blockly.Options = function(options) {
   /**
    * The SVG element for the grid pattern.
    * Created during injection.
-   * @type {!SVGElement|undefined}
+   * @type {!SVGElement}
    */
   this.gridPattern = undefined;
 

--- a/core/options.js
+++ b/core/options.js
@@ -156,6 +156,12 @@ Blockly.Options = function(options) {
 Blockly.BlocklyOptions = function() {};
 
 /**
+ * The SVG element for the grid pattern.
+ * @type {SVGElement}
+ */
+Blockly.Options.prototype.gridPattern = null;
+
+/**
  * The parent of the current workspace, or null if there is no parent workspace.
  * @type {Blockly.Workspace}
  */

--- a/core/options.js
+++ b/core/options.js
@@ -157,9 +157,9 @@ Blockly.BlocklyOptions = function() {};
 
 /**
  * The SVG element for the grid pattern.
- * @type {SVGElement}
+ * @type {!SVGElement}
  */
-Blockly.Options.prototype.gridPattern = null;
+Blockly.Options.prototype.gridPattern;
 
 /**
  * The parent of the current workspace, or null if there is no parent workspace.

--- a/core/options.js
+++ b/core/options.js
@@ -146,6 +146,20 @@ Blockly.Options = function(options) {
   this.theme = Blockly.Options.parseThemeOptions_(options);
   this.keyMap = keyMap;
   this.renderer = renderer;
+
+  /**
+   * The SVG element for the grid pattern.
+   * Created during injection.
+   * @type {!SVGElement|undefined}
+   */
+  this.gridPattern = undefined;
+
+  /**
+   * The parent of the current workspace, or null if there is no parent
+   * workspace.
+   * @type {Blockly.Workspace}
+   */
+  this.parentWorkspace = null
 };
 
 /**
@@ -154,18 +168,6 @@ Blockly.Options = function(options) {
  * @interface
  */
 Blockly.BlocklyOptions = function() {};
-
-/**
- * The SVG element for the grid pattern.
- * @type {!SVGElement}
- */
-Blockly.Options.prototype.gridPattern;
-
-/**
- * The parent of the current workspace, or null if there is no parent workspace.
- * @type {Blockly.Workspace}
- */
-Blockly.Options.prototype.parentWorkspace = null;
 
 /**
  * If set, sets the translation of the workspace to match the scrollbars.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -180,7 +180,7 @@ Blockly.Toolbox.prototype.init = function() {
         Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
       }, /* opt_noCaptureIdentifier */ false, /* opt_noPreventDefault */ true);
   var workspaceOptions = new Blockly.Options(
-      /** @type {Blockly.BlocklyOptions} */
+      /** @type {!Blockly.BlocklyOptions} */
       ({
         parentWorkspace: workspace,
         RTL: workspace.RTL,

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -179,7 +179,7 @@ Blockly.Toolbox.prototype.init = function() {
         }
         Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
       }, /* opt_noCaptureIdentifier */ false, /* opt_noPreventDefault */ true);
-  var workspaceOptions = /** @type {!Blockly.Options} */ ({
+  var workspaceOptions = new Blockly.Options({
     parentWorkspace: workspace,
     RTL: workspace.RTL,
     oneBasedIndex: workspace.options.oneBasedIndex,

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -179,14 +179,16 @@ Blockly.Toolbox.prototype.init = function() {
         }
         Blockly.Touch.clearTouchIdentifier();  // Don't block future drags.
       }, /* opt_noCaptureIdentifier */ false, /* opt_noPreventDefault */ true);
-  var workspaceOptions = new Blockly.Options({
-    parentWorkspace: workspace,
-    RTL: workspace.RTL,
-    oneBasedIndex: workspace.options.oneBasedIndex,
-    horizontalLayout: workspace.horizontalLayout,
-    toolboxPosition: workspace.options.toolboxPosition,
-    renderer: workspace.options.renderer
-  });
+  var workspaceOptions = new Blockly.Options(
+      /** @type {Blockly.BlocklyOptions} */
+      ({
+        parentWorkspace: workspace,
+        RTL: workspace.RTL,
+        oneBasedIndex: workspace.options.oneBasedIndex,
+        horizontalLayout: workspace.horizontalLayout,
+        toolboxPosition: workspace.options.toolboxPosition,
+        renderer: workspace.options.renderer
+      }));
   if (workspace.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -60,13 +60,15 @@ Blockly.Trashcan = function(workspace) {
     return;
   }
   // Create flyout options.
-  var flyoutWorkspaceOptions = new Blockly.Options({
-    scrollbars: true,
-    parentWorkspace: this.workspace_,
-    RTL: this.workspace_.RTL,
-    oneBasedIndex: this.workspace_.options.oneBasedIndex,
-    renderer: this.workspace_.options.renderer
-  });
+  var flyoutWorkspaceOptions = new Blockly.Options(
+      /** @type {Blockly.BlocklyOptions} */
+      ({
+        scrollbars: true,
+        parentWorkspace: this.workspace_,
+        RTL: this.workspace_.RTL,
+        oneBasedIndex: this.workspace_.options.oneBasedIndex,
+        renderer: this.workspace_.options.renderer
+      }));
   // Create vertical or horizontal flyout.
   if (this.workspace_.horizontalLayout) {
     flyoutWorkspaceOptions.toolboxPosition =

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -61,7 +61,7 @@ Blockly.Trashcan = function(workspace) {
   }
   // Create flyout options.
   var flyoutWorkspaceOptions = new Blockly.Options(
-      /** @type {Blockly.BlocklyOptions} */
+      /** @type {!Blockly.BlocklyOptions} */
       ({
         scrollbars: true,
         parentWorkspace: this.workspace_,

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -60,7 +60,7 @@ Blockly.Trashcan = function(workspace) {
     return;
   }
   // Create flyout options.
-  var flyoutWorkspaceOptions = /** @type {!Blockly.Options} */ ({
+  var flyoutWorkspaceOptions = new Blockly.Options({
     scrollbars: true,
     parentWorkspace: this.workspace_,
     RTL: this.workspace_.RTL,

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -41,7 +41,7 @@ Blockly.Workspace = function(opt_options) {
   this.id = Blockly.utils.genUid();
   Blockly.Workspace.WorkspaceDB_[this.id] = this;
   /** @type {!Blockly.Options} */
-  this.options = new Blockly.Options(opt_options || {});
+  this.options = opt_options || new Blockly.Options({});
   /** @type {boolean} */
   this.RTL = !!this.options.RTL;
   /** @type {boolean} */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -41,7 +41,8 @@ Blockly.Workspace = function(opt_options) {
   this.id = Blockly.utils.genUid();
   Blockly.Workspace.WorkspaceDB_[this.id] = this;
   /** @type {!Blockly.Options} */
-  this.options = opt_options || new Blockly.Options({});
+  this.options = opt_options ||
+      new Blockly.Options(/** @type {!Blockly.BlocklyOptions} */ ({}));
   /** @type {boolean} */
   this.RTL = !!this.options.RTL;
   /** @type {boolean} */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -24,6 +24,7 @@
 goog.provide('Blockly.Workspace');
 
 goog.require('Blockly.Events');
+goog.require('Blockly.Options');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
 goog.require('Blockly.VariableMap');
@@ -40,7 +41,7 @@ Blockly.Workspace = function(opt_options) {
   this.id = Blockly.utils.genUid();
   Blockly.Workspace.WorkspaceDB_[this.id] = this;
   /** @type {!Blockly.Options} */
-  this.options = opt_options || /** @type {!Blockly.Options} */ ({});
+  this.options = opt_options || new Blockly.Options({});
   /** @type {boolean} */
   this.RTL = !!this.options.RTL;
   /** @type {boolean} */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -41,7 +41,7 @@ Blockly.Workspace = function(opt_options) {
   this.id = Blockly.utils.genUid();
   Blockly.Workspace.WorkspaceDB_[this.id] = this;
   /** @type {!Blockly.Options} */
-  this.options = opt_options || new Blockly.Options({});
+  this.options = new Blockly.Options(opt_options || {});
   /** @type {boolean} */
   this.RTL = !!this.options.RTL;
   /** @type {boolean} */

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -892,7 +892,7 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
-  var workspaceOptions = /** @type {!Blockly.Options} */ ({
+  var workspaceOptions = new Blockly.Options({
     parentWorkspace: this,
     RTL: this.RTL,
     oneBasedIndex: this.options.oneBasedIndex,

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -892,14 +892,16 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
-  var workspaceOptions = new Blockly.Options({
-    parentWorkspace: this,
-    RTL: this.RTL,
-    oneBasedIndex: this.options.oneBasedIndex,
-    horizontalLayout: this.horizontalLayout,
-    toolboxPosition: this.options.toolboxPosition,
-    renderer: this.options.renderer
-  });
+  var workspaceOptions = new Blockly.Options(
+      /** @type {Blockly.BlocklyOptions} */
+      ({
+        parentWorkspace: this,
+        RTL: this.RTL,
+        oneBasedIndex: this.options.oneBasedIndex,
+        horizontalLayout: this.horizontalLayout,
+        toolboxPosition: this.options.toolboxPosition,
+        renderer: this.options.renderer
+      }));
   if (this.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -893,7 +893,7 @@ Blockly.WorkspaceSvg.prototype.addZoomControls = function() {
  */
 Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
   var workspaceOptions = new Blockly.Options(
-      /** @type {Blockly.BlocklyOptions} */
+      /** @type {!Blockly.BlocklyOptions} */
       ({
         parentWorkspace: this,
         RTL: this.RTL,

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -317,9 +317,10 @@ suite('Procedures', function() {
     suite('Composition', function() {
       suite('Statements', function() {
         function setStatementValue(mainWorkspace, defBlock, value) {
-          var mutatorWorkspace = new Blockly.Workspace({
-            parentWorkspace: mainWorkspace
-          });
+          var mutatorWorkspace = new Blockly.Workspace(
+              new Blockly.Options({
+                parentWorkspace: mainWorkspace
+              }));
           defBlock.decompose(mutatorWorkspace);
           var containerBlock = mutatorWorkspace.getTopBlocks()[0];
           var statementField = containerBlock.getField('STATEMENTS');
@@ -358,9 +359,10 @@ suite('Procedures', function() {
       });
       suite('Untyped Arguments', function() {
         function createMutator(argArray) {
-          this.mutatorWorkspace = new Blockly.Workspace({
-            parentWorkspace: this.workspace
-          });
+          this.mutatorWorkspace = new Blockly.Workspace(
+              new Blockly.Options({
+                parentWorkspace: this.workspace
+              }));
           this.containerBlock = this.defBlock.decompose(this.mutatorWorkspace);
           this.connection = this.containerBlock.getInput('STACK').connection;
           for (var i = 0; i < argArray.length; i++) {
@@ -477,9 +479,10 @@ suite('Procedures', function() {
       suite('Statements', function() {
         test('Has Statement Input', function() {
           this.callForAllTypes(function() {
-            var mutatorWorkspace = new Blockly.Workspace({
-              parentWorkspace: this.workspace
-            });
+            var mutatorWorkspace = new Blockly.Workspace(
+                new Blockly.Options({
+                  parentWorkspace: this.workspace
+                }));
             this.defBlock.decompose(mutatorWorkspace);
             var statementInput = mutatorWorkspace.getTopBlocks()[0]
                 .getInput('STATEMENT_INPUT');
@@ -493,9 +496,10 @@ suite('Procedures', function() {
         test('Has Statements', function() {
           var defBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
           defBlock.hasStatements_ = true;
-          var mutatorWorkspace = new Blockly.Workspace({
-            parentWorkspace: this.workspace
-          });
+          var mutatorWorkspace = new Blockly.Workspace(
+              new Blockly.Options({
+                parentWorkspace: this.workspace
+              }));
           defBlock.decompose(mutatorWorkspace);
           var statementValue = mutatorWorkspace.getTopBlocks()[0]
               .getField('STATEMENTS').getValueBoolean();
@@ -504,9 +508,10 @@ suite('Procedures', function() {
         test('No Has Statements', function() {
           var defBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
           defBlock.hasStatements_ = false;
-          var mutatorWorkspace = new Blockly.Workspace({
-            parentWorkspace: this.workspace
-          });
+          var mutatorWorkspace = new Blockly.Workspace(
+              new Blockly.Options({
+                parentWorkspace: this.workspace
+              }));
           defBlock.decompose(mutatorWorkspace);
           var statementValue = mutatorWorkspace.getTopBlocks()[0]
               .getField('STATEMENTS').getValueBoolean();
@@ -516,9 +521,10 @@ suite('Procedures', function() {
       suite('Untyped Arguments', function() {
         function assertArguments(argumentsArray) {
           this.defBlock.arguments_ = argumentsArray;
-          var mutatorWorkspace = new Blockly.Workspace({
-            parentWorkspace: this.workspace
-          });
+          var mutatorWorkspace = new Blockly.Workspace(
+              new Blockly.Options({
+                parentWorkspace: this.workspace
+              }));
           this.defBlock.decompose(mutatorWorkspace);
           var argBlocks = mutatorWorkspace.getBlocksByType('procedures_mutatorarg');
           chai.assert.equal(argBlocks.length, argumentsArray.length);

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -657,7 +657,8 @@ suite('XML', function() {
         comments: true
       };
       this.renderedWorkspace = Blockly.inject('blocklyDiv', options);
-      this.headlessWorkspace = new Blockly.Workspace(options);
+      this.headlessWorkspace =
+          new Blockly.Workspace(new Blockly.Options(options));
     });
     teardown(function() {
       this.renderedWorkspace.dispose();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3459

### Proposed Changes

Uses default `Blockly.Options` if it is not provided to the Workspace constructor.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Before this change, the options set for workspaces through the constructor vs inject when no options were provided were different. This especially caused confusion for the option for oneBasedIndexing which can result in different code being generated.

### Test Coverage

Compared code generation between headless and non-headless workspaces without parameters provided.

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
