### PR TITLE
Add programmatically setting shadows Take 2

### DIFF
--- a/core/block_events.js
+++ b/core/block_events.js
@@ -218,6 +218,10 @@ Blockly.Events.Create = function(opt_block) {
   if (!opt_block) {
     return;  // Blank event to be populated by fromJson.
   }
+  if (opt_block.isShadow()) {
+    // Moving shadow blocks is handled via disconnection.
+    this.recordUndo = false;
+  }
 
   if (opt_block.workspace.rendered) {
     this.xml = Blockly.Xml.blockToDomWithXY(opt_block);
@@ -302,6 +306,10 @@ Blockly.Events.Delete = function(opt_block) {
   if (opt_block.getParent()) {
     throw Error('Connected blocks cannot be deleted.');
   }
+  if (opt_block.isShadow()) {
+    // Respawning shadow blocks is handled via disconnection.
+    this.recordUndo = false;
+  }
 
   if (opt_block.workspace.rendered) {
     this.oldXml = Blockly.Xml.blockToDomWithXY(opt_block);
@@ -379,6 +387,10 @@ Blockly.Events.Move = function(opt_block) {
   Blockly.Events.Move.superClass_.constructor.call(this, opt_block);
   if (!opt_block) {
     return;  // Blank event to be populated by fromJson.
+  }
+  if (opt_block.isShadow()) {
+    // Moving shadow blocks is handled via disconnection.
+    this.recordUndo = false;
   }
 
   var location = this.currentLocation_();

--- a/core/connection.js
+++ b/core/connection.js
@@ -443,7 +443,10 @@ Blockly.Connection.prototype.disconnect = function() {
     Blockly.Events.setGroup(true);
   }
   this.disconnectInternal_(parentBlock, childBlock);
-  parentConnection.respawnShadow_();
+  if (!childBlock.isShadow()) {
+    // If we were disconnecting a shadow, no need to spawn a new one.
+    parentConnection.respawnShadow_();
+  }
   if (!eventGroup) {
     Blockly.Events.setGroup(false);
   }
@@ -596,6 +599,7 @@ Blockly.Connection.prototype.setShadowDom = function(shadow) {
   } else if (target.isShadow()) {
     // The disconnect from dispose will automatically generate the new shadow.
     target.dispose(false);
+    this.respawnShadow_();
   }
 };
 

--- a/core/connection.js
+++ b/core/connection.js
@@ -478,7 +478,7 @@ Blockly.Connection.prototype.disconnectInternal_ = function(parentBlock,
 Blockly.Connection.prototype.respawnShadow_ = function() {
   var parentBlock = this.getSourceBlock();
   var shadow = this.getShadowDom();
-  if (parentBlock.workspace && shadow && Blockly.Events.recordUndo) {
+  if (parentBlock.workspace && shadow) {
     var blockShadow =
         Blockly.Xml.domToBlock(shadow, parentBlock.workspace);
     if (blockShadow.outputConnection) {

--- a/core/input.js
+++ b/core/input.js
@@ -248,7 +248,7 @@ Blockly.Input.prototype.setAlign = function(align) {
 /**
  * Changes the connection's shadow block.
  * @param {Element} shadow DOM representation of a block or null.
- * @returns {Blockly.Input} The input being modified (to allow chaining).
+ * @return {Blockly.Input} The input being modified (to allow chaining).
  */
 Blockly.Input.prototype.setShadowDom = function(shadow) {
   if (!this.connection) {

--- a/core/input.js
+++ b/core/input.js
@@ -246,6 +246,30 @@ Blockly.Input.prototype.setAlign = function(align) {
 };
 
 /**
+ * Changes the connection's shadow block.
+ * @param {Element} shadow DOM representation of a block or null.
+ * @returns {Blockly.Input} The input being modified (to allow chaining).
+ */
+Blockly.Input.prototype.setShadowDom = function(shadow) {
+  if (!this.connection) {
+    throw Error('This input does not have a connection.');
+  }
+  this.connection.setShadowDom(shadow);
+  return this;
+};
+
+/**
+ * Returns the xml representation of the connection's shadow block.
+ * @return {Element} Shadow DOM representation of a block or null.
+ */
+Blockly.Input.prototype.getShadowDom = function() {
+  if (!this.connection) {
+    throw Error('This input does not have a connection.');
+  }
+  return this.connection.getShadowDom();
+};
+
+/**
  * Initialize the fields on this input.
  */
 Blockly.Input.prototype.init = function() {

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -478,20 +478,18 @@ Blockly.RenderedConnection.prototype.disconnectInternal_ = function(parentBlock,
  * @private
  */
 Blockly.RenderedConnection.prototype.respawnShadow_ = function() {
+  Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);
+  var blockShadow = this.targetBlock();
+  if (!blockShadow) {
+    // This connection must not have a shadowDom_.
+    return;
+  }
+  blockShadow.initSvg();
+  blockShadow.render(false);
+
   var parentBlock = this.getSourceBlock();
-  // Respawn the shadow block if there is one.
-  var shadow = this.getShadowDom();
-  if (parentBlock.workspace && shadow && Blockly.Events.recordUndo) {
-    Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);
-    var blockShadow = this.targetBlock();
-    if (!blockShadow) {
-      throw Error('Couldn\'t respawn the shadow block that should exist here.');
-    }
-    blockShadow.initSvg();
-    blockShadow.render(false);
-    if (parentBlock.rendered) {
-      parentBlock.render();
-    }
+  if (parentBlock.rendered) {
+    parentBlock.render();
   }
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -650,10 +650,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         }
       }
     }
-    // Use the shadow block if there is no child block.
-    if (!childBlockElement && childShadowElement) {
-      childBlockElement = childShadowElement;
-    }
 
     var name = xmlChild.getAttribute('name');
     var xmlChildElement = /** @type {!Element} */ (xmlChild);
@@ -708,9 +704,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
                        prototypeName);
           break;
         }
-        if (childShadowElement) {
-          input.connection.setShadowDom(childShadowElement);
-        }
         if (childBlockElement) {
           blockChild = Blockly.Xml.domToBlockHeadless_(childBlockElement,
               workspace);
@@ -723,11 +716,12 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
                 'Child block does not have output or previous statement.');
           }
         }
+        // Set shadow after so we don't create a shadow we delete immediately.
+        if (childShadowElement) {
+          input.connection.setShadowDom(childShadowElement);
+        }
         break;
       case 'next':
-        if (childShadowElement && block.nextConnection) {
-          block.nextConnection.setShadowDom(childShadowElement);
-        }
         if (childBlockElement) {
           if (!block.nextConnection) {
             throw TypeError('Next statement does not exist.');
@@ -742,6 +736,10 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
             throw TypeError('Next block does not have previous statement.');
           }
           block.nextConnection.connect(blockChild.previousConnection);
+        }
+        // Set shadow after so we don't create a shadow we delete immediately.
+        if (childShadowElement && block.nextConnection) {
+          block.nextConnection.setShadowDom(childShadowElement);
         }
         break;
       default:

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -18,9 +18,11 @@ suite('Connection', function() {
       return connection;
     };
   });
+
   teardown(function() {
     sharedTestTeardown.call(this);
   });
+
   test('Deprecated - canConnectWithReason passes', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
     var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
@@ -30,6 +32,7 @@ suite('Connection', function() {
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
         'Connection.prototype.canConnectWithReason');
   });
+
   test('Deprecated - canConnectWithReason fails', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
     var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
@@ -39,6 +42,7 @@ suite('Connection', function() {
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
         'Connection.prototype.canConnectWithReason');
   });
+
   test('Deprecated - checkConnection passes', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
     var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
@@ -49,6 +53,7 @@ suite('Connection', function() {
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
         'Connection.prototype.checkConnection');
   });
+
   test('Deprecated - checkConnection fails', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
     var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
@@ -59,1026 +64,723 @@ suite('Connection', function() {
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
         'Connection.prototype.checkConnection');
   });
+
   suite('Set Shadow Dom', function() {
-    setup(function() {
-      Blockly.defineBlocksWithJsonArray([
-        {
-          "type": "stack_block",
-          "message0": "",
-          "previousStatement": null,
-          "nextStatement": null
+
+    function assertBlockMatches(block, isShadow, opt_id) {
+      chai.assert.equal(block.isShadow(), isShadow,
+          `expected block ${block.id} to ${isShadow ? '' : 'not'} be a shadow`);
+      if (opt_id) {
+        chai.assert.equal(block.id, opt_id);
+      }
+    }
+
+    function assertInputHasBlock(parent, inputName, isShadow, opt_name) {
+      var block = parent.getInputTargetBlock(inputName);
+      chai.assert.exists(block,
+          `expected block ${opt_name || ''} to be attached to ${inputName}`);
+      assertBlockMatches(block, isShadow, opt_name);
+    }
+
+    function assertNextHasBlock(parent, isShadow, opt_name) {
+      var block = parent.getNextBlock();
+      chai.assert.exists(block,
+          `expected block ${opt_name || ''} to be attached to next connection`);
+      assertBlockMatches(block, isShadow, opt_name);
+    }
+
+    function assertInputNotHasBlock(parent, inputName) {
+      var block = parent.getInputTargetBlock(inputName);
+      chai.assert.notExists(block,
+          `expected block ${block && block.id} to not be attached to ${inputName}`);
+    }
+
+    function assertNextNotHasBlock(parent) {
+      var block = parent.getNextBlock();
+      chai.assert.notExists(block,
+          `expected block ${block && block.id} to not be attached to next connection`);
+    }
+
+    var testSuites = [
+      {
+        title: 'Rendered',
+        createWorkspace: () => {
+          return Blockly.inject('blocklyDiv');
         },
-        {
-          "type": "row_block",
-          "message0": "%1",
-          "args0": [
-            {
-              "type": "input_value",
-              "name": "INPUT"
-            }
-          ],
-          "output": null
+      },
+      {
+        title: 'Headless',
+        createWorkspace: () => {
+          return new Blockly.Workspace();
         },
-        {
-          "type": "statement_block",
-          "message0": "%1",
-          "args0": [
+      }
+    ];
+
+    testSuites.forEach((testSuite) => {
+      // Create a suite for each suite.
+      suite(testSuite.title, function() {
+        setup(function() {
+          this.workspace = testSuite.createWorkspace();
+
+          Blockly.defineBlocksWithJsonArray([
             {
-              "type": "input_statement",
-              "name": "STATEMENT"
-            }
-          ],
-          "previousStatement": null,
-          "nextStatement": null
-        }]);
-
-      this.runHeadlessAndRendered = function(func, context) {
-        var workspace = new Blockly.Workspace();
-        func.call(context, workspace);
-        workspace.clear();
-        workspace.dispose();
-
-        workspace = Blockly.inject('blocklyDiv');
-        func.call(context, workspace);
-        workspace.clear();
-        workspace.dispose();
-      };
-    });
-    teardown(function() {
-      delete this.runHeadlessAndRendered;
-      delete Blockly.Blocks['stack_block'];
-      delete Blockly.Blocks['row_block'];
-      delete Blockly.Blocks['statement_block'];
-    });
-    suite('Add - No Block Connected', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block"/>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlock;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block"/>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block"/>' +
-              '  </value>' +
-              '</shadow>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block"/>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block"/>' +
-              '  </statement>' +
-              '</shadow>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block"/>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block">' +
-              '  <next>' +
-              '    <shadow type="stack_block"/>' +
-              '  </next>' +
-              '</shadow>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-    });
-    suite('Add - With Block Connected', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlocks = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <block type="row_block"/>' +
-              '  </value>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlocks = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <block type="statement_block"/>' +
-              '  </statement>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlocks = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block">' +
-              '  <next>' +
-              '    <block type="stack_block"/>' +
-              '  </next>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlocks;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block"/>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('INPUT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block"/>' +
-              '  </value>' +
-              '</shadow>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNull(target2);
-
-          parent.getInput('INPUT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block"/>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('STATEMENT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block"/>' +
-              '  </statement>' +
-              '</shadow>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNull(target2);
-
-          parent.getInput('STATEMENT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block"/>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.nextConnection.disconnect();
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlocks(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block">' +
-              '  <next>' +
-              '    <shadow type="stack_block"/>' +
-              '  </next>' +
-              '</shadow>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-          var target2 = target.getNextBlock();
-          chai.assert.isNull(target2);
-
-          parent.nextConnection.disconnect();
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-    });
-    suite('Add - With Shadow Connected', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block"/>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlock;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block" id="1"/>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block" id="2"/>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target2 = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, '2');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block" id="1">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block" id="a"/>' +
-              '  </value>' +
-              '</shadow>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'a');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block" id="2">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block" id="b"/>' +
-              '  </value>' +
-              '</shadow>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '2');
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'b');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block" id="1"/>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block" id="2"/>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '2');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block" id="1">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block" id="a"/>' +
-              '  </statement>' +
-              '</shadow>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'a');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block" id="2">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block" id="b"/>' +
-              '  </statement>' +
-              '</shadow>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '2');
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'b');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block" id="1"/>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block" id="2"/>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '2');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block" id="1">' +
-              '  <next>' +
-              '    <shadow type="stack_block" id="a"/>' +
-              '  </next>' +
-              '</shadow>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '1');
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'a');
-
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block" id="2">' +
-              '  <next>' +
-              '    <shadow type="stack_block" id="b"/>' +
-              '  </next>' +
-              '</shadow>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          chai.assert.equal(target.id, '2');
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-          chai.assert.equal(target2.id, 'b');
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-    });
-    suite('Remove - No Block Connected', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block"/>' +
-              '  </value>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block"/>' +
-              '  </statement>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block">' +
-              '  <next>' +
-              '    <shadow type="stack_block"/>' +
-              '  </next>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlock;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          parent.getInput('INPUT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          parent.getInput('STATEMENT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          parent.nextConnection.setShadowDom(null);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-    });
-    suite('Remove - Block Connected', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block"/>' +
-              '    <block type="row_block"/>' +
-              '  </value>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block"/>' +
-              '    <block type="statement_block"/>' +
-              '  </statement>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block">' +
-              '  <next>' +
-              '    <shadow type="stack_block"/>' +
-              '    <block type="stack_block"/>' +
-              '  </next>' +
-              '</block>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlock;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          parent.getInput('INPUT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('INPUT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          parent.getInput('STATEMENT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('STATEMENT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          parent.nextConnection.setShadowDom(null);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.nextConnection.disconnect();
-
-          var target = parent.getNextBlock();
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-    });
-    suite('Add - Connect & Disconnect - Remove', function() {
-      setup(function() {
-        // These are defined separately in each suite.
-        this.createRowBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="row_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStatementBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="statement_block"/>'
-          ), workspace);
-          return block;
-        };
-
-        this.createStackBlock = function(workspace) {
-          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-              '<block type="stack_block"/>'
-          ), workspace);
-          return block;
-        };
-      });
-      teardown(function() {
-        delete this.createRowBlock;
-        delete this.createStatementBlock;
-        delete this.createStackBlock;
-      });
-      test('Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block"/>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          var child = this.createRowBlock(workspace);
-          parent.getInput('INPUT').connection.connect(child.outputConnection);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('INPUT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          parent.getInput('INPUT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Value', function() {
-        var func = function(workspace) {
-          var parent = this.createRowBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="row_block">' +
-              '  <value name="INPUT">' +
-              '    <shadow type="row_block"/>' +
-              '  </value>' +
-              '</shadow>'
-          );
-          parent.getInput('INPUT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          var child = this.createRowBlock(workspace);
-          parent.getInput('INPUT').connection.connect(child.outputConnection);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('INPUT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('INPUT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          parent.getInput('INPUT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('INPUT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block"/>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          var child = this.createStatementBlock(workspace);
-          parent.getInput('STATEMENT').connection
-              .connect(child.previousConnection);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('STATEMENT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          parent.getInput('STATEMENT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Statement', function() {
-        var func = function(workspace) {
-          var parent = this.createStatementBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="statement_block">' +
-              '  <statement name="STATEMENT">' +
-              '    <shadow type="statement_block"/>' +
-              '  </statement>' +
-              '</shadow>'
-          );
-          parent.getInput('STATEMENT').connection.setShadowDom(xml);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          var child = this.createStatementBlock(workspace);
-          parent.getInput('STATEMENT').connection
-              .connect(child.previousConnection);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.getInput('STATEMENT').connection.disconnect();
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getInputTargetBlock('STATEMENT');
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          parent.getInput('STATEMENT').connection.setShadowDom(null);
-
-          var target = parent.getInputTargetBlock('STATEMENT');
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block"/>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          var child = this.createStatementBlock(workspace);
-          parent.nextConnection.connect(child.previousConnection);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.nextConnection.disconnect();
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-
-          parent.nextConnection.setShadowDom(null);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
-      });
-      test('Multiple Next', function() {
-        var func = function(workspace) {
-          var parent = this.createStackBlock(workspace);
-          var xml = Blockly.Xml.textToDom(
-              '<shadow type="stack_block">' +
-              '  <next>' +
-              '    <shadow type="stack_block"/>' +
-              '  </next>' +
-              '</shadow>'
-          );
-          parent.nextConnection.setShadowDom(xml);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          var child = this.createStatementBlock(workspace);
-          parent.nextConnection.connect(child.previousConnection);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isFalse(target.isShadow());
-
-          parent.nextConnection.disconnect();
-
-          var target = parent.getNextBlock();
-          chai.assert.isNotNull(target);
-          chai.assert.isTrue(target.isShadow());
-          var target2 = target.getNextBlock();
-          chai.assert.isNotNull(target2);
-          chai.assert.isTrue(target2.isShadow());
-
-          parent.nextConnection.setShadowDom(null);
-
-          var target = parent.getNextBlock();
-          chai.assert.isNull(target);
-        };
-        this.runHeadlessAndRendered(func, this);
+              "type": "stack_block",
+              "message0": "",
+              "previousStatement": null,
+              "nextStatement": null
+            },
+            {
+              "type": "row_block",
+              "message0": "%1",
+              "args0": [
+                {
+                  "type": "input_value",
+                  "name": "INPUT"
+                }
+              ],
+              "output": null
+            },
+            {
+              "type": "statement_block",
+              "message0": "%1",
+              "args0": [
+                {
+                  "type": "input_statement",
+                  "name": "STATEMENT"
+                }
+              ],
+              "previousStatement": null,
+              "nextStatement": null
+            }]);
+        });
+
+        teardown(function() {
+          workspaceTeardown.call(this, this.workspace);
+          delete Blockly.Blocks['stack_block'];
+          delete Blockly.Blocks['row_block'];
+          delete Blockly.Blocks['statement_block'];
+        });
+
+        suite('Add - No Block Connected', function() {
+          // These are defined separately in each suite.
+          function createRowBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block"/>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true);
+          });
+
+          test('Multiple Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block"/>' +
+                '  </value>' +
+                '</shadow>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block"/>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true);
+          });
+
+          test('Multiple Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block"/>' +
+                '  </statement>' +
+                '</shadow>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+          });
+
+          test('Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block"/>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true);
+          });
+
+          test('Multiple Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block">' +
+                '  <next>' +
+                '    <shadow type="stack_block"/>' +
+                '  </next>' +
+                '</shadow>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true);
+            assertNextHasBlock(parent.getNextBlock(), true);
+          });
+        });
+
+        suite('Add - With Block Connected', function() {
+          // These are defined separately in each suite.
+          function createRowBlocks(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <block type="row_block"/>' +
+                '  </value>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlocks(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <block type="statement_block"/>' +
+                '  </statement>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlocks(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block">' +
+                '  <next>' +
+                '    <block type="stack_block"/>' +
+                '  </next>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block"/>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', false);
+            parent.getInput('INPUT').connection.disconnect();
+            assertInputHasBlock(parent, 'INPUT', true);
+          });
+
+          test('Multiple Value', function() {
+            var parent = createRowBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block"/>' +
+                '  </value>' +
+                '</shadow>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', false);
+            assertInputNotHasBlock(parent.getInputTargetBlock('INPUT'), 'INPUT');
+            parent.getInput('INPUT').connection.disconnect();
+            assertInputHasBlock(parent, 'INPUT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block"/>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', false);
+            parent.getInput('STATEMENT').connection.disconnect();
+            assertInputHasBlock(parent, 'STATEMENT', true);
+          });
+
+          test('Multiple Statement', function() {
+            var parent = createStatementBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block"/>' +
+                '  </statement>' +
+                '</shadow>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', false);
+            assertInputNotHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT');
+            parent.getInput('STATEMENT').connection.disconnect();
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+          });
+
+          test('Next', function() {
+            var parent = createStackBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block"/>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, false);
+            parent.nextConnection.disconnect();
+            assertNextHasBlock(parent, true);
+          });
+
+          test('Multiple Next', function() {
+            var parent = createStackBlocks(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block">' +
+                '  <next>' +
+                '    <shadow type="stack_block"/>' +
+                '  </next>' +
+                '</shadow>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, false);
+            assertNextNotHasBlock(parent.getNextBlock());
+            parent.nextConnection.disconnect();
+            assertNextHasBlock(parent, true);
+            assertNextHasBlock(parent.getNextBlock(), true);
+          });
+        });
+
+        suite('Add - With Shadow Connected', function() {
+          // These are defined separately in each suite.
+          function createRowBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block" id="1"/>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true, '1');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block" id="2"/>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true, '2');
+          });
+
+          test('Multiple Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block" id="1">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block" id="a"/>' +
+                '  </value>' +
+                '</shadow>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true, '1');
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'a');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block" id="2">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block" id="b"/>' +
+                '  </value>' +
+                '</shadow>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true, '2');
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'b');
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block" id="1"/>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true, '1');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block" id="2"/>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true, '2');
+          });
+
+          test('Multiple Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block" id="1">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block" id="a"/>' +
+                '  </statement>' +
+                '</shadow>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true, '1');
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true, 'a');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block" id="2">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block" id="b"/>' +
+                '  </statement>' +
+                '</shadow>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true, '2');
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true, 'b');
+          });
+
+          test('Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block" id="1"/>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true, '1');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block" id="2"/>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true, '2');
+          });
+
+          test('Multiple Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block" id="1">' +
+                '  <next>' +
+                '    <shadow type="stack_block" id="a"/>' +
+                '  </next>' +
+                '</shadow>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true, '1');
+            assertNextHasBlock(parent.getNextBlock(), true, 'a');
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block" id="2">' +
+                '  <next>' +
+                '    <shadow type="stack_block" id="b"/>' +
+                '  </next>' +
+                '</shadow>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true, '2');
+            assertNextHasBlock(parent.getNextBlock(), true, 'b');
+          });
+        });
+
+        suite('Remove - No Block Connected', function() {
+          // These are defined separately in each suite.
+          function createRowBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block"/>' +
+                '  </value>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block"/>' +
+                '  </statement>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block">' +
+                '  <next>' +
+                '    <shadow type="stack_block"/>' +
+                '  </next>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlock(this.workspace);
+            parent.getInput('INPUT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'INPUT');
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            parent.getInput('STATEMENT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'STATMENT');
+          });
+
+          test('Next', function() {
+            var parent = createStackBlock(this.workspace);
+            parent.nextConnection.setShadowDom(null);
+            assertNextNotHasBlock(parent);
+          });
+        });
+
+        suite('Remove - Block Connected', function() {
+          // These are defined separately in each suite.
+          function createRowBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block"/>' +
+                '    <block type="row_block"/>' +
+                '  </value>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block"/>' +
+                '    <block type="statement_block"/>' +
+                '  </statement>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block">' +
+                '  <next>' +
+                '    <shadow type="stack_block"/>' +
+                '    <block type="stack_block"/>' +
+                '  </next>' +
+                '</block>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlock(this.workspace);
+            parent.getInput('INPUT').connection.setShadowDom(null);
+            assertInputHasBlock(parent, 'INPUT', false);
+            parent.getInput('INPUT').connection.disconnect();
+            assertInputNotHasBlock(parent, 'INPUT');
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            parent.getInput('STATEMENT').connection.setShadowDom(null);
+            assertInputHasBlock(parent, 'STATEMENT', false);
+            parent.getInput('STATEMENT').connection.disconnect();
+            assertInputNotHasBlock(parent, 'STATEMENT');
+          });
+
+          test('Next', function() {
+            var parent = createStackBlock(this.workspace);
+            parent.nextConnection.setShadowDom(null);
+            assertNextHasBlock(parent, false);
+            parent.nextConnection.disconnect();
+            assertNextNotHasBlock(parent);
+          });
+        });
+
+        suite('Add - Connect & Disconnect - Remove', function() {
+          // These are defined separately in each suite.
+          function createRowBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="row_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStatementBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="statement_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          function createStackBlock(workspace) {
+            var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+                '<block type="stack_block"/>'
+            ), workspace);
+            return block;
+          }
+
+          test('Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block"/>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true);
+            var child = createRowBlock(this.workspace);
+            parent.getInput('INPUT').connection.connect(child.outputConnection);
+            assertInputHasBlock(parent, 'INPUT', false);
+            parent.getInput('INPUT').connection.disconnect();
+            assertInputHasBlock(parent, 'INPUT', true);
+            parent.getInput('INPUT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'INPUT');
+          });
+
+          test('Multiple Value', function() {
+            var parent = createRowBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block"/>' +
+                '  </value>' +
+                '</shadow>'
+            );
+            parent.getInput('INPUT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'INPUT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+            var child = createRowBlock(this.workspace);
+            parent.getInput('INPUT').connection.connect(child.outputConnection);
+            assertInputHasBlock(parent, 'INPUT', false);
+            parent.getInput('INPUT').connection.disconnect();
+            assertInputHasBlock(parent, 'INPUT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+            parent.getInput('INPUT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'INPUT');
+          });
+
+          test('Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block"/>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            var child = createStatementBlock(this.workspace);
+            parent.getInput('STATEMENT').connection
+                .connect(child.previousConnection);
+            assertInputHasBlock(parent, 'STATEMENT', false);
+            parent.getInput('STATEMENT').connection.disconnect();
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            parent.getInput('STATEMENT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'STATEMENT');
+          });
+
+          test('Multiple Statement', function() {
+            var parent = createStatementBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="statement_block"/>' +
+                '  </statement>' +
+                '</shadow>'
+            );
+            parent.getInput('STATEMENT').connection.setShadowDom(xml);
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+            var child = createStatementBlock(this.workspace);
+            parent.getInput('STATEMENT').connection
+                .connect(child.previousConnection);
+            assertInputHasBlock(parent, 'STATEMENT', false);
+            parent.getInput('STATEMENT').connection.disconnect();
+            assertInputHasBlock(parent, 'STATEMENT', true);
+            assertInputHasBlock(
+                parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+            parent.getInput('STATEMENT').connection.setShadowDom(null);
+            assertInputNotHasBlock(parent, 'STATEMENT');
+          });
+
+          test('Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block"/>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true);
+            var child = createStatementBlock(this.workspace);
+            parent.nextConnection.connect(child.previousConnection);
+            assertNextHasBlock(parent, false);
+            parent.nextConnection.disconnect();
+            assertNextHasBlock(parent, true);
+            parent.nextConnection.setShadowDom(null);
+            assertNextNotHasBlock(parent);
+          });
+
+          test('Multiple Next', function() {
+            var parent = createStackBlock(this.workspace);
+            var xml = Blockly.Xml.textToDom(
+                '<shadow type="stack_block">' +
+                '  <next>' +
+                '    <shadow type="stack_block"/>' +
+                '  </next>' +
+                '</shadow>'
+            );
+            parent.nextConnection.setShadowDom(xml);
+            assertNextHasBlock(parent, true);
+            assertNextHasBlock(parent.getNextBlock(), true);
+            var child = createStatementBlock(this.workspace);
+            parent.nextConnection.connect(child.previousConnection);
+            assertNextHasBlock(parent, false);
+            parent.nextConnection.disconnect();
+            assertNextHasBlock(parent, true);
+            assertNextHasBlock(parent.getNextBlock(), true);
+            parent.nextConnection.setShadowDom(null);
+            assertNextNotHasBlock(parent);
+          });
+        });
       });
     });
   });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -59,4 +59,1027 @@ suite('Connection', function() {
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
         'Connection.prototype.checkConnection');
   });
