### PR TITLE
Simplify Closure-sourced code for menus

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -220,7 +220,7 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
   this.dragBlock(e, currentDragDeltaXY);
   this.dragIconData_ = [];
   this.fireDragEndEvent_();
-  
+
   Blockly.utils.dom.stopTextWidthCache();
 
   Blockly.blockAnimations.disconnectUiStop();

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -115,7 +115,12 @@ Blockly.Component.Error = {
    * Error when an attempt is made to add a child component at an out-of-bounds
    * index.  We don't support sparse child arrays.
    */
-  CHILD_INDEX_OUT_OF_BOUNDS: 'Child component index out of bounds'
+  CHILD_INDEX_OUT_OF_BOUNDS: 'Child component index out of bounds',
+
+  /**
+   * Error when calling an abstract method that should be overriden.
+   */
+  ABSTRACT_METHOD: 'Unimplemented abstract method'
 };
 
 /**
@@ -195,12 +200,11 @@ Blockly.Component.prototype.isInDocument = function() {
 };
 
 /**
- * Creates the initial DOM representation for the component.  The default
- * implementation is to set this.element_ = div.
+ * Creates the initial DOM representation for the component.
  * @protected
  */
 Blockly.Component.prototype.createDom = function() {
-  this.element_ = document.createElement('div');
+  throw Error(Blockly.Component.Error.ABSTRACT_METHOD);
 };
 
 /**

--- a/core/components/component.js
+++ b/core/components/component.js
@@ -224,19 +224,6 @@ Blockly.Component.prototype.render = function(opt_parentElement) {
 };
 
 /**
- * Renders the component before another element. The other element should be in
- * the document already.
- *
- * Throws an Error if the component is already rendered.
- *
- * @param {Node} sibling Node to render the component before.
- * @protected
- */
-Blockly.Component.prototype.renderBefore = function(sibling) {
-  this.render_(/** @type {Element} */ (sibling.parentNode), sibling);
-};
-
-/**
  * Renders the component.  If a parent element is supplied, the component's
  * element will be appended to it.  If there is no optional parent element and
  * the element doesn't have a parentNode then it will be appended to the
@@ -498,21 +485,6 @@ Blockly.Component.prototype.getContentElement = function() {
 };
 
 /**
- * Set is right-to-left. This function should be used if the component needs
- * to know the rendering direction during DOM creation (i.e. before
- * {@link #enterDocument} is called and is right-to-left is set).
- * @param {boolean} rightToLeft Whether the component is rendered
- *     right-to-left.
- * @package
- */
-Blockly.Component.prototype.setRightToLeft = function(rightToLeft) {
-  if (this.inDocument_) {
-    throw Error(Blockly.Component.Error.ALREADY_RENDERED);
-  }
-  this.rightToLeft_ = rightToLeft;
-};
-
-/**
  * Returns true if the component has children.
  * @return {boolean} True if the component has children.
  * @protected
@@ -568,15 +540,4 @@ Blockly.Component.prototype.forEachChild = function(f, opt_obj) {
   for (var i = 0; i < this.children_.length; i++) {
     f.call(/** @type {?} */ (opt_obj), this.children_[i], i);
   }
