### PR TITLE
Capture expected warnings in navigation modify test

### DIFF
--- a/tests/mocha/navigation_modify_test.js
+++ b/tests/mocha/navigation_modify_test.js
@@ -5,6 +5,15 @@
  */
 
 suite('Insert/Modify', function() {
+  function assertModifyFails() {
+    var modifyResult;
+    var warnings = captureWarnings(function() {
+      modifyResult = Blockly.navigation.modify_();
+    });
+    chai.assert.isFalse(modifyResult);
+    chai.assert.equal(warnings.length, 1,
+        'Expecting 1 warnings for why modify failed.');
+  }
   setup(function() {
     sharedTestSetup.call(this);
     var xmlText = '<xml xmlns="https://developers.google.com/blockly/xml">' +
@@ -52,7 +61,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createWorkspaceNode(this.workspace,
                 new Blockly.utils.Coordinate(0, 0)));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on compatible connection', function() {
         this.workspace.getCursor().setCurNode(
@@ -74,7 +83,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_1.outputConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
         chai.assert.isNull(this.stack_block_1.getNextBlock());
       });
       test('Cursor on block', function() {
@@ -103,14 +112,14 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_2.previousConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
         chai.assert.isNull(this.stack_block_1.getPreviousBlock());
       });
       test('Cursor on really incompatible connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_1.outputConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
         chai.assert.isNull(this.stack_block_1.getNextBlock());
       });
       test('Cursor on block', function() {
@@ -124,7 +133,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createBlockNode(
                 this.row_block_1));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
         chai.assert.isNull(this.stack_block_1.getPreviousBlock());
       });
     });
@@ -156,7 +165,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_1.previousConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on block', function() {
         this.workspace.getCursor().setCurNode(
@@ -195,7 +204,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_1.outputConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
         chai.assert.isNull(this.row_block_1.getParent());
       });
 
@@ -218,13 +227,13 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.outputConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on really incompatible connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_1.previousConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on block', function() {
         this.workspace.getCursor().setCurNode(
@@ -329,7 +338,7 @@ suite('Insert/Modify', function() {
       this.workspace.getCursor().setCurNode(
           Blockly.ASTNode.createWorkspaceNode(
               this.workspace, new Blockly.utils.Coordinate(100, 100)));
-      chai.assert.isFalse(Blockly.navigation.modify_());
+      assertModifyFails();
     });
   });
 
@@ -348,8 +357,7 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createWorkspaceNode(
                 this.workspace, new Blockly.utils.Coordinate(100, 100)));
-        chai.assert.isFalse(Blockly.navigation.modify_());
-
+        assertModifyFails();
       });
     });
     suite('Marked stack block', function() {
@@ -362,25 +370,25 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createBlockNode(
                 this.row_block_1));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on stack block', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createBlockNode(
                 this.stack_block_1));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on next connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_2.nextConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on previous connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.stack_block_2.previousConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
     });
     suite('Marked row block', function() {
@@ -393,25 +401,25 @@ suite('Insert/Modify', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createBlockNode(
                 this.stack_block_1));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on row block', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createBlockNode(
                 this.row_block_1));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on value input connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.inputList[0].connection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
       test('Cursor on output connection', function() {
         this.workspace.getCursor().setCurNode(
             Blockly.ASTNode.createConnectionNode(
                 this.row_block_2.outputConnection));
-        chai.assert.isFalse(Blockly.navigation.modify_());
+        assertModifyFails();
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4194 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Capture expected warnings logged when `modify_` call fails in `navigation_modify_test`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Cleans up console logs.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
