### PR TITLE
Enable unusedPrivateMembers check

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -131,13 +131,6 @@ Blockly.BlockSvg.prototype.height = 0;
 Blockly.BlockSvg.prototype.width = 0;
 
 /**
- * Original location of block being dragged.
- * @type {Blockly.utils.Coordinate}
- * @private
- */
-Blockly.BlockSvg.prototype.dragStartXY_ = null;
-
-/**
  * Map from IDs for warnings text to PIDs of functions to apply them.
  * Used to be able to maintain multiple warnings.
  * @type {Object.<string, number>}

--- a/core/comment.js
+++ b/core/comment.js
@@ -86,7 +86,7 @@ Blockly.utils.object.inherits(Blockly.Comment, Blockly.Icon);
 /**
  * Draw the comment icon.
  * @param {!Element} group The icon group.
- * @private
+ * @protected
  */
 Blockly.Comment.prototype.drawIcon_ = function(group) {
   // Circle.

--- a/core/connection.js
+++ b/core/connection.js
@@ -619,6 +619,7 @@ Blockly.Connection.prototype.checkType = function(otherConnection) {
  * @return {boolean} True if the connections share a type.
  * @private
  * @deprecated October 2019, use connection.checkType instead.
+ * @suppress {unusedPrivateMembers}
  */
 Blockly.Connection.prototype.checkType_ = function(otherConnection) {
   console.warn('Deprecated call to Blockly.Connection.prototype.checkType_, ' +

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -247,7 +247,7 @@ Blockly.FieldAngle.prototype.render_ = function() {
  * Create and show the angle field's editor.
  * @param {Event=} opt_e Optional mouse event that triggered the field to open,
  *     or undefined if triggered programmatically.
- * @private
+ * @protected
  */
 Blockly.FieldAngle.prototype.showEditor_ = function(opt_e) {
   // Mobile browsers have issues with in-line textareas (focus & keyboards).

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -311,7 +311,7 @@ Blockly.FieldColour.prototype.setColumns = function(columns) {
 
 /**
  * Create and show the colour field's editor.
- * @private
+ * @protected
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
   this.picker_ = this.dropdownCreate_();

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -272,7 +272,7 @@ Blockly.FieldDropdown.prototype.createSVGArrow_ = function() {
  * Create a dropdown menu under the text.
  * @param {Event=} opt_e Optional mouse event that triggered the field to open,
  *     or undefined if triggered programmatically.
- * @private
+ * @protected
  */
 Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
   this.menu_ = this.dropdownCreate_();
@@ -552,7 +552,7 @@ Blockly.FieldDropdown.prototype.applyColour = function() {
 
 /**
  * Draws the border with the correct width.
- * @private
+ * @protected
  */
 Blockly.FieldDropdown.prototype.render_ = function() {
   // Hide both elements.

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -80,6 +80,13 @@ Blockly.FieldTextInput = function(opt_value, opt_validator, opt_config) {
    * @type {?boolean}
    */
   this.fullBlockClickTarget_ = false;
+
+  /**
+   * The workspace that this field belongs to.
+   * @type {?Blockly.WorkspaceSvg}
+   * @protected
+   */
+  this.workspace_ = null;
 };
 Blockly.utils.object.inherits(Blockly.FieldTextInput, Blockly.Field);
 
@@ -275,7 +282,8 @@ Blockly.FieldTextInput.prototype.setSpellcheck = function(check) {
  */
 Blockly.FieldTextInput.prototype.showEditor_ = function(_opt_e,
     opt_quietInput) {
-  this.workspace_ = this.sourceBlock_.workspace;
+  this.workspace_ =
+    (/** @type {!Blockly.BlockSvg} */ (this.sourceBlock_)).workspace;
   var quietInput = opt_quietInput || false;
   if (!quietInput && (Blockly.utils.userAgent.MOBILE ||
                       Blockly.utils.userAgent.ANDROID ||

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -99,13 +99,6 @@ Blockly.FieldVariable.fromJson = function(options) {
 };
 
 /**
- * The workspace that this variable field belongs to.
- * @type {?Blockly.Workspace}
- * @private
- */
-Blockly.FieldVariable.prototype.workspace_ = null;
-
-/**
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -65,6 +65,13 @@ Blockly.Flyout = function(workspaceOptions) {
   this.RTL = !!workspaceOptions.RTL;
 
   /**
+   * Whether the flyout should be laid out horizontally or not.
+   * @type {boolean}
+   * @package
+   */
+  this.horizontalLayout = false;
+
+  /**
    * Position of the toolbox and flyout relative to the workspace.
    * @type {number}
    * @protected
@@ -256,7 +263,7 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
    * @package
    */
   this.scrollbar = new Blockly.Scrollbar(this.workspace_,
-      this.horizontalLayout_, false, 'blocklyFlyoutScrollbar');
+      this.horizontalLayout, false, 'blocklyFlyoutScrollbar');
 
   this.hide();
 
@@ -473,8 +480,9 @@ Blockly.Flyout.prototype.show = function(flyoutDef) {
   // Parse the Array or NodeList passed in into an Array of
   // Blockly.utils.toolbox.Toolbox.
   var parsedContent = Blockly.utils.toolbox.convertToolboxToJSON(flyoutDef);
-  var flyoutInfo = /** @type {{contents:Array.<Object>, gaps:Array.<number>}} */
-      (this.createFlyoutInfo_(parsedContent));
+  var flyoutInfo =
+    /** @type {{contents:!Array.<!Object>, gaps:!Array.<number>}} */ (
+      this.createFlyoutInfo_(parsedContent));
 
   this.setVisible(true);
 
@@ -492,7 +500,7 @@ Blockly.Flyout.prototype.show = function(flyoutDef) {
   this.listeners_.push(Blockly.bindEventWithChecks_(this.svgBackground_,
       'mouseover', this, deselectAll));
 
-  if (this.horizontalLayout_) {
+  if (this.horizontalLayout) {
     this.height_ = 0;
   } else {
     this.width_ = 0;
@@ -522,7 +530,7 @@ Blockly.Flyout.prototype.createFlyoutInfo_ = function(parsedContent) {
   var contents = [];
   var gaps = [];
   this.permanentlyDisabled_.length = 0;
-  var defaultGap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
+  var defaultGap = this.horizontalLayout ? this.GAP_X : this.GAP_Y;
   for (var i = 0, contentInfo; (contentInfo = parsedContent[i]); i++) {
     switch (contentInfo.kind.toUpperCase()) {
       case 'BLOCK':
@@ -994,3 +1002,26 @@ Blockly.Flyout.prototype.getMetrics_;
  * @protected
  */
 Blockly.Flyout.prototype.setMetrics_;
+
+/**
+ * Lay out the blocks in the flyout.
+ * @param {!Array.<!Object>} contents The blocks and buttons to lay out.
+ * @param {!Array.<number>} gaps The visible gaps between blocks.
+ * @protected
+ */
+Blockly.Flyout.prototype.layout_;
+
+/**
+ * Scroll the flyout.
+ * @param {!Event} e Mouse wheel scroll event.
+ * @protected
+ */
+Blockly.Flyout.prototype.wheel_;
+
+/**
+ * Compute height of flyout.  Position mat under each block.
+ * For RTL: Lay out the blocks right-aligned.
+ * @return {void}
+ * @protected
+ */
+Blockly.Flyout.prototype.reflowInternal_;

--- a/core/flyout_dragger.js
+++ b/core/flyout_dragger.js
@@ -45,7 +45,7 @@ Blockly.FlyoutDragger = function(flyout) {
    * @type {boolean}
    * @private
    */
-  this.horizontalLayout_ = flyout.horizontalLayout_;
+  this.horizontalLayout_ = flyout.horizontalLayout;
 };
 Blockly.utils.object.inherits(Blockly.FlyoutDragger, Blockly.WorkspaceDragger);
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -32,12 +32,8 @@ goog.requireType('Blockly.utils.Metrics');
  */
 Blockly.HorizontalFlyout = function(workspaceOptions) {
   Blockly.HorizontalFlyout.superClass_.constructor.call(this, workspaceOptions);
-  /**
-   * Flyout should be laid out horizontally.
-   * @type {boolean}
-   * @private
-   */
-  this.horizontalLayout_ = true;
+  
+  this.horizontalLayout = true;
 };
 Blockly.utils.object.inherits(Blockly.HorizontalFlyout, Blockly.Flyout);
 
@@ -227,7 +223,7 @@ Blockly.HorizontalFlyout.prototype.scrollToStart = function() {
 /**
  * Scroll the flyout.
  * @param {!Event} e Mouse wheel scroll event.
- * @private
+ * @protected
  */
 Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
   var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
@@ -255,7 +251,7 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
  * Lay out the blocks in the flyout.
  * @param {!Array.<!Object>} contents The blocks and buttons to lay out.
  * @param {!Array.<number>} gaps The visible gaps between blocks.
- * @private
+ * @protected
  */
 Blockly.HorizontalFlyout.prototype.layout_ = function(contents, gaps) {
   this.workspace_.scale = this.targetWorkspace.scale;
@@ -352,7 +348,7 @@ Blockly.HorizontalFlyout.prototype.getClientRect = function() {
 /**
  * Compute height of flyout.  Position mat under each block.
  * For RTL: Lay out the blocks right-aligned.
- * @private
+ * @protected
  */
 Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
   this.workspace_.scale = this.targetWorkspace.scale;

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -33,12 +33,6 @@ goog.requireType('Blockly.utils.Metrics');
  */
 Blockly.VerticalFlyout = function(workspaceOptions) {
   Blockly.VerticalFlyout.superClass_.constructor.call(this, workspaceOptions);
-  /**
-   * Flyout should be laid out vertically.
-   * @type {boolean}
-   * @private
-   */
-  this.horizontalLayout_ = false;
 };
 Blockly.utils.object.inherits(Blockly.VerticalFlyout, Blockly.Flyout);
 
@@ -215,7 +209,7 @@ Blockly.VerticalFlyout.prototype.scrollToStart = function() {
 /**
  * Scroll the flyout.
  * @param {!Event} e Mouse wheel scroll event.
- * @private
+ * @protected
  */
 Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
   var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
@@ -242,7 +236,7 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
  * Lay out the blocks in the flyout.
  * @param {!Array.<!Object>} contents The blocks and buttons to lay out.
  * @param {!Array.<number>} gaps The visible gaps between blocks.
- * @private
+ * @protected
  */
 Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
   this.workspace_.scale = this.targetWorkspace.scale;
@@ -331,7 +325,7 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
 /**
  * Compute width of flyout.  Position mat under each block.
  * For RTL: Lay out the blocks and buttons to be right-aligned.
- * @private
+ * @protected
  */
 Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
   this.workspace_.scale = this.targetWorkspace.scale;

--- a/core/icon.js
+++ b/core/icon.js
@@ -22,6 +22,7 @@ goog.require('Blockly.utils.Size');
  * Class for an icon.
  * @param {Blockly.BlockSvg} block The block associated with this icon.
  * @constructor
+ * @abstract
  */
 Blockly.Icon = function(block) {
   /**
@@ -181,3 +182,10 @@ Blockly.Icon.prototype.getCorrectedSize = function() {
   return new Blockly.utils.Size(
       Blockly.Icon.prototype.SIZE, Blockly.Icon.prototype.SIZE - 2);
 };
+
+/**
+ * Draw the icon.
+ * @param {!Element} group The icon group.
+ * @protected
+ */
+Blockly.Icon.prototype.drawIcon_;

--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -112,7 +112,8 @@ Blockly.MenuItem.prototype.createDom = function() {
   element.className = 'blocklyMenuItem goog-menuitem ' +
       (this.enabled_ ? '' : 'blocklyMenuItemDisabled goog-menuitem-disabled ') +
       (this.checked_ ? 'blocklyMenuItemSelected goog-option-selected ' : '') +
-      (this.highlight_ ? 'blocklyMenuItemHighlight goog-menuitem-highlight ' : '') +
+      (this.highlight_ ?
+        'blocklyMenuItemHighlight goog-menuitem-highlight ' : '') +
       (this.rightToLeft_ ? 'blocklyMenuItemRtl goog-menuitem-rtl ' : '');
 
   var content = document.createElement('div');

--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -112,6 +112,7 @@ Blockly.MenuItem.prototype.createDom = function() {
   element.className = 'blocklyMenuItem goog-menuitem ' +
       (this.enabled_ ? '' : 'blocklyMenuItemDisabled goog-menuitem-disabled ') +
       (this.checked_ ? 'blocklyMenuItemSelected goog-option-selected ' : '') +
+      (this.highlight_ ? 'blocklyMenuItemHighlight goog-menuitem-highlight ' : '') +
       (this.rightToLeft_ ? 'blocklyMenuItemRtl goog-menuitem-rtl ' : '');
 
   var content = document.createElement('div');

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -76,7 +76,7 @@ Blockly.Mutator.prototype.getWorkspace = function() {
 /**
  * Draw the mutator icon.
  * @param {!Element} group The icon group.
- * @private
+ * @protected
  */
 Blockly.Mutator.prototype.drawIcon_ = function(group) {
   // Square with rounded corners.

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -128,13 +128,6 @@ Blockly.Toolbox = function(workspace) {
   this.height = 0;
 
   /**
-   * The SVG group currently selected.
-   * @type {SVGGElement}
-   * @private
-   */
-  this.selectedOption_ = null;
-
-  /**
    * The TreeNode most recently selected.
    * @type {Blockly.tree.BaseNode}
    * @private

--- a/core/warning.js
+++ b/core/warning.js
@@ -42,7 +42,7 @@ Blockly.Warning.prototype.collapseHidden = false;
 /**
  * Draw the warning icon.
  * @param {!Element} group The icon group.
- * @private
+ * @protected
  */
 Blockly.Warning.prototype.drawIcon_ = function(group) {
   // Triangle with rounded corners.
@@ -152,16 +152,6 @@ Blockly.Warning.prototype.disposeBubble = function() {
   this.bubble_ = null;
   this.body_ = null;
   this.paragraphElement_ = null;
-};
-
-/**
- * Bring the warning to the top of the stack when clicked on.
- * @param {!Event} _e Mouse up event.
- * @private
- */
-
-Blockly.Warning.prototype.bodyFocus_ = function(_e) {
-  this.bubble_.promote();
 };
 
 /**

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -410,18 +410,6 @@ Blockly.Workspace.prototype.deleteVariableById = function(id) {
 };
 
 /**
- * Deletes a variable and all of its uses from this workspace without asking
- * the user for confirmation.
- * @param {!Blockly.VariableModel} variable Variable to delete.
- * @param {!Array.<!Blockly.Block>} uses An array of uses of the variable.
- * @private
- * @suppress {unusedPrivateMembers}
- */
-Blockly.Workspace.prototype.deleteVariableInternal_ = function(variable, uses) {
-  this.variableMap_.deleteVariableInternal(variable, uses);
-};
-
-/**
  * Check whether a variable exists with the given name.  The check is
  * case-insensitive.
  * @param {string} _name The name to check for.

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -415,6 +415,7 @@ Blockly.Workspace.prototype.deleteVariableById = function(id) {
  * @param {!Blockly.VariableModel} variable Variable to delete.
  * @param {!Array.<!Blockly.Block>} uses An array of uses of the variable.
  * @private
+ * @suppress {unusedPrivateMembers}
  */
 Blockly.Workspace.prototype.deleteVariableInternal_ = function(variable, uses) {
   this.variableMap_.deleteVariableInternal(variable, uses);

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -40,16 +40,6 @@ Blockly.WorkspaceDragSurfaceSvg = function(container) {
 Blockly.WorkspaceDragSurfaceSvg.prototype.SVG_ = null;
 
 /**
- * SVG group inside the drag surface that holds blocks while a drag is in
- * progress. Blocks are moved here by the workspace at start of a drag and moved
- * back into the main SVG at the end of a drag.
- *
- * @type {Element}
- * @private
- */
-Blockly.WorkspaceDragSurfaceSvg.prototype.dragGroup_ = null;
-
-/**
  * Containing HTML element; parent of the workspace and the drag surface.
  * @type {Element}
  * @private

--- a/demos/custom-fields/pitch/field_pitch.js
+++ b/demos/custom-fields/pitch/field_pitch.js
@@ -63,7 +63,7 @@ CustomFields.FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/
 
 /**
  * Show the inline free-text editor on top of the text and the note picker.
- * @private
+ * @protected
  */
 CustomFields.FieldPitch.prototype.showEditor_ = function() {
   CustomFields.FieldPitch.superClass_.showEditor_.call(this);

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -94,7 +94,7 @@ var JSCOMP_ERROR = [
   'underscore',
   'unknownDefines',
   'unusedLocalVariables',
-  // 'unusedPrivateMembers',
+  'unusedPrivateMembers',
   'useOfGoogBase',
   'uselessCode',
   'untranspilableFeatures',

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -99,16 +99,6 @@ function testAWorkspace() {
       createVarBlocksNoEvents(this.workspace, ['id1', 'id1', 'id2']);
     });
 
-    test('deleteVariableInternal_(id1)', function() {
-      var uses = this.workspace.getVariableUsesById(this.var1.getId());
-      this.workspace.deleteVariableInternal_(this.var1, uses);
-
-      var variable = this.workspace.getVariableById('id1');
-      chai.assert.isNull(variable);
-      assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-      assertBlockVarModelName(this.workspace, 0, 'name2');
-    });
-
     test('deleteVariableById(id2) one usage', function() {
       // Deleting variable one usage should not trigger confirm dialog.
       var stub =


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Enables unusedPrivateMembers check

### Proposed Changes

Remove unused private members
Fix up the use of private on members the override a property.
Make Blockly.Icon abstract

### Reason for Changes

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