-};
-
-/**
- * Returns the 0-based index of the given child component, or -1 if no such
- * child is found.
- * @param {?Blockly.Component} child The child component.
- * @return {number} 0-based index of the child component; -1 if not found.
- * @protected
- */
-Blockly.Component.prototype.indexOfChild = function(child) {
-  return this.children_.indexOf(child);
 };

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -342,7 +342,7 @@ Blockly.Menu.prototype.highlightLast = function() {
  * Helper function that manages the details of moving the highlight among
  * child menuitems in response to keyboard events.
  * @param {number} startIndex Start index.
- * @param {boolean} delta Step direction: 1 to go down, -1 to go up.
+ * @param {number} delta Step direction: 1 to go down, -1 to go up.
  * @protected
  */
 Blockly.Menu.prototype.highlightHelper = function(startIndex, delta) {

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -78,6 +78,15 @@ Blockly.Menu = function() {
    * @private
    */
   this.onKeyDownWrapper_ = null;
+
+  /**
+   * Map of DOM IDs to child menuitems. Each key is the DOM ID of a child
+   * menuitems's root element; each value is a reference to the child menu
+   * item itself.
+   * @type {!Object}
+   * @private
+   */
+  this.childElementIdMap_ = {};
 };
 Blockly.utils.object.inherits(Blockly.Menu, Blockly.Component);
 
@@ -215,17 +224,8 @@ Blockly.Menu.prototype.detachEvents_ = function() {
 // Child component management.
 
 /**
- * Map of DOM IDs to child menuitems. Each key is the DOM ID of a child
- * menuitems's root element; each value is a reference to the child menu
- * item itself.
- * @type {?Object}
- * @private
- */
-Blockly.Menu.prototype.childElementIdMap_ = null;
-
-/**
  * Creates a DOM ID for the child menuitem and registers it to an internal
- * hash table to be able to find it fast by id.
+ * hash table to be able to find it fast by ID.
  * @param {Blockly.Component} child The child menuitem. Its root element has
  *     to be created yet.
  * @private
@@ -233,14 +233,8 @@ Blockly.Menu.prototype.childElementIdMap_ = null;
 Blockly.Menu.prototype.registerChildId_ = function(child) {
   // Map the DOM ID of the menuitem's root element to the menuitem itself.
   var childElem = child.getElement();
-
   // If the menuitem's root element doesn't have a DOM ID assign one.
   var id = childElem.id || (childElem.id = child.getId());
-
-  // Lazily create the child element ID map on first use.
-  if (!this.childElementIdMap_) {
-    this.childElementIdMap_ = {};
-  }
   this.childElementIdMap_[id] = child;
 };
 
@@ -252,17 +246,13 @@ Blockly.Menu.prototype.registerChildId_ = function(child) {
  * @protected
  */
 Blockly.Menu.prototype.getMenuItem = function(node) {
-  // Ensure that this menu actually has child menuitems before
-  // looking up the menuitem.
-  if (this.childElementIdMap_) {
-    var elem = this.getElement();
-    while (node && node !== elem) {
-      var id = node.id;
-      if (id in this.childElementIdMap_) {
-        return this.childElementIdMap_[id];
-      }
-      node = node.parentNode;
+  var elem = this.getElement();
+  while (node && node !== elem) {
+    var id = node.id;
+    if (id in this.childElementIdMap_) {
+      return this.childElementIdMap_[id];
     }
+    node = node.parentNode;
   }
   return null;
 };
@@ -372,8 +362,7 @@ Blockly.Menu.prototype.highlightPrevious = function() {
 Blockly.Menu.prototype.highlightHelper = function(fn, startIndex) {
   // If the start index is -1 (meaning there's nothing currently highlighted),
   // try starting from the currently open item, if any.
-  var curIndex =
-      startIndex < 0 ? -1 : startIndex;
+  var curIndex = startIndex < 0 ? -1 : startIndex;
   var numItems = this.getChildCount();
 
   curIndex = fn.call(this, curIndex, numItems);
@@ -486,8 +475,7 @@ Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
  * @protected
  */
 Blockly.Menu.prototype.handleKeyEvent = function(e) {
-  if (this.getChildCount() != 0 &&
-      this.handleKeyEventInternal(e)) {
+  if (this.getChildCount() != 0 && this.handleKeyEventInternal(e)) {
     e.preventDefault();
     e.stopPropagation();
     return true;

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -15,7 +15,8 @@ goog.provide('Blockly.Menu');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
-goog.require('Blockly.utils.object');
+goog.require('Blockly.utils.KeyCodes');
+goog.require('Blockly.utils.style');
 
 
 /**

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -243,7 +243,7 @@ Blockly.Menu.prototype.getMenuItem_ = function(elem) {
         }
       }
     }
-    elem = elem.parentNode;
+    elem = elem.parentElement;
   }
   return null;
 };

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -222,28 +222,28 @@ Blockly.Menu.prototype.dispose = function() {
 // Child component management.
 
 /**
- * Returns the child menu item that owns the given DOM node, or null if no such
- * menu item is found.
- * @param {Node} node DOM node whose owner is to be returned.
- * @return {?Blockly.MenuItem} Menu item for which the DOM node belongs to.
+ * Returns the child menu item that owns the given DOM element,
+ * or null if no such menu item is found.
+ * @param {Element} elem DOM element whose owner is to be returned.
+ * @return {?Blockly.MenuItem} Menu item for which the DOM element belongs to.
  * @private
  */
-Blockly.Menu.prototype.getMenuItem_ = function(node) {
+Blockly.Menu.prototype.getMenuItem_ = function(elem) {
   var menuElem = this.getElement();
   // Node might be the menu border (resulting in no associated menu item), or
-  // a menu item's div, or some node within the menu item.
+  // a menu item's div, or some element within the menu item.
   // Walk up parents until one meets either the menu's root element, or
   // a menu item's div.
-  while (node && node != menuElem) {
-    if (Blockly.utils.dom.hasClass(node, 'blocklyMenuItem')) {
+  while (elem && elem != menuElem) {
+    if (Blockly.utils.dom.hasClass(elem, 'blocklyMenuItem')) {
       // Having found a menu item's div, locate that menu item in this menu.
       for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
-        if (menuItem.getElement() == node) {
+        if (menuItem.getElement() == elem) {
           return menuItem;
         }
       }
     }
-    node = node.parentNode;
+    elem = elem.parentNode;
   }
   return null;
 };
@@ -330,13 +330,12 @@ Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
 // Mouse events.
 
 /**
- * Handles mouseover events. Highlight menuitems as the user
- * hovers over them.
- * @param {Event} e Mouse event to handle.
+ * Handles mouseover events. Highlight menuitems as the user hovers over them.
+ * @param {!Event} e Mouse event to handle.
  * @private
  */
 Blockly.Menu.prototype.handleMouseOver_ = function(e) {
-  var menuItem = this.getMenuItem_(/** @type {Node} */ (e.target));
+  var menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
 
   if (menuItem) {
     if (menuItem.isEnabled()) {
@@ -350,9 +349,8 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
 };
 
 /**
- * Handles click events. Pass the event onto the child
- * menuitem to handle.
- * @param {Event} e Click to handle.
+ * Handles click events. Pass the event onto the child menuitem to handle.
+ * @param {!Event} e Click event to handle.
  * @private
  */
 Blockly.Menu.prototype.handleClick_ = function(e) {
@@ -370,7 +368,7 @@ Blockly.Menu.prototype.handleClick_ = function(e) {
     }
   }
 
-  var menuItem = this.getMenuItem_(/** @type {Node} */ (e.target));
+  var menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
   if (menuItem) {
     menuItem.performAction();
   }

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -99,7 +99,8 @@ Blockly.Menu.prototype.addChild = function(menuItem) {
  */
 Blockly.Menu.prototype.render = function(container) {
   var element = document.createElement('div');
-  element.className = 'goog-menu blocklyNonSelectable';
+  // goog-menu is deprecated, use blocklyMenu.  May 2020.
+  element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
   Blockly.utils.aria.setRole(element, this.roleName_);
   this.element_ = element;
@@ -141,7 +142,7 @@ Blockly.Menu.prototype.focus = function() {
   var el = this.getElement();
   if (el) {
     el.focus({preventScroll:true});
-    Blockly.utils.dom.addClass(el, 'focused');
+    Blockly.utils.dom.addClass(el, 'blocklyFocused');
   }
 };
 
@@ -153,7 +154,7 @@ Blockly.Menu.prototype.blur = function() {
   var el = this.getElement();
   if (el) {
     el.blur();
-    Blockly.utils.dom.removeClass(el, 'focused');
+    Blockly.utils.dom.removeClass(el, 'blocklyFocused');
   }
 };
 
@@ -223,7 +224,7 @@ Blockly.Menu.prototype.getMenuItem = function(node) {
 
 /**
  * Highlights the given menu item, or clears highlighting if null.
- * @param {!Blockly.MenuItem} item Item to highlight.
+ * @param {Blockly.MenuItem} item Item to highlight, or null.
  * @protected
  */
 Blockly.Menu.prototype.setHighlighted = function(item) {

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -154,30 +154,10 @@ Blockly.Menu.prototype.enterDocument = function() {
 };
 
 /**
- * Cleans up the container before its DOM is removed from the document, and
- * removes event handlers.  Overrides {@link Blockly.Component#exitDocument}.
+ * Removes event handlers.  Overrides {@link Blockly.Component#exitDocument}.
  * @override
  */
 Blockly.Menu.prototype.exitDocument = function() {
-  // {@link #setHighlightedIndex} has to be called before
-  // {@link Blockly.Component#exitDocument}, otherwise it has no effect.
-  this.setHighlightedIndex(-1);
-
-  Blockly.Menu.superClass_.exitDocument.call(this);
-};
-
-/** @override */
-Blockly.Menu.prototype.disposeInternal = function() {
-  Blockly.Menu.superClass_.disposeInternal.call(this);
-
-  this.detachEvents_();
-};
-
-/**
- * Removes the event listeners from the menu.
- * @private
- */
-Blockly.Menu.prototype.detachEvents_ = function() {
   if (this.mouseOverHandler_) {
     Blockly.unbindEvent_(this.mouseOverHandler_);
     this.mouseOverHandler_ = null;
@@ -198,6 +178,8 @@ Blockly.Menu.prototype.detachEvents_ = function() {
     Blockly.unbindEvent_(this.onKeyDownWrapper_);
     this.onKeyDownWrapper_ = null;
   }
+
+  Blockly.Menu.superClass_.exitDocument.call(this);
 };
 
 // Child component management.

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -403,9 +403,8 @@ Blockly.Menu.prototype.handleClick_ = function(e) {
   }
 
   var menuItem = this.getMenuItem(/** @type {Node} */ (e.target));
-
-  if (menuItem && menuItem.handleClick(e)) {
-    e.preventDefault();
+  if (menuItem) {
+    menuItem.performAction();
   }
 };
 
@@ -465,7 +464,7 @@ Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
     case Blockly.utils.KeyCodes.ENTER:
     case Blockly.utils.KeyCodes.SPACE:
       if (highlighted) {
-        highlighted.performActionInternal(e);
+        highlighted.performAction();
       }
       break;
 

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -94,10 +94,10 @@ Blockly.Menu = function() {
 
   /**
    * ARIA name for this menu.
-   * @type {string}
+   * @type {Blockly.utils.aria.Role}
    * @private
    */
-  this.roleName_ = '';
+  this.roleName_ = null;
 };
 
 
@@ -118,7 +118,9 @@ Blockly.Menu.prototype.render = function(container) {
   // goog-menu is deprecated, use blocklyMenu.  May 2020.
   element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
-  Blockly.utils.aria.setRole(element, this.roleName_);
+  if (this.roleName_) {
+    Blockly.utils.aria.setRole(element, this.roleName_);
+  }
   this.element_ = element;
 
   // Add menu items.

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -84,6 +84,20 @@ Blockly.Menu = function() {
    * @private
    */
   this.onKeyDownHandler_ = null;
+
+  /**
+   * The menu's root DOM element.
+   * @type {Element}
+   * @private
+   */
+  this.element_ = null;
+
+  /**
+   * ARIA name for this menu.
+   * @type {string}
+   * @private
+   */
+  this.roleName_ = '';
 };
 
 
@@ -150,9 +164,9 @@ Blockly.Menu.prototype.focus = function() {
 
 /**
  * Blur the menu element.
- * @package
+ * @private
  */
-Blockly.Menu.prototype.blur = function() {
+Blockly.Menu.prototype.blur_ = function() {
   var el = this.getElement();
   if (el) {
     el.blur();
@@ -249,9 +263,9 @@ Blockly.Menu.prototype.setHighlighted_ = function(item) {
 /**
  * Highlights the next highlightable item (or the first if nothing is currently
  * highlighted).
- * @private
+ * @package
  */
-Blockly.Menu.prototype.highlightNext_ = function() {
+Blockly.Menu.prototype.highlightNext = function() {
   var index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index, 1);
 };
@@ -259,9 +273,9 @@ Blockly.Menu.prototype.highlightNext_ = function() {
 /**
  * Highlights the previous highlightable item (or the last if nothing is
  * currently highlighted).
- * @private
+ * @package
  */
-Blockly.Menu.prototype.highlightPrevious_ = function() {
+Blockly.Menu.prototype.highlightPrevious = function() {
   var index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index < 0 ? this.menuItems_.length : index, -1);
 };
@@ -366,7 +380,7 @@ Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
  */
 Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
   if (this.getElement()) {
-    this.blur();
+    this.blur_();
     this.setHighlighted_(null);
   }
 };
@@ -380,24 +394,13 @@ Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
  * @private
  */
 Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
-  if (this.menuItems_.length && this.handleKeyEventInternal_(e)) {
-    e.preventDefault();
-    e.stopPropagation();
+  if (!this.menuItems_.length) {
+    // Empty menu.
+    return;
   }
-};
-
-/**
- * Attempts to handle a keyboard event; returns true if the event was handled,
- * false otherwise.
- * @param {!Event} e Key event to handle.
- * @return {boolean} Whether the event was handled by the container (or one of
- *     its children).
- * @private
- */
-Blockly.Menu.prototype.handleKeyEventInternal_ = function(e) {
-  // Do not handle the key event if any modifier key is pressed.
   if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
-    return false;
+    // Do not handle the key event if any modifier key is pressed.
+    return;
   }
 
   var highlighted = this.highlightedItem_;
@@ -410,11 +413,11 @@ Blockly.Menu.prototype.handleKeyEventInternal_ = function(e) {
       break;
 
     case Blockly.utils.KeyCodes.UP:
-      this.highlightPrevious_();
+      this.highlightPrevious();
       break;
 
     case Blockly.utils.KeyCodes.DOWN:
-      this.highlightNext_();
+      this.highlightNext();
       break;
 
     case Blockly.utils.KeyCodes.PAGE_UP:
@@ -428,8 +431,10 @@ Blockly.Menu.prototype.handleKeyEventInternal_ = function(e) {
       break;
 
     default:
-      return false;
+      // Not a key the menu is interested in.
+      return;
   }
-
-  return true;
+  // The menu used this key, don't let it have secondary effects.
+  e.preventDefault();
+  e.stopPropagation();
 };

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -122,7 +122,7 @@ Blockly.Menu.prototype.render = function(container) {
   this.mouseLeaveHandler_ = Blockly.bindEventWithChecks_(element,
       'mouseleave', this, this.handleMouseLeave_, true);
   this.onKeyDownHandler_ = Blockly.bindEventWithChecks_(element,
-      'keydown', this, this.handleKeyEvent);
+      'keydown', this, this.handleKeyEvent_);
 
   container.appendChild(element);
 };
@@ -209,9 +209,9 @@ Blockly.Menu.prototype.dispose = function() {
  * menu item is found.
  * @param {Node} node DOM node whose owner is to be returned.
  * @return {?Blockly.MenuItem} Menu item for which the DOM node belongs to.
- * @protected
+ * @private
  */
-Blockly.Menu.prototype.getMenuItem = function(node) {
+Blockly.Menu.prototype.getMenuItem_ = function(node) {
   var elem = this.getElement();
   while (node && node !== elem) {
     if (node.blocklyMenuItem) {
@@ -227,9 +227,9 @@ Blockly.Menu.prototype.getMenuItem = function(node) {
 /**
  * Highlights the given menu item, or clears highlighting if null.
  * @param {Blockly.MenuItem} item Item to highlight, or null.
- * @protected
+ * @private
  */
-Blockly.Menu.prototype.setHighlighted = function(item) {
+Blockly.Menu.prototype.setHighlighted_ = function(item) {
   var currentHighlighted = this.highlightedItem_;
   if (currentHighlighted) {
     currentHighlighted.setHighlighted(false);
@@ -249,37 +249,37 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
 /**
  * Highlights the next highlightable item (or the first if nothing is currently
  * highlighted).
- * @package
+ * @private
  */
-Blockly.Menu.prototype.highlightNext = function() {
+Blockly.Menu.prototype.highlightNext_ = function() {
   var index = this.menuItems_.indexOf(this.highlightedItem_);
-  this.highlightHelper(index, 1);
+  this.highlightHelper_(index, 1);
 };
 
 /**
  * Highlights the previous highlightable item (or the last if nothing is
  * currently highlighted).
- * @package
+ * @private
  */
-Blockly.Menu.prototype.highlightPrevious = function() {
+Blockly.Menu.prototype.highlightPrevious_ = function() {
   var index = this.menuItems_.indexOf(this.highlightedItem_);
-  this.highlightHelper(index < 0 ? this.menuItems_.length : index, -1);
+  this.highlightHelper_(index < 0 ? this.menuItems_.length : index, -1);
 };
 
 /**
  * Highlights the first highlightable item.
- * @package
+ * @private
  */
-Blockly.Menu.prototype.highlightFirst = function() {
-  this.highlightHelper(-1, 1);
+Blockly.Menu.prototype.highlightFirst_ = function() {
+  this.highlightHelper_(-1, 1);
 };
 
 /**
  * Highlights the last highlightable item.
- * @package
+ * @private
  */
-Blockly.Menu.prototype.highlightLast = function() {
-  this.highlightHelper(this.menuItems_.length, -1);
+Blockly.Menu.prototype.highlightLast_ = function() {
+  this.highlightHelper_(this.menuItems_.length, -1);
 };
 
 /**
@@ -287,14 +287,14 @@ Blockly.Menu.prototype.highlightLast = function() {
  * child menuitems in response to keyboard events.
  * @param {number} startIndex Start index.
  * @param {number} delta Step direction: 1 to go down, -1 to go up.
- * @protected
+ * @private
  */
-Blockly.Menu.prototype.highlightHelper = function(startIndex, delta) {
+Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
   var index = startIndex + delta;
   var menuItem;
   while ((menuItem = this.menuItems_[index])) {
     if (menuItem.isEnabled()) {
-      this.setHighlighted(menuItem);
+      this.setHighlighted_(menuItem);
       break;
     }
     index += delta;
@@ -310,15 +310,15 @@ Blockly.Menu.prototype.highlightHelper = function(startIndex, delta) {
  * @private
  */
 Blockly.Menu.prototype.handleMouseOver_ = function(e) {
-  var menuItem = this.getMenuItem(/** @type {Node} */ (e.target));
+  var menuItem = this.getMenuItem_(/** @type {Node} */ (e.target));
 
   if (menuItem) {
     if (menuItem.isEnabled()) {
       if (this.highlightedItem_ != menuItem) {
-        this.setHighlighted(menuItem);
+        this.setHighlighted_(menuItem);
       }
     } else {
-      this.setHighlighted(null);
+      this.setHighlighted_(null);
     }
   }
 };
@@ -344,7 +344,7 @@ Blockly.Menu.prototype.handleClick_ = function(e) {
     }
   }
 
-  var menuItem = this.getMenuItem(/** @type {Node} */ (e.target));
+  var menuItem = this.getMenuItem_(/** @type {Node} */ (e.target));
   if (menuItem) {
     menuItem.performAction();
   }
@@ -367,7 +367,7 @@ Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
 Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
   if (this.getElement()) {
     this.blur();
-    this.setHighlighted(null);
+    this.setHighlighted_(null);
   }
 };
 
@@ -375,13 +375,12 @@ Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
 
 /**
  * Attempts to handle a keyboard event, if the menu item is enabled, by calling
- * {@link handleKeyEventInternal}.  Considered protected; should only be used
- * within this package and by subclasses.
+ * {@link handleKeyEventInternal_}.
  * @param {!Event} e Key event to handle.
- * @protected
+ * @private
  */
-Blockly.Menu.prototype.handleKeyEvent = function(e) {
-  if (this.menuItems_.length && this.handleKeyEventInternal(e)) {
+Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
+  if (this.menuItems_.length && this.handleKeyEventInternal_(e)) {
     e.preventDefault();
     e.stopPropagation();
   }
@@ -393,9 +392,9 @@ Blockly.Menu.prototype.handleKeyEvent = function(e) {
  * @param {!Event} e Key event to handle.
  * @return {boolean} Whether the event was handled by the container (or one of
  *     its children).
- * @protected
+ * @private
  */
-Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
+Blockly.Menu.prototype.handleKeyEventInternal_ = function(e) {
   // Do not handle the key event if any modifier key is pressed.
   if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
     return false;
@@ -411,21 +410,21 @@ Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
       break;
 
     case Blockly.utils.KeyCodes.UP:
-      this.highlightPrevious();
+      this.highlightPrevious_();
       break;
 
     case Blockly.utils.KeyCodes.DOWN:
-      this.highlightNext();
+      this.highlightNext_();
       break;
 
     case Blockly.utils.KeyCodes.PAGE_UP:
     case Blockly.utils.KeyCodes.HOME:
-      this.highlightFirst();
+      this.highlightFirst_();
       break;
 
     case Blockly.utils.KeyCodes.PAGE_DOWN:
     case Blockly.utils.KeyCodes.END:
-      this.highlightLast();
+      this.highlightLast_();
       break;
 
     default:

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -94,7 +94,7 @@ Blockly.Menu = function() {
 
   /**
    * ARIA name for this menu.
-   * @type {Blockly.utils.aria.Role}
+   * @type {?Blockly.utils.aria.Role}
    * @private
    */
   this.roleName_ = null;
@@ -215,6 +215,7 @@ Blockly.Menu.prototype.dispose = function() {
   for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
     menuItem.dispose();
   }
+  this.menuItems_length = 0;
   this.element_ = null;
 };
 
@@ -228,10 +229,19 @@ Blockly.Menu.prototype.dispose = function() {
  * @private
  */
 Blockly.Menu.prototype.getMenuItem_ = function(node) {
-  var elem = this.getElement();
-  while (node && node !== elem) {
-    if (node.blocklyMenuItem) {
-      return node.blocklyMenuItem;
+  var menuElem = this.getElement();
+  // Node might be the menu border (resulting in no associated menu item), or
+  // a menu item's div, or some node within the menu item.
+  // Walk up parents until one meets either the menu's root element, or
+  // a menu item's div.
+  while (node && node != menuElem) {
+    if (Blockly.utils.dom.hasClass(node, 'blocklyMenuItem')) {
+      // Having found a menu item's div, locate that menu item in this menu.
+      for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
+        if (menuItem.getElement() == node) {
+          return menuItem;
+        }
+      }
     }
     node = node.parentNode;
   }

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -309,9 +309,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
  * @package
  */
 Blockly.Menu.prototype.highlightNext = function() {
-  this.highlightHelper(function(index, max) {
-    return (index + 1) % max;
-  }, this.highlightedIndex_);
+  this.highlightHelper(this.highlightedIndex_, 1);
 };
 
 /**
@@ -320,10 +318,8 @@ Blockly.Menu.prototype.highlightNext = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightPrevious = function() {
-  this.highlightHelper(function(index, max) {
-    index--;
-    return index < 0 ? max - 1 : index;
-  }, this.highlightedIndex_);
+  this.highlightHelper(this.highlightedIndex_ < 0 ?
+      this.getChildCount() : this.highlightedIndex_, -1);
 };
 
 /**
@@ -331,50 +327,34 @@ Blockly.Menu.prototype.highlightPrevious = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightFirst = function() {
-  this.highlightHelper(function(index, max) {
-    return (index + 1) % max;
-  }, -1);
+  this.highlightHelper(-1, 1);
 };
 
 /**
- * Highlights the ranh highlightable item.
+ * Highlights the last highlightable item.
  * @package
  */
 Blockly.Menu.prototype.highlightLast = function() {
-  this.highlightHelper(function(index, max) {
-    index--;
-    return index < 0 ? max - 1 : index;
-  }, -1);
+  this.highlightHelper(this.getChildCount(), -1);
 };
 
 /**
  * Helper function that manages the details of moving the highlight among
  * child menuitems in response to keyboard events.
- * @param {function(this: Blockly.Component, number, number) : number} fn
- *     Function that accepts the current and maximum indices, and returns the
- *     next index to check.
  * @param {number} startIndex Start index.
- * @return {boolean} Whether the highlight has changed.
+ * @param {boolean} delta Step direction: 1 to go down, -1 to go up.
  * @protected
  */
-Blockly.Menu.prototype.highlightHelper = function(fn, startIndex) {
-  // If the start index is -1 (meaning there's nothing currently highlighted),
-  // try starting from the currently open item, if any.
-  var curIndex = startIndex < 0 ? -1 : startIndex;
-  var numItems = this.getChildCount();
-
-  curIndex = fn.call(this, curIndex, numItems);
-  var visited = 0;
-  while (visited <= numItems) {
-    var menuItem = /** @type {Blockly.MenuItem} */ (this.getChildAt(curIndex));
-    if (menuItem && menuItem.isEnabled()) {
-      this.setHighlightedIndex(curIndex);
-      return true;
+Blockly.Menu.prototype.highlightHelper = function(startIndex, delta) {
+  var index = startIndex + delta;
+  var menuItem;
+  while ((menuItem = this.getChildAt(index))) {
+    if (menuItem.isEnabled()) {
+      this.setHighlightedIndex(index);
+      break;
     }
-    visited++;
-    curIndex = fn.call(this, curIndex, numItems);
+    index += delta;
   }
-  return false;
 };
 
 // Mouse events.

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -340,6 +340,29 @@ Blockly.Menu.prototype.highlightPrevious = function() {
 };
 
 /**
+ * Highlights the first highlightable item.
+ * @package
+ */
+Blockly.Menu.prototype.highlightFirst = function() {
+  this.clearHighlighted();
+  this.highlightHelper(function(index, max) {
+    return (index + 1) % max;
+  }, -1);
+};
+
+/**
+ * Highlights the ranh highlightable item.
+ * @package
+ */
+Blockly.Menu.prototype.highlightLast = function() {
+  this.clearHighlighted();
+  this.highlightHelper(function(index, max) {
+    index--;
+    return index < 0 ? max - 1 : index;
+  }, -1);
+};
+
+/**
  * Helper function that manages the details of moving the highlight among
  * child menuitems in response to keyboard events.
  * @param {function(this: Blockly.Component, number, number) : number} fn
@@ -449,46 +472,34 @@ Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
  * Attempts to handle a keyboard event, if the menuitem is enabled, by calling
  * {@link handleKeyEventInternal}.  Considered protected; should only be used
  * within this package and by subclasses.
- * @param {Event} e Key event to handle.
- * @return {boolean} Whether the key event was handled.
+ * @param {!Event} e Key event to handle.
  * @protected
  */
 Blockly.Menu.prototype.handleKeyEvent = function(e) {
-  if (this.getChildCount() != 0 && this.handleKeyEventInternal(e)) {
+  if (this.getChildCount() && this.handleKeyEventInternal(e)) {
     e.preventDefault();
     e.stopPropagation();
-    return true;
   }
-  return false;
 };
 
 /**
  * Attempts to handle a keyboard event; returns true if the event was handled,
- * false otherwise.  If the container is enabled, and a child is highlighted,
- * calls the child menuitem's `handleKeyEvent` method to give the menuitem
- * a chance to handle the event first.
- * @param {Event} e Key event to handle.
+ * false otherwise.
+ * @param {!Event} e Key event to handle.
  * @return {boolean} Whether the event was handled by the container (or one of
  *     its children).
  * @protected
  */
 Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
-  // Give the highlighted menuitem the chance to handle the key event.
-  var highlighted = this.getHighlighted();
-  if (highlighted && typeof highlighted.handleKeyEvent == 'function' &&
-      highlighted.handleKeyEvent(e)) {
-    return true;
-  }
-
   // Do not handle the key event if any modifier key is pressed.
   if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
     return false;
   }
 
-  // Either nothing is highlighted, or the highlighted menuitem didn't handle
-  // the key event, so attempt to handle it here.
+  var highlighted = this.getHighlighted();
   switch (e.keyCode) {
     case Blockly.utils.KeyCodes.ENTER:
+    case Blockly.utils.KeyCodes.SPACE:
       if (highlighted) {
         highlighted.performActionInternal(e);
       }
@@ -500,6 +511,16 @@ Blockly.Menu.prototype.handleKeyEventInternal = function(e) {
 
     case Blockly.utils.KeyCodes.DOWN:
       this.highlightNext();
+      break;
+
+    case Blockly.utils.KeyCodes.PAGE_UP:
+    case Blockly.utils.KeyCodes.HOME:
+      this.highlightFirst();
+      break;
+
+    case Blockly.utils.KeyCodes.PAGE_DOWN:
+    case Blockly.utils.KeyCodes.END:
+      this.highlightLast();
       break;
 
     default:

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -258,7 +258,7 @@ Blockly.Menu.prototype.setHighlightedIndex = function(index) {
 /**
  * Highlights the given item if it exists and is a child of the container;
  * otherwise un-highlights the currently highlighted item.
- * @param {Blockly.MenuItem} item Item to highlight.
+ * @param {!Blockly.MenuItem} item Item to highlight.
  * @protected
  */
 Blockly.Menu.prototype.setHighlighted = function(item) {

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -260,14 +260,6 @@ Blockly.Menu.prototype.getMenuItem = function(node) {
 // Highlight management.
 
 /**
- * Clears the currently highlighted item.
- * @protected
- */
-Blockly.Menu.prototype.clearHighlighted = function() {
-  this.setHighlightedIndex(-1);
-};
-
-/**
  * Returns the currently highlighted item (if any).
  * @return {?Blockly.Component} Highlighted item (null if none).
  * @protected
@@ -284,18 +276,17 @@ Blockly.Menu.prototype.getHighlighted = function() {
  * @protected
  */
 Blockly.Menu.prototype.setHighlightedIndex = function(index) {
+  var currentHighlighted = this.getHighlighted();
+  if (currentHighlighted) {
+    currentHighlighted.setHighlighted(false);
+    this.highlightedIndex_ = -1;
+  }
   var child = this.getChildAt(index);
   if (child) {
     child.setHighlighted(true);
     this.highlightedIndex_ = index;
-  } else if (this.highlightedIndex_ > -1) {
-    this.getHighlighted().setHighlighted(false);
-    this.highlightedIndex_ = -1;
-  }
-
-  // Bring the highlighted item into view. This has no effect if the menu is not
-  // scrollable.
-  if (child) {
+    // Bring the highlighted item into view. This has no effect if the menu is
+    // not scrollable.
     Blockly.utils.style.scrollIntoContainerView(
         /** @type {!Element} */ (child.getElement()),
         /** @type {!Element} */ (this.getElement()));
@@ -318,11 +309,9 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
  * @package
  */
 Blockly.Menu.prototype.highlightNext = function() {
-  var highlightedIndex = this.highlightedIndex_;
-  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     return (index + 1) % max;
-  }, highlightedIndex);
+  }, this.highlightedIndex_);
 };
 
 /**
@@ -331,12 +320,10 @@ Blockly.Menu.prototype.highlightNext = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightPrevious = function() {
-  var highlightedIndex = this.highlightedIndex_;
-  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     index--;
     return index < 0 ? max - 1 : index;
-  }, highlightedIndex);
+  }, this.highlightedIndex_);
 };
 
 /**
@@ -344,7 +331,6 @@ Blockly.Menu.prototype.highlightPrevious = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightFirst = function() {
-  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     return (index + 1) % max;
   }, -1);
@@ -355,7 +341,6 @@ Blockly.Menu.prototype.highlightFirst = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightLast = function() {
-  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     index--;
     return index < 0 ? max - 1 : index;
@@ -409,10 +394,9 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
       if (currentHighlighted === menuItem) {
         return;
       }
-      this.clearHighlighted();
       this.setHighlighted(menuItem);
     } else {
-      this.clearHighlighted();
+      this.setHighlightedIndex(-1);
     }
   }
 };
@@ -462,7 +446,7 @@ Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
 Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
   if (this.getElement()) {
     this.blur();
-    this.clearHighlighted();
+    this.setHighlightedIndex(-1);
   }
 };
 

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -92,7 +92,7 @@ Blockly.Menu.prototype.createDom = function() {
   this.setElementInternal(element);
 
   // Set class
-  element.className = 'goog-menu goog-menu-vertical blocklyNonSelectable';
+  element.className = 'goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
 
   // Initialize ARIA role.

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -26,7 +26,9 @@ goog.require('Blockly.utils.style');
 Blockly.Menu = function() {
   /**
    * Array of menu items.
-   * @type {!Array.<!Blockly.MenuItem>}
+   * (Nulls are never in the array, but typing the array as nullable prevents
+   * the compiler from objecting to .indexOf(null))
+   * @type {!Array.<Blockly.MenuItem>}
    * @private
    */
   this.menuItems_ = [];

--- a/core/components/menu/menu.js
+++ b/core/components/menu/menu.js
@@ -260,22 +260,10 @@ Blockly.Menu.prototype.getMenuItem = function(node) {
 // Highlight management.
 
 /**
- * Unhighlight the current highlighted item.
- * @protected
- */
-Blockly.Menu.prototype.unhighlightCurrent = function() {
-  var highlighted = this.getHighlighted();
-  if (highlighted) {
-    highlighted.setHighlighted(false);
-  }
-};
-
-/**
  * Clears the currently highlighted item.
  * @protected
  */
 Blockly.Menu.prototype.clearHighlighted = function() {
-  this.unhighlightCurrent();
   this.setHighlightedIndex(-1);
 };
 
@@ -330,10 +318,11 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
  * @package
  */
 Blockly.Menu.prototype.highlightNext = function() {
-  this.unhighlightCurrent();
+  var highlightedIndex = this.highlightedIndex_;
+  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     return (index + 1) % max;
-  }, this.highlightedIndex_);
+  }, highlightedIndex);
 };
 
 /**
@@ -342,11 +331,12 @@ Blockly.Menu.prototype.highlightNext = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightPrevious = function() {
-  this.unhighlightCurrent();
+  var highlightedIndex = this.highlightedIndex_;
+  this.clearHighlighted();
   this.highlightHelper(function(index, max) {
     index--;
     return index < 0 ? max - 1 : index;
-  }, this.highlightedIndex_);
+  }, highlightedIndex);
 };
 
 /**
@@ -369,7 +359,7 @@ Blockly.Menu.prototype.highlightHelper = function(fn, startIndex) {
   var visited = 0;
   while (visited <= numItems) {
     var menuItem = /** @type {Blockly.MenuItem} */ (this.getChildAt(curIndex));
-    if (menuItem && this.canHighlightItem(menuItem)) {
+    if (menuItem && menuItem.isEnabled()) {
       this.setHighlightedIndex(curIndex);
       return true;
     }
@@ -377,16 +367,6 @@ Blockly.Menu.prototype.highlightHelper = function(fn, startIndex) {
     curIndex = fn.call(this, curIndex, numItems);
   }
   return false;
-};
-
-/**
- * Returns whether the given item can be highlighted.
- * @param {Blockly.MenuItem} item The item to check.
- * @return {boolean} Whether the item can be highlighted.
- * @protected
- */
-Blockly.Menu.prototype.canHighlightItem = function(item) {
-  return item.isEnabled();
 };
 
 // Mouse events.
@@ -406,11 +386,10 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
       if (currentHighlighted === menuItem) {
         return;
       }
-
-      this.unhighlightCurrent();
+      this.clearHighlighted();
       this.setHighlighted(menuItem);
     } else {
-      this.unhighlightCurrent();
+      this.clearHighlighted();
     }
   }
 };

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -63,7 +63,7 @@ Blockly.MenuItem = function(content, opt_value) {
 
   /**
    * ARIA name for this menu.
-   * @type {Blockly.utils.aria.Role}
+   * @type {?Blockly.utils.aria.Role}
    * @private
    */
   this.roleName_ = null;
@@ -98,7 +98,6 @@ Blockly.MenuItem = function(content, opt_value) {
 Blockly.MenuItem.prototype.createDom = function() {
   var element = document.createElement('div');
   element.id = Blockly.utils.IdGenerator.getNextUniqueId();
-  element.blocklyMenuItem = this;  // Link DOM back to this data structure.
   this.element_ = element;
 
   // Set class and style
@@ -134,10 +133,7 @@ Blockly.MenuItem.prototype.createDom = function() {
  * Dispose of this menu item.
  */
 Blockly.MenuItem.prototype.dispose = function() {
-  if (this.element_) {
-    this.element_.blocklyMenuItem = null;
-    this.element_ = null;
-  }
+  this.element_ = null;
 };
 
 /**

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -57,7 +57,7 @@ Blockly.MenuItem = function(content, opt_value) {
   /**
    * Whether the menu item is rendered right-to-left.
    * @type {boolean}
-   * @protected
+   * @private
    */
   this.rightToLeft_ = false;
 };

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -74,17 +74,18 @@ Blockly.MenuItem.prototype.createDom = function() {
   this.element_ = element;
 
   // Set class and style
-  element.className = 'goog-menuitem ' +
-      (!this.enabled_ ? 'goog-menuitem-disabled ' : '') +
-      (this.checked_ ? 'goog-option-selected ' : '') +
-      (this.rightToLeft_ ? 'goog-menuitem-rtl ' : '');
+  // goog-menuitem* is deprecated, use blocklyMenuItem*.  May 2020.
+  element.className = 'blocklyMenuItem goog-menuitem ' +
+      (this.enabled_ ? '' : 'blocklyMenuItemDisabled goog-menuitem-disabled ') +
+      (this.checked_ ? 'blocklyMenuItemSelected goog-option-selected ' : '') +
+      (this.rightToLeft_ ? 'blocklyMenuItemRtl goog-menuitem-rtl ' : '');
 
   var content = document.createElement('div');
-  content.className = 'goog-menuitem-content';
+  content.className = 'blocklyMenuItemContent goog-menuitem-content';
   // Add a checkbox for checkable menu items.
   if (this.checkable_) {
     var checkbox = document.createElement('div');
-    checkbox.className = 'goog-menuitem-checkbox';
+    checkbox.className = 'blocklyMenuItemCheckbox goog-menuitem-checkbox';
     content.appendChild(checkbox);
   }
 
@@ -183,10 +184,16 @@ Blockly.MenuItem.prototype.setHighlighted = function(highlight) {
 
   var el = this.getElement();
   if (el && this.isEnabled()) {
+    // goog-menuitem-highlight is deprecated, use blocklyMenuItemHighlight.
+    // May 2020.
+    var name = 'blocklyMenuItemHighlight';
+    var nameDep = 'goog-menuitem-highlight';
     if (highlight) {
-      Blockly.utils.dom.addClass(el, 'goog-menuitem-highlight');
+      Blockly.utils.dom.addClass(el, name);
+      Blockly.utils.dom.addClass(el, nameDep);
     } else {
-      Blockly.utils.dom.removeClass(el, 'goog-menuitem-highlight');
+      Blockly.utils.dom.removeClass(el, name);
+      Blockly.utils.dom.removeClass(el, nameDep);
     }
   }
 };
@@ -210,10 +217,16 @@ Blockly.MenuItem.prototype.setEnabled = function(enabled) {
 
   var el = this.getElement();
   if (el) {
+    // goog-menuitem-disabled is deprecated, use blocklyMenuItemDisabled.
+    // May 2020.
+    var name = 'blocklyMenuItemDisabled';
+    var nameDep = 'goog-menuitem-disabled';
     if (enabled) {
-      Blockly.utils.dom.removeClass(el, 'goog-menuitem-disabled');
+      Blockly.utils.dom.removeClass(el, name);
+      Blockly.utils.dom.removeClass(el, nameDep);
     } else {
-      Blockly.utils.dom.addClass(el, 'goog-menuitem-disabled');
+      Blockly.utils.dom.addClass(el, name);
+      Blockly.utils.dom.addClass(el, nameDep);
     }
   }
 };

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -63,10 +63,10 @@ Blockly.MenuItem = function(content, opt_value) {
 
   /**
    * ARIA name for this menu.
-   * @type {string}
+   * @type {Blockly.utils.aria.Role}
    * @private
    */
-  this.roleName_ = '';
+  this.roleName_ = null;
 
   /**
    * Is this menu item checkable.
@@ -121,7 +121,9 @@ Blockly.MenuItem.prototype.createDom = function() {
   element.appendChild(content);
 
   // Initialize ARIA role and state.
-  Blockly.utils.aria.setRole(element, this.roleName_);
+  if (this.roleName_) {
+    Blockly.utils.aria.setRole(element, this.roleName_);
+  }
   Blockly.utils.aria.setState(element, Blockly.utils.aria.State.SELECTED,
       (this.checkable_ && this.checked_) || false);
 

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -49,6 +49,7 @@ Blockly.utils.object.inherits(Blockly.MenuItem, Blockly.Component);
 Blockly.MenuItem.prototype.createDom = function() {
   var element = document.createElement('div');
   element.id = this.getId();
+  element.blocklyMenuItem = this;  // Link DOM back to this data structure.
   this.setElementInternal(element);
 
   // Set class and style

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -124,7 +124,7 @@ Blockly.MenuItem.prototype.getElement = function() {
  * @package
  */
 Blockly.MenuItem.prototype.getId = function() {
-  return this.element_.id_;
+  return this.element_.id;
 };
 
 /**

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -15,7 +15,6 @@ goog.provide('Blockly.MenuItem');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.IdGenerator');
-goog.require('Blockly.utils.object');
 
 
 /**
@@ -139,7 +138,7 @@ Blockly.MenuItem.prototype.getValue = function() {
 
 /**
  * Set menu item's rendering direction.
- * @param {boolean} rightToLeft True if RTL, false if LTR.
+ * @param {boolean} rtl True if RTL, false if LTR.
  * @package
  */
 Blockly.MenuItem.prototype.setRightToLeft = function(rtl) {

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -70,7 +70,7 @@ Blockly.MenuItem.prototype.createDom = function() {
       (this.checked_ ? 'goog-option-selected ' : '') +
       (this.rightToLeft_ ? 'goog-menuitem-rtl ' : '');
 
-  var content =  document.createElement('div');
+  var content = document.createElement('div');
   content.className = 'goog-menuitem-content';
   // Add a checkbox for checkable menu items.
   if (!this.checkable_) {
@@ -93,6 +93,7 @@ Blockly.MenuItem.prototype.disposeInternal = function() {
   this.getElement().blocklyMenuItem = null;
   Blockly.MenuItem.superClass_.disposeInternal.call(this);
 };
+
 /**
  * Gets the value associated with the menu item.
  * @return {*} value Value associated with the menu item.

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -64,7 +64,7 @@ Blockly.MenuItem.prototype.createDom = function() {
   this.setElementInternal(element);
 
   // Set class and style
-  element.className = 'goog-menuitem goog-option ' +
+  element.className = 'goog-menuitem ' +
       (!this.enabled_ ? 'goog-menuitem-disabled ' : '') +
       (this.checked_ ? 'goog-option-selected ' : '') +
       (this.rightToLeft_ ? 'goog-menuitem-rtl ' : '');

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -60,6 +60,34 @@ Blockly.MenuItem = function(content, opt_value) {
    * @private
    */
   this.rightToLeft_ = false;
+
+  /**
+   * ARIA name for this menu.
+   * @type {string}
+   * @private
+   */
+  this.roleName_ = '';
+
+  /**
+   * Is this menu item checkable.
+   * @type {boolean}
+   * @private
+   */
+  this.checkable_ = false;
+
+  /**
+   * Is this menu item currently checked.
+   * @type {boolean}
+   * @private
+   */
+  this.checked_ = false;
+
+  /**
+   * Bound function to call when this menu item is clicked.
+   * @type {Function}
+   * @private
+   */
+  this.actionHandler_ = null;
 };
 
 
@@ -214,21 +242,6 @@ Blockly.MenuItem.prototype.isEnabled = function() {
  */
 Blockly.MenuItem.prototype.setEnabled = function(enabled) {
   this.enabled_ = enabled;
-
-  var el = this.getElement();
-  if (el) {
-    // goog-menuitem-disabled is deprecated, use blocklyMenuItemDisabled.
-    // May 2020.
-    var name = 'blocklyMenuItemDisabled';
-    var nameDep = 'goog-menuitem-disabled';
-    if (enabled) {
-      Blockly.utils.dom.removeClass(el, name);
-      Blockly.utils.dom.removeClass(el, nameDep);
-    } else {
-      Blockly.utils.dom.addClass(el, name);
-      Blockly.utils.dom.addClass(el, nameDep);
-    }
-  }
 };
 
 /**
@@ -238,7 +251,7 @@ Blockly.MenuItem.prototype.setEnabled = function(enabled) {
  */
 Blockly.MenuItem.prototype.performAction = function() {
   if (this.isEnabled() && this.actionHandler_) {
-    this.actionHandler_.call(this.actionHandlerObj_, this);
+    this.actionHandler_(this);
   }
 };
 
@@ -250,6 +263,5 @@ Blockly.MenuItem.prototype.performAction = function() {
  * @package
  */
 Blockly.MenuItem.prototype.onAction = function(fn, obj) {
-  this.actionHandler_ = fn;
-  this.actionHandlerObj_ = obj;
+  this.actionHandler_ = fn.bind(obj);
 };

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -69,9 +69,7 @@ Blockly.MenuItem.prototype.createDom = function() {
   content.appendChild(this.getContentDom());
 
   // Initialize ARIA role and state.
-  Blockly.utils.aria.setRole(element, this.roleName_ || (this.checkable_ ?
-      Blockly.utils.aria.Role.MENUITEMCHECKBOX :
-      Blockly.utils.aria.Role.MENUITEM));
+  Blockly.utils.aria.setRole(element, this.roleName_);
   Blockly.utils.aria.setState(element, Blockly.utils.aria.State.SELECTED,
       (this.checkable_ && this.checked_) || false);
 };
@@ -242,7 +240,7 @@ Blockly.MenuItem.prototype.performAction = function() {
 /**
  * Set the handler that's called when the menu item is activated by the user.
  * `obj` will be used as the 'this' object in the function when called.
- * @param {function(this:T,!Blockly.MenuItem):?} fn The handler.
+ * @param {function(!Blockly.MenuItem)} fn The handler.
  * @param {!Object} obj Used as the 'this' object in fn when called.
  * @package
  */

--- a/core/components/menu/menuitem.js
+++ b/core/components/menu/menuitem.js
@@ -38,18 +38,6 @@ Blockly.MenuItem = function(content, opt_value) {
    * @private
    */
   this.enabled_ = true;
-
-  /**
-   * @type {Blockly.MenuItem}
-   * @private
-   */
-  this.previousSibling_;
-
-  /**
-   * @type {Blockly.MenuItem}
-   * @private
-   */
-  this.nextSibling_;
 };
 Blockly.utils.object.inherits(Blockly.MenuItem, Blockly.Component);
 
@@ -241,42 +229,24 @@ Blockly.MenuItem.prototype.setEnabled = function(enabled) {
 };
 
 /**
- * Handles click events. If the component is enabled, trigger
- * the action associated with this menu item.
- * @param {Event} _e Mouse event to handle.
- * @package
- */
-Blockly.MenuItem.prototype.handleClick = function(_e) {
-  if (this.isEnabled()) {
-    this.setHighlighted(true);
-    this.performActionInternal();
-  }
-};
-
-/**
  * Performs the appropriate action when the menu item is activated
  * by the user.
- * @protected
+ * @package
  */
-Blockly.MenuItem.prototype.performActionInternal = function() {
-  if (this.checkable_) {
-    this.setChecked(!this.checked_);
-  }
-  if (this.actionHandler_) {
-    this.actionHandler_.call(/** @type {?} */ (this.actionHandlerObj_), this);
+Blockly.MenuItem.prototype.performAction = function() {
+  if (this.isEnabled() && this.actionHandler_) {
+    this.actionHandler_.call(this.actionHandlerObj_, this);
   }
 };
 
 /**
- * Set the handler that's triggered when the menu item is activated
- * by the user. If `opt_obj` is provided, it will be used as the
- * 'this' object in the function when called.
+ * Set the handler that's called when the menu item is activated by the user.
+ * `obj` will be used as the 'this' object in the function when called.
  * @param {function(this:T,!Blockly.MenuItem):?} fn The handler.
- * @param {T=} opt_obj Used as the 'this' object in f when called.
- * @template T
+ * @param {!Object} obj Used as the 'this' object in fn when called.
  * @package
  */
-Blockly.MenuItem.prototype.onAction = function(fn, opt_obj) {
+Blockly.MenuItem.prototype.onAction = function(fn, obj) {
   this.actionHandler_ = fn;
-  this.actionHandlerObj_ = opt_obj;
+  this.actionHandlerObj_ = obj;
 };

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -722,16 +722,10 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
   var handled = true;
   switch (e.keyCode) {
     case Blockly.utils.KeyCodes.RIGHT:
-      if (e.altKey) {  // Why?
-        break;
-      }
       handled = this.selectChild();
       break;
 
     case Blockly.utils.KeyCodes.LEFT:
-      if (e.altKey) {  // Why?
-        break;
-      }
       handled = this.selectParent();
       break;
 

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -731,14 +731,14 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
   var handled = true;
   switch (e.keyCode) {
     case Blockly.utils.KeyCodes.RIGHT:
-      if (e.altKey) {
+      if (e.altKey) {  // Why?
         break;
       }
       handled = this.selectChild();
       break;
 
     case Blockly.utils.KeyCodes.LEFT:
-      if (e.altKey) {
+      if (e.altKey) {  // Why?
         break;
       }
       handled = this.selectParent();
@@ -750,6 +750,12 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
 
     case Blockly.utils.KeyCodes.UP:
       handled = this.selectPrevious();
+      break;
+
+    case Blockly.utils.KeyCodes.ENTER:
+    case Blockly.utils.KeyCodes.SPACE:
+      this.setExpanded(!this.expanded_);
+      handled = true;
       break;
 
     default:
@@ -847,18 +853,17 @@ Blockly.tree.BaseNode.prototype.getLastShownDescendant = function() {
 Blockly.tree.BaseNode.prototype.getNextShownNode = function() {
   if (this.hasChildren() && this.expanded_) {
     return this.getChildAt(0);
-  } else {
-    var parent = this;
-    var next;
-    while (parent != this.getTree()) {
-      next = parent.getNextSibling();
-      if (next != null) {
-        return next;
-      }
-      parent = parent.getParent();
-    }
-    return null;
   }
+  var parent = this;
+  var next;
+  while (parent != this.getTree()) {
+    next = parent.getNextSibling();
+    if (next != null) {
+      return next;
+    }
+    parent = parent.getParent();
+  }
+  return null;
 };
 
 /**

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -332,8 +332,8 @@ Blockly.tree.BaseNode.prototype.setDepth_ = function(depth) {
 };
 
 /**
- * Returns true if the node is a descendant of this node
- * @param {Blockly.tree.BaseNode} node The node to check.
+ * Returns true if the node is a descendant of this node.
+ * @param {Blockly.tree.Component} node The node to check.
  * @return {boolean} True if the node is a descendant of this node, false
  *    otherwise.
  * @protected

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -92,13 +92,6 @@ Blockly.tree.BaseNode = function(content, config) {
   this.expanded_ = false;
 
   /**
-   * Whether to allow user to collapse this node.
-   * @type {boolean}
-   * @protected
-   */
-  this.isUserCollapsible_ = true;
-
-  /**
    * Nesting depth of this node; cached result of getDepth.
    * -1 if value has not been cached.
    * @type {number}
@@ -174,8 +167,7 @@ Blockly.tree.BaseNode.prototype.initAccessibility = function() {
 
     var ce = this.getChildrenElement();
     if (ce) {
-      Blockly.utils.aria.setRole(ce,
-          Blockly.utils.aria.Role.GROUP);
+      Blockly.utils.aria.setRole(ce, Blockly.utils.aria.Role.GROUP);
 
       // In case the children will be created lazily.
       if (ce.hasChildNodes()) {
@@ -347,18 +339,17 @@ Blockly.tree.BaseNode.prototype.setDepth_ = function(depth) {
  * @protected
  */
 Blockly.tree.BaseNode.prototype.contains = function(node) {
-  var current = node;
-  while (current) {
-    if (current == this) {
+  while (node) {
+    if (node == this) {
       return true;
     }
-    current = current.getParent();
+    node = node.getParent();
   }
   return false;
 };
 
 /**
- * This is re-defined here to indicate to the closure compiler the correct
+ * This is re-defined here to indicate to the Closure Compiler the correct
  * child return type.
  * @param {number} index 0-based index.
  * @return {Blockly.tree.BaseNode} The child at the given index; null if none.
@@ -617,7 +608,7 @@ Blockly.tree.BaseNode.prototype.getIconDom = function() {
  * @protected
  */
 Blockly.tree.BaseNode.prototype.getCalculatedIconClass = function() {
-  throw Error('unimplemented abstract method');
+  throw Error(Blockly.Component.Error.ABSTRACT_METHOD);
 };
 
 /**
@@ -754,7 +745,7 @@ Blockly.tree.BaseNode.prototype.onKeyDown = function(e) {
 
     case Blockly.utils.KeyCodes.ENTER:
     case Blockly.utils.KeyCodes.SPACE:
-      this.setExpanded(!this.expanded_);
+      this.toggle();
       handled = true;
       break;
 
@@ -802,7 +793,7 @@ Blockly.tree.BaseNode.prototype.selectPrevious = function() {
  * @package
  */
 Blockly.tree.BaseNode.prototype.selectParent = function() {
-  if (this.hasChildren() && this.expanded_ && this.isUserCollapsible_) {
+  if (this.hasChildren() && this.expanded_) {
     this.setExpanded(false);
   } else {
     var parent = this.getParent();

--- a/core/components/tree/basenode.js
+++ b/core/components/tree/basenode.js
@@ -333,7 +333,7 @@ Blockly.tree.BaseNode.prototype.setDepth_ = function(depth) {
 
 /**
  * Returns true if the node is a descendant of this node.
- * @param {Blockly.tree.Component} node The node to check.
+ * @param {Blockly.Component} node The node to check.
  * @return {boolean} True if the node is a descendant of this node, false
  *    otherwise.
  * @protected

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -257,12 +257,8 @@ Blockly.tree.TreeControl.prototype.detachEvents_ = function() {
  */
 Blockly.tree.TreeControl.prototype.handleMouseEvent_ = function(e) {
   var node = this.getNodeFromEvent_(e);
-  if (node) {
-    switch (e.type) {
-      case 'click':
-        node.onClick_(e);
-        break;
-    }
+  if (node && e.type == 'click') {
+    node.onClick_(e);
   }
 };
 
@@ -273,10 +269,8 @@ Blockly.tree.TreeControl.prototype.handleMouseEvent_ = function(e) {
  * @private
  */
 Blockly.tree.TreeControl.prototype.handleKeyEvent_ = function(e) {
-  var handled = false;
-
   // Handle navigation keystrokes.
-  handled = (this.selectedItem_ && this.selectedItem_.onKeyDown(e)) || handled;
+  var handled = !!(this.selectedItem_ && this.selectedItem_.onKeyDown(e));
 
   if (handled) {
     Blockly.utils.style.scrollIntoContainerView(
@@ -299,7 +293,7 @@ Blockly.tree.TreeControl.prototype.getNodeFromEvent_ = function(e) {
   // find the right node
   var node = null;
   var target = e.target;
-  while (target != null) {
+  while (target) {
     var id = target.id;
     node = Blockly.tree.BaseNode.allNodes[id];
     if (node) {

--- a/core/components/tree/treecontrol.js
+++ b/core/components/tree/treecontrol.js
@@ -34,20 +34,6 @@ Blockly.tree.TreeControl = function(toolbox, config) {
   this.toolbox_ = toolbox;
 
   /**
-   * Focus event data.
-   * @type {?Blockly.EventData}
-   * @private
-   */
-  this.onFocusWrapper_ = null;
-
-  /**
-   * Blur event data.
-   * @type {?Blockly.EventData}
-   * @private
-   */
-  this.onBlurWrapper_ = null;
-
-  /**
    * Click event data.
    * @type {?Blockly.EventData}
    * @private
@@ -66,7 +52,7 @@ Blockly.tree.TreeControl = function(toolbox, config) {
   // The root is open and selected by default.
   this.expanded_ = true;
   this.selected_ = true;
-  
+
   /**
    * Currently selected item.
    * @type {Blockly.tree.BaseNode}
@@ -99,41 +85,6 @@ Blockly.tree.TreeControl.prototype.getToolbox = function() {
  */
 Blockly.tree.TreeControl.prototype.getDepth = function() {
   return 0;
-};
-
-/**
- * Handles focus on the tree.
- * @param {!Event} _e The browser event.
- * @private
- */
-Blockly.tree.TreeControl.prototype.handleFocus_ = function(_e) {
-  this.focused_ = true;
-  var el = /** @type {!Element} */ (this.getElement());
-  Blockly.utils.dom.addClass(el, 'focused');
-
-  if (this.selectedItem_) {
-    this.selectedItem_.select();
-  }
-};
-
-/**
- * Handles blur on the tree.
- * @param {!Event} _e The browser event.
- * @private
- */
-Blockly.tree.TreeControl.prototype.handleBlur_ = function(_e) {
-  this.focused_ = false;
-  var el = /** @type {!Element} */ (this.getElement());
-  Blockly.utils.dom.removeClass(el, 'focused');
-};
-
-/**
- * Get whether this tree has focus or not.
- * @return {boolean} True if it has focus.
- * @package
- */
-Blockly.tree.TreeControl.prototype.hasFocus = function() {
-  return this.focused_;
 };
 
 /** @override */
@@ -278,10 +229,6 @@ Blockly.tree.TreeControl.prototype.attachEvents_ = function() {
   var el = this.getElement();
   el.tabIndex = 0;
 
-  this.onFocusWrapper_ = Blockly.bindEvent_(el,
-      'focus', this, this.handleFocus_);
-  this.onBlurWrapper_ = Blockly.bindEvent_(el,
-      'blur', this, this.handleBlur_);
   this.onClickWrapper_ = Blockly.bindEventWithChecks_(el,
       'click', this, this.handleMouseEvent_);
   this.onKeydownWrapper_ = Blockly.bindEvent_(el,
@@ -293,14 +240,6 @@ Blockly.tree.TreeControl.prototype.attachEvents_ = function() {
  * @private
  */
 Blockly.tree.TreeControl.prototype.detachEvents_ = function() {
-  if (this.onFocusWrapper_) {
-    Blockly.unbindEvent_(this.onFocusWrapper_);
-    this.onFocusWrapper_ = null;
-  }
-  if (this.onBlurWrapper_) {
-    Blockly.unbindEvent_(this.onBlurWrapper_);
-    this.onBlurWrapper_ = null;
-  }
   if (this.onClickWrapper_) {
     Blockly.unbindEvent_(this.onClickWrapper_);
     this.onClickWrapper_ = null;

--- a/core/components/tree/treenode.js
+++ b/core/components/tree/treenode.js
@@ -93,7 +93,7 @@ Blockly.tree.TreeNode.prototype.getCalculatedIconClass = function() {
  */
 Blockly.tree.TreeNode.prototype.onClick_ = function(_e) {
   // Expand icon.
-  if (this.hasChildren() && this.isUserCollapsible_) {
+  if (this.hasChildren()) {
     this.toggle();
     this.select();
   } else if (this.isSelected()) {

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -77,7 +77,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
      callback: Blockly.MakeItSo}
   */
   var menu = new Blockly.Menu();
-  menu.setRightToLeft(rtl);
+  menu.setRole(Blockly.utils.aria.Role.MENU);
   for (var i = 0, option; (option = options[i]); i++) {
     var menuItem = new Blockly.MenuItem(option.text);
     menuItem.setRightToLeft(rtl);

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -60,7 +60,7 @@ Blockly.ContextMenu.show = function(e, options, rtl) {
   Blockly.ContextMenu.position_(menu, e, rtl);
   // 1ms delay is required for focusing on context menus because some other
   // mouse event is still waiting in the queue and clears focus.
-  setTimeout(function() {menu.getElement().focus();}, 1);
+  setTimeout(function() {menu.focus();}, 1);
   Blockly.ContextMenu.currentBlock = null;  // May be set by Blockly.Block.
 };
 
@@ -86,7 +86,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
     menu.addChild(menuItem);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
-      var actionHandler = function() {
+      var actionHandler = function(_menuItem) {
         var option = this;
         Blockly.ContextMenu.hide();
         option.callback();
@@ -128,7 +128,7 @@ Blockly.ContextMenu.position_ = function(menu, e, rtl) {
   // Calling menuDom.focus() has to wait until after the menu has been placed
   // correctly.  Otherwise it will cause a page scroll to get the misplaced menu
   // in view.  See issue #1329.
-  menu.getElement().focus();
+  menu.focus();
 };
 
 /**

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -83,7 +83,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
     var menuItem = new Blockly.MenuItem(option.text);
     menuItem.setRightToLeft(rtl);
     menuItem.setRole(Blockly.utils.aria.Role.MENUITEM);
-    menu.addChild(menuItem, true);
+    menu.addChild(menuItem);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
       var actionHandler = function() {

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -36,11 +36,11 @@ goog.require('Blockly.Xml');
 Blockly.ContextMenu.currentBlock = null;
 
 /**
- * Opaque data that can be passed to unbindEvent_.
- * @type {Array.<!Array>}
+ * Menu object.
+ * @type {Blockly.Menu}
  * @private
  */
-Blockly.ContextMenu.eventWrapper_ = null;
+Blockly.ContextMenu.menu_ = null;
 
 /**
  * Construct the menu based on the list of options and show the menu.
@@ -49,12 +49,13 @@ Blockly.ContextMenu.eventWrapper_ = null;
  * @param {boolean} rtl True if RTL, false if LTR.
  */
 Blockly.ContextMenu.show = function(e, options, rtl) {
-  Blockly.WidgetDiv.show(Blockly.ContextMenu, rtl, null);
+  Blockly.WidgetDiv.show(Blockly.ContextMenu, rtl, Blockly.ContextMenu.dispose);
   if (!options.length) {
     Blockly.ContextMenu.hide();
     return;
   }
   var menu = Blockly.ContextMenu.populate_(options, rtl);
+  Blockly.ContextMenu.menu_ = menu;
 
   Blockly.ContextMenu.position_(menu, e, rtl);
   // 1ms delay is required for focusing on context menus because some other
@@ -154,9 +155,15 @@ Blockly.ContextMenu.createWidget_ = function(menu) {
 Blockly.ContextMenu.hide = function() {
   Blockly.WidgetDiv.hideIfOwner(Blockly.ContextMenu);
   Blockly.ContextMenu.currentBlock = null;
-  if (Blockly.ContextMenu.eventWrapper_) {
-    Blockly.unbindEvent_(Blockly.ContextMenu.eventWrapper_);
-    Blockly.ContextMenu.eventWrapper_ = null;
+};
+
+/**
+ * Dispose of the menu.
+ */
+Blockly.ContextMenu.dispose = function() {
+  if (Blockly.ContextMenu.menu_) {
+    Blockly.ContextMenu.menu_.dispose();
+    Blockly.ContextMenu.menu_ = null;
   }
 };
 

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -81,6 +81,7 @@ Blockly.ContextMenu.populate_ = function(options, rtl) {
   for (var i = 0, option; (option = options[i]); i++) {
     var menuItem = new Blockly.MenuItem(option.text);
     menuItem.setRightToLeft(rtl);
+    menuItem.setRole(Blockly.utils.aria.Role.MENUITEM);
     menu.addChild(menuItem, true);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {

--- a/core/css.js
+++ b/core/css.js
@@ -150,8 +150,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 4px 4px 20px 1px rgba(0,0,0,.15);',
     'color: #000;',
     'display: none;',
-    'font-family: sans-serif;',
-    'font-size: 9pt;',
+    'font: 9pt sans-serif;',
     'opacity: .9;',
     'padding: 2px;',
     'position: absolute;',
@@ -333,7 +332,8 @@ Blockly.Css.CONTENT = [
     Don't allow users to select text.  It gets annoying when trying to
     drag a block and selected text moves instead.
   */
-  '.blocklySvg text, .blocklyBlockDragSurface text {',
+  '.blocklySvg text,',
+  '.blocklyBlockDragSurface text {',
     'user-select: none;',
     '-ms-user-select: none;',
     '-webkit-user-select: none;',
@@ -416,7 +416,8 @@ Blockly.Css.CONTENT = [
     'z-index: 30;',
   '}',
 
-  '.blocklyScrollbarHorizontal, .blocklyScrollbarVertical {',
+  '.blocklyScrollbarHorizontal,',
+  '.blocklyScrollbarVertical {',
     'position: absolute;',
     'outline: none;',
   '}',
@@ -449,6 +450,22 @@ Blockly.Css.CONTENT = [
     'background: #faa;',
   '}',
 
+  '.blocklyVerticalMarker {',
+    'stroke-width: 3px;',
+    'fill: rgba(255,255,255,.5);',
+    'pointer-events: none',
+  '}',
+
+  '.blocklyComputeCanvas {',
+    'position: absolute;',
+    'width: 0;',
+    'height: 0;',
+  '}',
+
+  '.blocklyNoPointerEvents {',
+    'pointer-events: none;',
+  '}',
+
   '.blocklyContextMenu {',
     'border-radius: 4px;',
     'max-height: 100%;',
@@ -466,7 +483,6 @@ Blockly.Css.CONTENT = [
   '}',
 
   /* BiDi override for the resting state. */
-  /* #noflip */
   '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl,',
   '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl {',
      /* Flip left/right padding for BiDi. */
@@ -474,37 +490,10 @@ Blockly.Css.CONTENT = [
     'padding-right: 28px;',
   '}',
 
-  '.blocklyVerticalMarker {',
-    'stroke-width: 3px;',
-    'fill: rgba(255,255,255,.5);',
-    'pointer-events: none',
-  '}',
-
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox {',
-    'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
-  '}',
-
-  /* Copied from: goog/css/menu.css */
-  /*
-   * Copyright 2009 The Closure Library Authors. All Rights Reserved.
-   *
-   * Use of this source code is governed by the Apache License, Version 2.0.
-   * See the COPYING file for details.
-   */
-
-  /**
-   * Standard styling for menus created by goog.ui.MenuRenderer.
-   *
-   * @author attila@google.com (Attila Bodis)
-   */
-
   '.blocklyWidgetDiv .goog-menu {',
     'background: #fff;',
-    'border-color: transparent;',
-    'border-style: solid;',
-    'border-width: 1px;',
-    'cursor: default;',
+    'border: 1px solid transparent;',
+    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
     'font: normal 13px Arial, sans-serif;',
     'margin: 0;',
     'outline: none;',
@@ -514,7 +503,6 @@ Blockly.Css.CONTENT = [
     'overflow-x: hidden;',
     'max-height: 100%;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
-    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
   '}',
 
   '.blocklyWidgetDiv .goog-menu.focused {',
@@ -522,63 +510,30 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownDiv .goog-menu {',
-    'cursor: default;',
     'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
     'outline: none;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 
-  /* Copied from: goog/css/menuitem.css */
-  /*
-   * Copyright 2009 The Closure Library Authors. All Rights Reserved.
-   *
-   * Use of this source code is governed by the Apache License, Version 2.0.
-   * See the COPYING file for details.
-   */
-
-  /**
-   * Standard styling for menus created by goog.ui.MenuItemRenderer.
-   *
-   * @author attila@google.com (Attila Bodis)
-   */
-
-  /**
-   * State: resting.
-   */
+  /* State: resting. */
   '.blocklyWidgetDiv .goog-menuitem,',
   '.blocklyDropDownDiv .goog-menuitem {',
+    'border: none;',
     'color: #000;',
-    'font: normal 13px Arial, sans-serif;',
+    'cursor: pointer;',
     'list-style: none;',
     'margin: 0;',
      /* 7em on the right for shortcut. */
     'min-width: 7em;',
-    'border: none;',
     'padding: 6px 15px;',
     'white-space: nowrap;',
-    'cursor: pointer;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-menuitem-content,',
-  '.blocklyDropDownDiv .goog-menuitem-content {',
-    'font-family: Arial, sans-serif;',
-    'font-size: 13px;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-menuitem-content,',
-  '.blocklyDropDownDiv .goog-menuitem-content {',
-    'color: #000;',
   '}',
 
   /* State: disabled. */
   '.blocklyWidgetDiv .goog-menuitem-disabled,',
   '.blocklyDropDownDiv .goog-menuitem-disabled {',
-    'cursor: inherit;',
-  '}',
-
-  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-content,',
-  '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-content {',
     'color: #ccc !important;',
+    'cursor: inherit;',
   '}',
 
   /* State: hover. */
@@ -590,39 +545,23 @@ Blockly.Css.CONTENT = [
   /* State: selected/checked. */
   '.blocklyWidgetDiv .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-menuitem-checkbox {',
-    'background-repeat: no-repeat;',
     'height: 16px;',
-    'left: 6px;',
     'position: absolute;',
-    'right: auto;',
-    'vertical-align: middle;',
     'width: 16px;',
   '}',
 
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox {',
-    'position: static;', /* Scroll with the menu. */
+    'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
     'float: left;',
     'margin-left: -24px;',
+    'position: static;', /* Scroll with the menu. */
   '}',
 
   '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
   '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox {',
     'float: right;',
     'margin-right: -24px;',
-     /* Flip left/right positioning. */
-    'left: auto;',
-    'right: 6px;',
-  '}',
-
-  '.blocklyComputeCanvas {',
-    'position: absolute;',
-    'width: 0;',
-    'height: 0;',
-  '}',
-
-  '.blocklyNoPointerEvents {',
-    'pointer-events: none;',
   '}',
   /* eslint-enable indent */
 ];

--- a/core/css.js
+++ b/core/css.js
@@ -308,7 +308,7 @@ Blockly.Css.CONTENT = [
   '.blocklyInsertionMarker>.blocklyPathLight,',
   '.blocklyInsertionMarker>.blocklyPathDark {',
     'fill-opacity: .2;',
-    'stroke: none',
+    'stroke: none;',
   '}',
 
   '.blocklyMultilineText {',
@@ -453,7 +453,7 @@ Blockly.Css.CONTENT = [
   '.blocklyVerticalMarker {',
     'stroke-width: 3px;',
     'fill: rgba(255,255,255,.5);',
-    'pointer-events: none',
+    'pointer-events: none;',
   '}',
 
   '.blocklyComputeCanvas {',

--- a/core/css.js
+++ b/core/css.js
@@ -171,7 +171,7 @@ Blockly.Css.CONTENT = [
     'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
   '}',
 
-  '.blocklyDropDownDiv.focused {',
+  '.blocklyDropDownDiv.blocklyFocused {',
     'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
   '}',
 
@@ -476,21 +476,19 @@ Blockly.Css.CONTENT = [
     'padding: 0 !important;',
   '}',
 
-  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem,',
-  '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem {',
+  '.blocklyDropdownMenu .blocklyMenuItem {',
     /* 28px on the left for icon or checkbox. */
     'padding-left: 28px;',
   '}',
 
   /* BiDi override for the resting state. */
-  '.blocklyWidgetDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl,',
-  '.blocklyDropDownDiv .blocklyDropdownMenu .goog-menuitem.goog-menuitem-rtl {',
+  '.blocklyDropdownMenu .blocklyMenuItemRtl {',
      /* Flip left/right padding for BiDi. */
     'padding-left: 5px;',
     'padding-right: 28px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menu {',
+  '.blocklyWidgetDiv .blocklyMenu {',
     'background: #fff;',
     'border: 1px solid transparent;',
     'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
@@ -505,19 +503,18 @@ Blockly.Css.CONTENT = [
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 
-  '.blocklyWidgetDiv .goog-menu.focused {',
+  '.blocklyWidgetDiv .blocklyMenu.blocklyFocused {',
     'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
   '}',
 
-  '.blocklyDropDownDiv .goog-menu {',
+  '.blocklyDropDownDiv .blocklyMenu {',
     'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
     'outline: none;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 
   /* State: resting. */
-  '.blocklyWidgetDiv .goog-menuitem,',
-  '.blocklyDropDownDiv .goog-menuitem {',
+  '.blocklyMenuItem {',
     'border: none;',
     'color: #000;',
     'cursor: pointer;',
@@ -530,36 +527,31 @@ Blockly.Css.CONTENT = [
   '}',
 
   /* State: disabled. */
-  '.blocklyWidgetDiv .goog-menuitem-disabled,',
-  '.blocklyDropDownDiv .goog-menuitem-disabled {',
-    'color: #ccc !important;',
+  '.blocklyMenuItemDisabled {',
+    'color: #ccc;',
     'cursor: inherit;',
   '}',
 
   /* State: hover. */
-  '.blocklyWidgetDiv .goog-menuitem-highlight ,',
-  '.blocklyDropDownDiv .goog-menuitem-highlight {',
+  '.blocklyMenuItemHighlight {',
     'background-color: rgba(0,0,0,.1);',
   '}',
 
   /* State: selected/checked. */
-  '.blocklyWidgetDiv .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-checkbox {',
+  '.blocklyMenuItemCheckbox {',
     'height: 16px;',
     'position: absolute;',
     'width: 16px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox {',
+  '.blocklyMenuItemSelected .blocklyMenuItemCheckbox {',
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
     'float: left;',
     'margin-left: -24px;',
     'position: static;', /* Scroll with the menu. */
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox {',
+  '.blocklyMenuItemRtl .blocklyMenuItemCheckbox {',
     'float: right;',
     'margin-right: -24px;',
   '}',

--- a/core/css.js
+++ b/core/css.js
@@ -74,13 +74,13 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
 
 /**
  * Set the cursor to be displayed when over something draggable.
- * See See https://github.com/google/blockly/issues/981 for context.
+ * See https://github.com/google/blockly/issues/981 for context.
  * @param {*} _cursor Enum.
  * @deprecated April 2017.
  */
 Blockly.Css.setCursor = function(_cursor) {
   console.warn('Deprecated call to Blockly.Css.setCursor. ' +
-      'See https://github.com/google/blockly/issues/981 for context');
+      'See issue #981 for context');
 };
 
 /**
@@ -169,11 +169,11 @@ Blockly.Css.CONTENT = [
     'background-color: #fff;',
     'border-radius: 2px;',
     'padding: 4px;',
-    'box-shadow: 0px 0px 3px 1px rgba(0,0,0,.3);',
+    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
   '}',
 
   '.blocklyDropDownDiv.focused {',
-    'box-shadow: 0px 0px 6px 1px rgba(0,0,0,.3);',
+    'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
   '}',
 
   '.blocklyDropDownContent {',
@@ -481,9 +481,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
+  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox {',
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
   '}',
 
@@ -516,11 +514,11 @@ Blockly.Css.CONTENT = [
     'overflow-x: hidden;',
     'max-height: 100%;',
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
-    'box-shadow: 0px 0px 3px 1px rgba(0,0,0,.3);',
+    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
   '}',
 
   '.blocklyWidgetDiv .goog-menu.focused {',
-    'box-shadow: 0px 0px 6px 1px rgba(0,0,0,.3);',
+    'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
   '}',
 
   '.blocklyDropDownDiv .goog-menu {',
@@ -546,18 +544,6 @@ Blockly.Css.CONTENT = [
 
   /**
    * State: resting.
-   *
-   * NOTE(mleibman,chrishenry):
-   * The RTL support in Closure is provided via two mechanisms -- "rtl" CSS
-   * classes and BiDi flipping done by the CSS compiler.  Closure supports RTL
-   * with or without the use of the CSS compiler.  In order for them not to
-   * conflict with each other, the "rtl" CSS classes need to have the #noflip
-   * annotation.  The non-rtl counterparts should ideally have them as well,
-   * but, since .goog-menuitem existed without .goog-menuitem-rtl for so long
-   * before being added, there is a risk of people having templates where they
-   * are not rendering the .goog-menuitem-rtl class when in RTL and instead
-   * rely solely on the BiDi flipping by the CSS compiler.  That's why we're
-   * not adding the #noflip to .goog-menuitem.
    */
   '.blocklyWidgetDiv .goog-menuitem,',
   '.blocklyDropDownDiv .goog-menuitem {',
@@ -573,26 +559,13 @@ Blockly.Css.CONTENT = [
     'cursor: pointer;',
   '}',
 
-  /* If a menu doesn't have checkable items or items with icons,
-   * remove padding.
-   */
-  '.blocklyWidgetDiv .goog-menu-nocheckbox .goog-menuitem,',
-  '.blocklyWidgetDiv .goog-menu-noicon .goog-menuitem,',
-  '.blocklyDropDownDiv .goog-menu-nocheckbox .goog-menuitem,',
-  '.blocklyDropDownDiv .goog-menu-noicon .goog-menuitem {',
-    'padding-left: 12px;',
-  '}',
-
   '.blocklyWidgetDiv .goog-menuitem-content,',
   '.blocklyDropDownDiv .goog-menuitem-content {',
     'font-family: Arial, sans-serif;',
     'font-size: 13px;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-content {',
-    'color: #000;',
-  '}',
-
+  '.blocklyWidgetDiv .goog-menuitem-content,',
   '.blocklyDropDownDiv .goog-menuitem-content {',
     'color: #000;',
   '}',
@@ -608,12 +581,6 @@ Blockly.Css.CONTENT = [
     'color: #ccc !important;',
   '}',
 
-  '.blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-menuitem-disabled .goog-menuitem-icon {',
-    'opacity: .3;',
-    'filter: alpha(opacity=30);',
-  '}',
-
   /* State: hover. */
   '.blocklyWidgetDiv .goog-menuitem-highlight ,',
   '.blocklyDropDownDiv .goog-menuitem-highlight {',
@@ -622,9 +589,7 @@ Blockly.Css.CONTENT = [
 
   /* State: selected/checked. */
   '.blocklyWidgetDiv .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-icon {',
+  '.blocklyDropDownDiv .goog-menuitem-checkbox {',
     'background-repeat: no-repeat;',
     'height: 16px;',
     'left: 6px;',
@@ -634,32 +599,20 @@ Blockly.Css.CONTENT = [
     'width: 16px;',
   '}',
 
-  /* BiDi override for the selected/checked state. */
-  /* #noflip */
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
-     /* Flip left/right positioning. */
-    'left: auto;',
-    'right: 6px;',
-  '}',
-
   '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-option-selected .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-icon {',
+  '.blocklyDropDownDiv .goog-option-selected .goog-menuitem-checkbox {',
     'position: static;', /* Scroll with the menu. */
     'float: left;',
     'margin-left: -24px;',
   '}',
 
   '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyWidgetDiv .goog-menuitem-rtl .goog-menuitem-icon,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox,',
-  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-icon {',
+  '.blocklyDropDownDiv .goog-menuitem-rtl .goog-menuitem-checkbox {',
     'float: right;',
     'margin-right: -24px;',
+     /* Flip left/right positioning. */
+    'left: auto;',
+    'right: 6px;',
   '}',
 
   '.blocklyComputeCanvas {',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -184,7 +184,7 @@ Blockly.DropDownDiv.setBoundsElement = function(boundsElement) {
 
 /**
  * Provide the div for inserting content into the drop-down.
- * @return {Element} Div to populate with content
+ * @return {!Element} Div to populate with content.
  */
 Blockly.DropDownDiv.getContentDiv = function() {
   return Blockly.DropDownDiv.content_;

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -166,10 +166,10 @@ Blockly.DropDownDiv.createDom = function() {
   // Handle focusin/out events to add a visual indicator when
   // a child is focused or blurred.
   div.addEventListener('focusin', function() {
-    Blockly.utils.dom.addClass(div, 'focused');
+    Blockly.utils.dom.addClass(div, 'blocklyFocused');
   });
   div.addEventListener('focusout', function() {
-    Blockly.utils.dom.removeClass(div, 'focused');
+    Blockly.utils.dom.removeClass(div, 'blocklyFocused');
   });
 };
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -330,7 +330,7 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
     menuItem.setRole(Blockly.utils.aria.Role.OPTION);
     menuItem.setRightToLeft(this.sourceBlock_.RTL);
     menuItem.setCheckable(true);
-    menu.addChild(menuItem, true);
+    menu.addChild(menuItem);
     menuItem.setChecked(value == this.value_);
     if (value == this.value_) {
       this.selectedMenuItem_ = menuItem;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -308,7 +308,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
  */
 Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
   var menu = new Blockly.Menu();
-  menu.setRightToLeft(this.sourceBlock_.RTL);
   menu.setRole(Blockly.utils.aria.Role.LISTBOX);
 
   var options = this.getOptions(false);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -322,10 +322,9 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
       image.alt = content['alt'] || '';
       content = image;
     }
-    var menuItem = new Blockly.MenuItem(content);
+    var menuItem = new Blockly.MenuItem(content, value);
     menuItem.setRole(Blockly.utils.aria.Role.OPTION);
     menuItem.setRightToLeft(this.sourceBlock_.RTL);
-    menuItem.setValue(value);
     menuItem.setCheckable(true);
     menu.addChild(menuItem, true);
     menuItem.setChecked(value == this.value_);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -270,8 +270,12 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
   }
   // Element gets created in render.
   this.menu_.render(Blockly.DropDownDiv.getContentDiv());
-  Blockly.utils.dom.addClass(
-      /** @type {!Element} */ (this.menu_.getElement()), 'blocklyDropdownMenu');
+  var menuElement = /** @type {!Element} */ (this.menu_.getElement());
+  Blockly.utils.dom.addClass(menuElement, 'blocklyDropdownMenu');
+
+  Blockly.utils.aria.setState(menuElement,
+      Blockly.utils.aria.State.ACTIVEDESCENDANT,
+      this.selectedMenuItem_ ? this.selectedMenuItem_.getId() : '');
 
   if (this.getConstants().FIELD_DROPDOWN_COLOURED_DIV) {
     var primaryColour = (this.sourceBlock_.isShadow()) ?
@@ -295,7 +299,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
   if (this.selectedMenuItem_) {
     Blockly.utils.style.scrollIntoContainerView(
         /** @type {!Element} */ (this.selectedMenuItem_.getElement()),
-        /** @type {!Element} */ (this.menu_.getElement()));
+        menuElement);
   }
 
   this.applyColour();
@@ -333,10 +337,6 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
     }
     menuItem.onAction(this.handleMenuActionEvent_, this);
   }
-
-  Blockly.utils.aria.setState(/** @type {!Element} */ (menu.getElement()),
-      Blockly.utils.aria.State.ACTIVEDESCENDANT,
-      this.selectedMenuItem_ ? this.selectedMenuItem_.getId() : '');
 
   return menu;
 };

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -166,7 +166,7 @@ Blockly.FlyoutButton.prototype.createDom = function() {
   var fontMetrics = Blockly.utils.dom.measureFontMetrics(text, fontSize,
       fontWeight, fontFamily);
   this.height = fontMetrics.height;
-  
+
   if (!this.isLabel_) {
     this.width += 2 * Blockly.FlyoutButton.MARGIN_X;
     this.height += 2 * Blockly.FlyoutButton.MARGIN_Y;

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -71,7 +71,7 @@ Blockly.BasicCursor.prototype.prev = function() {
     return null;
   }
   var newNode = this.getPreviousNode_(curNode, this.validNode_);
-  
+
   if (newNode) {
     this.setCurNode(newNode);
   }

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -23,7 +23,6 @@ goog.require('Blockly.navigation');
  * @constructor
  */
 Blockly.Marker = function() {
-  
   /**
    * The colour of the marker.
    * @type {?string}
@@ -119,4 +118,3 @@ Blockly.Marker.prototype.dispose = function() {
     this.getDrawer().dispose();
   }
 };
-

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -256,7 +256,7 @@ Blockly.blockRendering.ConstantProvider = function() {
    * @type {number}
    */
   this.FIELD_TEXT_HEIGHT = -1; // Dynamically set
-  
+
   /**
    * Text baseline.  This constant is dynamically set in ``setFontConstants_``
    * to be the baseline of the text based on the font used.
@@ -1168,9 +1168,8 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
     // Text.
     selector + ' .blocklyText, ',
     selector + ' .blocklyFlyoutLabelText {',
-      'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
-      'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
-      'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
+      'font: ' + this.FIELD_TEXT_FONTWEIGHT + ' ' +
+          this.FIELD_TEXT_FONTSIZE + 'pt ' + this.FIELD_TEXT_FONTFAMILY + ';',
     '}',
 
     // Fields.
@@ -1233,7 +1232,7 @@ Blockly.blockRendering.ConstantProvider.prototype.getCSS_ = function(selector) {
     // Insertion marker.
     selector + ' .blocklyInsertionMarker>.blocklyPath {',
       'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
-      'stroke: none',
+      'stroke: none;',
     '}',
     /* eslint-enable indent */
   ];

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -581,7 +581,7 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
   if (row.hasExternalInput || row.hasStatement) {
     row.widthWithConnectedBlocks += missingSpace;
   }
-  
+
   // Decide where the extra padding goes.
   if (row.align == Blockly.ALIGN_LEFT) {
     // Add padding to the end of the row.

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -57,7 +57,7 @@ Blockly.geras.ConstantProvider.prototype.getCSS_ = function(selector) {
         selector + ' .blocklyInsertionMarker>.blocklyPathLight,',
         selector + ' .blocklyInsertionMarker>.blocklyPathDark {',
           'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
-          'stroke: none',
+          'stroke: none;',
         '}',
         /* eslint-enable indent */
       ]);

--- a/core/renderers/geras/path_object.js
+++ b/core/renderers/geras/path_object.js
@@ -122,7 +122,7 @@ Blockly.geras.PathObject.prototype.applyColour = function(block) {
   this.svgPathDark.setAttribute('fill', this.colourDark);
 
   Blockly.geras.PathObject.superClass_.applyColour.call(this, block);
-  
+
   this.svgPath.setAttribute('stroke', 'none');
 };
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -69,7 +69,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.NOTCH_OFFSET_LEFT = 3 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -259,7 +259,7 @@ Blockly.zelos.ConstantProvider = function() {
    * @override
    */
   this.FIELD_BORDER_RECT_X_PADDING = 2 * this.GRID_UNIT;
-  
+
   /**
    * @override
    */
@@ -905,13 +905,12 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
   return [
     /* eslint-disable indent */
     // Text.
-    selector + ' .blocklyText, ',
+    selector + ' .blocklyText,',
     selector + ' .blocklyFlyoutLabelText {',
-      'font-family: ' + this.FIELD_TEXT_FONTFAMILY + ';',
-      'font-size: ' + this.FIELD_TEXT_FONTSIZE + 'pt;',
-      'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
+      'font: ' + this.FIELD_TEXT_FONTWEIGHT + ' ' +
+          this.FIELD_TEXT_FONTSIZE + 'pt ' + this.FIELD_TEXT_FONTFAMILY + ';',
     '}',
-  
+
     // Fields.
     selector + ' .blocklyText {',
       'fill: #fff;',
@@ -926,7 +925,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
     selector + ' .blocklyEditableText>g>text {',
       'fill: #575E75;',
     '}',
-  
+
     // Flyout labels.
     selector + ' .blocklyFlyoutLabelText {',
       'fill: #575E75;',
@@ -939,7 +938,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
 
     // Editable field hover.
     selector + ' .blocklyDraggable:not(.blocklyDisabled)',
-    ' .blocklyEditableText:not(.editing):hover>rect ,',
+    ' .blocklyEditableText:not(.editing):hover>rect,',
     selector + ' .blocklyDraggable:not(.blocklyDisabled)',
     ' .blocklyEditableText:not(.editing):hover>.blocklyPath {',
       'stroke: #fff;',
@@ -952,7 +951,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
       'font-weight: ' + this.FIELD_TEXT_FONTWEIGHT + ';',
       'color: #575E75;',
     '}',
-  
+
     // Dropdown field.
     selector + ' .blocklyDropdownText {',
       'fill: #fff !important;',
@@ -979,7 +978,7 @@ Blockly.zelos.ConstantProvider.prototype.getCSS_ = function(selector) {
     // Insertion marker.
     selector + ' .blocklyInsertionMarker>.blocklyPath {',
       'fill-opacity: ' + this.INSERTION_MARKER_OPACITY + ';',
-      'stroke: none',
+      'stroke: none;',
     '}',
     /* eslint-enable indent */
   ];

--- a/core/theme.js
+++ b/core/theme.js
@@ -210,7 +210,7 @@ Blockly.Theme.defineTheme = function(name, themeObj) {
     Blockly.utils.object.deepMerge(theme, base);
     theme.name = name;
   }
-  
+
   Blockly.utils.object.deepMerge(theme.blockStyles,
       themeObj['blockStyles']);
   Blockly.utils.object.deepMerge(theme.categoryStyles,

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -180,7 +180,7 @@ Blockly.Toolbox.prototype.init = function() {
         'rendererOverrides': workspace.options.rendererOverrides
       }));
   workspaceOptions.toolboxPosition = workspace.options.toolboxPosition;
-  
+
   if (workspace.horizontalLayout) {
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');
@@ -196,7 +196,7 @@ Blockly.Toolbox.prototype.init = function() {
     throw Error('One of Blockly.VerticalFlyout or Blockly.Horizontal must be' +
         'required.');
   }
-  
+
   // Insert the flyout after the workspace.
   Blockly.utils.dom.insertAfter(this.flyout_.createDom('svg'), svg);
   this.flyout_.init(workspace);
@@ -830,8 +830,7 @@ Blockly.Css.register([
 
   '.blocklyTreeLabel {',
     'cursor: default;',
-    'font-family: sans-serif;',
-    'font-size: 16px;',
+    'font: 16px sans-serif;',
     'padding: 0 3px;',
     'vertical-align: middle;',
   '}',

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -110,7 +110,7 @@ Blockly.WorkspaceAudio.prototype.preload = function() {
     } else {
       sound.pause();
     }
-    
+
     // iOS can only process one sound at a time.  Trying to load more than one
     // corrupts the earlier ones.  Just load one and leave the others uncached.
     if (Blockly.utils.userAgent.IPAD || Blockly.utils.userAgent.IPHONE) {

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -640,7 +640,7 @@ Blockly.Css.register([
   '.blocklyCommentRect {',
     'fill: #E7DE8E;',
     'stroke: #bcA903;',
-    'stroke-width: 1px',
+    'stroke-width: 1px;',
   '}',
 
   '.blocklyCommentTarget {',
@@ -673,11 +673,11 @@ Blockly.Css.register([
   '.blocklyCommentDeleteIcon {',
     'cursor: pointer;',
     'fill: #000;',
-    'display: none',
+    'display: none;',
   '}',
 
   '.blocklySelected > .blocklyCommentDeleteIcon {',
-    'display: block',
+    'display: block;',
   '}',
 
   '.blocklyDeleteIconShape {',


### PR DESCRIPTION
Bunch of changes relating to menus.  Highlights:
* Deleted a bunch of unused CSS rules and classes.
* Put the menu code on a diet, so it only supports features that we actually use.
* Improved menu UX with support for more keyboard navigation.
* Remove Component as a dependency of Menu/MenuItem.