### PR TITLE
Fix code demo size being incorrect for some langs

### DIFF
--- a/demos/code/style.css
+++ b/demos/code/style.css
@@ -74,6 +74,7 @@ td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;
   padding: 5px 19px;
+  white-space: nowrap;
 }
 td.taboff {
   cursor: pointer;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4245

### Proposed Changes

Adds a white-space: nowrap property to the tabon class.

### Reason for Changes

Certain unicode characters layout vertically by default. This was pushing the size of the content area down when it should not have been.
![Vertical](https://user-images.githubusercontent.com/25440652/91908893-1cf4a780-ec61-11ea-8ee0-6b0ed9ddfcce.png)

Adding an explicit white-space: nowrap property to the div makes it so that they always layout horizontally, so we don't get size issues:
![Horizontal](https://user-images.githubusercontent.com/25440652/91908934-2f6ee100-ec61-11ea-9252-6f5ba690bc0a.png)


### Test Coverage

Tried switching between Japanese, Traditional Chinese, and English. Observed no layout issues.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

### Additional Information

<!-- Anything else we should know? -->
N/A
