### PR TITLE
fix: Break breaking undo.

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -653,9 +653,12 @@ Blockly.Workspace.prototype.fireChangeListener = function(event) {
       this.undoStack_.shift();
     }
   }
+  var group = Blockly.Events.getGroup();
+  Blockly.Events.setGroup(event.group);
   for (var i = 0, func; (func = this.listeners_[i]); i++) {
     func(event);
   }
+  Blockly.Events.setGroup(group);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #2321 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This pull request makes it so that all events fired inside a listener to an event are automatically grouped with the firing event.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This makes it so that behavior resulting from an event gets grouped with that event for undo purposes. I think that this generally makes sense.

The breaking of undo was actually related to the onchange listener not properly filtering events. The disable event was getting undone, which fires an event, then the change listener would re-disable the block. Grouping the move event eliminates that problem. But I can definitely fix the event filtering on the onchange listener if you want as well.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![BreakBlocks](https://user-images.githubusercontent.com/25440652/74787113-330dbe00-5263-11ea-8b94-ab2cafd56ae8.gif)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
No clue what this might break. But with events, you know it's probably going to break something hehe.

[Edit: I'm going to test all of the existing change listeners]