### PR TITLE
Add clarification to remainingCapacityOfType and add tests for isCapa…

### DIFF
--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -509,87 +509,86 @@ function testAWorkspace() {
       chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
           -2,'With maxInstances limit 0');
     });
+  });
 
-    suite.skip('Max blocks and max instance interaction', function() {
-      // TODO(3836): Un-skip test suite after resolving.
-      test('Under block limit and no instance limit', function() {
-        this.workspace.options.maxBlocks = 3;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'), 1);
-      });
+  suite('isCapacityAvailable', function() {
+    setup(function() {
+      this.workspace.newBlock('get_var_block');
+      this.workspace.newBlock('get_var_block');
+      this.workspace.options.maxInstances = {};
+    });
 
-      test('At block limit and no instance limit', function() {
-        this.workspace.options.maxBlocks = 2;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'), 0);
-      });
+    test('Under block limit and no instance limit', function() {
+      this.workspace.options.maxBlocks = 3;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isTrue(this.workspace.isCapacityAvailable(typeCountsMap));
+    });
 
-      test('Over block limit of 0 and no instance limit', function() {
-        this.workspace.options.maxBlocks = 0;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'), -2);
-      });
+    test('At block limit and no instance limit', function() {
+      this.workspace.options.maxBlocks = 2;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
+    });
 
-      test('Over block limit but under instance limit', function() {
-        this.workspace.options.maxBlocks = 1;
-        this.workspace.options.maxInstances['get_var_block'] = 3;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -2,
-            'With maxBlocks limit 1 and maxInstances limit 3');
-      });
+    test('Over block limit of 0 and no instance limit', function() {
+      this.workspace.options.maxBlocks = 0;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
+    });
 
-      test('Over block limit of 0 but under instance limit', function() {
-        this.workspace.options.maxBlocks = 0;
-        this.workspace.options.maxInstances['get_var_block'] = 3;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -2,
-            'With maxBlocks limit 0 and maxInstances limit 3');
-      });
+    test('Over block limit but under instance limit', function() {
+      this.workspace.options.maxBlocks = 1;
+      this.workspace.options.maxInstances['get_var_block'] = 3;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 1 and maxInstances limit 3');
+    });
 
-      test('Over block limit but at instance limit', function() {
-        this.workspace.options.maxBlocks = 1;
-        this.workspace.options.maxInstances['get_var_block'] = 2;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -2,
-            'With maxBlocks limit 1 and maxInstances limit 2');
-      });
+    test('Over block limit of 0 but under instance limit', function() {
+      this.workspace.options.maxBlocks = 0;
+      this.workspace.options.maxInstances['get_var_block'] = 3;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 0 and maxInstances limit 3');
+    });
 
-      test('Over block limit and over instance limit', function() {
-        this.workspace.options.maxBlocks = 1;
-        this.workspace.options.maxInstances['get_var_block'] = 1;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -1,
-            'With maxBlocks limit 1 and maxInstances limit 1');
-      });
+    test('Over block limit but at instance limit', function() {
+      this.workspace.options.maxBlocks = 1;
+      this.workspace.options.maxInstances['get_var_block'] = 2;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 1 and maxInstances limit 2');
+    });
 
-      test('Over block limit of 0 and over instance limit', function() {
-        this.workspace.options.maxBlocks = 0;
-        this.workspace.options.maxInstances['get_var_block'] = 1;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -2,
-            'With maxBlocks limit 0 and maxInstances limit 1');
-      });
+    test('Over block limit and over instance limit', function() {
+      this.workspace.options.maxBlocks = 1;
+      this.workspace.options.maxInstances['get_var_block'] = 1;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 1 and maxInstances limit 1');
+    });
 
-      test('Over block limit and over instance limit of 0', function() {
-        this.workspace.options.maxBlocks = 1;
-        this.workspace.options.maxInstances['get_var_block'] = 0;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),
-            -1,
-            'With maxBlocks limit 1 and maxInstances limit 0');
-      });
+    test('Over block limit of 0 and over instance limit', function() {
+      this.workspace.options.maxBlocks = 0;
+      this.workspace.options.maxInstances['get_var_block'] = 1;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 0 and maxInstances limit 1');
+    });
 
-      test('Over block limit of 0 and over instance limit of 0', function() {
-        this.workspace.options.maxBlocks = 0;
-        this.workspace.options.maxInstances['get_var_block'] = 0;
-        chai.assert.equal(
-            this.workspace.remainingCapacityOfType('get_var_block'),-1);
-      });
+    test('Over block limit and over instance limit of 0', function() {
+      this.workspace.options.maxBlocks = 1;
+      this.workspace.options.maxInstances['get_var_block'] = 0;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+          'With maxBlocks limit 1 and maxInstances limit 0');
+    });
+
+    test('Over block limit of 0 and over instance limit of 0', function() {
+      this.workspace.options.maxBlocks = 0;
+      this.workspace.options.maxInstances['get_var_block'] = 0;
+      var typeCountsMap = {'get_var_block': 1};
+      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3836 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds clarification to `remainingCapacityOfType` JSDoc and adds tests for `isCapacityAvailable`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Since `isCapacityAvailable takes into account `maxInstance[type]` and `maxBlock`, its reasonable that `remainingCapacityOfType` doesn't take into account `maxBlock` and clarification was added to JSDoc to clearly communicate this.
Tests were updated for better coverage.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Ran mocha tests
