### PR TITLE
Add Ctrl-y (redo) support.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -249,6 +249,10 @@ Blockly.onKeyDown = function(e) {
       // 'z' for undo 'Z' is for redo.
       Blockly.hideChaff();
       mainWorkspace.undo(e.shiftKey);
+    } else if (e.ctrlKey && e.keyCode == Blockly.utils.KeyCodes.Y) {
+      // Ctrl-y is redo in Windows.  Command-y is never valid on Macs.
+      Blockly.hideChaff();
+      mainWorkspace.undo(true);
     }
   }
   // Common code for delete and cut.


### PR DESCRIPTION
Unlike the other existing shortcuts, this should not also cover Command-y since the latter is used on Macs for opening the history tab.  Ctrl-y is exclusively a Windows/DOS shortcut.