### PR TITLE
Remove some old deprecated functions

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -73,17 +73,6 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
 };
 
 /**
- * Set the cursor to be displayed when over something draggable.
- * See https://github.com/google/blockly/issues/981 for context.
- * @param {*} _cursor Enum.
- * @deprecated April 2017.
- */
-Blockly.Css.setCursor = function(_cursor) {
-  console.warn('Deprecated call to Blockly.Css.setCursor. ' +
-      'See issue #981 for context');
-};
-
-/**
  * Array making up the CSS content for Blockly.
  */
 Blockly.Css.CONTENT = [

--- a/core/variables.js
+++ b/core/variables.js
@@ -64,20 +64,6 @@ Blockly.Variables.allUsedVarModels = function(ws) {
 };
 
 /**
- * Find all user-created variables that are in use in the workspace and return
- * only their names.
- * For use by generators.
- * To get a list of all variables on a workspace, including unused variables,
- * call Workspace.getAllVariables.
- * @deprecated January 2018
- */
-Blockly.Variables.allUsedVariables = function() {
-  console.warn('Deprecated call to Blockly.Variables.allUsedVariables. ' +
-      'Use Blockly.Variables.allUsedVarModels instead.\nIf this is a major ' +
-      'issue please file a bug on GitHub.');
-};
-
-/**
  * @private
  * @type {Object<string,boolean>}
  */

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -410,21 +410,6 @@ Blockly.Workspace.prototype.deleteVariableById = function(id) {
 };
 
 /**
- * Check whether a variable exists with the given name.  The check is
- * case-insensitive.
- * @param {string} _name The name to check for.
- * @return {number} The index of the name in the variable list, or -1 if it is
- *     not present.
- * @deprecated April 2017
- */
-
-Blockly.Workspace.prototype.variableIndexOf = function(_name) {
-  console.warn(
-      'Deprecated call to Blockly.Workspace.prototype.variableIndexOf');
-  return -1;
-};
-
-/**
  * Find the variable by the given name and return it. Return null if it is not
  *     found.
  * @param {string} name The name to check for.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1232,16 +1232,6 @@ Blockly.WorkspaceSvg.prototype.render = function() {
 };
 
 /**
- * Was used back when block highlighting (for execution) and block selection
- * (for editing) were the same thing.
- * Any calls of this function can be deleted.
- * @deprecated October 2016
- */
-Blockly.WorkspaceSvg.prototype.traceOn = function() {
-  console.warn('Deprecated call to traceOn, delete this.');
-};
-
-/**
  * Highlight or unhighlight a block in the workspace.  Block highlighting is
  * often used to visually mark blocks currently being executed.
  * @param {?string} id ID of block to highlight/unhighlight,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Code cleanup.

### Proposed Changes

Delete the following functions:
- Blockly.Css.setCursor. Deprecated April 2017
- Blockly.Variables.allUsedVariables. Deprecated January 2018
- Blockly.Workspace.prototype.variableIndexOf. Deprecated April 2017
- Blockly.WorkspaceSvg.prototype.traceOn. Deprecated October 2016

### Reason for Changes

All of these were deprecated a long time ago and had messages to that effect for multiple years. It's time to fully delete them.

### Test Coverage

### Documentation

I don't know of any documentation that references these.

