### PR TITLE
Replace incorrect usage of ORDER_COMMA with ORDER_NONE

### DIFF
--- a/generators/javascript/colour.js
+++ b/generators/javascript/colour.js
@@ -36,11 +36,11 @@ Blockly.JavaScript['colour_random'] = function(block) {
 Blockly.JavaScript['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   var red = Blockly.JavaScript.valueToCode(block, 'RED',
-      Blockly.JavaScript.ORDER_COMMA) || 0;
+      Blockly.JavaScript.ORDER_NONE) || 0;
   var green = Blockly.JavaScript.valueToCode(block, 'GREEN',
-      Blockly.JavaScript.ORDER_COMMA) || 0;
+      Blockly.JavaScript.ORDER_NONE) || 0;
   var blue = Blockly.JavaScript.valueToCode(block, 'BLUE',
-      Blockly.JavaScript.ORDER_COMMA) || 0;
+      Blockly.JavaScript.ORDER_NONE) || 0;
   var functionName = Blockly.JavaScript.provideFunction_(
       'colourRgb',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
@@ -60,11 +60,11 @@ Blockly.JavaScript['colour_rgb'] = function(block) {
 Blockly.JavaScript['colour_blend'] = function(block) {
   // Blend two colours together.
   var c1 = Blockly.JavaScript.valueToCode(block, 'COLOUR1',
-      Blockly.JavaScript.ORDER_COMMA) || '\'#000000\'';
+      Blockly.JavaScript.ORDER_NONE) || '\'#000000\'';
   var c2 = Blockly.JavaScript.valueToCode(block, 'COLOUR2',
-      Blockly.JavaScript.ORDER_COMMA) || '\'#000000\'';
+      Blockly.JavaScript.ORDER_NONE) || '\'#000000\'';
   var ratio = Blockly.JavaScript.valueToCode(block, 'RATIO',
-      Blockly.JavaScript.ORDER_COMMA) || 0.5;
+      Blockly.JavaScript.ORDER_NONE) || 0.5;
   var functionName = Blockly.JavaScript.provideFunction_(
       'colourBlend',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -25,7 +25,7 @@ Blockly.JavaScript['lists_create_with'] = function(block) {
   var elements = new Array(block.itemCount_);
   for (var i = 0; i < block.itemCount_; i++) {
     elements[i] = Blockly.JavaScript.valueToCode(block, 'ADD' + i,
-        Blockly.JavaScript.ORDER_COMMA) || 'null';
+        Blockly.JavaScript.ORDER_NONE) || 'null';
   }
   var code = '[' + elements.join(', ') + ']';
   return [code, Blockly.JavaScript.ORDER_ATOMIC];
@@ -44,9 +44,9 @@ Blockly.JavaScript['lists_repeat'] = function(block) {
        '  return array;',
        '}']);
   var element = Blockly.JavaScript.valueToCode(block, 'ITEM',
-      Blockly.JavaScript.ORDER_COMMA) || 'null';
+      Blockly.JavaScript.ORDER_NONE) || 'null';
   var repeatCount = Blockly.JavaScript.valueToCode(block, 'NUM',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var code = functionName + '(' + element + ', ' + repeatCount + ')';
   return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
 };
@@ -85,7 +85,7 @@ Blockly.JavaScript['lists_getIndex'] = function(block) {
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   var mode = block.getFieldValue('MODE') || 'GET';
   var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var listOrder = (where == 'RANDOM') ? Blockly.JavaScript.ORDER_COMMA :
+  var listOrder = (where == 'RANDOM') ? Blockly.JavaScript.ORDER_NONE :
       Blockly.JavaScript.ORDER_MEMBER;
   var list = Blockly.JavaScript.valueToCode(block, 'VALUE', listOrder) || '[]';
 

--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -30,7 +30,7 @@ Blockly.JavaScript['math_arithmetic'] = function(block) {
     'MINUS': [' - ', Blockly.JavaScript.ORDER_SUBTRACTION],
     'MULTIPLY': [' * ', Blockly.JavaScript.ORDER_MULTIPLICATION],
     'DIVIDE': [' / ', Blockly.JavaScript.ORDER_DIVISION],
-    'POWER': [null, Blockly.JavaScript.ORDER_COMMA]  // Handle power separately.
+    'POWER': [null, Blockly.JavaScript.ORDER_NONE]  // Handle power separately.
   };
   var tuple = OPERATORS[block.getFieldValue('OP')];
   var operator = tuple[0];
@@ -230,12 +230,12 @@ Blockly.JavaScript['math_on_list'] = function(block) {
       break;
     case 'MIN':
       list = Blockly.JavaScript.valueToCode(block, 'LIST',
-          Blockly.JavaScript.ORDER_COMMA) || '[]';
+          Blockly.JavaScript.ORDER_NONE) || '[]';
       code = 'Math.min.apply(null, ' + list + ')';
       break;
     case 'MAX':
       list = Blockly.JavaScript.valueToCode(block, 'LIST',
-          Blockly.JavaScript.ORDER_COMMA) || '[]';
+          Blockly.JavaScript.ORDER_NONE) || '[]';
       code = 'Math.max.apply(null, ' + list + ')';
       break;
     case 'AVERAGE':
