### PR TITLE
Fix PHP multiline string

### DIFF
--- a/generators/php.js
+++ b/generators/php.js
@@ -206,8 +206,12 @@ Blockly.PHP.quote_ = function(string) {
  * @return {string} PHP string.
  * @private
  */
-Blockly.PHP.multiline_quote_ = function(string) {
-  return '<<<EOT\n' + string + '\nEOT';
+Blockly.PHP.multiline_quote_ = function (string) {
+  var lines = string.split(/\n/g).map(Blockly.PHP.quote_);
+  // Join with the following, plus a newline:
+  // . "\n" .
+  // Newline escaping only works in double-quoted strings.
+  return lines.join(' . \"\\n\" .\n');
 };
 
 /**


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3978 

### Proposed Changes

Changes PHP multiline string generation to use concatenation.

### Reason for Changes

Excessive indentation if using a multiline string in a loop.

Also, the previous code produced invalid PHP.

### Test Coverage
Tested in the advanced playground with these blocks:
![image](https://user-images.githubusercontent.com/13686399/93636301-8afed580-f9a8-11ea-921c-d09d67c80378.png)

The old generated code looked like this:
```
for ($count = 0; $count < 10; $count++) {
  print(<<<EOT
  this is
  a
  multiline
  string
  EOT);
}

```

The new code looks like this:
```
for ($count = 0; $count < 10; $count++) {
  print('this is' . "\n" .
  'a ' . "\n" .
  'multiline ' . "\n" .
  'string');
}
```

I tested the generated code on repl.it.

## Additional information

The print statement in PHP does not automatically add a newline at the end of the line. I did not add it here because I didn't want to change the existing generator, but the fact that we haven't been getting complaints says to me that this isn't getting used much.

Related, single-quoted strings in PHP don't allow for escaping of newlines. Another sign that this wasn't being used much before.
