### PR TITLE
Fix render issue with block factory connection dropdown

### DIFF
--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -87,7 +87,9 @@ Blockly.Blocks['factory_base'] = {
     type.setShadow(true);
     type.outputConnection.connect(this.getInput(outputType).connection);
     type.initSvg();
-    type.render();
+    if (this.rendered) {
+      type.render();
+    }
   },
   updateShape_: function(option) {
     var outputExists = this.getInput('OUTPUTTYPE');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://groups.google.com/g/blockly/c/Jm4_bSpjNes/m/m6HXBZNEBwAJ
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds a `rendered` check before calling `render` on block added in `connectOutputShadow_`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The change in #4296 caused issues with the block factory connection dropdown field. The `render` call in `connectOutputShadow_` is triggered when the validator is called in `domToHeadless_` and throws an error. 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

Previously an error was not thrown because `initSvg` was called before the dropdown field was processed. Reverting the PR would cause issues with variable models, but adding a `rendered` check before calling `render` seems reasonable. 
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

<!-- Anything else we should know? -->
