### PR TITLE
[Zelos] Value to stack block support

### DIFF
--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -60,6 +60,10 @@ Blockly.zelos.Drawer.prototype.draw = function() {
     // Store the output connection shape type for parent blocks to use during
     // rendering.
     pathObject.outputShapeType = this.info_.outputConnection.shape.type;
+    if (this.info_.bottomRow.hasNextConnection) {
+      // Store the height of the block for parent blocks to use.
+      pathObject.blockHeight = this.info_.height;
+    }
   }
   pathObject.endDrawing();
 };
@@ -70,7 +74,8 @@ Blockly.zelos.Drawer.prototype.draw = function() {
 Blockly.zelos.Drawer.prototype.drawOutline_ = function() {
   if (this.info_.outputConnection &&
       this.info_.outputConnection.isDynamicShape &&
-      !this.info_.hasStatementInput) {
+      !this.info_.hasStatementInput &&
+      !this.info_.bottomRow.hasNextConnection) {
     this.drawFlatTop_();
     this.drawRightDynamicConnection_();
     this.drawFlatBottom_();

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -60,10 +60,6 @@ Blockly.zelos.Drawer.prototype.draw = function() {
     // Store the output connection shape type for parent blocks to use during
     // rendering.
     pathObject.outputShapeType = this.info_.outputConnection.shape.type;
-    if (this.info_.bottomRow.hasNextConnection) {
-      // Store the height of the block for parent blocks to use.
-      pathObject.blockHeight = this.info_.height;
-    }
   }
   pathObject.endDrawing();
 };

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -385,7 +385,7 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
       this.outputConnection.shape.connectionOffsetX(connectionWidth);
 
   // Adjust right side measurable.
-  if (!this.hasStatementInput) {
+  if (!this.hasStatementInput && !this.bottomRow.hasNextConnection) {
     this.rightSide.height = connectionHeight;
     this.rightSide.width = connectionWidth;
     this.rightSide.centerline = connectionHeight / 2;

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -160,7 +160,7 @@ Blockly.zelos.RenderInfo.prototype.getInRowSpacing_ = function(prev, next) {
     // No need for padding at the beginning or end of the row if the
     // output shape is dynamic.
     if (this.outputConnection && this.outputConnection.isDynamicShape &&
-        !this.hasStatementInput) {
+        !this.hasStatementInput && !this.bottomRow.hasNextConnection) {
       return this.constants_.NO_PADDING;
     }
   }
@@ -247,6 +247,13 @@ Blockly.zelos.RenderInfo.prototype.getSpacerRowWidth_ = function(prev, next) {
 Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
   if (row.hasStatement && !Blockly.blockRendering.Types.isSpacer(elem)) {
     return row.yPos + this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT / 2;
+  }
+  if (Blockly.blockRendering.Types.isInlineInput(elem)) {
+    var connectedBlock = elem.connectedBlock;
+    if (connectedBlock && connectedBlock.outputConnection &&
+        connectedBlock.nextConnection) {
+      return row.yPos + connectedBlock.pathObject.blockHeight / 2;
+    }
   }
   return Blockly.zelos.RenderInfo.superClass_.getElemCenterline_.call(this,
       row, elem);
@@ -364,8 +371,10 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
   this.height = yCursor;
 
   // Adjust the height of the output connection.
-  var connectionHeight = this.outputConnection.shape.height(yCursor);
-  var connectionWidth = this.outputConnection.shape.width(yCursor);
+  var blockHeight = this.bottomRow.hasNextConnection ?
+      this.height - this.bottomRow.descenderHeight : this.height;
+  var connectionHeight = this.outputConnection.shape.height(blockHeight);
+  var connectionWidth = this.outputConnection.shape.width(blockHeight);
 
   this.outputConnection.height = connectionHeight;
   this.outputConnection.width = connectionWidth;
@@ -396,7 +405,8 @@ Blockly.zelos.RenderInfo.prototype.finalizeOutputConnection_ = function() {
  * @protected
  */
 Blockly.zelos.RenderInfo.prototype.finalizeHorizontalAlignment_ = function() {
-  if (!this.outputConnection || this.hasStatementInput) {
+  if (!this.outputConnection || this.hasStatementInput ||
+      this.bottomRow.hasNextConnection) {
     return;
   }
   var totalNegativeSpacing = 0;
@@ -470,9 +480,15 @@ Blockly.zelos.RenderInfo.prototype.getNegativeSpacing_ = function(elem) {
     }
   }
   if (Blockly.blockRendering.Types.isInlineInput(elem)) {
-    var innerShape = elem.connectedBlock ?
-        elem.connectedBlock.pathObject.outputShapeType :
+    var connectedBlock = elem.connectedBlock;
+    var innerShape = connectedBlock ?
+        connectedBlock.pathObject.outputShapeType :
         elem.shape.type;
+    // Special case for value to stack / value to statement blocks.
+    if (connectedBlock && connectedBlock.outputConnection &&
+        (connectedBlock.statementInputCount || connectedBlock.nextConnection)) {
+      return 0;
+    }
     // Special case for hexagonal output.
     if (outerShape == constants.SHAPES.HEXAGONAL &&
         outerShape != innerShape) {

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -252,7 +252,7 @@ Blockly.zelos.RenderInfo.prototype.getElemCenterline_ = function(row, elem) {
     var connectedBlock = elem.connectedBlock;
     if (connectedBlock && connectedBlock.outputConnection &&
         connectedBlock.nextConnection) {
-      return row.yPos + connectedBlock.pathObject.blockHeight / 2;
+      return row.yPos + connectedBlock.height / 2;
     }
   }
   return Blockly.zelos.RenderInfo.superClass_.getElemCenterline_.call(this,

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -62,7 +62,8 @@ Blockly.zelos.TopRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.TopRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.statementInputCount;
+  return !!block.outputConnection && !block.statementInputCount &&
+    !block.nextConnection;
 };
 
 /**
@@ -102,5 +103,6 @@ Blockly.zelos.BottomRow.prototype.hasLeftSquareCorner = function(block) {
  * @override
  */
 Blockly.zelos.BottomRow.prototype.hasRightSquareCorner = function(block) {
-  return !!block.outputConnection && !block.statementInputCount;
+  return !!block.outputConnection && !block.statementInputCount &&
+    !block.nextConnection;
 };

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -67,19 +67,9 @@ Blockly.zelos.PathObject = function(root, style, constants) {
   /**
    * The type of block's output connection shape.  This is set when a block with
    * an output connection is drawn.
-   * @type {?number}
    * @package
    */
   this.outputShapeType = null;
-
-  /**
-   * The height of the block.  This is set when a block with an output
-   * connection and a next connection is drawn to be referenced during
-   * rendering.
-   * @type {?number}
-   * @package
-   */
-  this.blockHeight = null;
 };
 Blockly.utils.object.inherits(Blockly.zelos.PathObject,
     Blockly.blockRendering.PathObject);

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -67,9 +67,19 @@ Blockly.zelos.PathObject = function(root, style, constants) {
   /**
    * The type of block's output connection shape.  This is set when a block with
    * an output connection is drawn.
+   * @type {?number}
    * @package
    */
   this.outputShapeType = null;
+
+  /**
+   * The height of the block.  This is set when a block with an output
+   * connection and a next connection is drawn to be referenced during
+   * rendering.
+   * @type {?number}
+   * @package
+   */
+  this.blockHeight = null;
 };
 Blockly.utils.object.inherits(Blockly.zelos.PathObject,
     Blockly.blockRendering.PathObject);


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This is what it looks like today:
<img width="318" alt="Screen Shot 2020-03-12 at 12 26 47 am" src="https://user-images.githubusercontent.com/16690124/76497979-40990c80-63f9-11ea-9c93-3a4112d15082.png">

### Proposed Changes

Similar to value to statement blocks, add checks to skip right side rendering of the block if we have an output connection + next statement.
<img width="419" alt="Screen Shot 2020-03-12 at 12 00 55 am" src="https://user-images.githubusercontent.com/16690124/76498001-4abb0b00-63f9-11ea-8c9b-064c3d697c4d.png">

### Reason for Changes

Zelos rendering.

### Test Coverage

Tested in playground with the value to stack block.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="371" alt="Screen Shot 2020-03-12 at 12 38 59 am" src="https://user-images.githubusercontent.com/16690124/76498347-f1071080-63f9-11ea-8e60-be9af4e34ff6.png">

