### PR TITLE
Add back setters for theme

### DIFF
--- a/core/theme.js
+++ b/core/theme.js
@@ -51,12 +51,14 @@ Blockly.Theme = function(name, blockStyles, categoryStyles,
   /**
    * The block styles map.
    * @type {!Object.<string, !Blockly.Theme.BlockStyle>}
+   * @package
    */
   this.blockStyles = blockStyles;
 
   /**
    * The category styles map.
    * @type {!Object.<string, Blockly.Theme.CategoryStyle>}
+   * @package
    */
   this.categoryStyles = categoryStyles;
 
@@ -86,6 +88,25 @@ Blockly.Theme.BlockStyle;
   *          }}
   */
 Blockly.Theme.CategoryStyle;
+
+/**
+ * Overrides or adds a style to the blockStyles map.
+ * @param {string} blockStyleName The name of the block style.
+ * @param {Blockly.Theme.BlockStyle} blockStyle The block style.
+*/
+Blockly.Theme.prototype.setBlockStyle = function(blockStyleName, blockStyle) {
+  this.blockStyles[blockStyleName] = blockStyle;
+};
+
+/**
+ * Overrides or adds a style to the categoryStyles map.
+ * @param {string} categoryStyleName The name of the category style.
+ * @param {Blockly.Theme.CategoryStyle} categoryStyle The category style.
+*/
+Blockly.Theme.prototype.setCategoryStyle = function(categoryStyleName,
+    categoryStyle) {
+  this.categoryStyles[categoryStyleName] = categoryStyle;
+};
 
 /**
  * Gets the style for a given Blockly UI component.  If the style value is a


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Adds back setBlockStyle and setCategoryStyle and makes blockStyles and categoryStyles @package again. 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Makes blockStyles and categoryStyles @package again.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
