### PR TITLE
Call initSvg for blocks with mutator after loading field xml

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -651,6 +651,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
       }
     }
 
+    var callInitSvg = false;
     var name = xmlChild.getAttribute('name');
     var xmlChildElement = /** @type {!Element} */ (xmlChild);
     switch (xmlChild.nodeName.toLowerCase()) {
@@ -660,7 +661,7 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
           block.domToMutation(xmlChildElement);
           if (block.initSvg) {
             // Mutation may have added some elements that need initializing.
-            block.initSvg();
+            callInitSvg = true;
           }
         }
         break;
@@ -746,6 +747,11 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
         // Unknown tag; ignore.  Same principle as HTML parsers.
         console.warn('Ignoring unknown tag: ' + xmlChild.nodeName);
     }
+  }
+
+  if (callInitSvg) {
+    // InitSvg needs to be called after variable fields are loaded.
+    block.initSvg();
   }
 
   var inline = xmlBlock.getAttribute('inline');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#3542
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Calls `initSvg` for block with mutator after fields' `fromXml` are called.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Fixes issue with variable fields with a mutator creating extra variable models.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

- Tested repro steps in #3542 and saw issue was fixed.
- Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

