### PR TITLE
Revert on blur for text input fields

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -86,13 +86,6 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
   this.onKeyInputWrapper_ = null;
 
   /**
-   * Blur input event data.
-   * @type {?Blockly.EventData}
-   * @private
-   */
-  this.onBlurInputWrapper_ = null;
-
-  /**
    * Whether the field should consider the whole parent block to be its click
    * target.
    * @type {?boolean}
@@ -432,9 +425,6 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
   this.onKeyInputWrapper_ =
       Blockly.bindEventWithChecks_(
           htmlInput, 'input', this, this.onHtmlInputChange_);
-  this.onBlurInputWrapper_ =
-      Blockly.bindEventWithChecks_(
-          htmlInput, 'blur', this, this.onHtmlInputBlur_);
 };
 
 /**
@@ -449,10 +439,6 @@ Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
   if (this.onKeyInputWrapper_) {
     Blockly.unbindEvent_(this.onKeyInputWrapper_);
     this.onKeyInputWrapper_ = null;
-  }
-  if (this.onBlurInputWrapper_) {
-    Blockly.unbindEvent_(this.onBlurInputWrapper_);
-    this.onBlurInputWrapper_ = null;
   }
 };
 
@@ -497,16 +483,6 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
     this.resizeEditor_();
     Blockly.Events.setGroup(false);
   }
-};
-
-/**
- * Handle blur for the editor.
- * @param {!Event} _e Focus event.
- * @protected
- */
-Blockly.FieldTextInput.prototype.onHtmlInputBlur_ = function(_e) {
-  Blockly.WidgetDiv.hide();
-  Blockly.DropDownDiv.hideWithoutAnimation();
 };
 
 /**


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes
Revert on blur for text input fields as it interferes with combo boxes. Any field that uses both a widgetdiv and a dropdown div would have trouble with this blur event as moving focus from the widget to the dropdown causes a blur and closes the editor. 

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
