### PR TITLE
Update rendering playground to use rendererOverrides

### DIFF
--- a/tests/rendering/zelos/pxtblockly/zelos.html
+++ b/tests/rendering/zelos/pxtblockly/zelos.html
@@ -5,26 +5,6 @@
   <script type="text/javascript" src="https://unpkg.com/pxt-blockly@2.1.12/blocks_compressed.js"></script>
   <script type="text/javascript" src="https://unpkg.com/pxt-blockly@2.1.12/msg/messages.js"></script>
   <script type="text/javascript" src="../../../playgrounds/screenshot.js"></script>
-
-  <style id="blocklycss">
-    .blocklyText,
-    .blocklyHtmlInput {
-      font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;
-      font-weight: bold;
-      font-size: 12pt;
-    }
-
-    .blocklyNonEditableText>text,
-    .blocklyEditableText>text,
-    .blocklyNonEditableText>g>text,
-    .blocklyEditableText>g>text {
-      fill: #575E75;
-    }
-
-    .blocklyHtmlInput {
-      color: #575E75;
-    }
-  </style>
 </head>
 
 <body>
@@ -33,10 +13,6 @@
     goog.require('Blockly.blockRendering.Debug');
     goog.require('Blockly.zelos.Renderer');
     // Blockly.blockRendering.startDebugger();
-
-    // This stub is a workaround in order to load pxt-blockly blocks, as they
-    // rely on a setOutputShape method on the block.
-    Blockly.BlockSvg.prototype.setOutputShape = function() { };
 
     var blocklyDiv = document.getElementById('blocklyDiv');
     var workspace;
@@ -56,6 +32,11 @@
 
       workspace = Blockly.inject(blocklyDiv, {
         renderer: 'zelos',
+        rendererOverrides: {
+          'FIELD_TEXT_FONTFAMILY': '"Helvetica Neue", "Segoe UI", Helvetica, sans-serif',
+          'FIELD_TEXT_FONTWEIGHT': 'bold',
+          'FIELD_TEXT_FONTSIZE': 12
+        },
         move: {
           scrollbars: true,
           drag: true,
@@ -66,10 +47,6 @@
           startScale: 2,
         }
       });
-      var constants = workspace.getRenderer().getConstants();
-      constants.FIELD_TEXT_FONTSIZE = 12;
-      constants.FIELD_TEXT_FONTWEIGHT = 'bold';
-      constants.FIELD_TEXT_FONTFAMILY = 'Helvetica Neue';
 
       Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
 
@@ -82,7 +59,7 @@
               from: 'zelos',
               text: datauri
             }, '*');
-          }, document.getElementById('blocklycss').innerText);
+          });
         } catch (err) {
           console.error(err);
         }

--- a/tests/rendering/zelos/scratchblocks/zelos.html
+++ b/tests/rendering/zelos/scratchblocks/zelos.html
@@ -7,31 +7,6 @@
   <script type="text/javascript"
     src="https://unpkg.com/scratch-blocks@0.1.0-prerelease.1578322100/msg/messages.js"></script>
   <script type="text/javascript" src="../../../playgrounds/screenshot.js"></script>
