### PR TITLE
Move flyout label css into the renderer

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -294,9 +294,5 @@ Blockly.Css.register([
   '.blocklyFlyoutLabelBackground {',
     'opacity: 0;',
   '}',
-
-  '.blocklyFlyoutLabelText {',
-    'fill: #000;',
-  '}'
   /* eslint-enable indent */
 ]);

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1165,13 +1165,17 @@ Blockly.blockRendering.ConstantProvider.prototype.injectCSS_ = function(
 Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
-    // Fields.
+    // Text.
     selector + ' .blocklyText, ',
     selector + ' .blocklyFlyoutLabelText {',
-      'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
       'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
+    '}',
+
+    // Fields.
+    selector + ' .blocklyText {',
+      'fill: #fff;',
     '}',
     selector + ' .blocklyNonEditableText>rect,',
     selector + ' .blocklyEditableText>rect {',

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1166,7 +1166,8 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
     // Fields.
-    selector + ' .blocklyText {',
+    selector + ' .blocklyText, ',
+    selector + ' .blocklyFlyoutLabelText {',
       'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
@@ -1180,6 +1181,11 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
     '}',
     selector + ' .blocklyNonEditableText>text,',
     selector + ' .blocklyEditableText>text {',
+      'fill: #000;',
+    '}',
+
+    // Flyout labels.
+    selector + ' .blocklyFlyoutLabelText {',
       'fill: #000;',
     '}',
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -905,7 +905,8 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
     // Fields.
-    selector + ' .blocklyText {',
+    selector + ' .blocklyText, ',
+    selector + ' .blocklyFlyoutLabelText {',
       'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
@@ -919,6 +920,11 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
     selector + ' .blocklyEditableText>text,',
     selector + ' .blocklyNonEditableText>g>text,',
     selector + ' .blocklyEditableText>g>text {',
+      'fill: #575E75;',
+    '}',
+  
+    // Flyout labels.
+    selector + ' .blocklyFlyoutLabelText {',
       'fill: #575E75;',
     '}',
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -904,13 +904,17 @@ Blockly.zelos.ConstantProvider.prototype.createDom = function(svg,
 Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
-    // Fields.
+    // Text.
     selector + ' .blocklyText, ',
     selector + ' .blocklyFlyoutLabelText {',
-      'fill: #fff;',
       'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
       'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
       'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
+    '}',
+  
+    // Fields.
+    selector + ' .blocklyText {',
+      'fill: #fff;',
     '}',
     selector + ' .blocklyNonEditableText>rect:not(.blocklyDropdownRect),',
     selector + ' .blocklyEditableText>rect:not(.blocklyDropdownRect) {',


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3778

### Proposed Changes

Move flyout label css into the renderer and set the theme font options in CSS. 
This still allows users (in CSS) font properties they want to override, like so: 
https://github.com/google/blockly/blob/develop/tests/playground.html#L607
but it defaults to using the same properties as set on ``blocklyText``

### Reason for Changes

Bug fix, expect theme font changes to be reflected in flyout labels (similar to flyout buttons). 

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
