### PR TITLE
Support maxInstance[type]=0 in remainingCapacityOfType

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -530,8 +530,11 @@ Blockly.Workspace.prototype.remainingCapacityOfType = function(type) {
   if (!this.options.maxInstances) {
     return Infinity;
   }
-  return (this.options.maxInstances[type] || Infinity) -
-      this.getBlocksByType(type, false).length;
+
+  var maxInstanceOfType = (this.options.maxInstances[type] !== undefined) ?
+      this.options.maxInstances[type] : Infinity;
+
+  return maxInstanceOfType - this.getBlocksByType(type, false).length;
 };
 
 /**

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -454,8 +454,7 @@ function testAWorkspace() {
           0, 'With maxInstances limit 2');
     });
 
-    test.skip('At instance limit of 0 after clear', function() {
-      // TODO(3837): Un-skip test after resolving.
+    test('At instance limit of 0 after clear', function() {
       this.workspace.clear();
       this.workspace.options.maxInstances['get_var_block'] = 0;
       chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
@@ -471,8 +470,7 @@ function testAWorkspace() {
           0, 'With maxInstances limit 2');
     });
 
-    test.skip('At instance limit of 0 with multiple block types', function() {
-      // TODO(3837): Un-skip test after resolving.
+    test('At instance limit of 0 with multiple block types', function() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.newBlock('');
@@ -488,8 +486,7 @@ function testAWorkspace() {
           -1,'With maxInstances limit 1');
     });
 
-    test.skip('Over instance limit of 0', function() {
-      // TODO(3837): Un-skip test after resolving.
+    test('Over instance limit of 0', function() {
       this.workspace.options.maxInstances['get_var_block'] = 0;
       chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
           -2,'With maxInstances limit 0');
@@ -504,8 +501,7 @@ function testAWorkspace() {
           -1,'With maxInstances limit 1');
     });
 
-    test.skip('Over instance limit of 0 with multiple block types', function() {
-      // TODO(3837): Un-skip test after resolving.
+    test('Over instance limit of 0 with multiple block types', function() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.newBlock('');
@@ -528,8 +524,7 @@ function testAWorkspace() {
             this.workspace.remainingCapacityOfType('get_var_block'), 0);
       });
 
-      test.skip('Over block limit of 0 and no instance limit', function() {
-        // TODO(3837|3836): Un-skip test after resolving both.
+      test('Over block limit of 0 and no instance limit', function() {
         this.workspace.options.maxBlocks = 0;
         chai.assert.equal(
             this.workspace.remainingCapacityOfType('get_var_block'), -2);
@@ -544,8 +539,7 @@ function testAWorkspace() {
             'With maxBlocks limit 1 and maxInstances limit 3');
       });
 
-      test.skip('Over block limit of 0 but under instance limit', function() {
-        // TODO(3837|3836): Un-skip test after resolving both.
+      test('Over block limit of 0 but under instance limit', function() {
         this.workspace.options.maxBlocks = 0;
         this.workspace.options.maxInstances['get_var_block'] = 3;
         chai.assert.equal(
@@ -572,8 +566,7 @@ function testAWorkspace() {
             'With maxBlocks limit 1 and maxInstances limit 1');
       });
 
-      test.skip('Over block limit of 0 and over instance limit', function() {
-        // TODO(3837|3836): Un-skip test after resolving both.
+      test('Over block limit of 0 and over instance limit', function() {
         this.workspace.options.maxBlocks = 0;
         this.workspace.options.maxInstances['get_var_block'] = 1;
         chai.assert.equal(
@@ -591,8 +584,7 @@ function testAWorkspace() {
             'With maxBlocks limit 1 and maxInstances limit 0');
       });
 
-      test.skip('Over block limit of 0 and over instance limit of 0', function() {
-        // TODO(3837|3836): Un-skip test after resolving both.
+      test('Over block limit of 0 and over instance limit of 0', function() {
         this.workspace.options.maxBlocks = 0;
         this.workspace.options.maxInstances['get_var_block'] = 0;
         chai.assert.equal(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3837
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Distinguish between `maxInstance[type] = 0` and `maxInstance[type] = undefined` in `remainingCapacityOfType`.

### Reason for Changes

This allows for setting maxInstance[type] to 0. Before this change, it would be treated as unset (and limit would be default be Infinity).
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
### Additional Information

Also unskippped and removed TODOs in corresponding mocha tests.
<!-- Anything else we should know? -->
