### PR TITLE
Fix defineTheme startHats

### DIFF
--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -45,7 +45,7 @@ Blockly.utils.object.mixin = function(target, source) {
  */
 Blockly.utils.object.deepMerge = function(target, source) {
   for (var x in source) {
-    if (typeof source[x] === 'object') {
+    if (source[x] != null && typeof source[x] === 'object') {
       target[x] = Blockly.utils.object.deepMerge(
           target[x] || Object.create(null), source[x]);
     } else {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes dark theme having startHats = true

### Proposed Changes

typeof null === "object", go figure..
Escape null when deep merging.

### Reason for Changes

Bug fix.

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
