### PR TITLE
Add expiration handler

### DIFF
--- a/appengine/expiration.py
+++ b/appengine/expiration.py
@@ -25,11 +25,13 @@ import datetime
 
 from google.cloud import ndb
 
+
+EXPIRATION_DAYS = 365
+# Limit the query to avoid timeouts.
+QUERY_LIMIT = 1000
+
 def delete_expired():
-  # Delete entries that have not been accessed in more than a year.
-  EXPIRATION_DAYS = 365
-  # Limit the query to avoid timeouts.
-  QUERY_LIMIT = 1000
+  """Deletes entries that have not been accessed in more than a year."""
   bestBefore = datetime.datetime.utcnow() - datetime.timedelta(days=EXPIRATION_DAYS)
   client = ndb.Client()
   with client.context():

--- a/appengine/expiration.py
+++ b/appengine/expiration.py
@@ -1,0 +1,49 @@
+"""
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Delete expired XML.
+"""
+
+__author__ = "fenichel@google.com (Rachel Fenichel)"
+
+
+import storage
+import datetime
+
+from google.cloud import ndb
+
+def delete_expired():
+  # Delete entries that have not been accessed in more than a year.
+  EXPIRATION_DAYS = 365
+  # Limit the query to avoid timeouts.
+  QUERY_LIMIT = 1000
+  bestBefore = datetime.datetime.utcnow() - datetime.timedelta(days=EXPIRATION_DAYS)
+  client = ndb.Client()
+  with client.context():
+    query = storage.Xml.query(storage.Xml.last_accessed < bestBefore)
+    results = query.fetch(limit=QUERY_LIMIT, keys_only=True)
+    for x in results:
+      x.delete()
+
+
+def app(environ, start_response):
+  out = ""
+  headers = [
+    ("Content-Type", "text/plain")
+  ]
+  start_response("200 OK", headers)
+  delete_expired()
+  return [out.encode("utf-8")]

--- a/appengine/main.py
+++ b/appengine/main.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import storage
+import expiration
 
 
 # Route to requested handler.
@@ -23,6 +24,8 @@ def app(environ, start_response):
     return redirect(environ, start_response)
   if environ["PATH_INFO"] == "/storage":
     return storage.app(environ, start_response)
+  if environ["PATH_INFO"] == "/expiration":
+    return retention_job.app(environ, start_response)
   start_response("404 Not Found", [])
   return [b"Page not found."]
 

--- a/appengine/main.py
+++ b/appengine/main.py
@@ -25,7 +25,7 @@ def app(environ, start_response):
   if environ["PATH_INFO"] == "/storage":
     return storage.app(environ, start_response)
   if environ["PATH_INFO"] == "/expiration":
-    return retention_job.app(environ, start_response)
+    return expiration.app(environ, start_response)
   start_response("404 Not Found", [])
   return [b"Page not found."]
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3899 

### Proposed Changes

Add an expiration handler that gets keys for expired items (last accessed more than a year ago) and deletes them.

I'm going to set up a cron job to hit this endpoint. But we don't need to start running that yet, since nothing expires for at least a year from now.

### Reason for Changes

Data retention.

### Test Coverage
Tested locally:
- dev_appserver
- local datastore
- set retention window to a few hours instead of a year

### Documentation

None

### Additional Information

Remaining work:
- handler to add dates to all existing entries
- cron.yaml