### PR TITLE
Create advanced playground; simplify basic playground

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -104,12 +104,7 @@ function start() {
   document.forms.options.elements.toolbox.selectedIndex =
       toolboxNames.indexOf(toolbox.id);
   match = location.search.match(/side=([^&]+)/);
-  var side = match ? match[1] : 'start';
-  document.forms.options.elements.side.value = side;
   var autoimport = !!location.search.match(/autoimport=([^&]+)/);
-  match = location.search.match(/renderer=([^&]+)/);
-  var renderer = match ? match[1] : 'geras';
-  document.forms.options.elements.renderer.value = renderer;
   // Create main workspace.
   workspace = Blockly.inject('blocklyDiv',
       {
@@ -123,7 +118,7 @@ function start() {
             colour: '#ccc',
             snap: true
           },
-        horizontalLayout: side == 'top' || side == 'bottom',
+        horizontalLayout: false,
         maxBlocks: Infinity,
         maxInstances: {'test_basic_limit_instances': 3},
         maxTrashcanContents: 256,
@@ -137,8 +132,8 @@ function start() {
           wheel: false,
         },
         toolbox: toolbox,
-        toolboxPosition: side == 'top' || side == 'start' ? 'start' : 'end',
-        renderer: renderer,
+        toolboxPosition: 'start',
+        renderer: 'geras',
         zoom:
           {
             controls: true,
@@ -151,7 +146,6 @@ function start() {
       });
   workspace.configureContextMenu = configureContextMenu;
   addToolboxButtonCallbacks();
-  addRenderDebugOptionsCheckboxes();
   populateTestThemes();
   // Restore previously displayed text.
   if (sessionStorage) {
@@ -162,13 +156,6 @@ function start() {
     // Restore event logging state.
     var state = sessionStorage.getItem('logEvents');
     logEvents(Boolean(Number(state)));
-    // Restore render debug state.
-    var renderDebugState = sessionStorage.getItem('blockRenderDebug');
-    toggleRenderingDebug(Boolean(Number(renderDebugState)));
-    // Restore render debug options state.
-    var renderDebugOptionsState =
-        JSON.parse(sessionStorage.getItem('blockRenderDebugOptions'));
-    setRenderDebugOptionCheckboxState(renderDebugOptionsState);
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);
@@ -287,86 +274,6 @@ function addToolboxButtonCallbacks() {
   workspace.registerButtonCallback(
       'insertConnectionStatements',
           Blockly.TestBlocks.insertConnectionStatements);
-}
-
-function setRenderDebugOptionCheckboxState(overrideOptions) {
-  if (!Blockly.blockRendering.Debug) {
-    return;
-  }
-  Blockly.blockRendering.Debug.config = overrideOptions || {};
-  if (!overrideOptions) {
-    return;
-  }
-  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
-  var renderDebugOptionInputs =
-      renderDebugOptionsListEl.getElementsByTagName('input');
-  for (var i = 0, optionInput;
-      (optionInput = renderDebugOptionInputs[i]); i++) {
-    var optionName = optionInput.getAttribute('data-optionName');
-    optionInput.checked = !!overrideOptions[optionName];
-  }
-}
-
-function updateRenderDebugOptions(e) {
-  if (!Blockly.blockRendering.Debug) {
-    return;
-  }
-  var target = e.target;
-  var optionName = target.getAttribute('data-optionName');
-  var config = Blockly.blockRendering.Debug.config;
-  config[optionName] = !!target.checked;
-  sessionStorage.setItem(
-      'blockRenderDebugOptions', JSON.stringify(config));
-  workspace.render();
-}
-
-function addRenderDebugOptionsCheckboxes() {
-  if (!Blockly.blockRendering.Debug) {
-    return;
-  }
-  var renderDebugConfig = Blockly.blockRendering.Debug.config;
-  var renderDebugOptionsListEl = document.getElementById('renderDebugOptions');
-  var optionNames = Object.keys(renderDebugConfig);
-  for (var i = 0, optionName; (optionName = optionNames[i]); i++) {
-    var optionCheckId = 'RenderDebug' + optionName + 'Check';
-    var optionLabel = document.createElement('label');
-    optionLabel.setAttribute('for', optionCheckId);
-    optionLabel.textContent = optionName;
-    var optionCheck = document.createElement('input');
-    optionCheck.setAttribute('type', 'checkbox');
-    optionCheck.setAttribute('id', optionCheckId);
-    optionCheck.setAttribute('data-optionName', optionName);
-    optionCheck.onclick = updateRenderDebugOptions;
-    var optionLi = document.createElement('li');
-    optionLi.appendChild(optionLabel);
-    optionLi.appendChild(optionCheck);
-    renderDebugOptionsListEl.appendChild(optionLi);
-  }
-}
-
-function changeTheme() {
-  var theme = document.getElementById('themeChanger');
-
-  if (theme.value === "dark") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.Dark);
-  } else if (theme.value === "high_contrast") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.HighContrast);
-  } else if (theme.value === "deuteranopia") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.Deuteranopia);
-  } else if (theme.value === "tritanopia") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.Tritanopia);
-  } else if (theme.value === "modern") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.Modern);
-  } else if (theme.value === "zelos") {
-    Blockly.getMainWorkspace().setTheme(Blockly.Themes.Zelos);
-  } else {
-    var testTheme = getTestTheme(theme.value);
-    if (testTheme) {
-      Blockly.getMainWorkspace().setTheme(testTheme);
-    } else {
-      Blockly.getMainWorkspace().setTheme(Blockly.Themes.Classic);
-    }
-  }
 }
 
 function changeRenderingConstant(value) {
@@ -629,28 +536,7 @@ var spaghettiXml = [
       <option value="simple">Simple</option>
       <option value="test-blocks">Test Blocks</option>
     </select>
-    <select name="side" onchange="document.forms.options.submit()">
-      <option value="start">Start</option>
-      <option value="end">End</option>
-      <option value="top">Top</option>
-      <option value="bottom">Bottom</option>
-    </select>
-    <select name="renderer" onchange="document.forms.options.submit()">
-      <option value="geras">Geras</option>
-      <option value="thrasos">Thrasos</option>
-      <option value="zelos">Zelos</option>
-      <option value="minimalist">Minimalist</option>
-    </select>
   </form>
-  <select id="themeChanger" name="theme" onchange="changeTheme()">
-    <option value="classic">Classic</option>
-    <option value="modern">Modern</option>
-    <option value="dark">Dark</option>
-    <option value="high_contrast">High Contrast</option>
-    <option value="deuteranopia">Deuteranopia/Protanopia</option>
-    <option value="tritanopia">Tritanopia</option>
-    <option value="zelos">Zelos</option>
-  </select>
   <p>
     <input type="button" value="Export to XML" onclick="toXml()">
     &nbsp;
@@ -675,28 +561,10 @@ var spaghettiXml = [
     <input type="button" value="Airstrike!" onclick="airstrike(100)">
     <input type="button" value="Spaghetti!" onclick="spaghetti(8)">
   </p>
-  <p>
-    Rendering: &nbsp;
-    <select id="rendering-constant-selector">
-      <option value="fontSize">Font Size</option>
-    </select>
-    <input type="range" min="3" max="50" value="4"
-      oninput="changeRenderingConstant(this.value)"
-      onchange="changeRenderingConstant(this.value)" />
-  </p>
   <ul class="playgroundToggleOptions">
     <li>
       <label for="logCheck">Log events:</label>
       <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
-    </li>
-    <li>
-      <label for="blockRenderDebugCheck">Enable block rendering debug:</label>
-      <input type="checkbox" onclick="toggleRenderingDebug(this.checked)" id="blockRenderDebugCheck">
-      <ul id="renderDebugOptions"></ul>
-    </li>
-    <li>
-      <label for="accessibilityModeCheck">Enable Accessibility Mode:</label>
-      <input type="checkbox" onclick="toggleAccessibilityMode(this.checked)" id="accessibilityModeCheck">
     </li>
   </ul>
 

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Advanced Blockly Playground</title>
+<script src="../../blockly_uncompressed.js"></script>
+<script src="../../generators/javascript.js"></script>
+<script src="../../generators/javascript/logic.js"></script>
+<script src="../../generators/javascript/loops.js"></script>
+<script src="../../generators/javascript/math.js"></script>
+<script src="../../generators/javascript/text.js"></script>
+<script src="../../generators/javascript/lists.js"></script>
+<script src="../../generators/javascript/colour.js"></script>
+<script src="../../generators/javascript/variables.js"></script>
+<script src="../../generators/javascript/variables_dynamic.js"></script>
+<script src="../../generators/javascript/procedures.js"></script>
+<script src="../../generators/python.js"></script>
+<script src="../../generators/python/logic.js"></script>
+<script src="../../generators/python/loops.js"></script>
+<script src="../../generators/python/math.js"></script>
+<script src="../../generators/python/text.js"></script>
+<script src="../../generators/python/lists.js"></script>
+<script src="../../generators/python/colour.js"></script>
+<script src="../../generators/python/variables.js"></script>
+<script src="../../generators/python/variables_dynamic.js"></script>
+<script src="../../generators/python/procedures.js"></script>
+<script src="../../generators/php.js"></script>
+<script src="../../generators/php/logic.js"></script>
+<script src="../../generators/php/loops.js"></script>
+<script src="../../generators/php/math.js"></script>
+<script src="../../generators/php/text.js"></script>
+<script src="../../generators/php/lists.js"></script>
+<script src="../../generators/php/colour.js"></script>
+<script src="../../generators/php/variables.js"></script>
+<script src="../../generators/php/variables_dynamic.js"></script>
+<script src="../../generators/php/procedures.js"></script>
+<script src="../../generators/lua.js"></script>
+<script src="../../generators/lua/logic.js"></script>
+<script src="../../generators/lua/loops.js"></script>
+<script src="../../generators/lua/math.js"></script>
+<script src="../../generators/lua/text.js"></script>
+<script src="../../generators/lua/lists.js"></script>
+<script src="../../generators/lua/colour.js"></script>
+<script src="../../generators/lua/variables.js"></script>
+<script src="../../generators/lua/variables_dynamic.js"></script>
+<script src="../../generators/lua/procedures.js"></script>
+<script src="../../generators/dart.js"></script>
+<script src="../../generators/dart/logic.js"></script>
+<script src="../../generators/dart/loops.js"></script>
+<script src="../../generators/dart/math.js"></script>
+<script src="../../generators/dart/text.js"></script>
+<script src="../../generators/dart/lists.js"></script>
+<script src="../../generators/dart/colour.js"></script>
+<script src="../../generators/dart/variables.js"></script>
+<script src="../../generators/dart/variables_dynamic.js"></script>
+<script src="../../generators/dart/procedures.js"></script>
+<script src="../../msg/messages.js"></script>
+<script src="../../blocks/logic.js"></script>
+<script src="../../blocks/loops.js"></script>
+<script src="../../blocks/math.js"></script>
+<script src="../../blocks/text.js"></script>
+<script src="../../blocks/lists.js"></script>
+<script src="../../blocks/colour.js"></script>
+<script src="../../blocks/variables.js"></script>
+<script src="../../blocks/variables_dynamic.js"></script>
+<script src="../../blocks/procedures.js"></script>
+<script src="../blocks/test_blocks.js"></script>
+<script src="../themes/test_themes.js"></script>
+<script src="./screenshot.js"></script>
+<script src="https://unpkg.com/@blockly/dev-tools@0.20200313.7/dist/index.js"></script>
+<script src="https://unpkg.com/@blockly/theme-modern@1.20200417.5/dist/index.js"></script>
+
+<script>
+// // Custom requires for the playground.
+// // Rendering.
+goog.require('Blockly.minimalist.Renderer');
+goog.require('Blockly.Themes.Zelos');
+
+// Other.
+goog.require('Blockly.WorkspaceCommentSvg');
+goog.require('Blockly.WorkspaceCommentSvg.render');
+</script>
+<script>
+'use strict';
+var workspace = null;
+
+function start() {
+  setBackgroundColour();
+
+  // Parse the URL arguments.
+  var toolbox = getToolboxElement();
+  var autoimport = !!location.search.match(/autoimport=([^&]+)/);
+  var match = location.search.match(/renderer=([^&]+)/);
+
+  var options = {
+        comments: true,
+        collapse: true,
+        disable: true,
+        grid:
+          {
+            spacing: 25,
+            length: 3,
+            colour: '#ccc',
+            snap: true
+          },
+        horizontalLayout: false,
+        maxBlocks: Infinity,
+        maxInstances: {'test_basic_limit_instances': 3},
+        maxTrashcanContents: 256,
+        media: '../../media/',
+        oneBasedIndex: true,
+        readOnly: false,
+        rtl: false,
+        move: {
+          scrollbars: true,
+          drag: true,
+          wheel: false,
+        },
+        toolbox: toolbox,
+        toolboxPosition: 'start',
+        renderer: 'geras',
+        zoom:
+          {
+            controls: true,
+            wheel: true,
+            startScale: 1.0,
+            maxScale: 4,
+            minScale: 0.25,
+            scaleSpeed: 1.1
+          }
+  };
+
+  // Create main workspace.
+  addGUIControls((options) => {
+    workspace = Blockly.inject('blocklyDiv', options);
+    workspace.configureContextMenu = configureContextMenu;
+    addToolboxButtonCallbacks();
+    return workspace;
+  }, options);
+
+
+  // Restore previously displayed text.
+  if (sessionStorage) {
+    var text = sessionStorage.getItem('textarea');
+    if (text) {
+      document.getElementById('importExport').value = text;
+    }
+    // Restore event logging state.
+    var state = sessionStorage.getItem('logEvents');
+    logEvents(Boolean(Number(state)));
+  } else {
+    // MSIE 11 does not support sessionStorage on file:// URLs.
+    logEvents(false);
+  }
+  taChange();
+  if (autoimport) {
+    fromXml();
+  }
+}
+
+function addToolboxButtonCallbacks() {
+  var addAllBlocksToWorkspace = function(button) {
+    var workspace = button.getTargetWorkspace();
+    var blocks = button.workspace_.getTopBlocks();
+    for(var i = 0, block; block = blocks[i]; i++) {
+      var xml = Blockly.utils.xml.createElement('xml');
+      xml.appendChild(Blockly.Xml.blockToDom(block));
+      Blockly.Xml.appendDomToWorkspace(xml, workspace);
+    }
+  };
+  var randomizeLabelText = function(button) {
+    var blocks = button.targetWorkspace_
+        .getBlocksByType('test_fields_label_serializable');
+    var possible = 'AB';
+    for (var i = 0, block; block = blocks[i]; i++) {
+      var text = '';
+      for (var j = 0; j < 4; j++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+      }
+      block.setFieldValue(text, 'LABEL');
+    }
+  };
+  var setRandomStyle = function(button) {
+    var blocks = button.workspace_.getAllBlocks(false);
+    var styles =
+        Object.keys(workspace.getRenderer().getConstants().blockStyles);
+    styles.splice(styles.indexOf(blocks[0].getStyleName()), 1);
+    var style = styles[Math.floor(Math.random() * styles.length)];
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setStyle(style);
+    }
+  };
+  var toggleEnabled = function(button) {
+    var blocks = button.workspace_.getAllBlocks(false);
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setEnabled(!block.isEnabled());
+    }
+  };
+  var toggleShadow = function(button) {
+    var blocks = button.workspace_.getAllBlocks(false);
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setShadow(!block.isShadow());
+    }
+  };
+  var toggleCollapsed = function(button) {
+    var blocks = button.workspace_.getAllBlocks(false);
+    for(var i = 0, block; block = blocks[i]; i++) {
+      block.setCollapsed(!block.isCollapsed());
+    }
+  };
+  var setInput = function(button) {
+    Blockly.prompt('Input text to set.', 'ab', function(input) {
+      var blocks = button.getTargetWorkspace().getAllBlocks(false);
+      for(var i = 0, block; block = blocks[i]; i++) {
+        if (block.getField('INPUT')) {
+          block.setFieldValue(input, 'INPUT');
+        }
+      }
+    })
+  };
+  var changeImage = function(button) {
+    var blocks = button.workspace_.getBlocksByType('test_fields_image');
+    var possible = 'abcdefghijklm';
+    var image = possible.charAt(Math.floor(Math.random() * possible.length));
+    var src = 'https://blockly-demo.appspot.com/static/tests/media/'
+      + image + '.png';
+    for (var i = 0, block; block = blocks[i]; i++) {
+      var imageField = block.getField('IMAGE');
+      imageField.setValue(src);
+    }
+  };
+  var addVariables = function(button) {
+    workspace.createVariable('1b', '', '1B');
+    workspace.createVariable('1c', '', '1C');
+    workspace.createVariable('2a', '', '2A');
+    workspace.createVariable('2b', '', '2B');
+    workspace.createVariable('2c', '', '2C');
+  };
+
+  workspace.registerButtonCallback(
+      'addVariables', addVariables);
+  workspace.registerButtonCallback(
+      'changeImage', changeImage);
+  workspace.registerButtonCallback(
+      'addAllBlocksToWorkspace', addAllBlocksToWorkspace);
+  workspace.registerButtonCallback(
+      'setInput', setInput);
+  workspace.registerButtonCallback(
+      'setRandomStyle', setRandomStyle);
+  workspace.registerButtonCallback(
+      'toggleEnabled', toggleEnabled);
+  workspace.registerButtonCallback(
+      'toggleShadow', toggleShadow);
+  workspace.registerButtonCallback(
+    'toggleCollapsed', toggleCollapsed);
+  workspace.registerButtonCallback(
+      'randomizeLabelText', randomizeLabelText);
+  workspace.registerButtonCallback(
+      'addDynamicOption', Blockly.TestBlocks.addDynamicDropdownOption);
+  workspace.registerButtonCallback(
+      'removeDynamicOption', Blockly.TestBlocks.removeDynamicDropdownOption);
+  workspace.registerButtonCallback(
+      'insertConnectionRows', Blockly.TestBlocks.insertConnectionRows);
+  workspace.registerButtonCallback(
+      'insertConnectionStacks', Blockly.TestBlocks.insertConnectionStacks);
+  workspace.registerButtonCallback(
+      'insertConnectionStatements',
+          Blockly.TestBlocks.insertConnectionStatements);
+}
+
+function changeRenderingConstant(value) {
+  var type = document.getElementById('rendering-constant-selector').value;
+  if (type == 'fontSize') {
+    var fontStyle = {
+      'size': value
+    };
+    workspace.getTheme().setFontStyle(fontStyle);
+  }
+  // Refresh theme.
+  workspace.setTheme(workspace.getTheme());
+}
+
+function setBackgroundColour() {
+  // Set background colour to differentiate server vs local copy.
+  if (location.protocol == 'file:') {
+    var lilac = '#d6d6ff';
+    document.body.style.backgroundColor = lilac;
+  }
+}
+
+function getToolboxElement() {
+  var match = location.search.match(/toolbox=([^&]+)/);
+  // Default to the basic toolbox with categories and untyped variables,
+  // but override that if the toolbox type is set in the URL.
+  var toolboxSuffix = (match ? match[1] : 'categories');
+
+  // The two toolboxes available from dev-tools are toolboxSimple and
+  // toolboxCategories.
+  if (toolboxSuffix == 'categories') {
+    document.forms.options.elements.toolbox.selectedIndex = 0;
+    return toolboxCategories;
+  }
+  document.forms.options.elements.toolbox.selectedIndex = 1;
+  return toolboxSimple;
+}
+
+function toXml() {
+  var output = document.getElementById('importExport');
+  var xml = Blockly.Xml.workspaceToDom(workspace);
+  output.value = Blockly.Xml.domToPrettyText(xml);
+  output.focus();
+  output.select();
+  taChange();
+}
+
+function fromXml() {
+  var input = document.getElementById('importExport');
+  if (!input.value) {
+    return;
+  }
+  var xml = Blockly.Xml.textToDom(input.value);
+  Blockly.Xml.domToWorkspace(xml, workspace);
+  taChange();
+}
+
+function toCode(lang) {
+  var output = document.getElementById('importExport');
+  output.value = Blockly[lang].workspaceToCode(workspace);
+  taChange();
+}
+
+// Disable the "Import from XML" button if the XML is invalid.
+// Preserve text between page reloads.
+function taChange() {
+  var textarea = document.getElementById('importExport');
+  if (sessionStorage) {
+    sessionStorage.setItem('textarea', textarea.value);
+  }
+  var valid = true;
+  try {
+    Blockly.Xml.textToDom(textarea.value);
+  } catch (e) {
+    valid = false;
+  }
+  document.getElementById('import').disabled = !valid;
+}
+
+function logEvents(state) {
+  var checkbox = document.getElementById('logCheck');
+  checkbox.checked = state;
+  if (sessionStorage) {
+    sessionStorage.setItem('logEvents', Number(state));
+  }
+  if (state) {
+    workspace.addChangeListener(logger);
+  } else {
+    workspace.removeChangeListener(logger);
+  }
+}
+
+function toggleAccessibilityMode(state) {
+  if (state) {
+    Blockly.navigation.enableKeyboardAccessibility();
+  } else {
+    Blockly.navigation.disableKeyboardAccessibility();
+  }
+}
+
+function configureContextMenu(menuOptions, e) {
+  var screenshotOption = {
+    text: 'Download Screenshot',
+    enabled: workspace.getTopBlocks().length,
+    callback: function() {
+      Blockly.downloadScreenshot(workspace);
+    }
+  };
+  menuOptions.push(screenshotOption);
+
+  // Adds a default-sized workspace comment to the workspace.
+  menuOptions.push(Blockly.ContextMenu.workspaceCommentOption(workspace, e));
+}
+
+function logger(e) {
+  console.log(e);
+}
+
+function populateRandom(n) {
+  var names = [];
+  for (var blockName in Blockly.Blocks) {
+    names.push(blockName);
+  }
+
+  for (var i = 0; i < n; i++) {
+    var name = names[Math.floor(Math.random() * names.length)];
+    var block = workspace.newBlock(name);
+    block.initSvg();
+    block.getSvgRoot().setAttribute('transform', 'translate(' +
+        Math.round(Math.random() * 450 + 40) + ', ' +
+        Math.round(Math.random() * 600 + 40) + ')');
+    block.render();
+  }
+}
+
+function spaghetti(n) {
+  var xml = spaghettiXml;
+  for(var i = 0; i < n; i++) {
+    xml = xml.replace(/(<(statement|next)( name="DO0")?>)<\//g,
+        '$1' + spaghettiXml + '</');
+  }
+  xml = '<xml xmlns="https://developers.google.com/blockly/xml">' + xml + '</xml>';
+  var dom = Blockly.Xml.textToDom(xml);
+  console.time('Spaghetti domToWorkspace');
+  Blockly.Xml.domToWorkspace(dom, workspace);
+  console.timeEnd('Spaghetti domToWorkspace');
+}
+var spaghettiXml = [
+  '  <block type="controls_if">',
+  '    <value name="IF0">',
+  '      <block type="logic_compare">',
+  '        <field name="OP">EQ</field>',
+  '        <value name="A">',
+  '          <block type="math_arithmetic">',
+  '            <field name="OP">MULTIPLY</field>',
+  '            <value name="A">',
+  '              <block type="math_number">',
+  '                <field name="NUM">6</field>',
+  '              </block>',
+  '            </value>',
+  '            <value name="B">',
+  '              <block type="math_number">',
+  '                <field name="NUM">7</field>',
+  '              </block>',
+  '            </value>',
+  '          </block>',
+  '        </value>',
+  '        <value name="B">',
+  '          <block type="math_number">',
+  '            <field name="NUM">42</field>',
+  '          </block>',
+  '        </value>',
+  '      </block>',
+  '    </value>',
+  '    <statement name="DO0"></statement>',
+  '    <next></next>',
+  '  </block>'].join('\n');
+
+</script>
+
+<style>
+  html, body {
+    height: 100%;
+  }
+  body {
+    background-color: #fff;
+    font-family: sans-serif;
+    overflow: hidden;
+  }
+  h1 {
+    font-weight: normal;
+    font-size: 140%;
+  }
+  #blocklyDiv {
+    float: right;
+    height: 95%;
+    width: 70%;
+  }
+  #importExport {
+    font-family: monospace;
+  }
+
+  .ioLabel>.blocklyFlyoutLabelText {
+    font-style: italic;
+  }
+
+  .playgroundToggleOptions {
+    list-style: none;
+    padding: 0;
+  }
+  .playgroundToggleOptions li {
+    margin-top: 1em;
+  }
+
+  .zelos-renderer .blocklyFlyoutButton .blocklyText {
+    font-size: 1.5rem;
+  }
+</style>
+</head>
+<body onload="start()">
+
+  <div id="blocklyDiv"></div>
+
+  <h1>Blockly Playground</h1>
+
+  <p><a href="javascript:void(workspace.setVisible(true))">Show</a>
+   - <a href="javascript:void(workspace.setVisible(false))">Hide</a></p>
+
+  <form id="options">
+    <select name="toolbox" onchange="document.forms.options.submit()">
+      <option value="categories">Categories (untyped variables)</option>
+      <option value="simple">Simple</option>
+    </select>
+  </form>
+  <p>
+    <input type="button" value="Export to XML" onclick="toXml()">
+    &nbsp;
+    <input type="button" value="Import from XML" onclick="fromXml()" id="import">
+    <br>
+    <input type="button" value="To JavaScript" onclick="toCode('JavaScript')">
+    &nbsp;
+    <input type="button" value="To Python" onclick="toCode('Python')">
+    &nbsp;
+    <input type="button" value="To PHP" onclick="toCode('PHP')">
+    &nbsp;
+    <input type="button" value="To Lua" onclick="toCode('Lua')">
+    &nbsp;
+    <input type="button" value="To Dart" onclick="toCode('Dart')">
+    <br>
+    <textarea id="importExport" style="width: 26%; height: 12em"
+      onchange="taChange();" onkeyup="taChange()"></textarea>
+  </p>
+
+  <p>
+    Stress test: &nbsp;
+    <input type="button" value="Random Blocks!" onclick="populateRandom(100)">
+    <input type="button" value="Spaghetti!" onclick="spaghetti(8)">
+  </p>
+  <p>
+    Rendering: &nbsp;
+    <select id="rendering-constant-selector">
+      <option value="fontSize">Font Size</option>
+    </select>
+    <input type="range" min="3" max="50" value="4"
+      oninput="changeRenderingConstant(this.value)"
+      onchange="changeRenderingConstant(this.value)" />
+  </p>
+  <ul class="playgroundToggleOptions">
+    <li>
+      <label for="logCheck">Log events:</label>
+      <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
+    </li>
+    <li>
+      <label for="accessibilityModeCheck">Enable Accessibility Mode:</label>
+      <input type="checkbox" onclick="toggleAccessibilityMode(this.checked)" id="accessibilityModeCheck">
+    </li>
+  </ul>
+
+</body>
+</html>

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -67,12 +67,12 @@
 <script src="../blocks/test_blocks.js"></script>
 <script src="../themes/test_themes.js"></script>
 <script src="./screenshot.js"></script>
