### PR TITLE
Unbind event handlers in dispose of zoom controls.

### DIFF
--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -29,6 +29,30 @@ Blockly.ZoomControls = function(workspace) {
    * @private
    */
   this.workspace_ = workspace;
+
+  /**
+   * A handle to use to unbind the mouse down event handler for zoom reset
+   *    button. Opaque data returned from Blockly.bindEventWithChecks_.
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onZoomResetWrapper_ = null;
+
+  /**
+   * A handle to use to unbind the mouse down event handler for zoom in button.
+   * Opaque data returned from Blockly.bindEventWithChecks_.
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onZoomInWrapper_ = null;
+
+  /**
+   * A handle to use to unbind the mouse down event handler for zoom out button.
+   * Opaque data returned from Blockly.bindEventWithChecks_.
+   * @type {?Blockly.EventData}
+   * @private
+   */
+  this.onZoomOutWrapper_ = null;
 };
 
 /**
@@ -79,30 +103,6 @@ Blockly.ZoomControls.prototype.left_ = 0;
  * @private
  */
 Blockly.ZoomControls.prototype.top_ = 0;
-
-/**
- * A handle to use to unbind the mouse down event handler for zoom reset button.
- * Opaque data returned from Blockly.bindEventWithChecks_.
- * @type {?Blockly.EventData}
- * @private
- */
-Blockly.ZoomControls.prototype.onZoomResetWrapper_ = null;
-
-/**
- * A handle to use to unbind the mouse down event handler for zoom in button.
- * Opaque data returned from Blockly.bindEventWithChecks_.
- * @type {?Blockly.EventData}
- * @private
- */
-Blockly.ZoomControls.prototype.onZoomInWrapper_ = null;
-
-/**
- * A handle to use to unbind the mouse down event handler for zoom out button.
- * Opaque data returned from Blockly.bindEventWithChecks_.
- * @type {?Blockly.EventData}
- * @private
- */
-Blockly.ZoomControls.prototype.onZoomOutWrapper_ = null;
 
 
 /**

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -81,6 +81,31 @@ Blockly.ZoomControls.prototype.left_ = 0;
 Blockly.ZoomControls.prototype.top_ = 0;
 
 /**
+ * A handle to use to unbind the mouse down event handler for zoom reset button.
+ * Opaque data returned from Blockly.bindEventWithChecks_.
+ * @type {?Blockly.EventData}
+ * @private
+ */
+Blockly.ZoomControls.prototype.onZoomResetWrapper_ = null;
+
+/**
+ * A handle to use to unbind the mouse down event handler for zoom in button.
+ * Opaque data returned from Blockly.bindEventWithChecks_.
+ * @type {?Blockly.EventData}
+ * @private
+ */
+Blockly.ZoomControls.prototype.onZoomInWrapper_ = null;
+
+/**
+ * A handle to use to unbind the mouse down event handler for zoom out button.
+ * Opaque data returned from Blockly.bindEventWithChecks_.
+ * @type {?Blockly.EventData}
+ * @private
+ */
+Blockly.ZoomControls.prototype.onZoomOutWrapper_ = null;
+
+
+/**
  * Create the zoom controls.
  * @return {!SVGElement} The zoom controls SVG group.
  */
@@ -121,6 +146,15 @@ Blockly.ZoomControls.prototype.init = function(verticalSpacing) {
 Blockly.ZoomControls.prototype.dispose = function() {
   if (this.svgGroup_) {
     Blockly.utils.dom.removeNode(this.svgGroup_);
+  }
+  if (this.onZoomResetWrapper_) {
+    Blockly.unbindEvent_(this.onZoomResetWrapper_);
+  }
+  if (this.onZoomInWrapper_) {
+    Blockly.unbindEvent_(this.onZoomInWrapper_);
+  }
+  if (this.onZoomOutWrapper_) {
+    Blockly.unbindEvent_(this.onZoomOutWrapper_);
   }
 };
 
@@ -209,7 +243,7 @@ Blockly.ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
 
   // Attach listener.
-  Blockly.bindEventWithChecks_(
+  this.onZoomOutWrapper_ = Blockly.bindEventWithChecks_(
       zoomoutSvg, 'mousedown', null, this.zoom_.bind(this, -1));
 };
 
@@ -256,7 +290,7 @@ Blockly.ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
 
   // Attach listener.
-  Blockly.bindEventWithChecks_(
+  this.onZoomInWrapper_ = Blockly.bindEventWithChecks_(
       zoominSvg, 'mousedown', null, this.zoom_.bind(this, 1));
 };
 
@@ -320,7 +354,7 @@ Blockly.ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
 
   // Attach event listeners.
-  Blockly.bindEventWithChecks_(
+  this.onZoomResetWrapper_ = Blockly.bindEventWithChecks_(
       zoomresetSvg, 'mousedown', null, this.resetZoom_.bind(this));
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds missing cleanup in dispose for unbinding events.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Follow up from #4025
<!-- Anything else we should know? -->
