### PR TITLE
Use the Blockly AST for block toString

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1384,7 +1384,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
   Blockly.ASTNode.NAVIGATE_ALL_FIELDS = prevNavigateFields;
 
   // Run through our text array and simplify expression to remove parentheses
-  // around a single field.
+  // around single field blocks.
   for (var i = 2, l = text.length; i < l; i++) {
     if (text[i - 2] == '(' && text[i] == ')') {
       text[i - 2] = text[i - 1];

--- a/core/block.js
+++ b/core/block.js
@@ -1317,7 +1317,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
 
   /**
    * Whether or not to add parentheses around an input.
-   * @param {Blockly.Connection} connection The connection.
+   * @param {!Blockly.Connection} connection The connection.
    * @return {boolean} True if we should add parentheses around the input.
    */
   function shouldAddParentheses(connection) {
@@ -1343,7 +1343,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
   while (node) {
     switch (node.getType()) {
       case Blockly.ASTNode.types.INPUT:
-        var connection = /** @type {Blockly.Connection} */ (node.getLocation());
+        var connection = /** @type {!Blockly.Connection} */ (node.getLocation());
         if (!node.in()) {
           text.push(emptyFieldPlaceholder);
         } else if (shouldAddParentheses(connection)) {
@@ -1370,7 +1370,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
         // If we hit an input on the way up, possibly close out parentheses.
         if (node && node.getType() == Blockly.ASTNode.types.INPUT &&
             shouldAddParentheses(
-                /** @type {Blockly.Connection} */ (node.getLocation()))) {
+                /** @type {!Blockly.Connection} */ (node.getLocation()))) {
           text.push(')');
         }
       }

--- a/core/block.js
+++ b/core/block.js
@@ -1368,12 +1368,10 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
         node = node.out();
         checkRoot();
         // If we hit an input on the way up, possibly close out parentheses.
-        if (node && node.getType() == Blockly.ASTNode.types.INPUT) {
-          var connection = /** @type {Blockly.Connection} */ (
-            node.getLocation());
-          if (shouldAddParentheses(connection)) {
-            text.push(')');
-          }
+        if (node && node.getType() == Blockly.ASTNode.types.INPUT &&
+            shouldAddParentheses(
+                /** @type {Blockly.Connection} */ (node.getLocation()))) {
+          text.push(')');
         }
       }
       if (node) {

--- a/core/block.js
+++ b/core/block.js
@@ -1307,7 +1307,7 @@ Blockly.Block.prototype.setCollapsed = function(collapsed) {
 Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
   var text = [];
   var emptyFieldPlaceholder = opt_emptyToken || '?';
-  
+
   // Temporarily set flag to navigate to all fields.
   var prevNavigateFields = Blockly.ASTNode.NAVIGATE_ALL_FIELDS;
   Blockly.ASTNode.NAVIGATE_ALL_FIELDS = true;
@@ -1357,7 +1357,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
         }
         break;
     }
-  
+
     var current = node;
     node = current.in() || current.next();
     if (!node) {

--- a/core/block.js
+++ b/core/block.js
@@ -1393,6 +1393,7 @@ Blockly.Block.prototype.toString = function(opt_maxLength, opt_emptyToken) {
     }
   }
 
+  // Join the text array, removing spaces around added paranthesis.
   text = text.join(' ').replace(/(\() | (\))/gmi, '$1$2').trim() || '???';
   if (opt_maxLength) {
     // TODO: Improve truncation so that text from this block is given priority.

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1680,4 +1680,116 @@ suite('Blocks', function() {
       });
     });
   });
+  suite('toString', function() {
+    var toStringTests = [
+      {
+        name: 'statement block',
+        xml: '<block type="controls_repeat_ext">' +
+          '<value name="TIMES">' +
+            '<shadow type="math_number">' +
+              '<field name="NUM">10</field>' +
+          '</shadow>' +
+          '</value>' +
+        '</block>',
+        toString: 'repeat 10 times do ?',
+      },
+      {
+        name: 'nested statement blocks',
+        xml: '<block type="controls_repeat_ext">' +
+          '<value name="TIMES">' +
+            '<shadow type="math_number">' +
+              '<field name="NUM">10</field>' +
+            '</shadow>' +
+          '</value>' +
+          '<statement name="DO">' +
+            '<block type="controls_if"></block>' +
+          '</statement>' +
+        '</block>',
+        toString: 'repeat 10 times do if ? do ?',
+      },
+      {
+        name: 'nested Boolean output blocks',
+        xml: '<block type="controls_if">' +
+          '<value name="IF0">' +
+            '<block type="logic_compare">' +
+              '<field name="OP">EQ</field>' +
+              '<value name="A">' +
+                '<block type="logic_operation">' +
+                  '<field name="OP">AND</field>' +
+                '</block>' +
+              '</value>' +
+            '</block>' +
+          '</value>' +
+        '</block>',
+        toString: 'if ((? and ?) = ?) do ?',
+      },
+      {
+        name: 'output block',
+        xml: '<block type="math_single">' +
+          '<field name="OP">ROOT</field>' +
+          '<value name="NUM">' +
+            '<shadow type="math_number">' +
+              '<field name="NUM">9</field>' +
+            '</shadow>' +
+          '</value>' +
+        '</block>',
+        toString: 'square root 9',
+      },
+      {
+        name: 'nested Number output blocks',
+        xml: '<block type="math_arithmetic">' +
+          '<field name="OP">ADD</field>' +
+          '<value name="A">' +
+            '<shadow type="math_number">' +
+              '<field name="NUM">1</field>' +
+            '</shadow>' +
+            '<block type="math_arithmetic">' +
+              '<field name="OP">MULTIPLY</field>' +
+              '<value name="A">' +
+                '<shadow type="math_number">' +
+                  '<field name="NUM">10</field>' +
+                '</shadow>' +
+              '</value>' +
+              '<value name="B">' +
+                '<shadow type="math_number">' +
+                  '<field name="NUM">5</field>' +
+                '</shadow>' +
+              '</value>' +
+            '</block>' +
+          '</value>' +
+          '<value name="B">' +
+            '<shadow type="math_number">' +
+              '<field name="NUM">3</field>' +
+            '</shadow>' +
+          '</value>' +
+        '</block>',
+        toString: '(10 × 5) + 3',
+      },
+      {
+        name: 'nested String output blocks',
+        xml: '<block type="text_join">' +
+          '<mutation items="2"></mutation>' +
+          '<value name="ADD0">' +
+            '<block type="text">' +
+              '<field name="TEXT">Hello</field>' +
+            '</block>' +
+          '</value>' +
+          '<value name="ADD1">' +
+            '<block type="text">' +
+              '<field name="TEXT">World</field>' +
+            '</block>' +
+          '</value>' +
+        '</block>',
+        toString: 'create text with “ Hello ” “ World ”',
+      },
+    ];
+    // Create mocha test cases for each toString test.
+    toStringTests.forEach(function(t) {
+      test(t.name, function() {
+        var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(t.xml),
+            this.workspace);
+        chai.assert.equal(block.toString(), t.toString);
+      });
+    });
+  });
 });

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -12,6 +12,7 @@
     <script src="../../generators/php.js"></script>
     <script src="../../generators/python.js"></script>
     <script src="../../msg/messages.js"></script>
