### PR TITLE
Update availble connections when we have unplugged a block

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -162,6 +162,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
 
     this.draggingBlock_.translate(newLoc.x, newLoc.y);
     Blockly.blockAnimations.disconnectUiEffect(this.draggingBlock_);
+    this.draggedConnectionManager_.updateAvailbleConnections();
   }
   this.draggingBlock_.setDragging(true);
   // For future consideration: we may be able to put moveToDragSurface inside

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -162,7 +162,7 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
 
     this.draggingBlock_.translate(newLoc.x, newLoc.y);
     Blockly.blockAnimations.disconnectUiEffect(this.draggingBlock_);
-    this.draggedConnectionManager_.updateAvailbleConnections();
+    this.draggedConnectionManager_.updateAvailableConnections();
   }
   this.draggingBlock_.setDragging(true);
   // For future consideration: we may be able to put moveToDragSurface inside

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -163,8 +163,9 @@ Blockly.InsertionMarkerManager.prototype.dispose = function() {
 /**
  * Update the available connections for the top block. These connections can
  * change if a block is unplugged and the stack is healed.
+ * @package
  */
-Blockly.InsertionMarkerManager.prototype.updateAvailbleConnections = function() {
+Blockly.InsertionMarkerManager.prototype.updateAvailableConnections = function() {
   this.availableConnections_ = this.initAvailableConnections_();
 };
 

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -161,6 +161,14 @@ Blockly.InsertionMarkerManager.prototype.dispose = function() {
 };
 
 /**
+ * Update the available connections for the top block. These connections can
+ * change if a block is unplugged and the stack is healed.
+ */
+Blockly.InsertionMarkerManager.prototype.updateAvailbleConnections = function() {
+  this.availableConnections_ = this.initAvailableConnections_();
+};
+
+/**
  * Return whether the block would be deleted if dropped immediately, based on
  * information from the most recent move event.
  * @return {boolean} True if the block would be deleted if dropped immediately.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #3898
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Update the available connections for the dragged block after it has been unplugged.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
We can also go the route to only initialize insertion manager in startBlockDrag however the change is farther reaching since getInsertionMarker uses the draggedConnectionManager.
<!-- Anything else we should know? -->
