### PR TITLE
Rename trashcan api calls for open/close lid.

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -287,7 +287,7 @@ Blockly.BlockDragger.prototype.maybeDeleteBlock_ = function() {
 
   if (this.wouldDeleteBlock_) {
     if (trashcan) {
-      setTimeout(trashcan.close.bind(trashcan), 100);
+      setTimeout(trashcan.closeLid.bind(trashcan), 100);
     }
     // Fire a move event, so we know where to go back to for an undo.
     this.fireMoveEvent_();
@@ -295,7 +295,7 @@ Blockly.BlockDragger.prototype.maybeDeleteBlock_ = function() {
     Blockly.draggingConnections = [];
   } else if (trashcan) {
     // Make sure the trash can is closed.
-    trashcan.close();
+    trashcan.closeLid();
   }
   return this.wouldDeleteBlock_;
 };
@@ -311,12 +311,12 @@ Blockly.BlockDragger.prototype.updateCursorDuringBlockDrag_ = function() {
   if (this.wouldDeleteBlock_) {
     this.draggingBlock_.setDeleteStyle(true);
     if (this.deleteArea_ == Blockly.DELETE_AREA_TRASH && trashcan) {
-      trashcan.setOpen(true);
+      trashcan.setLidOpen(true);
     }
   } else {
     this.draggingBlock_.setDeleteStyle(false);
     if (trashcan) {
-      trashcan.setOpen(false);
+      trashcan.setLidOpen(false);
     }
   }
 };

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -294,7 +294,7 @@ Blockly.BlockDragger.prototype.maybeDeleteBlock_ = function() {
     this.draggingBlock_.dispose(false, true);
     Blockly.draggingConnections = [];
   } else if (trashcan) {
-    // Make sure the trash can is closed.
+    // Make sure the trash can lid is closed.
     trashcan.closeLid();
   }
   return this.wouldDeleteBlock_;

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -145,14 +145,14 @@ Blockly.BubbleDragger.prototype.maybeDeleteBubble_ = function() {
 
   if (this.wouldDeleteBubble_) {
     if (trashcan) {
-      setTimeout(trashcan.close.bind(trashcan), 100);
+      setTimeout(trashcan.closeLid.bind(trashcan), 100);
     }
     // Fire a move event, so we know where to go back to for an undo.
     this.fireMoveEvent_();
     this.draggingBubble_.dispose(false, true);
   } else if (trashcan) {
     // Make sure the trash can is closed.
-    trashcan.close();
+    trashcan.closeLid();
   }
   return this.wouldDeleteBubble_;
 };
@@ -168,12 +168,12 @@ Blockly.BubbleDragger.prototype.updateCursorDuringBubbleDrag_ = function() {
   if (this.wouldDeleteBubble_) {
     this.draggingBubble_.setDeleteStyle(true);
     if (this.deleteArea_ == Blockly.DELETE_AREA_TRASH && trashcan) {
-      trashcan.setOpen(true);
+      trashcan.setLidOpen(true);
     }
   } else {
     this.draggingBubble_.setDeleteStyle(false);
     if (trashcan) {
-      trashcan.setOpen(false);
+      trashcan.setLidOpen(false);
     }
   }
 };

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -151,7 +151,7 @@ Blockly.BubbleDragger.prototype.maybeDeleteBubble_ = function() {
     this.fireMoveEvent_();
     this.draggingBubble_.dispose(false, true);
   } else if (trashcan) {
-    // Make sure the trash can is closed.
+    // Make sure the trash can lid is closed.
     trashcan.closeLid();
   }
   return this.wouldDeleteBubble_;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -149,7 +149,7 @@ Blockly.Trashcan.prototype.SPRITE_TOP_ = 32;
 Blockly.Trashcan.prototype.HAS_BLOCKS_LID_ANGLE_ = 0.1;
 
 /**
- * The length of the open/close animation in milliseconds.
+ * The length of the lid open/close animation in milliseconds.
  * @const {number}
  * @private
  */
@@ -188,7 +188,7 @@ Blockly.Trashcan.MAX_LID_ANGLE_ = 45;
  * Current open/close state of the lid.
  * @type {boolean}
  */
-Blockly.Trashcan.prototype.isOpen = false;
+Blockly.Trashcan.prototype.isLidOpen = false;
 
 /**
  * The minimum openness of the lid. Used to indicate if the trashcan contains
@@ -337,7 +337,7 @@ Blockly.Trashcan.prototype.init = function(verticalSpacing) {
   }
 
   this.verticalSpacing_ = this.MARGIN_BOTTOM_ + verticalSpacing;
-  this.setOpen(false);
+  this.setLidOpen(false);
   return this.verticalSpacing_ + this.BODY_HEIGHT_ + this.LID_HEIGHT_;
 };
 
@@ -473,12 +473,12 @@ Blockly.Trashcan.prototype.getClientRect = function() {
  * @param {boolean} state True if open.
  * @package
  */
-Blockly.Trashcan.prototype.setOpen = function(state) {
-  if (this.isOpen == state) {
+Blockly.Trashcan.prototype.setLidOpen = function(state) {
+  if (this.isLidOpen == state) {
     return;
   }
   clearTimeout(this.lidTask_);
-  this.isOpen = state;
+  this.isLidOpen = state;
   this.animateLid_();
 };
 
@@ -490,7 +490,7 @@ Blockly.Trashcan.prototype.animateLid_ = function() {
   var frames = Blockly.Trashcan.ANIMATION_FRAMES_;
 
   var delta = 1 / (frames + 1);
-  this.lidOpen_ += this.isOpen ? delta : -delta;
+  this.lidOpen_ += this.isLidOpen ? delta : -delta;
   this.lidOpen_ = Math.min(Math.max(this.lidOpen_, this.minOpenness_), 1);
 
   this.setLidAngle_(this.lidOpen_ * Blockly.Trashcan.MAX_LID_ANGLE_);
@@ -530,7 +530,7 @@ Blockly.Trashcan.prototype.setLidAngle_ = function(lidAngle) {
  */
 Blockly.Trashcan.prototype.setMinOpenness_ = function(newMin) {
   this.minOpenness_ = newMin;
-  if (!this.isOpen) {
+  if (!this.isLidOpen) {
     this.setLidAngle_(newMin * Blockly.Trashcan.MAX_LID_ANGLE_);
   }
 };
@@ -539,8 +539,8 @@ Blockly.Trashcan.prototype.setMinOpenness_ = function(newMin) {
  * Flip the lid shut.
  * Called externally after a drag.
  */
-Blockly.Trashcan.prototype.close = function() {
-  this.setOpen(false);
+Blockly.Trashcan.prototype.closeLid = function() {
+  this.setLidOpen(false);
 };
 
 /**
@@ -582,7 +582,7 @@ Blockly.Trashcan.prototype.blockMouseDownWhenFull_ = function(e) {
  */
 Blockly.Trashcan.prototype.mouseOver_ = function() {
   if (this.hasContents_()) {
-    this.setOpen(true);
+    this.setLidOpen(true);
   }
 };
 
@@ -594,7 +594,7 @@ Blockly.Trashcan.prototype.mouseOver_ = function() {
 Blockly.Trashcan.prototype.mouseOut_ = function() {
   // No need to do a .hasBlocks check here because if it doesn't the trashcan
   // won't be open in the first place, and setOpen won't run.
-  this.setOpen(false);
+  this.setLidOpen(false);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4061
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Renames methods for opening/closing trashcan lid to mention "lid".
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This rename makes it clearer that these methods are referring to closing the lid, rather than the trashcan flyout (which can also be opened/closed).
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

I searched devsite source and didn't find any places that should be updated, aside from the pages auto-generated from jsdoc.
<!-- Anything else we should know? -->
