### PR TITLE
Fix deeply nested categories visibility

### DIFF
--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -138,15 +138,6 @@ Blockly.ToolboxCategory = function(categoryDef, toolbox, opt_parent) {
   this.isHidden_ = false;
 
   /**
-   * True if the parent category is expanded, false otherwise.
-   * Children categories can only be visible if their parent category is
-   * expanded.
-   * @type {boolean}
-   * @private
-   */
-  this.isParentExpanded_ = true;
-
-  /**
    * True if this category is disabled, false otherwise.
    * @type {boolean}
    * @protected
@@ -529,12 +520,6 @@ Blockly.ToolboxCategory.prototype.setExpanded = function(isExpanded) {
   Blockly.utils.aria.setState(/** @type {!Element} */ (this.htmlDiv_),
       Blockly.utils.aria.State.EXPANDED, isExpanded);
 
-  if (this.hasSubcategories()) {
-    for (var i = 0; i < this.getChildToolboxItems().length; i++) {
-      var child = this.getChildToolboxItems()[i];
-      child.isParentExpanded_ = isExpanded;
-    }
-  }
   this.parentToolbox_.handleToolboxItemResize();
 };
 

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -610,12 +610,28 @@ Blockly.ToolboxCategory.prototype.show = function() {
 
 /**
  * Whether the category is visible.
- * A category is only visible if its parent is expanded and isHidden_ is false.
+ * A category is only visible if all of its ancestors are expanded and isHidden_ is false.
  * @return {boolean} True if the category is visible, false otherwise.
  * @public
  */
 Blockly.ToolboxCategory.prototype.isVisible = function() {
-  return !this.isHidden_ && this.isParentExpanded_;
+  return !this.isHidden_ && this.allAncestorsExpanded_();
+};
+
+/**
+ * Whether all ancestors of a category (parent and parent's parent, etc.) are expanded.
+ * @return {boolean} True only if every ancestor is expanded
+ * @protected
+ */
+Blockly.ToolboxCategory.prototype.allAncestorsExpanded_ = function() {
+  var category = this;
+  while (category.getParent()) {
+    category = category.getParent();
+    if (!category.isExpanded()) {
+      return false;
+    }
+  }
+  return true;
 };
 
 /**

--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -32,6 +32,7 @@
         "getCategoryJSON": true,
         "getChildItem": true,
         "getCollapsibleItem": true,
+        "getDeeplyNestedJSON": true,
         "getInjectedToolbox": true,
         "getNonCollapsibleItem": true,
         "getSeparator": true,

--- a/tests/mocha/toolbox_helper.js
+++ b/tests/mocha/toolbox_helper.js
@@ -6,11 +6,11 @@
 
 /**
  * Get JSON for a toolbox that contains categories.
- * @return {Array.<Blockly.utils.toolbox.Toolbox>} The array holding information
+ * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
  *    for a toolbox.
  */
 function getCategoryJSON() {
-  return {'contents': [
+  return {"contents": [
     {
       "kind": "CATEGORY",
       "cssconfig": {
@@ -42,11 +42,11 @@ function getCategoryJSON() {
 
 /**
  * Get JSON for a simple toolbox.
- * @return {Array.<Blockly.utils.toolbox.Toolbox>} The array holding information
+ * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
  *    for a simple toolbox.
  */
 function getSimpleJSON() {
-  return {'contents':[
+  return {"contents":[
     {
       "kind":"BLOCK",
       "blockxml": "<block type=\"logic_operation\"></block>",
@@ -69,8 +69,52 @@ function getSimpleJSON() {
 }
 
 /**
+ * Get JSON for a toolbox that contains categories that contain categories.
+ * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
+ *    for a toolbox.
+ */
+function getDeeplyNestedJSON() {
+  return {"contents": [
+    {
+      "kind": "CATEGORY",
+      "cssconfig": {
+        "container": "something"
+      },
+      "contents": [{
+        "kind": "CATEGORY",
+        "contents": [{
+          "kind": "CATEGORY",
+          "contents": [
+            {
+              "kind": "BLOCK",
+              "blockxml": '<block type="basic_block"><field name="TEXT">NestedCategory-FirstBlock</field></block>'
+            },
+            {
+              "kind": "BLOCK",
+              "blockxml": '<block type="basic_block"><field name="TEXT">NestedCategory-SecondBlock</field></block>'
+            }
+          ],
+          "name": "NestedCategoryInner"
+        }],
+        "name": "NestedCategoryMiddle",
+      }],
+      "name": "NestedCategoryOuter"
+    },
+    {
+      "kind": "CATEGORY",
+      "contents": [
+        {
+          "kind": "BLOCK",
+          "blockxml": '<block type="basic_block"><field name="TEXT">SecondCategory-FirstBlock</field></block>'
+        }
+      ],
+      "name": "Second"
+    }]};
+}
+
+/**
  * Get an array filled with xml elements.
- * @return {Array.<Nodde>} Array holding xml elements for a toolbox.
+ * @return {Array<Node>} Array holding xml elements for a toolbox.
  */
 function getXmlArray() {
   // Need to use HTMLElement instead of Element so parser output is

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -605,4 +605,41 @@ suite('Toolbox', function() {
       });
     });
   });
+  suite('Nested Categories', function() {
+    setup(function() {
+      this.toolbox = getInjectedToolbox();
+    });
+    teardown(function() {
+      this.toolbox.dispose();
+    });
+    test('Child categories visible if all ancestors expanded', function() {
+      this.toolbox.render(getDeeplyNestedJSON());
+      var outerCategory = this.toolbox.contents_[0];
+      var middleCategory = this.toolbox.contents_[1];
+      var innerCategory = this.toolbox.contents_[2];
+ 
+      outerCategory.toggleExpanded();
+      middleCategory.toggleExpanded();
+      innerCategory.toggleExpanded();
+      innerCategory.show();
+
+      chai.assert.isTrue(innerCategory.isVisible(),
+          'All ancestors are expanded, so category should be visible');
+    });
+    test('Child categories not visible if any ancestor not expanded', function() {
+      this.toolbox.render(getDeeplyNestedJSON());
+      var middleCategory = this.toolbox.contents_[1];
+      var innerCategory = this.toolbox.contents_[2];
+ 
+      // Don't expand the outermost category
+      // Even though the direct parent of inner is expanded, it shouldn't be visible
+      // because all ancestor categories need to be visible, not just parent
+      middleCategory.toggleExpanded();
+      innerCategory.toggleExpanded();
+      innerCategory.show();
+
+      chai.assert.isFalse(innerCategory.isVisible(),
+          'Not all ancestors are expanded, so category should not be visible');
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Categories that are nested twice currently do not work. 
Steps to reproduce: 
1. Add a double nested category to your toolbox
<category name="LogicNestedOne">
   <category name="LogicNestedTwo">
      <category name="LogicNestedThree"></category>
   </category>
</category>
2. Expand all the nested categories 
3. Close the top category.
4. Use the arrow keys to go to the next item 
Notice how the next item is only selected after hitting the down button two times.

### Proposed Changes

Checks all ancestor categories to make sure they are all expanded, in order for a category to be visible. The keyboard navigation uses visibility to tell if a category can be navigated to

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added tests for this case. also while I was here, I cleaned up some typos in types for test_helpers that were causing red squiggles.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

I'm pretty sure we can get rid of the property `isParentExpanded_` now, but I didn't remove it yet in case it has some use I didn't see. wanted to check with Abby first.
