### PR TITLE
Fixing custom fields turtle demo.

### DIFF
--- a/demos/custom-fields/turtle/field_turtle.js
+++ b/demos/custom-fields/turtle/field_turtle.js
@@ -471,8 +471,8 @@ CustomFields.FieldTurtle.prototype.dropdownDispose_ = function() {
 };
 
 // Updates the field's colour based on the colour of the block. Called by
-// block.updateColour.
-CustomFields.FieldTurtle.prototype.updateColour = function() {
+// block.applyColour.
+CustomFields.FieldTurtle.prototype.applyColour = function() {
   if (!this.sourceBlock_) {
     return;
   }
@@ -484,23 +484,25 @@ CustomFields.FieldTurtle.prototype.updateColour = function() {
   var borderColour = isShadow ? fillColour :
       this.sourceBlock_.style.colourTertiary;
 
-  var child = this.turtleGroup_.firstChild;
-  while(child) {
-    // If it is a text node, continue.
-    if (child.nodeType == 3) {
-      child = child.nextSibling;
-      continue;
-    }
-    // Or if it is a non-turtle node, continue.
-    var className = child.getAttribute('class');
-    if (!className || className.indexOf('turtleBody') == -1) {
-      child = child.nextSibling;
-      continue;
-    }
+  if (this.turtleGroup_) {
+    var child = this.turtleGroup_.firstChild;
+    while(child) {
+      // If it is a text node, continue.
+      if (child.nodeType == 3) {
+        child = child.nextSibling;
+        continue;
+      }
+      // Or if it is a non-turtle node, continue.
+      var className = child.getAttribute('class');
+      if (!className || className.indexOf('turtleBody') == -1) {
+        child = child.nextSibling;
+        continue;
+      }
 
-    child.style.fill = fillColour;
-    child.style.stroke = borderColour;
-    child = child.nextSibling;
+      child.style.fill = fillColour;
+      child.style.stroke = borderColour;
+      child = child.nextSibling;
+    }
   }
 };
 

--- a/demos/custom-fields/turtle/turtle.css
+++ b/demos/custom-fields/turtle/turtle.css
@@ -53,7 +53,7 @@
   width: 100%;
 }
 
-.blocklyNonEditableText text,
-.blocklyEditableText text {
+.blocklySvg .blocklyNonEditableText text,
+.blocklySvg .blocklyEditableText text {
   fill: #000;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3636

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Rename `updateColour` to `applyColour`. Add check due to handle case for when `initSvg` is not called before `updateColour`. Update css for turtle demo.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

It used to be the case that (the now named) `applyColour` would only be called if the block was renderered (and so `initSvg` would have been called), but that is no longer the case so a check needed to be added.
Additionally, the css selectors have changed after refactor of css into renderer to be more specific, so the css modifying the text color for the turtle demo needed to be made more specific so that they would override the renderer css.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->
