### PR TITLE
Fix two memory leaks

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -291,6 +291,7 @@ Blockly.BlockDragger.prototype.maybeDeleteBlock_ = function() {
     // Fire a move event, so we know where to go back to for an undo.
     this.fireMoveEvent_();
     this.draggingBlock_.dispose(false, true);
+    Blockly.draggingConnections = [];
   } else if (trashcan) {
     // Make sure the trash can is closed.
     trashcan.close();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -986,6 +986,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   Blockly.utils.dom.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();
   // Sever JavaScript to DOM connections.
+  this.pathObject = null;
   this.svgGroup_ = null;
   Blockly.utils.dom.stopTextWidthCache();
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -943,7 +943,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     // The block has already been deleted.
     return;
   }
-  Blockly.Tooltip.hide();
+  Blockly.Tooltip.dispose();
   Blockly.utils.dom.startTextWidthCache();
   // Save the block's workspace temporarily so we can resize the
   // contents once the block is disposed.
@@ -983,10 +983,12 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   }
   Blockly.BlockSvg.superClass_.dispose.call(this, !!healStack);
 
+  // This is needed to resolve the circular dependency through tooltip.
+  this.pathObject.svgPath.tooltip = null;
+
   Blockly.utils.dom.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();
   // Sever JavaScript to DOM connections.
-  this.pathObject = null;
   this.svgGroup_ = null;
   Blockly.utils.dom.stopTextWidthCache();
 };

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -944,6 +944,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     return;
   }
   Blockly.Tooltip.dispose();
+  Blockly.Tooltip.unbindMouseEvents(this.pathObject.svgPath);
   Blockly.utils.dom.startTextWidthCache();
   // Save the block's workspace temporarily so we can resize the
   // contents once the block is disposed.
@@ -982,9 +983,6 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
     icons[i].dispose();
   }
   Blockly.BlockSvg.superClass_.dispose.call(this, !!healStack);
-
-  // This is needed to resolve the circular dependency through tooltip.
-  this.pathObject.svgPath.tooltip = null;
 
   Blockly.utils.dom.removeNode(this.svgGroup_);
   blockWorkspace.resizeContents();

--- a/core/connection.js
+++ b/core/connection.js
@@ -195,9 +195,10 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
  */
 Blockly.Connection.prototype.dispose = function() {
 
+  this.setShadowDom(null);
+
   // isConnected returns true for shadows and non-shadows.
   if (this.isConnected()) {
-    this.setShadowDom(null);
     var targetBlock = this.targetBlock();
     if (targetBlock.isShadow()) {
       // Destroy the attached shadow block & its children.

--- a/core/connection.js
+++ b/core/connection.js
@@ -195,10 +195,9 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
  */
 Blockly.Connection.prototype.dispose = function() {
 
-  this.setShadowDom(null);
-
   // isConnected returns true for shadows and non-shadows.
   if (this.isConnected()) {
+    this.setShadowDom(null);
     var targetBlock = this.targetBlock();
     if (targetBlock.isShadow()) {
       // Destroy the attached shadow block & its children.

--- a/core/field.js
+++ b/core/field.js
@@ -394,6 +394,7 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 Blockly.Field.prototype.dispose = function() {
   Blockly.DropDownDiv.hideIfOwner(this);
   Blockly.WidgetDiv.hideIfOwner(this);
+  Blockly.Tooltip.unbindMouseEvents(this.getClickTarget_());
 
   if (this.mouseDownWrapper_) {
     Blockly.unbindEvent_(this.mouseDownWrapper_);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -548,7 +548,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   for (var j = 0; j < this.mats_.length; j++) {
     var rect = this.mats_[j];
     if (rect) {
-      rect.tooltip = null;
+      Blockly.Tooltip.unbindMouseEvents(rect);
       Blockly.utils.dom.removeNode(rect);
     }
   }

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -548,6 +548,7 @@ Blockly.Flyout.prototype.clearOldBlocks_ = function() {
   for (var j = 0; j < this.mats_.length; j++) {
     var rect = this.mats_[j];
     if (rect) {
+      rect.tooltip = null;
       Blockly.utils.dom.removeNode(rect);
     }
   }

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -129,15 +129,28 @@ Blockly.Tooltip.createDom = function() {
  * @param {!Element} element SVG element onto which tooltip is to be bound.
  */
 Blockly.Tooltip.bindMouseEvents = function(element) {
-  Blockly.bindEvent_(element, 'mouseover', null,
+  element.mouseOverWrapper_ = Blockly.bindEvent_(element, 'mouseover', null,
       Blockly.Tooltip.onMouseOver_);
-  Blockly.bindEvent_(element, 'mouseout', null,
+  element.mouseOutWrapper_ = Blockly.bindEvent_(element, 'mouseout', null,
       Blockly.Tooltip.onMouseOut_);
 
   // Don't use bindEvent_ for mousemove since that would create a
   // corresponding touch handler, even though this only makes sense in the
   // context of a mouseover/mouseout.
   element.addEventListener('mousemove', Blockly.Tooltip.onMouseMove_, false);
+};
+
+/**
+ * Unbinds tooltip mouse events from the SVG element.
+ * @param {!Element} element SVG element onto which tooltip is bound.
+ */
+Blockly.Tooltip.unbindMouseEvents = function(element) {
+  if (!element) {
+    return;
+  }
+  Blockly.unbindEvent_(element.mouseOverWrapper_);
+  Blockly.unbindEvent_(element.mouseOutWrapper_);
+  element.removeEventListener('mousemove', Blockly.Tooltip.onMouseMove_);
 };
 
 /**

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -224,6 +224,16 @@ Blockly.Tooltip.onMouseMove_ = function(e) {
 };
 
 /**
+ * Dispose of the tooltip.
+ * @package
+ */
+Blockly.Tooltip.dispose = function() {
+  Blockly.Tooltip.element_ = null;
+  Blockly.Tooltip.poisonedElement_ = null;
+  Blockly.Tooltip.hide();
+};
+
+/**
  * Hide the tooltip.
  */
 Blockly.Tooltip.hide = function() {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

2 memory leaks

### Proposed Changes

Connection.js: 
Generally connections are disconnected in block_svg's dispose method before they are disposed (eg: dragging a block into the trash can). Only setting the shadowDom_ to null if its connected does not suffice, and leaves around detached elements.

Block_svg.js
A path object maintains a reference to a block's svgRoot. Not disposing of the path object leaves around detached nodes.

### Reason for Changes

Performance.

### Test Coverage

Tested with the chrome memory tools.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
