### PR TITLE
Support multiple renderer / theme combos on the same page.

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -105,17 +105,17 @@ Blockly.DropDownDiv.onHide_ = null;
 
 /**
  * A class name representing the current owner's workspace renderer.
- * @type {?string}
+ * @type {string}
  * @private
  */
-Blockly.DropDownDiv.rendererClassName_ = null;
+Blockly.DropDownDiv.rendererClassName_ = '';
 
 /**
  * A class name representing the current owner's workspace theme.
- * @type {?string}
+ * @type {string}
  * @private
  */
-Blockly.DropDownDiv.themeClassName_ = null;
+Blockly.DropDownDiv.themeClassName_ = '';
 
 /**
  * Create and insert the DOM element for this div.
@@ -340,9 +340,9 @@ Blockly.DropDownDiv.show = function(owner, rtl, primaryX, primaryY,
   div.style.direction = rtl ? 'rtl' : 'ltr';
 
   Blockly.DropDownDiv.rendererClassName_ =
-      Blockly.getMainWorkspace().getRenderer().name + '-renderer';
+      Blockly.getMainWorkspace().getRenderer().getClassName();
   Blockly.DropDownDiv.themeClassName_ =
-      Blockly.getMainWorkspace().getTheme().name + '-theme';
+      Blockly.getMainWorkspace().getTheme().getClassName();
   Blockly.utils.dom.addClass(div, Blockly.DropDownDiv.rendererClassName_);
   Blockly.utils.dom.addClass(div, Blockly.DropDownDiv.themeClassName_);
 
@@ -642,11 +642,11 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
 
   if (Blockly.DropDownDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.DropDownDiv.rendererClassName_);
-    Blockly.DropDownDiv.rendererClassName_ = null;
+    Blockly.DropDownDiv.rendererClassName_ = '';
   }
   if (Blockly.DropDownDiv.themeClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.DropDownDiv.themeClassName_);
-    Blockly.DropDownDiv.themeClassName_ = null;
+    Blockly.DropDownDiv.themeClassName_ = '';
   }
   Blockly.getMainWorkspace().markFocused();
 };

--- a/core/inject.js
+++ b/core/inject.js
@@ -155,10 +155,12 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   svg.appendChild(mainWorkspace.createDom('blocklyMainBackground'));
 
   // Set the theme name and renderer name onto the injection div.
+  var rendererName = mainWorkspace.getRenderer().name;
+  var themeName = mainWorkspace.getTheme().name;
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
-      (wsOptions.renderer || 'geras') + '-renderer');
+      rendererName + '-' + themeName + '-renderer');
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
-      mainWorkspace.getTheme().name + '-theme');
+      themeName + '-theme');
 
   if (!wsOptions.hasCategories && wsOptions.languageTree) {
     // Add flyout as an <svg> that is a sibling of the workspace svg.

--- a/core/inject.js
+++ b/core/inject.js
@@ -155,12 +155,10 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
   svg.appendChild(mainWorkspace.createDom('blocklyMainBackground'));
 
   // Set the theme name and renderer name onto the injection div.
-  var rendererName = mainWorkspace.getRenderer().name;
-  var themeName = mainWorkspace.getTheme().name;
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
-      rendererName + '-' + themeName + '-renderer');
+      mainWorkspace.getRenderer().getClassName());
   Blockly.utils.dom.addClass(mainWorkspace.getInjectionDiv(),
-      themeName + '-theme');
+      mainWorkspace.getTheme().getClassName());
 
   if (!wsOptions.hasCategories && wsOptions.languageTree) {
     // Add flyout as an <svg> that is a sibling of the workspace svg.

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -782,6 +782,7 @@ Blockly.blockRendering.ConstantProvider.prototype.dispose = function() {
   if (this.debugFilter_) {
     Blockly.utils.dom.removeNode(this.debugFilter_);
   }
+  this.cssNode_ = null;
 };
 
 /**

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -984,13 +984,15 @@ Blockly.blockRendering.ConstantProvider.prototype.shapeFor = function(
 /**
  * Create any DOM elements that this renderer needs (filters, patterns, etc).
  * @param {!SVGElement} svg The root of the workspace's SVG.
- * @param {string} name The renderer and theme name combo.
+ * @param {string} tagName The name to use for the CSS style tag.
+ * @param {string} selector The CSS selector to use.
  * @suppress {strictModuleDepCheck} Debug renderer only included in playground.
  * @package
  */
 Blockly.blockRendering.ConstantProvider.prototype.createDom = function(svg,
-    name) {
-  this.injectCSS_(name);
+    tagName, selector) {
+  this.injectCSS_(tagName, selector);
+
   /*
   <defs>
     ... filters go here ...
@@ -1107,13 +1109,14 @@ Blockly.blockRendering.ConstantProvider.prototype.createDom = function(svg,
 
 /**
  * Inject renderer specific CSS into the page.
- * @param {string} name The renderer and theme name combo.
+ * @param {string} tagName The name of the style tag to use.
+ * @param {string} selector The CSS selector to use.
  * @protected
  */
 Blockly.blockRendering.ConstantProvider.prototype.injectCSS_ = function(
-    name) {
-  var cssArray = this.getCSS_(name);
-  var cssNodeId = 'blockly-renderer-style-' + name;
+    tagName, selector) {
+  var cssArray = this.getCSS_(selector);
+  var cssNodeId = 'blockly-renderer-style-' + tagName;
   this.cssNode_ =
     /** @type {!HTMLStyleElement} */ (document.getElementById(cssNodeId));
   if (this.cssNode_) {
@@ -1133,12 +1136,11 @@ Blockly.blockRendering.ConstantProvider.prototype.injectCSS_ = function(
 
 /**
  * Get any renderer specific CSS to inject when the renderer is initialized.
- * @param {string} name Name of the renderer.
+ * @param {string} selector CSS selector to use.
  * @return {!Array.<string>} Array of CSS strings.
  * @protected
  */
-Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(name) {
-  var selector = '.' + name + '-renderer';
+Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
     // Fields.

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1139,7 +1139,8 @@ Blockly.blockRendering.ConstantProvider.prototype.injectCSS_ = function(
     name) {
   var cssArray = this.getCSS_(name);
   var cssNodeId = 'blockly-renderer-style-' + name;
-  this.cssNode_ = document.getElementById(cssNodeId);
+  this.cssNode_ =
+    /** @type {!HTMLStyleElement} */ (document.getElementById(cssNodeId));
   if (this.cssNode_) {
     // Already injected.
     return;

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -782,9 +782,6 @@ Blockly.blockRendering.ConstantProvider.prototype.dispose = function() {
   if (this.debugFilter_) {
     Blockly.utils.dom.removeNode(this.debugFilter_);
   }
-  if (this.cssNode_) {
-    Blockly.utils.dom.removeNode(this.cssNode_);
-  }
 };
 
 /**
@@ -1011,13 +1008,13 @@ Blockly.blockRendering.ConstantProvider.prototype.shapeFor = function(
 /**
  * Create any DOM elements that this renderer needs (filters, patterns, etc).
  * @param {!SVGElement} svg The root of the workspace's SVG.
- * @param {string} rendererName Name of the renderer.
+ * @param {string} name The renderer and theme name combo.
  * @suppress {strictModuleDepCheck} Debug renderer only included in playground.
  * @package
  */
 Blockly.blockRendering.ConstantProvider.prototype.createDom = function(svg,
-    rendererName) {
-  this.injectCSS_(rendererName);
+    name) {
+  this.injectCSS_(name);
   /*
   <defs>
     ... filters go here ...
@@ -1134,14 +1131,15 @@ Blockly.blockRendering.ConstantProvider.prototype.createDom = function(svg,
 
 /**
  * Inject renderer specific CSS into the page.
- * @param {string} name Name of the renderer.
+ * @param {string} name The renderer and theme name combo.
  * @protected
  */
 Blockly.blockRendering.ConstantProvider.prototype.injectCSS_ = function(
     name) {
   var cssArray = this.getCSS_(name);
   var cssNodeId = 'blockly-renderer-style-' + name;
-  if (document.getElementById(cssNodeId)) {
+  this.cssNode_ = document.getElementById(cssNodeId);
+  if (this.cssNode_) {
     // Already injected.
     return;
   }

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -54,6 +54,15 @@ Blockly.blockRendering.Renderer = function(name) {
 };
 
 /**
+ * Gets the class name that identifies this renderer.
+ * @return {string} The CSS class name.
+ * @package
+ */
+Blockly.blockRendering.Renderer.prototype.getClassName = function() {
+  return this.name + '-renderer';
+};
+
+/**
  * Initialize the renderer.
  * @param {!Blockly.Theme} theme The workspace theme object.
  * @param {Object=} opt_rendererOverrides Rendering constant overrides.
@@ -71,12 +80,23 @@ Blockly.blockRendering.Renderer.prototype.init = function(theme,
 };
 
 /**
+ * Create any DOM elements that this renderer needs.
+ * @param {!SVGElement} svg The root of the workspace's SVG.
+ * @param {!Blockly.Theme} theme The workspace theme object.
+ * @package
+ */
+Blockly.blockRendering.Renderer.prototype.createDom = function(svg, theme) {
+  this.constants_.createDom(svg, this.name + '-' + theme.name,
+      '.' + this.getClassName() + '.' + theme.getClassName());
+};
+
+/**
  * Refresh the renderer after a theme change.
  * @param {!SVGElement} svg The root of the workspace's SVG.
  * @param {!Blockly.Theme} theme The workspace theme object.
  * @package
  */
-Blockly.blockRendering.Renderer.prototype.refresh = function(svg, theme) {
+Blockly.blockRendering.Renderer.prototype.refreshDom = function(svg, theme) {
   var previousConstants = this.getConstants();
   previousConstants.dispose();
   this.constants_ = this.makeConstants_();
@@ -87,7 +107,18 @@ Blockly.blockRendering.Renderer.prototype.refresh = function(svg, theme) {
   this.constants_.randomIdentifier = previousConstants.randomIdentifier;
   this.constants_.setTheme(theme);
   this.constants_.init();
-  this.getConstants().createDom(svg, this.name + '-' + theme.name);
+  this.createDom(svg, theme);
+};
+
+/**
+ * Dispose of this renderer.
+ * Delete all DOM elements that this renderer and its constants created.
+ * @package
+ */
+Blockly.blockRendering.Renderer.prototype.dispose = function() {
+  if (this.constants_) {
+    this.constants_.dispose();
+  }
 };
 
 /**

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -68,7 +68,7 @@ Blockly.blockRendering.Renderer.prototype.refresh = function(svg, theme) {
   constants.dispose();
   constants.setTheme(theme);
   constants.init();
-  constants.createDom(svg, this.name);
+  constants.createDom(svg, this.name + '-' + theme.name);
 };
 
 /**

--- a/core/renderers/geras/renderer.js
+++ b/core/renderers/geras/renderer.js
@@ -59,8 +59,8 @@ Blockly.geras.Renderer.prototype.init = function(theme,
 /**
  * @override
  */
-Blockly.geras.Renderer.prototype.refresh = function(svg, theme) {
-  Blockly.geras.Renderer.superClass_.refresh.call(this, svg, theme);
+Blockly.geras.Renderer.prototype.refreshDom = function(svg, theme) {
+  Blockly.geras.Renderer.superClass_.refreshDom.call(this, svg, theme);
   this.getHighlightConstants().init();
 };
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -794,9 +794,9 @@ Blockly.zelos.ConstantProvider.prototype.generateTertiaryColour_ = function(
  * @override
  */
 Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
-    rendererName) {
+    name) {
   Blockly.zelos.ConstantProvider.superClass_.createDom.call(this, svg,
-      rendererName);
+      name);
   /*
   <defs>
     ... filters go here ...

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -798,9 +798,9 @@ Blockly.zelos.ConstantProvider.prototype.generateTertiaryColour_ = function(
  * @override
  */
 Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
-    name) {
+    tagName, selector) {
   Blockly.zelos.ConstantProvider.superClass_.createDom.call(this, svg,
-      name);
+      tagName, selector);
   /*
   <defs>
     ... filters go here ...
@@ -901,8 +901,7 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
 /**
  * @override
  */
-Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(name) {
-  var selector = '.' + name + '-renderer';
+Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
     // Fields.

--- a/core/theme.js
+++ b/core/theme.js
@@ -122,6 +122,15 @@ Blockly.Theme.ComponentStyle;
 Blockly.Theme.FontStyle;
 
 /**
+ * Gets the class name that identifies this theme.
+ * @return {string} The CSS class name.
+ * @package
+ */
+Blockly.Theme.prototype.getClassName = function() {
+  return this.name + '-theme';
+};
+
+/**
  * Overrides or adds a style to the blockStyles map.
  * @param {string} blockStyleName The name of the block style.
  * @param {Blockly.Theme.BlockStyle} blockStyle The block style.

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -86,9 +86,9 @@ Blockly.ThemeManager.prototype.setTheme = function(theme) {
   var injectionDiv = this.workspace_.getInjectionDiv();
   if (injectionDiv) {
     if (prevTheme) {
-      Blockly.utils.dom.removeClass(injectionDiv, prevTheme.name + '-theme');
+      Blockly.utils.dom.removeClass(injectionDiv, prevTheme.getClassName());
     }
-    Blockly.utils.dom.addClass(injectionDiv, this.theme_.name + '-theme');
+    Blockly.utils.dom.addClass(injectionDiv, this.theme_.getClassName());
   }
 
   // Refresh all subscribed workspaces.

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -37,17 +37,17 @@ Blockly.WidgetDiv.dispose_ = null;
 
 /**
  * A class name representing the current owner's workspace renderer.
- * @type {?string}
+ * @type {string}
  * @private
  */
-Blockly.WidgetDiv.rendererClassName_ = null;
+Blockly.WidgetDiv.rendererClassName_ = '';
 
 /**
  * A class name representing the current owner's workspace theme.
- * @type {?string}
+ * @type {string}
  * @private
  */
-Blockly.WidgetDiv.themeClassName_ = null;
+Blockly.WidgetDiv.themeClassName_ = '';
 
 /**
  * Create the widget div and inject it onto the page.
@@ -80,9 +80,9 @@ Blockly.WidgetDiv.show = function(newOwner, rtl, dispose) {
   div.style.direction = rtl ? 'rtl' : 'ltr';
   div.style.display = 'block';
   Blockly.WidgetDiv.rendererClassName_ =
-      Blockly.getMainWorkspace().getRenderer().name + '-renderer';
+      Blockly.getMainWorkspace().getRenderer().getClassName();
   Blockly.WidgetDiv.themeClassName_ =
-      Blockly.getMainWorkspace().getTheme().name + '-theme';
+      Blockly.getMainWorkspace().getTheme().getClassName();
   Blockly.utils.dom.addClass(div, Blockly.WidgetDiv.rendererClassName_);
   Blockly.utils.dom.addClass(div, Blockly.WidgetDiv.themeClassName_);
 };
@@ -106,11 +106,11 @@ Blockly.WidgetDiv.hide = function() {
 
   if (Blockly.WidgetDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.rendererClassName_);
-    Blockly.WidgetDiv.rendererClassName_ = null;
+    Blockly.WidgetDiv.rendererClassName_ = '';
   }
   if (Blockly.WidgetDiv.themeClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.themeClassName_);
-    Blockly.WidgetDiv.themeClassName_ = null;
+    Blockly.WidgetDiv.themeClassName_ = '';
   }
   Blockly.getMainWorkspace().markFocused();
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -744,7 +744,8 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
       new Blockly.Marker());
 
   var constants = this.getRenderer().getConstants();
-  constants.createDom(this.svgGroup_, this.getRenderer().name);
+  constants.createDom(this.svgGroup_, this.getRenderer().name + '-' +
+      this.getTheme().name);
   return this.svgGroup_;
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -516,7 +516,7 @@ Blockly.WorkspaceSvg.prototype.setTheme = function(theme) {
  */
 Blockly.WorkspaceSvg.prototype.refreshTheme = function() {
   if (this.svgGroup_) {
-    this.getRenderer().refresh(this.svgGroup_, this.getTheme());
+    this.renderer_.refreshDom(this.svgGroup_, this.getTheme());
   }
 
   // Update all blocks in workspace that have a style name.
@@ -748,9 +748,7 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   this.markerManager_.registerMarker(Blockly.navigation.MARKER_NAME,
       new Blockly.Marker());
 
-  var constants = this.getRenderer().getConstants();
-  constants.createDom(this.svgGroup_, this.getRenderer().name + '-' +
-      this.getTheme().name);
+  this.renderer_.createDom(this.svgGroup_, this.getTheme());
   return this.svgGroup_;
 };
 
@@ -802,7 +800,7 @@ Blockly.WorkspaceSvg.prototype.dispose = function() {
     this.grid_ = null;
   }
 
-  this.renderer_.getConstants().dispose();
+  this.renderer_.dispose();
 
   if (this.themeManager_) {
     this.themeManager_.unsubscribeWorkspace(this);

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -218,8 +218,12 @@ suite('Text Input Fields', function() {
         this.prepField = function(field) {
           var workspace = {
             scale: 1,
-            getRenderer: function() { return {}; },
-            getTheme: function() { return {}; },
+            getRenderer: function() { return {
+              getClassName: function() { return ''; }
+            }; },
+            getTheme: function() { return {
+              getClassName: function() { return ''; }
+            }; },
             markFocused: function() {}
           };
           field.sourceBlock_ = {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

If we have multiple renderers with different themes, they begin to interfere with each other as all renderers of the same type share the CSS.

### Proposed Changes

Making it so that each renderer/theme combo share CSS on the page, and no renderer disposes of the CSS when it is disposed (only clears reference to it). This is because we don't know if another workspace is making use of it.

### Reason for Changes

Noticed in design meetings that multi workspaces with differing renderers / themes was broken.

### Test Coverage

Tested in multi playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
