### PR TITLE
Fix setValue not handling block disposal

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -858,16 +858,20 @@ Blockly.Field.prototype.setValue = function(newValue) {
       return;
     }
   }
+  var source = this.sourceBlock_;
+  if (source && source.disposed) {
+    doLogging && console.log('source disposed, return');
+    return;
+  }
   var oldValue = this.getValue();
   if (oldValue === newValue) {
     doLogging && console.log('same, return');
-    // No change.
     return;
   }
 
-  if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
+  if (source && Blockly.Events.isEnabled()) {
     Blockly.Events.fire(new Blockly.Events.BlockChange(
-        this.sourceBlock_, 'field', this.name || null, oldValue, newValue));
+        source, 'field', this.name || null, oldValue, newValue));
   }
   this.doValueUpdate_(newValue);
   if (this.isDirty_) {

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1343,6 +1343,22 @@ Blockly.Blocks['test_images_clickhandler'] = {
   }
 };
 
+Blockly.Blocks['test_validators_dispose_block'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("dispose block")
+        .appendField(new Blockly.FieldTextInput("default", this.validate), "INPUT");
+    this.setColour(230);
+    this.setCommentText('Any changes to the text cause the block to be disposed');
+  },
+
+  validate: function(newValue) {
+    if (newValue != "default") {
+      this.getSourceBlock().dispose(true);
+    }
+  }
+};
+
 Blockly.Blocks['test_validators_text_null'] = {
   init: function() {
     this.appendDummyInput()

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -1677,6 +1677,9 @@ var spaghettiXml = [
         <button text="add blocks to workspace" callbackKey="addAllBlocksToWorkspace"></button>
         <sep gap="8"></sep>
         <button text="set input" callbackKey="setInput"></button>
+        <label text="Dispose block"></label>
+        <sep gap="12"></sep>
+        <block type="test_validators_dispose_block"></block>
         <label text="Angles"></label>
         <sep gap="12"></sep>
         <block type="test_validators_angle_null"></block>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that setValue returns if the local validator disposes of the block.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) Firing an event with a disposed block throws errors.
2) We might as well skip the rest of the rerendering and stuff because the block is dead.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I added a test validator block that disposes of the block when the text input is edited. With the changes events are now correctly not being fired.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Noup

### Additional Information

<!-- Anything else we should know? -->
Discovered while working on #3750
