### PR TITLE
Support a custom container element for the dropdowndiv, widgetdiv and tooltip.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -95,7 +95,7 @@ Blockly.cache3dSupported_ = null;
  * @type {?Element}
  * @package
  */
-Blockly.PARENT_CONTAINER = null;
+Blockly.parentContainer = null;
 
 /**
  * Blockly opaque event data used to unbind events when using
@@ -673,8 +673,9 @@ Blockly.checkBlockColourConstant_ = function(
  * Set the parent container.  This is the container element that the WidgetDiv,
  * DropDownDiv, and Tooltip are rendered into the first time `Blockly.inject`
  * is called.
+ * This method is a NOP if called after the first ``Blockly.inject``.
  * @param {!Element} container The container element.
  */
 Blockly.setParentContainer = function(container) {
-  Blockly.PARENT_CONTAINER = container;
+  Blockly.parentContainer = container;
 };

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -91,6 +91,13 @@ Blockly.clipboardTypeCounts_ = null;
 Blockly.cache3dSupported_ = null;
 
 /**
+ * Container element to render the WidgetDiv, DropDownDiv and Tooltip.
+ * @type {?Element}
+ * @package
+ */
+Blockly.PARENT_CONTAINER = null;
+
+/**
  * Blockly opaque event data used to unbind events when using
  * `Blockly.bindEvent_` and `Blockly.bindEventWithChecks_`.
  * @typedef {!Array.<!Array>}
@@ -660,4 +667,14 @@ Blockly.checkBlockColourConstant_ = function(
     var warning = warningPattern.replace('%1', namePath).replace('%2', msgName);
     console.warn(warning);
   }
+};
+
+/**
+ * Set the parent container.  This is the container element that the WidgetDiv,
+ * DropDownDiv, and Tooltip are rendered into the first time `Blockly.inject`
+ * is called.
+ * @param {!Element} container The container element.
+ */
+Blockly.setParentContainer = function(container) {
+  Blockly.PARENT_CONTAINER = container;
 };

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -119,17 +119,15 @@ Blockly.DropDownDiv.themeClassName_ = '';
 
 /**
  * Create and insert the DOM element for this div.
- * @param {Element=} opt_container Optional container element to render the
- *    dropdown into.
  * @package
  */
