### PR TITLE
Fix checkbox field rerendering on setCheckChar

### DIFF
--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -130,9 +130,7 @@ Blockly.FieldCheckbox.prototype.getDisplayText_ = function() {
  */
 Blockly.FieldCheckbox.prototype.setCheckCharacter = function(character) {
   this.checkChar_ = character;
-  if (this.textContent_) {
-    this.textContent_.nodeValue = character || Blockly.FieldCheckbox.CHECK_CHAR;
-  }
+  this.forceRerender();
 };
 
 /**

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -165,7 +165,10 @@ suite('Checkbox Fields', function() {
       function assertCharacter(field, char) {
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
         field.sourceBlock_ = {
-          RTL: false
+          RTL: false,
+          rendered: true,
+          render: function() { field.render_(); },
+          bumpNeighbours: function() {}
         };
         field.constants_ = {
           FIELD_CHECKBOX_X_OFFSET: 2,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

Discovered this issue while testing #3698 and I decided to go ahead and fix it b/c it was small.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that checkboxes properly re-render when their character is set by calling forceRerender()

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Blocks should automatically re-render when ever they are modified.
![Size-CheckCharacter](https://user-images.githubusercontent.com/25440652/74892871-b13f9280-533f-11ea-925d-98f8d8396cbd.gif)

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Repeated steps and could not reproduce bug:
![CheckChar](https://user-images.githubusercontent.com/25440652/75067354-a8ff6880-54a1-11ea-8717-920e8e7525cd.gif)

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
