### PR TITLE
Hide flyout after Events are re-enabled when creating a block

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -765,11 +765,12 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
   this.targetWorkspace.setResizesEnabled(false);
   try {
     newBlock = this.placeNewBlock_(originalBlock);
-    // Close the flyout.
-    Blockly.hideChaff();
   } finally {
     Blockly.Events.enable();
   }
+
+  // Close the flyout.
+  Blockly.hideChaff();
 
   var newVariables = Blockly.Variables.getAddedVariables(this.targetWorkspace,
       variablesBeforeCreation);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4034
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Hide flyout after events are re-enabled when creating a block from the flyout.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Allows for the category event for a flyout category closing to be triggered, making events for category open/close more consistent. 
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually in playground by observing events logged.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
### Additional Information

The logic for hiding the flyout while Events are disabled was introduced in #1078.
This doesn't appear to cause any unintended side effects.
<!-- Anything else we should know? -->
