### PR TITLE
Remove mutator bump timeout

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -386,13 +386,6 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     if (oldMutation != newMutation) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
           block, 'mutation', null, oldMutation, newMutation));
-      // Ensure that any bump is part of this mutation's event group.
-      var group = Blockly.Events.getGroup();
-      setTimeout(function() {
-        Blockly.Events.setGroup(group);
-        block.bumpNeighbours();
-        Blockly.Events.setGroup(false);
-      }, Blockly.BUMP_DELAY);
     }
 
     // Don't update the bubble until the drag has ended, to avoid moving blocks


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Description

Anything that changes the shape of a block should be calling bumpNeighbors directly. For example:
* Append Input
* Add Comment
* Insert Field
* Etc

So this call is unnecessary. If this call /is/ making something bump that normally wouldn't, that should be treated as a bug, and the root should be made to call bumpNieghbours.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![BumpingMutators](https://user-images.githubusercontent.com/25440652/78067495-abc86580-734b-11ea-8da9-da3cee388afa.gif)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

<!-- Anything else we should know? -->
N/A
