### PR TITLE
fix: Break breaking undo.

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -327,24 +327,23 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
   /**
    * Called whenever anything on the workspace changes.
    * Add warning if this flow block is not nested inside a loop.
-   * @param {!Blockly.Events.Abstract} _e Change event.
+   * @param {!Blockly.Events.Abstract} e Change event.
    * @this {Blockly.Block}
    */
-  onchange: function(_e) {
-    if (!this.workspace.isDragging || this.workspace.isDragging()) {
+  onchange: function(e) {
+    if (!this.workspace.isDragging || this.workspace.isDragging() ||
+        e.type != Blockly.Events.BLOCK_MOVE || e.blockId != this.id) {
       return;  // Don't change state at the start of a drag.
     }
-    if (Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN
-        .getSurroundLoop(this)) {
-      this.setWarningText(null);
-      if (!this.isInFlyout) {
-        this.setEnabled(true);
-      }
-    } else {
-      this.setWarningText(Blockly.Msg['CONTROLS_FLOW_STATEMENTS_WARNING']);
-      if (!this.isInFlyout && !this.getInheritedDisabled()) {
-        this.setEnabled(false);
-      }
+    var enabled = Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN
+        .getSurroundLoop(this);
+    this.setWarningText(enabled ? null :
+        Blockly.Msg['CONTROLS_FLOW_STATEMENTS_WARNING']);
+    if (!this.isInFlyout) {
+      var group = Blockly.Events.getGroup();
+      Blockly.Events.setGroup(e.group);
+      this.setEnabled(enabled);
+      Blockly.Events.setGroup(group);
     }
   }
 };

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -331,9 +331,13 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
    * @this {Blockly.Block}
    */
   onchange: function(e) {
+    // Don't change state if:
+    //   * It's at the start of a drag.
+    //   * It's not a move event.
+    //   * Or the moving block is not this block.
     if (!this.workspace.isDragging || this.workspace.isDragging() ||
         e.type != Blockly.Events.BLOCK_MOVE || e.blockId != this.id) {
-      return;  // Don't change state at the start of a drag.
+      return;
     }
     var enabled = Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN
         .getSurroundLoop(this);
@@ -341,6 +345,7 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
         Blockly.Msg['CONTROLS_FLOW_STATEMENTS_WARNING']);
     if (!this.isInFlyout) {
       var group = Blockly.Events.getGroup();
+      // Makes it so the move and the disable event get undone together.
       Blockly.Events.setGroup(e.group);
       this.setEnabled(enabled);
       Blockly.Events.setGroup(group);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1180,7 +1180,7 @@ Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
 Blockly.BlockSvg.prototype.setEnabled = function(enabled) {
   if (this.isEnabled() != enabled) {
     Blockly.BlockSvg.superClass_.setEnabled.call(this, enabled);
-    if (this.rendered) {
+    if (this.rendered && !this.getInheritedDisabled()) {
       this.updateDisabled();
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2321 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes the event filtering and grouping in the break block so that it doesn't break undo.

Also makes it so that update disabled is called only if the block is not inherently disabled.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs are the worst.

This matches the current behavior, it's just called in a more centralized place now.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![BreakBlocks2](https://user-images.githubusercontent.com/25440652/74789027-55560a80-5268-11ea-87f0-8563c343d647.gif)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I like this much better than #3696 This may not fix the wider problem, but I think it's safer.
