### PR TITLE
Procedures.allProcedures only searches top-level blocks

### DIFF
--- a/core/procedures.js
+++ b/core/procedures.js
@@ -60,7 +60,8 @@ Blockly.Procedures.ProcedureBlock;
  *     list, and return value boolean.
  */
 Blockly.Procedures.allProcedures = function(root) {
-  var blocks = root.getAllBlocks(false);
+  // Assume that a procedure definition is a top block.
+  var blocks = root.getTopBlocks(false);
   var proceduresReturn = [];
   var proceduresNoReturn = [];
   for (var i = 0; i < blocks.length; i++) {


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Closes #2579

### Proposed Changes

Procedures.allProcedures only needs to check top-level blocks (instead of all blocks as it currently does) because procedures can only be top-level blocks. This should speed up allProcedures generation similar to Procedures.getDefinition