### PR TITLE
Convert workspace.resizesEnabled_ into a counter

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -217,34 +217,37 @@ Blockly.BlockDragger.prototype.dragBlock = function(e, currentDragDeltaXY) {
  * @package
  */
 Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
-  // Make sure internal state is fresh.
-  this.dragBlock(e, currentDragDeltaXY);
-  this.dragIconData_ = [];
-  this.fireDragEndEvent_();
+  try {
+    // Make sure internal state is fresh.
+    this.dragBlock(e, currentDragDeltaXY);
+    this.dragIconData_ = [];
+    this.fireDragEndEvent_();
 
-  Blockly.utils.dom.stopTextWidthCache();
+    Blockly.utils.dom.stopTextWidthCache();
 
-  Blockly.blockAnimations.disconnectUiStop();
+    Blockly.blockAnimations.disconnectUiStop();
 
-  var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
-  var newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
-  this.draggingBlock_.moveOffDragSurface(newLoc);
+    var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
+    var newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    this.draggingBlock_.moveOffDragSurface(newLoc);
 
-  var deleted = this.maybeDeleteBlock_();
-  if (!deleted) {
-    // These are expensive and don't need to be done if we're deleting.
-    this.draggingBlock_.moveConnections(delta.x, delta.y);
-    this.draggingBlock_.setDragging(false);
-    this.fireMoveEvent_();
-    if (this.draggedConnectionManager_.wouldConnectBlock()) {
-      // Applying connections also rerenders the relevant blocks.
-      this.draggedConnectionManager_.applyConnections();
-    } else {
-      this.draggingBlock_.render();
+    var deleted = this.maybeDeleteBlock_();
+    if (!deleted) {
+      // These are expensive and don't need to be done if we're deleting.
+      this.draggingBlock_.moveConnections(delta.x, delta.y);
+      this.draggingBlock_.setDragging(false);
+      this.fireMoveEvent_();
+      if (this.draggedConnectionManager_.wouldConnectBlock()) {
+        // Applying connections also rerenders the relevant blocks.
+        this.draggedConnectionManager_.applyConnections();
+      } else {
+        this.draggingBlock_.render();
+      }
+      this.draggingBlock_.scheduleSnapAndBump();
     }
-    this.draggingBlock_.scheduleSnapAndBump();
+  } finally {
+    this.workspace_.setResizesEnabled(true);
   }
-  this.workspace_.setResizesEnabled(true);
 
   var toolbox = this.workspace_.getToolbox();
   if (toolbox && typeof toolbox.removeStyle == 'function') {

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -187,26 +187,29 @@ Blockly.BubbleDragger.prototype.updateCursorDuringBubbleDrag_ = function() {
  */
 Blockly.BubbleDragger.prototype.endBubbleDrag = function(
     e, currentDragDeltaXY) {
-  // Make sure internal state is fresh.
-  this.dragBubble(e, currentDragDeltaXY);
+  try {
+    // Make sure internal state is fresh.
+    this.dragBubble(e, currentDragDeltaXY);
 
-  var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
-  var newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    var delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
+    var newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
 
-  // Move the bubble to its final location.
-  this.draggingBubble_.moveTo(newLoc.x, newLoc.y);
-  var deleted = this.maybeDeleteBubble_();
+    // Move the bubble to its final location.
+    this.draggingBubble_.moveTo(newLoc.x, newLoc.y);
+    var deleted = this.maybeDeleteBubble_();
 
-  if (!deleted) {
-    // Put everything back onto the bubble canvas.
-    if (this.dragSurface_) {
-      this.dragSurface_.clearAndHide(this.workspace_.getBubbleCanvas());
+    if (!deleted) {
+      // Put everything back onto the bubble canvas.
+      if (this.dragSurface_) {
+        this.dragSurface_.clearAndHide(this.workspace_.getBubbleCanvas());
+      }
+
+      this.draggingBubble_.setDragging && this.draggingBubble_.setDragging(false);
+      this.fireMoveEvent_();
     }
-
-    this.draggingBubble_.setDragging && this.draggingBubble_.setDragging(false);
-    this.fireMoveEvent_();
+  } finally {
+    this.workspace_.setResizesEnabled(true);
   }
-  this.workspace_.setResizesEnabled(true);
 
   var toolbox = this.workspace_.getToolbox();
   if (toolbox && typeof toolbox.removeStyle == 'function') {

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -759,7 +759,6 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
   var newBlock = null;
   Blockly.Events.disable();
   var variablesBeforeCreation = this.targetWorkspace.getAllVariables();
-  this.targetWorkspace.setResizesEnabled(false);
   try {
     newBlock = this.placeNewBlock_(originalBlock);
     // Close the flyout.
@@ -917,8 +916,8 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
 
   // Create the new block by cloning the block in the flyout (via XML).
   var xml = Blockly.Xml.blockToDom(oldBlock, true);
-  // The target workspace would normally resize during domToBlock, which will
-  // lead to weird jumps.  Save it for terminateDrag.
+  // The target workspace would normally resize during domToBlock since it
+  // starts blocks out at (0, 0), which would lead to weird jumps.
   targetWorkspace.setResizesEnabled(false);
 
   // Using domToBlock instead of domToWorkspace means that the new block will be
@@ -957,6 +956,10 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   finalOffset.scale(1 / targetWorkspace.scale);
 
   block.moveBy(finalOffset.x, finalOffset.y);
+
+  // Now that the block is properly positioned, we can re-enable resizing.
+  targetWorkspace.setResizesEnabled(true);
+
   return block;
 };
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -363,17 +363,30 @@ Blockly.Gesture.prototype.updateIsDraggingBlock_ = function() {
     return false;
   }
 
-  if (this.flyout_) {
-    this.isDraggingBlock_ = this.updateIsDraggingFromFlyout_();
-  } else if (this.targetBlock_.isMovable()) {
-    this.isDraggingBlock_ = true;
+  // Make sure we don't resize the workspace in between creating the flyout
+  // block and beginning to drag it.
+  var ws = this.flyout_ && this.flyout_.targetWorkspace;
+  if (ws) {
+    ws.setResizesEnabled(false);
   }
 
-  if (this.isDraggingBlock_) {
-    this.startDraggingBlock_();
-    return true;
+  try {
+    if (this.flyout_) {
+      this.isDraggingBlock_ = this.updateIsDraggingFromFlyout_();
+    } else if (this.targetBlock_.isMovable()) {
+      this.isDraggingBlock_ = true;
+    }
+
+    if (this.isDraggingBlock_) {
+      this.startDraggingBlock_();
+    }
+  } finally {
+    if (ws) {
+      ws.setResizesEnabled(true);
+    }
   }
-  return false;
+
+  return this.isDraggingBlock_;
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1662,22 +1662,25 @@ Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
  */
 Blockly.WorkspaceSvg.prototype.cleanUp = function() {
   this.setResizesEnabled(false);
-  Blockly.Events.setGroup(true);
-  var topBlocks = this.getTopBlocks(true);
-  var cursorY = 0;
-  for (var i = 0, block; (block = topBlocks[i]); i++) {
-    if (!block.isMovable()) {
-      continue;
+  try {
+    Blockly.Events.setGroup(true);
+    var topBlocks = this.getTopBlocks(true);
+    var cursorY = 0;
+    for (var i = 0, block; (block = topBlocks[i]); i++) {
+      if (!block.isMovable()) {
+        continue;
+      }
+      var xy = block.getRelativeToSurfaceXY();
+      block.moveBy(-xy.x, cursorY - xy.y);
+      block.snapToGrid();
+      cursorY = block.getRelativeToSurfaceXY().y +
+          block.getHeightWidth().height +
+          this.renderer_.getConstants().MIN_BLOCK_HEIGHT;
     }
-    var xy = block.getRelativeToSurfaceXY();
-    block.moveBy(-xy.x, cursorY - xy.y);
-    block.snapToGrid();
-    cursorY = block.getRelativeToSurfaceXY().y +
-        block.getHeightWidth().height +
-        this.renderer_.getConstants().MIN_BLOCK_HEIGHT;
+    Blockly.Events.setGroup(false);
+  } finally {
+    this.setResizesEnabled(true);
   }
-  Blockly.Events.setGroup(false);
-  this.setResizesEnabled(true);
 };
 
 /**
@@ -2582,9 +2585,12 @@ Blockly.WorkspaceSvg.prototype.setResizesEnabled = function(enabled) {
  */
 Blockly.WorkspaceSvg.prototype.clear = function() {
   this.setResizesEnabled(false);
-  Blockly.WorkspaceSvg.superClass_.clear.call(this);
-  this.topBoundedElements_ = [];
-  this.setResizesEnabled(true);
+  try {
+    Blockly.WorkspaceSvg.superClass_.clear.call(this);
+    this.topBoundedElements_ = [];
+  } finally {
+    this.setResizesEnabled(true);
+  }
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -222,10 +222,10 @@ Blockly.WorkspaceSvg.prototype.isMutator = false;
 /**
  * Whether this workspace has resizes enabled.
  * Disable during batch operations for a performance improvement.
- * @type {boolean}
+ * @type {number}
  * @private
  */
-Blockly.WorkspaceSvg.prototype.resizesEnabled_ = true;
+Blockly.WorkspaceSvg.prototype.resizesDisabled_ = 0;
 
 /**
  * Current horizontal scrolling offset in pixel units, relative to the
@@ -976,7 +976,7 @@ Blockly.WorkspaceSvg.prototype.updateScreenCalculations_ = function() {
  * @package
  */
 Blockly.WorkspaceSvg.prototype.resizeContents = function() {
-  if (!this.resizesEnabled_ || !this.rendered) {
+  if (this.resizesDisabled_ > 0 || !this.rendered) {
     return;
   }
   if (this.scrollbar) {
@@ -2565,8 +2565,12 @@ Blockly.WorkspaceSvg.prototype.getTopBoundedElements = function() {
  * @param {boolean} enabled Whether resizes should be enabled.
  */
 Blockly.WorkspaceSvg.prototype.setResizesEnabled = function(enabled) {
-  var reenabled = (!this.resizesEnabled_ && enabled);
-  this.resizesEnabled_ = enabled;
+  if (enabled) {
+    this.resizesDisabled_--;
+  } else {
+    this.resizesDisabled_++;
+  }
+  var reenabled = this.resizesDisabled_ <= 0;
   if (reenabled) {
     // Newly enabled.  Trigger a resize.
     this.resizeContents();

--- a/core/xml.js
+++ b/core/xml.js
@@ -383,10 +383,13 @@ Blockly.Xml.textToDom = function(text) {
  */
 Blockly.Xml.clearWorkspaceAndLoadFromXml = function(xml, workspace) {
   workspace.setResizesEnabled(false);
-  workspace.clear();
-  var blockIds = Blockly.Xml.domToWorkspace(xml, workspace);
-  workspace.setResizesEnabled(true);
-  return blockIds;
+  try {
+    workspace.clear();
+    var blockIds = Blockly.Xml.domToWorkspace(xml, workspace);
+    return blockIds;
+  } finally {
+    workspace.setResizesEnabled(true);
+  }
 };
 
 /**
@@ -478,11 +481,12 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
       Blockly.Events.setGroup(false);
     }
     Blockly.utils.dom.stopTextWidthCache();
+    // Re-enable workspace resizing.
+    if (workspace.setResizesEnabled) {
+      workspace.setResizesEnabled(true);
+    }
   }
-  // Re-enable workspace resizing.
-  if (workspace.setResizesEnabled) {
-    workspace.setResizesEnabled(true);
-  }
+
   Blockly.Events.fire(new Blockly.Events.FinishedLoading(workspace));
   return newBlockIds;
 };


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

This PR converts `WorkspaceSvg.setResizesEnabled` to use a counter internally to check whether resizes are enabled, in the same way events currently do.

### Resolves

Resolves https://github.com/google/blockly/issues/3905

### Proposed Changes

There are four parts here:
- Make `setResizesEnabled` use a counter instead of a simple boolean.
- Modify methods in `flyout_base.js` to properly reenable resizes after disabling them.
- Wrap all code before `setResizesEnabled(true)` in `try` blocks, and place `setResizesEnabled(true)` inside `finally` clauses
- Disable then reenable resizes inside `Blockly.Gesture.updateIsDraggingBlock_`

### Reason for Changes

- Make `setResizesEnabled` use a counter instead of a simple boolean.
  - Currently, many call sites disable and then reenable workspace resizing. This limits its usefulness and can lead to bugs-- for instance, if an outer function disables resizing, calls an inner function, then does some other stuff and reenables resizing, but the inner function also disables and reenables resizing, then everything that happens after the inner function is called could break if it expects resizing to be disabled.
  - The new behavior is more "stack-like"-- if workspace resizing is disabled twice, for instance, it must also be reenabled twice.
- Modify methods in `flyout_base.js` to properly reenable resizes after disabling them.
  - Previously, both `Flyout.createBlock` and `Flyout.placeNewBlock_` disabled resizes and then never reenabled them, expecting it to be done by `endBlockDrag`.
  - If you placed a block with keyboard navigation, or clicked a block on an autoclosing flyout to place it without dragging it, this would never happen. This is worse now because if you forget to match every `setResizesEnabled(false)` with a `setResizesEnabled(true)`, resizes will *never* be reenabled.
  - Now, `Flyout.createBlock` doesn't disable resizes, and `Flyout.placeNewBlock_` reenables resizes itself.
- Wrap all code before `setResizesEnabled(true)` in `try` blocks, and place `setResizesEnabled(true)` inside `finally` clauses
  - This ensures that even if code throws, resizes will always be reenabled.
- Disable then reenable resizes inside `Blockly.Gesture.updateIsDraggingBlock_`
  - This is the one I'm the least happy about. Since `Flyout.createBlock` now reenables resizes, we need a way to make sure that the workspace doesn't get resized between `createBlock` and `startBlockDrag`. This new behavior of disabling workspace resizes before the block is created and reenabling them after `startBlockDrag` is called does the job, but it relies on the new counter behavior: it knows that after `startBlockDrag` is called, `setResizesEnabled(true)` won't *actually* resize the workspace since `startBlockDrag` also disables resizes--it only "balances out" the `setResizesEnabled(false)` from earlier.
  - If you have an idea for how to do this more cleanly, I'd be glad to do that instead.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
