### PR TITLE
Add last accessed time to Xml model, and update it when getting from the db

### DIFF
--- a/appengine/storage.py
+++ b/appengine/storage.py
@@ -23,6 +23,7 @@ __author__ = "q.neutron@gmail.com (Quynh Neutron)"
 import cgi
 import hashlib
 from random import randint
+from datetime import timezone
 from google.cloud import ndb
 
 
@@ -30,6 +31,7 @@ class Xml(ndb.Model):
   # A row in the database.
   xml_hash = ndb.IntegerProperty()
   xml_content = ndb.TextProperty()
+  last_accessed = ndb.DateTimeProperty(auto_now = true)
 
 
 def keyGen():
@@ -72,10 +74,19 @@ def keyToXml(key_provided):
   client = ndb.Client()
   with client.context():
     result = Xml.get_by_id(key_provided)
+
   if not result:
     xml = ""
   else:
     xml = result.xml_content
+    # Update row to include last accessed time--because last_accessed is set to
+    # auto_now, any write updates the time.
+    with client.context():
+      row = Xml(id = key_provided,
+        xml_hash = result.xml_hash,
+        xml_content = result.xml_content)
+      row.put();
+
   return xml
 
 

--- a/appengine/storage.py
+++ b/appengine/storage.py
@@ -23,7 +23,6 @@ __author__ = "q.neutron@gmail.com (Quynh Neutron)"
 import cgi
 import hashlib
 from random import randint
-from datetime import timezone
 from google.cloud import ndb
 
 
@@ -31,8 +30,7 @@ class Xml(ndb.Model):
   # A row in the database.
   xml_hash = ndb.IntegerProperty()
   xml_content = ndb.TextProperty()
-  last_accessed = ndb.DateTimeProperty(auto_now = true)
-
+  last_accessed = ndb.DateTimeProperty(auto_now=True)
 
 def keyGen():
   # Generate a random string of length KEY_LEN.
@@ -74,19 +72,14 @@ def keyToXml(key_provided):
   client = ndb.Client()
   with client.context():
     result = Xml.get_by_id(key_provided)
-
   if not result:
     xml = ""
   else:
-    xml = result.xml_content
-    # Update row to include last accessed time--because last_accessed is set to
-    # auto_now, any write updates the time.
+    # Put it back into the datastore immediately, which updates the last
+    # accessed time.
     with client.context():
-      row = Xml(id = key_provided,
-        xml_hash = result.xml_hash,
-        xml_content = result.xml_content)
-      row.put();
-
+      result.put()
+    xml = result.xml_content
   return xml
 
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of data retention.

### Proposed Changes

- Add a `last_accessed` field to the `Xml` model
- Use `auto_now` to [make it update on every put](https://googleapis.dev/python/python-ndb/latest/model.html#google.cloud.ndb.model.DateTimeProperty)
- Update when accessed

### Reason for Changes

Data retention

### Test Coverage

Not yet tested. I think my best way to test would be to:
- deploy this on staging
- save some blocks
- inspect entities to find the correct one and confirm that the datetime is correct
- open the saved blocks from the link
- inspect entities to confirm that the last_accessed time has been updated


### Documentation


### Additional Information

I can also set the property to be required, but I'm not sure what value I would end up with. The documentation says "And unlike the legacy google.appengine.ext.db, auto_now does not supply a default value."

I will need to add a last+accessed time to all entities, but I will probably just do that in a separate batch job.