### PR TITLE
Do not add COLLAPSED_WARNINGS_WARNING by deleting of warning

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1135,22 +1135,22 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
     text = null;
   }
 
-  // Bubble up to add a warning on top-most collapsed block.
-  var parent = this.getSurroundParent();
-  var collapsedParent = null;
-  while (parent) {
-    if (parent.isCollapsed()) {
-      collapsedParent = parent;
-    }
-    parent = parent.getSurroundParent();
-  }
-  if (collapsedParent) {
-    collapsedParent.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
-        Blockly.BlockSvg.COLLAPSED_WARNING_ID);
-  }
-
   var changedState = false;
   if (typeof text == 'string') {
+    // Bubble up to add a warning on top-most collapsed block.
+    var parent = this.getSurroundParent();
+    var collapsedParent = null;
+    while (parent) {
+      if (parent.isCollapsed()) {
+        collapsedParent = parent;
+      }
+      parent = parent.getSurroundParent();
+    }
+    if (collapsedParent) {
+      collapsedParent.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
+          Blockly.BlockSvg.COLLAPSED_WARNING_ID);
+    }
+    
     if (!this.warning) {
       this.warning = new Blockly.Warning(this);
       changedState = true;


### PR DESCRIPTION
## The basics
- [ x ] I branched from develop
- [ x ] My pull request is against develop
- [ x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
It resolves my problem, that I am facing now. If I call this code: https://github.com/ioBroker/ioBroker.javascript/blob/master/src/public/google-blockly/own/blocks_trigger.js#L418

in collapsed state, I could see a warning, but it is wrong.

### Proposed Changes

This PR just fixes an error.

### Reason for Changes
If some block tries to remove warning with `block.setWarningText(null, block.id)` in collapsed state, the warning will be shown anyway.

### Test Coverage
Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

The change is so small and not depend on browser features relevant.

### Documentation
Not relevant

### Additional Information
