### PR TITLE
Add getters for private properties in flyout button

### DIFF
--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -228,12 +228,26 @@ Blockly.FlyoutButton.prototype.moveTo = function(x, y) {
 };
 
 /**
+ * @returns {boolean} Whether or not the button is a label.
+ */
+Blockly.FlyoutButton.prototype.isLabel = function() {
+  return this.isLabel_;
+};
+
+/**
  * Location of the button.
  * @return {!Blockly.utils.Coordinate} x, y coordinates.
  * @package
  */
 Blockly.FlyoutButton.prototype.getPosition = function() {
   return this.position_;
+};
+
+/**
+ * @returns {string} Text of the button.
+ */
+Blockly.FlyoutButton.prototype.getText = function() {
+  return this.text_;
 };
 
 /**

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -228,7 +228,7 @@ Blockly.FlyoutButton.prototype.moveTo = function(x, y) {
 };
 
 /**
- * @returns {boolean} Whether or not the button is a label.
+ * @return {boolean} Whether or not the button is a label.
  */
 Blockly.FlyoutButton.prototype.isLabel = function() {
   return this.isLabel_;
@@ -244,9 +244,9 @@ Blockly.FlyoutButton.prototype.getPosition = function() {
 };
 
 /**
- * @returns {string} Text of the button.
+ * @return {string} Text of the button.
  */
-Blockly.FlyoutButton.prototype.getText = function() {
+Blockly.FlyoutButton.prototype.getButtonText = function() {
   return this.text_;
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Proposed Changes

Adds public methods for getting the value of several private fields on flyout_button I'm using in the continuous toolbox plugin.
