### PR TITLE
Add ignoring insertion markers in xml gen

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -80,8 +80,9 @@ Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
   if (block.isInsertionMarker()) {  // Skip over insertion markers.
     block = block.getChildren(false)[0];
     if (!block) {
-      // Disappears when appended.
-      return /** @type{!Element} */ (new DocumentFragment());
+      // Disappears when appended. Cast to ANY b/c DocumentFragment -> Element
+      // is invalid. We have to cast to ANY in between.
+      return /** @type{?} */ (new DocumentFragment());
     }
   }
 
@@ -146,8 +147,9 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
     if (child) {
       return Blockly.Xml.blockToDom(child);
     } else {
-      // Disappears when appended.
-      return /** @type{!Element} */ (new DocumentFragment());
+      // Disappears when appended. Cast to ANY b/c DocumentFragment -> Element
+      // is invalid. We have to cast to ANY in between.
+      return /** @type{?} */ (new DocumentFragment());
     }
   }
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -81,7 +81,7 @@ Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
     block = block.getChildren(false)[0];
     if (!block) {
       // Disappears when appended.
-      return /** @type{!Element} */ new DocumentFragment();
+      return /** @type{!Element} */ (new DocumentFragment());
     }
   }
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -77,18 +77,25 @@ Blockly.Xml.variablesToDom = function(variableList) {
  * @return {!Element} Tree of XML elements.
  */
 Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
+  if (block.isInsertionMarker()) {  // Skip over insertion markers.
+    block = block.getChildren(false)[0];
+    if (!block) {
+      // Disappears when appended.
+      return /** @type{!Element} */ new DocumentFragment();
+    }
+  }
+
   var width;  // Not used in LTR.
   if (block.workspace.RTL) {
     width = block.workspace.getWidth();
   }
-  var elem = Blockly.Xml.blockToDom(block, opt_noId);
-  if (elem.nodeType == Blockly.utils.dom.NodeType.ELEMENT_NODE) {
-    var xy = block.getRelativeToSurfaceXY();
-    elem.setAttribute('x',
-        Math.round(block.workspace.RTL ? width - xy.x : xy.x));
-    elem.setAttribute('y', Math.round(xy.y));
-  }
-  return elem;
+
+  var element = Blockly.Xml.blockToDom(block, opt_noId);
+  var xy = block.getRelativeToSurfaceXY();
+  element.setAttribute('x',
+      Math.round(block.workspace.RTL ? width - xy.x : xy.x));
+  element.setAttribute('y', Math.round(xy.y));
+  return element;
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -82,7 +82,7 @@ Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
     width = block.workspace.getWidth();
   }
   var elem = Blockly.Xml.blockToDom(block, opt_noId);
