### PR TITLE
Delete some deprecated functions

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -229,7 +229,7 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
     // In case init threw, recordUndo flag should still be reset.
     Blockly.Events.recordUndo = initialUndoFlag;
   }
-  
+
   // Record initial inline state.
   /** @type {boolean|undefined} */
   this.inputsInlineDefault = this.inputsInline;
@@ -1259,20 +1259,6 @@ Blockly.Block.prototype.setOutputShape = function(outputShape) {
  */
 Blockly.Block.prototype.getOutputShape = function() {
   return this.outputShape_;
-};
-
-/**
- * Set whether the block is disabled or not.
- * @param {boolean} disabled True if disabled.
- * @deprecated May 2019
- */
-Blockly.Block.prototype.setDisabled = function(disabled) {
-  Blockly.utils.deprecation.warn(
-      'Block.prototype.setDisabled',
-      'May 2019',
-      'May 2020',
-      'Block.prototype.setEnabled');
-  this.setEnabled(!disabled);
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1135,20 +1135,6 @@ Blockly.BlockSvg.prototype.setMutator = function(mutator) {
 };
 
 /**
- * Set whether the block is disabled or not.
- * @param {boolean} disabled True if disabled.
- * @deprecated May 2019
- */
-Blockly.BlockSvg.prototype.setDisabled = function(disabled) {
-  Blockly.utils.deprecation.warn(
-      'BlockSvg.prototype.setDisabled',
-      'May 2019',
-      'May 2020',
-      'BlockSvg.prototype.setEnabled');
-  this.setEnabled(!disabled);
-};
-
-/**
  * Set whether the block is enabled or not.
  * @param {boolean} enabled True if enabled.
  */


### PR DESCRIPTION
### The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Deletes some deprecated functions.

### Proposed Changes

Deletes block.setDisabled and blockSvg.setDisabled.

### Reason for Changes

Both were past their marked removal dates.

### Test Coverage

### Documentation

None

### Additional Information

Breaking change (for release purposes)--removes functions.