### PR TITLE
Update types to include document fragments

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -932,7 +932,8 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
  */
 Blockly.BlockSvg.prototype.toCopyData = function() {
   var xml = Blockly.Xml.blockToDom(this, true);
-  // If this block is an insertion marker the xml is an empty Document Fragment.
+  // If this block is an insertion marker, then the xml is an empty DocumentFragment
+  // and the below code is not needed.
   if (!this.isInsertionMarker_) {
     // Copy only the selected block and internal blocks.
     Blockly.Xml.deleteNext(xml);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -932,12 +932,15 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
  */
 Blockly.BlockSvg.prototype.toCopyData = function() {
   var xml = Blockly.Xml.blockToDom(this, true);
-  // Copy only the selected block and internal blocks.
-  Blockly.Xml.deleteNext(xml);
-  // Encode start position in XML.
-  var xy = this.getRelativeToSurfaceXY();
-  xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
-  xml.setAttribute('y', xy.y);
+  // If this block is an insertion marker the xml is an empty Document Fragment.
+  if (!this.isInsertionMarker_) {
+    // Copy only the selected block and internal blocks.
+    Blockly.Xml.deleteNext(xml);
+    // Encode start position in XML.
+    var xy = this.getRelativeToSurfaceXY();
+    xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
+    xml.setAttribute('y', xy.y);
+  }
   return {
     xml: xml,
     source: this.workspace,

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -927,21 +927,21 @@ Blockly.BlockSvg.prototype.dispose = function(healStack, animate) {
 
 /**
  * Encode a block for copying.
- * @return {!Blockly.ICopyable.CopyData} Copy metadata.
+ * @return {?Blockly.ICopyable.CopyData} Copy metadata, or null if the block is
+ *     an insertion marker.
  * @package
  */
 Blockly.BlockSvg.prototype.toCopyData = function() {
-  var xml = Blockly.Xml.blockToDom(this, true);
-  // If this block is an insertion marker, then the xml is an empty DocumentFragment
-  // and the below code is not needed.
-  if (!this.isInsertionMarker_) {
-    // Copy only the selected block and internal blocks.
-    Blockly.Xml.deleteNext(xml);
-    // Encode start position in XML.
-    var xy = this.getRelativeToSurfaceXY();
-    xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
-    xml.setAttribute('y', xy.y);
+  if (this.isInsertionMarker_) {
+    return null;
   }
+  var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(this, true));
+  // Copy only the selected block and internal blocks.
+  Blockly.Xml.deleteNext(xml);
+  // Encode start position in XML.
+  var xy = this.getRelativeToSurfaceXY();
+  xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
+  xml.setAttribute('y', xy.y);
   return {
     xml: xml,
     source: this.workspace,

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -65,7 +65,7 @@ Blockly.draggingConnections = [];
 
 /**
  * Contents of the local clipboard.
- * @type {Element|DocumentFragment}
+ * @type {Element}
  * @private
  */
 Blockly.clipboardXml_ = null;
@@ -272,9 +272,11 @@ Blockly.onKeyDown = function(e) {
  */
 Blockly.copy_ = function(toCopy) {
   var data = toCopy.toCopyData();
-  Blockly.clipboardXml_ = data.xml;
-  Blockly.clipboardSource_ = data.source;
-  Blockly.clipboardTypeCounts_ = data.typeCounts;
+  if (data) {
+    Blockly.clipboardXml_ = data.xml;
+    Blockly.clipboardSource_ = data.source;
+    Blockly.clipboardTypeCounts_ = data.typeCounts;
+  }
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -65,7 +65,7 @@ Blockly.draggingConnections = [];
 
 /**
  * Contents of the local clipboard.
- * @type {Element}
+ * @type {Element|DocumentFragment}
  * @private
  */
 Blockly.clipboardXml_ = null;

--- a/core/connection.js
+++ b/core/connection.js
@@ -115,6 +115,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
     // Displaced shadow blocks dissolve rather than reattaching or bumping.
     if (orphanBlock.isShadow()) {
       // Save the shadow block so that field values are preserved.
+      // This cast assumes that a block can not be both a shadow block and an insertion marker.
       shadowDom = /** @type {!Element} */ (Blockly.Xml.blockToDom(orphanBlock));
       orphanBlock.dispose(false);
       orphanBlock = null;

--- a/core/connection.js
+++ b/core/connection.js
@@ -115,7 +115,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
     // Displaced shadow blocks dissolve rather than reattaching or bumping.
     if (orphanBlock.isShadow()) {
       // Save the shadow block so that field values are preserved.
-      shadowDom = Blockly.Xml.blockToDom(orphanBlock);
+      shadowDom = /** @type {!Element} */ (Blockly.Xml.blockToDom(orphanBlock));
       orphanBlock.dispose(false);
       orphanBlock = null;
     } else if (parentConnection.type == Blockly.INPUT_VALUE) {

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -945,6 +945,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   }
 
   // Create the new block by cloning the block in the flyout (via XML).
+  // This cast assumes that the oldBlock can not be an insertion marker.
   var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(oldBlock, true));
   // The target workspace would normally resize during domToBlock, which will
   // lead to weird jumps.  Save it for terminateDrag.

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -945,7 +945,7 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
   }
 
   // Create the new block by cloning the block in the flyout (via XML).
-  var xml = Blockly.Xml.blockToDom(oldBlock, true);
+  var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(oldBlock, true));
   // The target workspace would normally resize during domToBlock, which will
   // lead to weird jumps.  Save it for terminateDrag.
   targetWorkspace.setResizesEnabled(false);

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -25,14 +25,14 @@ Blockly.ICopyable = function() {};
 
 /**
  * Encode for copying.
- * @return {!Blockly.ICopyable.CopyData} Copy metadata.
+ * @return {?Blockly.ICopyable.CopyData} Copy metadata.
  */
 Blockly.ICopyable.prototype.toCopyData;
 
 /**
  * Copy Metadata.
  * @typedef {{
- *            xml:(!Element|!DocumentFragment),
+ *            xml:!Element,
  *            source:Blockly.WorkspaceSvg,
  *            typeCounts:?Object
  *          }}

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -32,7 +32,7 @@ Blockly.ICopyable.prototype.toCopyData;
 /**
  * Copy Metadata.
  * @typedef {{
- *            xml:!Element,
+ *            xml:(!Element|!DocumentFragment),
  *            source:Blockly.WorkspaceSvg,
  *            typeCounts:?Object
  *          }}

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -606,7 +606,7 @@ Blockly.Trashcan.prototype.onDelete_ = function(event) {
   if (this.workspace_.options.maxTrashcanContents <= 0) {
     return;
   }
-  // Document Fragments do not have tagNames so check that it exists.
+  // Must check that the tagName exists since oldXml can be a DocumentFragment.
   if (event.type == Blockly.Events.BLOCK_DELETE && event.oldXml.tagName &&
       event.oldXml.tagName.toLowerCase() != 'shadow') {
     var cleanedXML = this.cleanBlockXML_(event.oldXml);

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -606,7 +606,8 @@ Blockly.Trashcan.prototype.onDelete_ = function(event) {
   if (this.workspace_.options.maxTrashcanContents <= 0) {
     return;
   }
-  if (event.type == Blockly.Events.BLOCK_DELETE &&
+  // Document Fragments do not have tagNames so check that it exists.
+  if (event.type == Blockly.Events.BLOCK_DELETE && event.oldXml.tagName &&
       event.oldXml.tagName.toLowerCase() != 'shadow') {
     var cleanedXML = this.cleanBlockXML_(event.oldXml);
     if (this.contents_.indexOf(cleanedXML) != -1) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1326,13 +1326,16 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
 
 /**
  * Paste the provided block onto the workspace.
- * @param {!Element} xmlBlock XML block element.
+ * @param {!Element|!DocumentFragment} xmlBlock XML block element or an empty
+ *     document fragment if the block was an insertion marker.
  */
 Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
-  if (!this.rendered || xmlBlock.getElementsByTagName('block').length >=
+  if (!this.rendered || !xmlBlock.tagName || xmlBlock.getElementsByTagName('block').length >=
       this.remainingCapacity()) {
     return;
   }
+  // The check above for tagName rules out the possibility of this being a DocumentFragment.
+  xmlBlock = /** @type {!Element} */ (xmlBlock);
   if (this.currentGesture_) {
     this.currentGesture_.cancel();  // Dragging while pasting?  No.
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1327,7 +1327,7 @@ Blockly.WorkspaceSvg.prototype.highlightBlock = function(id, opt_state) {
 /**
  * Paste the provided block onto the workspace.
  * @param {!Element|!DocumentFragment} xmlBlock XML block element or an empty
- *     document fragment if the block was an insertion marker.
+ *     DocumentFragment if the block was an insertion marker.
  */
 Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
   if (!this.rendered || !xmlBlock.tagName || xmlBlock.getElementsByTagName('block').length >=

--- a/core/xml.js
+++ b/core/xml.js
@@ -74,15 +74,15 @@ Blockly.Xml.variablesToDom = function(variableList) {
  * Encode a block subtree as XML with XY coordinates.
  * @param {!Blockly.Block} block The root block to encode.
  * @param {boolean=} opt_noId True if the encoder should skip the block ID.
- * @return {!Element} Tree of XML elements.
+ * @return {!Element|!DocumentFragment} Tree of XML elements or an empty document
+ *     fragment if the block was an insertion marker.
  */
 Blockly.Xml.blockToDomWithXY = function(block, opt_noId) {
   if (block.isInsertionMarker()) {  // Skip over insertion markers.
     block = block.getChildren(false)[0];
     if (!block) {
-      // Disappears when appended. Cast to ANY b/c DocumentFragment -> Element
-      // is invalid. We have to cast to ANY in between.
-      return /** @type{?} */ (new DocumentFragment());
+      // Disappears when appended.
+      return new DocumentFragment();
     }
   }
 
@@ -138,7 +138,8 @@ Blockly.Xml.allFieldsToDom_ = function(block, element) {
  * Encode a block subtree as XML.
  * @param {!Blockly.Block} block The root block to encode.
  * @param {boolean=} opt_noId True if the encoder should skip the block ID.
- * @return {!Element} Tree of XML elements.
+ * @return {!Element|!DocumentFragment} Tree of XML elements or an empty document
+ *     fragment if the block was an insertion marker.
  */
 Blockly.Xml.blockToDom = function(block, opt_noId) {
   // Skip over insertion markers.
@@ -147,9 +148,8 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
     if (child) {
       return Blockly.Xml.blockToDom(child);
     } else {
-      // Disappears when appended. Cast to ANY b/c DocumentFragment -> Element
-      // is invalid. We have to cast to ANY in between.
-      return /** @type{?} */ (new DocumentFragment());
+      // Disappears when appended.
+      return new DocumentFragment();
     }
   }
 
@@ -808,7 +808,8 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
 
 /**
  * Remove any 'next' block (statements in a stack).
- * @param {!Element} xmlBlock XML block element.
+ * @param {!Element|!DocumentFragment} xmlBlock XML block element or an empty
+ *     document fragment if the block was an insertion marker.
  */
 Blockly.Xml.deleteNext = function(xmlBlock) {
   for (var i = 0, child; (child = xmlBlock.childNodes[i]); i++) {

--- a/core/xml.js
+++ b/core/xml.js
@@ -809,7 +809,7 @@ Blockly.Xml.domToField_ = function(block, fieldName, xml) {
 /**
  * Remove any 'next' block (statements in a stack).
  * @param {!Element|!DocumentFragment} xmlBlock XML block element or an empty
- *     document fragment if the block was an insertion marker.
+ *     DocumentFragment if the block was an insertion marker.
  */
 Blockly.Xml.deleteNext = function(xmlBlock) {
   for (var i = 0, child; (child = xmlBlock.childNodes[i]); i++) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#4048
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
The fix for the bug is this line: `event.type == Blockly.Events.BLOCK_DELETE && event.oldXml.tagName &&`
However, I updated the types on `blockToDom` and `blockToDomXy` to return an Element or a DocumentFragment as suggested so that we can hopefully avoid a similar problem in the future.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Document Fragments is not a subtype of Element and therefore does not contain the same methods and attributes as an Element such as tagName, setAttribute, getAttribute etc. <!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
I am assuming in one of my casts that there is no reason for a block to be both a shadow block and an insertion marker, but if you can think of a reason lmk.
<!-- Anything else we should know? -->
