### PR TITLE
Insertion marker properties in theme

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -917,7 +917,8 @@ Blockly.BlockSvg.prototype.setInsertionMarker = function(insertionMarker) {
   }
   this.isInsertionMarker_ = insertionMarker;
   if (this.isInsertionMarker_) {
-    this.setColour(Blockly.INSERTION_MARKER_COLOUR);
+    this.setColour(this.workspace.getRenderer().getConstants().
+        INSERTION_MARKER_COLOUR);
     this.pathObject.updateInsertionMarker(true);
   }
 };

--- a/core/constants.js
+++ b/core/constants.js
@@ -55,12 +55,6 @@ Blockly.CONNECTING_SNAP_RADIUS = Blockly.SNAP_RADIUS;
 Blockly.CURRENT_CONNECTION_PREFERENCE = 8;
 
 /**
- * The main colour of insertion markers, in hex.  The block is rendered a
- * transparent grey by changing the fill opacity in CSS.
- */
-Blockly.INSERTION_MARKER_COLOUR = '#000000';
-
-/**
  * Delay in ms between trigger and bumping unconnected block out of alignment.
  */
 Blockly.BUMP_DELAY = 250;

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -255,16 +255,18 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
     }
     result.setCollapsed(sourceBlock.isCollapsed());
     result.setInputsInline(sourceBlock.getInputsInline());
-    // Copy field values from the other block.  These values may impact the
-    // rendered size of the insertion marker.  Note that we do not care about
-    // child blocks here.
+    // Copy visible field values from the other block.  These values may impact
+    // the rendered size of the insertion marker.  Note that we do not care
+    // about child blocks here.
     for (var i = 0; i < sourceBlock.inputList.length; i++) {
       var sourceInput = sourceBlock.inputList[i];
-      var resultInput = result.inputList[i];
-      for (var j = 0; j < sourceInput.fieldRow.length; j++) {
-        var sourceField = sourceInput.fieldRow[j];
-        var resultField = resultInput.fieldRow[j];
-        resultField.setValue(sourceField.getValue());
+      if (sourceInput.isVisible()) {
+        var resultInput = result.inputList[i];
+        for (var j = 0; j < sourceInput.fieldRow.length; j++) {
+          var sourceField = sourceInput.fieldRow[j];
+          var resultField = resultInput.fieldRow[j];
+          resultField.setValue(sourceField.getValue());
+        }
       }
     }
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -651,7 +651,7 @@ Blockly.blockRendering.ConstantProvider.prototype.setComponentConstants_ =
     theme.getComponentStyle('insertionMarkerColour') ||
     this.INSERTION_MARKER_COLOUR;
   this.INSERTION_MARKER_OPACITY =
-    theme.getComponentStyle('insertionMarkerOpacity') ||
+    Number(theme.getComponentStyle('insertionMarkerOpacity')) ||
     this.INSERTION_MARKER_OPACITY;
 }; /* eslint-enable indent */
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -503,6 +503,21 @@ Blockly.blockRendering.ConstantProvider = function() {
   this.FULL_BLOCK_FIELDS = false;
 
   /**
+   * The main colour of insertion markers, in hex.  The block is rendered a
+   * transparent grey by changing the fill opacity in CSS.
+   * @type {string}
+   * @package
+   */
+  this.INSERTION_MARKER_COLOUR = '#000000';
+
+  /**
+   * The insertion marker opacity.
+   * @type {number}
+   * @package
+   */
+  this.INSERTION_MARKER_OPACITY = 0.2;
+
+  /**
    * Enum for connection shapes.
    * @enum {number}
    */
@@ -588,7 +603,7 @@ Blockly.blockRendering.ConstantProvider.prototype.setDynamicProperties_ =
     function(theme) {
     /* eslint-disable indent */
   this.setFontConstants_(theme);
-  this.setAccessibilityConstants_(theme);
+  this.setComponentConstants_(theme);
 
   this.ADD_START_HATS = theme.startHats != null ? theme.startHats :
       this.ADD_START_HATS;
@@ -621,17 +636,23 @@ Blockly.blockRendering.ConstantProvider.prototype.setFontConstants_ = function(
 };
 
 /**
- * Set constants related to accessibility.
+ * Set constants from a theme's component styles.
  * @param {!Blockly.Theme} theme The current workspace theme.
  * @protected
  */
-Blockly.blockRendering.ConstantProvider.prototype.setAccessibilityConstants_ =
+Blockly.blockRendering.ConstantProvider.prototype.setComponentConstants_ =
     function(theme) {
     /* eslint-disable indent */
   this.CURSOR_COLOUR = theme.getComponentStyle('cursorColour') ||
     this.CURSOR_COLOUR;
   this.MARKER_COLOUR = theme.getComponentStyle('markerColour') ||
     this.MARKER_COLOUR;
+  this.INSERTION_MARKER_COLOUR =
+    theme.getComponentStyle('insertionMarkerColour') ||
+    this.INSERTION_MARKER_COLOUR;
+  this.INSERTION_MARKER_OPACITY =
+    theme.getComponentStyle('insertionMarkerOpacity') ||
+    this.INSERTION_MARKER_OPACITY;
 }; /* eslint-enable indent */
 
 /**
@@ -1196,6 +1217,12 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
     selector + ' .blocklyReplaceable .blocklyPathLight,',
     selector + ' .blocklyReplaceable .blocklyPathDark {',
       'display: none;',
+    '}',
+
+    // Insertion marker.
+    selector + ' .blocklyInsertionMarker>.blocklyPath {',
+      'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
+      'stroke: none',
     '}',
     /* eslint-enable indent */
   ];

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -44,3 +44,21 @@ Blockly.geras.ConstantProvider = function() {
 };
 Blockly.utils.object.inherits(Blockly.geras.ConstantProvider,
     Blockly.blockRendering.ConstantProvider);
+
+
+/**
+ * @override
+ */
+Blockly.geras.ConstantProvider.prototype.getCSS_ = function(selector) {
+  return Blockly.geras.ConstantProvider.superClass_.getCSS_.call(this, selector)
+      .concat([
+        /* eslint-disable indent */
+        // Insertion marker.
+        selector + ' .blocklyInsertionMarker>.blocklyPathLight,',
+        selector + ' .blocklyInsertionMarker>.blocklyPathDark {',
+          'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
+          'stroke: none',
+        '}',
+        /* eslint-enable indent */
+      ]);
+};

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -965,6 +965,12 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
     selector + ' .blocklyDisabled > .blocklyOutlinePath {',
       'fill: url(#blocklyDisabledPattern' + this.randomIdentifier + ')',
     '}',
+
+    // Insertion marker.
+    selector + ' .blocklyInsertionMarker>.blocklyPath {',
+      'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
+      'stroke: none',
+    '}',
     /* eslint-enable indent */
   ];
 };

