### PR TITLE
Snap dev-tools in master to v1.1.0

### DIFF
--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -68,7 +68,7 @@
 <script src="../themes/test_themes.js"></script>
 <script src="./screenshot.js"></script>
 <script src="./test_blocks_toolbox.js"></script>
-<script src="https://unpkg.com/@blockly/dev-tools/dist/index.js"></script>
+<script src="https://unpkg.com/@blockly/dev-tools@1.1.0/dist/index.js"></script>
 <script src="https://unpkg.com/@blockly/theme-modern/dist/index.js"></script>
 
 <script>


### PR DESCRIPTION
## The basics
- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/4074

### Proposed Changes

This PR is against master.
Snap the dev-tools version to a specific version so upcoming changes don't affect master.

### Reason for Changes

Fix playground in master.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
