### PR TITLE
Perf: Move multiline xml text encoding out of domToText

### DIFF
--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -77,9 +77,10 @@ Blockly.FieldMultilineInput.fromJson = function(options) {
  * @package
  */
 Blockly.FieldMultilineInput.prototype.toXml = function(fieldElement) {
-  // Replace '\n' characters with html-escaped equivalent '&#10'. This is needed
-  // so the plain-text representation of the xml produced by `Blockly.Xml.domToText`
-  // will appear on a single line (this is a limitation of the plain-text format).
+  // Replace '\n' characters with html-escaped equivalent '&#10'. This is
+  // needed so the plain-text representation of the xml produced by
+  // `Blockly.Xml.domToText` will appear on a single line (this is a limitation
+  // of the plain-text format).
   fieldElement.textContent = this.getValue().replace(/\n/g, '&#10;');
   return fieldElement;
 };

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -70,6 +70,32 @@ Blockly.FieldMultilineInput.fromJson = function(options) {
 };
 
 /**
+ * Serializes this field's value to XML. Should only be called by Blockly.Xml.
+ * @param {!Element} fieldElement The element to populate with info about the
+ *    field's state.
+ * @return {!Element} The element containing info about the field's state.
+ * @package
+ */
+Blockly.FieldMultilineInput.prototype.toXml = function(fieldElement) {
+  // Replace '\n' characters with html-escaped equivalent '&#10'. This is needed
+  // so the plain-text representation of the xml produced by `Blockly.Xml.domToText`
+  // will appear on a single line (this is a limitation of the plain-text format).
+  fieldElement.textContent = this.getValue().replace(/\n/g, '&#10;');
+  return fieldElement;
+};
+
+/**
+ * Sets the field's value based on the given XML element. Should only be
+ * called by Blockly.Xml.
+ * @param {!Element} fieldElement The element containing info about the
+ *    field's state.
+ * @package
+ */
+Blockly.FieldMultilineInput.prototype.fromXml = function(fieldElement) {
+  this.setValue(fieldElement.textContent.replace(/&#10;/g, '\n'));
+};
+
+/**
  * Create the block UI for this field.
  * @package
  */

--- a/core/xml.js
+++ b/core/xml.js
@@ -311,17 +311,6 @@ Blockly.Xml.cloneShadow_ = function(shadow, opt_noId) {
  */
 Blockly.Xml.domToText = function(dom) {
   var text = Blockly.utils.xml.domToText(dom);
-  // Replace line breaks in text content with '&#10;' to make them single line.
-  // E.g. <foo>hello\nworld</foo> -> <foo>hello&#10;world</foo>
-  // Do not replace line breaks between tags.
-  // E.g. ...</foo>\n</bar> is unchanged.
-  // Can't use global flag on regexp since backtracking is needed.
-  var regexp = /(<[^/](?:[^>]*[^/])?>[^<]*)\n([^<]*<\/)/;
-  var oldText;
-  do {
-    oldText = text;
-    text = text.replace(regexp, '$1&#10;$2');
-  } while (text != oldText);
   // Unpack self-closing tags.  These tags fail when embedded in HTML.
   // <block name="foo"/> -> <block name="foo"></block>
   return text.replace(/<(\w+)([^<]*)\/>/g, '<$1$2></$1>');


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

A complex regular expression in `Blockly.Xml.domToText` was running on every save, causing performance problems on large projects. The regexp progressively replaces all `\n` with `&#10;` in content fields, and was added along with `FieldMultilineInput`, in #2663.

### Proposed Changes

Override `toXml` and `fromXml` on `FieldMultilineInput` and do the conversion there. This simplifies the regexp, and it only runs when there is multiline content in the program, improving performance - especially on large programs.

### Performance Comparison

Testing with this MakeCode Arcade game: https://arcade.makecode.com/74548-67333-76127-33508

Time spent in `Blockly.Xml.domToText`:

| Before | After |
| -- | -- |
| 10s | 250ms |



### Resolves

Resolves #4030

### Test Coverage

I tested this change in playground.html. Steps I followed:
1. Add a few paragraph blocks and populate them with multiline content.
2. Export to Xml. Inspect the Xml to verify content encoding.
3. Delete all blocks.
4. Import from Xml. Verify (visually) that the content looks correct.

Also: In the dev console, set breakpoints in the `toXml` and `fromXml` methods of `FieldMultilineInput` to verify they're getting called at the right times.

Tested on:
* Desktop Chrome

### Additional information

**Of note:** Another document-wide regexp has appeared in `domToText`, and will likely become a performance issue. You may want to fix it: https://github.com/google/blockly/blob/ba68081d8f0f8e81d76baf370716d5955bae82a1/core/xml.js#L327

I can see how `domToText` would be a tempting place to fixup formatting issues. It might be worth adding a comment in that method stating: "For performance reasons, don't run regular expressions on the whole document."