### PR TITLE
Fix bugs related to events firing during block create

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -200,29 +200,38 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   workspace.addTopBlock(this);
   workspace.addTypedBlock(this);
 
-  // Call an initialization function, if it exists.
-  if (typeof this.init == 'function') {
-    this.init();
+  // All events fired should be part of the same group.
+  // Any events fired during init should not be undoable,
+  // so that block creation is atomic.
+  var existingGroup = Blockly.Events.getGroup();
+  if (!existingGroup) {
+    Blockly.Events.setGroup(true);
   }
+
+  try {
+    // Call an initialization function, if it exists.
+    if (typeof this.init == 'function') {
+      var initialUndoFlag = Blockly.Events.recordUndo;
+      Blockly.Events.recordUndo = false;
+      this.init();
+      Blockly.Events.recordUndo = initialUndoFlag;
+    }
+
+    // Fire a create event.
+    if (Blockly.Events.isEnabled()) {
+      Blockly.Events.fire(new Blockly.Events.BlockCreate(this));
+    }
+
+  } finally {
+    if (!existingGroup) {
+      Blockly.Events.setGroup(false);
+    }
+  }
+  
   // Record initial inline state.
   /** @type {boolean|undefined} */
   this.inputsInlineDefault = this.inputsInline;
 
-  // Fire a create event.
-  if (Blockly.Events.isEnabled()) {
-    var existingGroup = Blockly.Events.getGroup();
-    if (!existingGroup) {
-      Blockly.Events.setGroup(true);
-    }
-    try {
-      Blockly.Events.fire(new Blockly.Events.BlockCreate(this));
-    } finally {
-      if (!existingGroup) {
-        Blockly.Events.setGroup(false);
-      }
-    }
-
-  }
   // Bind an onchange function, if it exists.
   if (typeof this.onchange == 'function') {
     this.setOnChange(this.onchange);

--- a/core/block.js
+++ b/core/block.js
@@ -210,7 +210,6 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   var initialUndoFlag = Blockly.Events.recordUndo;
 
   try {
-    
     // Call an initialization function, if it exists.
     if (typeof this.init == 'function') {
       Blockly.Events.recordUndo = false;

--- a/core/block.js
+++ b/core/block.js
@@ -207,11 +207,12 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
   if (!existingGroup) {
     Blockly.Events.setGroup(true);
   }
+  var initialUndoFlag = Blockly.Events.recordUndo;
 
   try {
+    
     // Call an initialization function, if it exists.
     if (typeof this.init == 'function') {
-      var initialUndoFlag = Blockly.Events.recordUndo;
       Blockly.Events.recordUndo = false;
       this.init();
       Blockly.Events.recordUndo = initialUndoFlag;
@@ -226,6 +227,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     if (!existingGroup) {
       Blockly.Events.setGroup(false);
     }
+    // In case init threw, recordUndo flag should still be reset.
+    Blockly.Events.recordUndo = initialUndoFlag;
   }
   
   // Record initial inline state.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -801,12 +801,17 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
 
   if (Blockly.Events.isEnabled()) {
     Blockly.Events.setGroup(true);
-    Blockly.Events.fire(new Blockly.Events.Create(newBlock));
     // Fire a VarCreate event for each (if any) new variable created.
     for (var i = 0; i < newVariables.length; i++) {
       var thisVariable = newVariables[i];
       Blockly.Events.fire(new Blockly.Events.VarCreate(thisVariable));
     }
+
+    // Block events come after var events, in case they refer to newly created
+    // variables.
+    Blockly.Events.fire(new Blockly.Events.Create(newBlock));
+
+    // Why don't we need to setgroup to false??
   }
   if (this.autoClose) {
     this.hide();

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -810,8 +810,6 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
     // Block events come after var events, in case they refer to newly created
     // variables.
     Blockly.Events.fire(new Blockly.Events.Create(newBlock));
-
-    // Why don't we need to setgroup to false??
   }
   if (this.autoClose) {
     this.hide();

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1750,4 +1750,34 @@ suite('Blocks', function() {
       });
     });
   });
+
+  suite('Initialization', function() {
+    setup(function() {
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "init_test_block",
+          "message0": ""
+        },
+      ]);
+    });
+    test('recordUndo is reset even if init throws', function() {
+      // The test could pass if init is never called,
+      // so we assert init was called to be safe.
+      var initCalled = false;
+      var recordUndoDuringInit;
+      Blockly.Blocks['init_test_block'].init = function() {
+        initCalled = true;
+        recordUndoDuringInit = Blockly.Events.recordUndo;
+        throw new Error();
+      };
+      chai.assert.throws(function() {
+        this.workspace.newBlock('init_test_block');
+      }.bind(this));
+      chai.assert.isFalse(recordUndoDuringInit,
+          'recordUndo should be false during block init function');
+      chai.assert.isTrue(Blockly.Events.recordUndo,
+          'recordUndo should be reset to true after init');
+      chai.assert.isTrue(initCalled, 'expected init function to be called');
+    });
+  });
 });

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -32,10 +32,16 @@ suite('Events', function() {
 
   function createSimpleTestBlock(workspace) {
     // Disable events while constructing the block: this is a test of the
-    // Blockly.Event constructors, not the block constructor.s
+    // Blockly.Event constructors, not the block constructors.
+    // Set the group id to avoid an extra call to genUid.
     Blockly.Events.disable();
-    var block = new Blockly.Block(
-        workspace, 'simple_test_block');
+    try {
+      Blockly.Events.setGroup('unused');
+      var block = new Blockly.Block(
+          workspace, 'simple_test_block');
+    } finally {
+      Blockly.Events.setGroup(false);
+    }
     Blockly.Events.enable();
     return block;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves #3584 and resolves #2627 

### Proposed Changes

1) In flyout, moves the block Create event after the var create events.
2) In block creation, disable recordUndo during block initialization and set the group id to match.

### Reason for Changes

There are two existing bugs, details in the issues linked above. Both are manifested by undo issues. After this change, the undo issues do not appear.

For 1) just drag a for loop out of the flyout, then undo. There will be a warning in the console.
For 2) do

```
var a = Blockly.getMainWorkspace().newBlock("controls_for");
a.initSvg();
a.render();
```

then undo. you notice the block is deleted, but you can press undo again, then get a console warning.
In this case, there is a block Change event that is fired before the Block create event. That is true after this change too but at least now it's associated with the same group, and it's not put into the undo stack now so undo is not broken. It maybe seems weird that the change event is before the block create event, but that was true before too.

### Test Coverage

Fixed existing tests and added a test case to make sure state is reset even if init function throws an error.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
