### PR TITLE
Handle undefined colour

### DIFF
--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -588,7 +588,7 @@ Blockly.Toolbox.prototype.setColour_ = function(colourValue, childOut,
   // Decode the colour for any potential message references
   // (eg. `%{BKY_MATH_HUE}`).
   var colour = Blockly.utils.replaceMessageReferences(colourValue);
-  if (colour === null || colour === '') {
+  if (colour == null || colour === '') {
     // No attribute. No colour.
     childOut.hexColour = '';
   } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3991
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adjust check for colour value from `=== null` to. `== null` to also catch on `undefined`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Without this change, there are a lot of warnings when someone does not set the optional colour value for a category.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on playground by checking Test Blocks (no colours on categories) and Categories (typed variables) (with colours for categories).
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

