### PR TITLE
Update link alert description in demos

### DIFF
--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -568,7 +568,7 @@ AppController.prototype.initializeBlocklyStorage = function() {
   BlocklyStorage.HTTPREQUEST_ERROR =
       'There was a problem with the request.\n';
   BlocklyStorage.LINK_ALERT =
-      'Share your blocks with this link:\n\n%1';
+      'Share your blocks with this public link. We'\ll delete them if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.:\n\n%1';
   BlocklyStorage.HASH_ERROR =
       'Sorry, "%1" doesn\'t correspond with any saved Blockly file.';
   BlocklyStorage.XML_ERROR = 'Could not load your saved file.\n' +

--- a/demos/code/msg/en.js
+++ b/demos/code/msg/en.js
@@ -17,7 +17,7 @@ var MSG = {
   listVariable: "list",
   textVariable: "text",
   httpRequestError: "There was a problem with the request.",
-  linkAlert: "Share your blocks with this link:\n\n%1",
+  linkAlert: "Share your blocks with this public link. We\'ll delete them if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.:\n\n%1",
   hashError: "Sorry, '%1' doesn't correspond with any saved program.",
   xmlError: "Could not load your saved file. Perhaps it was created with a different version of Blockly?",
   badXml: "Error parsing XML:\n%1\n\nSelect 'OK' to abandon your changes or 'Cancel' to further edit the XML."

--- a/demos/storage/index.html
+++ b/demos/storage/index.html
@@ -37,7 +37,7 @@
   <script>
     if ('BlocklyStorage' in window) {
       BlocklyStorage.HTTPREQUEST_ERROR = 'There was a problem with the request.\n';
-      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll store them for a year. Please be sure not to include any private information.\n\n%1';
+      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll if not used for a year. They are not associated with your account and handled as per Google's Privacy Policy. Please be sure not to include any private information.\n\n%1';
       BlocklyStorage.HASH_ERROR = 'Sorry, "%1" doesn\'t correspond with any saved Blockly file.';
       BlocklyStorage.XML_ERROR = 'Could not load your saved file.\n'+
           'Perhaps it was created with a different version of Blockly?';

--- a/demos/storage/index.html
+++ b/demos/storage/index.html
@@ -37,7 +37,7 @@
   <script>
     if ('BlocklyStorage' in window) {
       BlocklyStorage.HTTPREQUEST_ERROR = 'There was a problem with the request.\n';
-      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll if not used for a year. They are not associated with your account and handled as per Google's Privacy Policy. Please be sure not to include any private information.\n\n%1';
+      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.\n\n%1';
       BlocklyStorage.HASH_ERROR = 'Sorry, "%1" doesn\'t correspond with any saved Blockly file.';
       BlocklyStorage.XML_ERROR = 'Could not load your saved file.\n'+
           'Perhaps it was created with a different version of Blockly?';

--- a/demos/storage/index.html
+++ b/demos/storage/index.html
@@ -37,7 +37,7 @@
   <script>
     if ('BlocklyStorage' in window) {
       BlocklyStorage.HTTPREQUEST_ERROR = 'There was a problem with the request.\n';
-      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.\n\n%1';
+      BlocklyStorage.LINK_ALERT = 'Share your blocks with the below public link. We\'ll delete them if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.\n\n%1';
       BlocklyStorage.HASH_ERROR = 'Sorry, "%1" doesn\'t correspond with any saved Blockly file.';
       BlocklyStorage.XML_ERROR = 'Could not load your saved file.\n'+
           'Perhaps it was created with a different version of Blockly?';


### PR DESCRIPTION
Update the alerts in the three demos that have blocks storage on Google side. This is inline with the verbiage agreed with legal/privacy teams.