### PR TITLE
Add listener for flyout events to playground.

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -774,7 +774,7 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   } else if (Blockly.selected) {
     Blockly.selected.unselect();
   }
-  this.fireWorkspaceClick_(ws);
+  this.fireWorkspaceClick_(this.startWorkspace_);
 };
 
 /* End functions defining what actions to take to execute clicks on each type

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -774,7 +774,7 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   } else if (Blockly.selected) {
     Blockly.selected.unselect();
   }
-  this.fireWorkspaceClick_(this.startWorkspace_);
+  this.fireWorkspaceClick_(this.startWorkspace_ || this.creatorWorkspace_);
 };
 
 /* End functions defining what actions to take to execute clicks on each type

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -774,7 +774,7 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   } else if (Blockly.selected) {
     Blockly.selected.unselect();
   }
-  this.fireWorkspaceClick_(this.startWorkspace_ || this.creatorWorkspace_);
+  this.fireWorkspaceClick_(this.startWorkspace_ || ws);
 };
 
 /* End functions defining what actions to take to execute clicks on each type

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -80,8 +80,6 @@ suite('Gesture', function() {
     var ws = Blockly.inject('blocklyDiv', {});
     ws.keyboardAccessibilityMode = true;
     var gesture = new Blockly.Gesture(event, ws);
-    // Start workspace would normally be set in handleWsStart.
-    gesture.setStartWorkspace_(ws);
     gesture.doWorkspaceClick_(event);
     var cursor = ws.getCursor();
     chai.assert.equal(cursor.getCurNode().getType(), Blockly.ASTNode.types.WORKSPACE);

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -70,7 +70,7 @@ suite('Gesture', function() {
     gestureIsFieldClick_InFlyoutHelper.call(this, flyout, true);
   });
 
-  test('Workspace click - Shift click enters accessibility mode', function() {
+  test('Workspace click in accessibility mode - moves the cursor', function() {
     var event = {
       shiftKey : true,
       clientX : 10,
@@ -80,6 +80,8 @@ suite('Gesture', function() {
     var ws = Blockly.inject('blocklyDiv', {});
     ws.keyboardAccessibilityMode = true;
     var gesture = new Blockly.Gesture(event, ws);
+    // Start workspace would normally be set in handleWsStart.
+    gesture.setStartWorkspace_(ws);
     gesture.doWorkspaceClick_(event);
     var cursor = ws.getCursor();
     chai.assert.equal(cursor.getCurNode().getType(), Blockly.ASTNode.types.WORKSPACE);

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -147,10 +147,10 @@ function start() {
       document.getElementById('importExport').value = text;
     }
     // Restore event logging state.
-    var state = sessionStorage.getItem('logEvents');
-    logEvents(Boolean(Number(state)));
-    state = sessionStorage.getItem('logFlyoutEvents');
-    logFlyoutEvents(Boolean(Number(state)));
+    var logMainEventsState = sessionStorage.getItem('logEvents');
+    logEvents(Boolean(Number(logMainEventsState)));
+    var logToolboxFlyoutEventsState = sessionStorage.getItem('logFlyoutEvents');
+    logFlyoutEvents(Boolean(Number(logToolboxFlyoutEventsState)));
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -149,6 +149,8 @@ function start() {
     // Restore event logging state.
     var state = sessionStorage.getItem('logEvents');
     logEvents(Boolean(Number(state)));
+    state = sessionStorage.getItem('logFlyoutEvents');
+    logFlyoutEvents(Boolean(Number(state)));
   } else {
     // MSIE 11 does not support sessionStorage on file:// URLs.
     logEvents(false);
@@ -361,6 +363,20 @@ function logEvents(state) {
   }
 }
 
+function logFlyoutEvents(state) {
+  var checkbox = document.getElementById('logFlyoutCheck');
+  checkbox.checked = state;
+  if (sessionStorage) {
+    sessionStorage.setItem('logFlyoutEvents', Number(state));
+  }
+  var flyoutWorkspace = workspace.getFlyout().getWorkspace();
+  if (state) {
+    flyoutWorkspace.addChangeListener(logger);
+  } else {
+    flyoutWorkspace.removeChangeListener(logger);
+  }
+}
+
 function configureContextMenu(menuOptions, e) {
   var screenshotOption = {
     text: 'Download Screenshot',
@@ -537,9 +553,13 @@ var spaghettiXml = [
   </p>
   <ul class="playgroundToggleOptions">
     <li>
-      <label for="logCheck">Log events:</label>
+      <label for="logCheck">Log main workspace events:</label>
       <input type="checkbox" onclick="logEvents(this.checked)" id="logCheck">
     </li>
+    <li>
+    <label for="logFlyoutCheck">Log flyout events:</label>
+    <input type="checkbox" onclick="logFlyoutEvents(this.checked)" id="logFlyoutCheck">
+  </li>
   </ul>
 
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3976
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Changes workspace linked to event to `startWorkspace_` for firing workspace click events.
- Adds option to listen to flyout workspace events
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- This changes makes it so the workspace id for a click event made on a flyout references the flyout workspace.
- Adding an option to listen to flyout workspace events is useful for debugging. Being able to only listen to main workspace events is valuable because it reduces the amount of events.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Screenshots
The log events checkbox:
![image](https://user-images.githubusercontent.com/6621618/87211786-fb65e800-c2cf-11ea-8284-95224bd10c25.png)
was changed to log main workspace events and log flyout events:
![image](https://user-images.githubusercontent.com/6621618/87211581-08360c00-c2cf-11ea-8483-a940e2cab091.png)

<!-- Anything else we should know? -->