-<script src="https://unpkg.com/@blockly/dev-tools@0.20200313.7/dist/index.js"></script>
-<script src="https://unpkg.com/@blockly/theme-modern@1.20200417.5/dist/index.js"></script>
+<script src="https://unpkg.com/@blockly/dev-tools/dist/index.js"></script>
+<script src="https://unpkg.com/@blockly/theme-modern/dist/index.js"></script>
 
 <script>
-// // Custom requires for the playground.
-// // Rendering.
+// Custom requires for the playground.
+// Rendering.
 goog.require('Blockly.minimalist.Renderer');
 goog.require('Blockly.Themes.Zelos');
 
@@ -86,13 +86,33 @@ var workspace = null;
 
 function start() {
   setBackgroundColour();
+  createWorkspace();
+  // Restore previously displayed text.
+  if (sessionStorage) {
+    var text = sessionStorage.getItem('textarea');
+    if (text) {
+      document.getElementById('importExport').value = text;
+    }
+    // Restore event logging state.
+    var state = sessionStorage.getItem('logEvents');
+    logEvents(Boolean(Number(state)));
+  } else {
+    // MSIE 11 does not support sessionStorage on file:// URLs.
+    logEvents(false);
+  }
+  taChange();
+  var autoimport = !!location.search.match(/autoimport=([^&]+)/);
+  if (autoimport) {
+    fromXml();
+  }
+}
 
