### PR TITLE
Fixes blocks flying when mutator is open

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -401,15 +401,28 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     var block = this.block_;
     var oldMutationDom = block.mutationToDom();
     var oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
+
+    // Switch off rendering while the source block is rebuilt.
+    var savedRendered = block.rendered;
+    // TODO(#4288): We should not be setting the rendered property to false.
+    block.rendered = false;
+
     // Allow the source block to rebuild itself.
     block.compose(this.rootBlock_);
+    // Restore rendering and show the changes.
+    block.rendered = savedRendered;
+    // Mutation may have added some elements that need initializing.
     block.initSvg();
-    block.render();
 
     if ((/** @type {!Blockly.WorkspaceSvg} */ (Blockly.getMainWorkspace()))
         .keyboardAccessibilityMode) {
       Blockly.navigation.moveCursorOnBlockMutation(block);
     }
+
+    if (block.rendered) {
+      block.render();
+    }
+
     var newMutationDom = block.mutationToDom();
     var newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
     if (oldMutation != newMutation) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Reverts part of #3468 in order to fix #4175.
Remaining issue is documented in #4288.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Set rendered = false before mutating a block.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
