### PR TITLE
Rename dom Node enum

### DIFF
--- a/core/components/component.js
+++ b/core/components/component.js
@@ -476,7 +476,8 @@ Blockly.Component.prototype.addChildAt = function(child, index, opt_render) {
       child.element_.parentNode &&
       // Under some circumstances, IE8 implicitly creates a Document Fragment
       // for detached nodes, so ensure the parent is an Element as it should be.
-      child.element_.parentNode.nodeType == Blockly.utils.dom.Node.ELEMENT_NODE) {
+      child.element_.parentNode.nodeType ==
+          Blockly.utils.dom.NodeType.ELEMENT_NODE) {
     // We don't touch the DOM, but if the parent is in the document, and the
     // child element is in the document but not marked as such, then we call
     // enterDocument on the child.

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -44,7 +44,7 @@ Blockly.utils.dom.XLINK_NS = 'http://www.w3.org/1999/xlink';
  * https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
  * @enum {number}
  */
-Blockly.utils.dom.Node = {
+Blockly.utils.dom.NodeType = {
   ELEMENT_NODE: 1,
   TEXT_NODE: 3,
   COMMENT_NODE: 8,
@@ -76,10 +76,10 @@ Blockly.utils.dom.canvasContext_ = null;
  * Helper method for creating SVG elements.
  * @param {string} name Element's tag name.
  * @param {!Object} attrs Dictionary of attribute names and values.
- * @param {Element} parent Optional parent on which to append the element.
+ * @param {Element=} opt_parent Optional parent on which to append the element.
  * @return {!SVGElement} Newly created SVG element.
  */
-Blockly.utils.dom.createSvgElement = function(name, attrs, parent) {
+Blockly.utils.dom.createSvgElement = function(name, attrs, opt_parent) {
   var e = /** @type {!SVGElement} */
       (document.createElementNS(Blockly.utils.dom.SVG_NS, name));
   for (var key in attrs) {
@@ -91,8 +91,8 @@ Blockly.utils.dom.createSvgElement = function(name, attrs, parent) {
   if (document.body.runtimeStyle) {  // Indicates presence of IE-only attr.
     e.runtimeStyle = e.currentStyle = e.style;
   }
-  if (parent) {
-    parent.appendChild(e);
+  if (opt_parent) {
+    opt_parent.appendChild(e);
   }
   return e;
 };
@@ -192,7 +192,7 @@ Blockly.utils.dom.insertAfter = function(newNode, refNode) {
  */
 Blockly.utils.dom.containsNode = function(parent, descendant) {
   return !!(parent.compareDocumentPosition(descendant) &
-            Blockly.utils.dom.Node.DOCUMENT_POSITION_CONTAINED_BY);
+            Blockly.utils.dom.NodeType.DOCUMENT_POSITION_CONTAINED_BY);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -253,7 +253,7 @@ Blockly.Xml.cloneShadow_ = function(shadow, opt_noId) {
       while (node && !node.nextSibling) {
         textNode = node;
         node = node.parentNode;
-        if (textNode.nodeType == Blockly.utils.dom.Node.TEXT_NODE &&
+        if (textNode.nodeType == Blockly.utils.dom.NodeType.TEXT_NODE &&
             textNode.data.trim() == '' && node.firstChild != textNode) {
           // Prune whitespace after a tag.
           Blockly.utils.dom.removeNode(textNode);
@@ -262,7 +262,8 @@ Blockly.Xml.cloneShadow_ = function(shadow, opt_noId) {
       if (node) {
         textNode = node;
         node = node.nextSibling;
-        if (textNode.nodeType == Blockly.utils.dom.Node.TEXT_NODE && textNode.data.trim() == '') {
+        if (textNode.nodeType == Blockly.utils.dom.NodeType.TEXT_NODE &&
+            textNode.data.trim() == '') {
           // Prune whitespace before a tag.
           Blockly.utils.dom.removeNode(textNode);
         }
@@ -583,7 +584,7 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
  */
 Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
   for (var i = 0, xmlChild; (xmlChild = xmlVariables.childNodes[i]); i++) {
-    if (xmlChild.nodeType != Blockly.utils.dom.Node.ELEMENT_NODE) {
+    if (xmlChild.nodeType != Blockly.utils.dom.NodeType.ELEMENT_NODE) {
       continue;  // Skip text nodes.
     }
     var type = xmlChild.getAttribute('type');
@@ -613,7 +614,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
 
   var blockChild = null;
   for (var i = 0, xmlChild; (xmlChild = xmlBlock.childNodes[i]); i++) {
-    if (xmlChild.nodeType == Blockly.utils.dom.Node.TEXT_NODE) {
+    if (xmlChild.nodeType == Blockly.utils.dom.NodeType.TEXT_NODE) {
       // Ignore any text at the <block> level.  It's all whitespace anyway.
       continue;
     }
@@ -623,7 +624,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
     var childBlockElement = null;
     var childShadowElement = null;
     for (var j = 0, grandchild; (grandchild = xmlChild.childNodes[j]); j++) {
-      if (grandchild.nodeType == Blockly.utils.dom.Node.ELEMENT_NODE) {
+      if (grandchild.nodeType == Blockly.utils.dom.NodeType.ELEMENT_NODE) {
         if (grandchild.nodeName.toLowerCase() == 'block') {
           childBlockElement = /** @type {!Element} */ (grandchild);
         } else if (grandchild.nodeName.toLowerCase() == 'shadow') {


### PR DESCRIPTION

## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Rename Node enum to NodeType to avoid conflict with type Node.
Make ``createSvgElement`` last parameter actually optional matching description.

### Reason for Changes


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
