### PR TITLE
Give Blockly div in tests a height.

### DIFF
--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -19,6 +19,14 @@
     <script src="../../blocks/procedures.js"></script>
     <script src="../../blocks/text.js"></script>
   </head>
+  <style>
+    #blocklyDiv {
+      height: 1000px;
+      position: fixed;
+      visibility: hidden;
+      width: 1000px;
+    }
+  </style>
   <body>
 
     <div id="mocha"></div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4194 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Gives blocklyDiv used in mocha tests a height using css.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Tests were triggering warning:
```
inject.js:314 Moved object in bounds but there was no event group. This may break undo.
```
This fixes all instances aside for a couple in `navigation_modify_test.js`.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests and confirmed that css changes did not affect the test result styling.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
