### PR TITLE
Position zelos marker svg on top of connection point

### DIFF
--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -39,9 +39,7 @@ Blockly.zelos.MarkerSvg.prototype.showWithInput_ = function(curNode) {
   var connection = curNode.getLocation();
   var offsetInBlock = connection.getOffsetInBlock();
 
-  var y = offsetInBlock.y + this.constants_.CURSOR_RADIUS;
-  
-  this.positionCircle_(offsetInBlock.x, y);
+  this.positionCircle_(offsetInBlock.x, offsetInBlock.y);
   this.setParent_(block);
   this.showCurrent_();
 };


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<img width="549" alt="Screen Shot 2020-03-12 at 12 13 05 am" src="https://user-images.githubusercontent.com/16690124/76496489-67097880-63f6-11ea-9fd7-6c7c78402758.png">


### Proposed Changes

Position the zeros circle marker in the middle on top of the connection point.

### Reason for Changes

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
