### PR TITLE
Change order of tests to avoid timing issues

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -52,15 +52,6 @@ run_test_command () {
 # Lint the codebase.
 run_test_command "eslint" "eslint ."
 
-# Run Mocha tests inside a browser.
-run_test_command "mocha" "node tests/mocha/run_mocha_tests_in_browser.js"
-
-# Run Node tests.
-run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/node/.mocharc.js"
-
-# Run generator tests inside a browser and check the results.
-run_test_command "generators" "tests/scripts/run_generators.sh"
-
 # Run the closure compiler.
 run_test_command "compile" "npm run build"
 
@@ -69,6 +60,15 @@ run_test_command "compile:warnings" "npm run build:debug"
 
 # Generate TypeScript typings and ensure there are no errors.
 run_test_command "typings" "tests/scripts/compile_typings.sh"
+
+# Run Mocha tests inside a browser.
+run_test_command "mocha" "node tests/mocha/run_mocha_tests_in_browser.js"
+
+# Run Node tests.
+run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/node/.mocharc.js"
+
+# Run generator tests inside a browser and check the results.
+run_test_command "generators" "tests/scripts/run_generators.sh"
 
 # Check the sizes of built files for unexpected growth.
 run_test_command "metadata" "tests/scripts/check_metadata.sh"

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -61,17 +61,17 @@ run_test_command "compile:warnings" "npm run build:debug"
 # Generate TypeScript typings and ensure there are no errors.
 run_test_command "typings" "tests/scripts/compile_typings.sh"
 
+# Check the sizes of built files for unexpected growth.
+run_test_command "metadata" "tests/scripts/check_metadata.sh"
+
 # Run Mocha tests inside a browser.
 run_test_command "mocha" "node tests/mocha/run_mocha_tests_in_browser.js"
-
-# Run Node tests.
-run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/node/.mocharc.js"
 
 # Run generator tests inside a browser and check the results.
 run_test_command "generators" "tests/scripts/run_generators.sh"
 
-# Check the sizes of built files for unexpected growth.
-run_test_command "metadata" "tests/scripts/check_metadata.sh"
+# Run Node tests.
+run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/node/.mocharc.js"
 
 # # Attempt advanced compilation of a Blockly app.
 # run_test_command "advanced_compile" "tests/compile/compile.sh"


### PR DESCRIPTION
### The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Tests keep failing with ECONNREFUSED, and it looks like it's because the selenium server isn't up by the time mocha tests start.

### Proposed Changes

Move some longer tests that don't need the selenium server to run earlier.

