### PR TITLE
Fix dynamic category generation when part of an array

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -532,7 +532,7 @@ Blockly.Flyout.prototype.createFlyoutInfo_ = function(parsedContent) {
       var categoryName = customInfo['custom'];
       var flyoutDef = this.getDynamicCategoryContents_(categoryName);
       var parsedDynamicContent = /** @type {!Array<Blockly.utils.toolbox.FlyoutItem>} */
-        (Blockly.utils.toolbox.convertToolboxToJSON(flyoutDef));
+        (Blockly.utils.toolbox.convertToolboxContentsToJSON(flyoutDef));
       parsedContent.splice.apply(parsedContent, [i, 1].concat(parsedDynamicContent));
       contentInfo = parsedContent[i];
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Use `convertToolboxContentsToJSON` instead of `convertToolboxToJson` when parsing a dynamic category that's part of an array of toolbox contents.

### Reason for Changes

`convertToolboxToJSON` puts the parsed category contents into an object under a property called contents. Instead of merging the array of contents into parsedContent, it gets added as a sub-array which is never properly iterated through. This causes contentInfo (line 537) to contain that parent object instead of the first of the actual contents. That object does not contain a `kind` property, causing an error on the next line. Using `convertToolboxContentsToJSON` correctly puts the parsed contents directly into an array which is merged into parsedContent.

I was getting errors in the continuous flyout after pulling down the latest of toolbox, and this resolves those problems.

I feel like this worked at one point after this code was added, but I pulled again in order to update before my next round of code review comments for another PR and it stopped working, but I can't work out why the changes broke things or why it ever worked to begin with.
