### PR TITLE
Stub modify in navigation_modify workspace keys test

### DIFF
--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -312,7 +312,9 @@ suite('Navigation', function() {
     });
 
     test('Insert', function() {
-      sinon.spy(Blockly.navigation, 'modify_');
+      // Stub modify as we are not testing its behavior, only if it was called.
+      // Otherwise, there is a warning because there is no marked node.
+      sinon.stub(Blockly.navigation, 'modify_');
       this.mockEvent.keyCode = Blockly.utils.KeyCodes.I;
       chai.assert.isTrue(Blockly.navigation.onKeyPress(this.mockEvent));
       sinon.assert.calledOnce(Blockly.navigation.modify_);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4194 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Stubs modify in workspace keys insert test.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Cleans up console when running tests. The modify call in this tests was logging a warning. Since there are other tests that cover the behavior of modify, it seemed appropriate to stub modify here rather than to mark a node before calling insert.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
