### PR TITLE
Adding cleanup to theme tests

### DIFF
--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -51,7 +51,8 @@ function workspaceTeardown(workspace) {
     workspace.dispose();
     this.clock.runAll();  // Run all remaining queued setTimeout calls.
   } catch (e) {
-    console.error(this.currentTest.fullTitle() + '\n', e);
+    var testRef = this.currentTest || this.test;
+    console.error(testRef.fullTitle() + '\n', e);
   }
 }
 
@@ -109,8 +110,9 @@ function sharedTestSetup(options = {}) {
  * outermost suite using sharedTestTeardown.call(this).
  */
 function sharedTestTeardown() {
+  var testRef = this.currentTest || this.test;
   if (!this.sharedSetupCalled_) {
-    console.error('"' + this.currentTest.fullTitle() +
+    console.error('"' + testRef.fullTitle() +
         '" did not call sharedTestSetup');
   }
 
@@ -122,7 +124,7 @@ function sharedTestTeardown() {
       this.clock.runAll();  // Run all queued setTimeout calls.
     }
   } catch (e) {
-    console.error(this.currentTest.fullTitle() + '\n', e);
+    console.error(testRef.fullTitle() + '\n', e);
   } finally {
     // Clear Blockly.Event state.
     Blockly.Events.setGroup(false);
@@ -132,7 +134,7 @@ function sharedTestTeardown() {
       // (i.e. a previous test added an event to the queue on a timeout that
       // did not use a stubbed clock).
       Blockly.Events.FIRE_QUEUE_.length = 0;
-      console.warn(this.currentTest.fullTitle() +
+      console.warn(testRef.fullTitle() +
           '" needed cleanup of Blockly.Events.FIRE_QUEUE_. This may indicate ' +
           'leakage from an earlier test');
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4070
Part of #4064
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Adds call to shared setup and teardown and updates test logic for testing event firing.
- Updates logic for getting full test name in shared test helpers so that the correct reference is found when it is called from test (rather than setup/teardown).
- Adds proper cleanup to `'Set theme'` tests
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Cleans up async calls after tests.
- `'Set theme'` test cleanup (workspace dispose and undefining test blocks) was not correct as it would not cleanup if any asserts failed (thus the need for a try/finally).
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


