### PR TITLE
Fix parsing and passing of workspace options around Blockly

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -166,18 +166,17 @@ Blockly.Mutator.prototype.createEditor_ = function() {
       ({
         // If you want to enable disabling, also remove the
         // event filter from workspaceChanged_ .
-        disable: false,
-        languageTree: quarkXml,
-        parentWorkspace: this.block_.workspace,
-        pathToMedia: this.block_.workspace.options.pathToMedia,
-        RTL: this.block_.RTL,
-        toolboxPosition: this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
+        'disable': false,
+        'parentWorkspace': this.block_.workspace,
+        'media': this.block_.workspace.options.pathToMedia,
+        'rtl': this.block_.RTL,
+        'toolboxPosition': this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
             Blockly.TOOLBOX_AT_LEFT,
-        horizontalLayout: false,
-        getMetrics: this.getFlyoutMetrics_.bind(this),
-        setMetrics: null,
-        renderer: this.block_.workspace.options.renderer
+        'horizontalLayout': false,
+        'renderer': this.block_.workspace.options.renderer
       }));
+  workspaceOptions.languageTree = quarkXml;
+  workspaceOptions.getMetrics = this.getFlyoutMetrics_.bind(this);
   this.workspace_ = new Blockly.WorkspaceSvg(workspaceOptions);
   this.workspace_.isMutator = true;
   this.workspace_.addChangeListener(Blockly.Events.disableOrphans);

--- a/core/options.js
+++ b/core/options.js
@@ -155,7 +155,7 @@ Blockly.Options = function(options) {
    * workspace.
    * @type {Blockly.Workspace}
    */
-  this.parentWorkspace = null;
+  this.parentWorkspace = options['parentWorkspace'];
 };
 
 /**

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -182,13 +182,14 @@ Blockly.Toolbox.prototype.init = function() {
   var workspaceOptions = new Blockly.Options(
       /** @type {!Blockly.BlocklyOptions} */
       ({
-        parentWorkspace: workspace,
-        RTL: workspace.RTL,
-        oneBasedIndex: workspace.options.oneBasedIndex,
-        horizontalLayout: workspace.horizontalLayout,
-        toolboxPosition: workspace.options.toolboxPosition,
-        renderer: workspace.options.renderer
+        'parentWorkspace': workspace,
+        'rtl': workspace.RTL,
+        'oneBasedIndex': workspace.options.oneBasedIndex,
+        'horizontalLayout': workspace.horizontalLayout,
+        'toolboxPosition': workspace.options.toolboxPosition,
+        'renderer': workspace.options.renderer
       }));
+  
   if (workspace.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -63,11 +63,11 @@ Blockly.Trashcan = function(workspace) {
   var flyoutWorkspaceOptions = new Blockly.Options(
       /** @type {!Blockly.BlocklyOptions} */
       ({
-        scrollbars: true,
-        parentWorkspace: this.workspace_,
-        RTL: this.workspace_.RTL,
-        oneBasedIndex: this.workspace_.options.oneBasedIndex,
-        renderer: this.workspace_.options.renderer
+        'scrollbars': true,
+        'parentWorkspace': this.workspace_,
+        'rtl': this.workspace_.RTL,
+        'oneBasedIndex': this.workspace_.options.oneBasedIndex,
+        'renderer': this.workspace_.options.renderer
       }));
   // Create vertical or horizontal flyout.
   if (this.workspace_.horizontalLayout) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -895,12 +895,12 @@ Blockly.WorkspaceSvg.prototype.addFlyout = function(tagName) {
   var workspaceOptions = new Blockly.Options(
       /** @type {!Blockly.BlocklyOptions} */
       ({
-        parentWorkspace: this,
-        RTL: this.RTL,
-        oneBasedIndex: this.options.oneBasedIndex,
-        horizontalLayout: this.horizontalLayout,
-        toolboxPosition: this.options.toolboxPosition,
-        renderer: this.options.renderer
+        'parentWorkspace': this,
+        'rtl': this.RTL,
+        'oneBasedIndex': this.options.oneBasedIndex,
+        'horizontalLayout': this.horizontalLayout,
+        'toolboxPosition': this.options.toolboxPosition,
+        'renderer': this.options.renderer
       }));
   if (this.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3614

### Proposed Changes

Workspace options were moved to all pass through the Blockly.Options parser. This means that we have to update the options sent to reflect the differences in the property names.

There's a number of side effects to this issue, RTL, mutators, etc.
This also fixes issues with Advanced compilation where the options object properties are renamed if not fully qualified.

### Reason for Changes

Bug fix.

### Test Coverage

Tested in playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
