### PR TITLE
No flyout mutator

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -167,8 +167,12 @@ Blockly.Mutator.prototype.createEditor_ = function() {
       }));
   workspaceOptions.toolboxPosition = this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
       Blockly.TOOLBOX_AT_LEFT;
-  workspaceOptions.languageTree = Blockly.utils.toolbox.convertToolboxToJSON(quarkXml);
-  workspaceOptions.getMetrics = this.getFlyoutMetrics_.bind(this);
+  var hasFlyout = !!quarkXml;
+  if (hasFlyout) {
+    workspaceOptions.languageTree =
+        Blockly.utils.toolbox.convertToolboxToJSON(quarkXml);
+    workspaceOptions.getMetrics = this.getFlyoutMetrics_.bind(this);
+  }
   this.workspace_ = new Blockly.WorkspaceSvg(workspaceOptions);
   this.workspace_.isMutator = true;
   this.workspace_.addChangeListener(Blockly.Events.disableOrphans);
@@ -177,13 +181,15 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   // a top level svg. Instead of handling scale themselves, mutators
   // inherit scale from the parent workspace.
   // To fix this, scale needs to be applied at a different level in the dom.
-  var flyoutSvg = this.workspace_.addFlyout('g');
+  var flyoutSvg = hasFlyout ? this.workspace_.addFlyout('g') : null;
   var background = this.workspace_.createDom('blocklyMutatorBackground');
 
-  // Insert the flyout after the <rect> but before the block canvas so that
-  // the flyout is underneath in z-order.  This makes blocks layering during
-  // dragging work properly.
-  background.insertBefore(flyoutSvg, this.workspace_.svgBlockCanvas_);
+  if (flyoutSvg) {
+    // Insert the flyout after the <rect> but before the block canvas so that
+    // the flyout is underneath in z-order.  This makes blocks layering during
+    // dragging work properly.
+    background.insertBefore(flyoutSvg, this.workspace_.svgBlockCanvas_);
+  }
   this.svgDialog_.appendChild(background);
 
   return this.svgDialog_;

--- a/tests/blocks/test_blocks.js
+++ b/tests/blocks/test_blocks.js
@@ -1212,6 +1212,24 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "style": "text_blocks"
   },
   {
+    "type": "test_mutators_noflyout",
+    "message0": "noflyout mutator",
+    "mutator": "test_noflyout_mutator",
+    "colour": "#000000"
+  },
+  {
+    "type": "test_mutators_noflyout_block",
+    "message0": "colour %1",
+    "args0": [
+      {
+        "type": "field_colour",
+        "name": "COLOUR",
+        "colour": "#ff0000"
+      }
+    ],
+    "style": "colour_blocks"
+  },
+  {
     "type": "test_style_hat",
     "message0": "Hat block (event)",
     "nextStatement": null,
@@ -1734,6 +1752,62 @@ Blockly.Blocks['test_basic_empty_with_mutator'] = {
     this.setMutator(new Blockly.Mutator(['math_number']));
   }
 };
+
+/**
+ * Mutator methods added to the test_mutators_noflyout block.
+ * @mixin
+ * @augments Blockly.Block
+ * @package
+ * @readonly
+ */
+var NO_FLYOUT_MUTATOR = {
+  /**
+   * Create XML to represent the block mutation.
+   * @return {Element} XML storage element.
+   * @this {Blockly.Block}
+   */
+  mutationToDom: function() {
+    var container = Blockly.utils.xml.createElement('mutation');
+    container.setAttribute('colour', this.colour_);
+    this.setColour(this.colour_);
+    return container;
+  },
+  /**
+   * Restore a block from XML.
+   * @param {!Element} xmlElement XML storage element.
+   * @this {Blockly.Block}
+   */
+  domToMutation: function(xmlElement) {
+    this.colour_ = xmlElement.getAttribute('colour');
+  },
+  /**
+   * Populate the mutator's dialog with this block's components.
+   * @param {!Blockly.Workspace} workspace Mutator's workspace.
+   * @return {!Blockly.Block} Root block in mutator.
+   * @this {Blockly.Block}
+   */
+  decompose: function(workspace) {
+    var containerBlock = workspace.newBlock('test_mutators_noflyout_block');
+    containerBlock.getField('COLOUR').setValue(this.colour_);
+    containerBlock.initSvg();
+    return containerBlock;
+  },
+  /**
+   * Reconfigure this block based on the mutator dialog's components.
+   * @param {!Blockly.Block} containerBlock Root block in mutator.
+   * @this {Blockly.Block}
+   */
+  compose: function(containerBlock) {
+    this.colour_ = containerBlock.getFieldValue('COLOUR');
+    this.setColour(this.colour_);
+  },
+};
+
+/**
+ * Register custom mutator used by the test_mutators_noflyout block.
+ */
+Blockly.Extensions.registerMutator('test_noflyout_mutator',
+  NO_FLYOUT_MUTATOR, null, []);
 
 Blockly.Blocks['test_dropdowns_dynamic'] = {
   init: function() {

--- a/tests/playgrounds/test_blocks_toolbox.js
+++ b/tests/playgrounds/test_blocks_toolbox.js
@@ -875,7 +875,11 @@ var mutators = {
     {
       "kind": "BLOCK",
       "blockxml": "<block type=\"logic_compare\"><value name=\"A\"><block type=\"math_number\"><field name=\"NUM\">10</field></block></value><value name=\"B\"><block type=\"math_number\"><field name=\"NUM\">10</field></block></value></block>",
-    }
+    },
+    {
+      "kind": "BLOCK",
+      "type": "test_mutators_noflyout",
+    },
   ],
 };
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/3955

### Proposed Changes

Support showing the mutator UI for a single root block (with no flyout workspace).

### Reason for Changes

Bug fix.

### Test Coverage

Tested mutator blocks (controls_if), and added a new block to test no-flyout mutators, the block sets the colour of the parent block using the mutator UI.

![Screen Shot 2020-06-11 at 9 26 20 AM](https://user-images.githubusercontent.com/16690124/84414199-82874980-abc6-11ea-96a1-d586c32f76e6.png)


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@mattbishop FYI
