### PR TITLE
Adding getter to procedure call block for arguments_ property

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -807,6 +807,14 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   },
   /**
    * Return all variables referenced by this block.
+   * @return {!Array.<string>} List of variable names.
+   * @this {Blockly.Block}
+   */
+  getVars: function() {
+    return this.arguments_;
+  },
+  /**
+   * Return all variables referenced by this block.
    * @return {!Array.<!Blockly.VariableModel>} List of variable models.
    * @this {Blockly.Block}
    */
@@ -959,6 +967,7 @@ Blockly.Blocks['procedures_callreturn'] = {
   updateShape_: Blockly.Blocks['procedures_callnoreturn'].updateShape_,
   mutationToDom: Blockly.Blocks['procedures_callnoreturn'].mutationToDom,
   domToMutation: Blockly.Blocks['procedures_callnoreturn'].domToMutation,
+  getVars: Blockly.Blocks['procedures_callnoreturn'].getVars,
   getVarModels: Blockly.Blocks['procedures_callnoreturn'].getVarModels,
   onchange: Blockly.Blocks['procedures_callnoreturn'].onchange,
   customContextMenu:


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes test failure introduced by #3971
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds getter to procedure call blocks (`getVars` just as procedure definitions have).
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Adding this getter enables code outside of `blocks/procedures.js`, such as in generator code, to use a public method rather than accessing the private `arguments_` property directly.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
Ran generator tests.
