### PR TITLE
Fix order errors in text generators

### DIFF
--- a/generators/dart.js
+++ b/generators/dart.js
@@ -158,7 +158,7 @@ Blockly.Dart.scrubNakedValue = function(line) {
  * Encode a string as a properly escaped Dart string, complete with quotes.
  * @param {string} string Text to encode.
  * @return {string} Dart string.
- * @private
+ * @protected
  */
 Blockly.Dart.quote_ = function(string) {
   // Can't use goog.string.quote since $ must also be escaped.
@@ -170,6 +170,20 @@ Blockly.Dart.quote_ = function(string) {
 };
 
 /**
+ * Encode a string as a properly escaped multiline Dart string, complete with
+ * quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Dart string.
+ * @protected
+ */
+Blockly.Dart.multiline_quote_ = function (string) {
+  var lines = string.split(/\n/g).map(Blockly.Dart.quote_);
+  // Join with the following, plus a newline:
+  // + '\n' +
+  return lines.join(' + \'\\n\' + \n');
+};
+
+/**
  * Common tasks for generating Dart from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.
@@ -177,7 +191,7 @@ Blockly.Dart.quote_ = function(string) {
  * @param {string} code The Dart code created for this block.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string} Dart code with comments and subsequent blocks added.
- * @private
+ * @protected
  */
 Blockly.Dart.scrub_ = function(block, code, opt_thisOnly) {
   var commentCode = '';

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -170,21 +170,6 @@ Blockly.Dart.quote_ = function(string) {
 };
 
 /**
- * Encode a string as a properly escaped multiline Dart string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} Dart string.
- * @private
- */
-Blockly.Dart.multiline_quote_ = function (string) {
-  var lines = string.split(/\n/g).map(Blockly.Dart.quote_);
-  // Join with the following, plus a newline:
-  // + '\n' +
-  return lines.join(' + \'\\n\' + \n');
-};
-
-
-/**
  * Common tasks for generating Dart from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -50,7 +50,7 @@ Blockly.Dart.addReservedWords(
 
 /**
  * Order of operation ENUMs.
- * https://www.dartlang.org/docs/dart-up-and-running/ch02.html#operator_table
+ * https://dart.dev/guides/language/language-tour#operators
  */
 Blockly.Dart.ORDER_ATOMIC = 0;         // 0 "" ...
 Blockly.Dart.ORDER_UNARY_POSTFIX = 1;  // expr++ expr-- () [] . ?.

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -23,6 +23,20 @@ Blockly.Dart['text'] = function(block) {
   return [code, Blockly.Dart.ORDER_ATOMIC];
 };
 
+/**
+ * Encode a string as a properly escaped multiline Dart string, complete with
+ * quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Dart string.
+ * @private
+ */
+Blockly.Dart.multiline_quote_ = function (string) {
+  var lines = string.split(/\n/g).map(Blockly.Dart.quote_);
+  // Join with the following, plus a newline:
+  // + '\n' +
+  return lines.join(' + \'\\n\' + \n');
+};
+
 Blockly.Dart['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Dart.multiline_quote_(block.getFieldValue('TEXT'));

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -23,20 +23,6 @@ Blockly.Dart['text'] = function(block) {
   return [code, Blockly.Dart.ORDER_ATOMIC];
 };
 
-/**
- * Encode a string as a properly escaped multiline Dart string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} Dart string.
- * @private
- */
-Blockly.Dart.multiline_quote_ = function (string) {
-  var lines = string.split(/\n/g).map(Blockly.Dart.quote_);
-  // Join with the following, plus a newline:
-  // + '\n' +
-  return lines.join(' + \'\\n\' + \n');
-};
-
 Blockly.Dart['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Dart.multiline_quote_(block.getFieldValue('TEXT'));

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -152,17 +152,16 @@ Blockly.Dart['text_getSubstring'] = function(block) {
   // Get substring.
   var where1 = block.getFieldValue('WHERE1');
   var where2 = block.getFieldValue('WHERE2');
+  var requiresLengthCall = (where1 != 'FROM_END' && where2 == 'FROM_START');
+  var textOrder = requiresLengthCall ? Blockly.Dart.ORDER_UNARY_POSTFIX :
+      Blockly.Dart.ORDER_NONE;
+  var text = Blockly.Dart.valueToCode(block, 'STRING', textOrder) || '\'\'';
   if (where1 == 'FIRST' && where2 == 'LAST') {
-    var text = Blockly.Dart.valueToCode(block, 'STRING',
-        Blockly.Dart.ORDER_NONE) || '\'\'';
     var code = text;
     return [code, Blockly.Dart.ORDER_NONE];
-  } else if (text.match(/^'?\w+'?$/) ||
-      (where1 != 'FROM_END' && where2 == 'FROM_START')) {
+  } else if (text.match(/^'?\w+'?$/) || requiresLengthCall) {
     // If the text is a variable or literal or doesn't require a call for
     // length, don't generate a helper function.
-    var text = Blockly.Dart.valueToCode(block, 'STRING',
-        Blockly.Dart.ORDER_UNARY_POSTFIX) || '\'\'';
     switch (where1) {
       case 'FROM_START':
         var at1 = Blockly.Dart.getAdjusted(block, 'AT1');
@@ -198,8 +197,6 @@ Blockly.Dart['text_getSubstring'] = function(block) {
       var code = text + '.substring(' + at1 + ', ' + at2 + ')';
     }
   } else {
-    var text = Blockly.Dart.valueToCode(block, 'STRING',
-        Blockly.Dart.ORDER_NONE) || '\'\'';
     var at1 = Blockly.Dart.getAdjusted(block, 'AT1');
     var at2 = Blockly.Dart.getAdjusted(block, 'AT2');
     var functionName = Blockly.Dart.provideFunction_(

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -94,7 +94,7 @@ Blockly.Dart['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var textOrder = (where == 'FIRST' | where == 'FROM_START') ?
+  var textOrder = (where == 'FIRST' || where == 'FROM_START') ?
       Blockly.Dart.ORDER_UNARY_POSTFIX : Blockly.Dart.ORDER_NONE;
   var text = Blockly.Dart.valueToCode(block, 'VALUE', textOrder) || '\'\'';
   switch (where) {

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -200,20 +200,6 @@ Blockly.JavaScript.quote_ = function(string) {
 };
 
 /**
- * Encode a string as a properly escaped multiline JavaScript string, complete
- * with quotes.
- * @param {string} string Text to encode.
- * @return {string} JavaScript string.
- * @private
- */
-Blockly.JavaScript.multiline_quote_ = function(string) {
-  // Can't use goog.string.quote since Google's style guide recommends
-  // JS string literals use single quotes.
-  var lines = string.split(/\n/g).map(Blockly.JavaScript.quote_);
-  return lines.join(' + \'\\n\' +\n');
-};
-
-/**
  * Common tasks for generating JavaScript from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -188,7 +188,7 @@ Blockly.JavaScript.scrubNakedValue = function(line) {
  * quotes.
  * @param {string} string Text to encode.
  * @return {string} JavaScript string.
- * @private
+ * @protected
  */
 Blockly.JavaScript.quote_ = function(string) {
   // Can't use goog.string.quote since Google's style guide recommends
@@ -200,6 +200,20 @@ Blockly.JavaScript.quote_ = function(string) {
 };
 
 /**
+ * Encode a string as a properly escaped multiline JavaScript string, complete
+ * with quotes.
+ * @param {string} string Text to encode.
+ * @return {string} JavaScript string.
+ * @protected
+ */
+Blockly.JavaScript.multiline_quote_ = function(string) {
+  // Can't use goog.string.quote since Google's style guide recommends
+  // JS string literals use single quotes.
+  var lines = string.split(/\n/g).map(Blockly.JavaScript.quote_);
+  return lines.join(' + \'\\n\' +\n');
+};
+
+/**
  * Common tasks for generating JavaScript from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.
@@ -207,7 +221,7 @@ Blockly.JavaScript.quote_ = function(string) {
  * @param {string} code The JavaScript code created for this block.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string} JavaScript code with comments and subsequent blocks added.
- * @private
+ * @protected
  */
 Blockly.JavaScript.scrub_ = function(block, code, opt_thisOnly) {
   var commentCode = '';

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -25,7 +25,7 @@ Blockly.JavaScript['text'] = function(block) {
  * Encode a string as a properly escaped multiline JavaScript string, complete
  * with quotes.
  * @param {string} string Text to encode.
- * @return {[string, } JavaScript string.
+ * @return {string} JavaScript string.
  * @private
  */
 Blockly.JavaScript.multiline_quote_ = function(string) {

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -195,18 +195,20 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
   // Get substring.
   var where1 = block.getFieldValue('WHERE1');
   var where2 = block.getFieldValue('WHERE2');
+  var requiresLengthCall = (where1 != 'FROM_END' && where1 != 'LAST' &&
+      where2 != 'FROM_END' && where2 != 'LAST');
+  var textOrder = requiresLengthCall ? Blockly.JavaScript.ORDER_MEMBER :
+      Blockly.JavaScript.ORDER_NONE;
+  var text = Blockly.JavaScript.valueToCode(block, 'STRING',
+      textOrder) || '\'\'';
   if (where1 == 'FIRST' && where2 == 'LAST') {
     var text = Blockly.JavaScript.valueToCode(block, 'STRING',
         Blockly.JavaScript.ORDER_NONE) || '\'\'';
     var code = text;
     return [code, Blockly.JavaScript.ORDER_NONE];
-  } else if (text.match(/^'?\w+'?$/) ||
-      (where1 != 'FROM_END' && where1 != 'LAST' &&
-      where2 != 'FROM_END' && where2 != 'LAST')) {
+  } else if (text.match(/^'?\w+'?$/) || requiresLengthCall) {
     // If the text is a variable or literal or doesn't require a call for
     // length, don't generate a helper function.
-    var text = Blockly.JavaScript.valueToCode(block, 'STRING',
-        Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
     switch (where1) {
       case 'FROM_START':
         var at1 = Blockly.JavaScript.getAdjusted(block, 'AT1');
@@ -239,8 +241,6 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
     }
     code = text + '.slice(' + at1 + ', ' + at2 + ')';
   } else {
-    var text = Blockly.JavaScript.valueToCode(block, 'STRING',
-        Blockly.JavaScript.ORDER_NONE) || '\'\'';
     var at1 = Blockly.JavaScript.getAdjusted(block, 'AT1');
     var at2 = Blockly.JavaScript.getAdjusted(block, 'AT2');
     var getIndex_ = Blockly.JavaScript.text.getIndex_;

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -21,20 +21,6 @@ Blockly.JavaScript['text'] = function(block) {
   return [code, Blockly.JavaScript.ORDER_ATOMIC];
 };
 
-/**
- * Encode a string as a properly escaped multiline JavaScript string, complete
- * with quotes.
- * @param {string} string Text to encode.
- * @return {string} JavaScript string.
- * @private
- */
-Blockly.JavaScript.multiline_quote_ = function(string) {
-  // Can't use goog.string.quote since Google's style guide recommends
-  // JS string literals use single quotes.
-  var lines = string.split(/\n/g).map(Blockly.JavaScript.quote_);
-  return lines.join(' + \'\\n\' +\n');
-};
-
 Blockly.JavaScript['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.JavaScript.multiline_quote_(block.getFieldValue('TEXT'));

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -85,7 +85,7 @@ Blockly.JavaScript['text_join'] = function(block) {
       var elements = new Array(block.itemCount_);
       for (var i = 0; i < block.itemCount_; i++) {
         elements[i] = Blockly.JavaScript.valueToCode(block, 'ADD' + i,
-            Blockly.JavaScript.ORDER_COMMA) || '\'\'';
+            Blockly.JavaScript.ORDER_NONE) || '\'\'';
       }
       var code = '[' + elements.join(',') + '].join(\'\')';
       return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -144,20 +144,6 @@ Blockly.Lua.quote_ = function(string) {
 };
 
 /**
- * Encode a string as a properly escaped multiline Lua string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} Lua string.
- * @private
- */
-Blockly.Lua.multiline_quote_ = function(string) {
-  var lines = string.split(/\n/g).map(Blockly.Lua.quote_);
-  // Join with the following, plus a newline:
-  // .. '\n' ..
-  return lines.join(' .. \'\\n\' ..\n');
-};
-
-/**
  * Common tasks for generating Lua from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -134,13 +134,27 @@ Blockly.Lua.scrubNakedValue = function(line) {
  * quotes.
  * @param {string} string Text to encode.
  * @return {string} Lua string.
- * @private
+ * @protected
  */
 Blockly.Lua.quote_ = function(string) {
   string = string.replace(/\\/g, '\\\\')
                  .replace(/\n/g, '\\\n')
                  .replace(/'/g, '\\\'');
   return '\'' + string + '\'';
+};
+
+/**
+ * Encode a string as a properly escaped multiline Lua string, complete with
+ * quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Lua string.
+ * @protected
+ */
+Blockly.Lua.multiline_quote_ = function(string) {
+  var lines = string.split(/\n/g).map(Blockly.Lua.quote_);
+  // Join with the following, plus a newline:
+  // .. '\n' ..
+  return lines.join(' .. \'\\n\' ..\n');
 };
 
 /**
@@ -151,7 +165,7 @@ Blockly.Lua.quote_ = function(string) {
  * @param {string} code The Lua code created for this block.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string} Lua code with comments and subsequent blocks added.
- * @private
+ * @protected
  */
 Blockly.Lua.scrub_ = function(block, code, opt_thisOnly) {
   var commentCode = '';

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -21,20 +21,6 @@ Blockly.Lua['text'] = function(block) {
   return [code, Blockly.Lua.ORDER_ATOMIC];
 };
 
-/**
- * Encode a string as a properly escaped multiline Lua string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} Lua string.
- * @private
- */
-Blockly.Lua.multiline_quote_ = function(string) {
-  var lines = string.split(/\n/g).map(Blockly.Lua.quote_);
-  // Join with the following, plus a newline:
-  // .. '\n' ..
-  return lines.join(' .. \'\\n\' ..\n');
-};
-
 Blockly.Lua['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Lua.multiline_quote_(block.getFieldValue('TEXT'));

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -21,10 +21,26 @@ Blockly.Lua['text'] = function(block) {
   return [code, Blockly.Lua.ORDER_ATOMIC];
 };
 
+/**
+ * Encode a string as a properly escaped multiline Lua string, complete with
+ * quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Lua string.
+ * @private
+ */
+Blockly.Lua.multiline_quote_ = function(string) {
+  var lines = string.split(/\n/g).map(Blockly.Lua.quote_);
+  // Join with the following, plus a newline:
+  // .. '\n' ..
+  return lines.join(' .. \'\\n\' ..\n');
+};
+
 Blockly.Lua['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Lua.multiline_quote_(block.getFieldValue('TEXT'));
-  return [code, Blockly.Lua.ORDER_ATOMIC];
+  var order = code.indexOf('..') != -1 ? Blockly.Lua.ORDER_CONCATENATION :
+      Blockly.Lua.ORDER_ATOMIC;
+  return [code, order];
 };
 
 Blockly.Lua['text_join'] = function(block) {
@@ -347,7 +363,7 @@ Blockly.Lua['text_replace'] = function(block) {
 
 Blockly.Lua['text_reverse'] = function(block) {
   var text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_HIGH) || '\'\'';
+      Blockly.Lua.ORDER_NONE) || '\'\'';
   var code = 'string.reverse(' + text + ')';
   return [code, Blockly.Lua.ORDER_HIGH];
 };

--- a/generators/php.js
+++ b/generators/php.js
@@ -190,13 +190,28 @@ Blockly.PHP.scrubNakedValue = function(line) {
  * quotes.
  * @param {string} string Text to encode.
  * @return {string} PHP string.
- * @private
+ * @protected
  */
 Blockly.PHP.quote_ = function(string) {
   string = string.replace(/\\/g, '\\\\')
                  .replace(/\n/g, '\\\n')
                  .replace(/'/g, '\\\'');
   return '\'' + string + '\'';
+};
+
+/**
+ * Encode a string as a properly escaped multiline PHP string, complete with
+ * quotes.
+ * @param {string} string Text to encode.
+ * @return {string} PHP string.
+ * @protected
+ */
+Blockly.PHP.multiline_quote_ = function (string) {
+  var lines = string.split(/\n/g).map(Blockly.PHP.quote_);
+  // Join with the following, plus a newline:
+  // . "\n" .
+  // Newline escaping only works in double-quoted strings.
+  return lines.join(' . \"\\n\" .\n');
 };
 
 /**
@@ -207,7 +222,7 @@ Blockly.PHP.quote_ = function(string) {
  * @param {string} code The PHP code created for this block.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string} PHP code with comments and subsequent blocks added.
- * @private
+ * @protected
  */
 Blockly.PHP.scrub_ = function(block, code, opt_thisOnly) {
   var commentCode = '';

--- a/generators/php.js
+++ b/generators/php.js
@@ -200,21 +200,6 @@ Blockly.PHP.quote_ = function(string) {
 };
 
 /**
- * Encode a string as a properly escaped multiline PHP string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} PHP string.
- * @private
- */
-Blockly.PHP.multiline_quote_ = function (string) {
-  var lines = string.split(/\n/g).map(Blockly.PHP.quote_);
-  // Join with the following, plus a newline:
-  // . "\n" .
-  // Newline escaping only works in double-quoted strings.
-  return lines.join(' . \"\\n\" .\n');
-};
-
-/**
  * Common tasks for generating PHP from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.

--- a/generators/php/text.js
+++ b/generators/php/text.js
@@ -21,21 +21,6 @@ Blockly.PHP['text'] = function(block) {
   return [code, Blockly.PHP.ORDER_ATOMIC];
 };
 
-/**
- * Encode a string as a properly escaped multiline PHP string, complete with
- * quotes.
- * @param {string} string Text to encode.
- * @return {string} PHP string.
- * @private
- */
-Blockly.PHP.multiline_quote_ = function (string) {
-  var lines = string.split(/\n/g).map(Blockly.PHP.quote_);
-  // Join with the following, plus a newline:
-  // . "\n" .
-  // Newline escaping only works in double-quoted strings.
-  return lines.join(' . \"\\n\" .\n');
-};
-
 Blockly.PHP['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.PHP.multiline_quote_(block.getFieldValue('TEXT'));

--- a/generators/php/text.js
+++ b/generators/php/text.js
@@ -64,7 +64,7 @@ Blockly.PHP['text_join'] = function(block) {
     var elements = new Array(block.itemCount_);
     for (var i = 0; i < block.itemCount_; i++) {
       elements[i] = Blockly.PHP.valueToCode(block, 'ADD' + i,
-          Blockly.PHP.ORDER_COMMA) || '\'\'';
+          Blockly.PHP.ORDER_NONE) || '\'\'';
     }
     var code = 'implode(\'\', array(' + elements.join(',') + '))';
     return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
@@ -108,9 +108,9 @@ Blockly.PHP['text_indexOf'] = function(block) {
   var operator = block.getFieldValue('END') == 'FIRST' ?
       'strpos' : 'strrpos';
   var substring = Blockly.PHP.valueToCode(block, 'FIND',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var text = Blockly.PHP.valueToCode(block, 'VALUE',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   if (block.workspace.options.oneBasedIndex) {
     var errorIndex = ' 0';
     var indexAdjustment = ' + 1';
@@ -135,7 +135,7 @@ Blockly.PHP['text_charAt'] = function(block) {
   // Get letter at index.
   var where = block.getFieldValue('WHERE') || 'FROM_START';
   var textOrder = (where == 'RANDOM') ? Blockly.PHP.ORDER_NONE :
-      Blockly.PHP.ORDER_COMMA;
+      Blockly.PHP.ORDER_NONE;
   var text = Blockly.PHP.valueToCode(block, 'VALUE', textOrder) || '\'\'';
   switch (where) {
     case 'FIRST':
@@ -175,7 +175,7 @@ Blockly.PHP['text_getSubstring'] = function(block) {
     return [code, Blockly.PHP.ORDER_NONE];
   } else {
     var text = Blockly.PHP.valueToCode(block, 'STRING',
-        Blockly.PHP.ORDER_COMMA) || '\'\'';
+        Blockly.PHP.ORDER_NONE) || '\'\'';
     var at1 = Blockly.PHP.getAdjusted(block, 'AT1');
     var at2 = Blockly.PHP.getAdjusted(block, 'AT2');
     var functionName = Blockly.PHP.provideFunction_(
@@ -263,9 +263,9 @@ Blockly.PHP['text_prompt'] = Blockly.PHP['text_prompt_ext'];
 
 Blockly.PHP['text_count'] = function(block) {
   var text = Blockly.PHP.valueToCode(block, 'TEXT',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var sub = Blockly.PHP.valueToCode(block, 'SUB',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var code = 'strlen(' + sub + ') === 0'
     + ' ? strlen(' + text + ') + 1'
     + ' : substr_count(' + text + ', ' + sub + ')';
@@ -274,11 +274,11 @@ Blockly.PHP['text_count'] = function(block) {
 
 Blockly.PHP['text_replace'] = function(block) {
   var text = Blockly.PHP.valueToCode(block, 'TEXT',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var from = Blockly.PHP.valueToCode(block, 'FROM',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var to = Blockly.PHP.valueToCode(block, 'TO',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var code = 'str_replace(' + from + ', ' + to + ', ' + text + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
 };

--- a/generators/python.js
+++ b/generators/python.js
@@ -227,20 +227,6 @@ Blockly.Python.quote_ = function(string) {
 };
 
 /**
- * Encode a string as a properly escaped multiline Python string, complete
- * with quotes.
- * @param {string} string Text to encode.
- * @return {string} Python string.
- * @private
- */
-Blockly.Python.multiline_quote_ = function(string) {
-  var lines = string.split(/\n/g).map(Blockly.Python.quote_);
-  // Join with the following, plus a newline:
-  // + '\n' +
-  return lines.join(' + \'\\n\' + \n');
-};
-
-/**
  * Common tasks for generating Python from blocks.
  * Handles comments for the specified block and any connected value blocks.
  * Calls any statements following this block.

--- a/generators/python.js
+++ b/generators/python.js
@@ -207,7 +207,7 @@ Blockly.Python.scrubNakedValue = function(line) {
  * Encode a string as a properly escaped Python string, complete with quotes.
  * @param {string} string Text to encode.
  * @return {string} Python string.
- * @private
+ * @protected
  */
 Blockly.Python.quote_ = function(string) {
   // Can't use goog.string.quote since % must also be escaped.
@@ -222,8 +222,22 @@ Blockly.Python.quote_ = function(string) {
     } else {
       string = string.replace(/'/g, '\\\'');
     }
-  };
+  }
   return quote + string + quote;
+};
+
+/**
+ * Encode a string as a properly escaped multiline Python string, complete
+ * with quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Python string.
+ * @protected
+ */
+Blockly.Python.multiline_quote_ = function(string) {
+  var lines = string.split(/\n/g).map(Blockly.Python.quote_);
+  // Join with the following, plus a newline:
+  // + '\n' +
+  return lines.join(' + \'\\n\' + \n');
 };
 
 /**
@@ -234,7 +248,7 @@ Blockly.Python.quote_ = function(string) {
  * @param {string} code The Python code created for this block.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string} Python code with comments and subsequent blocks added.
- * @private
+ * @protected
  */
 Blockly.Python.scrub_ = function(block, code, opt_thisOnly) {
   var commentCode = '';

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -21,24 +21,41 @@ Blockly.Python['text'] = function(block) {
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
+/**
+ * Encode a string as a properly escaped multiline Python string, complete
+ * with quotes.
+ * @param {string} string Text to encode.
+ * @return {string} Python string.
+ * @private
+ */
+Blockly.Python.multiline_quote_ = function(string) {
+  var lines = string.split(/\n/g).map(Blockly.Python.quote_);
+  // Join with the following, plus a newline:
+  // + '\n' +
+  return lines.join(' + \'\\n\' + \n');
+};
+
 Blockly.Python['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Python.multiline_quote_(block.getFieldValue('TEXT'));
-  return [code, Blockly.Python.ORDER_ATOMIC];
+  var order = code.indexOf('+') != -1 ? Blockly.Python.ORDER_ADDITIVE :
+      Blockly.Python.ORDER_ATOMIC;
+  return [code, order];
 };
 
 /**
  * Enclose the provided value in 'str(...)' function.
  * Leave string literals alone.
  * @param {string} value Code evaluating to a value.
- * @return {string} Code evaluating to a string.
+ * @return {[string, number]} Array containing code evaluating to a string and
+ *    the order of the returned code.
  * @private
  */
 Blockly.Python.text.forceString_ = function(value) {
   if (Blockly.Python.text.forceString_.strRegExp.test(value)) {
-    return value;
+    return [value, Blockly.Python.ORDER_ATOMIC];
   }
-  return 'str(' + value + ')';
+  return ['str(' + value + ')', Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 /**
@@ -56,16 +73,16 @@ Blockly.Python['text_join'] = function(block) {
     case 1:
       var element = Blockly.Python.valueToCode(block, 'ADD0',
               Blockly.Python.ORDER_NONE) || '\'\'';
-      var code = Blockly.Python.text.forceString_(element);
-      return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+      var codeAndOrder = Blockly.Python.text.forceString_(element);
+      return codeAndOrder;
       break;
     case 2:
       var element0 = Blockly.Python.valueToCode(block, 'ADD0',
           Blockly.Python.ORDER_NONE) || '\'\'';
       var element1 = Blockly.Python.valueToCode(block, 'ADD1',
           Blockly.Python.ORDER_NONE) || '\'\'';
-      var code = Blockly.Python.text.forceString_(element0) + ' + ' +
-          Blockly.Python.text.forceString_(element1);
+      var code = Blockly.Python.text.forceString_(element0)[0] + ' + ' +
+          Blockly.Python.text.forceString_(element1)[0];
       return [code, Blockly.Python.ORDER_ADDITIVE];
       break;
     default:
@@ -89,7 +106,7 @@ Blockly.Python['text_append'] = function(block) {
   var value = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_NONE) || '\'\'';
   return varName + ' = str(' + varName + ') + ' +
-      Blockly.Python.text.forceString_(value) + '\n';
+      Blockly.Python.text.forceString_(value)[0] + '\n';
 };
 
 Blockly.Python['text_length'] = function(block) {
@@ -126,8 +143,9 @@ Blockly.Python['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var text = Blockly.Python.valueToCode(block, 'VALUE',
-      Blockly.Python.ORDER_MEMBER) || '\'\'';
+  var textOrder = (where == 'RANDOM') ? Blockly.Python.ORDER_NONE :
+      Blockly.Python.ORDER_MEMBER;
+  var text = Blockly.Python.valueToCode(block, 'VALUE', textOrder) || '\'\'';
   switch (where) {
     case 'FIRST':
       var code = text + '[0]';
@@ -271,7 +289,7 @@ Blockly.Python['text_count'] = function(block) {
   var sub = Blockly.Python.valueToCode(block, 'SUB',
       Blockly.Python.ORDER_NONE) || '\'\'';
   var code = text + '.count(' + sub + ')';
-  return [code, Blockly.Python.ORDER_MEMBER];
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['text_replace'] = function(block) {

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -21,20 +21,6 @@ Blockly.Python['text'] = function(block) {
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
-/**
- * Encode a string as a properly escaped multiline Python string, complete
- * with quotes.
- * @param {string} string Text to encode.
- * @return {string} Python string.
- * @private
- */
-Blockly.Python.multiline_quote_ = function(string) {
-  var lines = string.split(/\n/g).map(Blockly.Python.quote_);
-  // Join with the following, plus a newline:
-  // + '\n' +
-  return lines.join(' + \'\\n\' + \n');
-};
-
 Blockly.Python['text_multiline'] = function(block) {
   // Text value.
   var code = Blockly.Python.multiline_quote_(block.getFieldValue('TEXT'));

--- a/tests/generators/golden/generated.dart
+++ b/tests/generators/golden/generated.dart
@@ -732,16 +732,16 @@ void test_get_text_complex() {
   unittest_assertequals((true ? get_Blockly() : null)[0], 'B', 'get first order complex');
   check_number_of_calls('get first order complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_from_end((get_Blockly()), 1), 'y', 'get last complex');
+  unittest_assertequals(text_get_from_end(get_Blockly(), 1), 'y', 'get last complex');
   check_number_of_calls('get last complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_from_end((true ? get_Blockly() : null), 1), 'y', 'get last order complex');
+  unittest_assertequals(text_get_from_end(true ? get_Blockly() : null, 1), 'y', 'get last order complex');
   check_number_of_calls('get last order complex');
   number_of_calls = 0;
-  unittest_assertequals(text.indexOf(text_random_letter((get_Blockly()))) + 1 > 0, true, 'get random complex');
+  unittest_assertequals(text.indexOf(text_random_letter(get_Blockly())) + 1 > 0, true, 'get random complex');
   check_number_of_calls('get random complex');
   number_of_calls = 0;
-  unittest_assertequals(text.indexOf(text_random_letter((true ? get_Blockly() : null))) + 1 > 0, true, 'get random order complex');
+  unittest_assertequals(text.indexOf(text_random_letter(true ? get_Blockly() : null)) + 1 > 0, true, 'get random order complex');
   check_number_of_calls('get random order complex');
   number_of_calls = 0;
   unittest_assertequals((get_Blockly())[2], 'o', 'get # complex');
@@ -750,11 +750,11 @@ void test_get_text_complex() {
   unittest_assertequals((true ? get_Blockly() : null)[((true ? 3 : null) - 1)], 'o', 'get # order complex');
   check_number_of_calls('get # order complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_from_end((get_Blockly()), 3), 'k', 'get #-end complex');
+  unittest_assertequals(text_get_from_end(get_Blockly(), 3), 'k', 'get #-end complex');
   check_number_of_calls('get #-end complex');
   number_of_calls = 0;
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
-  unittest_assertequals(text_get_from_end((true ? get_Blockly() : null), 0 + 3), 'k', 'get #-end order complex');
+  unittest_assertequals(text_get_from_end(true ? get_Blockly() : null, 0 + 3), 'k', 'get #-end order complex');
   check_number_of_calls('get #-end order complex');
 }
 
@@ -813,41 +813,41 @@ void test_substring_complex() {
   check_number_of_calls('substring # complex order');
   number_of_calls = 0;
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end complex');
   check_number_of_calls('substring #-end complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((true ? get_numbers() : null), 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end order order');
+  unittest_assertequals(text_get_substring(true ? get_numbers() : null, 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end order order');
   check_number_of_calls('substring #-end order order');
   number_of_calls = 0;
-  unittest_assertequals((get_numbers()), text, 'substring first-last');
+  unittest_assertequals(get_numbers(), text, 'substring first-last');
   check_number_of_calls('substring first-last');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end complex');
   check_number_of_calls('substring # #-end complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # complex');
   check_number_of_calls('substring #-end # complex');
   number_of_calls = 0;
   unittest_assertequals((get_numbers()).substring(0, 4), '1234', 'substring first # complex');
   check_number_of_calls('substring first # complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FIRST', 0, 'FROM_END', 1), '12345678', 'substring first #-end complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FIRST', 0, 'FROM_END', 1), '12345678', 'substring first #-end complex');
   check_number_of_calls('substring first #-end complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_START', 6, 'LAST', 0), '789', 'substring # last complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_START', 6, 'LAST', 0), '789', 'substring # last complex');
   check_number_of_calls('substring # last complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_END', 2, 'LAST', 0), '789', 'substring #-end last complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_END', 2, 'LAST', 0), '789', 'substring #-end last complex');
   check_number_of_calls('substring #-end last complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_START', 0, 'FROM_END', 0), '123456789', 'substring all with # #-end complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_START', 0, 'FROM_END', 0), '123456789', 'substring all with # #-end complex');
   check_number_of_calls('substring all with # #-end complex');
   number_of_calls = 0;
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_END', 8, 'FROM_START', 8), '123456789', 'substring all with #-end # complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_END', 8, 'FROM_START', 8), '123456789', 'substring all with #-end # complex');
   check_number_of_calls('substring all with #-end # complex');
   number_of_calls = 0;
   // Checks that the whole string is properly retrieved even if the value for start and end is not a simple number. This is especially important in generators where substring uses [x:length - y] for # #-end.
-  unittest_assertequals(text_get_substring((get_numbers()), 'FROM_START', ((0 + 1) - 1), 'FROM_END', ((0 + 1) - 1)), '123456789', 'substring all with # #-end math complex');
+  unittest_assertequals(text_get_substring(get_numbers(), 'FROM_START', ((0 + 1) - 1), 'FROM_END', ((0 + 1) - 1)), '123456789', 'substring all with # #-end math complex');
   check_number_of_calls('substring all with # #-end math complex');
 }
 

--- a/tests/generators/golden/generated.js
+++ b/tests/generators/golden/generated.js
@@ -745,7 +745,7 @@ function test_substring_simple() {
   assertEquals(text.slice(text.length - 3, text.length - 1), '78', 'substring #-end simple');
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
   assertEquals(text.slice(text.length - (0 + 3), text.length - ((0 + 2) - 1)), '78', 'substring #-end simple order');
-  assertEquals((text), text, 'substring first-last simple');
+  assertEquals(text, text, 'substring first-last simple');
   assertEquals(text.slice(1, text.length - 1), '2345678', 'substring # #-end simple');
   assertEquals(text.slice(text.length - 7, 4), '34', 'substring #-end # simple');
   assertEquals(text.slice(0, 4), '1234', 'substring first # simple');
@@ -810,7 +810,7 @@ function test_substring_complex() {
   assertEquals(subsequenceFromEndFromEnd(true ? get_numbers() : null, ((0 + 3) - 1), ((0 + 2) - 1)), '78', 'substring #-end order order');
   check_number_of_calls('substring #-end order order');
   number_of_calls = 0;
-  assertEquals((get_numbers()), text, 'substring first-last');
+  assertEquals(get_numbers(), text, 'substring first-last');
   check_number_of_calls('substring first-last');
   number_of_calls = 0;
   assertEquals(subsequenceFromStartFromEnd(get_numbers(), 1, 1), '2345678', 'substring # #-end complex');

--- a/tests/generators/golden/generated.js
+++ b/tests/generators/golden/generated.js
@@ -745,7 +745,7 @@ function test_substring_simple() {
   assertEquals(text.slice(text.length - 3, text.length - 1), '78', 'substring #-end simple');
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
   assertEquals(text.slice(text.length - (0 + 3), text.length - ((0 + 2) - 1)), '78', 'substring #-end simple order');
-  assertEquals(text, text, 'substring first-last simple');
+  assertEquals((text), text, 'substring first-last simple');
   assertEquals(text.slice(1, text.length - 1), '2345678', 'substring # #-end simple');
   assertEquals(text.slice(text.length - 7, 4), '34', 'substring #-end # simple');
   assertEquals(text.slice(0, 4), '1234', 'substring first # simple');
@@ -807,10 +807,10 @@ function test_substring_complex() {
   assertEquals(subsequenceFromEndFromEnd(get_numbers(), 2, 1), '78', 'substring #-end complex');
   check_number_of_calls('substring #-end complex');
   number_of_calls = 0;
-  assertEquals(subsequenceFromEndFromEnd((true ? get_numbers() : null), ((0 + 3) - 1), ((0 + 2) - 1)), '78', 'substring #-end order order');
+  assertEquals(subsequenceFromEndFromEnd(true ? get_numbers() : null, ((0 + 3) - 1), ((0 + 2) - 1)), '78', 'substring #-end order order');
   check_number_of_calls('substring #-end order order');
   number_of_calls = 0;
-  assertEquals(get_numbers(), text, 'substring first-last');
+  assertEquals((get_numbers()), text, 'substring first-last');
   check_number_of_calls('substring first-last');
   number_of_calls = 0;
   assertEquals(subsequenceFromStartFromEnd(get_numbers(), 1, 1), '2345678', 'substring # #-end complex');

--- a/tests/generators/golden/generated.php
+++ b/tests/generators/golden/generated.php
@@ -602,8 +602,8 @@ function check_number_of_calls($test_name) {
 function test_create_text() {
   global $test_name, $naked, $proc_x, $proc_y, $func_x, $func_y, $func_a, $n, $ok, $log, $count, $varToChange, $rand, $item, $text, $number_of_calls, $list2, $proc_z, $func_z, $x, $proc_w, $func_c, $if2, $i, $loglist, $changing_list, $list_copy, $unittestResults;
   assertEquals('', '', 'no text');
-  assertEquals(('Hello'), 'Hello', 'create single');
-  assertEquals((-1), '-1', 'create single number');
+  assertEquals('Hello', 'Hello', 'create single');
+  assertEquals(-1, '-1', 'create single number');
   assertEquals('K' . 9, 'K9', 'create double text');
   assertEquals(4 . 2, '42', 'create double text numbers');
   assertEquals(implode('', array(1,2,3)), '123', 'create triple');
@@ -803,7 +803,7 @@ function test_substring_simple() {
   assertEquals(text_get_substring($text, 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end simple');
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
   assertEquals(text_get_substring($text, 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end simple order');
-  assertEquals(($text), $text, 'substring first-last simple');
+  assertEquals($text, $text, 'substring first-last simple');
   assertEquals(text_get_substring($text, 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end simple');
   assertEquals(text_get_substring($text, 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # simple');
   assertEquals(text_get_substring($text, 'FIRST', 0, 'FROM_START', 3), '1234', 'substring first # simple');
@@ -833,7 +833,7 @@ function test_substring_complex() {
   assertEquals(text_get_substring(true ? get_numbers() : null, 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end order order');
   check_number_of_calls('substring #-end order order');
   $number_of_calls = 0;
-  assertEquals((get_numbers()), $text, 'substring first-last');
+  assertEquals(get_numbers(), $text, 'substring first-last');
   check_number_of_calls('substring first-last');
   $number_of_calls = 0;
   assertEquals(text_get_substring(get_numbers(), 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end complex');

--- a/tests/generators/golden/generated.php
+++ b/tests/generators/golden/generated.php
@@ -602,8 +602,8 @@ function check_number_of_calls($test_name) {
 function test_create_text() {
   global $test_name, $naked, $proc_x, $proc_y, $func_x, $func_y, $func_a, $n, $ok, $log, $count, $varToChange, $rand, $item, $text, $number_of_calls, $list2, $proc_z, $func_z, $x, $proc_w, $func_c, $if2, $i, $loglist, $changing_list, $list_copy, $unittestResults;
   assertEquals('', '', 'no text');
-  assertEquals('Hello', 'Hello', 'create single');
-  assertEquals(-1, '-1', 'create single number');
+  assertEquals(('Hello'), 'Hello', 'create single');
+  assertEquals((-1), '-1', 'create single number');
   assertEquals('K' . 9, 'K9', 'create double text');
   assertEquals(4 . 2, '42', 'create double text numbers');
   assertEquals(implode('', array(1,2,3)), '123', 'create triple');
@@ -803,7 +803,7 @@ function test_substring_simple() {
   assertEquals(text_get_substring($text, 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end simple');
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
   assertEquals(text_get_substring($text, 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end simple order');
-  assertEquals($text, $text, 'substring first-last simple');
+  assertEquals(($text), $text, 'substring first-last simple');
   assertEquals(text_get_substring($text, 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end simple');
   assertEquals(text_get_substring($text, 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # simple');
   assertEquals(text_get_substring($text, 'FIRST', 0, 'FROM_START', 3), '1234', 'substring first # simple');
@@ -820,48 +820,48 @@ function test_substring_simple() {
 function test_substring_complex() {
   global $test_name, $naked, $proc_x, $proc_y, $func_x, $func_y, $func_a, $n, $ok, $log, $count, $varToChange, $rand, $item, $text, $number_of_calls, $list2, $proc_z, $func_z, $x, $proc_w, $func_c, $if2, $i, $loglist, $changing_list, $list_copy, $unittestResults;
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_START', 1, 'FROM_START', 2), '23', 'substring # complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_START', 1, 'FROM_START', 2), '23', 'substring # complex');
   check_number_of_calls('substring # complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((true ? get_numbers() : null), 'FROM_START', ((true ? 2 : null) - 1), 'FROM_START', ((true ? 3 : null) - 1)), '23', 'substring # complex order');
+  assertEquals(text_get_substring(true ? get_numbers() : null, 'FROM_START', ((true ? 2 : null) - 1), 'FROM_START', ((true ? 3 : null) - 1)), '23', 'substring # complex order');
   check_number_of_calls('substring # complex order');
   $number_of_calls = 0;
   // The order for index for #-end is addition because this will catch errors in generators where most perform the operation ... - index.
-  assertEquals(text_get_substring((get_numbers()), 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_END', 2, 'FROM_END', 1), '78', 'substring #-end complex');
   check_number_of_calls('substring #-end complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((true ? get_numbers() : null), 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end order order');
+  assertEquals(text_get_substring(true ? get_numbers() : null, 'FROM_END', ((0 + 3) - 1), 'FROM_END', ((0 + 2) - 1)), '78', 'substring #-end order order');
   check_number_of_calls('substring #-end order order');
   $number_of_calls = 0;
   assertEquals((get_numbers()), $text, 'substring first-last');
   check_number_of_calls('substring first-last');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_START', 1, 'FROM_END', 1), '2345678', 'substring # #-end complex');
   check_number_of_calls('substring # #-end complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_END', 6, 'FROM_START', 3), '34', 'substring #-end # complex');
   check_number_of_calls('substring #-end # complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FIRST', 0, 'FROM_START', 3), '1234', 'substring first # complex');
+  assertEquals(text_get_substring(get_numbers(), 'FIRST', 0, 'FROM_START', 3), '1234', 'substring first # complex');
   check_number_of_calls('substring first # complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FIRST', 0, 'FROM_END', 1), '12345678', 'substring first #-end complex');
+  assertEquals(text_get_substring(get_numbers(), 'FIRST', 0, 'FROM_END', 1), '12345678', 'substring first #-end complex');
   check_number_of_calls('substring first #-end complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_START', 6, 'LAST', 0), '789', 'substring # last complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_START', 6, 'LAST', 0), '789', 'substring # last complex');
   check_number_of_calls('substring # last complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_END', 2, 'LAST', 0), '789', 'substring #-end last complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_END', 2, 'LAST', 0), '789', 'substring #-end last complex');
   check_number_of_calls('substring #-end last complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_START', 0, 'FROM_END', 0), '123456789', 'substring all with # #-end complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_START', 0, 'FROM_END', 0), '123456789', 'substring all with # #-end complex');
   check_number_of_calls('substring all with # #-end complex');
   $number_of_calls = 0;
-  assertEquals(text_get_substring((get_numbers()), 'FROM_END', 8, 'FROM_START', 8), '123456789', 'substring all with #-end # complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_END', 8, 'FROM_START', 8), '123456789', 'substring all with #-end # complex');
   check_number_of_calls('substring all with #-end # complex');
   $number_of_calls = 0;
   // Checks that the whole string is properly retrieved even if the value for start and end is not a simple number. This is especially important in generators where substring uses [x:length - y] for # #-end.
-  assertEquals(text_get_substring((get_numbers()), 'FROM_START', ((0 + 1) - 1), 'FROM_END', ((0 + 1) - 1)), '123456789', 'substring all with # #-end math complex');
+  assertEquals(text_get_substring(get_numbers(), 'FROM_START', ((0 + 1) - 1), 'FROM_END', ((0 + 1) - 1)), '123456789', 'substring all with # #-end math complex');
   check_number_of_calls('substring all with # #-end math complex');
 }
 

--- a/tests/generators/golden/generated.py
+++ b/tests/generators/golden/generated.py
@@ -636,7 +636,7 @@ def test_get_text_complex():
   assertEquals(text.find(text_random_letter(get_Blockly())) + 1 > 0, True, 'get random complex')
   check_number_of_calls('get random complex')
   number_of_calls = 0
-  assertEquals(text.find(text_random_letter((get_Blockly() if True else None))) + 1 > 0, True, 'get random order complex')
+  assertEquals(text.find(text_random_letter(get_Blockly() if True else None)) + 1 > 0, True, 'get random order complex')
   check_number_of_calls('get random order complex')
   number_of_calls = 0
   assertEquals(get_Blockly()[2], 'o', 'get # complex')

--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -104,11 +104,11 @@ Blockly.JavaScript['unittest_main'].defineAssert_ = function(block) {
 Blockly.JavaScript['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = Blockly.JavaScript.valueToCode(block, 'MESSAGE',
-      Blockly.JavaScript.ORDER_COMMA) || '';
+      Blockly.JavaScript.ORDER_NONE) || '';
   var actual = Blockly.JavaScript.valueToCode(block, 'ACTUAL',
-      Blockly.JavaScript.ORDER_COMMA) || 'null';
+      Blockly.JavaScript.ORDER_NONE) || 'null';
   var expected = Blockly.JavaScript.valueToCode(block, 'EXPECTED',
-      Blockly.JavaScript.ORDER_COMMA) || 'null';
+      Blockly.JavaScript.ORDER_NONE) || 'null';
   return Blockly.JavaScript['unittest_main'].defineAssert_() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
@@ -116,9 +116,9 @@ Blockly.JavaScript['unittest_assertequals'] = function(block) {
 Blockly.JavaScript['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = Blockly.JavaScript.valueToCode(block, 'MESSAGE',
-      Blockly.JavaScript.ORDER_COMMA) || '';
+      Blockly.JavaScript.ORDER_NONE) || '';
   var actual = Blockly.JavaScript.valueToCode(block, 'ACTUAL',
-      Blockly.JavaScript.ORDER_COMMA) || 'null';
+      Blockly.JavaScript.ORDER_NONE) || 'null';
   var expected = block.getFieldValue('EXPECTED');
   if (expected == 'TRUE') {
     expected = 'true';

--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -104,7 +104,7 @@ Blockly.JavaScript['unittest_main'].defineAssert_ = function(block) {
 Blockly.JavaScript['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = Blockly.JavaScript.valueToCode(block, 'MESSAGE',
-      Blockly.JavaScript.ORDER_NONE) || '';
+      Blockly.JavaScript.ORDER_COMMA) || '';
   var actual = Blockly.JavaScript.valueToCode(block, 'ACTUAL',
       Blockly.JavaScript.ORDER_COMMA) || 'null';
   var expected = Blockly.JavaScript.valueToCode(block, 'EXPECTED',
@@ -116,7 +116,7 @@ Blockly.JavaScript['unittest_assertequals'] = function(block) {
 Blockly.JavaScript['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = Blockly.JavaScript.valueToCode(block, 'MESSAGE',
-      Blockly.JavaScript.ORDER_NONE) || '';
+      Blockly.JavaScript.ORDER_COMMA) || '';
   var actual = Blockly.JavaScript.valueToCode(block, 'ACTUAL',
       Blockly.JavaScript.ORDER_COMMA) || 'null';
   var expected = block.getFieldValue('EXPECTED');

--- a/tests/generators/unittest_lua.js
+++ b/tests/generators/unittest_lua.js
@@ -162,5 +162,5 @@ Blockly.Lua['unittest_adjustindex'] = function(block) {
     return [Number(index) + 1, Blockly.Lua.ORDER_ATOMIC];
   }
   // If the index is dynamic, adjust it in code.
-  return [index + ' + 1', Blockly.Lua.ORDER_ATOMIC];
+  return [index + ' + 1', Blockly.Lua.ORDER_ADDITIVE];
 };

--- a/tests/generators/unittest_php.js
+++ b/tests/generators/unittest_php.js
@@ -90,7 +90,7 @@ Blockly.PHP['unittest_main'].defineAssert_ = function(block) {
 Blockly.PHP['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = Blockly.PHP.valueToCode(block, 'MESSAGE',
-    Blockly.PHP.ORDER_NONE) || '';
+    Blockly.PHP.ORDER_COMMA) || '';
   var actual = Blockly.PHP.valueToCode(block, 'ACTUAL',
           Blockly.PHP.ORDER_COMMA) || 'null';
   var expected = Blockly.PHP.valueToCode(block, 'EXPECTED',
@@ -102,7 +102,7 @@ Blockly.PHP['unittest_assertequals'] = function(block) {
 Blockly.PHP['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = Blockly.PHP.valueToCode(block, 'MESSAGE',
-    Blockly.PHP.ORDER_NONE) || '';
+    Blockly.PHP.ORDER_COMMA) || '';
   var actual = Blockly.PHP.valueToCode(block, 'ACTUAL',
           Blockly.PHP.ORDER_COMMA) || 'null';
   var expected = block.getFieldValue('EXPECTED');

--- a/tests/generators/unittest_php.js
+++ b/tests/generators/unittest_php.js
@@ -90,11 +90,11 @@ Blockly.PHP['unittest_main'].defineAssert_ = function(block) {
 Blockly.PHP['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = Blockly.PHP.valueToCode(block, 'MESSAGE',
-    Blockly.PHP.ORDER_COMMA) || '';
+    Blockly.PHP.ORDER_NONE) || '';
   var actual = Blockly.PHP.valueToCode(block, 'ACTUAL',
-          Blockly.PHP.ORDER_COMMA) || 'null';
+          Blockly.PHP.ORDER_NONE) || 'null';
   var expected = Blockly.PHP.valueToCode(block, 'EXPECTED',
-          Blockly.PHP.ORDER_COMMA) || 'null';
+          Blockly.PHP.ORDER_NONE) || 'null';
   return Blockly.PHP['unittest_main'].defineAssert_() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
@@ -102,9 +102,9 @@ Blockly.PHP['unittest_assertequals'] = function(block) {
 Blockly.PHP['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = Blockly.PHP.valueToCode(block, 'MESSAGE',
-    Blockly.PHP.ORDER_COMMA) || '';
+    Blockly.PHP.ORDER_NONE) || '';
   var actual = Blockly.PHP.valueToCode(block, 'ACTUAL',
-          Blockly.PHP.ORDER_COMMA) || 'null';
+          Blockly.PHP.ORDER_NONE) || 'null';
   var expected = block.getFieldValue('EXPECTED');
   if (expected == 'TRUE') {
       expected = 'true';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Fixes text block generators logic to use the correct order
- Fixes unit test blocks logic to use the correct order (didn't seem to have caused any issues before, but were incorrect)
- Moves multiline string helper into `text.js` files
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Fixes errors in code generation for text blocks
- multiline string helper is only used in `text.js` files and moving it makes it easier to understand the logic in code for block `text_multiline`
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Generated and ran unit tests for text in interpreters for all languages.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

### Additional Information

First noticed error in order after creating tests for `text_multiline` in  #4317 and saw that generated code was invalid for python for the new tests added.

In creation of this PR, also learned that `ORDER_COMMA` was being misused. In most of our use cases, `ORDER_COMMA` should have been `ORDER_NONE` because although there may be a comma, it is not a [comma operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator). This also helped fix issues with extra parenthesis.

<!-- Anything else we should know? -->
