### PR TITLE
Fix toolbox resize problem

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -614,9 +614,9 @@ Blockly.Toolbox.prototype.handleToolboxItemResize = function() {
   var workspace = this.workspace_;
   var rect = this.HtmlDiv.getBoundingClientRect();
   var newX = this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT ?
-      workspace.scrollX + rect.width : 0;
+      workspace.scrollX + rect.width : workspace.scrollX;
   var newY = this.toolboxPosition == Blockly.TOOLBOX_AT_TOP ?
-      workspace.scrollY + rect.height : 0;
+      workspace.scrollY + rect.height : workspace.scrollY;
   workspace.translate(newX, newY);
 
   // Even though the div hasn't changed size, the visible workspace


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #4338
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Instead of setting the newX or newY to 0 when we don't want their position to change, we can set to workspace.scrollX, or workspace.scrollY
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
When the toolbox was not at the top the newY was getting set to 0. This was making the blocks jump. It is now getting set to the workspace.scrollY so that the blocks will stay at their current location. 

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
