### PR TITLE
Fix warning text color.

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -320,10 +320,6 @@ Blockly.Css.CONTENT = [
     'pointer-events: none;',
   '}',
 
-  '.blocklyBubbleText {',
-    'fill: #000;',
-  '}',
-
   '.blocklyFlyout {',
     'position: absolute;',
     'z-index: 20;',

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1184,6 +1184,11 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(name) {
       'fill: #000;',
     '}',
 
+    // Bubbles.
+    selector + ' .blocklyText.blocklyBubbleText {',
+      'fill: #000;',
+    '}',
+
     // Editable field hover.
     selector + ' .blocklyEditableText:not(.editing):hover>rect {',
       'stroke: #fff;',

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -919,6 +919,11 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
       'fill: #575E75;',
     '}',
 
+    // Bubbles.
+    selector + ' .blocklyText.blocklyBubbleText {',
+      'fill: #575E75;',
+    '}',
+
     // Editable field hover.
     selector + ' .blocklyDraggable:not(.blocklyDisabled)',
     ' .blocklyEditableText:not(.editing):hover>rect ,',


### PR DESCRIPTION
##The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3657

### Proposed Changes

More specific CSS in renderer.

### Reason for Changes

Bug fix.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
