### PR TITLE
Check if WidgetDiv is visible before hide logic.

### DIFF
--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -91,16 +91,19 @@ Blockly.WidgetDiv.show = function(newOwner, rtl, dispose) {
  * Destroy the widget and hide the div.
  */
 Blockly.WidgetDiv.hide = function() {
-  var div = Blockly.WidgetDiv.DIV;
-  if (Blockly.WidgetDiv.owner_) {
-    Blockly.WidgetDiv.owner_ = null;
-    div.style.display = 'none';
-    div.style.left = '';
-    div.style.top = '';
-    Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
-    Blockly.WidgetDiv.dispose_ = null;
-    div.innerHTML = '';
+  if (!Blockly.WidgetDiv.isVisible()) {
+    return;
   }
+  Blockly.WidgetDiv.owner_ = null;
+
+  var div = Blockly.WidgetDiv.DIV;
+  div.style.display = 'none';
+  div.style.left = '';
+  div.style.top = '';
+  Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
+  Blockly.WidgetDiv.dispose_ = null;
+  div.innerHTML = '';
+
   if (Blockly.WidgetDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.rendererClassName_);
     Blockly.WidgetDiv.rendererClassName_ = null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Checks if WidgetDiv is visible before hide logic.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This follows the pattern of `Blockly.DropDownDiv.hideWithoutAnimation` and prevents unnecessary side effect of marking focus on workspace in the case where the WidgetDiv didn't need to be hidden.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
