### PR TITLE
Support extending themes with a base theme property.

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -282,8 +282,7 @@ Blockly.Options.parseThemeOptions_ = function(options) {
   if (theme instanceof Blockly.Theme) {
     return /** @type {!Blockly.Theme} */ (theme);
   }
-  return new Blockly.Theme('builtin',
-      theme['blockStyles'], theme['categoryStyles'], theme['componentStyles']);
+  return Blockly.Theme.defineTheme('builtin', theme);
 };
 
 /**

--- a/core/theme.js
+++ b/core/theme.js
@@ -40,24 +40,28 @@ Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
   /**
    * The block styles map.
    * @type {!Object.<string, !Blockly.Theme.BlockStyle>}
+   * @pacakge
    */
   this.blockStyles = opt_blockStyles || Object.create(null);
 
   /**
    * The category styles map.
    * @type {!Object.<string, Blockly.Theme.CategoryStyle>}
+   * @pacakge
    */
   this.categoryStyles = opt_categoryStyles || Object.create(null);
 
   /**
    * The UI components styles map.
    * @type {!Object.<string, *>}
+   * @pacakge
    */
   this.componentStyles = opt_componentStyles || Object.create(null);
 
   /**
    * The font style.
    * @type {Blockly.Theme.FontStyle}
+   * @pacakge
    */
   this.fontStyle = /** @type {Blockly.Theme.FontStyle} */ (Object.create(null));
 
@@ -65,6 +69,7 @@ Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
    * Whether or not to add a 'hat' on top of all blocks with no previous or
    * output connections.
    * @type {boolean}
+   * @pacakge
    */
   this.startHats = false;
 };
@@ -118,23 +123,6 @@ Blockly.Theme.prototype.setCategoryStyle = function(categoryStyleName,
 };
 
 /**
- * Configure a theme's font style.
- * @param {Blockly.Theme.FontStyle} fontStyle The font style.
-*/
-Blockly.Theme.prototype.setFontStyle = function(fontStyle) {
-  this.fontStyle = fontStyle;
-};
-
-/**
- * Configure a theme's start hats.
- * @param {boolean} startHats True if the theme enables start hats, false
- *     otherwise.
-*/
-Blockly.Theme.prototype.setStartHats = function(startHats) {
-  this.startHats = startHats;
-};
-
-/**
  * Gets the style for a given Blockly UI component.  If the style value is a
  * string, we attempt to find the value of any named references.
  * @param {string} componentName The name of the component.
@@ -160,9 +148,26 @@ Blockly.Theme.prototype.setComponentStyle = function(componentName,
 };
 
 /**
+ * Configure a theme's font style.
+ * @param {Blockly.Theme.FontStyle} fontStyle The font style.
+*/
+Blockly.Theme.prototype.setFontStyle = function(fontStyle) {
+  this.fontStyle = fontStyle;
+};
+
+/**
+ * Configure a theme's start hats.
+ * @param {boolean} startHats True if the theme enables start hats, false
+ *     otherwise.
+*/
+Blockly.Theme.prototype.setStartHats = function(startHats) {
+  this.startHats = startHats;
+};
+
+/**
  * Define a new Blockly theme.
  * @param {string} name The name of the theme.
- * @param {Object} themeObj An object containing theme properties.
+ * @param {!Object} themeObj An object containing theme properties.
  * @return {!Blockly.Theme} A new Blockly theme.
 */
 Blockly.Theme.defineTheme = function(name, themeObj) {

--- a/core/theme.js
+++ b/core/theme.js
@@ -40,28 +40,28 @@ Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
   /**
    * The block styles map.
    * @type {!Object.<string, !Blockly.Theme.BlockStyle>}
-   * @pacakge
+   * @package
    */
   this.blockStyles = opt_blockStyles || Object.create(null);
 
   /**
    * The category styles map.
    * @type {!Object.<string, Blockly.Theme.CategoryStyle>}
-   * @pacakge
+   * @package
    */
   this.categoryStyles = opt_categoryStyles || Object.create(null);
 
   /**
    * The UI components styles map.
    * @type {!Object.<string, *>}
-   * @pacakge
+   * @package
    */
   this.componentStyles = opt_componentStyles || Object.create(null);
 
   /**
    * The font style.
    * @type {Blockly.Theme.FontStyle}
-   * @pacakge
+   * @package
    */
   this.fontStyle = /** @type {Blockly.Theme.FontStyle} */ (Object.create(null));
 
@@ -69,7 +69,7 @@ Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
    * Whether or not to add a 'hat' on top of all blocks with no previous or
    * output connections.
    * @type {boolean}
-   * @pacakge
+   * @package
    */
   this.startHats = false;
 };

