### PR TITLE
Fix bug with dropdown divs in mutator dialogs.

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -303,9 +303,13 @@ Blockly.DropDownDiv.showPositionedByRect_ = function(bBox, field,
     secondaryY += opt_secondaryYOffset;
   }
   var sourceBlock = field.getSourceBlock();
-  // Set bounds to workspace; show the drop-down.
+  // Set bounds to main workspace; show the drop-down.
+  var workspace = sourceBlock.workspace;
+  while (workspace.options.parentWorkspace) {
+    workspace = workspace.options.parentWorkspace;
+  }
   Blockly.DropDownDiv.setBoundsElement(
-      sourceBlock.workspace.getParentSvg().parentNode);
+      workspace.getParentSvg().parentNode);
   return Blockly.DropDownDiv.show(
       field, sourceBlock.RTL,
       primaryX, primaryY, secondaryX, secondaryY, opt_onHide);

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -658,6 +658,25 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     ]
   },
   {
+    "type": "test_dropdowns_in_mutator",
+    "message0": "dropdown mutator",
+    "mutator": "test_dropdown_mutator"
+  },
+  {
+    "type": "test_dropdowns_in_mutator_block",
+    "message0": "dropdown %1",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "DROPDOWN",
+        "options": [
+          [ "option", "ONE" ],
+          [ "option", "TWO" ]
+        ]
+      },
+    ]
+  },
+  {
     "type": "test_fields_angle",
     "message0": "angle: %1",
     "args0": [
@@ -1817,6 +1836,57 @@ Blockly.Blocks['test_dropdowns_dynamic_random'] = {
     return options;
   }
 };
+
+/**
+ * Mutator methods added to the test_dropdowns_in_mutator block.
+ * @mixin
+ * @augments Blockly.Block
+ * @package
+ * @readonly
+ */
+var DROPDOWN_MUTATOR = {
+  /**
+   * Create XML to represent the block mutation.
+   * @return {Element} XML storage element.
+   * @this {Blockly.Block}
+   */
+  mutationToDom: function() {
+    var container = Blockly.utils.xml.createElement('mutation');
+    return container;
+  },
+  /**
+   * Restore a block from XML.
+   * @param {!Element} _xmlElement XML storage element.
+   * @this {Blockly.Block}
+   */
+  domToMutation: function(_xmlElement) {
+  },
+  /**
+   * Populate the mutator's dialog with this block's components.
+   * @param {!Blockly.Workspace} workspace Mutator's workspace.
+   * @return {!Blockly.Block} Root block in mutator.
+   * @this {Blockly.Block}
+   */
+  decompose: function(workspace) {
+    var containerBlock = workspace.newBlock('test_dropdowns_in_mutator_block');
+    containerBlock.initSvg();
+    
+    return containerBlock;
+  },
+  /**
+   * Reconfigure this block based on the mutator dialog's components.
+   * @param {!Blockly.Block} _containerBlock Root block in mutator.
+   * @this {Blockly.Block}
+   */
+  compose: function(_containerBlock) {  
+  },
+};
+
+/**
+ * Register custom mutator used by the test_dropdowns_in_mutator block.
+ */
+Blockly.Extensions.registerMutator('test_dropdown_mutator',
+  DROPDOWN_MUTATOR, null, ['test_dropdowns_in_mutator_block']);
 
 /**
  * Handles "insert" button in the connection row test category. This will insert


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3834

### Proposed Changes

Dropdown divs were using the tiny mutator workspace as their bounds. Use the root workspace as the bound instead.

### Reason for Changes

Bug fix.

### Test Coverage

Added test dropdown in mutator block and tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
