### PR TITLE
Fix IE11 serializing block ids

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -146,7 +146,9 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
       Blockly.utils.xml.createElement(block.isShadow() ? 'shadow' : 'block');
   element.setAttribute('type', block.type);
   if (!opt_noId) {
-    element.id = block.id;
+    // It's important to use setAttribute here otherwise IE11 won't serialize
+    // the block's id when domToText is called.
+    element.setAttribute('id', block.id);
   }
   if (block.mutationToDom) {
     // Custom data for an advanced block.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3174

### Proposed Changes

Use setAttribute instead of block.id for setting the block's id as IE11 doesn't serialize the id otherwise. 

The bug linked is one of the side effects of this bug, but another side effect is if you export a workspace to XML, no id's are present in IE11.

### Reason for Changes

Bug fix.

### Test Coverage

Tested in Chrome and IE11.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
