### PR TITLE
Add privacy policy to demos that use storage

### DIFF
--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -566,3 +566,14 @@ td.taboff:hover {
 .shadowBlock>.blocklyPathDark {
   display: none;
 }
+
+/* Privacy link */
+.privacyLink {
+  font-family: Roboto, Arial, Helvetica, sans-serif;
+  font-size: small;
+  text-decoration: none;
+}
+
+.privacyButton {
+  float: right;
+}

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -50,6 +50,8 @@
     <button id="helpButton" title="View documentation in new window.">
       <span>Help</span>
     </button>
+    <button class="privacyButton" title="Open Google privacy policy"><a class="privacyLink" href="https://policies.google.com/privacy">Privacy</a>
+    </button>
   </h1>
   <div id="tabContainer">
     <div id="blockFactory_tab" class="tab tabon">Block Factory</div>

--- a/demos/code/index.html
+++ b/demos/code/index.html
@@ -27,6 +27,7 @@
       </td>
       <td class="farSide">
         <select id="languageMenu"></select>
+        <a class="privacyLink" href="https://policies.google.com/privacy">Privacy</a>
       </td>
     </tr>
     <tr>

--- a/demos/code/style.css
+++ b/demos/code/style.css
@@ -174,3 +174,10 @@ button {
     display: table-cell;
   }
 }
+
+/* Privacy link */
+.privacyLink {
+  font-family: Roboto, Arial, Helvetica, sans-serif;
+  font-size: small;
+  text-decoration: none;
+}

--- a/demos/storage/index.html
+++ b/demos/storage/index.html
@@ -21,6 +21,11 @@
       background-color: #f9edbe;
       border: solid 1px #f0c36d;
     }
+    .privacyLink {
+      font-family: Roboto, Arial, Helvetica, sans-serif;
+      font-size: small;
+      text-decoration: none;
+    }
   </style>
 </head>
 <body>
@@ -93,4 +98,7 @@
   </script>
 
 </body>
+<footer>
+  <a class="privacyLink" href="https://policies.google.com/privacy">Privacy</a>
+</footer>
 </html>


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4063

### Proposed Changes

Adds a link to the google privacy policy on the demos that use storage.
- code
- storage
- block factory

### Reason for Changes

See #4063 

### Test Coverage

Opened the demos locally