@@ -361,11 +361,11 @@ Blockly.JavaScript['math_modulo'] = function(block) {
 Blockly.JavaScript['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   var argument0 = Blockly.JavaScript.valueToCode(block, 'VALUE',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var argument1 = Blockly.JavaScript.valueToCode(block, 'LOW',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var argument2 = Blockly.JavaScript.valueToCode(block, 'HIGH',
-      Blockly.JavaScript.ORDER_COMMA) || 'Infinity';
+      Blockly.JavaScript.ORDER_NONE) || 'Infinity';
   var code = 'Math.min(Math.max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
   return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
@@ -374,9 +374,9 @@ Blockly.JavaScript['math_constrain'] = function(block) {
 Blockly.JavaScript['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   var argument0 = Blockly.JavaScript.valueToCode(block, 'FROM',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var argument1 = Blockly.JavaScript.valueToCode(block, 'TO',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var functionName = Blockly.JavaScript.provideFunction_(
       'mathRandomInt',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
@@ -401,9 +401,9 @@ Blockly.JavaScript['math_random_float'] = function(block) {
 Blockly.JavaScript['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   var argument0 = Blockly.JavaScript.valueToCode(block, 'X',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   var argument1 = Blockly.JavaScript.valueToCode(block, 'Y',
-      Blockly.JavaScript.ORDER_COMMA) || '0';
+      Blockly.JavaScript.ORDER_NONE) || '0';
   return ['Math.atan2(' + argument1 + ', ' + argument0 + ') / Math.PI * 180',
       Blockly.JavaScript.ORDER_DIVISION];
 };

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -75,7 +75,7 @@ Blockly.JavaScript['procedures_callreturn'] = function(block) {
   var variables = block.getVars();
   for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.JavaScript.valueToCode(block, 'ARG' + i,
-        Blockly.JavaScript.ORDER_COMMA) || 'null';
+        Blockly.JavaScript.ORDER_NONE) || 'null';
   }
   var code = funcName + '(' + args.join(', ') + ')';
   return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];

