### PR TITLE
Use baseline for positioning rendered connection.

### DIFF
--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -461,8 +461,7 @@ Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
     var connInfo = bottomRow.connection;
     var x = connInfo.xPos; // Already contains info about startX
     var connX = (this.info_.RTL ? -x : x);
-    connInfo.connectionModel.setOffsetInBlock(
-        connX, (connInfo.centerline - connInfo.height / 2));
+    connInfo.connectionModel.setOffsetInBlock(connX, bottomRow.baseline);
   }
 };
 

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -211,7 +211,6 @@ Blockly.geras.Drawer.prototype.positionNextConnection_ = function() {
     var connX = (this.info_.RTL ? -x : x) +
         (this.constants_.DARK_PATH_OFFSET / 2);
     connInfo.connectionModel.setOffsetInBlock(
-        connX, (connInfo.centerline - connInfo.height / 2) +
-        this.constants_.DARK_PATH_OFFSET);
+        connX, bottomRow.baseline + this.constants_.DARK_PATH_OFFSET);
   }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3288
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Use baseline for positioning rendered next connection.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previous connection is hard set to always be the top of the block, so for consistency, the next connection is at baseline (this does not change the positioning in any of the current renderers).

### Test Coverage

Tested in playground with all renderers.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

