### PR TITLE
Remove img deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5987,15 +5987,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-      "dev": true,
-      "requires": {
-        "pngjs": "^3.0.0"
-      }
-    },
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -6012,12 +6003,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-    },
-    "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,6 @@
     "js-green-licenses": "^2.0.1",
     "jshint": "^2.11.0",
     "mocha": "^6.2.3",
-    "pixelmatch": "^4.0.2",
-    "pngjs": "^3.4.0",
     "rimraf": "^2.6.3",
     "selenium-standalone": "^6.17.0",
     "through2": "^3.0.1",


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Remove unused dev dependencies.

### Proposed Changes

Remove dev dependencies on pngjs and pixelmatch.

### Reason for Changes

These were only used in the pixel-perfect screenshot tests that I recently deleted.

### Additional Information

Brought up by dependabot trying to update pngjs: https://github.com/google/blockly/pull/4148

I will close that issue after this lands.