### PR TITLE
Check if toolbox item has attr kind before using it

### DIFF
--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -278,7 +278,7 @@ Blockly.utils.toolbox.hasCategories = function(toolboxDef) {
   var toolboxContents = toolboxDef['contents'] || toolboxDef;
   if (Array.isArray(toolboxContents)) {
     var categories = toolboxContents.filter(function(item) {
-      return item['kind'].toUpperCase() == 'CATEGORY';
+      return item['kind'] && item['kind'].toUpperCase() == 'CATEGORY';
     });
     return !!categories.length;
   } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Custom categories (variables and procedures) don't have a 'kind' property so just make sure it exists before referencing it.


