### PR TITLE
Fix inner html

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -193,7 +193,7 @@ Blockly.DropDownDiv.getContentDiv = function() {
  * Clear the content of the drop-down.
  */
 Blockly.DropDownDiv.clearContent = function() {
-  Blockly.DropDownDiv.content_.innerHTML = '';
+  Blockly.DropDownDiv.content_.innerText = '';
   Blockly.DropDownDiv.content_.style.width = '';
 };
 

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -193,7 +193,7 @@ Blockly.DropDownDiv.getContentDiv = function() {
  * Clear the content of the drop-down.
  */
 Blockly.DropDownDiv.clearContent = function() {
-  Blockly.DropDownDiv.content_.innerText = '';
+  Blockly.DropDownDiv.content_.textContent = '';
   Blockly.DropDownDiv.content_.style.width = '';
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -294,7 +294,7 @@ Blockly.Tooltip.show_ = function() {
     return;
   }
   // Erase all existing text.
-  Blockly.Tooltip.DIV.innerHTML = '';
+  Blockly.Tooltip.DIV.innerText = '';
   // Get the new text.
   var tip = Blockly.Tooltip.element_.tooltip;
   while (typeof tip == 'function') {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -294,7 +294,7 @@ Blockly.Tooltip.show_ = function() {
     return;
   }
   // Erase all existing text.
-  Blockly.Tooltip.DIV.innerText = '';
+  Blockly.Tooltip.DIV.textContent = '';
   // Get the new text.
   var tip = Blockly.Tooltip.element_.tooltip;
   while (typeof tip == 'function') {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -102,7 +102,7 @@ Blockly.WidgetDiv.hide = function() {
   div.style.top = '';
   Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
   Blockly.WidgetDiv.dispose_ = null;
-  div.innerText = '';
+  div.textContent = '';
 
   if (Blockly.WidgetDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.rendererClassName_);

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -102,7 +102,7 @@ Blockly.WidgetDiv.hide = function() {
   div.style.top = '';
   Blockly.WidgetDiv.dispose_ && Blockly.WidgetDiv.dispose_();
   Blockly.WidgetDiv.dispose_ = null;
-  div.innerHTML = '';
+  div.innerText = '';
 
   if (Blockly.WidgetDiv.rendererClassName_) {
     Blockly.utils.dom.removeClass(div, Blockly.WidgetDiv.rendererClassName_);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Problem with calling Blockly.WidgetDiv.hide in ie11. 
It was setting the innerHtml of the child of the Blockly.WidgetDiv to null as well as the innerHtml for Blockly.WidgetDiv.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Changing to textContent = '';
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
