### PR TITLE
Add ignoring insertion markers in code/xml gen

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -172,6 +172,10 @@ Blockly.Generator.prototype.blockToCode = function(block, opt_thisOnly) {
     // Skip past this block if it is disabled.
     return opt_thisOnly ? '' : this.blockToCode(block.getNextBlock());
   }
+  if (block.isInsertionMarker()) {
+    // Skip past insertion markers.
+    return opt_thisOnly ? '' : this.blockToCode(block.getChildren(false)[0]);
+  }
 
   var func = this[block.type];
   if (typeof func != 'function') {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -59,6 +59,7 @@
     <script src="generator_test.js"></script>
     <script src="gesture_test.js"></script>
     <script src="input_test.js"></script>
+    <script src="insertion_marker_test.js"></script>
     <script src="json_test.js"></script>
     <script src="key_map_test.js"></script>
     <script src="logic_ternary_test.js"></script>

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -46,17 +46,17 @@ suite('InsertionMarkers', function() {
   });
   suite('Code Generation', function() {
     setup(function() {
-      Blockly.JavaScript['stack_block'] = function(_) {
-        return 'stack;\n';
+      Blockly.JavaScript['stack_block'] = function(block) {
+        return 'stack[' + block.id + '];\n';
       };
       Blockly.JavaScript['row_block'] = function(block) {
         var value = Blockly.JavaScript
             .valueToCode(block, 'INPUT', Blockly.JavaScript.ORDER_NONE);
-        var code = 'row(' + value + ')';
+        var code = 'row[' + block.id + '](' + value + ')';
         return [code, Blockly.JavaScript.ORDER_NONE];
       };
       Blockly.JavaScript['statement_block'] = function(block) {
-        return 'statement{\n' + Blockly.JavaScript
+        return 'statement[' + block.id + ']{\n' + Blockly.JavaScript
             .statementToCode(block, 'STATEMENT') + '};\n';
       };
 
@@ -79,39 +79,39 @@ suite('InsertionMarkers', function() {
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="insertion">' +
           '    <statement name="STATEMENT">' +
-          '      <block type="statement_block"/>' +
+          '      <block type="statement_block" id="a"/>' +
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'statement{\n};\n');
+      this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="statement_block">' +
+          '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
           '      <block type="statement_block" id="insertion"/>' +
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'statement{\n};\n');
+      this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed and Surrounds', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="statement_block">' +
+          '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
           '      <block type="statement_block" id="insertion">' +
           '        <statement name="STATEMENT">' +
-          '          <block type="statement_block"/>' +
+          '          <block type="statement_block" id="b"/>' +
           '        </statement>' +
           '      </block>' +
           '    </statement>' +
           '  </block>' +
           '</xml>');
       this.assertGen(xml,
-          'statement{\n' +
-          '  statement{\n' +
+          'statement[a]{\n' +
+          '  statement[b]{\n' +
           '  };\n' +
           '};\n');
     });
@@ -120,84 +120,84 @@ suite('InsertionMarkers', function() {
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion">' +
           '    <next>' +
-          '      <block type="stack_block"/>' +
+          '      <block type="stack_block" id="a"/>' +
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'stack;\n');
+      this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Next', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="stack_block">' +
+          '  <block type="stack_block" id="a">' +
           '    <next>' +
           '      <block type="stack_block" id="insertion"/>' +
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'stack;\n');
+      this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Middle of Stack', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="stack_block">' +
+          '  <block type="stack_block" id="a">' +
           '    <next>' +
           '      <block type="stack_block" id="insertion">' +
           '        <next>' +
-          '          <block type="stack_block"/>' +
+          '          <block type="stack_block" id="b"/>' +
           '        </next>' +
           '      </block>' +
           '    </next>' +
           '  </block>' +
           '</xml>');
       this.assertGen(xml,
-          'stack;\n' +
-          'stack;\n');
+          'stack[a];\n' +
+          'stack[b];\n');
     });
     test('Marker On Output', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="insertion">' +
           '    <value name="INPUT">' +
-          '      <block type="row_block"/>' +
+          '      <block type="row_block" id="a"/>' +
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'row();\n');
+      this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker On Input', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="row_block">' +
+          '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
           '      <block type="row_block" id="insertion"/>' +
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'row();\n');
+      this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker Middle of Row', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="row_block">' +
+          '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
           '      <block type="row_block" id="insertion">' +
           '        <value name="INPUT">' +
-          '          <block type="row_block"/>' +
+          '          <block type="row_block" id="b"/>' +
           '        </value>' +
           '      </block>' +
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml, 'row(row());\n');
+      this.assertGen(xml, 'row[a](row[b]());\n');
     });
     test('Marker Detatched', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
-          '  <block type="stack_block"/>' +
+          '  <block type="stack_block" id="a"/>' +
           '</xml>');