+  suite('Set Shadow Dom', function() {
+    setup(function() {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "stack_block",
+          "message0": "",
+          "previousStatement": null,
+          "nextStatement": null
+        },
+        {
+          "type": "row_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "input_value",
+              "name": "INPUT"
+            }
+          ],
+          "output": null
+        },
+        {
+          "type": "statement_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "input_statement",
+              "name": "STATEMENT"
+            }
+          ],
+          "previousStatement": null,
+          "nextStatement": null
+        }]);
+
+      this.runHeadlessAndRendered = function(func, context) {
+        var workspace = new Blockly.Workspace();
+        func.call(context, workspace);
+        workspace.clear();
+        workspace.dispose();
+
+        var workspace = Blockly.inject('blocklyDiv');
+        func.call(context, workspace);
+        workspace.clear();
+        workspace.dispose();
+      };
+    });
+    teardown(function() {
+      delete this.runHeadlessAndRendered;
+      delete Blockly.Blocks['stack_block'];
+      delete Blockly.Blocks['row_block'];
+      delete Blockly.Blocks['statement_block'];
+    });
+    suite('Add - No Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - With Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlocks = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlocks;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target2);
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target2);
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlocks(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNull(target2);
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - With Shadow Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="1"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="2"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target2 = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="1">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block" id="a"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block" id="2">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block" id="b"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="1"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="2"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="1">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block" id="a"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block" id="2">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block" id="b"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="1"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="2"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="1">' +
+              '  <next>' +
+              '    <shadow type="stack_block" id="a"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '1');
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'a');
+
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block" id="2">' +
+              '  <next>' +
+              '    <shadow type="stack_block" id="b"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          chai.assert.equal(target.id, '2');
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+          chai.assert.equal(target2.id, 'b');
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Remove - No Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Remove - Block Connected', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+    suite('Add - Connect & Disconnect - Remove', function() {
+      setup(function() {
+        // These are defined separately in each suite.
+        this.createRowBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="row_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStatementBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="statement_block"/>'
+          ), workspace);
+          return block;
+        };
+
+        this.createStackBlock = function(workspace) {
+          var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              '<block type="stack_block"/>'
+          ), workspace);
+          return block;
+        };
+      });
+      teardown(function() {
+        delete this.createRowBlock;
+        delete this.createStatementBlock;
+        delete this.createStackBlock;
+      });
+      test('Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block"/>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.connect(child.outputConnection);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Value', function() {
+        var func = function(workspace) {
+          var parent = this.createRowBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="row_block">' +
+              '  <value name="INPUT">' +
+              '    <shadow type="row_block"/>' +
+              '  </value>' +
+              '</shadow>'
+          );
+          parent.getInput('INPUT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createRowBlock(workspace);
+          parent.getInput('INPUT').connection.connect(child.outputConnection);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('INPUT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('INPUT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.getInput('INPUT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('INPUT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block"/>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection
+              .connect(child.previousConnection);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Statement', function() {
+        var func = function(workspace) {
+          var parent = this.createStatementBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="statement_block">' +
+              '  <statement name="STATEMENT">' +
+              '    <shadow type="statement_block"/>' +
+              '  </statement>' +
+              '</shadow>'
+          );
+          parent.getInput('STATEMENT').connection.setShadowDom(xml);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.getInput('STATEMENT').connection
+              .connect(child.previousConnection);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.getInput('STATEMENT').connection.disconnect();
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getInputTargetBlock('STATEMENT');
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.getInput('STATEMENT').connection.setShadowDom(null);
+
+          var target = parent.getInputTargetBlock('STATEMENT');
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block"/>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.nextConnection.connect(child.previousConnection);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+      test('Multiple Next', function() {
+        var func = function(workspace) {
+          var parent = this.createStackBlock(workspace);
+          var xml = Blockly.Xml.textToDom(
+              '<shadow type="stack_block">' +
+              '  <next>' +
+              '    <shadow type="stack_block"/>' +
+              '  </next>' +
+              '</shadow>'
+          );
+          parent.nextConnection.setShadowDom(xml);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          var child = this.createStatementBlock(workspace);
+          parent.nextConnection.connect(child.previousConnection);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isFalse(target.isShadow());
+
+          parent.nextConnection.disconnect();
+
+          var target = parent.getNextBlock();
+          chai.assert.isNotNull(target);
+          chai.assert.isTrue(target.isShadow());
+          var target2 = target.getNextBlock();
+          chai.assert.isNotNull(target2);
+          chai.assert.isTrue(target2.isShadow());
+
+          parent.nextConnection.setShadowDom(null);
+
+          var target = parent.getNextBlock();
+          chai.assert.isNull(target);
+        };
+        this.runHeadlessAndRendered(func, this);
+      });
+    });
+  });
 });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -98,7 +98,7 @@ suite('Connection', function() {
         workspace.clear();
         workspace.dispose();
 
-        var workspace = Blockly.inject('blocklyDiv');
+        workspace = Blockly.inject('blocklyDiv');
         func.call(context, workspace);
         workspace.clear();
         workspace.dispose();

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -221,6 +221,148 @@ suite('Events', function() {
       });
     });
 
