### PR TITLE
Convert toolbox position to enum

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -23,12 +23,12 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.global');
 goog.require('Blockly.utils.object');
+goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.utils.xml');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
 goog.requireType('Blockly.utils.Metrics');
-goog.requireType('Blockly.utils.toolbox');
 
 
 /**
@@ -169,8 +169,9 @@ Blockly.Mutator.prototype.createEditor_ = function() {
         'renderer': this.block_.workspace.options.renderer,
         'rendererOverrides': this.block_.workspace.options.rendererOverrides
       }));
-  workspaceOptions.toolboxPosition = this.block_.RTL ? Blockly.TOOLBOX_AT_RIGHT :
-      Blockly.TOOLBOX_AT_LEFT;
+  workspaceOptions.toolboxPosition = this.block_.RTL ?
+      Blockly.utils.toolbox.Position.RIGHT :
+      Blockly.utils.toolbox.Position.LEFT;
   var hasFlyout = !!quarkXml;
   if (hasFlyout) {
     workspaceOptions.languageTree =

--- a/core/options.js
+++ b/core/options.js
@@ -80,7 +80,7 @@ Blockly.Options = function(options) {
   var toolboxAtStart = options['toolboxPosition'];
   toolboxAtStart = toolboxAtStart !== 'end';
 
-  /** @type {Blockly.utils.toolbox.Position} */
+  /** @type {!Blockly.utils.toolbox.Position} */
   var toolboxPosition;
   if (horizontalLayout) {
     toolboxPosition = toolboxAtStart ?
@@ -152,7 +152,7 @@ Blockly.Options = function(options) {
   this.gridOptions = Blockly.Options.parseGridOptions_(options);
   /** @type {!Blockly.Options.ZoomOptions} */
   this.zoomOptions = Blockly.Options.parseZoomOptions_(options);
-  /** @type {Blockly.utils.toolbox.Position} */
+  /** @type {!Blockly.utils.toolbox.Position} */
   this.toolboxPosition = toolboxPosition;
   /** @type {!Blockly.Theme} */
   this.theme = Blockly.Options.parseThemeOptions_(options);

--- a/core/options.js
+++ b/core/options.js
@@ -80,12 +80,14 @@ Blockly.Options = function(options) {
   var toolboxAtStart = options['toolboxPosition'];
   toolboxAtStart = toolboxAtStart !== 'end';
 
+  /** @type {Blockly.utils.toolbox.Position} */
+  var toolboxPosition;
   if (horizontalLayout) {
-    var toolboxPosition = toolboxAtStart ?
-        Blockly.TOOLBOX_AT_TOP : Blockly.TOOLBOX_AT_BOTTOM;
+    toolboxPosition = toolboxAtStart ?
+        Blockly.utils.toolbox.Position.TOP : Blockly.utils.toolbox.Position.BOTTOM;
   } else {
-    var toolboxPosition = (toolboxAtStart == rtl) ?
-        Blockly.TOOLBOX_AT_RIGHT : Blockly.TOOLBOX_AT_LEFT;
+    toolboxPosition = (toolboxAtStart == rtl) ?
+        Blockly.utils.toolbox.Position.RIGHT : Blockly.utils.toolbox.Position.LEFT;
   }
 
   var hasCss = options['css'];
@@ -150,7 +152,7 @@ Blockly.Options = function(options) {
   this.gridOptions = Blockly.Options.parseGridOptions_(options);
   /** @type {!Blockly.Options.ZoomOptions} */
   this.zoomOptions = Blockly.Options.parseZoomOptions_(options);
-  /** @type {number} */
+  /** @type {Blockly.utils.toolbox.Position} */
   this.toolboxPosition = toolboxPosition;
   /** @type {!Blockly.Theme} */
   this.theme = Blockly.Options.parseThemeOptions_(options);

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -23,6 +23,7 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.toolbox');
 
 goog.requireType('Blockly.Action');
 goog.requireType('Blockly.IBlocklyActionable');
@@ -33,7 +34,6 @@ goog.requireType('Blockly.ISelectableToolboxItem');
 goog.requireType('Blockly.IStyleable');
 goog.requireType('Blockly.IToolbox');
 goog.requireType('Blockly.IToolboxItem');
-goog.requireType('Blockly.utils.toolbox');
 goog.requireType('Blockly.WorkspaceSvg');
 
 
@@ -126,8 +126,7 @@ Blockly.Toolbox = function(workspace) {
 
   /**
    * Position of the toolbox and flyout relative to the workspace.
-   * TODO (#4246): Add an enum for toolbox types.
-   * @type {number}
+   * @type {!Blockly.utils.toolbox.Position}
    */
   this.toolboxPosition = workspace.options.toolboxPosition;
 
@@ -484,11 +483,11 @@ Blockly.Toolbox.prototype.getClientRect = function() {
 
   // Assumes that the toolbox is on the SVG edge.  If this changes
   // (e.g. toolboxes in mutators) then this code will need to be more complex.
-  if (this.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+  if (this.toolboxPosition == Blockly.utils.toolbox.Position.TOP) {
     return new Blockly.utils.Rect(-BIG_NUM, bottom, -BIG_NUM, BIG_NUM);
-  } else if (this.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
+  } else if (this.toolboxPosition == Blockly.utils.toolbox.Position.BOTTOM) {
     return new Blockly.utils.Rect(top, BIG_NUM, -BIG_NUM, BIG_NUM);
-  } else if (this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+  } else if (this.toolboxPosition == Blockly.utils.toolbox.Position.LEFT) {
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, right);
   } else {  // Right
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, left, BIG_NUM);

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.Trashcan');
 goog.require('Blockly.Scrollbar');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.Xml');
 
 goog.requireType('Blockly.IDeleteArea');
@@ -66,16 +67,16 @@ Blockly.Trashcan = function(workspace) {
   // Create vertical or horizontal flyout.
   if (this.workspace_.horizontalLayout) {
     flyoutWorkspaceOptions.toolboxPosition =
-        this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_TOP ?
-        Blockly.TOOLBOX_AT_BOTTOM : Blockly.TOOLBOX_AT_TOP;
+        this.workspace_.toolboxPosition == Blockly.utils.toolbox.Position.TOP ?
+        Blockly.utils.toolbox.Position.BOTTOM : Blockly.utils.toolbox.Position.TOP;
     if (!Blockly.HorizontalFlyout) {
       throw Error('Missing require for Blockly.HorizontalFlyout');
     }
     this.flyout = new Blockly.HorizontalFlyout(flyoutWorkspaceOptions);
   } else {
     flyoutWorkspaceOptions.toolboxPosition =
-      this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT ?
-        Blockly.TOOLBOX_AT_LEFT : Blockly.TOOLBOX_AT_RIGHT;
+      this.workspace_.toolboxPosition == Blockly.utils.toolbox.Position.RIGHT ?
+        Blockly.utils.toolbox.Position.LEFT : Blockly.utils.toolbox.Position.RIGHT;
     if (!Blockly.VerticalFlyout) {
       throw Error('Missing require for Blockly.VerticalFlyout');
     }

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -169,6 +169,17 @@ Blockly.utils.toolbox.CATEGORY_TOOLBOX_KIND = 'categoryToolbox';
 Blockly.utils.toolbox.FLYOUT_TOOLBOX_KIND = 'flyoutToolbox';
 
 /**
+ * Position of the the toolbox relative to the flyout.
+ * @enum {number}
+ */
+Blockly.utils.toolbox.Position = {
+  TOP: Blockly.TOOLBOX_AT_TOP,
+  BOTTOM: Blockly.TOOLBOX_AT_BOTTOM,
+  LEFT: Blockly.TOOLBOX_AT_LEFT,
+  RIGHT: Blockly.TOOLBOX_AT_RIGHT
+};
+
+/**
  * Converts the toolbox definition into toolbox JSON.
  * @param {?Blockly.utils.toolbox.ToolboxDefinition} toolboxDef The definition
  *     of the toolbox in one of its many forms.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves #4246 

### Proposed Changes

Converts toolbox position from a number to an enum. Backwards compatible.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on various demos including RTL.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
