### PR TITLE
Add missing workspace cleanup in astnode tests

### DIFF
--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -88,7 +88,6 @@ suite('ASTNode', function() {
       fieldWithOutput: fieldWithOutput,
       valueInput: valueInput
     };
-    sinon.stub(Blockly, "getMainWorkspace").returns(new Blockly.Workspace());
   });
   teardown(function() {
     sharedTestTeardown.call(this);
@@ -308,19 +307,8 @@ suite('ASTNode', function() {
       var outputNextBlock = this.workspace.newBlock('output_next');
       this.blocks.secondBlock = secondBlock;
       this.blocks.outputNextBlock = outputNextBlock;
-
-
     });
     teardown(function() {
-      delete this.blocks.noNextConnection;
-      delete this.blocks.fieldAndInputs;
-      delete this.blocks.twoFields;
-      delete this.blocks.fieldAndInputs2;
-      delete this.blocks.noPrevConnection;
-      delete this.blocks.dummyInput;
-      delete this.blocks.dummyInputValue;
-      delete this.blocks.fieldWithOutput2;
-
       delete Blockly.Blocks['output_next'];
       delete Blockly.Blocks['fields_and_input2'];
       delete Blockly.Blocks['two_fields'];
@@ -337,7 +325,7 @@ suite('ASTNode', function() {
         this.blocks.singleBlock = singleBlock;
       });
       teardown(function() {
-        delete this.blocks.singleBlock;
+        workspaceTeardown.call(this, this.singleBlockWorkspace);
       });
 
       test('fromPreviousToBlock', function() {
@@ -537,7 +525,7 @@ suite('ASTNode', function() {
         this.emptyWorkspace = new Blockly.Workspace();
       });
       teardown(function() {
-        delete this.emptyWorkspace;
+        workspaceTeardown.call(this, this.emptyWorkspace);
       });
 
       test('fromInputToOutput', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4080
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Removes unecessary delete calls
- Remove unecessary stub call
- Adds missing workspace dispose cleanup (`workspaceTeardown`) 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Cleanup of tests.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

