### PR TITLE
Update access level of methods in FieldTextInput

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -385,7 +385,7 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
 /**
  * Closes the editor, saves the results, and disposes of any events or
  * dom-references belonging to the editor.
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
   // Non-disposal related things that we do when the editor closes.
@@ -430,7 +430,7 @@ Blockly.FieldTextInput.prototype.bindInputEvents_ = function(htmlInput) {
 
 /**
  * Unbind handlers for user input and workspace size changes.
- * @private
+ * @protected
  */
 Blockly.FieldTextInput.prototype.unbindInputEvents_ = function() {
   if (this.onKeyDownWrapper_) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Changes access level of `widgetDispose_` and `unbindInputEvents_` in `FieldTextInput from `@private` to `@protected` so that subclasses have access to these methods.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Since `widgetCreate_` and `bindInputEvents_` are `@protected`, it makes sense for the paired methods `widgetDispose_` and `unbindInputEvents_` to also be `@protected` so that subclasses can override them for cleanup needed to unbind events or dispose of elements created.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->


