### PR TITLE
Add Blockly.constants dependency to utils/toolbox.js

### DIFF
--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -16,6 +16,8 @@ goog.provide('Blockly.utils.toolbox');
 goog.requireType('Blockly.ToolboxCategory');
 goog.requireType('Blockly.ToolboxSeparator');
 
+goog.require("Blockly.constants");
+
 /**
  * The information needed to create a block in the toolbox.
  * @typedef {{


### PR DESCRIPTION
An issue was discovered while trying to update the maze game from https://github.com/google/blockly-games. The game worked fine without debugging enabled. However when debugging was enabled the toolbox on the left side was not visible anymore.

I never worked with blockly before so it took a while to figure out what was going on. I am not 100% sure the fix is correct.

In debugging mode (session storage, debug=1) the core/options.js does not initialise the toolboxPosition correctly because the Blockly.utils.toolbox.Position.xxx are undefined. This is caused by an unspecified dependency on Blockly.constants in utils/toolbox.js which was introduced in https://github.com/google/blockly/commit/f6688d033923a2b53da401d6998e906b7d938ff2

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

None

### Proposed Changes

Include necessary dependency in utils/toolbox.js

### Reason for Changes

Before fix (debugging enabled):
<img width="1426" alt="Screenshot 2020-10-11 at 17 47 37" src="https://user-images.githubusercontent.com/60326668/95683221-21aa6500-0bea-11eb-855b-ab4790a602b9.png">

After fix (debugging enabled):
<img width="1426" alt="Screenshot 2020-10-11 at 17 46 54" src="https://user-images.githubusercontent.com/60326668/95683224-24a55580-0bea-11eb-80be-f49c5c5c0dca.png">

This is equal to the the behaviour when debugging is turned off.

### Test Coverage

This fix was tested by setting debug=1 on the maze demo from the blockly games website mentioned above.

Tested on:
- Google chrome: Version 86.0.4240.75 (Official Build) (x86_64)

### Documentation

None

### Additional Information

None