### PR TITLE
Use getter for variables in procedure generators.

### DIFF
--- a/generators/dart/procedures.js
+++ b/generators/dart/procedures.js
@@ -48,8 +48,9 @@ Blockly.Dart['procedures_defreturn'] = function(block) {
   }
   var returnType = returnValue ? 'dynamic' : 'void';
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
-    args[i] = Blockly.Dart.variableDB_.getName(block.arguments_[i],
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
+    args[i] = Blockly.Dart.variableDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
   var code = returnType + ' ' + funcName + '(' + args.join(', ') + ') {\n' +
@@ -69,7 +70,8 @@ Blockly.Dart['procedures_callreturn'] = function(block) {
   var funcName = Blockly.Dart.variableDB_.getName(block.getFieldValue('NAME'),
       Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.Dart.valueToCode(block, 'ARG' + i,
         Blockly.Dart.ORDER_NONE) || 'null';
   }

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -49,8 +49,9 @@ Blockly.JavaScript['procedures_defreturn'] = function(block) {
     returnValue = Blockly.JavaScript.INDENT + 'return ' + returnValue + ';\n';
   }
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
-    args[i] = Blockly.JavaScript.variableDB_.getName(block.arguments_[i],
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
+    args[i] = Blockly.JavaScript.variableDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
   var code = 'function ' + funcName + '(' + args.join(', ') + ') {\n' +
@@ -71,7 +72,8 @@ Blockly.JavaScript['procedures_callreturn'] = function(block) {
   var funcName = Blockly.JavaScript.variableDB_.getName(
       block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.JavaScript.valueToCode(block, 'ARG' + i,
         Blockly.JavaScript.ORDER_COMMA) || 'null';
   }

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -49,8 +49,9 @@ Blockly.Lua['procedures_defreturn'] = function(block) {
     branch = '';
   }
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
-    args[i] = Blockly.Lua.variableDB_.getName(block.arguments_[i],
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
+    args[i] = Blockly.Lua.variableDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
   var code = 'function ' + funcName + '(' + args.join(', ') + ')\n' +
@@ -71,7 +72,8 @@ Blockly.Lua['procedures_callreturn'] = function(block) {
   var funcName = Blockly.Lua.variableDB_.getName(
       block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.Lua.valueToCode(block, 'ARG' + i,
         Blockly.Lua.ORDER_NONE) || 'nil';
   }

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -24,7 +24,7 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
   for (var i = 0, variable; variable = variables[i]; i++) {
     varName = variable.name;
-    if (block.arguments_.indexOf(varName) == -1) {
+    if (block.getVars().indexOf(varName) == -1) {
       globals.push(Blockly.PHP.variableDB_.getName(varName,
           Blockly.VARIABLE_CATEGORY_NAME));
     }
@@ -68,8 +68,9 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
     returnValue = Blockly.PHP.INDENT + 'return ' + returnValue + ';\n';
   }
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
-    args[i] = Blockly.PHP.variableDB_.getName(block.arguments_[i],
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
+    args[i] = Blockly.PHP.variableDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
   var code = 'function ' + funcName + '(' + args.join(', ') + ') {\n' +
@@ -90,7 +91,8 @@ Blockly.PHP['procedures_callreturn'] = function(block) {
   var funcName = Blockly.PHP.variableDB_.getName(
       block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.PHP.valueToCode(block, 'ARG' + i,
         Blockly.PHP.ORDER_COMMA) || 'null';
   }

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -25,7 +25,7 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
   for (var i = 0, variable; variable = variables[i]; i++) {
     varName = variable.name;
-    if (block.arguments_.indexOf(varName) == -1) {
+    if (block.getVars().indexOf(varName) == -1) {
       globals.push(Blockly.Python.variableDB_.getName(varName,
           Blockly.VARIABLE_CATEGORY_NAME));
     }
@@ -71,8 +71,9 @@ Blockly.Python['procedures_defreturn'] = function(block) {
     branch = Blockly.Python.PASS;
   }
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
-    args[i] = Blockly.Python.variableDB_.getName(block.arguments_[i],
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
+    args[i] = Blockly.Python.variableDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
   var code = 'def ' + funcName + '(' + args.join(', ') + '):\n' +
@@ -93,7 +94,8 @@ Blockly.Python['procedures_callreturn'] = function(block) {
   var funcName = Blockly.Python.variableDB_.getName(block.getFieldValue('NAME'),
       Blockly.PROCEDURE_CATEGORY_NAME);
   var args = [];
-  for (var i = 0; i < block.arguments_.length; i++) {
+  var variables = block.getVars();
+  for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.Python.valueToCode(block, 'ARG' + i,
         Blockly.Python.ORDER_NONE) || 'None';
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Changes usages of private property `arguments_` in `procedures_defreturn` and `procedures_defnoreturn` generators to public `getVars` call.
Fixes https://github.com/google/blockly-samples/issues/301
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Allows for more flexibility in custom implementation of procedure block by removing reference to internal variable.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
Mocha tests and playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
