### PR TITLE
Add programmatically setting shadows

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -105,7 +105,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
     var orphanBlock = parentConnection.targetBlock();
     var shadowDom = parentConnection.getShadowDom();
     // Temporarily set the shadow DOM to null so it does not respawn.
-    parentConnection.setShadowDom(null);
+    parentConnection.shadowDom_ = null;
     // Displaced shadow blocks dissolve rather than reattaching or bumping.
     if (orphanBlock.isShadow()) {
       // Save the shadow block so that field values are preserved.
@@ -172,7 +172,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
       }
     }
     // Restore the shadow DOM.
-    parentConnection.setShadowDom(shadowDom);
+    parentConnection.shadowDom_ = shadowDom;
   }
 
   var event;
@@ -197,12 +197,11 @@ Blockly.Connection.prototype.dispose = function() {
 
   // isConnected returns true for shadows and non-shadows.
   if (this.isConnected()) {
+    // Destroy the attached shadow block & its children (if it exists).
     this.setShadowDom(null);
+
     var targetBlock = this.targetBlock();
-    if (targetBlock.isShadow()) {
-      // Destroy the attached shadow block & its children.
-      targetBlock.dispose(false);
-    } else {
+    if (targetBlock) {
       // Disconnect the attached normal block.
       targetBlock.unplug();
     }
@@ -669,15 +668,22 @@ Blockly.Connection.prototype.getCheck = function() {
 };
 
 /**
- * Change a connection's shadow block.
+ * Changes the connection's shadow block.
  * @param {Element} shadow DOM representation of a block or null.
  */
 Blockly.Connection.prototype.setShadowDom = function(shadow) {
   this.shadowDom_ = shadow;
+  var target = this.targetBlock();
+  if (!target) {
+    this.respawnShadow_();
+  } else if (target.isShadow()) {
+    // The disconnect from dispose will automatically generate the new shadow.
+    target.dispose(false);
+  }
 };
 
 /**
- * Return a connection's shadow block.
+ * Returns the xml representation of the connection's shadow block.
  * @return {Element} Shadow DOM representation of a block or null.
  */
 Blockly.Connection.prototype.getShadowDom = function() {

--- a/core/input.js
+++ b/core/input.js
@@ -232,6 +232,30 @@ Blockly.Input.prototype.setAlign = function(align) {
 };
 
 /**
+ * Changes the connection's shadow block.
+ * @param {Element} shadow DOM representation of a block or null.
+ * @returns {Blockly.Input} The input being modified (to allow chaining).
+ */
+Blockly.Input.prototype.setShadowDom = function(shadow) {
+  if (!this.connection) {
+    throw Error('This input does not have a connection.');
+  }
+  this.connection.setShadowDom(shadow);
+  return this;
+};
+
+/**
+ * Returns the xml representation of the connection's shadow block.
+ * @return {Element} Shadow DOM representation of a block or null.
+ */
+Blockly.Input.prototype.getShadowDom = function() {
+  if (!this.connection) {
+    throw Error('This input does not have a connection.');
+  }
+  return this.connection.getShadowDom();
+};
+
+/**
  * Initialize the fields on this input.
  */
 Blockly.Input.prototype.init = function() {

--- a/core/input.js
+++ b/core/input.js
@@ -234,7 +234,7 @@ Blockly.Input.prototype.setAlign = function(align) {
 /**
  * Changes the connection's shadow block.
  * @param {Element} shadow DOM representation of a block or null.
- * @returns {Blockly.Input} The input being modified (to allow chaining).
+ * @return {Blockly.Input} The input being modified (to allow chaining).
  */
 Blockly.Input.prototype.setShadowDom = function(shadow) {
   if (!this.connection) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -632,10 +632,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         }
       }
     }
-    // Use the shadow block if there is no child block.
-    if (!childBlockElement && childShadowElement) {
-      childBlockElement = childShadowElement;
-    }
 
     var name = xmlChild.getAttribute('name');
     var xmlChildElement = /** @type {!Element} */ (xmlChild);
@@ -690,9 +686,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
                        prototypeName);
           break;
         }
-        if (childShadowElement) {
-          input.connection.setShadowDom(childShadowElement);
-        }
         if (childBlockElement) {
           blockChild = Blockly.Xml.domToBlockHeadless_(childBlockElement,
               workspace);
@@ -705,11 +698,12 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
                 'Child block does not have output or previous statement.');
           }
         }
