### PR TITLE
Fix gulp build on Windows

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -191,7 +191,8 @@ function buildCompressed() {
     // Flatten all files so they're in the same directory, but ensure that
     // files with the same name don't conflict.
     .pipe(gulp.rename(function (p) {
-      var dirname = p.dirname.replace(new RegExp(path.sep.replace(/\\/,'\\\\'), "g"), "-");
+      var dirname = p.dirname.replace(
+        new RegExp(path.sep.replace(/\\/, '\\\\'), "g"), "-");
       p.dirname = "";
       p.basename = dirname + "-" + p.basename;
     }))

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -191,7 +191,7 @@ function buildCompressed() {
     // Flatten all files so they're in the same directory, but ensure that
     // files with the same name don't conflict.
     .pipe(gulp.rename(function (p) {
-      var dirname = p.dirname.replace(new RegExp(path.sep, "g"), "-");
+      var dirname = p.dirname.replace(new RegExp(path.sep.replace(/\\/,'\\\\'), "g"), "-");
       p.dirname = "";
       p.basename = dirname + "-" + p.basename;
     }))


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes build issue of gulp build script on Windows, reported: 
https://groups.google.com/forum/#!topic/blockly/vkwHBjmIpFU

### Proposed Changes

Escape the path separator for the regex. It's `\` on Windows, and that needs to be escaped to `\\`.

### Reason for Changes

Fix build

### Test Coverage

Tested build on Windows.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
