### PR TITLE
Update Blockly size metdata for the 3.20200625.1 release

### DIFF
--- a/tests/scripts/check_metadata.sh
+++ b/tests/scripts/check_metadata.sh
@@ -5,13 +5,13 @@
 
 # These values should be updated with each release
 # Size of blockly_compressed.js
-blockly_size_expected=573000 # 813K in July 2019 release
+blockly_size_expected=619547 # 813K in July 2019 release
 # Size of blocks_compressed.js
-blocks_size_expected=76500 # 75K in July 2019 release
+blocks_size_expected=76262 # 75K in July 2019 release
 # Size of blockly_compressed.js.gz
-blockly_gz_size_expected=123000 # 180K in July 2019 release
+blockly_gz_size_expected=134334 # 180K in July 2019 release
 # Size of blocks_compressed.js.gz
-blocks_gz_size_expected=15200 # 14.5K in July 2019 release
+blocks_gz_size_expected=15192 # 14.5K in July 2019 release
 
 # ANSI colors
 BOLD_GREEN='\033[1;32m'


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

### Proposed Changes

Update metadata of Blockly compressed and gzip'd sizes after the 3.20200625.1 release.

### Reason for Changes

### Test Coverage

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
