### PR TITLE
Zelos adjust top / bottom row padding based on

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -109,7 +109,7 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
-  this.TOP_ROW_MIN_HEIGHT = this.GRID_UNIT;
+  this.TOP_ROW_MIN_HEIGHT = this.CORNER_RADIUS;
 
   /**
    * @override
@@ -119,7 +119,7 @@ Blockly.zelos.ConstantProvider = function() {
   /**
    * @override
    */
-  this.BOTTOM_ROW_MIN_HEIGHT = this.GRID_UNIT;
+  this.BOTTOM_ROW_MIN_HEIGHT = this.CORNER_RADIUS;
 
   /**
    * @override

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -212,21 +212,28 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowHeight_ = function(
       Blockly.blockRendering.Types.isInputRow(next) && next.hasStatement;
   if (precedesStatement || followsStatement) {
     var cornerHeight = this.constants_.INSIDE_CORNERS.rightHeight || 0;
-    var height = Math.max(this.constants_.MEDIUM_PADDING,
-        Math.max(this.constants_.NOTCH_HEIGHT, cornerHeight));
+    var height = Math.max(this.constants_.NOTCH_HEIGHT, cornerHeight);
     return precedesStatement && followsStatement ?
         Math.max(height, this.constants_.DUMMY_INPUT_MIN_HEIGHT) : height;
   }
   // Top and bottom rows act as a spacer so we don't need any extra padding.
   if ((Blockly.blockRendering.Types.isTopRow(prev))) {
-    if (!prev.hasPreviousConnection && !this.outputConnection) {
-      return this.constants_.SMALL_PADDING;
+    if (!prev.hasPreviousConnection &&
+        (!this.outputConnection || this.hasStatementInput)) {
+      return Math.abs(this.constants_.NOTCH_HEIGHT -
+          this.constants_.CORNER_RADIUS);
     }
     return this.constants_.NO_PADDING;
   }
   if ((Blockly.blockRendering.Types.isBottomRow(next))) {
     if (!this.outputConnection) {
-      return this.constants_.SMALL_PADDING;
+      var topHeight = Math.max(this.topRow.minHeight,
+          Math.max(this.constants_.NOTCH_HEIGHT,
+              this.constants_.CORNER_RADIUS)) - this.constants_.CORNER_RADIUS;
+      return topHeight;
+    } else if (!next.hasNextConnection && this.hasStatementInput) {
+      return Math.abs(this.constants_.NOTCH_HEIGHT -
+          this.constants_.CORNER_RADIUS);
     }
     return this.constants_.NO_PADDING;
   }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Make it clearer what the padding after the top row and before the bottom row is based on. Make it based on the top row's height (min height, corner height and notch). Making it so that there's always equal padding in the top / bottom. 

### Reason for Changes

Allow adjusting the corner radius and notch height, and have everything adjust accordingly.

### Test Coverage

Tested in playground and rendering playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
