### PR TITLE
Add deprecation helper + 2 uses

### DIFF
--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -21,12 +21,12 @@ this.BLOCKLY_DIR = (function(root) {
 
 this.BLOCKLY_BOOT = function(root) {
   // Execute after Closure has loaded.
-goog.addDependency('../../core/block.js', ['Blockly.Block'], ['Blockly.ASTNode', 'Blockly.Blocks', 'Blockly.Connection', 'Blockly.Events', 'Blockly.Events.BlockChange', 'Blockly.Events.BlockCreate', 'Blockly.Events.BlockDelete', 'Blockly.Events.BlockMove', 'Blockly.Extensions', 'Blockly.Input', 'Blockly.Workspace', 'Blockly.fieldRegistry', 'Blockly.navigation', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es5'});
+goog.addDependency('../../core/block.js', ['Blockly.Block'], ['Blockly.ASTNode', 'Blockly.Blocks', 'Blockly.Connection', 'Blockly.Events', 'Blockly.Events.BlockChange', 'Blockly.Events.BlockCreate', 'Blockly.Events.BlockDelete', 'Blockly.Events.BlockMove', 'Blockly.Extensions', 'Blockly.Input', 'Blockly.Workspace', 'Blockly.fieldRegistry', 'Blockly.navigation', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.deprecation', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es5'});
 goog.addDependency('../../core/block_animations.js', ['Blockly.blockAnimations'], ['Blockly.utils.dom'], {});
 goog.addDependency('../../core/block_drag_surface.js', ['Blockly.BlockDragSurfaceSvg'], ['Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.dom'], {});
 goog.addDependency('../../core/block_dragger.js', ['Blockly.BlockDragger'], ['Blockly.Events', 'Blockly.Events.BlockMove', 'Blockly.Events.Ui', 'Blockly.InsertionMarkerManager', 'Blockly.blockAnimations', 'Blockly.utils.Coordinate', 'Blockly.utils.dom'], {});
 goog.addDependency('../../core/block_events.js', ['Blockly.Events.BlockBase', 'Blockly.Events.BlockChange', 'Blockly.Events.BlockCreate', 'Blockly.Events.BlockDelete', 'Blockly.Events.BlockMove', 'Blockly.Events.Change', 'Blockly.Events.Create', 'Blockly.Events.Delete', 'Blockly.Events.Move'], ['Blockly.Events', 'Blockly.Events.Abstract', 'Blockly.utils.Coordinate', 'Blockly.utils.object', 'Blockly.utils.xml'], {});
-goog.addDependency('../../core/block_svg.js', ['Blockly.BlockSvg'], ['Blockly.ASTNode', 'Blockly.Block', 'Blockly.ContextMenu', 'Blockly.Events', 'Blockly.Events.BlockMove', 'Blockly.Events.Ui', 'Blockly.Msg', 'Blockly.RenderedConnection', 'Blockly.TabNavigateCursor', 'Blockly.Tooltip', 'Blockly.Touch', 'Blockly.blockAnimations', 'Blockly.blockRendering.IPathObject', 'Blockly.navigation', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.object'], {});
+goog.addDependency('../../core/block_svg.js', ['Blockly.BlockSvg'], ['Blockly.ASTNode', 'Blockly.Block', 'Blockly.ContextMenu', 'Blockly.ContextMenuRegistry', 'Blockly.Events', 'Blockly.Events.BlockMove', 'Blockly.Events.Ui', 'Blockly.Msg', 'Blockly.RenderedConnection', 'Blockly.TabNavigateCursor', 'Blockly.Tooltip', 'Blockly.Touch', 'Blockly.blockAnimations', 'Blockly.blockRendering.IPathObject', 'Blockly.navigation', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.object'], {});
 goog.addDependency('../../core/blockly.js', ['Blockly'], ['Blockly.Events', 'Blockly.Events.Ui', 'Blockly.Procedures', 'Blockly.Tooltip', 'Blockly.Touch', 'Blockly.Variables', 'Blockly.WidgetDiv', 'Blockly.WorkspaceSvg', 'Blockly.Xml', 'Blockly.constants', 'Blockly.inject', 'Blockly.navigation', 'Blockly.utils', 'Blockly.utils.Size', 'Blockly.utils.colour'], {});
 goog.addDependency('../../core/blocks.js', ['Blockly.Blocks'], [], {});
 goog.addDependency('../../core/bubble.js', ['Blockly.Bubble'], ['Blockly.Scrollbar', 'Blockly.Touch', 'Blockly.Workspace', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.dom', 'Blockly.utils.math', 'Blockly.utils.userAgent'], {});
@@ -40,7 +40,7 @@ goog.addDependency('../../core/connection.js', ['Blockly.Connection'], ['Blockly
 goog.addDependency('../../core/connection_db.js', ['Blockly.ConnectionDB'], ['Blockly.RenderedConnection'], {});
 goog.addDependency('../../core/constants.js', ['Blockly.constants'], [], {});
 goog.addDependency('../../core/contextmenu.js', ['Blockly.ContextMenu'], ['Blockly.Events', 'Blockly.Events.BlockCreate', 'Blockly.Menu', 'Blockly.MenuItem', 'Blockly.Msg', 'Blockly.Xml', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.userAgent'], {});
-goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems'], [], {});
+goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems'], [], {'lang': 'es5'});
 goog.addDependency('../../core/contextmenu_registry.js', ['Blockly.ContextMenuRegistry'], ['Blockly.ContextMenuItems'], {'lang': 'es5'});
 goog.addDependency('../../core/css.js', ['Blockly.Css'], [], {'lang': 'es5'});
 goog.addDependency('../../core/dropdowndiv.js', ['Blockly.DropDownDiv'], ['Blockly.utils.dom', 'Blockly.utils.math', 'Blockly.utils.style'], {});
@@ -160,6 +160,7 @@ goog.addDependency('../../core/utils.js', ['Blockly.utils'], ['Blockly.Msg', 'Bl
 goog.addDependency('../../core/utils/aria.js', ['Blockly.utils.aria'], [], {});
 goog.addDependency('../../core/utils/colour.js', ['Blockly.utils.colour'], [], {});
 goog.addDependency('../../core/utils/coordinate.js', ['Blockly.utils.Coordinate'], [], {});
+goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], [], {});
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.userAgent'], {});
 goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], [], {});
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], [], {});

--- a/core/block.js
+++ b/core/block.js
@@ -25,6 +25,7 @@ goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.Input');
 goog.require('Blockly.navigation');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.deprecation');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.string');
@@ -1242,8 +1243,11 @@ Blockly.Block.prototype.getOutputShape = function() {
  * @deprecated May 2019
  */
 Blockly.Block.prototype.setDisabled = function(disabled) {
-  console.warn('Deprecated call to Blockly.Block.prototype.setDisabled, ' +
-               'use Blockly.Block.prototype.setEnabled instead.');
+  Blockly.utils.deprecation.warn(
+      'Blockly.Block.prototype.setDisabled',
+      'May 2019',
+      'May 2020',
+      'Blockly.Block.prototype.setEnabled');
   this.setEnabled(!disabled);
 };
 

--- a/core/block.js
+++ b/core/block.js
@@ -1247,7 +1247,7 @@ Blockly.Block.prototype.setDisabled = function(disabled) {
       'Block.prototype.setDisabled',
       'May 2019',
       'May 2020',
-      'Blockly.Block.prototype.setEnabled');
+      'Block.prototype.setEnabled');
   this.setEnabled(!disabled);
 };
 

--- a/core/block.js
+++ b/core/block.js
@@ -1244,7 +1244,7 @@ Blockly.Block.prototype.getOutputShape = function() {
  */
 Blockly.Block.prototype.setDisabled = function(disabled) {
   Blockly.utils.deprecation.warn(
-      'Blockly.Block.prototype.setDisabled',
+      'Block.prototype.setDisabled',
       'May 2019',
       'May 2020',
       'Blockly.Block.prototype.setEnabled');

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -28,6 +28,7 @@ goog.require('Blockly.TabNavigateCursor');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.deprecation');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
@@ -1066,7 +1067,7 @@ Blockly.BlockSvg.prototype.setWarningText = function(text, opt_id) {
       collapsedParent.setWarningText(Blockly.Msg['COLLAPSED_WARNINGS_WARNING'],
           Blockly.BlockSvg.COLLAPSED_WARNING_ID);
     }
-    
+
     if (!this.warning) {
       this.warning = new Blockly.Warning(this);
       changedState = true;
@@ -1120,8 +1121,11 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
  * @deprecated May 2019
  */
 Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
-  console.warn('Deprecated call to Blockly.BlockSvg.prototype.setDisabled, ' +
-  'use Blockly.BlockSvg.prototype.setEnabled instead.');
+  Blockly.utils.deprecation.warn(
+      'Blockly.BlockSvg.prototype.setDisabled',
+      'May 2019',
+      'May 2020',
+      'Blockly.BlockSvg.prototype.setEnabled');
   this.setEnabled(!disabled);
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1135,7 +1135,7 @@ Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
       'BlockSvg.prototype.setDisabled',
       'May 2019',
       'May 2020',
-      'Blockly.BlockSvg.prototype.setEnabled');
+      'BlockSvg.prototype.setEnabled');
   this.setEnabled(!disabled);
 };
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -240,6 +240,11 @@ Blockly.BlockSvg.prototype.getColourTertiary = function() {
  * @deprecated Use style.colourSecondary. (2020 January 21)
  */
 Blockly.BlockSvg.prototype.getColourShadow = function() {
+  Blockly.utils.deprecation.warn(
+      'BlockSvg.prototype.getColourShadow',
+      'January 2020',
+      'January 2021',
+      'style.colourSecondary');
   return this.getColourSecondary();
 };
 
@@ -253,6 +258,11 @@ Blockly.BlockSvg.prototype.getColourShadow = function() {
  * @deprecated Use style.colourTertiary. (2020 January 21)
  */
 Blockly.BlockSvg.prototype.getColourBorder = function() {
+  Blockly.utils.deprecation.warn(
+      'BlockSvg.prototype.getColourBorder',
+      'January 2020',
+      'January 2021',
+      'style.colourTertiary');
   var colourTertiary = this.getColourTertiary();
   return {
     colourBorder: colourTertiary,
@@ -1122,7 +1132,7 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
  */
 Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
   Blockly.utils.deprecation.warn(
-      'Blockly.BlockSvg.prototype.setDisabled',
+      'BlockSvg.prototype.setDisabled',
       'May 2019',
       'May 2020',
       'Blockly.BlockSvg.prototype.setEnabled');

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Helper function for warning developers about deprecations.
+ * This method is not specific to Blockly.
+ * @author fenichel@google.com (Rachel Fenichel);
+ */
+'use strict';
+
+goog.provide('Blockly.utils.deprecation');
+
+/**
+ * Warn developers that a function is deprecated.
+ * @param {string} functionName The name of the function.
+ * @param {string} deprecationDate The date when the function was deprecated.
+ *     Prefer 'month yyyy' or 'quarter yyyy' format.
+ * @param {string} deletionDate The date when the function will be deleted, in
+ *     the same format as the deprecation date.
+ * @param {?string} opt_use The name of a function to use instead, if any.
+ * @package
+ */
+Blockly.utils.deprecation.warn = function(
+    functionName, deprecationDate, deletionDate, opt_use) {
+  var msg = functionName + ' was deprecated on ' + deprecationDate +
+        ' and will be deleted on ' + deletionDate + '.';
+  if (opt_use) {
+    msg += '\nUse ' + opt_use + ' instead.';
+  }
+  console.warn(msg);
+};

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -20,7 +20,7 @@ goog.provide('Blockly.utils.deprecation');
  *     Prefer 'month yyyy' or 'quarter yyyy' format.
  * @param {string} deletionDate The date when the function will be deleted, in
  *     the same format as the deprecation date.
- * @param {?string} opt_use The name of a function to use instead, if any.
+ * @param {string=} opt_use The name of a function to use instead, if any.
  * @package
  */
 Blockly.utils.deprecation.warn = function(


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4049 

### Proposed Changes

Adds a deprecation warning helper to standardize our deprecation messages.

### Reason for Changes

Standardization.

### Test Coverage

Checked in the advanced playground.


### Documentation


### Additional Information

It would be nice to automatically know what function was being called, instead of typing it as a string.