### PR TITLE
Adds support for both categories and blocks

### DIFF
--- a/core/registry.js
+++ b/core/registry.js
@@ -207,6 +207,7 @@ Blockly.registry.getItem_ = function(type, name) {
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @return {boolean} True if the registry has an item with the given type and
  *     name, false otherwise.
+ * @template T
  */
 Blockly.registry.hasItem = function(type, name) {
   type = String(type).toLowerCase();

--- a/core/registry.js
+++ b/core/registry.js
@@ -81,7 +81,7 @@ Blockly.registry.Type.TOOLBOX = new Blockly.registry.Type('toolbox');
 Blockly.registry.Type.THEME = new Blockly.registry.Type('theme');
 
 /** @type {!Blockly.registry.Type<Blockly.ToolboxItem>} */
-Blockly.registry.Type.TOOLBOX_ITEM = new Blockly.registry.Type('toolbox-item');
+Blockly.registry.Type.TOOLBOX_ITEM = new Blockly.registry.Type('toolboxItem');
 
 /** @type {!Blockly.registry.Type<Blockly.IFlyout>} */
 Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX =
@@ -93,7 +93,7 @@ Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX =
 
 /**
  * Registers a class based on a type and name.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @param {?function(new:T, ...?)|Object} registryItem The class or object to
@@ -154,7 +154,7 @@ Blockly.registry.validate_ = function(type, registryItem) {
 
 /**
  * Unregisters the registry item with the given type and name.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @template T
@@ -177,7 +177,7 @@ Blockly.registry.unregister = function(type, name) {
 /**
  * Gets the registry item for the given name and type. This can be either a
  * class or an object.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @return {?function(new:T, ...?)|Object} The class or object with the given
@@ -202,7 +202,7 @@ Blockly.registry.getItem_ = function(type, name) {
 /**
  * Returns whether or not the registry contains an item with the given type and
  * name.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @return {boolean} True if the registry has an item with the given type and
@@ -221,7 +221,7 @@ Blockly.registry.hasItem = function(type, name) {
 
 /**
  * Gets the class for the given name and type.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
  * @return {?function(new:T, ...?)} The class with the given name and type or
@@ -234,7 +234,7 @@ Blockly.registry.getClass = function(type, name) {
 
 /**
  * Gets the object for the given name and type.
- * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {string|!Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Category)
  * @param {string} name The plugin's name. (Ex. logic_category)
  * @returns {T} The object with the given name and type or null if none exists.
@@ -247,7 +247,7 @@ Blockly.registry.getObject = function(type, name) {
 /**
  * Gets the class from Blockly options for the given type.
  * This is used for plugins that override a built in feature. (e.g. Toolbox)
- * @param {Blockly.registry.Type<T>} type The type of the plugin.
+ * @param {!Blockly.registry.Type<T>} type The type of the plugin.
  * @param {!Blockly.Options} options The option object to check for the given
  *     plugin.
  * @return {?function(new:T, ...?)} The class for the plugin.

--- a/core/registry.js
+++ b/core/registry.js
@@ -176,7 +176,7 @@ Blockly.registry.unregister = function(type, name) {
 
 /**
  * Gets the registry item for the given name and type. This can be either a
- * class or an object.l
+ * class or an object.
  * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
  *     (e.g. Field, Renderer)
  * @param {string} name The plugin's name. (Ex. field_angle, geras)
@@ -197,6 +197,25 @@ Blockly.registry.getItem_ = function(type, name) {
     return null;
   }
   return typeRegistry[name];
+};
+
+/**
+ * Returns whether or not the registry contains an item with the given type and
+ * name.
+ * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ *     (e.g. Field, Renderer)
+ * @param {string} name The plugin's name. (Ex. field_angle, geras)
+ * @return {boolean} True if the registry has an item with the given type and
+ *     name, false otherwise.
+ */
+Blockly.registry.hasItem = function(type, name) {
+  type = String(type).toLowerCase();
+  name = name.toLowerCase();
+  var typeRegistry = Blockly.registry.typeMap_[type];
+  if (!typeRegistry) {
+    return false;
+  }
+  return !!(typeRegistry[name]);
 };
 
 /**

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -169,7 +169,7 @@ Blockly.ToolboxCategory = function(categoryDef, toolbox, opt_parent) {
    */
   this.toolboxItems_ = [];
 
-  this.parseContents_(categoryDef, this.hasChildren_);
+  this.parseContents_(categoryDef);
 };
 
 Blockly.utils.object.inherits(Blockly.ToolboxCategory,
@@ -226,17 +226,28 @@ Blockly.ToolboxCategory.prototype.parseContents_ = function(categoryDef) {
   var contents = categoryDef['contents'];
   if (categoryDef['custom']) {
     this.contents_ = categoryDef['custom'];
-  } else {
+  } else if (contents) {
     for (var i = 0, item; (item = contents[i]); i++) {
-      var ToolboxItemClass = Blockly.registry.getClass(
-          Blockly.registry.Type.TOOLBOX_ITEM, item['kind'].toLowerCase());
-      if (ToolboxItemClass) {
-        var toolboxItem = new ToolboxItemClass(item, this.parentToolbox_, this);
-        this.toolboxItems_.push(toolboxItem);
-      } else {
-        this.contents_.push(item);
-      }
+      this.addItem_(item);
     }
+  }
+};
+
+/**
+ * Adds either a toolbox item or a flyout item to their respective lists.
+ * @param {!Blockly.utils.toolbox.ToolboxItem} itemDef The information needed
+ *     to create a toolbox item.
+ */
+Blockly.ToolboxCategory.prototype.addItem_ = function(itemDef) {
+  if (Blockly.registry.hasItem(
+      Blockly.registry.Type.TOOLBOX_ITEM, itemDef['kind'])) {
+    var ToolboxItemClass = Blockly.registry.getClass(
+        Blockly.registry.Type.TOOLBOX_ITEM, itemDef['kind']);
+    var toolboxItem = new ToolboxItemClass(itemDef, this.parentToolbox_, this);
+    this.toolboxItems_.push(toolboxItem);
+  } else {
+    var flyoutItem = /** @type {Blockly.utils.toolbox.FlyoutItem} */ (itemDef);
+    this.contents_.push(flyoutItem);
   }
 };
 
@@ -715,8 +726,7 @@ Blockly.ToolboxCategory.prototype.updateFlyoutContents = function(contents) {
     this.toolboxItemDef_['contents'] = Blockly.utils.toolbox.convertToolboxToJSON(contents);
   }
   this.parseContents_(
-      /** @type {Blockly.utils.toolbox.CategoryJson} */ (this.toolboxItemDef_),
-      this.hasChildren());
+      /** @type {Blockly.utils.toolbox.CategoryJson} */ (this.toolboxItemDef_));
 };
 
 /**

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -160,7 +160,7 @@ Blockly.ToolboxCategory = function(categoryDef, toolbox, opt_parent) {
    * @type {string|!Array<!Blockly.utils.toolbox.FlyoutItem>}
    * @protected
    */
