### PR TITLE
Update test asserts on stubs to use sinon asserts

### DIFF
--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -33,7 +33,7 @@ suite('Dropdown Fields', function() {
       chai.assert.throws(function() {
         new Blockly.FieldDropdown([1, 2, 3]);
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Array Items with Invalid IDs', function() {
@@ -41,7 +41,7 @@ suite('Dropdown Fields', function() {
       chai.assert.throws(function() {
         new Blockly.FieldDropdown([['1', 1], ['2', 2], ['3', 3]]);
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Array Items with Invalid Content', function() {
@@ -49,7 +49,7 @@ suite('Dropdown Fields', function() {
       chai.assert.throws(function() {
         new Blockly.FieldDropdown([[1, '1'], [2, '2'], [3, '3']]);
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Text Dropdown', function() {
@@ -99,7 +99,7 @@ suite('Dropdown Fields', function() {
       chai.assert.throws(function() {
         Blockly.FieldDropdown.fromJson({ options: [1, 2, 3] });
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Array Items with Invalid IDs', function() {
@@ -108,7 +108,7 @@ suite('Dropdown Fields', function() {
         Blockly.FieldDropdown.fromJson(
             { options:[['1', 1], ['2', 2], ['3', 3]] });
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Array Items with Invalid Content', function() {
@@ -117,7 +117,7 @@ suite('Dropdown Fields', function() {
         Blockly.FieldDropdown.fromJson(
             { options:[[1, '1'], [2, '2'], [3, '3']] });
       });
-      chai.assert(stub.calledThrice);
+      sinon.assert.calledThrice(stub);
       stub.restore();
     });
     test('Text Dropdown', function() {

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -43,7 +43,7 @@ suite('Abstract Fields', function() {
       var field = new FieldDefault();
       var stub = sinon.stub(console, 'warn');
       chai.assert.isTrue(field.isSerializable());
-      chai.assert(stub.calledOnce);
+      sinon.assert.calledOnce(stub);
       stub.restore();
     });
     test('Editable False, Serializable Default(false)', function() {
@@ -98,16 +98,16 @@ suite('Abstract Fields', function() {
     test('Null', function() {
       addSpies(this.field);
       this.field.setValue(null);
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('No Validators, Dirty (Default)', function() {
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.forceRerender);
     });
     test('No Validators, Not Dirty', function() {
       this.field.doValueUpdate_ = function(newValue) {
@@ -116,9 +116,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('Class Validator Returns Invalid, Not Dirty (Default)', function() {
       this.field.doClassValidation_ = function() {
@@ -126,9 +126,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('Class Validator Returns Invalid, Dirty', function() {
       this.field.doClassValidation_ = function() {
@@ -139,9 +139,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.calledOnce);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.forceRerender);
     });
     test('Class Validator Returns Valid, Not Dirty', function() {
       this.field.doClassValidation_ = function(newValue) {
@@ -152,9 +152,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('Class Validator Returns Valid, Dirty (Default)', function() {
       this.field.doClassValidation_ = function(newValue) {
@@ -162,9 +162,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.forceRerender);
     });
     test('Local Validator Returns Invalid, Not Dirty (Default)', function() {
       this.field.setValidator(function() {
@@ -172,9 +172,9 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('Local Validator Returns Invalid, Dirty', function() {
       this.field.setValidator(function() {
@@ -185,9 +185,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.calledOnce);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.forceRerender);
     });
     test('Local Validator Returns Valid, Not Dirty', function() {
       this.field.setValidator(function(newValue) {
@@ -198,9 +198,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('Local Validator Returns Valid, Dirty (Default)', function() {
       this.field.setValidator(function(newValue) {
@@ -208,17 +208,17 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
-      chai.assert(this.field.forceRerender.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.forceRerender);
     });
     test('New Value Matches Old Value', function() {
       this.field.setValue('value');
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Class)Validates to Old Value', function() {
       this.field.setValue('value');
@@ -227,9 +227,9 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('notValue');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Local)Validates to Old Value', function() {
       this.field.setValue('value');
@@ -238,9 +238,9 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('notValue');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.notCalled);
-      chai.assert(this.field.forceRerender.notCalled);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Class)Validates to not Old Value', function() {
       this.field.setValue('value');
@@ -249,8 +249,8 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('New Value (Local)Validates to not Old Value', function() {
       this.field.setValue('value');
@@ -259,8 +259,8 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Class Validator Returns Null', function() {
       this.field.doClassValidation_ = function() {
@@ -268,8 +268,8 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
     });
     test('Class Validator Returns Same', function() {
       this.field.doClassValidation_ = function(newValue) {
@@ -277,8 +277,8 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Class Validator Returns Different', function() {
       this.field.doClassValidation_ = function() {
@@ -286,16 +286,16 @@ suite('Abstract Fields', function() {
       };
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Class Validator Returns Undefined', function() {
       this.field.doClassValidation_ = function() {};
       addSpies(this.field);
       this.field.setValue('value');
       chai.assert.equal(this.field.getValue(), 'value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Local Validator Returns Null', function() {
       this.field.setValidator(function() {
@@ -303,8 +303,8 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.calledOnce);
-      chai.assert(this.field.doValueUpdate_.notCalled);
+      sinon.assert.calledOnce(this.field.doValueInvalid_);
+      sinon.assert.notCalled(this.field.doValueUpdate_);
     });
     test('Local Validator Returns Same', function() {
       this.field.setValidator(function(newValue) {
@@ -312,8 +312,8 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Local Validator Returns Different', function() {
       this.field.setValidator(function() {
@@ -321,16 +321,16 @@ suite('Abstract Fields', function() {
       });
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
     test('Local Validator Returns Undefined', function() {
       this.field.setValidator(function() {});
       addSpies(this.field);
       this.field.setValue('value');
       chai.assert.equal(this.field.getValue(), 'value');
-      chai.assert(this.field.doValueInvalid_.notCalled);
-      chai.assert(this.field.doValueUpdate_.calledOnce);
+      sinon.assert.notCalled(this.field.doValueInvalid_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
   });
   suite('Customization', function() {

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -125,7 +125,7 @@ suite('Variable Fields', function() {
       var stub = sinon.stub(console, 'warn');
       variableField.setValue(undefined);
       assertValue(variableField, 'name1');
-      chai.assert(stub.calledOnce);
+      sinon.assert.calledOnce(stub);
       stub.restore();
     });
     test('New Variable ID', function() {
@@ -147,7 +147,7 @@ suite('Variable Fields', function() {
       var stub = sinon.stub(console, 'warn');
       variableField.setValue('id1');
       assertValue(variableField, 'name1');
-      chai.assert(stub.calledOnce);
+      sinon.assert.calledOnce(stub);
       stub.restore();
     });
   });

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -145,11 +145,11 @@ suite('Inputs', function() {
         var initSpy = sinon.spy(field, 'init');
 
         this.dummy.insertFieldAt(0, field);
-        chai.assert(setBlockSpy.calledOnce);
+        sinon.assert.calledOnce(setBlockSpy);
         chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
-        chai.assert(initSpy.calledOnce);
-        chai.assert(this.renderStub.calledOnce);
-        chai.assert(this.bumpNeighboursStub.calledOnce);
+        sinon.assert.calledOnce(initSpy);
+        sinon.assert.calledOnce(this.renderStub);
+        sinon.assert.calledOnce(this.bumpNeighboursStub);
 
         setBlockSpy.restore();
         initSpy.restore();
@@ -164,11 +164,11 @@ suite('Inputs', function() {
         this.block.rendered = false;
 
         this.dummy.insertFieldAt(0, field);
-        chai.assert(setBlockSpy.calledOnce);
+        sinon.assert.calledOnce(setBlockSpy);
         chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
-        chai.assert(initModelSpy.calledOnce);
-        chai.assert(this.renderStub.notCalled);
-        chai.assert(this.bumpNeighboursStub.notCalled);
+        sinon.assert.calledOnce(initModelSpy);
+        sinon.assert.notCalled(this.renderStub);
+        sinon.assert.notCalled(this.bumpNeighboursStub);
 
         setBlockSpy.restore();
         initModelSpy.restore();
@@ -190,9 +190,9 @@ suite('Inputs', function() {
       this.bumpNeighboursStub.resetHistory();
 
       this.dummy.removeField('FIELD');
-      chai.assert(disposeSpy.calledOnce);
-      chai.assert(this.renderStub.calledOnce);
-      chai.assert(this.bumpNeighboursStub.calledOnce);
+      sinon.assert.calledOnce(disposeSpy);
+      sinon.assert.calledOnce(this.renderStub);
+      sinon.assert.calledOnce(this.bumpNeighboursStub);
     });
     test('Headless', function() {
       var field = new Blockly.FieldLabel('field');
@@ -205,9 +205,9 @@ suite('Inputs', function() {
       this.block.rendered = false;
 
       this.dummy.removeField('FIELD');
-      chai.assert(disposeSpy.calledOnce);
-      chai.assert(this.renderStub.notCalled);
-      chai.assert(this.bumpNeighboursStub.notCalled);
+      sinon.assert.calledOnce(disposeSpy);
+      sinon.assert.notCalled(this.renderStub);
+      sinon.assert.notCalled(this.bumpNeighboursStub);
     });
   });
   suite('Field Ordering/Manipulation', function() {

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -386,7 +386,7 @@ suite('Navigation', function() {
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.N;
       var isHandled = Blockly.navigation.onKeyPress(this.mockEvent);
       chai.assert.isFalse(isHandled);
-      chai.assert.isFalse(field.onBlocklyAction.calledOnce);
+      sinon.assert.notCalled(field.onBlocklyAction);
 
       field.onBlocklyAction.restore();
     });

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -272,7 +272,7 @@ suite('Navigation', function() {
       sinon.spy(this.workspace.getCursor(), 'prev');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.W;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.isTrue(this.workspace.getCursor().prev.calledOnce);
+      sinon.assert.calledOnce(this.workspace.getCursor().prev);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_WS);
       this.workspace.getCursor().prev.restore();
@@ -283,7 +283,7 @@ suite('Navigation', function() {
       sinon.spy(cursor, 'next');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.S;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.isTrue(cursor.next.calledOnce);
+      sinon.assert.calledOnce(cursor.next);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_WS);
       cursor.next.restore();
@@ -294,7 +294,7 @@ suite('Navigation', function() {
       sinon.spy(cursor, 'out');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.A;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.isTrue(cursor.out.calledOnce);
+      sinon.assert.calledOnce(cursor.out);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_WS);
       cursor.out.restore();
@@ -305,7 +305,7 @@ suite('Navigation', function() {
       sinon.spy(cursor, 'in');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.D;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.isTrue(cursor.in.calledOnce);
+      sinon.assert.calledOnce(cursor.in);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_WS);
       cursor.in.restore();
@@ -315,7 +315,7 @@ suite('Navigation', function() {
       sinon.spy(Blockly.navigation, 'modify_');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.I;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
-      chai.assert.isTrue(Blockly.navigation.modify_.calledOnce);
+      sinon.assert.calledOnce(Blockly.navigation.modify_);
       chai.assert.equal(Blockly.navigation.currentState_,
           Blockly.navigation.STATE_WS);
       Blockly.navigation.modify_.restore();
@@ -400,7 +400,7 @@ suite('Navigation', function() {
 
       var isHandled = Blockly.navigation.onBlocklyAction(Blockly.navigation.ACTION_OUT);
       chai.assert.isTrue(isHandled);
-      chai.assert.isTrue(field.onBlocklyAction.calledOnce);
+      sinon.assert.calledOnce(field.onBlocklyAction);
 
       field.onBlocklyAction.restore();
     });
@@ -414,7 +414,7 @@ suite('Navigation', function() {
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.A;
       var isHandled = Blockly.navigation.onBlocklyAction(Blockly.navigation.ACTION_OUT);
       chai.assert.isTrue(isHandled);
-      chai.assert.isTrue(field.onBlocklyAction.calledOnce);
+      sinon.assert.calledOnce(field.onBlocklyAction);
 
       field.onBlocklyAction.restore();
     });
@@ -426,7 +426,7 @@ suite('Navigation', function() {
 
       var isHandled = Blockly.navigation.onKeyPress(this.mockEvent);
       chai.assert.isTrue(isHandled);
-      chai.assert.isTrue(Blockly.navigation.onBlocklyAction.calledOnce);
+      sinon.assert.calledOnce(Blockly.navigation.onBlocklyAction);
       chai.assert.isFalse(Blockly.getMainWorkspace().keyboardAccessibilityMode);
       Blockly.navigation.onBlocklyAction.restore();
     });
@@ -438,7 +438,7 @@ suite('Navigation', function() {
 
       var isHandled = Blockly.navigation.onKeyPress(this.mockEvent);
       chai.assert.isTrue(isHandled);
-      chai.assert.isTrue(Blockly.navigation.focusWorkspace_.calledOnce);
+      sinon.assert.calledOnce(Blockly.navigation.focusWorkspace_);
       chai.assert.isTrue(Blockly.getMainWorkspace().keyboardAccessibilityMode);
       Blockly.navigation.focusWorkspace_.restore();
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Updates test asserts on stubs to use sinon asserts
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Better assert messages
- In some cases, clearer intention
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information
Used the following regex to perform cleanup:

| Search | Replace |
| --- | --- |
| chai\\.assert\\((.+)\\.called(Once\|Twice\|Thrice)\\); | sinon\\.assert\\.called$2\\($1\\); |
| chai\\.assert\\.isTrue\\((.+)\\.called(Once\|Twice\|Thrice)\\); | sinon\\.assert\\.called$2\\($1\\); |
| chai\\.assert\\((.+)\\.notCalled\\); | sinon\\.assert\\.notCalled\\($1\\); |
| chai\\.assert\\.isTrue\\((.+)\\.notCalled\\); | sinon\\.assert\\.notCalled\\($1\\); **[no occurrences]** |
| chai\\.assert\\.isFalse\\((.+)\\.notCalled\\); | sinon\\.assert\\.isCalled\\($1\\); **[no occurrences]** |
| chai\\.assert\\.isFalse\\((.+)\\.calledOnce\\); | sinon\\.assert\\.notCalled\\($1\\);  **[separately checked to confirm intention]**|
<!-- Anything else we should know? -->
