### PR TITLE
Fix dart multiline strings

### DIFF
--- a/generators/dart.js
+++ b/generators/dart.js
@@ -176,10 +176,11 @@ Blockly.Dart.quote_ = function(string) {
  * @return {string} Dart string.
  * @private
  */
-Blockly.Dart.multiline_quote_ = function(string) {
-  // Can't use goog.string.quote since $ must also be escaped.
-  string = string.replace(/'''/g, '\\\'\\\'\\\'');
-  return '\'\'\'' + string + '\'\'\'';
+Blockly.Dart.multiline_quote_ = function (string) {
+  var lines = string.split(/\n/g).map(Blockly.Dart.quote_);
+  // Join with the following, plus a newline:
+  // + '\n' +
+  return lines.join(' + \'\\n\' + \n');
 };
 
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #3978 

### Proposed Changes

Change Dart multiline string generation to use concatenation.

### Reason for Changes

Excessive indentation if using a multiline string in a loop.

### Test Coverage
Tested in the advanced playground with these blocks:
![image](https://user-images.githubusercontent.com/13686399/93636301-8afed580-f9a8-11ea-921c-d09d67c80378.png)

The old generated code looked like this:
```
  for (int count = 0; count < 10; count++) {
    print('''this is
    a
    multiline
    string''');
  }
```

The new code looks like this:
```
  for (int count = 0; count < 10; count++) {
    print('this is' + '\n' +
    'a ' + '\n' +
    'multiline ' + '\n' +
    'string');
  }
```

I tested the generated code on [dartpad.dev](dartpad.dev).
