### PR TITLE
Cleanup of chai asserts

### DIFF
--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -469,7 +469,7 @@ suite('Events', function() {
         new Blockly.Events.Ui(block, 'click', undefined, undefined)
       ];
       var filteredEvents = Blockly.Events.filter(events, true);
-      chai.assert.equal(4, filteredEvents.length);  // no event should have been removed.
+      chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
@@ -487,7 +487,7 @@ suite('Events', function() {
         new Blockly.Events.BlockMove(block2)
       ];
       var filteredEvents = Blockly.Events.filter(events, true);
-      chai.assert.equal(4, filteredEvents.length);  // no event should have been removed.
+      chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
     });
 
     test('Forward', function() {
@@ -497,12 +497,12 @@ suite('Events', function() {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       var filteredEvents = Blockly.Events.filter(events, true);
-      chai.assert.equal(2, filteredEvents.length);  // duplicate moves should have been removed.
+      chai.assert.equal(filteredEvents.length, 2);  // duplicate moves should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.equal(3, filteredEvents[1].newCoordinate.x);
-      chai.assert.equal(3, filteredEvents[1].newCoordinate.y);
+      chai.assert.equal(filteredEvents[1].newCoordinate.x, 3);
+      chai.assert.equal(filteredEvents[1].newCoordinate.y, 3);
     });
 
     test('Backward', function() {
@@ -512,12 +512,12 @@ suite('Events', function() {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       var filteredEvents = Blockly.Events.filter(events, false);
-      chai.assert.equal(2, filteredEvents.length);  // duplicate event should have been removed.
+      chai.assert.equal(filteredEvents.length, 2);  // duplicate event should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.equal(1, filteredEvents[1].newCoordinate.x);
-      chai.assert.equal(1, filteredEvents[1].newCoordinate.y);
+      chai.assert.equal(filteredEvents[1].newCoordinate.x, 1);
+      chai.assert.equal(filteredEvents[1].newCoordinate.y, 1);
     });
 
     test('Merge move events', function() {
@@ -526,9 +526,9 @@ suite('Events', function() {
       addMoveEvent(events, block, 0, 0);
       addMoveEvent(events, block, 1, 1);
       var filteredEvents = Blockly.Events.filter(events, true);
-      chai.assert.equal(1, filteredEvents.length);  // second move event merged into first
-      chai.assert.equal(1, filteredEvents[0].newCoordinate.x);
-      chai.assert.equal(1, filteredEvents[0].newCoordinate.y);
+      chai.assert.equal(filteredEvents.length, 1);  // second move event merged into first
+      chai.assert.equal(filteredEvents[0].newCoordinate.x, 1);
+      chai.assert.equal(filteredEvents[0].newCoordinate.y, 1);
     });
 
     test('Merge change events', function() {
@@ -538,7 +538,7 @@ suite('Events', function() {
         new Blockly.Events.Change(block1, 'field', 'VAR', 'item1', 'item2')
       ];
       var filteredEvents = Blockly.Events.filter(events, true);
-      chai.assert.equal(1, filteredEvents.length);  // second change event merged into first
+      chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
       chai.assert.equal(filteredEvents[0].oldValue, 'item');
       chai.assert.equal(filteredEvents[0].newValue, 'item2');
     });
@@ -573,7 +573,7 @@ suite('Events', function() {
       ];
       var filteredEvents = Blockly.Events.filter(events, true);
       // click and stackclick should both exist
-      chai.assert.equal(2, filteredEvents.length);
+      chai.assert.equal(filteredEvents.length, 2);
       chai.assert.equal(filteredEvents[0].element, 'click');
       chai.assert.equal(filteredEvents[1].element, 'stackclick');
     });
@@ -594,7 +594,7 @@ suite('Events', function() {
       var filteredEvents = Blockly.Events.filter(events, true);
       // The two events should be merged, but because nothing has changed
       // they will be filtered out.
-      chai.assert.equal(0, filteredEvents.length);
+      chai.assert.equal(filteredEvents.length, 0);
     });
 
     test('Move events different blocks not merged', function() {
@@ -614,7 +614,7 @@ suite('Events', function() {
 
       var filteredEvents = Blockly.Events.filter(events, true);
       // Nothing should have merged.
-      chai.assert.equal(4, filteredEvents.length);
+      chai.assert.equal(filteredEvents.length, 4);
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -143,8 +143,8 @@ suite('JSON Block Definitions', function() {
       }]);
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(1, block.inputList.length);
-      chai.assert.equal(1, block.inputList[0].fieldRow.length);
+      chai.assert.equal(block.inputList.length, 1);
+      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var textField = block.inputList[0].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE0, textField.getText());
@@ -164,14 +164,14 @@ suite('JSON Block Definitions', function() {
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       this.blocks_.push(block);
-      chai.assert.equal(2, block.inputList.length);
+      chai.assert.equal(block.inputList.length, 2);
 
-      chai.assert.equal(1, block.inputList[0].fieldRow.length);
+      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var textField = block.inputList[0].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE0, textField.getText());
 
-      chai.assert.equal(1, block.inputList[1].fieldRow.length);
+      chai.assert.equal(block.inputList[1].fieldRow.length, 1);
       var textField = block.inputList[1].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE1, textField.getText());
@@ -192,8 +192,8 @@ suite('JSON Block Definitions', function() {
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       this.blocks_.push(block);
-      chai.assert.equal(1, block.inputList.length);
-      chai.assert.equal(1, block.inputList[0].fieldRow.length);
+      chai.assert.equal(block.inputList.length, 1);
+      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var textField = block.inputList[0].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE, textField.getText());
@@ -224,8 +224,8 @@ suite('JSON Block Definitions', function() {
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       this.blocks_.push(block);
-      chai.assert.equal(1, block.inputList.length);
-      chai.assert.equal(1, block.inputList[0].fieldRow.length);
+      chai.assert.equal(block.inputList.length, 1);
+      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var dropdown = block.inputList[0].fieldRow[0];
       chai.assert.equal(dropdown, block.getField(FIELD_NAME));
       chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);
@@ -285,8 +285,8 @@ suite('JSON Block Definitions', function() {
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       this.blocks_.push(block);
-      chai.assert.equal(1, block.inputList.length);
-      chai.assert.equal(1, block.inputList[0].fieldRow.length);
+      chai.assert.equal(block.inputList.length, 1);
+      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var dropdown = block.inputList[0].fieldRow[0];
       chai.assert.equal(dropdown, block.getField(FIELD_NAME));
       chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);

--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -249,8 +249,8 @@ suite('Insert/Modify', function() {
               this.row_block_1));
       chai.assert.isTrue(Blockly.navigation.modify_());
       var pos = this.row_block_1.getRelativeToSurfaceXY();
-      chai.assert.equal(100, pos.x);
-      chai.assert.equal(200, pos.y);
+      chai.assert.equal(pos.x, 100);
+      chai.assert.equal(pos.y, 200);
     });
 
     test('Cursor on output connection', function() {
@@ -259,8 +259,8 @@ suite('Insert/Modify', function() {
               this.row_block_1.outputConnection));
       chai.assert.isTrue(Blockly.navigation.modify_());
       var pos = this.row_block_1.getRelativeToSurfaceXY();
-      chai.assert.equal(100, pos.x);
-      chai.assert.equal(200, pos.y);
+      chai.assert.equal(pos.x, 100);
+      chai.assert.equal(pos.y, 200);
     });
 
     test('Cursor on previous connection', function() {
@@ -269,8 +269,8 @@ suite('Insert/Modify', function() {
               this.stack_block_1.previousConnection));
       chai.assert.isTrue(Blockly.navigation.modify_());
       var pos = this.stack_block_1.getRelativeToSurfaceXY();
-      chai.assert.equal(100, pos.x);
-      chai.assert.equal(200, pos.y);
+      chai.assert.equal(pos.x, 100);
+      chai.assert.equal(pos.y, 200);
     });
 
     test('Cursor on input connection', function() {
@@ -300,8 +300,8 @@ suite('Insert/Modify', function() {
       chai.assert.isTrue(Blockly.navigation.modify_());
       chai.assert.isNull(this.row_block_2.getParent());
       var pos = this.row_block_2.getRelativeToSurfaceXY();
-      chai.assert.equal(100, pos.x);
-      chai.assert.equal(200, pos.y);
+      chai.assert.equal(pos.x, 100);
+      chai.assert.equal(pos.y, 200);
     });
 
     test('Cursor on child block (stack)', function() {
@@ -315,8 +315,8 @@ suite('Insert/Modify', function() {
       chai.assert.isTrue(Blockly.navigation.modify_());
       chai.assert.isNull(this.stack_block_2.getParent());
       var pos = this.stack_block_2.getRelativeToSurfaceXY();
-      chai.assert.equal(100, pos.x);
-      chai.assert.equal(200, pos.y);
+      chai.assert.equal(pos.x, 100);
+      chai.assert.equal(pos.y, 200);
     });
 
     test('Cursor on workspace', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Fixes asserts in tests to follow the form: (actual, expected) so that error messages are correct.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This fixes test assert messages so the values aren't swapped, making for a better debugging experience.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Files updated using the regex:
Find:
`chai.assert.equal\((\d+), ([^\s\)]+)\);`
Replace:
`chai.assert.equal\($2, $1\);`



<!-- Anything else we should know? -->
