### PR TITLE
Remove unnecessary block dispose that was causing test leakage.

### DIFF
--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -8,7 +8,6 @@ suite('JSON Block Definitions', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace_ = new Blockly.Workspace();
-    this.blocks_ = [];
     this.blockTypes_ = [];
     this.messages_ = [];
   });
@@ -36,7 +35,6 @@ suite('JSON Block Definitions', function() {
         }]);
         block = new Blockly.Block(workspace, BLOCK_TYPE);
       });
-      this.blocks_.push(block);
 
       chai.assert.isNotNull(block);
       chai.assert.equal(BLOCK_TYPE, block.type);
@@ -160,7 +158,6 @@ suite('JSON Block Definitions', function() {
       }]);
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      this.blocks_.push(block);
       chai.assert.equal(block.inputList.length, 2);
 
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
@@ -188,7 +185,6 @@ suite('JSON Block Definitions', function() {
       }]);
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      this.blocks_.push(block);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var textField = block.inputList[0].fieldRow[0];
@@ -220,7 +216,6 @@ suite('JSON Block Definitions', function() {
       }]);
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      this.blocks_.push(block);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var dropdown = block.inputList[0].fieldRow[0];
@@ -281,7 +276,6 @@ suite('JSON Block Definitions', function() {
       }]);
 
       var block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      this.blocks_.push(block);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
       var dropdown = block.inputList[0].fieldRow[0];

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -15,10 +15,6 @@ suite('JSON Block Definitions', function() {
 
   teardown(function() {
     sharedTestTeardown.call(this);
-    for (var i = 0; i < this.blocks_.length; i++) {
-      var block = this.blocks_[i];
-      block.dispose();
-    }
     for (var i = 0, blockType; (blockType = this.blockTypes_[i]); i++) {
       delete Blockly.Blocks[blockType];
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4194 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Removes unnecessary block `dispose` calls.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This call was causing issues with test leakage because it is called after the `sharedTestCleanup`. Since the `dispose` is not needed, I removed the `dispose` calls rather than swapping the order.

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
