### PR TITLE
Decompose padding constants in constant provider construction

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -37,35 +37,7 @@ goog.require('Blockly.utils.userAgent');
  */
 Blockly.blockRendering.ConstantProvider = function() {
 
-  /**
-   * The size of an empty spacer.
-   * @type {number}
-   */
-  this.NO_PADDING = 0;
-
-  /**
-   * The size of small padding.
-   * @type {number}
-   */
-  this.SMALL_PADDING = 3;
-
-  /**
-   * The size of medium padding.
-   * @type {number}
-   */
-  this.MEDIUM_PADDING = 5;
-
-  /**
-   * The size of medium-large padding.
-   * @type {number}
-   */
-  this.MEDIUM_LARGE_PADDING = 8;
-
-  /**
-   * The size of large padding.
-   * @type {number}
-   */
-  this.LARGE_PADDING = 10;
+  this.setPaddingConstants_();
 
   /**
    * Offset from the top of the row for placing fields on inline input rows
@@ -700,6 +672,66 @@ Blockly.blockRendering.ConstantProvider.prototype.dispose = function() {
   if (this.disabledPattern_) {
     Blockly.utils.dom.removeNode(this.disabledPattern_);
   }
+};
+
+/**
+ * Get constants related to padding sizes.  All values must be provided.
+ * @return {{
+ *  noPadding: number,
+ *  smallPadding: number,
+ *  mediumPadding: number,
+ *  mediumLargePadding: number,
+ *  largePadding: number,
+ * }} An object containing information about padding sizes.
+ * @protected
+ */
+Blockly.blockRendering.ConstantProvider.prototype.getPaddingConstants_ = function() {
+  return {
+    noPadding: 0,
+    smallPadding: 3,
+    mediumPadding: 5,
+    mediumLargePadding: 8,
+    largePadding: 10
+  };
+};
+
+/**
+ * Set constants related to padding sizes.  Values come from
+ * getPaddingConstants_.
+ * @protected
+ */
+Blockly.blockRendering.ConstantProvider.prototype.setPaddingConstants_ = function() {
+  var constants = this.getPaddingConstants_();
+
+  /**
+   * The size of an empty spacer.
+   * @type {number}
+   */
+  this.NO_PADDING = constants.noPadding;
+
+  /**
+   * The size of small padding.
+   * @type {number}
+   */
+  this.SMALL_PADDING = constants.smallPadding;
+
+  /**
+   * The size of medium padding.
+   * @type {number}
+   */
+  this.MEDIUM_PADDING = constants.mediumPadding;
+
+  /**
+   * The size of medium-large padding.
+   * @type {number}
+   */
+  this.MEDIUM_LARGE_PADDING = constants.mediumLargePadding;
+
+  /**
+   * The size of large padding.
+   * @type {number}
+   */
+  this.LARGE_PADDING = constants.largePadding;
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -41,25 +41,7 @@ Blockly.zelos.ConstantProvider = function() {
 
   this.GRID_UNIT = 4;
 
-  /**
-   * @override
-   */
-  this.SMALL_PADDING = this.GRID_UNIT;
-
-  /**
-   * @override
-   */
-  this.MEDIUM_PADDING = 2 * this.GRID_UNIT;
-
-  /**
-   * @override
-   */
-  this.MEDIUM_LARGE_PADDING = 3 * this.GRID_UNIT;
-
-  /**
-   * @override
-   */
-  this.LARGE_PADDING = 4 * this.GRID_UNIT;
+  this.setPaddingConstants_();
 
   /**
    * @override
@@ -80,7 +62,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.NOTCH_OFFSET_LEFT = 3 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -282,7 +264,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.FIELD_BORDER_RECT_X_PADDING = 2 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -411,6 +393,24 @@ Blockly.zelos.ConstantProvider.prototype.dispose = function() {
   if (this.selectedGlowFilter_) {
     Blockly.utils.dom.removeNode(this.selectedGlowFilter_);
   }
+};
+
+/**
+ * @override
+ */
+Blockly.zelos.ConstantProvider.prototype.getPaddingConstants_ = function() {
+  var gridUnit = this.GRID_UNIT;
+  if (!gridUnit) {
+    return Blockly.zelos.ConstantProvider.superClass_.getPaddingConstants_.call(
+        this);
+  }
+  return {
+    noPadding: 0,
+    smallPadding: gridUnit,
+    mediumPadding: 2 * gridUnit,
+    mediumLargePadding: 3 * gridUnit,
+    largePadding: 4 * gridUnit
+  };
 };
 
 /**
@@ -886,7 +886,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
       'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
       'color: #575E75;',
     '}',
-  
+
     // Dropdown field.
     selector + ' .blocklyDropdownText {',
       'fill: #fff !important;',


### PR DESCRIPTION
For discussion, along with #3668.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Related to #3668 

This one makes an object for the padding constants.

### Reason for Changes
Make it easier to override a single set of values in the constructor.

This is the internal structure I was talking about for bucketing.

### Test Coverage
Tested Zelos and Geras in the playground.

### Documentation
### Additional Information
I think it would make sense to put GRID_UNIT in here as well, even though it's not technically padding.  As with the previous PR, the first time that this is called it sets the values wrong (in the super constructor) and then it sets them right.  That's because GRID_UNIT isn't set the first time.