### PR TITLE
Fix lua multiline quote

### DIFF
--- a/generators/lua.js
+++ b/generators/lua.js
@@ -151,10 +151,10 @@ Blockly.Lua.quote_ = function(string) {
  * @private
  */
 Blockly.Lua.multiline_quote_ = function(string) {
-  string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/'/g, '\\\'');
-  return '[===' + string + '===]';
+  var lines = string.split(/\n/g).map(Blockly.Lua.quote_);
+  // Join with the following, plus a newline:
+  // .. '\n' ..
+  return lines.join(' .. \'\\n\' ..\n');
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3978 and part of #3979 

### Proposed Changes

Make the Lua multiline quote function generate multiple concatenated strings instead of a single multiline string.

### Reason for Changes

Previous code was wrong anyway.
Multiline literals get additional indentation in loops, and the easiest way to fix it is to switch to concatenation.

### Test Coverage
Tested with these blocks:
![image](https://user-images.githubusercontent.com/13686399/93630397-db713580-f99e-11ea-987b-45d02facc04b.png)

```
<xml xmlns="https://developers.google.com/blockly/xml">
  <block type="controls_repeat_ext">
    <value name="TIMES">
      <shadow type="math_number">
        <field name="NUM">10</field>
      </shadow>
    </value>
    <statement name="DO">
      <block type="text_print">
        <value name="TEXT">
          <shadow type="text">
            <field name="TEXT">abc</field>
          </shadow>
          <block type="text_multiline">
            <field name="TEXT">this is&amp;#10;a &amp;#10;multiline &amp;#10;string</field>
          </block>
        </value>
      </block>
    </statement>
  </block>
</xml>
```

Generated this code:
```
for count = 1, 10 do
  print('this is' .. '\n' ..
  'a ' .. '\n' ..
  'multiline ' .. '\n' ..
  'string')
end
```

I ran it in the [Lua demo online](https://www.lua.org/cgi-bin/demo).

It generated this output x10:
```
this is
a 
multiline 
string
```

### Additional Information

We don't have a generator test for this yet.