--- a/core/theme.js
+++ b/core/theme.js
@@ -13,65 +13,60 @@ goog.provide('Blockly.Theme');
 
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.colour');
+goog.require('Blockly.utils.object');
 
 
 /**
  * Class for a theme.
  * @param {string} name Theme name.
- * @param {!Object.<string, Blockly.Theme.BlockStyle>} blockStyles A map from
- *     style names (strings) to objects with style attributes for blocks.
- * @param {!Object.<string, Blockly.Theme.CategoryStyle>} categoryStyles A map
- *     from style names (strings) to objects with style attributes for
+ * @param {!Object.<string, Blockly.Theme.BlockStyle>=} opt_blockStyles A map
+ *     from style names (strings) to objects with style attributes for blocks.
+ * @param {!Object.<string, Blockly.Theme.CategoryStyle>=} opt_categoryStyles A
+ *     map from style names (strings) to objects with style attributes for
  *     categories.
  * @param {!Object.<string, *>=} opt_componentStyles A map of Blockly component
  *     names to style value.
  * @constructor
  */
-Blockly.Theme = function(name, blockStyles, categoryStyles,
+Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
     opt_componentStyles) {
 
   /**
    * The theme name. This can be used to reference a specific theme in CSS.
    * @type {string}
-   * @package
    */
   this.name = name;
 
   /**
    * The block styles map.
    * @type {!Object.<string, !Blockly.Theme.BlockStyle>}
-   * @package
    */
-  this.blockStyles = blockStyles;
+  this.blockStyles = opt_blockStyles || Object.create(null);;
 
   /**
    * The category styles map.
    * @type {!Object.<string, Blockly.Theme.CategoryStyle>}
-   * @package
    */
-  this.categoryStyles = categoryStyles;
+  this.categoryStyles = opt_categoryStyles || Object.create(null);
 
   /**
    * The UI components styles map.
    * @type {!Object.<string, *>}
-   * @private
    */
-  this.componentStyles_ = opt_componentStyles || Object.create(null);
+  this.componentStyles = opt_componentStyles || Object.create(null);
 
   /**
    * The font style.
-   * @type {?Blockly.Theme.FontStyle}
-   * @package
+   * @type {Blockly.Theme.FontStyle}
    */
-  this.fontStyle = null;
+  this.fontStyle = /** @type {Blockly.Theme.FontStyle} */ (Object.create(null));
 
   /**
    * Whether or not to add a 'hat' on top of all blocks with no previous or
    * output connections.
-   * @type {?boolean}
-   * @package
+   * @type {boolean}
    */
-  this.startHats = null;
+  this.startHats = false;
 };
 
 /**
@@ -146,7 +141,7 @@ Blockly.Theme.prototype.setStartHats = function(startHats) {
  * @return {?string} The style value.
  */
 Blockly.Theme.prototype.getComponentStyle = function(componentName) {
-  var style = this.componentStyles_[componentName];
+  var style = this.componentStyles[componentName];
   if (style && typeof propertyValue == 'string' &&
       this.getComponentStyle(/** @type {string} */ (style))) {
     return this.getComponentStyle(/** @type {string} */ (style));
@@ -161,5 +156,32 @@ Blockly.Theme.prototype.getComponentStyle = function(componentName) {
 */
 Blockly.Theme.prototype.setComponentStyle = function(componentName,
     styleValue) {
-  this.componentStyles_[componentName] = styleValue;
+  this.componentStyles[componentName] = styleValue;
+};
+
+/**
+ * Define a new Blockly theme.
+ * @param {string} name The name of the theme.
+ * @param {Object} themeObj An object containing theme properties.
+ * @return {!Blockly.Theme} A new Blockly theme.
+*/
+Blockly.Theme.defineTheme = function(name, themeObj) {
+  var theme = new Blockly.Theme(name);
+  var base = themeObj['base'];
+  if (base && base instanceof Blockly.Theme) {
+    Blockly.utils.object.deepMerge(theme, base);
+  }
+  
+  Blockly.utils.object.deepMerge(theme.blockStyles,
+      themeObj['blockStyles']);
+  Blockly.utils.object.deepMerge(theme.categoryStyles,
+      themeObj['categoryStyles']);
+  Blockly.utils.object.deepMerge(theme.componentStyles,
+      themeObj['componentStyles']);
+  Blockly.utils.object.deepMerge(theme.fontStyle,
+      themeObj['fontStyle']);
+  if (themeObj['startHats'] != null) {
+    theme.startHats = themeObj['startHats'];
+  }
+  return theme;
 };

--- a/core/theme.js
+++ b/core/theme.js
@@ -41,7 +41,7 @@ Blockly.Theme = function(name, opt_blockStyles, opt_categoryStyles,
    * The block styles map.
    * @type {!Object.<string, !Blockly.Theme.BlockStyle>}
    */
-  this.blockStyles = opt_blockStyles || Object.create(null);;
+  this.blockStyles = opt_blockStyles || Object.create(null);
 
   /**
    * The category styles map.

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -12,101 +12,11 @@
 
 goog.provide('Blockly.Themes.Dark');
 
-goog.require('Blockly.Css');
 goog.require('Blockly.Theme');
 
-
-// Temporary holding object.
-Blockly.Themes.Dark = {};
-
-Blockly.Themes.Dark.defaultBlockStyles = {
-  "colour_blocks": {
-    "colourPrimary": "#a5745b",
-    "colourSecondary": "#dbc7bd",
-    "colourTertiary": "#845d49"
-  },
-  "list_blocks": {
-    "colourPrimary": "#745ba5",
-    "colourSecondary": "#c7bddb",
-    "colourTertiary": "#5d4984"
-  },
-  "logic_blocks": {
-    "colourPrimary": "#5b80a5",
-    "colourSecondary": "#bdccdb",
-    "colourTertiary": "#496684"
-  },
-  "loop_blocks": {
-    "colourPrimary": "#5ba55b",
-    "colourSecondary": "#bddbbd",
-    "colourTertiary": "#498449"
-  },
-  "math_blocks": {
-    "colourPrimary": "#5b67a5",
-    "colourSecondary": "#bdc2db",
-    "colourTertiary": "#495284"
-  },
-  "procedure_blocks": {
-    "colourPrimary": "#995ba5",
-    "colourSecondary": "#d6bddb",
-    "colourTertiary": "#7a4984"
-  },
-  "text_blocks": {
-    "colourPrimary": "#5ba58c",
-    "colourSecondary": "#bddbd1",
-    "colourTertiary": "#498470"
-  },
-  "variable_blocks": {
-    "colourPrimary": "#a55b99",
-    "colourSecondary": "#dbbdd6",
-    "colourTertiary": "#84497a"
-  },
-  "variable_dynamic_blocks": {
-    "colourPrimary": "#a55b99",
-    "colourSecondary": "#dbbdd6",
-    "colourTertiary": "#84497a"
-  },
-  "hat_blocks": {
-    "colourPrimary": "#a55b99",
-    "colourSecondary": "#dbbdd6",
-    "colourTertiary": "#84497a",
-    "hat": "cap"
-  }
-};
-
-Blockly.Themes.Dark.categoryStyles = {
-  "colour_category": {
-    "colour": "#a5745b"
-  },
-  "list_category": {
-    "colour": "#745ba5"
-  },
-  "logic_category": {
-    "colour": "#5b80a5"
-  },
-  "loop_category": {
-    "colour": "#5ba55b"
-  },
-  "math_category": {
-    "colour": "#5b67a5"
-  },
-  "procedure_category": {
-    "colour": "#995ba5"
-  },
-  "text_category": {
-    "colour": "#5ba58c"
-  },
-  "variable_category": {
-    "colour": "#a55b99"
-  },
-  "variable_dynamic_category": {
-    "colour": "#a55b99"
-  }
-};
-
-// This style is still being fleshed out and may change.
-Blockly.Themes.Dark =
-    new Blockly.Theme('dark', Blockly.Themes.Dark.defaultBlockStyles,
-        Blockly.Themes.Dark.categoryStyles);
+Blockly.Themes.Dark = Blockly.Theme.defineTheme('dark', {
+  'base': Blockly.Themes.Classic
+});
 
 Blockly.Themes.Dark.setComponentStyle('workspaceBackgroundColour', '#1e1e1e');
 Blockly.Themes.Dark.setComponentStyle('toolboxBackgroundColour', '#333');
@@ -116,39 +26,3 @@ Blockly.Themes.Dark.setComponentStyle('flyoutForegroundColour', '#ccc');
 Blockly.Themes.Dark.setComponentStyle('flyoutOpacity', 1);
 Blockly.Themes.Dark.setComponentStyle('scrollbarColour', '#797979');
 Blockly.Themes.Dark.setComponentStyle('scrollbarOpacity', 0.4);
-
-/**
- * CSS for the dark theme.
- * This registers CSS that is specific to this theme. It does so by prepending a
- * ``.dark-theme`` selector before every CSS rule that we wish to override by
- * this theme.
- */
-(function() {
-  var selector = '.dark-theme';
-  Blockly.Css.register([
-    /* eslint-disable indent */
-    // Toolbox hover
-    selector + ' .blocklyTreeRow:not(.blocklyTreeSelected):hover {',
-      'background-color: #2a2d2e;',
-    '}',
-    // Dropdown and Widget div.
-    selector + '.blocklyWidgetDiv .goog-menu, ',
-    selector + '.blocklyDropDownDiv {',
-      'background-color: #3c3c3c;',
-    '}',
-    selector + '.blocklyDropDownDiv {',
-      'border-color: #565656;',
-    '}',
-    selector + '.blocklyWidgetDiv .goog-menuitem-content, ',
-    selector + '.blocklyDropDownDiv .goog-menuitem-content {',
-      'color: #f0f0f0;',
-    '}',
-    selector + '.blocklyWidgetDiv .goog-menuitem-disabled',
-    ' .goog-menuitem-content,',
-    selector + '.blocklyDropDownDiv .goog-menuitem-disabled',
-    ' .goog-menuitem-content {',
-      'color: #8a8a8a !important;',
-    '}',
-    /* eslint-enable indent */
-  ]);
-})();

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -15,14 +15,15 @@ goog.provide('Blockly.Themes.Dark');
 goog.require('Blockly.Theme');
 
 Blockly.Themes.Dark = Blockly.Theme.defineTheme('dark', {
-  'base': Blockly.Themes.Classic
+  'base': Blockly.Themes.Classic,
+  'componentStyles': {
+    'workspaceBackgroundColour': '#1e1e1e',
+    'toolboxBackgroundColour': '#333',
+    'toolboxForegroundColour': '#fff',
+    'flyoutBackgroundColour': '#252526',
+    'flyoutForegroundColour': '#ccc',
+    'flyoutOpacity': 1,
+    'scrollbarColour': '#797979',
+    'scrollbarOpacity': 0.4
+  }
 });
-
-Blockly.Themes.Dark.setComponentStyle('workspaceBackgroundColour', '#1e1e1e');
-Blockly.Themes.Dark.setComponentStyle('toolboxBackgroundColour', '#333');
-Blockly.Themes.Dark.setComponentStyle('toolboxForegroundColour', '#fff');
-Blockly.Themes.Dark.setComponentStyle('flyoutBackgroundColour', '#252526');
-Blockly.Themes.Dark.setComponentStyle('flyoutForegroundColour', '#ccc');
-Blockly.Themes.Dark.setComponentStyle('flyoutOpacity', 1);
-Blockly.Themes.Dark.setComponentStyle('scrollbarColour', '#797979');
-Blockly.Themes.Dark.setComponentStyle('scrollbarOpacity', 0.4);

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -780,7 +780,7 @@ Blockly.Css.register([
   '}',
 
   '.blocklyTreeRow:not(.blocklyTreeSelected):hover {',
-    'background-color: #e4e4e4;',
+    'background-color: rgba(255, 255, 255, 0.2);',
   '}',
 
   '.blocklyTreeSeparator {',

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -38,6 +38,24 @@ Blockly.utils.object.mixin = function(target, source) {
 };
 
 /**
+ * Complete a deep merge of all members of a source object with a target object.
+ * @param {!Object} target Target.
+ * @param {!Object} source Source.
+ * @return {!Object} The resulting object.
+ */
+Blockly.utils.object.deepMerge = function(target, source) {
+  for (var x in source) {
+    if (typeof source[x] === 'object') {
+      target[x] = Blockly.utils.object.deepMerge(
+          target[x] || Object.create(null), source[x]);
+    } else {
+      target[x] = source[x];
+    }
+  }
+  return target;
+};
+
+/**
  * Returns an array of a given object's own enumerable property values.
  * @param {!Object} obj Object containing values.
  * @return {!Array} Array of values.

--- a/tests/themes/test_themes.js
+++ b/tests/themes/test_themes.js
@@ -11,15 +11,17 @@ goog.provide('Blockly.TestThemes');
 /**
  * A theme with classic colours but enables start hats.
  */
-Blockly.Themes.TestHats = new Blockly.Theme('testhats',
-    Blockly.Themes.Classic.blockStyles, Blockly.Themes.Classic.categoryStyles);
+Blockly.Themes.TestHats = Blockly.Theme.defineTheme('testhats', {
+  'base': Blockly.Themes.Classic
+});
 Blockly.Themes.TestHats.setStartHats(true);
 
 /**
  * A theme with classic colours but a different font.
  */
-Blockly.Themes.TestFont = new Blockly.Theme('testfont',
-    Blockly.Themes.Classic.blockStyles, Blockly.Themes.Classic.categoryStyles);
+Blockly.Themes.TestFont = Blockly.Theme.defineTheme('testfont', {
+  'base': Blockly.Themes.Classic
+});
 Blockly.Themes.TestFont.setFontStyle({
   'family': '"Times New Roman", Times, serif',
   'weight': null, // Use default font-weight


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Related to https://github.com/google/blockly/issues/3113

### Proposed Changes

```
Blockly.Theme.defineTheme(name, {
   'base': Blockly.Themes.Classic,
   'blockStyles': ...,
   'categoryStyles': ...,
   'fontStyles': ...
});
```

Developers can call the factory themselves when defining a theme, before passing in the theme object to the workspace options. In addition, if a developer is authoring a theme in workspace options in JSON, we would pass those options to this factory instead of doing this.

The defineTheme method would read the base property if it exists, and complete a deep merge of the base theme object's properties with the properties passed into the method and return a new Blockly.Theme.

Removed Dark theme CSS, and got around the need to specify a hover color by using an rgba value instead of a specific colour.

### Reason for Changes

Support developers in extending themes.

### Test Coverage

Tested in playground.


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