-      this.assertGen(xml, 'stack;\n');
+      this.assertGen(xml, 'stack[a];\n');
     });
   });
 });

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+suite('InsertionMarkers', function() {
+  setup(function() {
+    this.workspace = new Blockly.Workspace();
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "stack_block",
+        "message0": "",
+        "previousStatement": null,
+        "nextStatement": null
+      },
+      {
+        "type": "row_block",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "input_value",
+            "name": "INPUT"
+          }
+        ],
+        "output": null
+      },
+      {
+        "type": "statement_block",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "input_statement",
+            "name": "STATEMENT"
+          }
+        ],
+        "previousStatement": null,
+        "nextStatement": null
+      }]);
+  });
+  teardown(function() {
+    this.workspace.dispose();
+    delete Blockly.Blocks['stack_block'];
+    delete Blockly.Blocks['row_block'];
+    delete Blockly.Blocks['statement_block'];
+  });
+  suite('Code Generation', function() {
+    setup(function() {
+      Blockly.JavaScript['stack_block'] = function(_) {
+        return 'stack;\n';
+      };
+      Blockly.JavaScript['row_block'] = function(block) {
+        var value = Blockly.JavaScript
+            .valueToCode(block, 'INPUT', Blockly.JavaScript.ORDER_NONE);
+        var code = 'row(' + value + ')';
+        return [code, Blockly.JavaScript.ORDER_NONE];
+      };
+      Blockly.JavaScript['statement_block'] = function(block) {
+        return 'statement{\n' + Blockly.JavaScript
+            .statementToCode(block, 'STATEMENT') + '};\n';
+      };
+
+      this.assertGen = function(xml, expectedCode) {
+        Blockly.Xml.domToWorkspace(xml, this.workspace);
+        var block = this.workspace.getBlockById('insertion');
+        block.isInsertionMarker_ = true;
+        var code = Blockly.JavaScript.workspaceToCode(this.workspace);
+        chai.assert.equal(code, expectedCode);
+      };
+    });
+    teardown(function() {
+      delete Blockly.JavaScript['stack_block'];
+      delete Blockly.JavaScript['row_block'];
+      delete Blockly.JavaScript['statement_block'];
+      delete this.assertGen;
+    });
+    test('Marker Surrounds', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block" id="insertion">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block"/>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'statement{\n};\n');
+    });
+    test('Marker Enclosed', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block" id="insertion"/>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'statement{\n};\n');
+    });
+    test('Marker Enclosed and Surrounds', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block" id="insertion">' +
+          '        <statement name="STATEMENT">' +
+          '          <block type="statement_block"/>' +
+          '        </statement>' +
+          '      </block>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          'statement{\n' +
+          '  statement{\n' +
+          '  };\n' +
+          '};\n');
+    });
+    test('Marker Prev', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="insertion">' +
+          '    <next>' +
+          '      <block type="stack_block"/>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'stack;\n');
+    });
+    test('Marker Next', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block">' +
+          '    <next>' +
+          '      <block type="stack_block" id="insertion"/>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'stack;\n');
+    });
+    test('Marker Middle of Stack', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block">' +
+          '    <next>' +
+          '      <block type="stack_block" id="insertion">' +
+          '        <next>' +
+          '          <block type="stack_block"/>' +
+          '        </next>' +
+          '      </block>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          'stack;\n' +
+          'stack;\n');
+    });
+    test('Marker On Output', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block" id="insertion">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block"/>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'row();\n');
+    });
+    test('Marker On Input', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block" id="insertion"/>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'row();\n');
+    });
+    test('Marker Middle of Row', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block" id="insertion">' +
+          '        <value name="INPUT">' +
+          '          <block type="row_block"/>' +
+          '        </value>' +
+          '      </block>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml, 'row(row());\n');
+    });
+    test('Marker Detatched', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="insertion"/>' +
+          '  <block type="stack_block"/>' +
+          '</xml>');
+      this.assertGen(xml, 'stack;\n');
+    });
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#2322
#2646

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that code generation and serialization skip over insertion markers.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Supports real time code generation and real time serialization.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested generation & serialization for the following cases:
* Marker Surrounds
* Marker Enclosed
* Marker Enclosed and Surrounds
* Marker Prev
* Marker Next
* Marker Middle of Stack
* Marker On Output
* Marker On Input
* Marker Middle of Row
* Marker Detatched

I also check that this matches the pre-insertion marker generation.
Pre-Insertion Markers:
![OldGen1](https://user-images.githubusercontent.com/25440652/80764240-17d9ed00-8af5-11ea-83d0-a9402835881f.gif)

This Branch:
![NewGen1](https://user-images.githubusercontent.com/25440652/80764246-1ad4dd80-8af5-11ea-90a0-3a9b1130e6d6.gif)

Tested on:
 * Desktop Chrome

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Nope, I checked and the docs still show the "old" method, so we should be good!

### Additional Information

<!-- Anything else we should know? -->

I went ahead and fixed both things but if you want me to remove the serialization fix that's cool!
