### PR TITLE
Fix advanced playground options passing

### DIFF
--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -152,11 +152,11 @@ function createWorkspace() {
 
   // Create main workspace.
   addGUIControls((options) => {
-    workspace = Blockly.inject('blocklyDiv', defaultOptions);
+    workspace = Blockly.inject('blocklyDiv', options);
     workspace.configureContextMenu = configureContextMenu;
     addToolboxButtonCallbacks();
     return workspace;
-  }, options);
+  }, defaultOptions);
 }
 
 function addToolboxButtonCallbacks() {


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Advanced playground options weren't being piped correctly. 

### Proposed Changes

Fix advanced playground options passing.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
