### PR TITLE
Revert "Don't render children of collapsed blocks"

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -87,6 +87,7 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
    */
   this.renderIsInProgress_ = false;
 
+
   /** @type {!Blockly.WorkspaceSvg} */
   this.workspace = workspace;
 
@@ -642,21 +643,14 @@ Blockly.BlockSvg.prototype.updateCollapsed_ = function() {
   var collapsedInputName = Blockly.Block.COLLAPSED_INPUT_NAME;
   var collapsedFieldName = Blockly.Block.COLLAPSED_FIELD_NAME;
 
-  var renderList = [];
-  // Show/hide the inputs.
   for (var i = 0, input; (input = this.inputList[i]); i++) {
     if (input.name != collapsedInputName) {
-      renderList.push.apply(renderList, input.setVisible(!collapsed));
+      input.setVisible(!collapsed);
     }
   }
 
   if (!collapsed) {
     this.removeInput(collapsedInputName);
-    if (this.rendered) {
-      for (var i = 0, block; (block = renderList[i]); i++) {
-        block.render();
-      }
-    }
     return;
   }
 
@@ -981,9 +975,7 @@ Blockly.BlockSvg.prototype.updateDisabled = function() {
   var children = this.getChildren(false);
   this.applyColour();
   for (var i = 0, child; (child = children[i]); i++) {
-    if (child.rendered) {
-      child.updateDisabled();
-    }
+    child.updateDisabled();
   }
 };
 
@@ -1634,12 +1626,10 @@ Blockly.BlockSvg.prototype.render = function(opt_bubble) {
     if (this.isCollapsed()) {
       this.updateCollapsed_();
     }
-
     this.workspace.getRenderer().render(this);
     this.updateConnectionLocations_();
 
     if (opt_bubble !== false) {
-      // Render all blocks above this one (propogate a reflow).
       var parentBlock = this.getParent();
       if (parentBlock) {
         parentBlock.render(true);

--- a/core/input.js
+++ b/core/input.js
@@ -200,9 +200,6 @@ Blockly.Input.prototype.setVisible = function(visible) {
     }
     var child = this.connection.targetBlock();
     if (child) {
-      if (!visible) {
-        child.rendered = false;
-      }
       child.getSvgRoot().style.display = visible ? 'block' : 'none';
     }
   }

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -459,11 +459,6 @@ Blockly.RenderedConnection.prototype.onFailedConnect = function(
  */
 Blockly.RenderedConnection.prototype.disconnectInternal_ = function(parentBlock,
     childBlock) {
-  // The input the child block was connected to (if any).
-  var parentInput = parentBlock.getInputWithBlock(childBlock);
-  if (parentInput && !parentInput.isVisible()) {
-    childBlock.rendered = true;
-  }
   Blockly.RenderedConnection.superClass_.disconnectInternal_.call(this,
       parentBlock, childBlock);
   // Rerender the parent so that it may reflow.
@@ -549,9 +544,6 @@ Blockly.RenderedConnection.prototype.connect_ = function(childConnection) {
   var parentInput = parentBlock.getInputWithBlock(childBlock);
   if (parentInput) {
     var visible = parentInput.isVisible();
-    if (!visible) {
-      childBlock.rendered = false;
-    }
     childBlock.getSvgRoot().style.display = visible ? 'block' : 'none';
   }
 };


### PR DESCRIPTION
Reverts google/blockly#4264

Caused issues with deleting collapsed blocks.