### PR TITLE
Fix field dropdown with images

### DIFF
--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -21,13 +21,13 @@ goog.require('Blockly.utils.IdGenerator');
  * Class representing an item in a menu.
  *
  * @param {string|!HTMLElement} content Text caption to display as the content
- *     of the item.
+ *     of the item, or a HTML element to display.
  * @param {string=} opt_value Data/model associated with the menu item.
  * @constructor
  */
 Blockly.MenuItem = function(content, opt_value) {
   /**
-   * Human-readable text of this menu item.
+   * Human-readable text of this menu item, or the HTML element to display.
    * @type {string|!HTMLElement}
    * @private
    */

--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -20,15 +20,15 @@ goog.require('Blockly.utils.IdGenerator');
 /**
  * Class representing an item in a menu.
  *
- * @param {string} content Text caption to display as the content of
- *     the item.
+ * @param {string|!HTMLElement} content Text caption to display as the content
+ *     of the item.
  * @param {string=} opt_value Data/model associated with the menu item.
  * @constructor
  */
 Blockly.MenuItem = function(content, opt_value) {
   /**
    * Human-readable text of this menu item.
-   * @type {string}
+   * @type {string|!HTMLElement}
    * @private
    */
   this.content_ = content;
@@ -125,7 +125,11 @@ Blockly.MenuItem.prototype.createDom = function() {
     content.appendChild(checkbox);
   }
 
-  content.appendChild(document.createTextNode(this.content_));
+  var contentDom = /** @type {!HTMLElement} */ (this.content_);
+  if (typeof this.content_ == 'string') {
+    contentDom = document.createTextNode(this.content_);
+  }
+  content.appendChild(contentDom);
   element.appendChild(content);
 
   // Initialize ARIA role and state.


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/4015

### Proposed Changes

Handle cases where the content of the menu item is a HTML element.

### Reason for Changes

Fix regression.

### Test Coverage

Tested with the test field dropdown image block.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
