### PR TITLE
Replace console "WARNING" log calls with warn call

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -311,7 +311,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
           }
           if (e) {
             if (!e.group && object) {
-              console.log('WARNING: Moved object in bounds but there was no' +
+              console.warn('Moved object in bounds but there was no' +
                   ' event group. This may break undo.');
             }
             if (oldGroup !== null) {

--- a/core/utils.js
+++ b/core/utils.js
@@ -250,7 +250,7 @@ Blockly.utils.checkMessageReferences = function(message) {
   for (var i = 0; i < m.length; i++) {
     var msgKey = m[i].toUpperCase();
     if (msgTable[msgKey.slice(6, -1)] == undefined) {
-      console.log('WARNING: No message string for ' + m[i] + ' in ' + message);
+      console.warn('No message string for ' + m[i] + ' in ' + message);
       validSoFar = false;  // Continue to report other errors.
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Changing `console.log` calls that start with "WARNING:" with `console.war` and removing "WARNING".
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Using `console.warn` seems to better fit intention.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

