### PR TITLE
Add getTooltip

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -905,12 +905,22 @@ Blockly.Block.prototype.setHelpUrl = function(url) {
 };
 
 /**
- * Change the tooltip text for a block.
- * @param {string|!Function} newTip Text for tooltip or a parent element to
- *     link to for its tooltip.  May be a function that returns a string.
+ * Sets the tooltip for this block.
+ * @param {!string|!function(): (!string|!Function)|!{tooltip}} newTip The text
+ *     for the tooltip, a function that returns the text for the tooltip, or a
+ *     parent object whose tooltip will be used. To not display a tooltip pass
+ *     the empty string.
  */
 Blockly.Block.prototype.setTooltip = function(newTip) {
   this.tooltip = newTip;
+};
+
+/**
+ * Returns the tooltip text for this block.
+ * @returns {!string} The tooltip text for this block.
+ */
+Blockly.Block.prototype.getTooltip = function() {
+  return Blockly.Tooltip.getTooltipOfObject(this);
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -66,7 +66,7 @@ Blockly.Field = function(value, opt_validator, opt_config) {
   /**
    * Used to cache the field's tooltip value if setTooltip is called when the
    * field is not yet initialized. Is *not* guaranteed to be accurate.
-   * @type {string|Function|!SVGElement}
+   * @type {!string|!function(): (!string|!Function)|!SVGElement|null}
    * @private
    */
   this.tooltip_ = null;
@@ -996,23 +996,36 @@ Blockly.Field.prototype.onMouseDown_ = function(e) {
 };
 
 /**
- * Change the tooltip text for this field.
- * @param {string|Function|!SVGElement} newTip Text for tooltip or a parent
- *    element to link to for its tooltip.
+ * Sets the tooltip for this field.
+ * @param {!string|!function(): (!string|!Function)|!{tooltip}|null} newTip The
+ *     text for the tooltip, a function that returns the text for the tooltip, a
+ *     parent object whose tooltip will be used, or null to display the tooltip
+ *     of the parent block. To not display a tooltip pass the empty string.
  */
 Blockly.Field.prototype.setTooltip = function(newTip) {
+  if (!newTip && newTip !== '') {  // If null or undefined.
+    newTip = this.sourceBlock_;
+  }
   var clickTarget = this.getClickTarget_();
-  if (!clickTarget) {
+  if (clickTarget) {
+    clickTarget.tooltip = newTip;
+  } else {
     // Field has not been initialized yet.
     this.tooltip_ = newTip;
-    return;
   }
+};
 
-  if (!newTip && newTip !== '') {  // If null or undefined.
-    clickTarget.tooltip = this.sourceBlock_;
-  } else {
-    clickTarget.tooltip = newTip;
+/**
+ * Returns the tooltip text for this block.
+ * @returns {!string} The tooltip text for this block.
+ */
+Blockly.Field.prototype.getTooltip = function() {
+  var tooltipObj = this.getClickTarget_();
+  if (!tooltipObj) {
+    // Field has not been initialized yet. Return stashed this.tooltip_ value.
+    tooltipObj = {tooltip: this.tooltip_};
   }
+  return Blockly.Tooltip.getTooltipOfObject(tooltipObj);
 };
 
 /**

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -112,6 +112,45 @@ Blockly.Tooltip.MARGINS = 5;
 Blockly.Tooltip.DIV = null;
 
 /**
+ * Returns the tooltip text for the given element.
+ * @param {!{tooltip}} obj The object to get the the tooltip text of.
+ * @returns {!string} The tooltip text of the element.
+ */
+Blockly.Tooltip.getTooltipOfObject = function(obj) {
+  obj = Blockly.Tooltip.getTargetObject_(obj);
+  if (obj) {
+    var tooltip = obj.tooltip;
+    while (typeof tooltip == 'function') {
+      tooltip = tooltip();
+    }
+    if (typeof tooltip != 'string') {
+      throw Error('Tooltip function must return a string.');
+    }
+    return tooltip;
+  }
+  return '';
+};
+
+/**
+ * Returns the target object that the given object is targeting for its
+ * tooltip. Could be the object itself.
+ * @param {!{tooltip}} obj The object are trying to find the target tooltip
+ *     object of.
+ * @returns {!{tooltip}|null} The target tooltip object.
+ * @private
+ */
+Blockly.Tooltip.getTargetObject_ = function(obj) {
+  while (obj.tooltip) {
+    if ((typeof obj.tooltip == 'string') ||
+        (typeof obj.tooltip == 'function')) {
+      return obj;
+    }
+    obj = obj.tooltip;
+  }
+  return null;
+};
+
+/**
  * Create the tooltip div and inject it onto the page.
  */
 Blockly.Tooltip.createDom = function() {
@@ -167,11 +206,7 @@ Blockly.Tooltip.onMouseOver_ = function(e) {
   }
   // If the tooltip is an object, treat it as a pointer to the next object in
   // the chain to look at.  Terminate when a string or function is found.
-  var element = e.currentTarget;
-  while ((typeof element.tooltip != 'string') &&
-         (typeof element.tooltip != 'function')) {
-    element = element.tooltip;
-  }
+  var element = Blockly.Tooltip.getTargetObject_(e.currentTarget);
   if (Blockly.Tooltip.element_ != element) {
     Blockly.Tooltip.hide();
     Blockly.Tooltip.poisonedElement_ = null;
@@ -296,11 +331,7 @@ Blockly.Tooltip.show_ = function() {
   }
   // Erase all existing text.
   Blockly.Tooltip.DIV.textContent = '';
-  // Get the new text.
-  var tip = Blockly.Tooltip.element_.tooltip;
-  while (typeof tip == 'function') {
-    tip = tip();
-  }
+  var tip = Blockly.Tooltip.getTooltipOfObject(Blockly.Tooltip.element_);
   tip = Blockly.utils.string.wrap(tip, Blockly.Tooltip.LIMIT);
   // Create new text, line by line.
   var lines = tip.split('\n');

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -83,6 +83,7 @@
     <script src="registry_test.js"></script>
     <script src="theme_test.js"></script>
     <script src="toolbox_test.js"></script>
+    <script src="tooltip_test.js"></script>
     <script src="trashcan_test.js"></script>
     <script src="utils_test.js"></script>
     <script src="variable_map_test.js"></script>

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+suite('Tooltip', function() {
+
+  setup(function() {
+    sharedTestSetup.call(this);
+    this.workspace = new Blockly.Workspace();
+  });
+
+  teardown(function() {
+    sharedTestTeardown.call(this);
+  });
+
+  suite('set/getTooltip', function() {
+    setup(function() {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "test_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "field_input",
+              "name": "FIELD"
+            }
+          ]
+        }
+      ]);
+    });
+
+    teardown(function() {
+      delete Blockly.Blocks["test_block"];
+    });
+
+    var tooltipText = 'testTooltip';
+
+    function assertTooltip(obj) {
+      chai.assert.equal(obj.getTooltip(), tooltipText);
+    }
+
+    function setStringTooltip(obj) {
+      obj.setTooltip(tooltipText);
+    }
+
+    function setFunctionTooltip(obj) {
+      obj.setTooltip(() => tooltipText);
+    }
+
+    function setNestedFunctionTooltip(obj) {
+      function nestFunction(fn, count) {
+        if (!count) {
+          return fn;
+        }
+        return () => nestFunction(fn, --count);
+      }
+      obj.setTooltip(nestFunction(() => tooltipText, 5));
+    }
+
+    function setFunctionReturningObjectTooltip(obj) {
+      obj.setTooltip(() => {
+        return {
+          tooltip: tooltipText
+        };
+      });
+    }
+
+    function setObjectTooltip(obj) {
+      obj.setTooltip({tooltip: tooltipText});
+    }
+
+    suite('Headless Blocks', function() {
+      setup(function() {
+        this.block = this.workspace.newBlock('test_block');
+      });
+
+      test('String', function() {
+        setStringTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Function', function() {
+        setFunctionTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Nested Function', function() {
+        setNestedFunctionTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Function returning object', function() {
+        setFunctionReturningObjectTooltip(this.block);
+        chai.assert.throws(this.block.getTooltip.bind(this.block),
+            'Tooltip function must return a string.');
+      });
+
+      test('Object', function() {
+        setObjectTooltip(this.block);
+        assertTooltip(this.block);
+      });
+    });
+
+    suite('Rendered Blocks', function() {
+      setup(function() {
+        this.renderedWorkspace = Blockly.inject('blocklyDiv');
+        this.block = this.renderedWorkspace.newBlock('test_block');
+        this.block.initSvg();
+        this.block.render();
+      });
+
+      teardown(function() {
+        workspaceTeardown.call(this, this.renderedWorkspace);
+      });
+
+      test('String', function() {
+        setStringTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Function', function() {
+        setFunctionTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Nested Function', function() {
+        setNestedFunctionTooltip(this.block);
+        assertTooltip(this.block);
+      });
+
+      test('Function returning object', function() {
+        setFunctionReturningObjectTooltip(this.block);
+        chai.assert.throws(this.block.getTooltip.bind(this.block),
+            'Tooltip function must return a string.');
+      });
+
+      test('Object', function() {
+        setObjectTooltip(this.block);
+        assertTooltip(this.block);
+      });
+    });
+
+    suite('Headless Fields', function() {
+      setup(function() {
+        this.block = this.workspace.newBlock('test_block');
+        this.field = this.block.getField('FIELD');
+      });
+
+      test('String', function() {
+        setStringTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Function', function() {
+        setFunctionTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Nested Function', function() {
+        setNestedFunctionTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Function returning object', function() {
+        setFunctionReturningObjectTooltip(this.field);
+        chai.assert.throws(this.field.getTooltip.bind(this.field),
+            'Tooltip function must return a string.');
+      });
+
+      test('Object', function() {
+        setObjectTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Null', function() {
+        setStringTooltip(this.block);
+        this.field.setTooltip(null);
+        assertTooltip(this.field);
+      });
+    });
+
+    suite('Rendered Fields', function() {
+      setup(function() {
+        this.renderedWorkspace = Blockly.inject('blocklyDiv');
+        this.block = this.renderedWorkspace.newBlock('test_block');
+        this.block.initSvg();
+        this.block.render();
+        this.field = this.block.getField('FIELD');
+      });
+
+      teardown(function() {
+        workspaceTeardown.call(this, this.renderedWorkspace);
+      });
+
+      test('String', function() {
+        setStringTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Function', function() {
+        setFunctionTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Nested Function', function() {
+        setNestedFunctionTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Function returning object', function() {
+        setFunctionReturningObjectTooltip(this.field);
+        chai.assert.throws(this.field.getTooltip.bind(this.field),
+            'Tooltip function must return a string.');
+      });
+
+      test('Object', function() {
+        setObjectTooltip(this.field);
+        assertTooltip(this.field);
+      });
+
+      test('Null', function() {
+        setStringTooltip(this.block);
+        this.field.setTooltip(null);
+        assertTooltip(this.field);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #4252 

### Proposed Changes

Adds getters to the block and field for the tooltip text.

### Reason for Changes

Handy for if you want to get the tooltip text for something like voice assistance.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

#### set/getTooltip
* Headless Blocks
  * String
  * Function
  * Nested Function
  * Function returning object
  * Object
* Rendered Blocks
  * String
  * Function
  * Nested Function
  * Function returning object
  * Object
* Headless Fields
  * String
  * Function
  * Nested Function
  * Function returning object
  * Object
  * Null
* Rendered Fields
  * String
  * Function
  * Nested Function
  * Function returning object
  * Object
  * Null

I also did some manual testing. For example these blocks and their tooltips:
![Tooltips](https://user-images.githubusercontent.com/25440652/92159854-ea72b800-ede2-11ea-88e4-2488b550f4fc.png)

But I mostly focused on the automated testing.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Info

In all likelyhood I broke the typings, so I'll be watching it.