-  if (elem instanceof Element) {
+  if (elem.nodeType == Blockly.utils.dom.NodeType.ELEMENT_NODE) {
     var xy = block.getRelativeToSurfaceXY();
     elem.setAttribute('x',
         Math.round(block.workspace.RTL ? width - xy.x : xy.x));
@@ -201,7 +201,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
       }
       if (childBlock) {
         var elem = Blockly.Xml.blockToDom(childBlock, opt_noId);
-        if (elem instanceof Element) {
+        if (elem.nodeType == Blockly.utils.dom.NodeType.ELEMENT_NODE) {
           container.appendChild(elem);
           empty = false;
         }
@@ -235,7 +235,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
   var nextBlock = block.getNextBlock();
   if (nextBlock) {
     var elem = Blockly.Xml.blockToDom(nextBlock, opt_noId);
-    if (elem instanceof Element) {
+    if (elem.nodeType == Blockly.utils.dom.NodeType.ELEMENT_NODE) {
       var container = Blockly.utils.xml.createElement('next');
       container.appendChild(elem);
       element.appendChild(container);

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -205,8 +205,9 @@ suite('InsertionMarkers', function() {
       this.assertXml = function(xml, expectXml) {
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         var block = this.workspace.getBlockById('insertion');
-        block.isInsertionMarker_ = true;
+        block.setInsertionMarker(true);
         var xml = Blockly.Xml.workspaceToDom(this.workspace);
+        Blockly.Xml.domToWorkspace(xml, this.workspace);
         xml = Blockly.Xml.domToText(xml);
         chai.assert.equal(xml, expectXml);
       };

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -200,4 +200,189 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'stack[a];\n');
     });
   });
+  suite('Serialization', function() {
+    setup(function() {
+      this.assertGen = function(xml, expectXml) {
+        Blockly.Xml.domToWorkspace(xml, this.workspace);
+        var block = this.workspace.getBlockById('insertion');
+        block.isInsertionMarker_ = true;
+        var xml = Blockly.Xml.workspaceToDom(this.workspace);
+        xml = Blockly.Xml.domToText(xml);
+        chai.assert.equal(xml, expectXml);
+      };
+    });
+    teardown(function() {
+      delete this.assertGen;
+    });
+    test('Marker Surrounds', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block" id="insertion" x="10" y="10">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block" id="a"/>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      // The block wouldn't technically be at 10, it would be slightly lower
+      // and end-er but I think that's a fair compromise when we're comparing
+      // it against extra blocks.
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="statement_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker Enclosed', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block" id="a" x="10" y="10">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block" id="insertion"/>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="statement_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker Enclosed and Surrounds', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="statement_block" id="a" x="10" y="10">' +
+          '    <statement name="STATEMENT">' +
+          '      <block type="statement_block" id="insertion">' +
+          '        <statement name="STATEMENT">' +
+          '          <block type="statement_block" id="b"/>' +
+          '        </statement>' +
+          '      </block>' +
+          '    </statement>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="statement_block" id="a" x="10" y="10">' +
+          '<statement name="STATEMENT">' +
+          '<block type="statement_block" id="b"></block>' +
+          '</statement>' +
+          '</block>' +
+          '</xml>');
+    });
+    test('Marker Prev', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="insertion" x="10" y="10">' +
+          '    <next>' +
+          '      <block type="stack_block" id="a"/>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      // The block wouldn't technically be at 10, it would be slightly lower
+      // but I think that's a fair compromise when we're comparing
+      // it against extra blocks.
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker Next', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="a" x="10" y="10">' +
+          '    <next>' +
+          '      <block type="stack_block" id="insertion"/>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker Middle of Stack', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="a" x="10" y="10">' +
+          '    <next>' +
+          '      <block type="stack_block" id="insertion">' +
+          '        <next>' +
+          '          <block type="stack_block" id="b"/>' +
+          '        </next>' +
+          '      </block>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="stack_block" id="a" x="10" y="10">' +
+          '<next>' +
+          '<block type="stack_block" id="b"></block>' +
+          '</next>' +
+          '</block>' +
+          '</xml>');
+    });
+    test('Marker On Output', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block" id="insertion" x="10" y="10">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block" id="a"/>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      // The block wouldn't technically be at 10, it would be slightly end-er
+      // but I think that's a fair compromise when we're comparing
+      // it against extra blocks.
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="row_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker On Input', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block" id="a">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block" id="insertion"/>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="row_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+    test('Marker Middle of Row', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="row_block" id="a">' +
+          '    <value name="INPUT">' +
+          '      <block type="row_block" id="insertion">' +
+          '        <value name="INPUT">' +
+          '          <block type="row_block" id="b"/>' +
+          '        </value>' +
+          '      </block>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="row_block" id="a" x="10" y="10">' +
+          '<value name="INPUT">' +
+          '<block type="row_block" id="b"></block>' +
+          '</value>' +
+          '</block>' +
+          '</xml>');
+    });
+    test('Marker Detatched', function() {
+      var xml = Blockly.Xml.textToDom(
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="stack_block" id="insertion"/>' +
+          '  <block type="stack_block" id="a" x="10" y="10"/>' +
+          '</xml>');
+      this.assertGen(xml,
+          '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '</xml>');
+    });
+  });
 });

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -6,7 +6,7 @@
 
 suite('InsertionMarkers', function() {
   setup(function() {
-    this.workspace = new Blockly.Workspace();
+    this.workspace = Blockly.inject('blocklyDiv', {});
     Blockly.defineBlocksWithJsonArray([
       {
         "type": "stack_block",
@@ -218,24 +218,23 @@ suite('InsertionMarkers', function() {
     test('Marker Surrounds', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="statement_block" id="insertion" x="10" y="10">' +
+          '  <block type="statement_block" id="insertion" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
           '      <block type="statement_block" id="a"/>' +
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      // The block wouldn't technically be at 10, it would be slightly lower
-      // and end-er but I think that's a fair compromise when we're comparing
-      // it against extra blocks.
+      // Note how the x and y are not 20, they are slightly lower and end-er
+      // because these are the coords of the wrapped block.
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="10" y="10"></block>' +
+          '<block type="statement_block" id="a" x="41" y="31"></block>' +
           '</xml>');
     });
     test('Marker Enclosed', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="statement_block" id="a" x="10" y="10">' +
+          '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
           '      <block type="statement_block" id="insertion"/>' +
           '    </statement>' +
@@ -243,13 +242,13 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="10" y="10"></block>' +
+          '<block type="statement_block" id="a" x="20" y="20"></block>' +
           '</xml>');
     });
     test('Marker Enclosed and Surrounds', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="statement_block" id="a" x="10" y="10">' +
+          '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
           '      <block type="statement_block" id="insertion">' +
           '        <statement name="STATEMENT">' +
@@ -261,7 +260,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="10" y="10">' +
+          '<block type="statement_block" id="a" x="20" y="20">' +
           '<statement name="STATEMENT">' +
           '<block type="statement_block" id="b"></block>' +
           '</statement>' +
@@ -271,24 +270,23 @@ suite('InsertionMarkers', function() {
     test('Marker Prev', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="stack_block" id="insertion" x="10" y="10">' +
+          '  <block type="stack_block" id="insertion" x="20" y="20">' +
           '    <next>' +
           '      <block type="stack_block" id="a"/>' +
           '    </next>' +
           '  </block>' +
           '</xml>');
-      // The block wouldn't technically be at 10, it would be slightly lower
-      // but I think that's a fair compromise when we're comparing
-      // it against extra blocks.
+      // Note how the y coord is not at 20, it is lower. This is because these
+      // are the coords of the next block.
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '<block type="stack_block" id="a" x="20" y="46"></block>' +
           '</xml>');
     });
     test('Marker Next', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="stack_block" id="a" x="10" y="10">' +
+          '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
           '      <block type="stack_block" id="insertion"/>' +
           '    </next>' +
@@ -296,13 +294,13 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '<block type="stack_block" id="a" x="20" y="20"></block>' +
           '</xml>');
     });
     test('Marker Middle of Stack', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="stack_block" id="a" x="10" y="10">' +
+          '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
           '      <block type="stack_block" id="insertion">' +
           '        <next>' +
@@ -314,7 +312,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="10" y="10">' +
+          '<block type="stack_block" id="a" x="20" y="20">' +
           '<next>' +
           '<block type="stack_block" id="b"></block>' +
           '</next>' +
@@ -324,24 +322,23 @@ suite('InsertionMarkers', function() {
     test('Marker On Output', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="row_block" id="insertion" x="10" y="10">' +
+          '  <block type="row_block" id="insertion" x="20" y="20">' +
           '    <value name="INPUT">' +
           '      <block type="row_block" id="a"/>' +
           '    </value>' +
           '  </block>' +
           '</xml>');
-      // The block wouldn't technically be at 10, it would be slightly end-er
-      // but I think that's a fair compromise when we're comparing
-      // it against extra blocks.
+      // Note how the x value is not at 20. This is because these are the coords
+      // of the wrapped block.
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="10" y="10"></block>' +
+          '<block type="row_block" id="a" x="41" y="20"></block>' +
           '</xml>');
     });
     test('Marker On Input', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="row_block" id="a">' +
+          '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
           '      <block type="row_block" id="insertion"/>' +
           '    </value>' +
@@ -349,13 +346,13 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="10" y="10"></block>' +
+          '<block type="row_block" id="a" x="20" y="20"></block>' +
           '</xml>');
     });
     test('Marker Middle of Row', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="row_block" id="a">' +
+          '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
           '      <block type="row_block" id="insertion">' +
           '        <value name="INPUT">' +
@@ -367,7 +364,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="10" y="10">' +
+          '<block type="row_block" id="a" x="20" y="20">' +
           '<value name="INPUT">' +
           '<block type="row_block" id="b"></block>' +
           '</value>' +
@@ -378,11 +375,11 @@ suite('InsertionMarkers', function() {
       var xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
-          '  <block type="stack_block" id="a" x="10" y="10"/>' +
+          '  <block type="stack_block" id="a" x="20" y="20"/>' +
           '</xml>');
       this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="10" y="10"></block>' +
+          '<block type="stack_block" id="a" x="20" y="20"></block>' +
           '</xml>');
     });
   });

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -202,7 +202,7 @@ suite('InsertionMarkers', function() {
   });
   suite('Serialization', function() {
     setup(function() {
-      this.assertGen = function(xml, expectXml) {
+      this.assertXml = function(xml, expectXml) {
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         var block = this.workspace.getBlockById('insertion');
         block.isInsertionMarker_ = true;
@@ -212,7 +212,7 @@ suite('InsertionMarkers', function() {
       };
     });
     teardown(function() {
-      delete this.assertGen;
+      delete this.assertXml;
     });
     test('Marker Surrounds', function() {
       var xml = Blockly.Xml.textToDom(
@@ -226,7 +226,7 @@ suite('InsertionMarkers', function() {
       // The block wouldn't technically be at 10, it would be slightly lower
       // and end-er but I think that's a fair compromise when we're comparing
       // it against extra blocks.
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="statement_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -240,7 +240,7 @@ suite('InsertionMarkers', function() {
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="statement_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -258,7 +258,7 @@ suite('InsertionMarkers', function() {
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="statement_block" id="a" x="10" y="10">' +
           '<statement name="STATEMENT">' +
@@ -279,7 +279,7 @@ suite('InsertionMarkers', function() {
       // The block wouldn't technically be at 10, it would be slightly lower
       // but I think that's a fair compromise when we're comparing
       // it against extra blocks.
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="stack_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -293,7 +293,7 @@ suite('InsertionMarkers', function() {
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="stack_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -311,7 +311,7 @@ suite('InsertionMarkers', function() {
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="stack_block" id="a" x="10" y="10">' +
           '<next>' +
@@ -332,7 +332,7 @@ suite('InsertionMarkers', function() {
       // The block wouldn't technically be at 10, it would be slightly end-er
       // but I think that's a fair compromise when we're comparing
       // it against extra blocks.
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="row_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -346,7 +346,7 @@ suite('InsertionMarkers', function() {
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="row_block" id="a" x="10" y="10"></block>' +
           '</xml>');
@@ -364,7 +364,7 @@ suite('InsertionMarkers', function() {
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="row_block" id="a" x="10" y="10">' +
           '<value name="INPUT">' +
@@ -379,7 +379,7 @@ suite('InsertionMarkers', function() {
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a" x="10" y="10"/>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertXml(xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '<block type="stack_block" id="a" x="10" y="10"></block>' +
           '</xml>');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #2322 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Skips over insertion markers, returning the xml of the insertion marker's child instead. If the insertion marker has no children we return a DocumentFragment instead (as suggested by @NeilFraser ).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
If the developer happens to serialize the workspace while the user is dragging we don't want insertion markers to be included in the xml.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Unit tests for all of the following:
* Marker Surrounds
* Marker Enclosed
* Marker Enclosed and Surrounds
* Marker Prev
* Marker Next
* Marker Middle of Stack
* Marker On Output
* Marker On Input
* Marker Middle of Row
* Marker Detatched


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Noup

### Additional Information

<!-- Anything else we should know? -->
Hopefully the compiler likes this! :crossed_fingers: 
