### PR TITLE
Fix plane demo bug.

### DIFF
--- a/demos/plane/blocks.js
+++ b/demos/plane/blocks.js
@@ -35,12 +35,14 @@ Blockly.Blocks['plane_get_rows'] = {
     this.setHelpUrl(Blockly.Msg['VARIABLES_GET_HELPURL']);
     this.setColour(330);
     this.appendDummyInput()
-        .appendField(Plane.getMsg('Plane_getRows'), 'title');
+        .appendField(Plane.getMsg('Plane_getRows')
+            .replace('%1', Plane.rows1st), 'title');
     this.setOutput(true, 'Number');
   },
   customUpdate: function() {
     this.setFieldValue(
-        Plane.getMsg('Plane_getRows').replace('%1', Plane.rows1st), 'title');
+        Plane.getMsg('Plane_getRows')
+            .replace('%1', Plane.rows1st), 'title');
   }
 };
 
@@ -55,12 +57,14 @@ Blockly.Blocks['plane_get_rows1st'] = {
     this.setHelpUrl(Blockly.Msg['VARIABLES_GET_HELPURL']);
     this.setColour(330);
     this.appendDummyInput()
-        .appendField(Plane.getMsg('Plane_getRows1'), 'title');
+        .appendField(Plane.getMsg('Plane_getRows1')
+            .replace('%1', Plane.rows1st), 'title');
     this.setOutput(true, 'Number');
   },
   customUpdate: function() {
     this.setFieldValue(
-        Plane.getMsg('Plane_getRows1').replace('%1', Plane.rows1st), 'title');
+        Plane.getMsg('Plane_getRows1')
+            .replace('%1', Plane.rows1st), 'title');
   }
 };
 
@@ -75,12 +79,14 @@ Blockly.Blocks['plane_get_rows2nd'] = {
     this.setHelpUrl(Blockly.Msg['VARIABLES_GET_HELPURL']);
     this.setColour(330);
     this.appendDummyInput()
-        .appendField(Plane.getMsg('Plane_getRows2'), 'title');
+        .appendField(Plane.getMsg('Plane_getRows2')
+            .replace('%1', Plane.rows2nd), 'title');
     this.setOutput(true, 'Number');
   },
   customUpdate: function() {
     this.setFieldValue(
-        Plane.getMsg('Plane_getRows2').replace('%1', Plane.rows2nd), 'title');
+        Plane.getMsg('Plane_getRows2')
+            .replace('%1', Plane.rows2nd), 'title');
   }
 };
 

--- a/demos/plane/plane.js
+++ b/demos/plane/plane.js
@@ -200,12 +200,20 @@ Plane.rows1st = 0;
 Plane.rows2nd = 0;
 
 /**
- * Redraw the rows when the slider has moved.
+ * Redraw the rows and update blocks when the slider has moved.
  * @param {number} value New slider position.
  */
 Plane.sliderChange = function(value) {
   var newRows = Math.round(value * 410 / 20);
   Plane.redraw(newRows);
+
+  function updateBlocks(blocks, verbose) {
+    for (var i = 0, block; block = blocks[i]; i++) {
+      block.customUpdate && block.customUpdate();
+    }
+  }
+  updateBlocks(Plane.workspace.getAllBlocks(false), true);
+  updateBlocks(Plane.workspace.flyout_.workspace_.getAllBlocks(false));
 };
 
 /**
@@ -340,15 +348,6 @@ Plane.recalculate = function() {
       Plane.getMsg('Plane_seats').replace(
           '%1', isNaN(seats) ? '?' : seats));
   Plane.setCorrect(isNaN(seats) ? null : (Plane.answer() == seats));
-
-  // Update blocks to show values.
-  function updateBlocks(blocks) {
-    for (var i = 0, block; block = blocks[i]; i++) {
-      block.customUpdate && block.customUpdate();
-    }
-  }
-  updateBlocks(Plane.workspace.getAllBlocks(false));
-  updateBlocks(Plane.workspace.flyout_.workspace_.getAllBlocks(false));
 };
 
 /**

--- a/demos/plane/plane.js
+++ b/demos/plane/plane.js
@@ -207,7 +207,7 @@ Plane.sliderChange = function(value) {
   var newRows = Math.round(value * 410 / 20);
   Plane.redraw(newRows);
 
-  function updateBlocks(blocks, verbose) {
+  function updateBlocks(blocks) {
     for (var i = 0, block; block = blocks[i]; i++) {
       block.customUpdate && block.customUpdate();
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3639
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Reduce unnecessary calls to update block field value by only updating when slider value changes and setting field label at init (rather than at Block.CREATE).
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Row blocks were misaligned when dragged directly from the toolbox. Reducing calls and setting field value on init prevents this issue.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Additional Information

Filed bug #3773 to investigate further why there are issues with updating field value on trigger of Block.CREATE
<!-- Anything else we should know? -->
