### PR TITLE
scroll perfomance fix

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -65,7 +65,10 @@ Blockly.inject = function(container, opt_options) {
   // Create surfaces for dragging things. These are optimizations
   // so that the browser does not repaint during the drag.
   var blockDragSurface = new Blockly.BlockDragSurfaceSvg(subContainer);
-  var workspaceDragSurface = new Blockly.WorkspaceDragSurfaceSvg(subContainer);
+
+  // September 19, 2020, the trick with dragSurface shows bad fps
+  // in all modern browsers this is the reason why it is disabled
+  var workspaceDragSurface = null;
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);
@@ -145,7 +148,7 @@ Blockly.createDom_ = function(container, options) {
  * @param {!Blockly.Options} options Dictionary of options.
  * @param {!Blockly.BlockDragSurfaceSvg} blockDragSurface Drag surface SVG
  *     for the blocks.
- * @param {!Blockly.WorkspaceDragSurfaceSvg} workspaceDragSurface Drag surface
+ * @param {Blockly.WorkspaceDragSurfaceSvg|null} workspaceDragSurface Drag surface
  *     SVG for the workspace.
  * @return {!Blockly.WorkspaceSvg} Newly created main workspace.
  * @private

--- a/core/inject.js
+++ b/core/inject.js
@@ -66,9 +66,15 @@ Blockly.inject = function(container, opt_options) {
   // so that the browser does not repaint during the drag.
   var blockDragSurface = new Blockly.BlockDragSurfaceSvg(subContainer);
 
+  var workspaceDragSurface;
+
   // September 19, 2020, the trick with dragSurface shows bad fps
-  // in all modern browsers this is the reason why it is disabled
-  var workspaceDragSurface = null;
+  // in last Google Chrome this is the reason why it is disabled
+  if (Blockly.utils.getChromeVersion() >= 85) {
+    workspaceDragSurface = null;
+  } else {
+    workspaceDragSurface = new Blockly.WorkspaceDragSurfaceSvg(subContainer);
+  }
 
   var workspace = Blockly.createMainWorkspace_(svg, options, blockDragSurface,
       workspaceDragSurface);

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -853,7 +853,12 @@ Blockly.Scrollbar.prototype.onScroll_ = function() {
   } else {
     xyRatio.y = ratio;
   }
-  this.workspace_.setMetrics(xyRatio);
+  var scrollbar = this;
+  window.requestAnimationFrame( function() {
+    if (scrollbar.workspace_) {
+      scrollbar.workspace_.setMetrics(xyRatio);
+    }
+  });
 };
 
 /**

--- a/core/utils.js
+++ b/core/utils.js
@@ -653,7 +653,7 @@ Blockly.utils.parseBlockColour = function(colour) {
 
 /**
  * Get version of desktop Google Chrome
- * @return {number|false} Version of desktop Google Chrome or false if it is not Chrome
+ * @return {number|boolean} Version of desktop Google Chrome or false if it is not Chrome
  */
 Blockly.utils.getChromeVersion = function() {
   var userAgent = Blockly.utils.userAgent;

--- a/core/utils.js
+++ b/core/utils.js
@@ -650,3 +650,17 @@ Blockly.utils.parseBlockColour = function(colour) {
     }
   }
 };
+
+/**
+ * Get version of desktop Google Chrome
+ * @return {number|false} Version of desktop Google Chrome or false if it is not Chrome
+ */
+Blockly.utils.getChromeVersion = function() {
+  var userAgent = Blockly.utils.userAgent;
+  if (userAgent.MOBILE || !userAgent.CHROME) {
+    return false;
+  }
+
+  var raw = userAgent.raw.match(/Chrom(e|ium)\/([0-9]+)\./);
+  return raw ? parseInt(raw[2], 10) : false;
+};


### PR DESCRIPTION
Fix for scroll large DOM tree in the latest Google Chrome

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

When we have a large DOM tree scroll performance is very poor in the latest Google Chrome

Here is the link - https://blockly-demo.appspot.com/static/tests/playground.html

Click on spaghetti and try to scroll

And I deployed this fix you can see a difference - http://ydubr-blockly-perfomance-fix.surge.sh/

### Proposed Changes

Disable workspace drag surface and use requestAnimationFrame in onScroll handler

### Reason for Changes

Performance improvements

### Test Coverage

Tested via the playground

Tested on Mac and Windows:

* Desktop Chrome
* Desktop Firefox
* Desktop Safari

### Additional Information

I tested in all modern browser and seems the problem with scroll performance exist only in Google Chrome on Mac and Windows