-  this.contents_ = [];
+  this.flyoutItems_ = [];
 
   /**
    * The child toolbox items for this category.
@@ -225,7 +225,7 @@ Blockly.ToolboxCategory.defaultBackgroundColour = '#57e';
 Blockly.ToolboxCategory.prototype.parseContents_ = function(categoryDef) {
   var contents = categoryDef['contents'];
   if (categoryDef['custom']) {
-    this.contents_ = categoryDef['custom'];
+    this.flyoutItems_ = categoryDef['custom'];
   } else if (contents) {
     for (var i = 0, item; (item = contents[i]); i++) {
       this.addItem_(item);
@@ -247,7 +247,7 @@ Blockly.ToolboxCategory.prototype.addItem_ = function(itemDef) {
     this.toolboxItems_.push(toolboxItem);
   } else {
     var flyoutItem = /** @type {Blockly.utils.toolbox.FlyoutItem} */ (itemDef);
-    this.contents_.push(flyoutItem);
+    this.flyoutItems_.push(flyoutItem);
   }
 };
 
@@ -696,7 +696,7 @@ Blockly.ToolboxCategory.prototype.getDiv = function() {
  * @override
  */
 Blockly.ToolboxCategory.prototype.getContents = function() {
-  return this.contents_;
+  return this.flyoutItems_;
 };
 
 /**

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.ToolboxCategory');
 
 goog.require('Blockly.CollapsibleToolboxItem');
+goog.require('Blockly.registry');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.toolbox');
@@ -219,22 +220,23 @@ Blockly.ToolboxCategory.defaultBackgroundColour = '#57e';
  * dynamic category, or if its contents are meant to be shown in the flyout.
  * @param {!Blockly.utils.toolbox.CategoryJson} categoryDef The information needed
  *     to create a category.
- * @param {boolean} hasChildren True if this category has subcategories, false
- *     otherwise.
  * @protected
  */
-Blockly.ToolboxCategory.prototype.parseContents_ = function(categoryDef,
-    hasChildren) {
+Blockly.ToolboxCategory.prototype.parseContents_ = function(categoryDef) {
   var contents = categoryDef['contents'];
-  if (hasChildren) {
-    for (var i = 0; i < contents.length; i++) {
-      var child = new Blockly.ToolboxCategory(contents[i], this.parentToolbox_, this);
-      this.toolboxItems_.push(child);
-    }
-  } else if (categoryDef['custom']) {
+  if (categoryDef['custom']) {
     this.contents_ = categoryDef['custom'];
   } else {
-    this.contents_ = contents;
+    for (var i = 0, item; (item = contents[i]); i++) {
+      var ToolboxItemClass = Blockly.registry.getClass(
+          Blockly.registry.Type.TOOLBOX_ITEM, item['kind'].toLowerCase());
+      if (ToolboxItemClass) {
+        var toolboxItem = new ToolboxItemClass(item, this.parentToolbox_, this);
+        this.toolboxItems_.push(toolboxItem);
+      } else {
+        this.contents_.push(item);
+      }
+    }
   }
 };
 

--- a/core/toolbox/separator.js
+++ b/core/toolbox/separator.js
@@ -13,6 +13,7 @@
 
 goog.provide('Blockly.ToolboxSeparator');
 
+goog.require('Blockly.registry');
 goog.require('Blockly.ToolboxItem');
 
 goog.requireType('Blockly.utils.toolbox');

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -734,10 +734,13 @@ Blockly.Toolbox.prototype.selectItemByPosition = function(position) {
  * @protected
  */
 Blockly.Toolbox.prototype.updateFlyout_ = function(oldItem, newItem) {
+  if (newItem && !newItem.isSelectable()) {
+    return;
+  }
   if ((oldItem == newItem && !newItem.isCollapsible()) || !newItem ||
       !newItem.getContents().length) {
     this.flyout_.hide();
-  } else if (newItem.isSelectable()) {
+  } else {
     var selectableItem = /** @type {!Blockly.SelectableToolboxItem} */ (newItem);
     this.flyout_.show(selectableItem.getContents());
     this.flyout_.scrollToStart();

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -734,7 +734,8 @@ Blockly.Toolbox.prototype.selectItemByPosition = function(position) {
  * @protected
  */
 Blockly.Toolbox.prototype.updateFlyout_ = function(oldItem, newItem) {
-  if (oldItem == newItem || !newItem || newItem.isCollapsible()) {
+  if ((oldItem == newItem && !newItem.isCollapsible()) || !newItem ||
+      !newItem.getContents().length) {
     this.flyout_.hide();
   } else if (newItem.isSelectable()) {
     var selectableItem = /** @type {!Blockly.SelectableToolboxItem} */ (newItem);

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -734,15 +734,11 @@ Blockly.Toolbox.prototype.selectItemByPosition = function(position) {
  * @protected
  */
 Blockly.Toolbox.prototype.updateFlyout_ = function(oldItem, newItem) {
-  if (newItem && !newItem.isSelectable()) {
-    return;
-  }
   if ((oldItem == newItem && !newItem.isCollapsible()) || !newItem ||
       !newItem.getContents().length) {
     this.flyout_.hide();
   } else {
-    var selectableItem = /** @type {!Blockly.SelectableToolboxItem} */ (newItem);
-    this.flyout_.show(selectableItem.getContents());
+    this.flyout_.show(newItem.getContents());
     this.flyout_.scrollToStart();
   }
 };

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -289,7 +289,7 @@ suite('Toolbox', function() {
       });
       test('Selected item is collapsed -> Should skip over its children', function() {
         var item = getCollapsibleItem(this.toolbox);
-        var childItem = item.contents_[0];
+        var childItem = item.flyoutItems_[0];
         item.expanded_ = false;
         this.toolbox.selectedItem_ = item;
         var handled = this.toolbox.selectNext_();

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -419,14 +419,6 @@ suite('Toolbox', function() {
       sinon.assert.called(showFlyoutstub);
       sinon.assert.called(scrollToStartFlyout);
     });
-    test('Select non selectable item -> Should not update the flyout', function() {
-      var showFlyoutstub = sinon.stub(this.toolbox.flyout_, 'show');
-      var hideFlyoutStub = sinon.stub(this.toolbox.flyout_, 'hide');
-      var nonSelectableItem = getSeparator(this.toolbox);
-      this.toolbox.updateFlyout_(null, nonSelectableItem);
-      sinon.assert.notCalled(showFlyoutstub);
-      sinon.assert.notCalled(hideFlyoutStub);
-    });
   });
 
   suite('position', function() {

--- a/tests/scripts/selenium-config.js
+++ b/tests/scripts/selenium-config.js
@@ -9,7 +9,7 @@ module.exports = {
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '83.0.4103.39',
+      version: '85.0.4183.83',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Adds support for having both categories and blocks as children of a category. Ex: 

<category name="something">
  <category name="somethingElse"></category>
  <block></block>
</category>
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
I had originally decided to not have this in core, however I was re reading documentation and realized that we offer this feature in the old toolbox. So adding this as to not break anyone.
<!-- Anything else we should know? -->
