### PR TITLE
add argument to flyout button callback

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -73,6 +73,15 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, json, isLabel) {
                       json['callbackkey'];
 
   /**
+   * The argument to the function called when this button is clicked.
+   * @type {string}
+   * @private
+   */
+  this.callbackArg_ = xml.getAttribute('callbackArg')||
+  /* Check the lower case version too to satisfy IE */
+                      xml.getAttribute('callbackarg');
+
+  /**
    * If specified, a CSS class to add to this button.
    * @type {?string}
    * @private
@@ -267,7 +276,7 @@ Blockly.FlyoutButton.prototype.onMouseUp_ = function(e) {
       this.targetWorkspace_.getButtonCallback(this.callbackKey_))) {
     console.warn('Buttons should have callbacks. Button text: ' + this.text_);
   } else if (!this.isLabel_) {
-    this.targetWorkspace_.getButtonCallback(this.callbackKey_)(this);
+    this.targetWorkspace_.getButtonCallback(this.callbackKey_)(this, this.callbackArg_);
   }
 };
 

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -77,9 +77,9 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, json, isLabel) {
    * @type {string}
    * @private
    */
-  this.callbackArg_ = xml.getAttribute('callbackArg')||
+  this.callbackArg_ = json('callbackArg')||
   /* Check the lower case version too to satisfy IE */
-                      xml.getAttribute('callbackarg');
+                      json('callbackarg');
 
   /**
    * If specified, a CSS class to add to this button.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4027

### Proposed Changes

Flyout buttons can be defined with an argument that will be passed to their callback when they are clicked.

### Reason for Changes

This allows for better distinction between content authoring and programming.

### Test Coverage

Tested manually by defining a flyout button with an argument and confirming that it is passed to the callback.

### Documentation

Toolbox docs.