### PR TITLE
Decompose text constants in constant provider construction

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -242,30 +242,6 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.JAGGED_TEETH_WIDTH = 6;
 
   /**
-   * Point size of text.
-   * @type {number}
-   */
-  this.FIELD_TEXT_FONTSIZE = 11;
-
-  /**
-   * Height of text.
-   * @type {number}
-   */
-  this.FIELD_TEXT_HEIGHT = 16;
-
-  /**
-   * Text font weight.
-   * @type {string}
-   */
-  this.FIELD_TEXT_FONTWEIGHT = 'normal';
-
-  /**
-   * Text font family.
-   * @type {string}
-   */
-  this.FIELD_TEXT_FONTFAMILY = 'sans-serif';
-
-  /**
    * A field's border rect corner radius.
    * @type {number}
    */
@@ -295,26 +271,6 @@ Blockly.blockRendering.ConstantProvider = function() {
    * @package
    */
   this.FIELD_BORDER_RECT_COLOUR = '#fff';
-
-  /**
-   * Field text baseline.
-   * This is only used if `FIELD_TEXT_BASELINE_CENTER` is false.
-   * @type {number}
-   */
-  this.FIELD_TEXT_BASELINE_Y = Blockly.utils.userAgent.GECKO ? 12 : 13.09;
-
-  /**
-   * An text offset adjusting the Y position of text after positioning.
-   * @type {number}
-   */
-  this.FIELD_TEXT_Y_OFFSET = 0;
-
-  /**
-   * A field's text element's dominant baseline.
-   * @type {boolean}
-   */
-  this.FIELD_TEXT_BASELINE_CENTER =
-      !Blockly.utils.userAgent.IE && !Blockly.utils.userAgent.EDGE;
 
   /**
    * A dropdown field's border rect height.
@@ -515,6 +471,8 @@ Blockly.blockRendering.ConstantProvider = function() {
     PUZZLE: 1,
     NOTCH: 2
   };
+
+  this.setTextConstants_();
 };
 
 /**
@@ -701,6 +659,87 @@ Blockly.blockRendering.ConstantProvider.prototype.dispose = function() {
     Blockly.utils.dom.removeNode(this.disabledPattern_);
   }
 };
+
+/**
+ * Get constants related to text sizing for fields.  All values must be
+ * provided.
+ * In general, changing one of these constants means you should change all of
+ * them.
+ * @return {{
+ *  fontSize: number,
+ *  height: number,
+ *  weight: string,
+ *  family: string,
+ *  baselineY: number,
+ *  baselineCenter: boolean,
+ *  yOffset: number
+ * }} An object containing information about text sizing for fields.
+ * @protected
+ */
+Blockly.blockRendering.ConstantProvider.prototype.getTextConstants_ = function() {
+  return {
+    fontSize: 11,
+    height: 16,
+    weight: 'normal',
+    family: 'sans-serif',
+    baselineY: Blockly.utils.userAgent.GECKO ? 12 : 13.09,
+    baselineCenter:
+        !Blockly.utils.userAgent.IE && !Blockly.utils.userAgent.EDGE,
+    yOffset: 0
+  };
+};
+
+/**
+ * Set constants related to text sizing for fields.  Values come from
+ * getTextConstants_, with default values set if properties are missing.
+ * @protected
+ */
+Blockly.blockRendering.ConstantProvider.prototype.setTextConstants_ = function() {
+  var constants = this.getTextConstants_();
+  /**
+   * Point size of text.
+   * @type {number}
+   */
+  this.FIELD_TEXT_FONTSIZE = constants.fontSize;
+
+  /**
+   * Height of text.
+   * @type {number}
+   */
+  this.FIELD_TEXT_HEIGHT = constants.height;
+
+  /**
+   * Text font weight.
+   * @type {string}
+   */
+  this.FIELD_TEXT_FONTWEIGHT = constants.weight;
+
+  /**
+   * Text font family.
+   * @type {string}
+   */
+  this.FIELD_TEXT_FONTFAMILY = constants.family;
+
+  /**
+   * Field text baseline.
+   * This is only used if `FIELD_TEXT_BASELINE_CENTER` is false.
+   * @type {number}
+   */
+  this.FIELD_TEXT_BASELINE_Y = constants.baselineY;
+
+  /**
+   * A field's text element's dominant baseline.
+   * @type {boolean}
+   */
+  this.FIELD_TEXT_BASELINE_CENTER = constants.baselineCenter;
+
+  /**
+   * An text offset adjusting the Y position of text after positioning.
+   * @type {number}
+   */
+  this.FIELD_TEXT_Y_OFFSET = constants.yOffset;
+};
+
 
 /**
  * @return {!Object} An object containing sizing and path information about

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -80,7 +80,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.NOTCH_OFFSET_LEFT = 3 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -248,41 +248,13 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
-  this.FIELD_TEXT_FONTSIZE = 3 * this.GRID_UNIT;
-
-  /**
-   * @override
-   */
-  this.FIELD_TEXT_FONTWEIGHT = 'bold';
-
-  /**
-   * @override
-   */
-  this.FIELD_TEXT_FONTFAMILY =
-      '"Helvetica Neue", "Segoe UI", Helvetica, sans-serif';
-
-  /**
-   * @override
-   */
-  this.FIELD_TEXT_HEIGHT = 13.1;
-
-  /**
-   * Used by positioning text on IE and Edge as they don't support
-   * dominant-baseline:center.
-   * @override
-   */
-  this.FIELD_TEXT_BASELINE_Y = 13.1;
-
-  /**
-   * @override
-   */
   this.FIELD_BORDER_RECT_RADIUS = this.CORNER_RADIUS;
 
   /**
    * @override
    */
   this.FIELD_BORDER_RECT_X_PADDING = 2 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -387,6 +359,8 @@ Blockly.zelos.ConstantProvider = function() {
    * @private
    */
   this.replacementGlowFilter_ = null;
+
+  this.setTextConstants_();
 };
 Blockly.utils.object.inherits(Blockly.zelos.ConstantProvider,
     Blockly.blockRendering.ConstantProvider);
@@ -411,6 +385,21 @@ Blockly.zelos.ConstantProvider.prototype.dispose = function() {
   if (this.selectedGlowFilter_) {
     Blockly.utils.dom.removeNode(this.selectedGlowFilter_);
   }
+};
+
+/**
+ * @override
+ */
+Blockly.zelos.ConstantProvider.prototype.getTextConstants_ = function() {
+  var constants =
+      Blockly.zelos.ConstantProvider.superClass_.getTextConstants_.call(this);
+
+  constants.baselineY = 13.1;
+  constants.height = 13.1;
+  constants.fontSize = 3 * this.GRID_UNIT;
+  constants.weight = 'bold';
+  constants.family = '"Helvetica Neue", "Segoe UI", Helvetica, sans-serif';
+  return constants;
 };
 
 /**
@@ -886,7 +875,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
       'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
       'color: #575E75;',
     '}',
-  
+
     // Dropdown field.
     selector + ' .blocklyDropdownText {',
       'fill: #fff !important;',


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Create `getTextConstants_` and `setTextConstants_` functions.  Use them to set up text constants.

### Reason for Changes
Make it easier to override a single set of values in the constructor.

This is the internal structure I was talking about for bucketing.

### Test Coverage
Tested Zelos and Geras in the playground.

### Documentation
### Additional Information

Note that I had to call `setTextConstants_` again in the zelos constructor, because it depends on the grid unit, which is not set before the super constructor is called.  I chose this over moving part of the configuration above the constructor.

I decided that values must be provided for everything in the text constants struct, and that child classes should call the super class to get a fully populated struct and then modify it.