### PR TITLE
Move registering objects to constructor

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -105,6 +105,22 @@ Blockly.WorkspaceSvg = function(options,
    */
   this.markerManager_ = new Blockly.MarkerManager(this);
 
+  /**
+  * Map from function names to callbacks, for deciding what to do when a custom
+  * toolbox category is opened.
+  * @type {!Object.<string, ?function(!Blockly.Workspace):!Array.<!Element>>}
+  * @private
+  */
+  this.toolboxCategoryCallbacks_ = {};
+
+  /**
+  * Map from function names to callbacks, for deciding what to do when a button
+  * is clicked.
+  * @type {!Object.<string, ?function(!Blockly.FlyoutButton)>}
+  * @private
+  */
+  this.flyoutButtonCallbacks_ = {};
+
   if (Blockly.Variables && Blockly.Variables.flyoutCategory) {
     this.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME,
         Blockly.Variables.flyoutCategory);
@@ -373,22 +389,6 @@ Blockly.WorkspaceSvg.prototype.injectionDiv_ = null;
  * @private
  */
 Blockly.WorkspaceSvg.prototype.lastRecordedPageScroll_ = null;
-
-/**
- * Map from function names to callbacks, for deciding what to do when a button
- * is clicked.
- * @type {!Object.<string, ?function(!Blockly.FlyoutButton)>}
- * @private
- */
-Blockly.WorkspaceSvg.prototype.flyoutButtonCallbacks_ = {};
-
-/**
- * Map from function names to callbacks, for deciding what to do when a custom
- * toolbox category is opened.
- * @type {!Object.<string, ?function(!Blockly.Workspace):!Array.<!Element>>}
- * @private
- */
-Blockly.WorkspaceSvg.prototype.toolboxCategoryCallbacks_ = {};
 
 /**
  * Developers may define this function to add custom menu options to the


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Running into the problem when calling registerToolboxCategoryCallback and registerButtonCallback where it was registering them for all workspaces. 

### Proposed Changes
Move flyoutButtonCallbacks_ and toolboxCategoryCallbacks_ to the constructor instead of having them on the prototype.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
