### PR TITLE
Make block.removeInput return a boolean.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1717,6 +1717,7 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  * Remove an input from this block.
  * @param {string} name The name of the input.
  * @param {boolean=} opt_quiet True to prevent error if input is not present.
+ * @return {boolean} True if operation succeeded, false if input is not present and opt_quiet is true
  * @throws {Error} if the input is not present and opt_quiet is not true.
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
@@ -1727,10 +1728,12 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
       }
       input.dispose();
       this.inputList.splice(i, 1);
-      return;
+      return true;
     }
   }
-  if (!opt_quiet) {
+  if (opt_quiet) {
+    return false;
+  } else {
     throw Error('Input not found: ' + name);
   }
 };

--- a/core/block.js
+++ b/core/block.js
@@ -1717,7 +1717,7 @@ Blockly.Block.prototype.moveNumberedInputBefore = function(
  * Remove an input from this block.
  * @param {string} name The name of the input.
  * @param {boolean=} opt_quiet True to prevent error if input is not present.
- * @return {boolean} True if operation succeeded, false if input is not present and opt_quiet is true
+ * @return {boolean} True if operation succeeds, false if input is not present and opt_quiet is true
  * @throws {Error} if the input is not present and opt_quiet is not true.
  */
 Blockly.Block.prototype.removeInput = function(name, opt_quiet) {

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1369,17 +1369,20 @@ Blockly.BlockSvg.prototype.setInputsInline = function(newBoolean) {
  * Remove an input from this block.
  * @param {string} name The name of the input.
  * @param {boolean=} opt_quiet True to prevent error if input is not present.
+ * @return {boolean} True if operation succeeds, false if input is not present and opt_quiet is true
  * @throws {Error} if the input is not present and
  *     opt_quiet is not true.
  */
 Blockly.BlockSvg.prototype.removeInput = function(name, opt_quiet) {
-  Blockly.BlockSvg.superClass_.removeInput.call(this, name, opt_quiet);
+  var removed = Blockly.BlockSvg.superClass_.removeInput.call(this, name, opt_quiet);
 
   if (this.rendered) {
     this.render();
     // Removing an input will cause the block to change shape.
     this.bumpNeighbours();
   }
+
+  return removed;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #3803 

### Proposed Changes

Makes block.removeInput return a boolean (false if opt_quiet is set, instead of throwing an error or  doing nothing)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Currently if removeInput fails while opt_quiet is set, nothing happens so there is no way to tell if it succeeded.

### Additional Information

I have it always return true if it succeeds because it's simpler, but I can change it to only return true if opt_quiet is set if you'd prefer.
