### PR TITLE
Fixing issues with workspace dispose in event tests.

### DIFF
--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -221,17 +221,19 @@ suite('Events', function() {
       });
     });
 
-    suite('With variable getter blocks', function() {
+    suite.only('With variable getter blocks', function() {
       setup(function() {
-        this.genUidStub = createGenUidStubWithReturns(this.TEST_BLOCK_ID);
-        this.block =
-            createSimpleTestBlock(this.workspace, 'field_variable_test_block');
+        this.genUidStub = createGenUidStubWithReturns(
+            [this.TEST_BLOCK_ID, 'test_var_id', 'test_group_id']);
+        // Disabling events when creating a block with variable can cause issues
+        // at workspace dispose.
+        this.block = new Blockly.Block(
+            this.workspace, 'field_variable_test_block');
       });
 
       test('Change', function() {
         var event = new Blockly.Events.Change(
             this.block, 'field', 'VAR', 'id1', 'id2');
-        sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.CHANGE, this.workspace.id,
             this.TEST_BLOCK_ID,
             {
@@ -247,7 +249,6 @@ suite('Events', function() {
       test('Block change', function() {
         var event = new Blockly.Events.BlockChange(
             this.block, 'field', 'VAR', 'id1', 'id2');
-        sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.CHANGE, this.workspace.id,
             this.TEST_BLOCK_ID,
             {

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -32,12 +32,12 @@ suite('Events', function() {
     delete Blockly.Blocks['simple_test_block'];
   });
 
-  function createSimpleTestBlock(workspace, opt_prototypeName) {
+  function createSimpleTestBlock(workspace) {
     // Disable events while constructing the block: this is a test of the
     // Blockly.Event constructors, not the block constructor.s
     Blockly.Events.disable();
     var block = new Blockly.Block(
-        workspace, opt_prototypeName || 'simple_test_block');
+        workspace, 'simple_test_block');
     Blockly.Events.enable();
     return block;
   }

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -221,7 +221,7 @@ suite('Events', function() {
       });
     });
 
-    suite.only('With variable getter blocks', function() {
+    suite('With variable getter blocks', function() {
       setup(function() {
         this.genUidStub = createGenUidStubWithReturns(
             [this.TEST_BLOCK_ID, 'test_var_id', 'test_group_id']);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4194 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Modifying setup in event tests to not disable/enable events when creating a block with variable.

### Reason for Changes

Disabling/enabling events was causing the error:
```
Events Constructors With variable getter blocks Block change
 Error: Tried to call dropdownCreate on a variable field with no variable selected.
    at Blockly.FieldVariable.dropdownCreate [as menuGenerator_] (field_variable.js:390)
    at Blockly.FieldVariable.Blockly.FieldDropdown.getOptions (field_dropdown.js:478)
    at Blockly.FieldVariable.Blockly.FieldDropdown.doValueUpdate_ (field_dropdown.js:521)
    at Blockly.FieldVariable.doValueUpdate_ (field_variable.js:285)
    at Blockly.FieldVariable.initModel (field_variable.js:133)
    at Blockly.FieldVariable.toXml (field_variable.js:180)
    at Object.Blockly.Xml.fieldToDom_ (xml.js:113)
    at Object.Blockly.Xml.allFieldsToDom_ (xml.js:129)
    at Object.Blockly.Xml.blockToDom (xml.js:173)
    at new Blockly.Events.Delete (block_events.js:309)
```
to happen at workspace dispose

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->