-Blockly.DropDownDiv.createDom = function(opt_container) {
+Blockly.DropDownDiv.createDom = function() {
   if (Blockly.DropDownDiv.DIV_) {
     return;  // Already created.
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  var container = opt_container || document.body;
+  var container = Blockly.PARENT_CONTAINER || document.body;
   container.appendChild(div);
   /**
    * The div element.

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -89,12 +89,6 @@ Blockly.DropDownDiv.PADDING_Y = 16;
 Blockly.DropDownDiv.ANIMATION_TIME = 0.25;
 
 /**
- * Container element to render the dropdown div into.
- * @type {?Element}
- */
-Blockly.DropDownDiv.CONTAINER_ELEMENT = null;
-
-/**
  * Timer for animation out, to be cleared if we need to immediately hide
  * without disrupting new shows.
  * @type {?number}
@@ -125,15 +119,17 @@ Blockly.DropDownDiv.themeClassName_ = '';
 
 /**
  * Create and insert the DOM element for this div.
+ * @param {Element=} opt_container Optional container element to render the
+ *    dropdown into.
  * @package
  */
-Blockly.DropDownDiv.createDom = function() {
+Blockly.DropDownDiv.createDom = function(opt_container) {
   if (Blockly.DropDownDiv.DIV_) {
     return;  // Already created.
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  var container = Blockly.DropDownDiv.CONTAINER_ELEMENT || document.body;
+  var container = opt_container || document.body;
   container.appendChild(div);
   /**
    * The div element.

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -127,7 +127,7 @@ Blockly.DropDownDiv.createDom = function() {
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  var container = Blockly.PARENT_CONTAINER || document.body;
+  var container = Blockly.parentContainer || document.body;
   container.appendChild(div);
   /**
    * The div element.

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -91,7 +91,6 @@ Blockly.DropDownDiv.ANIMATION_TIME = 0.25;
 /**
  * Container element to render the dropdown div into.
  * @type {?Element}
- * @const
  */
 Blockly.DropDownDiv.CONTAINER_ELEMENT = null;
 

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -89,6 +89,13 @@ Blockly.DropDownDiv.PADDING_Y = 16;
 Blockly.DropDownDiv.ANIMATION_TIME = 0.25;
 
 /**
+ * Container element to render the dropdown div into.
+ * @type {?Element}
+ * @const
+ */
+Blockly.DropDownDiv.CONTAINER_ELEMENT = null;
+
+/**
  * Timer for animation out, to be cleared if we need to immediately hide
  * without disrupting new shows.
  * @type {?number}
@@ -127,7 +134,8 @@ Blockly.DropDownDiv.createDom = function() {
   }
   var div = document.createElement('div');
   div.className = 'blocklyDropDownDiv';
-  document.body.appendChild(div);
+  var container = Blockly.DropDownDiv.CONTAINER_ELEMENT || document.body;
+  container.appendChild(div);
   /**
    * The div element.
    * @type {!Element}

--- a/core/inject.js
+++ b/core/inject.js
@@ -322,9 +322,9 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
   // The SVG is now fully assembled.
   Blockly.svgResize(mainWorkspace);
-  Blockly.WidgetDiv.createDom(Blockly.PARENT_CONTAINER);
-  Blockly.DropDownDiv.createDom(Blockly.PARENT_CONTAINER);
-  Blockly.Tooltip.createDom(Blockly.PARENT_CONTAINER);
+  Blockly.WidgetDiv.createDom();
+  Blockly.DropDownDiv.createDom();
+  Blockly.Tooltip.createDom();
   return mainWorkspace;
 };
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -322,9 +322,9 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
 
   // The SVG is now fully assembled.
   Blockly.svgResize(mainWorkspace);
-  Blockly.WidgetDiv.createDom();
-  Blockly.DropDownDiv.createDom();
-  Blockly.Tooltip.createDom();
+  Blockly.WidgetDiv.createDom(Blockly.PARENT_CONTAINER);
+  Blockly.DropDownDiv.createDom(Blockly.PARENT_CONTAINER);
+  Blockly.Tooltip.createDom(Blockly.PARENT_CONTAINER);
   return mainWorkspace;
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -121,7 +121,7 @@ Blockly.Tooltip.createDom = function() {
   // Create an HTML container for popup overlays (e.g. editor widgets).
   Blockly.Tooltip.DIV = document.createElement('div');
   Blockly.Tooltip.DIV.className = 'blocklyTooltipDiv';
-  var container = Blockly.PARENT_CONTAINER || document.body;
+  var container = Blockly.parentContainer || document.body;
   container.appendChild(Blockly.Tooltip.DIV);
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -112,6 +112,13 @@ Blockly.Tooltip.MARGINS = 5;
 Blockly.Tooltip.DIV = null;
 
 /**
+ * Container element to render the tooltip into.
+ * @type {?Element}
+ * @const
+ */
+Blockly.Tooltip.CONTAINER_ELEMENT = null;
+
+/**
  * Create the tooltip div and inject it onto the page.
  */
 Blockly.Tooltip.createDom = function() {
@@ -121,7 +128,8 @@ Blockly.Tooltip.createDom = function() {
   // Create an HTML container for popup overlays (e.g. editor widgets).
   Blockly.Tooltip.DIV = document.createElement('div');
   Blockly.Tooltip.DIV.className = 'blocklyTooltipDiv';
-  document.body.appendChild(Blockly.Tooltip.DIV);
+  var container = Blockly.Tooltip.CONTAINER_ELEMENT || document.body;
+  container.appendChild(Blockly.Tooltip.DIV);
 };
 
 /**

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -113,17 +113,15 @@ Blockly.Tooltip.DIV = null;
 
 /**
  * Create the tooltip div and inject it onto the page.
- * @param {Element=} opt_container Optional container element to render the
- *    tooltip into.
  */
-Blockly.Tooltip.createDom = function(opt_container) {
+Blockly.Tooltip.createDom = function() {
   if (Blockly.Tooltip.DIV) {
     return;  // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
   Blockly.Tooltip.DIV = document.createElement('div');
   Blockly.Tooltip.DIV.className = 'blocklyTooltipDiv';
-  var container = opt_container || document.body;
+  var container = Blockly.PARENT_CONTAINER || document.body;
   container.appendChild(Blockly.Tooltip.DIV);
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -112,22 +112,18 @@ Blockly.Tooltip.MARGINS = 5;
 Blockly.Tooltip.DIV = null;
 
 /**
- * Container element to render the tooltip into.
- * @type {?Element}
- */
-Blockly.Tooltip.CONTAINER_ELEMENT = null;
-
-/**
  * Create the tooltip div and inject it onto the page.
+ * @param {Element=} opt_container Optional container element to render the
+ *    tooltip into.
  */
-Blockly.Tooltip.createDom = function() {
+Blockly.Tooltip.createDom = function(opt_container) {
   if (Blockly.Tooltip.DIV) {
     return;  // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
   Blockly.Tooltip.DIV = document.createElement('div');
   Blockly.Tooltip.DIV.className = 'blocklyTooltipDiv';
-  var container = Blockly.Tooltip.CONTAINER_ELEMENT || document.body;
+  var container = opt_container || document.body;
   container.appendChild(Blockly.Tooltip.DIV);
 };
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -114,7 +114,6 @@ Blockly.Tooltip.DIV = null;
 /**
  * Container element to render the tooltip into.
  * @type {?Element}
- * @const
  */
 Blockly.Tooltip.CONTAINER_ELEMENT = null;
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -51,10 +51,8 @@ Blockly.WidgetDiv.themeClassName_ = '';
 
 /**
  * Create the widget div and inject it onto the page.
- * @param {Element=} opt_container Optional container element to render the
- *    widgetdiv into.
  */
-Blockly.WidgetDiv.createDom = function(opt_container) {
+Blockly.WidgetDiv.createDom = function() {
   if (Blockly.WidgetDiv.DIV) {
     return;  // Already created.
   }
@@ -64,7 +62,7 @@ Blockly.WidgetDiv.createDom = function(opt_container) {
    */
   Blockly.WidgetDiv.DIV = document.createElement('div');
   Blockly.WidgetDiv.DIV.className = 'blocklyWidgetDiv';
-  var container = opt_container || document.body;
+  var container = Blockly.PARENT_CONTAINER || document.body;
   container.appendChild(Blockly.WidgetDiv.DIV);
 };
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -62,7 +62,7 @@ Blockly.WidgetDiv.createDom = function() {
    */
   Blockly.WidgetDiv.DIV = document.createElement('div');
   Blockly.WidgetDiv.DIV.className = 'blocklyWidgetDiv';
-  var container = Blockly.PARENT_CONTAINER || document.body;
+  var container = Blockly.parentContainer || document.body;
   container.appendChild(Blockly.WidgetDiv.DIV);
 };
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -50,6 +50,13 @@ Blockly.WidgetDiv.rendererClassName_ = '';
 Blockly.WidgetDiv.themeClassName_ = '';
 
 /**
+ * Container element to render the widget div into.
+ * @type {?Element}
+ * @const
+ */
+Blockly.WidgetDiv.CONTAINER_ELEMENT = null;
+
+/**
  * Create the widget div and inject it onto the page.
  */
 Blockly.WidgetDiv.createDom = function() {
@@ -62,7 +69,8 @@ Blockly.WidgetDiv.createDom = function() {
    */
   Blockly.WidgetDiv.DIV = document.createElement('div');
   Blockly.WidgetDiv.DIV.className = 'blocklyWidgetDiv';
-  document.body.appendChild(Blockly.WidgetDiv.DIV);
+  var container = Blockly.WidgetDiv.CONTAINER_ELEMENT || document.body;
+  container.appendChild(Blockly.WidgetDiv.DIV);
 };
 
 /**

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -50,15 +50,11 @@ Blockly.WidgetDiv.rendererClassName_ = '';
 Blockly.WidgetDiv.themeClassName_ = '';
 
 /**
- * Container element to render the widget div into.
- * @type {?Element}
- */
-Blockly.WidgetDiv.CONTAINER_ELEMENT = null;
-
-/**
  * Create the widget div and inject it onto the page.
+ * @param {Element=} opt_container Optional container element to render the
+ *    widgetdiv into.
  */
-Blockly.WidgetDiv.createDom = function() {
+Blockly.WidgetDiv.createDom = function(opt_container) {
   if (Blockly.WidgetDiv.DIV) {
     return;  // Already created.
   }
@@ -68,7 +64,7 @@ Blockly.WidgetDiv.createDom = function() {
    */
   Blockly.WidgetDiv.DIV = document.createElement('div');
   Blockly.WidgetDiv.DIV.className = 'blocklyWidgetDiv';
-  var container = Blockly.WidgetDiv.CONTAINER_ELEMENT || document.body;
+  var container = opt_container || document.body;
   container.appendChild(Blockly.WidgetDiv.DIV);
 };
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -52,7 +52,6 @@ Blockly.WidgetDiv.themeClassName_ = '';
 /**
  * Container element to render the widget div into.
  * @type {?Element}
- * @const
  */
 Blockly.WidgetDiv.CONTAINER_ELEMENT = null;
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves https://github.com/google/blockly/issues/3758

### Proposed Changes

Support a custom container element for the dropdowndiv, widgetdiv and tooltip.

### Reason for Changes

Allow developers to change where these divs get placed.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@bartbutenaers

For full screen, you can support your scenario by: 

```
var blocklyArea = document.getElementById('blocklyArea');
Blockly.WidgetDiv.CONTAINER_ELEMENT = blocklyArea;
Blockly.DropDownDiv.CONTAINER_ELEMENT = blocklyArea;
Blockly.Tooltip.CONTAINER_ELEMENT = blocklyArea;
```

And just make sure you inject your workspace into ``blocklyArea``.
This makes sure everything ends up there, and then you can call ``fullscreen`` on the blockly area element.