### PR TITLE
Don't update disabled on children of collapsed blocks.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -974,6 +974,9 @@ Blockly.BlockSvg.prototype.applyColour = function() {
 Blockly.BlockSvg.prototype.updateDisabled = function() {
   var children = this.getChildren(false);
   this.applyColour();
+  if (this.isCollapsed()) {
+    return;
+  }
   for (var i = 0, child; (child = children[i]); i++) {
     if (child.rendered) {
       child.updateDisabled();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4229 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Don't recursively call `updateDisabled` on children of collapsed blocks.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Children of collapsed blocks are hidden and don't need to be updated. Unnecessarily calling `updateDisabled` (and `appyColour` on these blocks is a big drain on performance.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested in playground by:
- Creating a large spaghetti stack
- Collapsing all blocks
- Disconnecting one of the collapsed blocks
- Starting a performance log
- Dragging the disconnected block across the collapsed stacks
- Stopping the performance log
- Observing significant reduction of `updateDisabled` calls
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This change improves performance for collapsed block, but there still appears to be drag lag issue.
<!-- Anything else we should know? -->
