### PR TITLE
Fix geras collapsed rendering incorrect in RTL

### DIFF
--- a/core/renderers/geras/highlight_constants.js
+++ b/core/renderers/geras/highlight_constants.js
@@ -53,7 +53,7 @@ Blockly.geras.HighlightConstantProvider = function(constants) {
  * @package
  */
 Blockly.geras.HighlightConstantProvider.prototype.init = function() {
-  
+
   /**
    * An object containing sizing and path information about inside corner
    * highlights.
@@ -273,7 +273,9 @@ Blockly.geras.HighlightConstantProvider.prototype.makeJaggedTeeth = function() {
       Blockly.utils.svgPaths.moveBy(-10.2, 6.8) +
       Blockly.utils.svgPaths.lineTo(5.1, 2.6);
   return {
-    pathLeft: pathLeft
+    pathLeft: pathLeft,
+    height: 12,
+    width: 10.2
   };
 };
 

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -110,11 +110,10 @@ Blockly.geras.Highlighter.prototype.drawTopCorner = function(row) {
 
 Blockly.geras.Highlighter.prototype.drawJaggedEdge_ = function(row) {
   if (this.info_.RTL) {
-    this.steps_ += Blockly.utils.svgPaths.lineOnAxis('H', row.width - this.highlightOffset_);
-    this.steps_ += this.jaggedTeethPaths_.pathLeft;
     var remainder =
         row.height - this.jaggedTeethPaths_.height - this.highlightOffset_;
-    this.steps_ += Blockly.utils.svgPaths.lineOnAxis('v', remainder);
+    this.steps_ += this.jaggedTeethPaths_.pathLeft +
+        Blockly.utils.svgPaths.lineOnAxis('v', remainder);
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#3700 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Add height and width to geras jaggedTeeth constants object.
* Remove horizontal-line-to step.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* These being undefined causes NaN errors if/when they are accessed.
* This step was causing errors for blocks with output notches, and seems to be unneccessary.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![CollapsedBlocksGeras](https://user-images.githubusercontent.com/25440652/75072875-31373b00-54ad-11ea-9d21-d55a9354e6eb.png)

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A