### PR TITLE
scroll perfomance fix

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -64,7 +64,10 @@ Blockly.inject = function(container, opt_options) {
   // Create surfaces for dragging things. These are optimizations
   // so that the browser does not repaint during the drag.
   var blockDragSurface = new Blockly.BlockDragSurfaceSvg(subContainer);
-  var workspaceDragSurface = new Blockly.WorkspaceDragSurfaceSvg(subContainer);
+  
+  // September 19, 2020, the trick with dragSurface shows bad fps
+  // in all modern browsers this is the reason why it is disabled
+  var workspaceDragSurface = null;
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -844,7 +844,7 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
 
   var scrollbar = this;
   requestAnimationFrame( function() {
-    scrollbar.workspace_.setMetrics(xyRatio);
+    scrollbar.workspace_.setMetrics(xyRatio)
   });
 };
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -844,7 +844,7 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
 
   var scrollbar = this;
   requestAnimationFrame( function() {
-    scrollbar.workspace_.setMetrics(xyRatio)
+    scrollbar.workspace_.setMetrics(xyRatio);
   });
 };
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -843,7 +843,7 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
   }
 
   var scrollbar = this;
-  requestAnimationFrame( function() {
+  window.requestAnimationFrame( function() {
     if (scrollbar.workspace_) {
       scrollbar.workspace_.setMetrics(xyRatio);
     }

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -844,7 +844,9 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
 
   var scrollbar = this;
   requestAnimationFrame( function() {
-    scrollbar.workspace_.setMetrics(xyRatio);
+    if (scrollbar.workspace_) {
+      scrollbar.workspace_.setMetrics(xyRatio);
+    }
   });
 };
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -841,7 +841,11 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
   } else {
     xyRatio.y = ratio;
   }
-  this.workspace_.setMetrics(xyRatio);
+
+  var scrollbar = this;
+  requestAnimationFrame( function() {
+    scrollbar.workspace_.setMetrics(xyRatio)
+  });
 };
 
 /**


### PR DESCRIPTION
Fix for scroll large DOM tree

## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

When we have a large DOM tree scroll performance is very poor

Here is the link - https://blockly-demo.appspot.com/static/tests/playground.html

Click on spaghetti and try to scroll

And I deployed this fix you can see a difference - http://ydubr-blockly-perfomance-fix.surge.sh/

### Proposed Changes

Disable workspace drag surface and use requestAnimationFrame in onScroll handler

### Reason for Changes

Performance improvements

### Test Coverage

Tested via the playground

Tested on:

Tested on Mac and Windows

* Desktop Chrome 
* Desktop Firefox
* Desktop Safari

### Documentation
### Additional Information
