### PR TITLE
Add workspace comment context menu option to playground

### DIFF
--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -24,7 +24,6 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WorkspaceComment');
-goog.require('Blockly.WorkspaceCommentSvg.render');
 
 
 /**

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -24,6 +24,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WorkspaceComment');
+goog.require('Blockly.WorkspaceCommentSvg.render');
 
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -395,6 +395,7 @@ Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
  * Developers may define this function to add custom menu options to the
  * workspace's context menu or edit the workspace-created set of menu options.
  * @param {!Array.<!Object>} options List of menu options to add to.
+ * @param {!Event} e The right-click event that triggered the context menu.
  */
 Blockly.WorkspaceSvg.prototype.configureContextMenu;
 
@@ -1800,7 +1801,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
 
   // Allow the developer to add or modify menuOptions.
   if (this.configureContextMenu) {
-    this.configureContextMenu(menuOptions);
+    this.configureContextMenu(menuOptions, e);
   }
 
   Blockly.ContextMenu.show(e, menuOptions, this.RTL);

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -69,12 +69,17 @@
 
 <script>
 // Custom requires for the playground.
+
+// Rendering.
 goog.require('Blockly.blockRendering.Debug');
 goog.require('Blockly.minimalist.Renderer');
 goog.require('Blockly.Themes.Modern');
 goog.require('Blockly.Themes.Zelos');
 goog.require('Blockly.thrasos.Renderer');
 goog.require('Blockly.zelos.Renderer');
+
+// Other.
+goog.require('Blockly.WorkspaceCommentSvg');
 </script>
 <script>
 'use strict';
@@ -465,6 +470,21 @@ function configureContextMenu(menuOptions) {
     }
   };
   menuOptions.push(screenshotOption);
+
+  // Adds a default-sized workspace comment to the workspace.
+  var workspaceCommentOption = {
+    text: "Add a Comment",
+    enabled: true,
+    callback: function() {
+      var xml = Blockly.Xml.textToDom(
+        '<xml>' +
+          '<comment>Test</comment>' +
+        '</xml>'
+      );
+      Blockly.Xml.appendDomToWorkspace(xml, workspace);
+    }
+  }
+  menuOptions.push(workspaceCommentOption);
 }
 
 function logger(e) {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -80,6 +80,7 @@ goog.require('Blockly.zelos.Renderer');
 
 // Other.
 goog.require('Blockly.WorkspaceCommentSvg');
+goog.require('Blockly.WorkspaceCommentSvg.render');
 </script>
 <script>
 'use strict';
@@ -461,7 +462,7 @@ function toggleAccessibilityMode(state) {
   }
 }
 
-function configureContextMenu(menuOptions) {
+function configureContextMenu(menuOptions, e) {
   var screenshotOption = {
     text: 'Download Screenshot',
     enabled: workspace.getTopBlocks().length,
@@ -472,19 +473,7 @@ function configureContextMenu(menuOptions) {
   menuOptions.push(screenshotOption);
 
   // Adds a default-sized workspace comment to the workspace.
-  var workspaceCommentOption = {
-    text: "Add a Comment",
-    enabled: true,
-    callback: function() {
-      var xml = Blockly.Xml.textToDom(
-        '<xml>' +
-          '<comment>Test</comment>' +
-        '</xml>'
-      );
-      Blockly.Xml.appendDomToWorkspace(xml, workspace);
-    }
-  }
-  menuOptions.push(workspaceCommentOption);
+  menuOptions.push(Blockly.ContextMenu.workspaceCommentOption(workspace, e));
 }
 
 function logger(e) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a context menu option to the playground so that you can test workspace comments.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I was doing some testing with workspace comments earlier and I think it is handy to be able to create one through right-clicking instead of having to load xml.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
This is for testing silly!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
