### PR TITLE
Fix RTL appendDomToWorkspace positioning.

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -484,9 +484,10 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
     var offsetY = 0;  // offset to add to y of the new block
     var offsetX = 0;
     var farY = bbox.bottom;  // bottom position
-    var topX = bbox.left;  // x of bounding box
+    var topX = workspace.RTL ? bbox.right : bbox.left;  // x of bounding box
     // Check position of the new blocks.
-    var newX = Infinity;  // x of top corner
+    var newLeftX = Infinity;  // x of top left corner
+    var newRightX = -Infinity;  // x of top rigth corner
     var newY = Infinity;  // y of top corner
     var ySeparation = 10;
     for (var i = 0; i < newBlockIds.length; i++) {
@@ -495,20 +496,18 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
       if (blockXY.y < newY) {
         newY = blockXY.y;
       }
-      if (blockXY.x < newX) {  // if we align also on x
-        newX = blockXY.x;
+      if (blockXY.x < newLeftX) {  // if we left align also on x
+        newLeftX = blockXY.x;
+      }
+      if (blockXY.x > newRightX) {  // if we right align also on x
+        newRightX = blockXY.x;
       }
     }
     offsetY = farY - newY + ySeparation;
-    offsetX = topX - newX;
-    // move the new blocks to append them at the bottom
-    var width;  // Not used in LTR.
-    if (workspace.RTL) {
-      width = workspace.getWidth();
-    }
+    offsetX = workspace.RTL ? topX - newRightX : topX - newLeftX;
     for (var i = 0; i < newBlockIds.length; i++) {
       var block = workspace.getBlockById(newBlockIds[i]);
-      block.moveBy(workspace.RTL ? width - offsetX : offsetX, offsetY);
+      block.moveBy(offsetX, offsetY);
     }
   }
   return newBlockIds;

--- a/core/xml.js
+++ b/core/xml.js
@@ -487,7 +487,7 @@ Blockly.Xml.appendDomToWorkspace = function(xml, workspace) {
     var topX = workspace.RTL ? bbox.right : bbox.left;  // x of bounding box
     // Check position of the new blocks.
     var newLeftX = Infinity;  // x of top left corner
-    var newRightX = -Infinity;  // x of top rigth corner
+    var newRightX = -Infinity;  // x of top right corner
     var newY = Infinity;  // y of top corner
     var ySeparation = 10;
     for (var i = 0; i < newBlockIds.length; i++) {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3408

### Proposed Changes

Fix positioning of blocks when appending blocks to the workspace with ``Blockly.Xml.appendDomToWorkspace`` in RTL mode.

### Reason for Changes

Bug fix.

### Test Coverage

Tested with test blocks in the playground in both LTR and RTL mode.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
