### PR TITLE
Strict types in input

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -171,6 +171,9 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
    */
   this.hat = undefined;
 
+  /** @type {?boolean} */
+  this.rendered = null;
+
   /**
    * A count of statement inputs on the block.
    * @type {number}

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -67,6 +67,20 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
    */
   this.generatedOptions_ = null;
 
+  /**
+   * The prefix field label, of common words set after options are trimmed.
+   * @type {string}
+   * @package
+   */
+  this.prefixField = null;
+
+  /**
+   * The suffix field label, of common words set after options are trimmed.
+   * @type {string}
+   * @package
+   */
+  this.suffixField = null;
+
   this.trimOptions_();
 
   /**
@@ -373,8 +387,6 @@ Blockly.FieldDropdown.prototype.onItemSelected_ = function(menu, menuItem) {
  * @private
  */
 Blockly.FieldDropdown.prototype.trimOptions_ = function() {
-  this.prefixField = null;
-  this.suffixField = null;
   var options = this.menuGenerator_;
   if (!Array.isArray(options)) {
     return;

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -69,14 +69,14 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
 
   /**
    * The prefix field label, of common words set after options are trimmed.
-   * @type {string}
+   * @type {?string}
    * @package
    */
   this.prefixField = null;
 
   /**
    * The suffix field label, of common words set after options are trimmed.
-   * @type {string}
+   * @type {?string}
    * @package
    */
   this.suffixField = null;

--- a/core/input.js
+++ b/core/input.js
@@ -109,19 +109,21 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
   field.name = opt_name;
   field.setVisible(this.isVisible());
 
-  if (field.prefixField) {
+  var fieldDropdown = /** @type {Blockly.FieldDropdown} */ (field);
+  if (fieldDropdown.prefixField) {
     // Add any prefix.
-    index = this.insertFieldAt(index, field.prefixField);
+    index = this.insertFieldAt(index, fieldDropdown.prefixField);
   }
   // Add the field to the field row.
   this.fieldRow.splice(index, 0, field);
   ++index;
-  if (field.suffixField) {
+  if (fieldDropdown.suffixField) {
     // Add any suffix.
-    index = this.insertFieldAt(index, field.suffixField);
+    index = this.insertFieldAt(index, fieldDropdown.suffixField);
   }
 
   if (this.sourceBlock_.rendered) {
+    this.sourceBlock_ = /** @type {!Blockly.BlockSvg} */ (this.sourceBlock_);
     this.sourceBlock_.render();
     // Adding a field will cause the block to change shape.
     this.sourceBlock_.bumpNeighbours();
@@ -140,6 +142,7 @@ Blockly.Input.prototype.removeField = function(name) {
       field.dispose();
       this.fieldRow.splice(i, 1);
       if (this.sourceBlock_.rendered) {
+        this.sourceBlock_ = /** @type {!Blockly.BlockSvg} */ (this.sourceBlock_);
         this.sourceBlock_.render();
         // Removing a field will cause the block to change shape.
         this.sourceBlock_.bumpNeighbours();
@@ -162,7 +165,7 @@ Blockly.Input.prototype.isVisible = function() {
  * Sets whether this input is visible or not.
  * Should only be used to collapse/uncollapse a block.
  * @param {boolean} visible True if visible.
- * @return {!Array.<!Blockly.Block>} List of blocks to render.
+ * @return {!Array.<!Blockly.BlockSvg>} List of blocks to render.
  * @package
  */
 Blockly.Input.prototype.setVisible = function(visible) {
@@ -179,6 +182,8 @@ Blockly.Input.prototype.setVisible = function(visible) {
     field.setVisible(visible);
   }
   if (this.connection) {
+    this.connection =
+      /** @type {!Blockly.RenderedConnection} */ (this.connection);
     // Has a connection.
     if (visible) {
       renderList = this.connection.startTrackingAll();
@@ -226,6 +231,7 @@ Blockly.Input.prototype.setCheck = function(check) {
 Blockly.Input.prototype.setAlign = function(align) {
   this.align = align;
   if (this.sourceBlock_.rendered) {
+    this.sourceBlock_ = /** @type {!Blockly.BlockSvg} */ (this.sourceBlock_);
     this.sourceBlock_.render();
   }
   return this;


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Strict types in input.js.
Added prefixField and suffixField properties to FieldDropdown 
Add rendered property to Blockly.Block and set to null such that:
 - Blockly.Block, rendered = null
 - Blockly.BlockSvg, rendered = false
 - Blockly.BlockSvg (after render is called), rendered = true

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
