### PR TITLE
Fix mutator field scale

### DIFF
--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -208,7 +208,7 @@ Blockly.FieldMultilineInput.prototype.updateSize_ = function() {
  */
 Blockly.FieldMultilineInput.prototype.widgetCreate_ = function() {
   var div = Blockly.WidgetDiv.DIV;
-  var scale = this.workspace_.scale;
+  var scale = this.workspace_.getScale();
 
   var htmlInput =
     /** @type {HTMLTextAreaElement} */ (document.createElement('textarea'));

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -330,7 +330,7 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
   var htmlInput = /** @type {HTMLInputElement} */ (document.createElement('input'));
   htmlInput.className = 'blocklyHtmlInput';
   htmlInput.setAttribute('spellcheck', this.spellcheck_);
-  var scale = this.workspace_.scale;
+  var scale = this.workspace_.getScale();
   var fontSize =
       (this.getConstants().FIELD_TEXT_FONTSIZE * scale) + 'pt';
   div.style.fontSize = fontSize;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2152,6 +2152,18 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
   }
 };
 
+
+/**
+ * Get the workspace's zoom factor.
+ * @return {number} The workspace zoom factor. Units: (pixels / workspaceUnit).
+ */
+Blockly.WorkspaceSvg.prototype.getScale = function() {
+  if (this.options.parentWorkspace) {
+    return this.options.parentWorkspace.getScale();
+  }
+  return this.scale;
+};
+
 /**
  * Scroll the workspace to a specified offset (in pixels), keeping in the
  * workspace bounds. See comment on workspaceSvg.scrollX for more detail on

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2154,7 +2154,8 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
 
 
 /**
- * Get the workspace's zoom factor.
+ * Get the workspace's zoom factor.  If the workspace has a parent, we call into
+ * the parent to get the workspace scale.
  * @return {number} The workspace zoom factor. Units: (pixels / workspaceUnit).
  */
 Blockly.WorkspaceSvg.prototype.getScale = function() {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -217,7 +217,9 @@ suite('Text Input Fields', function() {
       setup(function() {
         this.prepField = function(field) {
           var workspace = {
-            scale: 1,
+            getScale: function() {
+              return 1;
+            },
             getRenderer: function() { return {
               getClassName: function() { return ''; }
             }; },


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3166

### Proposed Changes

Fix the scale used by fields inside of the mutator dialog. Mutators should borrow their scale from their parent.

### Reason for Changes

Bug fix.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
