### PR TITLE
[DEMO NO MERGE] Decouple procedure callers from mutator UI implemenation

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -852,7 +852,10 @@ Blockly.Field.prototype.setValue = function(newValue) {
     return;
   }
 
-  if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
+  if (this.sourceBlock_ &&
+      !this.sourceBlock_.disposed &&
+      Blockly.Events.isEnabled()
+  ) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
         this.sourceBlock_, 'field', this.name || null, oldValue, newValue));
   }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -371,7 +371,7 @@ Blockly.Procedures.mutateCallers = function(defBlock) {
   var procedureBlock = /** @type {!Blockly.Procedures.ProcedureBlock} */ (
     defBlock);
   var name = procedureBlock.getProcedureDef()[0];
-  var xmlElement = defBlock.mutationToDom(true);
+  var xmlElement = defBlock.mutationToDom();
   var callers = Blockly.Procedures.getCallers(name, defBlock.workspace);
   for (var i = 0, caller; (caller = callers[i]); i++) {
     var oldMutationDom = caller.mutationToDom();


### PR DESCRIPTION
### Basics

This is just a demo showing how the procedure callers could be generalized so that they are no longer tightly coupled to Blockly's current mutator-ui implimentation.

This is not for merging, and will be closed immediately after it is opened.

### Description

#### Background

The code I am talking about is inside [setProcedureParameters_](https://github.com/google/blockly/blob/master/blocks/procedures.js#L650).

Procedure callers currently rely on the IDs of blocks in the mutator, which means that if the mutator UI is not the default UI procedure callers break.

Procedure callers use the IDs of the blocks as keys in a dictionary. Because each block is associated with a parameter of the function, they are by extension associated with inputs on the caller. Because of this the caller can use the IDs of mutator blocks as keys for the blocks connected to its inputs.

But again, if the mutator UI doesn't have blocks, it has no way to keep track of what blocks should be connected to what inputs.

#### Solution

Instead of using block IDs as keys this solution uses variable IDs as keys. This works because each variable ID is also associated with a parameter of the function, and by extension an input on the caller.

This implimentation also has the advantage that we can get rid of the onFinishedEditing hack. Because each mutatorarg sets the id of its variable explicitly, it can simply rename its var as its text input is edited, instead of creating a bunch of new variables that have to be deleted in onFinishEditing.