### PR TITLE
Update css

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -44,7 +44,7 @@ Blockly.Options = function(options) {
     var toolboxDef = options['toolbox'];
     if (toolboxDef && !Array.isArray(toolboxDef['contents'])) {
       toolboxDef = /** @type {Node} */
-          (Blockly.Options.parseToolboxTree(toolboxDef || null));
+          (Blockly.utils.toolbox.parseToolboxTree(toolboxDef || null));
     }
     var toolboxJsonDef = /** @type {!Blockly.utils.toolbox.ToolboxJson} */
         (Blockly.utils.toolbox.convertToolboxToJSON(toolboxDef));
@@ -363,35 +363,4 @@ Blockly.Options.parseThemeOptions_ = function(options) {
   }
   return Blockly.Theme.defineTheme(theme.name ||
       ('builtin' + Blockly.utils.IdGenerator.getNextUniqueId()), theme);
-};
-
-/**
- * Parse the provided toolbox tree into a consistent DOM format.
- * @param {?Node|?string} toolboxDef DOM tree of blocks, or text representation
- *    of same.
- * @return {?Node} DOM tree of blocks, or null.
- */
-Blockly.Options.parseToolboxTree = function(toolboxDef) {
-  if (toolboxDef) {
-    if (typeof toolboxDef != 'string') {
-      if (Blockly.utils.userAgent.IE && toolboxDef.outerHTML) {
-        // In this case the tree will not have been properly built by the
-        // browser. The HTML will be contained in the element, but it will
-        // not have the proper DOM structure since the browser doesn't support
-        // XSLTProcessor (XML -> HTML).
-        toolboxDef = toolboxDef.outerHTML;
-      } else if (!(toolboxDef instanceof Element)) {
-        toolboxDef = null;
-      }
-    }
-    if (typeof toolboxDef == 'string') {
-      toolboxDef = Blockly.Xml.textToDom(toolboxDef);
-      if (toolboxDef.nodeName.toLowerCase() != 'xml') {
-        throw TypeError('Toolbox should be an <xml> document.');
-      }
-    }
-  } else {
-    toolboxDef = null;
-  }
-  return toolboxDef;
 };

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -46,7 +46,7 @@ Blockly.ToolboxCategory = function(categoryDef, toolbox, opt_parent) {
    * @type {boolean}
    * @private
    */
-  this.hasChildren_ = Blockly.utils.toolbox.hasCategories(categoryDef['contents']);;
+  this.hasChildren_ = Blockly.utils.toolbox.hasCategories(categoryDef['contents'] || []);
 
   /**
    * The parent of the category.

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -15,9 +15,9 @@ goog.provide('Blockly.ToolboxCategory');
 goog.require('Blockly.CollapsibleToolboxItem');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.object');
+goog.require('Blockly.utils.toolbox');
 
 goog.requireType('Blockly.ToolboxItem');
-goog.requireType('Blockly.utils.toolbox');
 
 
 /**
@@ -41,16 +41,13 @@ Blockly.ToolboxCategory = function(categoryDef, toolbox, opt_parent) {
    */
   this.name_ = Blockly.utils.replaceMessageReferences(categoryDef['name']);
 
-  var contents = categoryDef['contents'];
-
   /**
    * True if this category has subcategories, false otherwise.
    * @type {boolean}
    * @private
    */
-  this.hasChildren_ = contents && contents.length &&
-    typeof contents != 'string' &&
-    contents[0].kind.toUpperCase() == 'CATEGORY';
+  this.hasChildren_ = Blockly.utils.toolbox.hasCategories(categoryDef['contents']);;
+
   /**
    * The parent of the category.
    * @type {?Blockly.ToolboxCategory}
@@ -675,7 +672,7 @@ Blockly.ToolboxCategory.prototype.getChildToolboxItems = function() {
  * Updates the contents to be displayed in the flyout.
  * If the flyout is open when the contents are updated, refreshSelection on the
  * toolbox must also be called.
- * @param {!Blockly.utils.toolbox.ToolboxDefinition|string} contents The contents
+ * @param {!Blockly.utils.toolbox.ToolboxDefinition} contents The contents
  *     to be displayed in the flyout. A string can be supplied to create a
  *     dynamic category.
  * @public
@@ -701,6 +698,89 @@ Blockly.ToolboxCategory.prototype.updateFlyoutContents = function(contents) {
 Blockly.ToolboxCategory.prototype.dispose = function() {
   Blockly.utils.dom.removeNode(this.htmlDiv_);
 };
+
+/**
+ * CSS for Toolbox.  See css.js for use.
+ */
+Blockly.Css.register([
+  /* eslint-disable indent */
+  '.blocklyToolboxCategory {',
+    'padding-bottom: 3px',
+  '}',
+
+  '.blocklyToolboxCategory:not(.blocklyTreeSelected):hover {',
+    'background-color: rgba(255, 255, 255, 0.2);',
+  '}',
+
+  '.blocklyToolboxDiv[layout="h"] .blocklyToolboxCategory {',
+    'margin: 1px 5px 1px 0;',
+  '}',
+
+  '.blocklyToolboxDiv[dir="RTL"][layout="h"] .blocklyToolboxCategory {',
+    'margin: 1px 0 1px 5px;',
+  '}',
+
+  '.blocklyTreeRow {',
+    'height: 22px;',
+    'line-height: 22px;',
+    'padding-right: 8px;',
+    'pointer-events: none',
+    'white-space: nowrap;',
+  '}',
+
+  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeRow {',
+    'margin-left: 8px;',
+    'padding-right: 0px',
+  '}',
+
+  '.blocklyTreeIcon {',
+    'background-image: url(<<<PATH>>>/sprites.png);',
+    'height: 16px;',
+    'vertical-align: middle;',
+    'visibility: hidden;',
+    'width: 16px;',
+  '}',
+
+  '.blocklyTreeIconClosed {',
+    'background-position: -32px -1px;',
+  '}',
+
+  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeIconClosed {',
+    'background-position: 0 -1px;',
+  '}',
+
+  '.blocklyTreeSelected>.blocklyTreeIconClosed {',
+    'background-position: -32px -17px;',
+  '}',
+
+  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeSelected>.blocklyTreeIconClosed {',
+    'background-position: 0 -17px;',
+  '}',
+
+  '.blocklyTreeIconOpen {',
+    'background-position: -16px -1px;',
+  '}',
+
+  '.blocklyTreeSelected>.blocklyTreeIconOpen {',
+    'background-position: -16px -17px;',
+  '}',
+
+  '.blocklyTreeLabel {',
+    'cursor: default;',
+    'font: 16px sans-serif;',
+    'padding: 0 3px;',
+    'vertical-align: middle;',
+  '}',
+
+  '.blocklyToolboxDelete .blocklyTreeLabel {',
+    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
+  '}',
+
+  '.blocklyTreeSelected .blocklyTreeLabel {',
+    'color: #fff;',
+  '}'
+  /* eslint-enable indent */
+]);
 
 Blockly.registry.register(Blockly.registry.Type.TOOLBOX_ITEM,
     Blockly.ToolboxCategory.registrationName, Blockly.ToolboxCategory);

--- a/core/toolbox/separator.js
+++ b/core/toolbox/separator.js
@@ -83,5 +83,27 @@ Blockly.ToolboxSeparator.prototype.dispose = function() {
   Blockly.utils.dom.removeNode(this.htmlDiv_);
 };
 
+/**
+ * CSS for Toolbox.  See css.js for use.
+ */
+Blockly.Css.register([
+  /* eslint-disable indent */
+  '.blocklyTreeSeparator {',
+    'border-bottom: solid #e5e5e5 1px;',
+    'height: 0;',
+    'margin: 5px 0;',
+  '}',
+
+  '.blocklyToolboxDiv[layout="h"] .blocklyTreeSeparator {',
+    'border-right: solid #e5e5e5 1px;',
+    'border-bottom: none;',
+    'height: auto;',
+    'margin: 0 5px 0 5px;',
+    'padding: 5px 0;',
+    'width: 0;',
+  '}',
+  /* eslint-enable indent */
+]);
+
 Blockly.registry.register(Blockly.registry.Type.TOOLBOX_ITEM,
     Blockly.ToolboxSeparator.registrationName, Blockly.ToolboxSeparator);

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -381,6 +381,8 @@ Blockly.Toolbox.prototype.renderContents_ = function(toolboxDef) {
  * Creates and renders the toolbox item.
  * @param {Blockly.utils.toolbox.ToolboxItem} childIn Any information that
  *    can be used to create an item in the toolbox.
+ * @param {!DocumentFragment} fragment The document fragment to add the child
+ *     toolbox elements to.
  */
 Blockly.Toolbox.prototype.renderToolboxItem_ = function(childIn, fragment) {
   var ToolboxItemClass = Blockly.registry.getClass(

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -906,22 +906,6 @@ Blockly.Css.register([
     '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
   '}',
 
-  '.blocklyToolboxCategory {',
-    'padding-bottom: 3px',
-  '}',
-
-  '.blocklyToolboxCategory:not(.blocklyTreeSelected):hover {',
-    'background-color: rgba(255, 255, 255, 0.2);',
-  '}',
-
-  '.blocklyToolboxDiv[layout="h"] .blocklyToolboxCategory {',
-    'margin: 1px 5px 1px 0;',
-  '}',
-
-  '.blocklyToolboxDiv[dir="RTL"][layout="h"] .blocklyToolboxCategory {',
-    'margin: 1px 0 1px 5px;',
-  '}',
-
   '.blocklyToolboxContents {',
     'display: flex;',
     'flex-wrap: wrap;',
@@ -931,82 +915,6 @@ Blockly.Css.register([
   '.blocklyToolboxContents:focus {',
     'outline: none;',
   '}',
-
-  '.blocklyTreeRow {',
-    'height: 22px;',
-    'line-height: 22px;',
-    'padding-right: 8px;',
-    'pointer-events: none',
-    'white-space: nowrap;',
-  '}',
-
-  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeRow {',
-    'margin-left: 8px;',
-    'padding-right: 0px',
-  '}',
-
-
-  '.blocklyTreeSeparator {',
-    'border-bottom: solid #e5e5e5 1px;',
-    'height: 0;',
-    'margin: 5px 0;',
-  '}',
-
-  '.blocklyToolboxDiv[layout="h"] .blocklyTreeSeparator {',
-    'border-right: solid #e5e5e5 1px;',
-    'border-bottom: none;',
-    'height: auto;',
-    'margin: 0 5px 0 5px;',
-    'padding: 5px 0;',
-    'width: 0;',
-  '}',
-
-  '.blocklyTreeIcon {',
-    'background-image: url(<<<PATH>>>/sprites.png);',
-    'height: 16px;',
-    'vertical-align: middle;',
-    'visibility: hidden;',
-    'width: 16px;',
-  '}',
-
-  '.blocklyTreeIconClosed {',
-    'background-position: -32px -1px;',
-  '}',
-
-  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeIconClosed {',
-    'background-position: 0 -1px;',
-  '}',
-
-  '.blocklyTreeSelected>.blocklyTreeIconClosed {',
-    'background-position: -32px -17px;',
-  '}',
-
-  '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeSelected>.blocklyTreeIconClosed {',
-    'background-position: 0 -17px;',
-  '}',
-
-  '.blocklyTreeIconOpen {',
-    'background-position: -16px -1px;',
-  '}',
-
-  '.blocklyTreeSelected>.blocklyTreeIconOpen {',
-    'background-position: -16px -17px;',
-  '}',
-
-  '.blocklyTreeLabel {',
-    'cursor: default;',
-    'font: 16px sans-serif;',
-    'padding: 0 3px;',
-    'vertical-align: middle;',
-  '}',
-
-  '.blocklyToolboxDelete .blocklyTreeLabel {',
-    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
-  '}',
-
-  '.blocklyTreeSelected .blocklyTreeLabel {',
-    'color: #fff;',
-  '}'
   /* eslint-enable indent */
 ]);
 

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -256,7 +256,7 @@ Blockly.utils.toolbox.addAttributes_ = function(node, obj) {
 };
 
 /**
- * Whether or not the toolbox definition has categories or not.
+ * Whether or not the toolbox definition has categories.
  * @param {!Blockly.utils.toolbox.ToolboxDefinition} toolboxDef The
  *     definition of the toolbox. Either in xml or JSON.
  * @return {boolean} True if the toolbox has categories.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1709,7 +1709,7 @@ Blockly.WorkspaceSvg.prototype.showContextMenu = function(e) {
 Blockly.WorkspaceSvg.prototype.updateToolbox = function(toolboxDef) {
   var toolboxContents = (toolboxDef && toolboxDef['contents']) || toolboxDef;
   if (!Array.isArray(toolboxContents)) {
-    toolboxContents = Blockly.Options.parseToolboxTree(toolboxContents);
+    toolboxContents = Blockly.utils.toolbox.parseToolboxTree(toolboxContents);
   }
   var parsedToolboxDef = Blockly.utils.toolbox.convertToolboxToJSON(toolboxContents);
   if (!toolboxDef) {

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -110,7 +110,7 @@ suite('WorkspaceSvg', function() {
       }.bind(this), 'Existing toolbox has categories.  Can\'t change mode.');
     });
     test('Passing in string as toolboxdef', function() {
-      var parseToolboxFake = sinon.spy(Blockly.Options, 'parseToolboxTree');
+      var parseToolboxFake = sinon.spy(Blockly.utils.toolbox, 'parseToolboxTree');
       this.workspace.updateToolbox('<xml><category name="something"></category></xml>');
       sinon.assert.calledOnce(parseToolboxFake);
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
1. Adds ability for someone to define kind on the toolbox definition. Ex:
```
{
  'kind': 'categoryToolbox',
  'contents': []
}
```

```
<xml kind='flyoutToolbox'></xml>
```
2. Search the entire toolbox for a category instead of just the first value.
3. Moves CSS to category and separator.
4. Moves `parseToolboxTree` to the toolbox utils.

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
