### PR TITLE
Editable field spacing

### DIFF
--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -303,7 +303,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ===
+      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ==
           (/** @type Blockly.blockRendering.Field */ (next)).isEditable)) {
     return this.constants_.LARGE_PADDING;
   }

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -172,7 +172,8 @@ Blockly.geras.RenderInfo.prototype.addElemSpacing_ = function() {
 Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
-    if (next && Blockly.blockRendering.Types.isField(next) && next.isEditable) {
+    if (next && Blockly.blockRendering.Types.isField(next) &&
+        (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -190,7 +191,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) && (!next ||
       Blockly.blockRendering.Types.isStatementInput(next))) {
     // Between an editable field and the end of the row.
-    if (Blockly.blockRendering.Types.isField(prev) && prev.isEditable) {
+    if (Blockly.blockRendering.Types.isField(prev) &&
+        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -231,7 +233,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
-    if (prev.isEditable) {
+    if ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -259,7 +261,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && !Blockly.blockRendering.Types.isInput(next)) {
     // Editable field after inline input.
-    if (next.isEditable) {
+    if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -300,7 +302,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && !Blockly.blockRendering.Types.isInput(next) &&
-      (prev.isEditable == next.isEditable)) {
+      ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
+          (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -173,7 +173,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next && Blockly.blockRendering.Types.isField(next) &&
-        (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -192,7 +192,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       Blockly.blockRendering.Types.isStatementInput(next))) {
     // Between an editable field and the end of the row.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -234,7 +234,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -262,7 +262,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
-    if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
+    if ((/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -303,8 +303,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
-          (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
+      ((/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE ===
+          (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -233,7 +233,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
-    if ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+    if (Blockly.blockRendering.Types.isField(prev) &&
+        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -259,7 +260,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 
   // Spacing between an inline input and a field.
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next)) {
+      next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
     if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
@@ -300,8 +301,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   }
 
   // Spacing between two fields of the same editability.
-  if (!Blockly.blockRendering.Types.isInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next) &&
+  if (Blockly.blockRendering.Types.isField(prev) &&
+      next && Blockly.blockRendering.Types.isField(next) &&
       ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
           (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -173,7 +173,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next && Blockly.blockRendering.Types.isField(next) &&
-        (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (next)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -192,7 +192,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       Blockly.blockRendering.Types.isStatementInput(next))) {
     // Between an editable field and the end of the row.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -234,7 +234,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).isEditable) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -262,7 +262,7 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
-    if ((/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
+    if ((/** @type Blockly.blockRendering.Field */ (next)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -303,8 +303,8 @@ Blockly.geras.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE ===
-          (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE)) {
+      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ===
+          (/** @type Blockly.blockRendering.Field */ (next)).isEditable)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/measurables/row_elements.js
+++ b/core/renderers/measurables/row_elements.js
@@ -91,7 +91,7 @@ Blockly.utils.object.inherits(Blockly.blockRendering.JaggedEdge,
 Blockly.blockRendering.Field = function(constants, field, parentInput) {
   Blockly.blockRendering.Field.superClass_.constructor.call(this, constants);
   this.field = field;
-  this.isEditable = field.isCurrentlyEditable();
+  this.isEditable = field.EDITABLE;
   this.flipRtl = field.getFlipRtl();
   this.type |= Blockly.blockRendering.Types.FIELD;
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -115,7 +115,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next && Blockly.blockRendering.Types.isField(next) &&
-        (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (next)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -133,7 +133,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) && !next) {
     // Between an editable field and the end of the row.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -175,7 +175,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).isEditable) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -203,7 +203,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
-    if ((/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
+    if ((/** @type Blockly.blockRendering.Field */ (next)).isEditable) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -231,8 +231,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE ===
-          (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE)) {
+      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ===
+          (/** @type Blockly.blockRendering.Field */ (next)).isEditable)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -114,7 +114,8 @@ Blockly.thrasos.RenderInfo.prototype.addElemSpacing_ = function() {
 Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
-    if (next && Blockly.blockRendering.Types.isField(next) && next.isEditable) {
+    if (next && Blockly.blockRendering.Types.isField(next) &&
+        (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -131,7 +132,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between a non-input and the end of the row.
   if (!Blockly.blockRendering.Types.isInput(prev) && !next) {
     // Between an editable field and the end of the row.
-    if (Blockly.blockRendering.Types.isField(prev) && prev.isEditable) {
+    if (Blockly.blockRendering.Types.isField(prev) &&
+        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -172,7 +174,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
-    if (prev.isEditable) {
+    if ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -200,7 +202,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && !Blockly.blockRendering.Types.isInput(next)) {
     // Editable field after inline input.
-    if (next.isEditable) {
+    if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -228,7 +230,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && !Blockly.blockRendering.Types.isInput(next) &&
-      (prev.isEditable == next.isEditable)) {
+      ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
+          (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -231,7 +231,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ===
+      ((/** @type Blockly.blockRendering.Field */ (prev)).isEditable ==
           (/** @type Blockly.blockRendering.Field */ (next)).isEditable)) {
     return this.constants_.LARGE_PADDING;
   }

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -115,7 +115,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!prev) {
     // Between an editable field and the beginning of the row.
     if (next && Blockly.blockRendering.Types.isField(next) &&
-        (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Inline input at the beginning of the row.
@@ -133,7 +133,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) && !next) {
     // Between an editable field and the end of the row.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     }
     // Padding at the end of an icon-only row to make the block shape clearer.
@@ -175,7 +175,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
     if (Blockly.blockRendering.Types.isField(prev) &&
-        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+        (/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -203,7 +203,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
       next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
-    if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
+    if ((/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
     } else {
       // Noneditable field after inline input.
@@ -231,8 +231,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   // Spacing between two fields of the same editability.
   if (Blockly.blockRendering.Types.isField(prev) &&
       next && Blockly.blockRendering.Types.isField(next) &&
-      ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
-          (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
+      ((/** @type Blockly.blockRendering.Field */ (prev)).field.EDITABLE ===
+          (/** @type Blockly.blockRendering.Field */ (next)).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;
   }
 

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -174,7 +174,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   if (!Blockly.blockRendering.Types.isInput(prev) &&
       next && Blockly.blockRendering.Types.isInput(next)) {
     // Between an editable field and an input.
-    if ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
+    if (Blockly.blockRendering.Types.isField(prev) &&
+        (/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE) {
       if (Blockly.blockRendering.Types.isInlineInput(next)) {
         return this.constants_.SMALL_PADDING;
       } else if (Blockly.blockRendering.Types.isExternalInput(next)) {
@@ -200,7 +201,7 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
 
   // Spacing between an inline input and a field.
   if (Blockly.blockRendering.Types.isInlineInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next)) {
+      next && Blockly.blockRendering.Types.isField(next)) {
     // Editable field after inline input.
     if ((/** @type Blockly.blockRendering.Field */ next).field.EDITABLE) {
       return this.constants_.MEDIUM_PADDING;
@@ -228,8 +229,8 @@ Blockly.thrasos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
   }
 
   // Spacing between two fields of the same editability.
-  if (!Blockly.blockRendering.Types.isInput(prev) &&
-      next && !Blockly.blockRendering.Types.isInput(next) &&
+  if (Blockly.blockRendering.Types.isField(prev) &&
+      next && Blockly.blockRendering.Types.isField(next) &&
       ((/** @type Blockly.blockRendering.Field */ prev).field.EDITABLE ===
           (/** @type Blockly.blockRendering.Field */ next).field.EDITABLE)) {
     return this.constants_.LARGE_PADDING;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3632

### Proposed Changes

Subsituting checks for isEditable for field EDITABLE property for determining element spacing.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Fields that can be editable like `TextInput` have property `isEditable = false` in `readonly`  and element spacing calculation uses the `isEditable` property, which causes a difference in padding depending on `readonly` state.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Opened all blocks in playground in geras and thasos.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
