### PR TITLE
Add test block for field image with a click handler

### DIFF
--- a/core/field_image.js
+++ b/core/field_image.js
@@ -191,6 +191,10 @@ Blockly.FieldImage.prototype.initView = function() {
           this.fieldGroup_));
   this.imageElement_.setAttributeNS(Blockly.utils.dom.XLINK_NS,
       'xlink:href', /** @type {string} */ (this.value_));
+
+  if (this.clickHandler_) {
+    this.imageElement_.style.cursor = 'pointer';
+  }
 };
 
 /**

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1337,6 +1337,20 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   }
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
+Blockly.Blocks['test_images_clickhandler'] = {
+  init: function() {
+    this.appendDummyInput()
+      .appendField("Image click handler")
+      .appendField(new Blockly.FieldImage(
+        "https://blockly-demo.appspot.com/static/tests/media/a.png", 32, 32,
+        "image with click handlder", this.onClick_), "IMAGE");
+    this.setStyle('text_blocks');
+  },
+  onClick_: function() {
+    alert('Image clicked');
+  }
+};
+
 Blockly.Blocks['test_validators_text_null'] = {
   init: function() {
     this.appendDummyInput()

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1608,6 +1608,7 @@ var spaghettiXml = [
         <block type="test_images_fliprtl"></block>
         <block type="test_images_missing"></block>
         <block type="test_images_many_icons"></block>
+        <block type="test_images_clickhandler"></block>
       </category>
       <category name="Emoji! o((*^ᴗ^*))o">
         <label text="Unicode & Emojis"></label>


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Add test block for field image with a click handler.

### Reason for Changes
Testing.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
