### PR TITLE
Revert closure deps package update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -679,7 +679,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -3600,6 +3600,12 @@
       "integrity": "sha512-DLlcY875mQB7PA9wtfbPBVL9chJj+si/cmxyp3euw7x09MiFYynR4tmQJ9KjWUffPbhvCRDEO/jKcVyNWQVS1Q==",
       "dev": true
     },
+    "google-closure-compiler-js": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20200719.0.0.tgz",
+      "integrity": "sha512-cuowL5A4VOx9yxxMc3sSiqcj/d9aYjnHgFDvDB/dpMMOhlUMN1MDsVubuEc32tut7k/FTYFZY114CLH4r2q9/A==",
+      "dev": true
+    },
     "google-closure-compiler-linux": {
       "version": "20200830.0.0",
       "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20200830.0.0.tgz",
@@ -3622,56 +3628,57 @@
       "optional": true
     },
     "google-closure-deps": {
-      "version": "20200830.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-deps/-/google-closure-deps-20200830.0.0.tgz",
-      "integrity": "sha512-Oc5vMsR1RpYb8QZlWYdD46/V22E7ZGXaF/oPbpltKlKmNRpOO3jfIqfAotDKo9itA9SFCHnVfxHklmBSIOUyjw==",
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-deps/-/google-closure-deps-20200719.0.0.tgz",
+      "integrity": "sha512-BFWth9JZgaUwapaHMexxQbw4H9f/23rkD+GNKsyazVl8RSWma1s7i5fI/3AdEDcpgFMsyNbnEb3uOpaetSE6gA==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.9",
-        "google-closure-compiler": "^20200830.0.0",
+        "google-closure-compiler": "^20200719.0.0",
         "yargs": "^12.0.2"
       },
       "dependencies": {
         "google-closure-compiler": {
-          "version": "20200830.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200830.0.0.tgz",
-          "integrity": "sha512-Pri8kyHGmd2xqLM38QBarx+fdkm2HuLniGz7GimbdjQ1KUuPNIz7IJOYc8NGGwYPGAB45vg4IZRk/LepAqnoxg==",
+          "version": "20200719.0.0",
+          "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200719.0.0.tgz",
+          "integrity": "sha512-2fZl8M6U7KTXami1joNo9e5hW88iZX1MGBSHWlDaeBqSYkvLUH2Qn/VltAQuluSRBIjPXXhxZGKHyJamVoFFnA==",
           "dev": true,
           "requires": {
             "chalk": "2.x",
-            "google-closure-compiler-java": "^20200830.0.0",
-            "google-closure-compiler-linux": "^20200830.0.0",
-            "google-closure-compiler-osx": "^20200830.0.0",
-            "google-closure-compiler-windows": "^20200830.0.0",
+            "google-closure-compiler-java": "^20200719.0.0",
+            "google-closure-compiler-js": "^20200719.0.0",
+            "google-closure-compiler-linux": "^20200719.0.0",
+            "google-closure-compiler-osx": "^20200719.0.0",
+            "google-closure-compiler-windows": "^20200719.0.0",
             "minimist": "1.x",
             "vinyl": "2.x",
             "vinyl-sourcemaps-apply": "^0.2.0"
           }
         },
         "google-closure-compiler-java": {
-          "version": "20200830.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200830.0.0.tgz",
-          "integrity": "sha512-DLlcY875mQB7PA9wtfbPBVL9chJj+si/cmxyp3euw7x09MiFYynR4tmQJ9KjWUffPbhvCRDEO/jKcVyNWQVS1Q==",
+          "version": "20200719.0.0",
+          "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200719.0.0.tgz",
+          "integrity": "sha512-/alYc8OC9zAETZ2m10OhtqI+PAs2b8y6cLn2VlN/53dHrCC6gKqj7Ajun/GAVAUOW4HMRMnpBYdCJgMLpAniSA==",
           "dev": true
         },
         "google-closure-compiler-linux": {
-          "version": "20200830.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20200830.0.0.tgz",
-          "integrity": "sha512-QfxFA3+fOrNe0RH2lcXmkdiaM97KvZQOtO3trobNvfkMNr2h9OUtpXkqWExwolo/jsJWNumsdaRnEAwEthMUOw==",
+          "version": "20200719.0.0",
+          "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20200719.0.0.tgz",
+          "integrity": "sha512-hqPP8/7g7IMhcVle9xJ0aeiI4oRCucUGrWtQ12VwswKu2tyXTk2BDcXj5WqHae6TDPUONikQ8MCJSIENGLBC2Q==",
           "dev": true,
           "optional": true
         },
         "google-closure-compiler-osx": {
-          "version": "20200830.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200830.0.0.tgz",
-          "integrity": "sha512-qHKjRBJVq2+2mT25eoT6iOMVbUGT02sJUwkdLlsohWKV4sMEY8/nwnkZYsdm7KnPJnmQLlrfYJ1ZTh1VTlAJpQ==",
+          "version": "20200719.0.0",
+          "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200719.0.0.tgz",
+          "integrity": "sha512-Y0RDdOAJ7CLya0pMjmLahiqh7b9aJGybKBTxPywK2CiJj1+z+EtvXN+QsaM0aSE8yvuvIbAWHOX4FjEXMRiTmw==",
           "dev": true,
           "optional": true
         },
         "google-closure-compiler-windows": {
-          "version": "20200830.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20200830.0.0.tgz",
-          "integrity": "sha512-IpJAyxJo+GQ2DSVC4sslPydhIPyWRINkdNynIK/Bk+vbM/7i4LoEm/Y5rY/KJOLRCSds+s3Ov9LYdFkN8C//7g==",
+          "version": "20200719.0.0",
+          "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20200719.0.0.tgz",
+          "integrity": "sha512-U1onpG6RaTpRlR2nac+4GPU27LhJMr4kB4meNihwGvPRXcLh1qVcrKo+BjBuoX+Oq8KFwjc+mif3ldmv4AZzew==",
           "dev": true,
           "optional": true
         },
@@ -3945,7 +3952,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -6225,7 +6232,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6355,7 +6362,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -6845,7 +6852,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -7319,7 +7326,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -7357,7 +7364,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint": "^7.6.0",
     "eslint-plugin-es5": "^1.5.0",
     "google-closure-compiler": "^20200830.0.0",
-    "google-closure-deps": "^20200830.0.0",
+    "google-closure-deps": "^20200719.0.0",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-insert": "^0.5.0",

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -61,8 +61,11 @@ run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/nod
 # Run generator tests inside a browser and check the results.
 run_test_command "generators" "tests/scripts/run_generators.sh"
 
-# Run the closure compiler ensuring there are no errors.
-run_test_command "compile" "npm run build:debug"
+# Run the closure compiler.
+run_test_command "compile" "npm run build"
+
+# Run the closure compiler ensuring there are no compiler warnings / errors.
+run_test_command "compile:warnings" "npm run build:debug"
 
 # Generate TypeScript typings and ensure there are no errors.
 run_test_command "typings" "tests/scripts/compile_typings.sh"


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix issue with uncompressed build.

### Proposed Changes

Revert google-closure-deps update to avoid regression.  https://github.com/google/blockly/pull/4259
Add build test to build all of Blockly and catch cases like this in the future.

### Reason for Changes

Fix build.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