--- a/generators/php/colour.js
+++ b/generators/php/colour.js
@@ -36,11 +36,11 @@ Blockly.PHP['colour_random'] = function(block) {
 Blockly.PHP['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   var red = Blockly.PHP.valueToCode(block, 'RED',
-      Blockly.PHP.ORDER_COMMA) || 0;
+      Blockly.PHP.ORDER_NONE) || 0;
   var green = Blockly.PHP.valueToCode(block, 'GREEN',
-      Blockly.PHP.ORDER_COMMA) || 0;
+      Blockly.PHP.ORDER_NONE) || 0;
   var blue = Blockly.PHP.valueToCode(block, 'BLUE',
-      Blockly.PHP.ORDER_COMMA) || 0;
+      Blockly.PHP.ORDER_NONE) || 0;
   var functionName = Blockly.PHP.provideFunction_(
       'colour_rgb',
       ['function ' + Blockly.PHP.FUNCTION_NAME_PLACEHOLDER_ +
@@ -61,11 +61,11 @@ Blockly.PHP['colour_rgb'] = function(block) {
 Blockly.PHP['colour_blend'] = function(block) {
   // Blend two colours together.
   var c1 = Blockly.PHP.valueToCode(block, 'COLOUR1',
-      Blockly.PHP.ORDER_COMMA) || '\'#000000\'';
+      Blockly.PHP.ORDER_NONE) || '\'#000000\'';
   var c2 = Blockly.PHP.valueToCode(block, 'COLOUR2',
-      Blockly.PHP.ORDER_COMMA) || '\'#000000\'';
+      Blockly.PHP.ORDER_NONE) || '\'#000000\'';
   var ratio = Blockly.PHP.valueToCode(block, 'RATIO',
-      Blockly.PHP.ORDER_COMMA) || 0.5;
+      Blockly.PHP.ORDER_NONE) || 0.5;
   var functionName = Blockly.PHP.provideFunction_(
       'colour_blend',
       ['function ' + Blockly.PHP.FUNCTION_NAME_PLACEHOLDER_ +

--- a/generators/php/lists.js
+++ b/generators/php/lists.js
@@ -36,7 +36,7 @@ Blockly.PHP['lists_create_with'] = function(block) {
   var code = new Array(block.itemCount_);
   for (var i = 0; i < block.itemCount_; i++) {
     code[i] = Blockly.PHP.valueToCode(block, 'ADD' + i,
-        Blockly.PHP.ORDER_COMMA) || 'null';
+        Blockly.PHP.ORDER_NONE) || 'null';
   }
   code = 'array(' + code.join(', ') + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
@@ -55,9 +55,9 @@ Blockly.PHP['lists_repeat'] = function(block) {
        '  return $array;',
        '}']);
   var element = Blockly.PHP.valueToCode(block, 'ITEM',
-      Blockly.PHP.ORDER_COMMA) || 'null';
+      Blockly.PHP.ORDER_NONE) || 'null';
   var repeatCount = Blockly.PHP.valueToCode(block, 'NUM',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var code = functionName + '(' + element + ', ' + repeatCount + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
 };
@@ -177,19 +177,19 @@ Blockly.PHP['lists_getIndex'] = function(block) {
         return [code, Blockly.PHP.ORDER_MEMBER];
       } else if (mode == 'GET_REMOVE') {
         var list = Blockly.PHP.valueToCode(block, 'VALUE',
-                Blockly.PHP.ORDER_COMMA) || 'array()';
+                Blockly.PHP.ORDER_NONE) || 'array()';
         var code = 'array_splice(' + list + ', ' + at + ', 1)[0]';
         return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
       } else if (mode == 'REMOVE') {
         var list = Blockly.PHP.valueToCode(block, 'VALUE',
-                Blockly.PHP.ORDER_COMMA) || 'array()';
+                Blockly.PHP.ORDER_NONE) || 'array()';
         return 'array_splice(' + list + ', ' + at + ', 1);\n';
       }
       break;
     case 'FROM_END':
       if (mode == 'GET') {
         var list = Blockly.PHP.valueToCode(block, 'VALUE',
-                Blockly.PHP.ORDER_COMMA) || 'array()';
+                Blockly.PHP.ORDER_NONE) || 'array()';
         var at = Blockly.PHP.getAdjusted(block, 'AT', 1, true);
         var code = 'array_slice(' + list + ', ' + at + ', 1)[0]';
         return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