+    suite('With shadow blocks', function() {
+      setup(function() {
+        this.TEST_BLOCK_ID = 'test_block_id';
+        this.TEST_PARENT_ID = 'parent';
+        // genUid is expected to be called either once or twice in this suite.
+        this.genUidStub = createGenUidStubWithReturns(
+            [this.TEST_BLOCK_ID, this.TEST_PARENT_ID]);
+        this.block = createSimpleTestBlock(this.workspace);
+        this.block.setShadow(true);
+      });
+
+      test('Block base', function() {
+        var event = new Blockly.Events.BlockBase(this.block);
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, undefined,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'varId': undefined,
+              'recordUndo': true,
+              'group': '',
+            });
+      });
+
+      test('Change', function() {
+        var event = new Blockly.Events.Change(
+            this.block, 'field', 'FIELD_NAME', 'old', 'new');
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.CHANGE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'varId': undefined,
+              'element': 'field',
+              'name': 'FIELD_NAME',
+              'oldValue': 'old',
+              'newValue': 'new',
+              'recordUndo': true,
+              'group': '',
+            });
+      });
+
+      test('Block change', function() {
+        var event = new Blockly.Events.BlockChange(
+            this.block, 'field', 'FIELD_NAME', 'old', 'new');
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.CHANGE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'varId': undefined,
+              'element': 'field',
+              'name': 'FIELD_NAME',
+              'oldValue': 'old',
+              'newValue': 'new',
+              'recordUndo': true,
+              'group': '',
+            });
+      });
+
+      test('Create', function() {
+        var event = new Blockly.Events.Create(this.block);
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.CREATE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'recordUndo': false,
+              'group': '',
+            });
+      });
+
+      test('Block create', function() {
+        var event = new Blockly.Events.BlockCreate(this.block);
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.CREATE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'recordUndo': false,
+              'group': '',
+            });
+      });
+
+      test('Delete', function() {
+        var event = new Blockly.Events.Delete(this.block);
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.DELETE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'recordUndo': false,
+              'group': '',
+            });
+      });
+
+      test('Block delete', function() {
+        var event = new Blockly.Events.BlockDelete(this.block);
+        sinon.assert.calledOnce(this.genUidStub);
+        assertEventEquals(event, Blockly.Events.DELETE,
+            this.workspace.id, this.TEST_BLOCK_ID,
+            {
+              'recordUndo': false,
+              'group': '',
+            });
+      });
+
+      suite('Move', function() {
+        setup(function() {
+          this.parentBlock = createSimpleTestBlock(this.workspace);
+          this.block.parentBlock_ = this.parentBlock;
+          this.block.xy_ = new Blockly.utils.Coordinate(3, 4);
+        });
+
+        teardown(function() {
+          // This needs to be cleared, otherwise workspace.dispose will fail.
+          this.block.parentBlock_ = null;
+        });
+
+        test('Move', function() {
+          var event = new Blockly.Events.Move(this.block);
+          sinon.assert.calledTwice(this.genUidStub);
+          assertEventEquals(event, Blockly.Events.MOVE, this.workspace.id,
+              this.TEST_BLOCK_ID, {
+                'oldParentId': this.TEST_PARENT_ID,
+                'oldInputName': undefined,
+                'oldCoordinate': undefined,
+                'recordUndo': false,
+                'group': ''
+              });
+        });
+
+        test('Block move', function() {
+          var event = new Blockly.Events.BlockMove(this.block);
+          sinon.assert.calledTwice(this.genUidStub);
+          assertEventEquals(event, Blockly.Events.MOVE, this.workspace.id,
+              this.TEST_BLOCK_ID,
+              {
+                'oldParentId': this.TEST_PARENT_ID,
+                'oldInputName': undefined,
+                'oldCoordinate': undefined,
+                'recordUndo': false,
+                'group': ''
+              });
+        });
+      });
+    });
+
     suite('With variable getter blocks', function() {
       setup(function() {
         this.genUidStub = createGenUidStubWithReturns(

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -44,13 +44,13 @@
     <script src="test_helpers.js"></script>
     <script src="toolbox_helper.js"></script>
 
-    <script src="astnode_test.js"></script>
+    <!--<script src="astnode_test.js"></script>
     <script src="block_test.js"></script>
     <script src="comment_test.js"></script>
     <script src="connection_db_test.js"></script>
-    <script src="connection_checker_test.js"></script>
+    <script src="connection_checker_test.js"></script>-->
     <script src="connection_test.js"></script>
-    <script src="contextmenu_items_test.js"></script>
+    <!--<script src="contextmenu_items_test.js"></script>
     <script src="cursor_test.js"></script>
     <script src="dropdowndiv_test.js"></script>
     <script src="event_test.js"></script>
@@ -94,7 +94,7 @@
     <script src="workspace_comment_test.js"></script>
     <script src="xml_procedures_test.js"></script>
     <script src="xml_test.js"></script>
-    <script src="zoom_controls_test.js"></script>
+    <script src="zoom_controls_test.js"></script>-->
 
     <div id="blocklyDiv"></div>
     <xml xmlns="https://developers.google.com/blockly/xml" id="toolbox-simple" style="display: none">

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -44,13 +44,13 @@
     <script src="test_helpers.js"></script>
     <script src="toolbox_helper.js"></script>
 
-    <!--<script src="astnode_test.js"></script>
+    <script src="astnode_test.js"></script>
     <script src="block_test.js"></script>
     <script src="comment_test.js"></script>
     <script src="connection_db_test.js"></script>
-    <script src="connection_checker_test.js"></script>-->
+    <script src="connection_checker_test.js"></script>
     <script src="connection_test.js"></script>
-    <!--<script src="contextmenu_items_test.js"></script>
+    <script src="contextmenu_items_test.js"></script>
     <script src="cursor_test.js"></script>
     <script src="dropdowndiv_test.js"></script>
     <script src="event_test.js"></script>
@@ -94,7 +94,7 @@
     <script src="workspace_comment_test.js"></script>
     <script src="xml_procedures_test.js"></script>
     <script src="xml_test.js"></script>
-    <script src="zoom_controls_test.js"></script>-->
+    <script src="zoom_controls_test.js"></script>
 
     <div id="blocklyDiv"></div>
     <xml xmlns="https://developers.google.com/blockly/xml" id="toolbox-simple" style="display: none">

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -640,369 +640,523 @@ function testAWorkspace() {
   });
 
   suite('Undo/Redo', function() {
-    function createTwoVarsDifferentTypes(workspace) {
-      workspace.createVariable('name1', 'type1', 'id1');
-      workspace.createVariable('name2', 'type2', 'id2');
-    }
 
-    suite('createVariable', function() {
-      test('Undo only', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-
-        this.workspace.undo();
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-      });
-
-      test('Undo and redo', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-
-        this.workspace.undo(true);
-
-        // Expect that variable 'id2' is recreated
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo();
-        this.workspace.undo();
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-        this.workspace.undo(true);
-
-        // Expect that variable 'id1' is recreated
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-      });
-    });
-
-    suite('deleteVariableById', function() {
-      test('Undo only no usages', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-        this.workspace.deleteVariableById('id1');
-        this.workspace.deleteVariableById('id2');
-
-        this.workspace.undo();
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-      });
-
-      test('Undo only with usages', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-        // Create blocks to refer to both of them.
-        createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-        this.workspace.deleteVariableById('id1');
-        this.workspace.deleteVariableById('id2');
-
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name2');
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name2');
-        assertBlockVarModelName(this.workspace, 1, 'name1');
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-      });
-
-      test('Reference exists no usages', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-        this.workspace.deleteVariableById('id1');
-        this.workspace.deleteVariableById('id2');
-
-        this.workspace.undo();
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo(true);
-        // Expect that both variables are deleted
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-
-        this.workspace.undo();
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo(true);
-        // Expect that variable 'id2' is recreated
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-      });
-
-      test('Reference exists with usages', function() {
-        createTwoVarsDifferentTypes(this.workspace);
-        // Create blocks to refer to both of them.
-        createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-        this.workspace.deleteVariableById('id1');
-        this.workspace.deleteVariableById('id2');
-
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name2');
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo(true);
-        // Expect that both variables are deleted
-        chai.assert.equal(this.workspace.topBlocks_.length, 0);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
-
-        this.workspace.undo();
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name2');
-        assertBlockVarModelName(this.workspace, 1, 'name1');
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-        this.workspace.undo(true);
-        // Expect that variable 'id2' is recreated
-        assertBlockVarModelName(this.workspace,0, 'name2');
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-      });
-
-      test('Delete same variable twice no usages', function() {
-        this.workspace.createVariable('name1', 'type1', 'id1');
-        this.workspace.deleteVariableById('id1');
-        var workspace = this.workspace;
-        assertWarnings(() => {
-          workspace.deleteVariableById('id1');
-        }, [/Can't delete non-existent variable/]);
-        // Check the undoStack only recorded one delete event.
-        var undoStack = this.workspace.undoStack_;
-        chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-        chai.assert.notEqual(undoStack[undoStack.length - 2].type, 'var_delete');
-
-        // Undo delete
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-
-        // Redo delete
-        this.workspace.undo(true);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-
-        // Redo delete, nothing should happen
-        this.workspace.undo(true);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-      });
-
-      test('Delete same variable twice with usages', function() {
-        this.workspace.createVariable('name1', 'type1', 'id1');
-        createVarBlocksNoEvents(this.workspace, ['id1']);
-        this.workspace.deleteVariableById('id1');
-        var workspace = this.workspace;
-        assertWarnings(() => {
-          workspace.deleteVariableById('id1');
-        }, [/Can't delete non-existent variable/]);
-        // Check the undoStack only recorded one delete event.
-        var undoStack = this.workspace.undoStack_;
-        chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-        chai.assert.equal(undoStack[undoStack.length - 2].type, 'delete');
-        chai.assert.notEqual(undoStack[undoStack.length - 3].type, 'var_delete');
-
-        // Undo delete
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name1');
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-
-        // Redo delete
-        this.workspace.undo(true);
-        chai.assert.equal(this.workspace.topBlocks_.length, 0);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-
-        // Redo delete, nothing should happen
-        this.workspace.undo(true);
-        chai.assert.equal(this.workspace.topBlocks_.length, 0);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
-      });
-    });
-
-    suite('renameVariableById', function() {
+    suite('Undo Delete', function() {
       setup(function() {
-        this.workspace.createVariable('name1', 'type1', 'id1');
+        Blockly.defineBlocksWithJsonArray([
+          {
+            "type": "stack_block",
+            "message0": "",
+            "previousStatement": null,
+            "nextStatement": null
+          },
+          {
+            "type": "row_block",
+            "message0": "%1",
+            "args0": [
+              {
+                "type": "input_value",
+                "name": "INPUT"
+              }
+            ],
+            "output": null
+          },
+          {
+            "type": "statement_block",
+            "message0": "%1",
+            "args0": [
+              {
+                "type": "input_statement",
+                "name": "STATEMENT"
+              }
+            ],
+            "previousStatement": null,
+            "nextStatement": null
+          }]);
       });
 
-      test('Reference exists no usages rename to name2', function() {
-        this.workspace.renameVariableById('id1', 'name2');
+      teardown(function() {
+        delete Blockly.Blocks['stack_block'];
+        delete Blockly.Blocks['row_block'];
+        delete Blockly.Blocks['statement_block'];
+      });
 
+      /**
+       * Assert that two nodes are equal.
+       * @param {!Element} actual the actual node.
+       * @param {!Element} expected the expected node.
+       */
+      function assertNodesEqual(actual, expected) {
+        var actualId = actual.getAttribute('id');
+        var expectedId = expected.getAttribute('id');
+
+        chai.assert.equal(actual.tagName, expected.tagName);
+        for (var i = 0, attr; (attr = expected.attributes[i]); i++) {
+          chai.assert.equal(actual.getAttribute(attr.name), attr.value,
+              `expected attribute ${attr.name} on ${actualId} to match ` +
+              `${expectedId}`);
+        }
+        chai.assert.equal(actual.childElementCount, expected.childElementCount,
+            `expected block ${actualId} to have the same children as  block ` +
+            `${expectedId}`);
+        for (var i = 0; i < expected.childElementCount; i++) {
+          assertNodesEqual(actual.children[i], expected.children[i]);
+        }
+      }
+
+      function testUndoDelete(xmlText) {
+        var xml = Blockly.Xml.textToDom(xmlText);
+        Blockly.Xml.domToBlock(xml, this.workspace);
+        this.workspace.getTopBlocks()[0].dispose(false);
         this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+        var newXml = Blockly.Xml.workspaceToDom(this.workspace);
+        assertNodesEqual(newXml.firstChild, xml);
+      }
 
-        this.workspace.undo(true);
-        assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
-
+      test('Stack', function() {
+        testUndoDelete.call(this, '<block type="stack_block" id="1"/>');
       });
 
-      test('Reference exists with usages rename to name2', function() {
-        createVarBlocksNoEvents(this.workspace, ['id1']);
-        this.workspace.renameVariableById('id1', 'name2');
-
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name1');
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-
-        this.workspace.undo(true);
-        assertBlockVarModelName(this.workspace, 0, 'name2');
-        assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+      test('Row', function() {
+        testUndoDelete.call(this, '<block type="row_block" id="1"/>');
       });
 
-      test('Reference exists different capitalization no usages rename to Name1', function() {
-        this.workspace.renameVariableById('id1', 'Name1');
-
-        this.workspace.undo();
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-
-        this.workspace.undo(true);
-        assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+      test('Statement', function() {
+        testUndoDelete.call(this, '<block type="statement_block" id="1"/>');
       });
 
-      test('Reference exists different capitalization with usages rename to Name1', function() {
-        createVarBlocksNoEvents(this.workspace, ['id1']);
-        this.workspace.renameVariableById('id1', 'Name1');
-
-        this.workspace.undo();
-        assertBlockVarModelName(this.workspace, 0, 'name1');
-        assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-
-        this.workspace.undo(true);
-        assertBlockVarModelName(this.workspace, 0, 'Name1');
-        assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+      test('Stack w/ child', function() {
+        testUndoDelete.call(this,
+            '<block type="stack_block" id="1">' +
+            '  <next>' +
+            '    <block type="stack_block" id="2"></block>' +
+            '  </next>' +
+            '</block>'
+        );
       });
 
-      suite('Two variables rename overlap', function() {
-        test('Same type no usages rename variable with id1 to name2', function() {
-          this.workspace.createVariable('name2', 'type1', 'id2');
-          this.workspace.renameVariableById('id1', 'name2');
+      test('Row w/ child', function() {
+        testUndoDelete.call(this,
+            '<block type="row_block" id="1">' +
+            '  <value name="INPUT">' +
+            '    <block type="row_block" id="2"></block>' +
+            '  </value>' +
+            '</block>'
+        );
+      });
+
+      test('Statement w/ child', function() {
+        testUndoDelete.call(this,
+            '<block type="statement_block" id="1">' +
+            '  <statement name="STATEMENT">' +
+            '    <block type="stack_block" id="2"></block>' +
+            '  </statement>' +
+            '</block>'
+        );
+      });
+
+      test('Stack w/ shadow', function() {
+        testUndoDelete.call(this,
+            '<block type="stack_block" id="1">' +
+            '  <next>' +
+            '    <shadow type="stack_block" id="2"></shadow>' +
+            '  </next>' +
+            '</block>'
+        );
+      });
+
+      test('Row w/ shadow', function() {
+        testUndoDelete.call(this,
+            '<block type="row_block" id="1">' +
+            '  <value name="INPUT">' +
+            '    <shadow type="row_block" id="2"></shadow>' +
+            '  </value>' +
+            '</block>'
+        );
+      });
+
+      test('Statement w/ shadow', function() {
+        testUndoDelete.call(this,
+            '<block type="statement_block" id="1">' +
+            '  <statement name="STATEMENT">' +
+            '    <shadow type="stack_block" id="2"></shadow>' +
+            '  </statement>' +
+            '</block>'
+        );
+      });
+    });
+
+    suite('Variables', function() {
+      function createTwoVarsDifferentTypes(workspace) {
+        workspace.createVariable('name1', 'type1', 'id1');
+        workspace.createVariable('name2', 'type2', 'id2');
+      }
+
+      suite('createVariable', function() {
+        test('Undo only', function() {
+          createTwoVarsDifferentTypes(this.workspace);
 
           this.workspace.undo();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
 
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+          this.workspace.undo();
           chai.assert.isNull(this.workspace.getVariableById('id1'));
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
         });
 
-        test('Same type with usages rename variable with id1 to name2', function() {
-          this.workspace.createVariable('name2', 'type1', 'id2');
-          createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-          this.workspace.renameVariableById('id1', 'name2');
+        test('Undo and redo', function() {
+          createTwoVarsDifferentTypes(this.workspace);
 
           this.workspace.undo();
-          assertBlockVarModelName(this.workspace, 0, 'name1');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
 
           this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+
+          // Expect that variable 'id2' is recreated
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+          this.workspace.undo();
+          this.workspace.undo();
           chai.assert.isNull(this.workspace.getVariableById('id1'));
-        });
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          this.workspace.undo(true);
 
-        test('Same type different capitalization no usages rename variable with id1 to Name2', function() {
-          this.workspace.createVariable('name2', 'type1', 'id2');
-          this.workspace.renameVariableById('id1', 'Name2');
+          // Expect that variable 'id1' is recreated
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
+        });
+      });
+
+      suite('deleteVariableById', function() {
+        test('Undo only no usages', function() {
+          createTwoVarsDifferentTypes(this.workspace);
+          this.workspace.deleteVariableById('id1');
+          this.workspace.deleteVariableById('id2');
 
           this.workspace.undo();
-          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-          chai.assert.isNull(this.workspace.getVariable('name1'));
-        });
-
-        test('Same type different capitalization with usages rename variable with id1 to Name2', function() {
-          this.workspace.createVariable('name2', 'type1', 'id2');
-          createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-          this.workspace.renameVariableById('id1', 'Name2');
-
-          this.workspace.undo();
-          assertBlockVarModelName(this.workspace, 0, 'name1');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
-          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
           chai.assert.isNull(this.workspace.getVariableById('id1'));
-          assertBlockVarModelName(this.workspace, 0, 'Name2');
-          assertBlockVarModelName(this.workspace, 1, 'Name2');
-        });
-
-        test('Different type no usages rename variable with id1 to name2', function() {
-          this.workspace.createVariable('name2', 'type2', 'id2');
-          this.workspace.renameVariableById('id1', 'name2');
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
         });
 
-        test('Different type with usages rename variable with id1 to name2', function() {
-          this.workspace.createVariable('name2', 'type2', 'id2');
+        test('Undo only with usages', function() {
+          createTwoVarsDifferentTypes(this.workspace);
+          // Create blocks to refer to both of them.
           createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-          this.workspace.renameVariableById('id1', 'name2');
+          this.workspace.deleteVariableById('id1');
+          this.workspace.deleteVariableById('id2');
 
           this.workspace.undo();
-          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-          assertBlockVarModelName(this.workspace, 0, 'name1');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
-
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
           assertBlockVarModelName(this.workspace, 0, 'name2');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name2');
+          assertBlockVarModelName(this.workspace, 1, 'name1');
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
         });
 
-        test('Different type different capitalization no usages rename variable with id1 to Name2', function() {
-          this.workspace.createVariable('name2', 'type2', 'id2');
-          this.workspace.renameVariableById('id1', 'Name2');
+        test('Reference exists no usages', function() {
+          createTwoVarsDifferentTypes(this.workspace);
+          this.workspace.deleteVariableById('id1');
+          this.workspace.deleteVariableById('id2');
 
+          this.workspace.undo();
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+          this.workspace.undo(true);
+          // Expect that both variables are deleted
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
+
+          this.workspace.undo();
           this.workspace.undo();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+          // Expect that variable 'id2' is recreated
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
         });
 
-        test('Different type different capitalization with usages rename variable with id1 to Name2', function() {
-          this.workspace.createVariable('name2', 'type2', 'id2');
+        test('Reference exists with usages', function() {
+          createTwoVarsDifferentTypes(this.workspace);
+          // Create blocks to refer to both of them.
           createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-          this.workspace.renameVariableById('id1', 'Name2');
+          this.workspace.deleteVariableById('id1');
+          this.workspace.deleteVariableById('id2');
+
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name2');
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+          this.workspace.undo(true);
+          // Expect that both variables are deleted
+          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          chai.assert.isNull(this.workspace.getVariableById('id2'));
+
+          this.workspace.undo();
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name2');
+          assertBlockVarModelName(this.workspace, 1, 'name1');
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+          this.workspace.undo(true);
+          // Expect that variable 'id2' is recreated
+          assertBlockVarModelName(this.workspace,0, 'name2');
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+        });
+
+        test('Delete same variable twice no usages', function() {
+          this.workspace.createVariable('name1', 'type1', 'id1');
+          this.workspace.deleteVariableById('id1');
+          var workspace = this.workspace;
+          var warnings = captureWarnings(function() {
+            workspace.deleteVariableById('id1');
+          });
+          chai.assert.equal(warnings.length, 1,
+              'Expected 1 warning for second deleteVariableById call.');
+
+          // Check the undoStack only recorded one delete event.
+          var undoStack = this.workspace.undoStack_;
+          chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
+          chai.assert.notEqual(undoStack[undoStack.length - 2].type, 'var_delete');
+
+          // Undo delete
+          this.workspace.undo();
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+
+          // Redo delete
+          this.workspace.undo(true);
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+
+          // Redo delete, nothing should happen
+          this.workspace.undo(true);
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+        });
+
+        test('Delete same variable twice with usages', function() {
+          this.workspace.createVariable('name1', 'type1', 'id1');
+          createVarBlocksNoEvents(this.workspace, ['id1']);
+          this.workspace.deleteVariableById('id1');
+          var workspace = this.workspace;
+          var warnings = captureWarnings(function() {
+            workspace.deleteVariableById('id1');
+          });
+          chai.assert.equal(warnings.length, 1,
+              'Expected 1 warning for second deleteVariableById call.');
+
+          // Check the undoStack only recorded one delete event.
+          var undoStack = this.workspace.undoStack_;
+          chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
+          chai.assert.equal(undoStack[undoStack.length - 2].type, 'delete');
+          chai.assert.notEqual(undoStack[undoStack.length - 3].type, 'var_delete');
+
+          // Undo delete
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name1');
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+
+          // Redo delete
+          this.workspace.undo(true);
+          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+
+          // Redo delete, nothing should happen
+          this.workspace.undo(true);
+          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.isNull(this.workspace.getVariableById('id1'));
+        });
+      });
+
+      suite('renameVariableById', function() {
+        setup(function() {
+          this.workspace.createVariable('name1', 'type1', 'id1');
+        });
+
+        test('Reference exists no usages rename to name2', function() {
+          this.workspace.renameVariableById('id1', 'name2');
 
           this.workspace.undo();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-          assertBlockVarModelName(this.workspace, 0, 'name1');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
 
           this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
-          assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-          assertBlockVarModelName(this.workspace, 0, 'Name2');
-          assertBlockVarModelName(this.workspace, 1, 'name2');
+          assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+
+        });
+
+        test('Reference exists with usages rename to name2', function() {
+          createVarBlocksNoEvents(this.workspace, ['id1']);
+          this.workspace.renameVariableById('id1', 'name2');
+
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name1');
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+
+          this.workspace.undo(true);
+          assertBlockVarModelName(this.workspace, 0, 'name2');
+          assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+        });
+
+        test('Reference exists different capitalization no usages rename to Name1', function() {
+          this.workspace.renameVariableById('id1', 'Name1');
+
+          this.workspace.undo();
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+
+          this.workspace.undo(true);
+          assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+        });
+
+        test('Reference exists different capitalization with usages rename to Name1', function() {
+          createVarBlocksNoEvents(this.workspace, ['id1']);
+          this.workspace.renameVariableById('id1', 'Name1');
+
+          this.workspace.undo();
+          assertBlockVarModelName(this.workspace, 0, 'name1');
+          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+
+          this.workspace.undo(true);
+          assertBlockVarModelName(this.workspace, 0, 'Name1');
+          assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+        });
+
+        suite('Two variables rename overlap', function() {
+          test('Same type no usages rename variable with id1 to name2', function() {
+            this.workspace.createVariable('name2', 'type1', 'id2');
+            this.workspace.renameVariableById('id1', 'name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+            chai.assert.isNull(this.workspace.getVariableById('id1'));
+          });
+
+          test('Same type with usages rename variable with id1 to name2', function() {
+            this.workspace.createVariable('name2', 'type1', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+            this.workspace.renameVariableById('id1', 'name2');
+
+            this.workspace.undo();
+            assertBlockVarModelName(this.workspace, 0, 'name1');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+            chai.assert.isNull(this.workspace.getVariableById('id1'));
+          });
+
+          test('Same type different capitalization no usages rename variable with id1 to Name2', function() {
+            this.workspace.createVariable('name2', 'type1', 'id2');
+            this.workspace.renameVariableById('id1', 'Name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
+            chai.assert.isNull(this.workspace.getVariable('name1'));
+          });
+
+          test('Same type different capitalization with usages rename variable with id1 to Name2', function() {
+            this.workspace.createVariable('name2', 'type1', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+            this.workspace.renameVariableById('id1', 'Name2');
+
+            this.workspace.undo();
+            assertBlockVarModelName(this.workspace, 0, 'name1');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
+            chai.assert.isNull(this.workspace.getVariableById('id1'));
+            assertBlockVarModelName(this.workspace, 0, 'Name2');
+            assertBlockVarModelName(this.workspace, 1, 'Name2');
+          });
+
+          test('Different type no usages rename variable with id1 to name2', function() {
+            this.workspace.createVariable('name2', 'type2', 'id2');
+            this.workspace.renameVariableById('id1', 'name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+          });
+
+          test('Different type with usages rename variable with id1 to name2', function() {
+            this.workspace.createVariable('name2', 'type2', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+            this.workspace.renameVariableById('id1', 'name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+            assertBlockVarModelName(this.workspace, 0, 'name1');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+            assertBlockVarModelName(this.workspace, 0, 'name2');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+          });
+
+          test('Different type different capitalization no usages rename variable with id1 to Name2', function() {
+            this.workspace.createVariable('name2', 'type2', 'id2');
+            this.workspace.renameVariableById('id1', 'Name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+          });
+
+          test('Different type different capitalization with usages rename variable with id1 to Name2', function() {
+            this.workspace.createVariable('name2', 'type2', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+            this.workspace.renameVariableById('id1', 'Name2');
+
+            this.workspace.undo();
+            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+            assertBlockVarModelName(this.workspace, 0, 'name1');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+
+            this.workspace.undo(true);
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+            assertBlockVarModelName(this.workspace, 0, 'Name2');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+          });
         });
       });
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Closes #3964 
Addresses #3929

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
See #3902 for more details.

To address #3929:
I looked into the `Blockly.Events.recordUndo` issue mentioned [here](https://github.com/google/blockly/issues/3929#issuecomment-641419970). I tracked it back to [this commit](https://github.com/google/blockly/commit/2a1ffa11c4c167e013cb1505afcd6e4cde9291f5#diff-1a1453e5905aa4f669088c9cfc5e6951R510).

After some testing it seems like the reason this was added is because it was allowing create, move, and delete events to handle deleting/respawning shadows in the context of undoing/redoing events (recordUndo is always false when undoing/redoing events). I've changed it so that if those events are recording info about a shadow block, they no longer get applied to the undo stack. This means that shadow spawning/deleting is now handled invariantly by the connect / disconnect functions, which should make this system easier to debug in the future.

### Test Coverage

1) #3929 
  Could not reproduce given the steps in the given issue.

2) Connecting & disconnecting Blocks.
![ConnectAndDisconnect](https://user-images.githubusercontent.com/25440652/90933828-13dc1e80-e3b5-11ea-9bfc-752e14b7b710.gif)

3) Undoing a connect.
![UndoConnect](https://user-images.githubusercontent.com/25440652/90933834-163e7880-e3b5-11ea-96c1-38b1470fa214.gif)

4) Undoing a disconnect.
![UndoDisconnect](https://user-images.githubusercontent.com/25440652/90933853-1c345980-e3b5-11ea-87bb-5e1bea67c68b.gif)


Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

I would really love to add unit tests for this. @moniika do you have any ideas for unit testing undo & redo?