### PR TITLE
Zelos rename highlightfilter

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -359,7 +359,7 @@ Blockly.zelos.ConstantProvider = function() {
   this.FIELD_CHECKBOX_DEFAULT_WIDTH = 6 * this.GRID_UNIT;
 
   /**
-   * The ID of the highlight glow filter, or the empty string if no filter is
+   * The ID of the selected glow filter, or the empty string if no filter is
    * set.
    * @type {string}
    * @package
@@ -367,7 +367,7 @@ Blockly.zelos.ConstantProvider = function() {
   this.selectedGlowFilterId = '';
 
   /**
-   * The <filter> element to use for a higlight glow, or null if not set.
+   * The <filter> element to use for a selected glow, or null if not set.
    * @type {SVGElement}
    * @private
    */

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -364,17 +364,17 @@ Blockly.zelos.ConstantProvider = function() {
    * @type {string}
    * @package
    */
-  this.highlightGlowFilterId = '';
+  this.selectedGlowFilterId = '';
 
   /**
    * The <filter> element to use for a higlight glow, or null if not set.
    * @type {SVGElement}
    * @private
    */
-  this.highlightGlowFilter_ = null;
+  this.selectedGlowFilter_ = null;
 
   /**
-   * The ID of the highlight glow filter, or the empty string if no filter is
+   * The ID of the replacement glow filter, or the empty string if no filter is
    * set.
    * @type {string}
    * @package
@@ -382,7 +382,7 @@ Blockly.zelos.ConstantProvider = function() {
   this.replacementGlowFilterId = '';
 
   /**
-   * The <filter> element to use for a higlight glow, or null if not set.
+   * The <filter> element to use for a replacement glow, or null if not set.
    * @type {SVGElement}
    * @private
    */
@@ -408,8 +408,8 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
  */
 Blockly.zelos.ConstantProvider.prototype.dispose = function() {
   Blockly.zelos.ConstantProvider.superClass_.dispose.call(this);
-  if (this.highlightGlowFilter_) {
-    Blockly.utils.dom.removeNode(this.highlightGlowFilter_);
+  if (this.selectedGlowFilter_) {
+    Blockly.utils.dom.removeNode(this.selectedGlowFilter_);
   }
 };
 
@@ -757,9 +757,9 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
   var defs = Blockly.utils.dom.createSvgElement('defs', {}, svg);
   // Using a dilate distorts the block shape.
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
-  var highlightGlowFilter = Blockly.utils.dom.createSvgElement('filter',
+  var selectedGlowFilter = Blockly.utils.dom.createSvgElement('filter',
       {
-        'id': 'blocklyHighlightGlowFilter' + this.randomIdentifier_,
+        'id': 'blocklySelectedGlowFilter' + this.randomIdentifier_,
         'height': '160%',
         'width': '180%',
         y: '-30%',
@@ -771,15 +771,15 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
         'in': 'SourceGraphic',
         'stdDeviation': 0.5  // TODO: configure size in theme.
       },
-      highlightGlowFilter);
+      selectedGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
-  var highlightComponentTransfer = Blockly.utils.dom.createSvgElement(
-      'feComponentTransfer', {'result': 'outBlur'}, highlightGlowFilter);
+  var selectedComponentTransfer = Blockly.utils.dom.createSvgElement(
+      'feComponentTransfer', {'result': 'outBlur'}, selectedGlowFilter);
   Blockly.utils.dom.createSvgElement('feFuncA',
       {
         'type': 'table', 'tableValues': '0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
       },
-      highlightComponentTransfer);
+      selectedComponentTransfer);
   // Color the highlight
   Blockly.utils.dom.createSvgElement('feFlood',
       {
@@ -787,15 +787,15 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg) {
         'flood-opacity': 1,
         'result': 'outColor'
       },
-      highlightGlowFilter);
+      selectedGlowFilter);
   Blockly.utils.dom.createSvgElement('feComposite',
       {
         'in': 'outColor', 'in2': 'outBlur',
         'operator': 'in', 'result': 'outGlow'
       },
-      highlightGlowFilter);
-  this.highlightGlowFilterId = highlightGlowFilter.id;
-  this.highlightGlowFilter_ = highlightGlowFilter;
+      selectedGlowFilter);
+  this.selectedGlowFilterId = selectedGlowFilter.id;
+  this.selectedGlowFilter_ = selectedGlowFilter;
 
   // Using a dilate distorts the block shape.
   // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -135,7 +135,7 @@ Blockly.zelos.PathObject.prototype.updateSelected = function(enable) {
         /** @type {!SVGElement} */ (this.svgPath.cloneNode(true));
       this.svgPathSelected_.setAttribute('fill', 'none');
       this.svgPathSelected_.setAttribute('filter',
-          'url(#' + this.constants_.highlightGlowFilterId + ')');
+          'url(#' + this.constants_.selectedGlowFilterId + ')');
       this.svgRoot.appendChild(this.svgPathSelected_);
     }
   } else {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Rename highlight filter to selected filter as it more accurately describes what it is.

### Reason for Changes

Cleanup. 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