--- a/core/theme.js
+++ b/core/theme.js
@@ -105,6 +105,8 @@ Blockly.Theme.CategoryStyle;
  *            flyoutOpacity:number?,
  *            scrollbarColour:string?,
  *            scrollbarOpacity:number?,
+ *            insertionMarkerColour:string?,
+ *            insertionMarkerOpacity:number?,
  *            markerColour:string?,
  *            cursorColour:string?
  *          }}
@@ -202,6 +204,7 @@ Blockly.Theme.defineTheme = function(name, themeObj) {
   var base = themeObj['base'];
   if (base && base instanceof Blockly.Theme) {
     Blockly.utils.object.deepMerge(theme, base);
+    theme.name = name;
   }
   
   Blockly.utils.object.deepMerge(theme.blockStyles,

--- a/core/theme.js
+++ b/core/theme.js
@@ -112,7 +112,7 @@ Blockly.Theme.CategoryStyle;
  *            selectedGlowColour:string?,
  *            selectedGlowOpacity:number?,
  *            replacementGlowColour:string?,
- *            replacementGlowOpacity:number?,
+ *            replacementGlowOpacity:number?
  *          }}
  */
 Blockly.Theme.ComponentStyle;

--- a/core/theme.js
+++ b/core/theme.js
@@ -108,7 +108,11 @@ Blockly.Theme.CategoryStyle;
  *            insertionMarkerColour:string?,
  *            insertionMarkerOpacity:number?,
  *            markerColour:string?,
- *            cursorColour:string?
+ *            cursorColour:string?,
+ *            selectedGlowColour:string?,
+ *            selectedGlowOpacity:number?,
+ *            replacementGlowColour:string?,
+ *            replacementGlowOpacity:number?,
  *          }}
  */
 Blockly.Theme.ComponentStyle;

--- a/core/theme/dark.js
+++ b/core/theme/dark.js
@@ -24,6 +24,8 @@ Blockly.Themes.Dark = Blockly.Theme.defineTheme('dark', {
     'flyoutForegroundColour': '#ccc',
     'flyoutOpacity': 1,
     'scrollbarColour': '#797979',
+    'insertionMarkerColour': '#fff',
+    'insertionMarkerOpacity': 0.3,
     'scrollbarOpacity': 0.4,
     'cursorColour': '#d0d0d0'
   }


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/3113

### Proposed Changes

Moving insertion marker colour and opacity from global constants, into a theme property.

### Reason for Changes

Colours should live in theme.

### Test Coverage

Tested in playground and with dark theme.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
