### PR TITLE
Updating css rules for blocklyText cursor

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -340,6 +340,10 @@ Blockly.Css.CONTENT = [
     'z-index: 20;',
   '}',
 
+  '.blocklyText text {',
+    'cursor: default;',
+  '}',
+
   /*
     Don't allow users to select text.  It gets annoying when trying to
     drag a block and selected text moves instead.

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1041,7 +1041,6 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(name) {
     /* eslint-disable indent */
     // Fields.
     selector + ' .blocklyText {',
-      'cursor: default;',
       'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -855,7 +855,6 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
     /* eslint-disable indent */
     // Fields.
     selector + ' .blocklyText {',
-      'cursor: default;',
       'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3617

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Moves css for cursor out of renderer.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Block text on draggable blocks should have the cursor style from the css rule `.blocklySvg text, .blocklyBlockDragSurface text` applied (and the css selector for blockText needs to be made less specific for that to happen).
Moving the css out is the closest to the previous behavior for css rules.

### Test Coverage

Tested in playground.