### PR TITLE
[DEMO NO MERGE] Decouple procedure callers from mutator UI implemenation Mk2

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -852,7 +852,10 @@ Blockly.Field.prototype.setValue = function(newValue) {
     return;
   }
 
-  if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
+  if (this.sourceBlock_ &&
+      !this.sourceBlock_.disposed &&
+      Blockly.Events.isEnabled()
+  ) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
         this.sourceBlock_, 'field', this.name || null, oldValue, newValue));
   }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -371,7 +371,7 @@ Blockly.Procedures.mutateCallers = function(defBlock) {
   var procedureBlock = /** @type {!Blockly.Procedures.ProcedureBlock} */ (
     defBlock);
   var name = procedureBlock.getProcedureDef()[0];
-  var xmlElement = defBlock.mutationToDom(true);
+  var xmlElement = defBlock.mutationToDom();
   var callers = Blockly.Procedures.getCallers(name, defBlock.workspace);
   for (var i = 0, caller; (caller = callers[i]); i++) {
     var oldMutationDom = caller.mutationToDom();


### PR DESCRIPTION
## Basics
This is just a demo showing how the procedure callers could be generalized so that they are no longer tightly coupled to Blockly's current mutator-ui implimentation.

This is not for merging, and will be closed immediately after it is opened.

## Description
### Background
See #3724 

### Solution
This solution gives each parameter an ID that is separate from both the variable ID and the mutator block ID. It is very similar to the previous demo, but this one avoids coalescing vars accidentally.

This implementation brings back onFinishEditing. It's not necessarily necessary, you could handle deleting the previous var inside the validator. But I thought this was easier.

---
I think this is a pretty good for a demo, but if this was actually for PR there are still things I would want to clean up. Deleting arguments sometimes leaves unused vars in the flyout (although I think this happens on master). And I would want to explore refactoring `mutateCallers`.