### PR TITLE
Fix toolbox sizes not being updated properly

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -367,6 +367,17 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
         this.moveRectToBlock_(block.flyoutRect_, block);
       }
     }
+
+    if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
+        this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP &&
+        !this.targetWorkspace.getToolbox()) {
+      // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
+      // is in the correct position relative to the new absolute edge (ie
+      // toolbox edge).
+      this.targetWorkspace.translate(
+          0, this.targetWorkspace.scrollY + flyoutHeight);
+    }
+
     // Record the height for .getMetrics_ and .position.
     this.height_ = flyoutHeight;
     this.position();

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -376,6 +376,17 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
         button.moveTo(x, y);
       }
     }
+
+    if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
+        this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT &&
+        !this.targetWorkspace.getToolbox()) {
+      // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
+      // is in the correct position relative to the new absolute edge (ie
+      // toolbox edge).
+      this.targetWorkspace.translate(
+          this.targetWorkspace.scrollX + flyoutWidth, 0);
+    }
+
     // Record the width for .getMetrics_ and .position.
     this.width_ = flyoutWidth;
     this.position();

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -234,7 +234,8 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
   if (this.block_.RTL) {
     width = -workspaceSize.x;
   } else {
-    width = workspaceSize.width + workspaceSize.x;
+    width = workspaceSize.width + workspaceSize.x +
+        this.workspace_.flyout_.getWidth();
   }
   var height = workspaceSize.height + doubleBorderWidth * 3;
   var flyout = this.workspace_.getFlyout();
@@ -311,7 +312,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.rootBlock_.setDeletable(false);
     if (flyout) {
       var margin = flyout.CORNER_RADIUS * 2;
-      var x = flyout.getWidth() + margin;
+      var x = this.rootBlock_.RTL ? flyout.getWidth() + margin : margin;
     } else {
       var margin = 16;
       var x = margin;
@@ -369,12 +370,22 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;
+
     for (var b = 0, block; (block = blocks[b]); b++) {
       var blockXY = block.getRelativeToSurfaceXY();
-      var blockHW = block.getHeightWidth();
-      if (blockXY.y + blockHW.height < MARGIN) {
-        // Bump any block that's above the top back inside.
-        block.moveBy(0, MARGIN - blockHW.height - blockXY.y);
+
+      // Bump any block that's above the top back inside.
+      if (blockXY.y < MARGIN) {
+        block.moveBy(0, MARGIN - blockXY.y);
+      }
+      // Bump any block overlapping the flyout back inside.
+      if (block.RTL) {
+        var right = -(this.workspace_.getFlyout().getWidth() + MARGIN);
+        if (blockXY.x > right) {
+          block.moveBy(right - blockXY.x, 0);
+        }
+      } else if (blockXY.x < MARGIN) {
+        block.moveBy(MARGIN - blockXY.x, 0);
       }
     }
   }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -235,7 +235,7 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
     width = -workspaceSize.x;
   } else {
     width = workspaceSize.width + workspaceSize.x +
-        this.workspace_.flyout_.getWidth();
+        this.workspace_.getFlyout().getWidth();
   }
   var height = workspaceSize.height + doubleBorderWidth * 3;
   var flyout = this.workspace_.getFlyout();

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -472,9 +472,19 @@ Blockly.Toolbox.prototype.handleAfterTreeSelected_ = function(
  * @private
  */
 Blockly.Toolbox.prototype.handleNodeSizeChanged_ = function() {
+  // Reposition the workspace so that (0,0) is in the correct position relative
+  // to the new absolute edge (ie toolbox edge).
+  var workspace = this.workspace_;
+  var rect = this.HtmlDiv.getBoundingClientRect();
+  var newX = this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT ?
+      workspace.scrollX + rect.width : 0;
+  var newY = this.toolboxPosition == Blockly.TOOLBOX_AT_TOP ?
+      workspace.scrollY + rect.height : 0;
+  workspace.translate(newX, newY);
+
   // Even though the div hasn't changed size, the visible workspace
   // surface of the workspace has, so we may need to reposition everything.
-  Blockly.svgResize(this.workspace_);
+  Blockly.svgResize(workspace);
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #4138 
Fixes most of #4086 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that the size of the toolbox gets properly updated so that block bumping happens correctly.
![BumpToolbox](https://user-images.githubusercontent.com/25440652/89742119-f372a280-da4b-11ea-877a-7610465d1977.gif)

The problem was actually that the absolute left/top value was not getting updated because the workspace wasn't getting translated.

Also makes it so that mutator blocks get properly bumped away from the top edge and flyout edge:
![BumpMutator](https://user-images.githubusercontent.com/25440652/89742122-f66d9300-da4b-11ea-80f2-ae7d2fef1551.gif)

#4086 is partially fixed. Blocks get moved when the flyout resizes, but only in LTR. And the bubble doesn't get resized.
![ResizeMutatorLTR](https://user-images.githubusercontent.com/25440652/89742293-7811f080-da4d-11ea-8415-eb6aa15b89c1.gif)

![BumpMutatorRTL](https://user-images.githubusercontent.com/25440652/89742146-2ddc3f80-da4c-11ea-91a6-15468f23d85d.gif)

To fix this you should just need to fire a resize event on the workspace whenever the toolbox size changes. That will make should make the bump and bubble resize trigger. But adding workspace resize events seemed a bit outside the scope of this PR, so I decided to punt on it.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bash the bugs.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
I know you've been doing a lot of work on unit tests, but I haven't been able to keep up on it :/ Is this stuff unit-testable now? For now I did some manual testing.

Toolbox Resize LTR:
![BumpToolbox](https://user-images.githubusercontent.com/25440652/89742193-b1962c00-da4c-11ea-95dd-f953e0db0a8a.gif)

Flyout Resize LTR:
![BumpFlyout](https://user-images.githubusercontent.com/25440652/89742198-b65ae000-da4c-11ea-8cd4-25759a8c5aab.gif)

Mutator Bumping LTR:
![BumpMutator](https://user-images.githubusercontent.com/25440652/89742201-be1a8480-da4c-11ea-96b5-b279dec2259b.gif)

Mutator Bumping RTL:
![BumpMutatorRTL](https://user-images.githubusercontent.com/25440652/89742312-9d9efa00-da4d-11ea-9ccf-b8832a5c5f02.gif)

Note that Flyout/Toolbox resizing does cover up the blocks in RTL.
![ResizeToolboxRTL](https://user-images.githubusercontent.com/25440652/89742353-05554500-da4e-11ea-86b9-fe504c89a783.gif)
![ResizeFlyoutRTL](https://user-images.githubusercontent.com/25440652/89742354-071f0880-da4e-11ea-87cf-c3691c84e7cc.gif)

But this also happens when the workspace resizes normally, and will be solved once the aformentioned resize events are added.
![ResizeWorkspace](https://user-images.githubusercontent.com/25440652/89742383-45b4c300-da4e-11ea-9d42-f0a0fabf885a.gif)

Tested on:
 * Desktop Chrome

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Nope!

### Additional Information

<!-- Anything else we should know? -->
1. I love love love the new playground.
2. I might be slow to respond to feedback
