### PR TITLE
Fix #714

### DIFF
--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -372,6 +372,10 @@ Blockly.tree.TreeControl.prototype.getNodeFromEvent_ = function(e) {
     if (target == this.getElement()) {
       break;
     }
+    // Don't bubble if we hit a group. See issue #714.
+    if (target.getAttribute('role') == Blockly.utils.aria.Role.GROUP) {
+      return null;
+    }
     target = target.parentNode;
   }
   return null;


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #714 

## Proposed Changes

Don't bubble event if we hit a tree group.
Problem was any space in between tree items (margin space) would cause the event to bubble up as if it was a click on the parent category. In the case of toolbox subcategories, that was causing the parent category to collapse.

### Reason for Changes

Fix bug.

### Test Coverage

Tested in playground with Chrome.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
