### PR TITLE
Block factory fix

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -363,3 +363,19 @@ Blockly.Options.parseThemeOptions_ = function(options) {
   return Blockly.Theme.defineTheme(theme.name ||
       ('builtin' + Blockly.utils.IdGenerator.getNextUniqueId()), theme);
 };
+
+/**
+ * Parse the provided toolbox tree into a consistent DOM format.
+ * @param {?Node|?string} toolboxDef DOM tree of blocks, or text representation
+ *    of same.
+ * @return {?Node} DOM tree of blocks, or null.
+ * @deprecated Use Blockly.utils.toolbox.parseToolboxTree. (2020 September 28)
+ */
+Blockly.Options.parseToolboxTree = function(toolboxDef) {
+  Blockly.utils.deprecation.warn(
+      'Blockly.Options.parseToolboxTree',
+      'September 2020',
+      'September 2021',
+      'Blockly.utils.toolbox.parseToolboxTree');
+  return Blockly.utils.toolbox.parseToolboxTree(toolboxDef);
+};

--- a/core/toolbox/toolbox_item.js
+++ b/core/toolbox/toolbox_item.js
@@ -34,7 +34,7 @@ Blockly.ToolboxItem = function(toolboxItemDef, toolbox, opt_parent) {
    * @type {string}
    * @protected
    */
-  this.id_ = toolboxItemDef['data-id'] || Blockly.utils.IdGenerator.getNextUniqueId();
+  this.id_ = toolboxItemDef['toolboxitemid'] || Blockly.utils.IdGenerator.getNextUniqueId();
 
   /**
    * The parent of the category.

--- a/core/toolbox/toolbox_item.js
+++ b/core/toolbox/toolbox_item.js
@@ -34,7 +34,7 @@ Blockly.ToolboxItem = function(toolboxItemDef, toolbox, opt_parent) {
    * @type {string}
    * @protected
    */
-  this.id_ = toolboxItemDef['id'] || Blockly.utils.IdGenerator.getNextUniqueId();
+  this.id_ = toolboxItemDef['data-id'] || Blockly.utils.IdGenerator.getNextUniqueId();
 
   /**
    * The parent of the category.

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -398,7 +398,7 @@ WorkspaceFactoryController.prototype.updatePreview = function() {
   // Only update the toolbox if not in read only mode.
   if (!this.model.options['readOnly']) {
     // Get toolbox XML.
-    var tree = Blockly.Options.parseToolboxTree(
+    var tree = Blockly.utils.toolbox.parseToolboxTree(
         this.generator.generateToolboxXml());
 
     // No categories, creates a simple flyout.
@@ -1084,7 +1084,7 @@ WorkspaceFactoryController.prototype.setStandardOptionsAndUpdate = function() {
 WorkspaceFactoryController.prototype.generateNewOptions = function() {
   this.model.setOptions(this.readOptions_());
 
-  this.reinjectPreview(Blockly.Options.parseToolboxTree(
+  this.reinjectPreview(Blockly.utils.toolbox.parseToolboxTree(
       this.generator.generateToolboxXml()));
 };
 

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -146,10 +146,10 @@
       <category name="Second">
         <block type="stack_block"></block>
       </category>
-      <sep id="separator" gap="-1"></sep>
+      <sep toolboxitemid="separator" gap="-1"></sep>
       <category name="Variables" custom="VARIABLE"></category>
       <category name="NestedCategory" >
-        <category id="nestedCategory" name="NestedItemOne"></category>
+        <category toolboxitemid="nestedCategory" name="NestedItemOne"></category>
       </category>
       <category name="lastItem"></category>
     </xml>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Block factory was broken due to: 
1. Using Blockly.Options.parseToolbox instead of Blockly.utils.toolbox.parseToolbox
2. Toolbox Items use the given id on the `<category>` element when creating the html for the toolbox. This causes problems since the `<category>` xml has the same id.

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
1. Use Blockly.utils.toolbox.parseToolbox.
2. .  Use a different name for the id so that there are not two elements on the page with the same id.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
I could potentially keep it as `id` for JSON and change it for xml but I thought this would be more confusing. So changing the name for both.
<!-- Anything else we should know? -->
