### PR TITLE
Advanced compilation fixes

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -994,7 +994,6 @@ Blockly.Block.prototype.getField = function(name) {
 /**
  * Return all variables referenced by this block.
  * @return {!Array.<string>} List of variable names.
- * @package
  */
 Blockly.Block.prototype.getVars = function() {
   var vars = [];

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -532,7 +532,7 @@ Blockly.Flyout.prototype.createFlyoutInfo_ = function(parsedContent) {
   this.permanentlyDisabled_.length = 0;
   var defaultGap = this.horizontalLayout ? this.GAP_X : this.GAP_Y;
   for (var i = 0, contentInfo; (contentInfo = parsedContent[i]); i++) {
-    switch (contentInfo.kind.toUpperCase()) {
+    switch (contentInfo['kind'].toUpperCase()) {
       case 'BLOCK':
         var blockInfo = /** @type {Blockly.utils.toolbox.Block} */ (contentInfo);
         var blockXml = this.getBlockXml_(blockInfo);

--- a/core/options.js
+++ b/core/options.js
@@ -168,9 +168,9 @@ Blockly.Options = function(options) {
   /**
    * The SVG element for the grid pattern.
    * Created during injection.
-   * @type {!SVGElement}
+   * @type {SVGElement}
    */
-  this.gridPattern = undefined;
+  this.gridPattern = null;
 
   /**
    * The parent of the current workspace, or null if there is no parent

--- a/core/registry.js
+++ b/core/registry.js
@@ -123,7 +123,7 @@ Blockly.registry.register = function(type, name, registryItem) {
 Blockly.registry.validate_ = function(type, registryItem) {
   switch (type) {
     case String(Blockly.registry.Type.FIELD):
-      if (typeof registryItem['fromJson'] != 'function') {
+      if (typeof registryItem.fromJson != 'function') {
         throw Error('Type "' + type + '" must have a fromJson function');
       }
       break;

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -275,7 +275,7 @@ Blockly.Toolbox.prototype.createTree_ = function(toolboxDef, treeOut) {
   }
 
   for (var i = 0, childIn; (childIn = toolboxDef[i]); i++) {
-    switch (childIn.kind.toUpperCase()) {
+    switch (childIn['kind'].toUpperCase()) {
       case 'CATEGORY':
         var categoryInfo = /** @type {Blockly.utils.toolbox.Category} */ (childIn);
         openNode = this.addCategory_(categoryInfo, treeOut) || openNode;
@@ -324,7 +324,7 @@ Blockly.Toolbox.prototype.addCategory_ = function(categoryInfo, treeOut) {
     // Variables and procedures are special dynamic categories.
     childOut.contents = custom;
   } else {
-    openNode = this.createTree_(categoryInfo.contents, childOut) || openNode;
+    openNode = this.createTree_(categoryInfo['contents'], childOut) || openNode;
   }
   this.setColourOrStyle_(categoryInfo, childOut, categoryName);
   openNode = this.setExpanded_(categoryInfo, childOut) || openNode;
@@ -369,7 +369,7 @@ Blockly.Toolbox.prototype.setColourOrStyle_ = function(
  */
 Blockly.Toolbox.prototype.addSeparator_ = function(
     separatorInfo, treeOut, lastElement) {
-  if (lastElement && lastElement.kind.toUpperCase() == 'CATEGORY') {
+  if (lastElement && lastElement['kind'].toUpperCase() == 'CATEGORY') {
     // Separator between two categories.
     // <sep></sep>
     treeOut.add(new Blockly.Toolbox.TreeSeparator(

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -102,7 +102,7 @@ Blockly.WorkspaceSvg = function(options,
    * @private
    */
   this.grid_ = this.options.gridPattern ?
-      new Blockly.Grid(options.gridPattern, options.gridOptions) : null;
+      new Blockly.Grid(this.options.gridPattern, options.gridOptions) : null;
 
   /**
    * Manager in charge of markers and cursors.

--- a/tests/compile/compile.sh
+++ b/tests/compile/compile.sh
@@ -75,6 +75,7 @@ done
 echo "Compiling Blockly..."
 COMPILATION_COMMAND="java -jar $COMPILER --js='$BLOCKLY_ROOT/tests/compile/main.js' \
   --js='$tempPath/**.js' \
+  --js='$BLOCKLY_ROOT/tests/blocks/**.js' \
   --js='$BLOCKLY_ROOT/blocks/**.js' \
   --js='$BLOCKLY_ROOT/generators/**.js' \
   --generate_exports \


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes for Advanced compilation.

### Proposed Changes

- gridPattern can't be set to undefined if the type is !SVGElement
- Block.getVars used by procedures.js (can't be package, must be public)
- registryItem['fromJson'] is not found when the compiler aliases field methods.

### Reason for Changes

Fix advanced compilation.

### Test Coverage

Tested with the advanced compilation script.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