+    <script src="../../blocks/loops.js"></script>
     <script src="../../blocks/lists.js"></script>
     <script src="../../blocks/logic.js"></script>
     <script src="../../blocks/math.js"></script>

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -669,15 +669,15 @@ function testAWorkspace() {
 
     test('After dispose', function() {
       this.blockA.dispose();
-      chai.assert.isNull(this.workspace.getBlockById(this.blockA));
+      chai.assert.isNull(this.workspace.getBlockById(this.blockA.id));
       chai.assert.equal(
           this.workspace.getBlockById(this.blockB.id), this.blockB);
     });
 
     test('After clear', function() {
       this.workspace.clear();
-      chai.assert.isNull(this.workspace.getBlockById(this.blockA));
-      chai.assert.isNull(this.workspace.getBlockById(this.blockB));
+      chai.assert.isNull(this.workspace.getBlockById(this.blockA.id));
+      chai.assert.isNull(this.workspace.getBlockById(this.blockB.id));
     });
   });
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/57

### Proposed Changes

The block ``toString`` method which is what's shown to users when a block is collapsed doesn't allow users to tell the difference between the block configuration: 
<img width="289" alt="Screen Shot 2020-05-09 at 9 52 40 AM" src="https://user-images.githubusercontent.com/16690124/81479865-f2c33980-91da-11ea-8a2f-bbe2408791d0.png">
<img width="146" alt="Screen Shot 2020-05-09 at 9 53 14 AM" src="https://user-images.githubusercontent.com/16690124/81479871-f656c080-91da-11ea-94e7-d8f32f6df4fc.png">

Instead, now that we have a Blockly AST, we can go through and build up a block's textual representation by traversing the tree. In addition, we can add parentheses around `Number` and `Boolean` connections to make it clearer to user the order of precedence. 
The previous example turns into (when collapsed):
<img width="153" alt="Screen Shot 2020-05-09 at 9 52 48 AM" src="https://user-images.githubusercontent.com/16690124/81479924-2a31e600-91db-11ea-8f3c-d25d25d2f207.png">

Finally, I run through the text array and remove any simple parentheses around single input blocks. eg: ``((10) * (50)) + (10)`` turns into ``(10 * 50) + 10``.

### Reason for Changes

Fix ambiguity around order of precedence of collapsed blocks. 

### Test Coverage

Tested in playground.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
<img width="279" alt="Screen Shot 2020-05-09 at 9 30 11 AM" src="https://user-images.githubusercontent.com/16690124/81480603-99a9d480-91df-11ea-9e10-849c4f3bf8a4.png">
turns into
<img width="139" alt="Screen Shot 2020-05-09 at 9 30 16 AM" src="https://user-images.githubusercontent.com/16690124/81479965-741acc00-91db-11ea-80b1-4604116f868f.png">

<img width="327" alt="Screen Shot 2020-05-09 at 9 33 25 AM" src="https://user-images.githubusercontent.com/16690124/81480002-9876a880-91db-11ea-93a3-90bc97b6f8b5.png">
turns into
<img width="201" alt="Screen Shot 2020-05-09 at 9 33 29 AM" src="https://user-images.githubusercontent.com/16690124/81480005-9dd3f300-91db-11ea-9049-84c5d16b14d2.png">

@NeilFraser FYI, I know you had some thoughts about parenthesis in the bug, do you think this design makes things better in most cases?
