### PR TITLE
Use camel case for registry types

### DIFF
--- a/core/registry.js
+++ b/core/registry.js
@@ -80,14 +80,13 @@ Blockly.registry.Type.TOOLBOX = new Blockly.registry.Type('toolbox');
 /** @type {!Blockly.registry.Type<Blockly.Theme>} */
 Blockly.registry.Type.THEME = new Blockly.registry.Type('theme');
 
-
 /** @type {!Blockly.registry.Type<Blockly.IFlyout>} */
 Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX =
-    new Blockly.registry.Type('flyouts-vertical-toolbox');
+    new Blockly.registry.Type('flyoutsVerticalToolbox');
 
 /** @type {!Blockly.registry.Type<Blockly.IFlyout>} */
 Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX =
-    new Blockly.registry.Type('flyouts-horizontal-toolbox');
+    new Blockly.registry.Type('flyoutsHorizontalToolbox');
 
 /**
  * Registers a class based on a type and name.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Changes registry types to use camel case.

### Reason for Changes

1. Consistency - some types already used camelCase and we shouldn't mix conventions
2. Eliminates the need to quote property names. In the following example:

```
const defaultOptions = {
    toolbox: toolboxCategories,
    plugins: {
      'toolbox': ContinuousToolbox,
      'flyouts-vertical-toolbox': ContinuousFlyout
    },
  };
```

the quotation marks are required around `flyouts-vertical-toolbox` or else a JavaScript syntax error occurs. By using camel case, we avoid this problem.

These two registry types are not yet in master, so this isn't a breaking change.