+        // Set shadow after so we don't create a shadow we delete immediately.
+        if (childShadowElement) {
+          input.connection.setShadowDom(childShadowElement);
+        }
         break;
       case 'next':
-        if (childShadowElement && block.nextConnection) {
-          block.nextConnection.setShadowDom(childShadowElement);
-        }
         if (childBlockElement) {
           if (!block.nextConnection) {
             throw TypeError('Next statement does not exist.');
@@ -724,6 +718,10 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
             throw TypeError('Next block does not have previous statement.');
           }
           block.nextConnection.connect(blockChild.previousConnection);
+        }
+        // Set shadow after so we don't create a shadow we delete immediately.
+        if (childShadowElement && block.nextConnection) {
+          block.nextConnection.setShadowDom(childShadowElement);
         }
         break;
       default:

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -184,4 +184,1027 @@ suite('Connections', function() {
       chai.assert.isFalse(this.con1.checkType((this.con2)));
     });
   });
+  suite('Set Shadow Dom', function() {
+    setup(function() {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "stack_block",
+          "message0": "",
+          "previousStatement": null,
+          "nextStatement": null
+        },
+        {
+          "type": "row_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "input_value",
+              "name": "INPUT"
+            }
+          ],
+          "output": null
+        },
+        {
+          "type": "statement_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "input_statement",
+              "name": "STATEMENT"
+            }
+          ],
+          "previousStatement": null,
+          "nextStatement": null
+        }]);
+
+      this.runHeadlessAndRendered = function(func, context) {
+        var workspace = new Blockly.Workspace();
+        func.call(context, workspace);
+        workspace.clear();
+        workspace.dispose();
+
+        var workspace = Blockly.inject('blocklyDiv');
+        func.call(context, workspace);
+        workspace.clear();
+        workspace.dispose();
+      };
+    });
+    teardown(function() {
+      delete this.runHeadlessAndRendered;
+      delete Blockly.Blocks['stack_block'];
+      delete Blockly.Blocks['row_block'];
+      delete Blockly.Blocks['statement_block'];
+    });
+    suite('Add - No Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - With Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlocks;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target2);
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target2);
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNull(target2);
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - With Shadow Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="1"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="2"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target2 = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="1">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block" id="a"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="2">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block" id="b"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="1"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="2"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="1">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block" id="a"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="2">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block" id="b"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="1"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="2"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="1">' +
+              '  <next>' +
+              '    <shadow type="stack_block" id="a"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="2">' +
+              '  <next>' +
+              '    <shadow type="stack_block" id="b"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Remove - No Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Remove - Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - Connect & Disconnect - Remove', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.connect(child.outputConnection);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.connect(child.outputConnection);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection
+              .connect(child.previousConnection);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection
+              .connect(child.previousConnection);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.nextConnection.connect(child.previousConnection);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.nextConnection.connect(child.previousConnection);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+  });
 });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -223,7 +223,7 @@ suite('Connections', function() {
         workspace.clear();
         workspace.dispose();
 
-        var workspace = Blockly.inject('blocklyDiv');
+        workspace = Blockly.inject('blocklyDiv');
         func.call(context, workspace);
         workspace.clear();
         workspace.dispose();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This PR allows developers to assign shadow blocks to connections/inputs programmatically.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This functionality is necessary if you want to assign shadow blocks based on the mutation of a block. For example: if you have a mutable addition block and you want to add a shadow to each input.

![PlusBlock](https://user-images.githubusercontent.com/25440652/82086613-9c0aa380-96a3-11ea-85ca-27c1ff66781b.png)


### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![NewTests](https://user-images.githubusercontent.com/25440652/82086716-c8262480-96a3-11ea-86c3-61ce021d4abc.png)

I also flipped through the toolbox, and everything seems fine!


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
None as far as I know.

### Additional Information

This was actually really easy to add, which kind of scares me.

If anyone can think of other areas that need testing I'm happy to test.
