### PR TITLE
do value update if the value is valid again

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -931,6 +931,8 @@ Blockly.Field.prototype.processValidation_ = function(newValue,
   }
   if (validatedValue !== undefined) {
     newValue = validatedValue;
+    this.doValueUpdate_(newValue);
+    this.forceRerender();
   }
   return newValue;
 };

--- a/core/field.js
+++ b/core/field.js
@@ -899,6 +899,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
   var oldValue = this.getValue();
   if (oldValue === newValue) {
     doLogging && console.log('same, return');
+    this.doValueUpdate_(newValue);
     return;
   }
 
@@ -931,8 +932,6 @@ Blockly.Field.prototype.processValidation_ = function(newValue,
   }
   if (validatedValue !== undefined) {
     newValue = validatedValue;
-    this.doValueUpdate_(newValue);
-    this.forceRerender();
   }
   return newValue;
 };

--- a/core/field.js
+++ b/core/field.js
@@ -898,7 +898,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
   }
   var oldValue = this.getValue();
   if (oldValue === newValue) {
-    doLogging && console.log('same, return');
+    doLogging && console.log('same, doValueUpdate_, return');
     this.doValueUpdate_(newValue);
     return;
   }

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -215,7 +215,7 @@ suite('Abstract Fields', function() {
       addSpies(this.field);
       this.field.setValue('value');
       sinon.assert.notCalled(this.field.doValueInvalid_);
-      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
       sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Class)Validates to Old Value', function() {
@@ -224,7 +224,7 @@ suite('Abstract Fields', function() {
       addSpies(this.field);
       this.field.setValue('notValue');
       sinon.assert.notCalled(this.field.doValueInvalid_);
-      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
       sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Local)Validates to Old Value', function() {
@@ -233,7 +233,7 @@ suite('Abstract Fields', function() {
       addSpies(this.field);
       this.field.setValue('notValue');
       sinon.assert.notCalled(this.field.doValueInvalid_);
-      sinon.assert.notCalled(this.field.doValueUpdate_);
+      sinon.assert.calledOnce(this.field.doValueUpdate_);
       sinon.assert.notCalled(this.field.forceRerender);
     });
     test('New Value (Class)Validates to not Old Value', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
https://github.com/google/blockly/issues/4345

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The issue was, in the field, if the user has entered invalid once the flag `isTextValid_;` was being set to false at `doValueInvalid_` which is fine. If however the user enters correct value, then the flag is never se to true.

I made it so that at field.js `processValidation_` we do `doValueUpdate_` so that we update the flag.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
To solve the bug that was opened.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
Desktop Firefox
### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
