### PR TITLE
Don't update disabled on unrendered children

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -975,7 +975,9 @@ Blockly.BlockSvg.prototype.updateDisabled = function() {
   var children = this.getChildren(false);
   this.applyColour();
   for (var i = 0, child; (child = children[i]); i++) {
-    child.updateDisabled();
+    if (child.rendered) {
+      child.updateDisabled();
+    }
   }
 };
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves


### Proposed Changes

Checks whether a child block is rendered before calling updateDisabled.

### Reason for Changes

Cut off a deep recursive stack that was happening on every mouse move.

### Test Coverage

Tested in the playground by:
- creating a large spaghetti stack
- collapsing top blocks
- starting a performance log
- dragging a block over the collapsed stacks
- stopping the performance log
- inspecting the flame chart and making sure that there aren't 100+ ms of recursive updateDisabled calls

### Additional Information
Updating disabled is expensive because it applies a change to the dom every time, instead of checking if a change has actually occurred and only then doing the update.