### PR TITLE
Remove ORDER_COMMA from PHP generator.

### DIFF
--- a/generators/php.js
+++ b/generators/php.js
@@ -92,7 +92,6 @@ Blockly.PHP.ORDER_ASSIGNMENT = 20;        // = += -= *= /= %= <<= >>= ...
 Blockly.PHP.ORDER_LOGICAL_AND_WEAK = 21;  // and
 Blockly.PHP.ORDER_LOGICAL_XOR = 22;       // xor
 Blockly.PHP.ORDER_LOGICAL_OR_WEAK = 23;   // or
-Blockly.PHP.ORDER_COMMA = 24;             // ,
 Blockly.PHP.ORDER_NONE = 99;              // (...)
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/pull/4354#issuecomment-704512863
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Removes comma operator order from PHP generator.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

PHP does not have a comma operator.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Additional Information

Enum was unused in code base.

<!-- Anything else we should know? -->