@@ -271,13 +271,13 @@ Blockly.PHP['lists_setIndex'] = function(block) {
         return list + '[0] = ' + value + ';\n';
       } else if (mode == 'INSERT') {
         var list = Blockly.PHP.valueToCode(block, 'LIST',
-                Blockly.PHP.ORDER_COMMA) || 'array()';
+                Blockly.PHP.ORDER_NONE) || 'array()';
         return 'array_unshift(' + list + ', ' + value + ');\n';
       }
       break;
     case 'LAST':
       var list = Blockly.PHP.valueToCode(block, 'LIST',
-              Blockly.PHP.ORDER_COMMA) || 'array()';
+              Blockly.PHP.ORDER_NONE) || 'array()';
       if (mode == 'SET') {
         var functionName = Blockly.PHP.provideFunction_(
             'lists_set_last_item',
@@ -298,13 +298,13 @@ Blockly.PHP['lists_setIndex'] = function(block) {
         return list + '[' + at + '] = ' + value + ';\n';
       } else if (mode == 'INSERT') {
         var list = Blockly.PHP.valueToCode(block, 'LIST',
-                Blockly.PHP.ORDER_COMMA) || 'array()';
+                Blockly.PHP.ORDER_NONE) || 'array()';
         return 'array_splice(' + list + ', ' + at + ', 0, ' + value + ');\n';
       }
       break;
     case 'FROM_END':
       var list = Blockly.PHP.valueToCode(block, 'LIST',
-              Blockly.PHP.ORDER_COMMA) || 'array()';
+              Blockly.PHP.ORDER_NONE) || 'array()';
       var at = Blockly.PHP.getAdjusted(block, 'AT', 1);
       if (mode == 'SET') {
         var functionName = Blockly.PHP.provideFunction_(
@@ -347,7 +347,7 @@ Blockly.PHP['lists_setIndex'] = function(block) {
 Blockly.PHP['lists_getSublist'] = function(block) {
   // Get sublist.
   var list = Blockly.PHP.valueToCode(block, 'LIST',
-      Blockly.PHP.ORDER_COMMA) || 'array()';
+      Blockly.PHP.ORDER_NONE) || 'array()';
   var where1 = block.getFieldValue('WHERE1');
   var where2 = block.getFieldValue('WHERE2');
   if (where1 == 'FIRST' && where2 == 'LAST') {
@@ -440,7 +440,7 @@ Blockly.PHP['lists_getSublist'] = function(block) {
 Blockly.PHP['lists_sort'] = function(block) {
   // Block for sorting a list.
   var listCode = Blockly.PHP.valueToCode(block, 'LIST',
-      Blockly.PHP.ORDER_COMMA) || 'array()';
+      Blockly.PHP.ORDER_NONE) || 'array()';
   var direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
   var type = block.getFieldValue('TYPE');
   var functionName = Blockly.PHP.provideFunction_(
@@ -468,9 +468,9 @@ Blockly.PHP['lists_sort'] = function(block) {
 Blockly.PHP['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   var value_input = Blockly.PHP.valueToCode(block, 'INPUT',
-      Blockly.PHP.ORDER_COMMA);
+      Blockly.PHP.ORDER_NONE);
   var value_delim = Blockly.PHP.valueToCode(block, 'DELIM',
-      Blockly.PHP.ORDER_COMMA) || '\'\'';
+      Blockly.PHP.ORDER_NONE) || '\'\'';
   var mode = block.getFieldValue('MODE');
   if (mode == 'SPLIT') {
     if (!value_input) {
@@ -492,7 +492,7 @@ Blockly.PHP['lists_split'] = function(block) {
 Blockly.PHP['lists_reverse'] = function(block) {
   // Block for reversing a list.
   var list = Blockly.PHP.valueToCode(block, 'LIST',
-      Blockly.PHP.ORDER_COMMA) || '[]';
+      Blockly.PHP.ORDER_NONE) || '[]';
   var code = 'array_reverse(' + list + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
 };

--- a/generators/php/math.js
+++ b/generators/php/math.js
@@ -325,11 +325,11 @@ Blockly.PHP['math_modulo'] = function(block) {
 Blockly.PHP['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   var argument0 = Blockly.PHP.valueToCode(block, 'VALUE',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var argument1 = Blockly.PHP.valueToCode(block, 'LOW',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var argument2 = Blockly.PHP.valueToCode(block, 'HIGH',
-      Blockly.PHP.ORDER_COMMA) || 'Infinity';
+      Blockly.PHP.ORDER_NONE) || 'Infinity';
   var code = 'min(max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];
@@ -338,9 +338,9 @@ Blockly.PHP['math_constrain'] = function(block) {
 Blockly.PHP['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   var argument0 = Blockly.PHP.valueToCode(block, 'FROM',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var argument1 = Blockly.PHP.valueToCode(block, 'TO',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var functionName = Blockly.PHP.provideFunction_(
       'math_random_int',
       ['function ' + Blockly.PHP.FUNCTION_NAME_PLACEHOLDER_ +
@@ -362,9 +362,9 @@ Blockly.PHP['math_random_float'] = function(block) {
 Blockly.PHP['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   var argument0 = Blockly.PHP.valueToCode(block, 'X',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   var argument1 = Blockly.PHP.valueToCode(block, 'Y',
-      Blockly.PHP.ORDER_COMMA) || '0';
+      Blockly.PHP.ORDER_NONE) || '0';
   return ['atan2(' + argument1 + ', ' + argument0 + ') / pi() * 180',
       Blockly.PHP.ORDER_DIVISION];
 };

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -94,7 +94,7 @@ Blockly.PHP['procedures_callreturn'] = function(block) {
   var variables = block.getVars();
   for (var i = 0; i < variables.length; i++) {
     args[i] = Blockly.PHP.valueToCode(block, 'ARG' + i,
-        Blockly.PHP.ORDER_COMMA) || 'null';
+        Blockly.PHP.ORDER_NONE) || 'null';
   }
   var code = funcName + '(' + args.join(', ') + ')';
   return [code, Blockly.PHP.ORDER_FUNCTION_CALL];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4353 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Changes incorrect instances of `ORDER_COMMA` to `ORDER_NONE`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The `ORDER_COMMA` operator enum is meant for instances of the comma operator. 
Commas inside of parentheses of function calls are not instances of the comma operator.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Does not change generated code output from generator tests.

### Additional Information

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator
<!-- Anything else we should know? -->
