### PR TITLE
Update click event handling for workspace and trashcan.

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -662,7 +662,7 @@ Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
  * @private
  */
 Blockly.Gesture.prototype.fireWorkspaceClick_ = function(ws) {
-  var clickEvent = new Blockly.Events.Ui(null, 'workspaceClick', null, null);
+  var clickEvent = new Blockly.Events.Ui(null, 'click', null, 'workspace');
   clickEvent.workspaceId = ws.id;
   Blockly.Events.fire(clickEvent);
 };
@@ -752,7 +752,7 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
   } else {
     // Clicks events are on the start block, even if it was a shadow.
     Blockly.Events.fire(
-        new Blockly.Events.Ui(this.startBlock_, 'click', undefined, undefined));
+        new Blockly.Events.Ui(this.startBlock_, 'click', undefined, 'block'));
   }
   this.bringBlockToFront_();
   Blockly.Events.setGroup(false);

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -301,6 +301,8 @@ Blockly.Trashcan.prototype.createDom = function() {
   this.svgLid_.setAttributeNS(Blockly.utils.dom.XLINK_NS, 'xlink:href',
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
 
+  Blockly.bindEventWithChecks_(
+      this.svgGroup_, 'mousedown', this, this.blockMouseDownWhenFull_);
   Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup', this, this.click);
   // bindEventWithChecks_ quashes events too aggressively. See:
   // https://groups.google.com/forum/#!topic/blockly/QF4yB9Wx00s
@@ -346,6 +348,15 @@ Blockly.Trashcan.prototype.dispose = function() {
 };
 
 /**
+ * RWhether the trashcan has contents.
+ * @return {boolean} True if the trashcan has contents.
+ * @private
+ */
+Blockly.Trashcan.prototype.hasContents_ = function() {
+  return !!this.contents_.length;
+};
+
+/**
  * Returns true if the trashcan contents-flyout is currently open.
  * @return {boolean} True if the trashcan contents-flyout is currently open.
  */
@@ -358,7 +369,7 @@ Blockly.Trashcan.prototype.contentsIsOpen = function() {
  * it will be closed.
  */
 Blockly.Trashcan.prototype.emptyContents = function() {
-  if (!this.contents_.length) {
+  if (!this.hasContents_()) {
     return;
   }
   this.contents_.length = 0;
@@ -501,7 +512,7 @@ Blockly.Trashcan.prototype.close = function() {
  * Inspect the contents of the trash.
  */
 Blockly.Trashcan.prototype.click = function() {
-  if (!this.contents_.length) {
+  if (!this.hasContents_()) {
     return;
   }
 
@@ -510,14 +521,38 @@ Blockly.Trashcan.prototype.click = function() {
     xml[i] = Blockly.Xml.textToDom(text);
   }
   this.flyout.show(xml);
+
+  this.fireUiEvent_();
 };
+
+/**
+ * Fires a ui event for trashcan click.
+ * @private
+ */
+Blockly.Trashcan.prototype.fireUiEvent_ = function() {
+  var uiEvent = new Blockly.Events.Ui(null, 'trashcan', null, null);
+  uiEvent.workspaceId = this.workspace_.id;
+  Blockly.Events.fire(uiEvent);
+};
+
+/**
+ * Prevents a workspace scroll and click event if the trashcan has blocks.
+ * @param {!Event} e A mouse down event.
+ * @private
+ */
+Blockly.Trashcan.prototype.blockMouseDownWhenFull_ = function(e) {
+  if (this.hasContents_()) {
+    e.stopPropagation();  // Don't start a workspace scroll.
+  }
+};
+
 
 /**
  * Indicate that the trashcan can be clicked (by opening it) if it has blocks.
  * @private
  */
 Blockly.Trashcan.prototype.mouseOver_ = function() {
-  if (this.contents_.length) {
+  if (this.hasContents_()) {
     this.setOpen(true);
   }
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -348,7 +348,7 @@ Blockly.Trashcan.prototype.dispose = function() {
 };
 
 /**
- * RWhether the trashcan has contents.
+ * Whether the trashcan has contents.
  * @return {boolean} True if the trashcan has contents.
  * @private
  */

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -526,11 +526,11 @@ Blockly.Trashcan.prototype.click = function() {
 };
 
 /**
- * Fires a ui event for trashcan click.
+ * Fires a ui event for trashcan flyout opening.
  * @private
  */
 Blockly.Trashcan.prototype.fireUiEvent_ = function() {
-  var uiEvent = new Blockly.Events.Ui(null, 'trashcan', null, null);
+  var uiEvent = new Blockly.Events.Ui(null, 'trashcanOpen', null, true);
   uiEvent.workspaceId = this.workspace_.id;
   Blockly.Events.fire(uiEvent);
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3975 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Changes ui events emitted on workspace and on block click to both be 'click' and adding string in newValue to differentiate between what has been clicked.
- Stops event propagation on mouse down when trashcan is clicked (and has contents) to prevent workspace click from being emitted.
- Emits ui event when trashcan is opened (mouseUp) 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Consistency in naming of events
- Clicking on trashcan is not expected to trigger a workspace click event
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Playground
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

We may also want to update https://developers.google.com/blockly/guides/configure/web/events to include the new possible value for element (i.e. 'trashcan').
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Any support for emitting an event on trashcan flyout closing will be addressed in future PR.