-
-  <style id="blocklycss">
-    .blocklyText,
-    .blocklyHtmlInput {
-      font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;
-      font-weight: bold;
-      font-size: 12pt;
-    }
-
-    .blocklyNonEditableText>text,
-    .blocklyEditableText>text,
-    .blocklyNonEditableText>g>text,
-    .blocklyEditableText>g>text {
-      fill: #575E75;
-    }
-
-    .blocklyHtmlInput {
-      color: #575E75;
-    }
-    .zelos-renderer .blocklyText {
-      font-weight: 500 !important;
-    }
-  </style>
-
-
   <script>
 
     Blockly.Block.prototype.setColourFromRawValues_ = function (primary, secondary,
@@ -62,10 +37,6 @@
     goog.require('Blockly.zelos.Renderer');
     // Blockly.blockRendering.startDebugger();
 
-    // This stub is a workaround in order to load pxt-blockly blocks, as they
-    // rely on a setOutputShape method on the block.
-    Blockly.BlockSvg.prototype.setOutputShape = function () { };
-
     var blocklyDiv = document.getElementById('blocklyDiv');
     var workspace;
     window.addEventListener('message', function (msg) {
@@ -84,6 +55,13 @@
 
       workspace = Blockly.inject(blocklyDiv, {
         renderer: 'zelos',
+        rendererOverrides: {
+          'FIELD_TEXT_FONTFAMILY': 'Helvetica Neue',
+          'FIELD_TEXT_FONTWEIGHT': '500',
+          'FIELD_TEXT_FONTSIZE': 12,
+          'FIELD_BORDER_RECT_X_PADDING': 2.75 * 4,
+          'ADD_START_HATS': true
+        },
         move: {
           scrollbars: true,
           drag: true,
@@ -95,14 +73,6 @@
         },
         media: 'https://unpkg.com/scratch-blocks@0.1.0-prerelease.1578322100/media/'
       });
-      var constants = workspace.getRenderer().getConstants();
-      constants.FIELD_TEXT_FONTSIZE = 12;
-      constants.FIELD_TEXT_FONTWEIGHT = '500';
-      constants.FIELD_TEXT_FONTFAMILY = 'Helvetica Neue';
-
-      constants.FIELD_BORDER_RECT_X_PADDING = 2.75 * constants.GRID_UNIT;
-
-      constants.ADD_START_HATS = true;
 
       Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
 
@@ -115,7 +85,7 @@
               from: 'zelos',
               text: datauri
             }, '*');
-          }, document.getElementById('blocklycss').innerText);
+          });
         } catch (err) {
           console.error(err);
         }

--- a/tests/rendering/zelos/zelos.html
+++ b/tests/rendering/zelos/zelos.html
@@ -5,26 +5,6 @@
   <script type="text/javascript" src="https://unpkg.com/pxt-blockly@2.1.12/blocks_compressed.js"></script>
   <script type="text/javascript" src="https://unpkg.com/pxt-blockly@2.1.12/msg/messages.js"></script>
   <script type="text/javascript" src="../../playgrounds/screenshot.js"></script>
-
-  <style id="blocklycss">
-    .blocklyText,
-    .blocklyHtmlInput {
-      font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;
-      font-weight: bold;
-      font-size: 12pt;
-    }
-
-    .blocklyNonEditableText>text,
-    .blocklyEditableText>text,
-    .blocklyNonEditableText>g>text,
-    .blocklyEditableText>g>text {
-      fill: #575E75;
-    }
-
-    .blocklyHtmlInput {
-      color: #575E75;
-    }
-  </style>
 </head>
 
 <body>
@@ -33,10 +13,6 @@
     goog.require('Blockly.blockRendering.Debug');
     goog.require('Blockly.zelos.Renderer');
     // Blockly.blockRendering.startDebugger();
-
-    // This stub is a workaround in order to load pxt-blockly blocks, as they
-    // rely on a setOutputShape method on the block.
-    Blockly.BlockSvg.prototype.setOutputShape = function() { };
 
     var blocklyDiv = document.getElementById('blocklyDiv');
     var workspace;
@@ -56,6 +32,11 @@
 
       workspace = Blockly.inject(blocklyDiv, {
         renderer: 'zelos',
+        rendererOverrides: {
+          'FIELD_TEXT_FONTFAMILY': '"Helvetica Neue", "Segoe UI", Helvetica, sans-serif',
+          'FIELD_TEXT_FONTWEIGHT': 'bold',
+          'FIELD_TEXT_FONTSIZE': 12
+        },
         move: {
           scrollbars: true,
           drag: true,
@@ -66,10 +47,6 @@
           startScale: 2,
         }
       });
-      var constants = workspace.getRenderer().getConstants();
-      constants.FIELD_TEXT_FONTSIZE = 12;
-      constants.FIELD_TEXT_FONTWEIGHT = 'bold';
-      constants.FIELD_TEXT_FONTFAMILY = 'Helvetica Neue';
 
       Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
 
@@ -82,7 +59,7 @@
               from: 'zelos',
               text: datauri
             }, '*');
-          }, document.getElementById('blocklycss').innerText);
+          });
         } catch (err) {
           console.error(err);
         }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Keep our rendering playground up to date and have it use the new renderer overrides. 

### Reason for Changes

Keep our tests up to date.

### Test Coverage


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
