### PR TITLE
[zelos] Fix centered textinputs

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -59,6 +59,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.nextConnection = null;
   /** @type {Blockly.Connection} */
   this.previousConnection = null;
+  /** @type {boolean} */
+  this.hasStatementInput = false;
   /** @type {!Array.<!Blockly.Input>} */
   this.inputList = [];
   /** @type {boolean|undefined} */
@@ -1634,6 +1636,9 @@ Blockly.Block.prototype.appendInput_ = function(type, name) {
   var connection = null;
   if (type == Blockly.INPUT_VALUE || type == Blockly.NEXT_STATEMENT) {
     connection = this.makeConnection_(type);
+  }
+  if (type == Blockly.NEXT_STATEMENT) {
+    this.hasStatementInput = true;
   }
   var input = new Blockly.Input(type, name, this, connection);
   // Append input to list.

--- a/core/block.js
+++ b/core/block.js
@@ -1721,10 +1721,10 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
   for (var i = 0, input; (input = this.inputList[i]); i++) {
-    if (input.type == Blockly.NEXT_STATEMENT) {
-      this.statementInputCount--;
-    }
     if (input.name == name) {
+      if (input.type == Blockly.NEXT_STATEMENT) {
+        this.statementInputCount--;
+      }
       input.dispose();
       this.inputList.splice(i, 1);
       return;

--- a/core/block.js
+++ b/core/block.js
@@ -175,7 +175,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    * @type {number}
    * @package
    */
-  this.statementInputs = 0;
+  this.statementInputCount = 0;
 
   // Copy the type-specific functions and data from the prototype.
   if (prototypeName) {
@@ -1643,7 +1643,7 @@ Blockly.Block.prototype.appendInput_ = function(type, name) {
     connection = this.makeConnection_(type);
   }
   if (type == Blockly.NEXT_STATEMENT) {
-    this.statementInputs++;
+    this.statementInputCount++;
   }
   var input = new Blockly.Input(type, name, this, connection);
   // Append input to list.
@@ -1722,7 +1722,7 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
   for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.type == Blockly.NEXT_STATEMENT) {
-      this.statementInputs--;
+      this.statementInputCount--;
     }
     if (input.name == name) {
       input.dispose();

--- a/core/block.js
+++ b/core/block.js
@@ -59,8 +59,6 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   this.nextConnection = null;
   /** @type {Blockly.Connection} */
   this.previousConnection = null;
-  /** @type {boolean} */
-  this.hasStatementInput = false;
   /** @type {!Array.<!Blockly.Input>} */
   this.inputList = [];
   /** @type {boolean|undefined} */
@@ -171,6 +169,13 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    * @type {string|undefined}
    */
   this.hat = undefined;
+
+  /**
+   * A count of statement inputs on the block.
+   * @type {number}
+   * @package
+   */
+  this.statementInputs = 0;
 
   // Copy the type-specific functions and data from the prototype.
   if (prototypeName) {
@@ -1638,7 +1643,7 @@ Blockly.Block.prototype.appendInput_ = function(type, name) {
     connection = this.makeConnection_(type);
   }
   if (type == Blockly.NEXT_STATEMENT) {
-    this.hasStatementInput = true;
+    this.statementInputs++;
   }
   var input = new Blockly.Input(type, name, this, connection);
   // Append input to list.
@@ -1716,6 +1721,9 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
   for (var i = 0, input; (input = this.inputList[i]); i++) {
+    if (input.type == Blockly.NEXT_STATEMENT) {
+      this.statementInputs--;
+    }
     if (input.name == name) {
       input.dispose();
       this.inputList.splice(i, 1);

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -82,7 +82,7 @@ Blockly.zelos.RenderInfo = function(renderer, block) {
    * Whether or not the block has a statement input in one of its rows.
    * @type {boolean}
    */
-  this.hasStatementInput = block.hasStatementInput;
+  this.hasStatementInput = block.statementInputs > 0;
 
   /**
    * An object with rendering information about the right connection shape.

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -82,7 +82,7 @@ Blockly.zelos.RenderInfo = function(renderer, block) {
    * Whether or not the block has a statement input in one of its rows.
    * @type {boolean}
    */
-  this.hasStatementInput = false;
+  this.hasStatementInput = block.hasStatementInput;
 
   /**
    * An object with rendering information about the right connection shape.
@@ -264,32 +264,7 @@ Blockly.zelos.RenderInfo.prototype.addInput_ = function(input, activeRow) {
       input.align == Blockly.ALIGN_RIGHT) {
     activeRow.rightAlignedDummyInput = input;
   }
-  // Non-dummy inputs have visual representations onscreen.
-  if (this.isInline && input.type == Blockly.INPUT_VALUE) {
-    activeRow.elements.push(
-        new Blockly.blockRendering.InlineInput(this.constants_, input));
-    activeRow.hasInlineInput = true;
-  } else if (input.type == Blockly.NEXT_STATEMENT) {
-    activeRow.elements.push(
-        new Blockly.zelos.StatementInput(this.constants_, input));
-    activeRow.hasStatement = true;
-    this.hasStatementInput = true;
-  } else if (input.type == Blockly.INPUT_VALUE) {
-    activeRow.elements.push(
-        new Blockly.blockRendering.ExternalValueInput(this.constants_, input));
-    activeRow.hasExternalInput = true;
-  } else if (input.type == Blockly.DUMMY_INPUT) {
-    // Dummy inputs have no visual representation, but the information is still
-    // important.
-    activeRow.minHeight = Math.max(activeRow.minHeight,
-        input.getSourceBlock() && input.getSourceBlock().isShadow() ?
-        this.constants_.DUMMY_INPUT_SHADOW_MIN_HEIGHT :
-        this.constants_.DUMMY_INPUT_MIN_HEIGHT);
-    activeRow.hasDummyInput = true;
-  }
-  if (activeRow.align == null) {
-    activeRow.align = input.align;
-  }
+  Blockly.zelos.RenderInfo.superClass_.addInput_.call(this, input, activeRow);
 };
 
 /**

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -82,7 +82,7 @@ Blockly.zelos.RenderInfo = function(renderer, block) {
    * Whether or not the block has a statement input in one of its rows.
    * @type {boolean}
    */
-  this.hasStatementInput = block.statementInputs > 0;
+  this.hasStatementInput = block.statementInputCount > 0;
 
   /**
    * An object with rendering information about the right connection shape.

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -62,7 +62,7 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.hasStatementInput;
+  return !!block.outputConnection && !block.statementInputs;
 };
 
 /**
@@ -102,5 +102,5 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.hasStatementInput;
+  return !!block.outputConnection && !block.statementInputs;
 };

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -61,8 +61,8 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
  * Render a round corner unless the block has an output connection.
  * @override
  */
-Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(_block) {
-  return false;
+Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
+  return !!block.outputConnection && !block.hasStatementInput;
 };
 
 /**
@@ -101,6 +101,6 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
  * Render a round corner unless the block has an output connection.
  * @override
  */
-Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(_block) {
-  return false;
+Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
+  return !!block.outputConnection && !block.hasStatementInput;
 };

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -62,7 +62,7 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.statementInputs;
+  return !!block.outputConnection && !block.statementInputCount;
 };
 
 /**
@@ -102,5 +102,5 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.statementInputs;
+  return !!block.outputConnection && !block.statementInputCount;
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/pull/3685 introduced a bug where blocks with only output connections had right corners added to their elements resulting in an offset when centering the text of text fields: 
![Screen Shot 2020-02-20 at 4 57 30 PM](https://user-images.githubusercontent.com/16690124/74994203-486d1e80-5402-11ea-8c1d-8f0c41b8065a.png)

### Proposed Changes

Only add a right corner if we don't have an output connection or if we do but we have a statement input to account for:

![Screen Shot 2020-02-20 at 4 56 59 PM](https://user-images.githubusercontent.com/16690124/74994243-6470c000-5402-11ea-97da-6731fe87e191.png)

### Reason for Changes

Rendering bug fix.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
