### PR TITLE
[zelos] Fix rtl placement of arrow in non-borderbox dropdown fields

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -288,8 +288,10 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
     var primaryColour = (this.sourceBlock_.isShadow()) ?
         this.sourceBlock_.getParent().getColour() :
         this.sourceBlock_.getColour();
-    Blockly.DropDownDiv.setColour(primaryColour,
-        this.sourceBlock_.style.colourTertiary);
+    var borderColour = (this.sourceBlock_.isShadow()) ?
+        this.sourceBlock_.getParent().style.colourTertiary :
+        this.sourceBlock_.style.colourTertiary;
+    Blockly.DropDownDiv.setColour(primaryColour, borderColour);
   }
 
   Blockly.DropDownDiv.showPositionedByField(
@@ -680,12 +682,14 @@ Blockly.FieldDropdown.prototype.positionSVGArrow_ = function(x, y) {
   if (!this.svgArrow_) {
     return 0;
   }
-  var padding = this.constants_.FIELD_DROPDOWN_SVG_ARROW_PADDING;
+  var hasBorder = !!this.borderRect_;
+  var xPadding = hasBorder ? this.constants_.FIELD_BORDER_RECT_X_PADDING : 0;
+  var textPadding = this.constants_.FIELD_DROPDOWN_SVG_ARROW_PADDING;
   var svgArrowSize = this.constants_.FIELD_DROPDOWN_SVG_ARROW_SIZE;
-  var arrowX = this.sourceBlock_.RTL ? padding : x + padding;
+  var arrowX = this.sourceBlock_.RTL ? xPadding : x + textPadding;
   this.svgArrow_.setAttribute('transform',
       'translate(' + arrowX + ',' + y + ')');
-  return svgArrowSize + padding;
+  return svgArrowSize + textPadding;
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3628

### Proposed Changes

Fix logic for positioning an arrow in RTL when there is no border rect.

### Reason for Changes

Rendering bug fix.

### Test Coverage

Tested in playground with the variable getter block.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