+function createWorkspace() {
   // Parse the URL arguments.
   var toolbox = getToolboxElement();
-  var autoimport = !!location.search.match(/autoimport=([^&]+)/);
   var match = location.search.match(/renderer=([^&]+)/);
 
-  var options = {
+  var defaultOptions = {
         comments: true,
         collapse: true,
         disable: true,
@@ -132,30 +152,11 @@ function start() {
 
   // Create main workspace.
   addGUIControls((options) => {
-    workspace = Blockly.inject('blocklyDiv', options);
+    workspace = Blockly.inject('blocklyDiv', defaultOptions);
     workspace.configureContextMenu = configureContextMenu;
     addToolboxButtonCallbacks();
     return workspace;
   }, options);
-
-
-  // Restore previously displayed text.
-  if (sessionStorage) {
-    var text = sessionStorage.getItem('textarea');
-    if (text) {
-      document.getElementById('importExport').value = text;
-    }
-    // Restore event logging state.
-    var state = sessionStorage.getItem('logEvents');
-    logEvents(Boolean(Number(state)));
-  } else {
-    // MSIE 11 does not support sessionStorage on file:// URLs.
-    logEvents(false);
-  }
-  taChange();
-  if (autoimport) {
-    fromXml();
-  }
 }
 
 function addToolboxButtonCallbacks() {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/3882

### Proposed Changes

Create advanced playground:
- Use the @blockly/dev-tools package to import the debug renderer, simple toolbox, category toolbox, and gui controls.
- Remove lots of checkboxes and dropdowns in favor of gui controls.
- Modify airstrike to randomly select from all blocks instead of all blocks in the toolbox.
  - Open to discussion

Update the standard playground:
 - Remove various controls + logic:
  - Debug renderer
  - Renderer picker
  - Theme picker
  - Accessibility checkbox

### Reason for Changes

Use published dev tools where possible.
Simplify standard playground while continuing to have a functional playground that works w/no internet access, installation, etc.

### Test Coverage

Opened both playgrounds and clicked around.

### Documentation
None

### Additional Information

There's more that can be done. I'm tracking some ideas in #3882.