### PR TITLE
flyout button stores all the deserialized properties

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -85,6 +85,12 @@ Blockly.FlyoutButton = function(workspace, targetWorkspace, json, isLabel) {
    * @private
    */
   this.onMouseUpWrapper_ = null;
+
+  /**
+   * The JSON specifying the label / button.
+   * @type {!Blockly.utils.toolbox.Button|!Blockly.utils.toolbox.Label}
+   */
+  this.info = json;
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x ] I branched from develop
- [x ] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4027

### Proposed Changes

Flyout buttons store all attributes/properties of their xml/json definition. This information can be useful for button callbacks. See [this comment](https://github.com/google/blockly/issues/4027#issuecomment-656325534)
