### PR TITLE
Fix duplicate variable model type

### DIFF
--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -355,11 +355,13 @@ Blockly.VariableMap.prototype.getVariablesOfType = function(type) {
  * @package
  */
 Blockly.VariableMap.prototype.getVariableTypes = function(ws) {
-  var potentialTypes = [];
+  var variableMap = {};
+  Blockly.utils.object.mixin(variableMap, this.variableMap_);
   if (ws && ws.getPotentialVariableMap()) {
-    potentialTypes = Object.keys(ws.getPotentialVariableMap().variableMap_);
+    Blockly.utils.object.mixin(variableMap,
+        ws.getPotentialVariableMap().variableMap_);
   }
-  var types = Object.keys(this.variableMap_).concat(potentialTypes);
+  var types = Object.keys(variableMap);
   var hasEmpty = false;
   for (var i = 0; i < types.length; i++) {
     if (types[i] == '') {

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -28,6 +28,7 @@ goog.require('Blockly.Events.VarDelete');
 goog.require('Blockly.Events.VarRename');
 goog.require('Blockly.Msg');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.object');
 
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3593

### Proposed Changes

getVariableTypes wasn't returning a set but instead was concatenating the types returned from the variable model's map and the potential variable model map.
Instead, return a set of the two objects merged together.

### Reason for Changes

Bug fix.

### Test Coverage

Tested with the mirror demo.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
