### PR TITLE
Include async in JS reserved words

### DIFF
--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -35,7 +35,7 @@ Blockly.JavaScript.addReservedWords(
     'break,case,catch,class,const,continue,debugger,default,delete,do,else,export,extends,finally,for,function,if,import,in,instanceof,new,return,super,switch,this,throw,try,typeof,var,void,while,with,yield,' +
     'enum,' +
     'implements,interface,let,package,private,protected,public,static,' +
-    'await,' +
+    'async,await,' +
     'null,true,false,' +
     // Magic variable.
     'arguments,' +


### PR DESCRIPTION
## The basics

- [ x] I branched from develop
- [ x] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

There is no issue for this.

### Proposed Changes

Javascript's `async` keyword was missing from the generator's reserved word list.
