### PR TITLE
Add Selectable interface

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -32,6 +32,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 
+goog.requireType('Blockly.ISelectable');
 
 /**
  * Class for a block's SVG representation.
@@ -42,6 +43,7 @@ goog.require('Blockly.utils.Rect');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @extends {Blockly.Block}
+ * @implements {Blockly.ISelectable}
  * @constructor
  */
 Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
@@ -990,6 +992,26 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
   // Sever JavaScript to DOM connections.
   this.svgGroup_ = null;
   Blockly.utils.dom.stopTextWidthCache();
+};
+
+/**
+ * Encode a block for copying.
+ * @return {!Blockly.ISelectable.CopyData} Copy metadata.
+ * @package
+ */
+Blockly.BlockSvg.prototype.toCopyData = function() {
+  var xml = Blockly.Xml.blockToDom(this, true);
+  // Copy only the selected block and internal blocks.
+  Blockly.Xml.deleteNext(xml);
+  // Encode start position in XML.
+  var xy = this.getRelativeToSurfaceXY();
+  xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
+  xml.setAttribute('y', xy.y);
+  return {
+    xml: xml,
+    source: this.workspace,
+    typeCounts: Blockly.utils.getBlockTypeCounts(this, true)
+  };
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -32,7 +32,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 
-goog.requireType('Blockly.ISelectable');
+goog.requireType('Blockly.ICopyable');
 
 /**
  * Class for a block's SVG representation.
@@ -43,7 +43,7 @@ goog.requireType('Blockly.ISelectable');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @extends {Blockly.Block}
- * @implements {Blockly.ISelectable}
+ * @implements {Blockly.ICopyable}
  * @constructor
  */
 Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
@@ -996,7 +996,7 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
 
 /**
  * Encode a block for copying.
- * @return {!Blockly.ISelectable.CopyData} Copy metadata.
+ * @return {!Blockly.ICopyable.CopyData} Copy metadata.
  * @package
  */
 Blockly.BlockSvg.prototype.toCopyData = function() {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -51,7 +51,7 @@ Blockly.mainWorkspace = null;
 
 /**
  * Currently selected block.
- * @type {?Blockly.ISelectable}
+ * @type {?Blockly.ICopyable}
  */
 Blockly.selected = null;
 
@@ -264,7 +264,7 @@ Blockly.onKeyDown = function(e) {
 
 /**
  * Copy a block or workspace comment onto the local clipboard.
- * @param {!Blockly.ISelectable} toCopy Block or Workspace Comment to be copied.
+ * @param {!Blockly.ICopyable} toCopy Block or Workspace Comment to be copied.
  * @private
  */
 Blockly.copy_ = function(toCopy) {
@@ -276,7 +276,7 @@ Blockly.copy_ = function(toCopy) {
 
 /**
  * Duplicate this block and its children, or a workspace comment.
- * @param {!Blockly.ISelectable} toDuplicate Block or Workspace Comment to be
+ * @param {!Blockly.ICopyable} toDuplicate Block or Workspace Comment to be
  *     copied.
  * @package
  */

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -51,7 +51,7 @@ Blockly.mainWorkspace = null;
 
 /**
  * Currently selected block.
- * @type {Blockly.Block}
+ * @type {?Blockly.ISelectable}
  */
 Blockly.selected = null;
 
@@ -264,32 +264,20 @@ Blockly.onKeyDown = function(e) {
 
 /**
  * Copy a block or workspace comment onto the local clipboard.
- * @param {!Blockly.Block | !Blockly.WorkspaceComment} toCopy Block or
- *    Workspace Comment to be copied.
+ * @param {!Blockly.ISelectable} toCopy Block or Workspace Comment to be copied.
  * @private
  */
 Blockly.copy_ = function(toCopy) {
-  if (toCopy.isComment) {
-    var xml = toCopy.toXmlWithXY();
-  } else {
-    var xml = Blockly.Xml.blockToDom(toCopy, true);
-    // Copy only the selected block and internal blocks.
-    Blockly.Xml.deleteNext(xml);
-    // Encode start position in XML.
-    var xy = toCopy.getRelativeToSurfaceXY();
-    xml.setAttribute('x', toCopy.RTL ? -xy.x : xy.x);
-    xml.setAttribute('y', xy.y);
-  }
-  Blockly.clipboardXml_ = xml;
-  Blockly.clipboardSource_ = toCopy.workspace;
-  Blockly.clipboardTypeCounts_ = toCopy.isComment ? null :
-      Blockly.utils.getBlockTypeCounts(toCopy, true);
+  var data = toCopy.toCopyData();
+  Blockly.clipboardXml_ = data.xml;
+  Blockly.clipboardSource_ = data.source;
+  Blockly.clipboardTypeCounts_ = data.typeCounts;
 };
 
 /**
  * Duplicate this block and its children, or a workspace comment.
- * @param {!Blockly.Block | !Blockly.WorkspaceComment} toDuplicate Block or
- *     Workspace Comment to be copied.
+ * @param {!Blockly.ISelectable} toDuplicate Block or Workspace Comment to be
+ *     copied.
  * @package
  */
 Blockly.duplicate = function(toDuplicate) {

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for an object that is copyable.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+'use strict';
+
+goog.provide('Blockly.ICopyable');
+
+goog.require('Blockly.ISelectable');
+
+goog.requireType('Blockly.WorkspaceSvg');
+
+
+/**
+ * @extends {Blockly.ISelectable}
+ * @interface
+ */
+Blockly.ICopyable = function() {};
+
+/**
+ * Encode for copying.
+ * @return {!Blockly.ICopyable.CopyData} Copy metadata.
+ */
+Blockly.ICopyable.prototype.toCopyData;
+
+/**
+ * Copy Metadata.
+ * @typedef {{
+ *            xml:!Element,
+ *            source:Blockly.WorkspaceSvg,
+ *            typeCounts:?Object
+ *          }}
+ */
+Blockly.ICopyable.CopyData;

--- a/core/interfaces/i_deletable.js
+++ b/core/interfaces/i_deletable.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for an object that is deletable.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+'use strict';
+
+goog.provide('Blockly.IDeletable');
+
+
+/** @interface */
+Blockly.IDeletable = function() {};
+
+/**
+ * Get whether this object is deletable or not.
+ * @return {boolean} True if deletable.
+ */
+Blockly.IDeletable.prototype.isDeletable;

--- a/core/interfaces/i_movable.js
+++ b/core/interfaces/i_movable.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for an object that is movable.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+'use strict';
+
+goog.provide('Blockly.IMovable');
+
+
+/** @interface */
+Blockly.IMovable = function() {};
+
+/**
+ * Get whether this is movable or not.
+ * @return {boolean} True if movable.
+ */
+Blockly.IMovable.prototype.isMovable;

--- a/core/interfaces/i_selectable.js
+++ b/core/interfaces/i_selectable.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for an object that is selectable.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+'use strict';
+
+goog.provide('Blockly.ISelectable');
+
+goog.requireType('Blockly.WorkspaceSvg');
+
+
+/** @interface */
+Blockly.ISelectable = function() {};
+
+/**
+ * @type {string}
+ */
+Blockly.ISelectable.prototype.id;
+
+/**
+ * Get whether this is deletable or not.
+ * @return {boolean} True if deletable.
+ */
+Blockly.ISelectable.prototype.isDeletable;
+
+/**
+ * Get whether this is movable or not.
+ * @return {boolean} True if movable.
+ */
+Blockly.ISelectable.prototype.isMovable;
+
+/**
+ * Select this.  Highlight it visually.
+ * @return {void}
+ */
+Blockly.ISelectable.prototype.select;
+
+/**
+ * Unselect this.  Unhighlight it visually.
+ * @return {void}
+ */
+Blockly.ISelectable.prototype.unselect;
+
+/**
+ * Encode for copying.
+ * @return {!Blockly.ISelectable.CopyData} Copy metadata.
+ */
+Blockly.ISelectable.prototype.toCopyData;
+
+/**
+ * Copy Metadata.
+ * @typedef {{
+ *            xml:!Element,
+ *            source:Blockly.WorkspaceSvg,
+ *            typeCounts:Object
+ *          }}
+ */
+Blockly.ISelectable.CopyData;

--- a/core/interfaces/i_selectable.js
+++ b/core/interfaces/i_selectable.js
@@ -13,28 +13,21 @@
 
 goog.provide('Blockly.ISelectable');
 
-goog.requireType('Blockly.WorkspaceSvg');
+goog.require('Blockly.IDeletable');
+goog.require('Blockly.IMovable');
 
 
-/** @interface */
+/**
+ * @extends {Blockly.IDeletable}
+ * @extends {Blockly.IMovable}
+ * @interface
+ */
 Blockly.ISelectable = function() {};
 
 /**
  * @type {string}
  */
 Blockly.ISelectable.prototype.id;
-
-/**
- * Get whether this is deletable or not.
- * @return {boolean} True if deletable.
- */
-Blockly.ISelectable.prototype.isDeletable;
-
-/**
- * Get whether this is movable or not.
- * @return {boolean} True if movable.
- */
-Blockly.ISelectable.prototype.isMovable;
 
 /**
  * Select this.  Highlight it visually.
@@ -47,19 +40,3 @@ Blockly.ISelectable.prototype.select;
  * @return {void}
  */
 Blockly.ISelectable.prototype.unselect;
-
-/**
- * Encode for copying.
- * @return {!Blockly.ISelectable.CopyData} Copy metadata.
- */
-Blockly.ISelectable.prototype.toCopyData;
-
-/**
- * Copy Metadata.
- * @typedef {{
- *            xml:!Element,
- *            source:Blockly.WorkspaceSvg,
- *            typeCounts:Object
- *          }}
- */
-Blockly.ISelectable.CopyData;

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -25,7 +25,7 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WorkspaceComment');
 
-goog.requireType('Blockly.ISelectable');
+goog.requireType('Blockly.ICopyable');
 
 /**
  * Class for a workspace comment's SVG representation.
@@ -36,7 +36,7 @@ goog.requireType('Blockly.ISelectable');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @extends {Blockly.WorkspaceComment}
- * @implements {Blockly.ISelectable}
+ * @implements {Blockly.ICopyable}
  * @constructor
  */
 Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
@@ -616,7 +616,7 @@ Blockly.WorkspaceCommentSvg.prototype.toXmlWithXY = function(opt_noId) {
 
 /**
  * Encode a comment for copying.
- * @return {!Blockly.ISelectable.CopyData} Copy metadata.
+ * @return {!Blockly.ICopyable.CopyData} Copy metadata.
  * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.toCopyData = function() {

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -25,6 +25,7 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WorkspaceComment');
 
+goog.requireType('Blockly.ISelectable');
 
 /**
  * Class for a workspace comment's SVG representation.
@@ -35,6 +36,7 @@ goog.require('Blockly.WorkspaceComment');
  * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
  *     create a new ID.
  * @extends {Blockly.WorkspaceComment}
+ * @implements {Blockly.ISelectable}
  * @constructor
  */
 Blockly.WorkspaceCommentSvg = function(workspace, content, height, width,
@@ -610,6 +612,19 @@ Blockly.WorkspaceCommentSvg.prototype.toXmlWithXY = function(opt_noId) {
   element.setAttribute('h', this.getHeight());
   element.setAttribute('w', this.getWidth());
   return element;
+};
+
+/**
+ * Encode a comment for copying.
+ * @return {!Blockly.ISelectable.CopyData} Copy metadata.
+ * @package
+ */
+Blockly.WorkspaceCommentSvg.prototype.toCopyData = function() {
+  return {
+    xml: this.toXmlWithXY(),
+    source: this.workspace,
+    typeCounts: null
+  };
 };
 
 /**

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -33,6 +33,7 @@ function typings() {
     "core/renderers/common",
     "core/renderers/measurables",
     "core/theme",
+    "core/interfaces",
     "core/utils",
     "msg/"
   ];


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Add an interface for what a "Selectable" object is.
Right now Selectable and Copyable are the same thing, we could split them up but we don't really have much use for a selectable object that is not copyable.

### Reason for Changes

### Test Coverage

Build passes.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
