### PR TITLE
Fix for mocha tests

### DIFF
--- a/package/node/core.js
+++ b/package/node/core.js
@@ -22,7 +22,7 @@ Blockly.setLocale = function (locale) {
 
 // Override textToDomDocument and provide Node.js alternatives to DOMParser and
 // XMLSerializer.
-if (typeof Blockly.utils.global.DOMParser !== 'function') {
+if (typeof Blockly.utils.global.document !== 'object') {
   Blockly.utils.global.DOMParser = require("jsdom/lib/jsdom/living").DOMParser;
   Blockly.utils.global.XMLSerializer = require("jsdom/lib/jsdom/living").XMLSerializer;
   var doc = Blockly.utils.xml.textToDomDocument(


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Mocha tests in blockly-samples run multiple tests with the same global scope. 
On subsequent tries, Blockly's document object is not reset as the global.DOMParser object had already been set on the previous iteration.

This makes it the document is set every time.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
