### PR TITLE
Use toLocaleString to count decimal places consistently

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -231,7 +231,7 @@ Blockly.FieldNumber.prototype.setPrecisionInternal_ = function(precision) {
     }
   }
 
-  var precisionString = this.precision_.toString();
+  var precisionString = this.precision_.toLocaleString("en-US", {maximumFractionDigits: 20});
   var decimalIndex = precisionString.indexOf('.');
   if (decimalIndex == -1) {
     // If the precision is 0 (float) allow any number of decimals,

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -112,9 +112,8 @@ suite('Number Fields', function() {
         {title: 'Float', json: {}, value: 123.456, expectedValue: 123.456},
         {title: '0.01', json: {precision: .01}, value: 123.456,
           expectedValue: 123.46},
-        // TODO(#4105): Un-skip after fixing bug.
         {title: '1e-7', json: {precision: .0000001}, value: 123.00000456,
-          expectedValue: 123.0000046, skip: true},
+          expectedValue: 123.0000046},
         {title: '0.5', json: {precision: .5}, value: 123.456,
           expectedValue: 123.5},
         {title: '1', json: {precision: 1}, value: 123.456,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes issue #4105 

### Proposed Changes

Use toLocaleString when counting decimal places for consistent results around small values. Numbers like 1e-7 automatically get converted to exponential notation with .toString()

### Test Coverage

Test coverage added in separate PR #4115 

Tested on:
* Desktop Chrome 
* Desktop Firefox 
* Desktop Safari 
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Info
There is potentially issues with IE 10 support here since the "locale" and "options" arguments for .toLocaleString are not supported for IE 10. I don't have an easy way to test IE 10 at the moment. 


