### PR TITLE
Emit UI event on zoom control clicks.

### DIFF
--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -210,7 +210,7 @@ Blockly.ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
 
   // Attach listener.
   Blockly.bindEventWithChecks_(
-      zoominSvg, 'mousedown', null, this.zoom_.bind(this, -1));
+      zoomoutSvg, 'mousedown', null, this.zoom_.bind(this, -1));
 };
 
 /**

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -261,7 +261,8 @@ Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
 };
 
 /**
- * Zooms in or out of the workspace.
+ * Handles a mouse down event on the zoom in or zoom out buttons on the
+ *    workspace.
  * @param {number} amount Amount of zooming. Negative amount values zoom out,
  *    and positive amount values zoom in.
  * @param {!Event} e A mouse down event.
@@ -324,7 +325,7 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
 };
 
 /**
- * Resets zoom on the workspace.
+ * Handles a mouse down event on the reset zoom button on the workspace.
  * @param {!Event} e A mouse down event.
  * @private
  */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Emits a ui event when zoom control is clicked including old and new workspace scale.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Since clicking on zoom controls does not emit a workspace click event, it makes sense to emit some kind of event instead to describe what happened.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Playground
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

We may also want to update https://developers.google.com/blockly/guides/configure/web/events to include the new possible value for element (i.e. 'zoom').
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This PR also does some refactoring cleanup of the mouseDown event handlers for clicking on zoom controls.
<!-- Anything else we should know? -->
