### PR TITLE
Configure zelos selected glow properties in theme

### DIFF
--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -413,15 +413,19 @@ Blockly.zelos.ConstantProvider.prototype.setTheme = function(theme) {
   this.SELECTED_GLOW_COLOUR =
       theme.getComponentStyle('selectedGlowColour') ||
       this.SELECTED_GLOW_COLOUR;
+  var selectedGlowSize =
+      Number(theme.getComponentStyle('selectedGlowSize'));
   this.SELECTED_GLOW_SIZE =
-      theme.getComponentStyle('selectedGlowSize') ||
-      this.SELECTED_GLOW_SIZE;
+      selectedGlowSize && !isNaN(selectedGlowSize) ?
+      selectedGlowSize : this.SELECTED_GLOW_SIZE;
   this.REPLACEMENT_GLOW_COLOUR =
       theme.getComponentStyle('replacementGlowColour') ||
       this.REPLACEMENT_GLOW_COLOUR;
+  var replacementGlowSize =
+      Number(theme.getComponentStyle('replacementGlowSize'));
   this.REPLACEMENT_GLOW_SIZE =
-      theme.getComponentStyle('replacementGlowSize') ||
-      this.REPLACEMENT_GLOW_SIZE;
+      replacementGlowSize && !isNaN(replacementGlowSize) ?
+      replacementGlowSize : this.REPLACEMENT_GLOW_SIZE;
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -318,6 +318,7 @@ Blockly.zelos.ConstantProvider = function() {
 
   /**
    * The size of the selected glow.
+   * @type {number}
    */
   this.SELECTED_GLOW_SIZE = 0.5;
 
@@ -329,6 +330,7 @@ Blockly.zelos.ConstantProvider = function() {
 
   /**
    * The size of the selected glow.
+   * @type {number}
    */
   this.REPLACEMENT_GLOW_SIZE = 2;
 
@@ -408,18 +410,18 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
 Blockly.zelos.ConstantProvider.prototype.setTheme = function(theme) {
   Blockly.zelos.ConstantProvider.superClass_.setTheme.call(this, theme);
 
-  var selectedGlowColour = theme.getComponentStyle('selectedGlowColour');
-  this.SELECTED_GLOW_COLOUR = selectedGlowColour != null ?
-      selectedGlowColour : this.SELECTED_GLOW_COLOUR;
-  var selectedGlowSize = theme.getComponentStyle('selectedGlowSize');
-  this.SELECTED_GLOW_SIZE = selectedGlowSize != null ?
-      selectedGlowSize : this.SELECTED_GLOW_SIZE;
-  var replacementGlowColour = theme.getComponentStyle('replacementGlowColour');
-  this.REPLACEMENT_GLOW_COLOUR = replacementGlowColour != null ?
-      replacementGlowColour : this.REPLACEMENT_GLOW_COLOUR;
-  var replacementGlowSize = theme.getComponentStyle('replacementGlowSize');
-  this.REPLACEMENT_GLOW_SIZE = replacementGlowSize != null ?
-      replacementGlowSize : this.REPLACEMENT_GLOW_SIZE;
+  this.SELECTED_GLOW_COLOUR =
+      theme.getComponentStyle('selectedGlowColour') ||
+      this.SELECTED_GLOW_COLOUR;
+  this.SELECTED_GLOW_SIZE =
+      theme.getComponentStyle('selectedGlowSize') ||
+      this.SELECTED_GLOW_SIZE;
+  this.REPLACEMENT_GLOW_COLOUR =
+      theme.getComponentStyle('replacementGlowColour') ||
+      this.REPLACEMENT_GLOW_COLOUR;
+  this.REPLACEMENT_GLOW_SIZE =
+      theme.getComponentStyle('replacementGlowSize') ||
+      this.REPLACEMENT_GLOW_SIZE;
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -311,6 +311,28 @@ Blockly.zelos.ConstantProvider = function() {
   this.MAX_DYNAMIC_CONNECTION_SHAPE_WIDTH = 12 * this.GRID_UNIT;
 
   /**
+   * The selected glow colour.
+   * @type {string}
+   */
+  this.SELECTED_GLOW_COLOUR = '#fff200';
+
+  /**
+   * The size of the selected glow.
+   */
+  this.SELECTED_GLOW_SIZE = 0.5;
+
+  /**
+   * The replacement glow colour.
+   * @type {string}
+   */
+  this.REPLACEMENT_GLOW_COLOUR = '#fff200';
+
+  /**
+   * The size of the selected glow.
+   */
+  this.REPLACEMENT_GLOW_SIZE = 2;
+
+  /**
    * The ID of the selected glow filter, or the empty string if no filter is
    * set.
    * @type {string}
@@ -383,10 +405,33 @@ Blockly.zelos.ConstantProvider.prototype.init = function() {
 /**
  * @override
  */
+Blockly.zelos.ConstantProvider.prototype.setTheme = function(theme) {
+  Blockly.zelos.ConstantProvider.superClass_.setTheme.call(this, theme);
+
+  var selectedGlowColour = theme.getComponentStyle('selectedGlowColour');
+  this.SELECTED_GLOW_COLOUR = selectedGlowColour != null ?
+      selectedGlowColour : this.SELECTED_GLOW_COLOUR;
+  var selectedGlowSize = theme.getComponentStyle('selectedGlowSize');
+  this.SELECTED_GLOW_SIZE = selectedGlowSize != null ?
+      selectedGlowSize : this.SELECTED_GLOW_SIZE;
+  var replacementGlowColour = theme.getComponentStyle('replacementGlowColour');
+  this.REPLACEMENT_GLOW_COLOUR = replacementGlowColour != null ?
+      replacementGlowColour : this.REPLACEMENT_GLOW_COLOUR;
+  var replacementGlowSize = theme.getComponentStyle('replacementGlowSize');
+  this.REPLACEMENT_GLOW_SIZE = replacementGlowSize != null ?
+      replacementGlowSize : this.REPLACEMENT_GLOW_SIZE;
+};
+
+/**
+ * @override
+ */
 Blockly.zelos.ConstantProvider.prototype.dispose = function() {
   Blockly.zelos.ConstantProvider.superClass_.dispose.call(this);
   if (this.selectedGlowFilter_) {
     Blockly.utils.dom.removeNode(this.selectedGlowFilter_);
+  }
+  if (this.replacementGlowFilter_) {
+    Blockly.utils.dom.removeNode(this.replacementGlowFilter_);
   }
 };
 
@@ -764,7 +809,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
   Blockly.utils.dom.createSvgElement('feGaussianBlur',
       {
         'in': 'SourceGraphic',
-        'stdDeviation': 0.5  // TODO: configure size in theme.
+        'stdDeviation': this.SELECTED_GLOW_SIZE
       },
       selectedGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
@@ -778,7 +823,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
   // Color the highlight
   Blockly.utils.dom.createSvgElement('feFlood',
       {
-        'flood-color': '#fff200', // TODO: configure colour in theme.
+        'flood-color': this.SELECTED_GLOW_COLOUR,
         'flood-opacity': 1,
         'result': 'outColor'
       },
@@ -806,7 +851,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
   Blockly.utils.dom.createSvgElement('feGaussianBlur',
       {
         'in': 'SourceGraphic',
-        'stdDeviation': 2  // TODO: configure size in theme.
+        'stdDeviation': this.REPLACEMENT_GLOW_SIZE
       },
       replacementGlowFilter);
   // Set all gaussian blur pixels to 1 opacity before applying flood
@@ -820,7 +865,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
   // Color the highlight
   Blockly.utils.dom.createSvgElement('feFlood',
       {
-        'flood-color': '#fff200', // TODO: configure colour in theme.
+        'flood-color': this.REPLACEMENT_GLOW_COLOUR,
         'flood-opacity': 1,
         'result': 'outColor'
       },
@@ -897,7 +942,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
 
     // Connection highlight.
     selector + ' .blocklyHighlightedConnectionPath {',
-      'stroke: #fff200;',
+      'stroke: ' + this.SELECTED_GLOW_COLOUR + ';',
     '}',
 
     // Disabled outline paths.

--- a/core/theme/highcontrast.js
+++ b/core/theme/highcontrast.js
@@ -108,6 +108,10 @@ Blockly.Themes.HighContrast =
         Blockly.Themes.HighContrast.defaultBlockStyles,
         Blockly.Themes.HighContrast.categoryStyles);
 
+Blockly.Themes.HighContrast.setComponentStyle('selectedGlowColour', '#000000');
+Blockly.Themes.HighContrast.setComponentStyle('selectedGlowSize', 1);
+Blockly.Themes.HighContrast.setComponentStyle('replacementGlowColour', '#000000');
+
 Blockly.Themes.HighContrast.setFontStyle({
   'family': null, // Use default font-family
   'weight': null, // Use default font-weight


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Configure selected and replacement glow size and colour in zelos from the theme.

### Reason for Changes

Show how to pipe theme properties to renderer properties.

### Test Coverage

Tested in playground with high contrast theme.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
