### PR TITLE
Support ES6 classes in renderer initialization

### DIFF
--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -87,19 +87,8 @@ Blockly.blockRendering.init = function(name) {
   if (!Blockly.blockRendering.rendererMap_[name]) {
     throw Error('Renderer not registered: ', name);
   }
-  /**
-   * Wrap the renderer constructor into a temporary constructor
-   * function so the closure compiler treats it as a constructor.
-   * @param {string} name The renderer name.
-   * @constructor
-   * @extends {Blockly.blockRendering.Renderer}
-   */
-  var rendererCtor = function(name) {
-    rendererCtor.superClass_.constructor.call(this, name);
-  };
-  Blockly.utils.object.inherits(rendererCtor,
-      Blockly.blockRendering.rendererMap_[name]);
-  var renderer = new rendererCtor(name);
+  var renderer = (/** @type {!Blockly.blockRendering.Renderer} */ (
+    new Blockly.blockRendering.rendererMap_[name](name)));
   renderer.init();
   return renderer;
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

We are currently unable to do ``Blockly.blockRendering.register('test', Renderer);`` where Renderer is an ES6 class.

### Proposed Changes

Remove wrapper class during initialization (which was only really there to make the compiler happy).

### Reason for Changes

Make the renderer compatible with ES6 classes.

### Test Coverage


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
