### PR TITLE
Unhighlight current when hovering over disabled menu item

### DIFF
--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -431,6 +431,8 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
 
       this.unhighlightCurrent();
       this.setHighlighted(menuItem);
+    } else {
+      this.unhighlightCurrent();
     }
   }
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Unhighlight current menu item when hovering over disabled menu items in a menu.

### Reason for Changes

Match expected behaviour of a context menu.

### Test Coverage

Tested in playground's context menu which has disabled menu items.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
