### PR TITLE
Fix broken field demos

### DIFF
--- a/demos/custom-fields/pitch/field_pitch.js
+++ b/demos/custom-fields/pitch/field_pitch.js
@@ -88,9 +88,8 @@ CustomFields.FieldPitch.prototype.showEditor_ = function() {
   var editor = this.dropdownCreate_();
   Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
-  var border = this.sourceBlock_.getColourBorder();
-  border = border.colourBorder || border.colourLight;
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
+      this.sourceBlock_.style.colourTertiary);
 
   Blockly.DropDownDiv.showPositionedByField(
       this, this.dropdownDispose_.bind(this));

--- a/demos/custom-fields/turtle/field_turtle.js
+++ b/demos/custom-fields/turtle/field_turtle.js
@@ -337,10 +337,8 @@ CustomFields.FieldTurtle.prototype.showEditor_ = function() {
 
   // These allow us to have the editor match the block's colour.
   var fillColour = this.sourceBlock_.getColour();
-  // This is technically a package function, meaning it could change.
-  var borderColours = this.sourceBlock_.getColourBorder();
-  var borderColour = borderColours.colourBorder || borderColours.colourDark;
-  Blockly.DropDownDiv.setColour(fillColour, borderColour);
+  Blockly.DropDownDiv.setColour(fillColour,
+      this.sourceBlock_.style.colourTertiary);
 
   // Always pass the dropdown div a dispose function so that you can clean
   // up event listeners when the editor closes.
@@ -483,9 +481,8 @@ CustomFields.FieldTurtle.prototype.updateColour = function() {
   var fillColour = isShadow  ?
       this.sourceBlock_.getColourShadow() : this.sourceBlock_.getColour();
   // This is technically a package function, meaning it could change.
-  var borderColours = this.sourceBlock_.getColourBorder();
   var borderColour = isShadow ? fillColour :
-      borderColours.colourBorder || borderColours.colourDark;
+      this.sourceBlock_.style.colourTertiary;
 
   var child = this.turtleGroup_.firstChild;
   while(child) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Turtle and pitch custom fields demo were both broken because they still had references to getColourBorder.

Problem was reported here: #3621
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Remove getColourBorder in favor of style.getColourTertiary.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
