### PR TITLE
Use flex to compute measure font metrics

### DIFF
--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -347,25 +347,25 @@ Blockly.utils.dom.measureFontMetrics = function(text, fontSize, fontWeight,
     fontFamily) {
 
   var span = document.createElement('span');
-  span.setAttribute('style', 'display: inline-block;');
   span.style.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
   span.textContent = text;
 
   var block = document.createElement('div');
-  block.setAttribute('style',
-      'display: inline-block; width: 1px; height: 0px;');
-  
+  block.style.width = '1px';
+  block.style.height = '0px';
+  block.className = 'blockStyle';
+
   var div = document.createElement('div');
-  div.setAttribute('style', 'line-height: 0;');
+  div.setAttribute('style', 'position: fixed; top: 0; left: 0; display: flex;');
   div.appendChild(span);
   div.appendChild(block);
 
   document.body.appendChild(div);
   try {
     var result = {};
-    block.style.verticalAlign = 'baseline';
+    div.style.alignItems = 'baseline';
     result.baseline = block.offsetTop - span.offsetTop;
-    block.style.verticalAlign = 'bottom';
+    div.style.alignItems = 'flex-end';
     result.height = block.offsetTop - span.offsetTop;
   } finally {
     document.body.removeChild(div);

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -353,7 +353,6 @@ Blockly.utils.dom.measureFontMetrics = function(text, fontSize, fontWeight,
   var block = document.createElement('div');
   block.style.width = '1px';
   block.style.height = '0px';
-  block.className = 'blockStyle';
 
   var div = document.createElement('div');
   div.setAttribute('style', 'position: fixed; top: 0; left: 0; display: flex;');


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3710

### Proposed Changes

Use ``display:flex`` and align-items when computing the height and baseline of text (based on a specific font) rather than inline-block with vertical-align. 

### Reason for Changes

Fix bug when user is using flex.

### Test Coverage

Tested on all major browsers with both display:block and display:flex

Tested on:
* Desktop Chrome
* Desktop Firefox
* Desktop Safari
* Windows IE 11

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@BeksOmega FYI
