### PR TITLE
Add missing require Blockly.constants

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.Block');
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Connection');
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Events.BlockCreate');

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.BlockDragger');
 
 goog.require('Blockly.blockAnimations');
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockMove');
 goog.require('Blockly.Events.Ui');

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -16,6 +16,7 @@ goog.require('Blockly.ASTNode');
 goog.require('Blockly.Block');
 goog.require('Blockly.blockAnimations');
 goog.require('Blockly.blockRendering.IPathObject');
+goog.require('Blockly.constants');
 goog.require('Blockly.ContextMenu');
 goog.require('Blockly.ContextMenuRegistry');
 goog.require('Blockly.Events');

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.BubbleDragger');
 
 goog.require('Blockly.Bubble');
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.CommentMove');
 goog.require('Blockly.utils');

--- a/core/connection.js
+++ b/core/connection.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.Connection');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockMove');
 goog.require('Blockly.utils.deprecation');

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -13,6 +13,7 @@
 
 goog.provide('Blockly.ConnectionChecker');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.registry');
 
 goog.requireType('Blockly.Connection');

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -14,6 +14,7 @@
 
 goog.provide('Blockly.ConnectionDB');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.RenderedConnection');
 
 goog.requireType('Blockly.IConnectionChecker');

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -16,6 +16,7 @@
  */
 goog.provide('Blockly.ContextMenu');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Menu');

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -16,6 +16,8 @@
  */
 goog.provide('Blockly.ContextMenuItems');
 
+goog.require('Blockly.constants');
+
 goog.requireType('Blockly.BlockSvg');
 
 /** Option to undo previous action. */

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.FieldVariable');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.FieldDropdown');

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.HorizontalFlyout');
 
 goog.require('Blockly.Block');
+goog.require('Blockly.constants');
 goog.require('Blockly.Flyout');
 goog.require('Blockly.registry');
 goog.require('Blockly.Scrollbar');

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.VerticalFlyout');
 
 goog.require('Blockly.Block');
+goog.require('Blockly.constants');
 goog.require('Blockly.Flyout');
 goog.require('Blockly.registry');
 goog.require('Blockly.Scrollbar');

--- a/core/generator.js
+++ b/core/generator.js
@@ -13,6 +13,7 @@
 
 goog.provide('Blockly.Generator');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Block');
 
 

--- a/core/input.js
+++ b/core/input.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.Input');
 
 goog.require('Blockly.Connection');
+goog.require('Blockly.constants');
 goog.require('Blockly.FieldLabel');
 
 

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.InsertionMarkerManager');
 
 goog.require('Blockly.blockAnimations');
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 
 

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.ASTNode');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.Coordinate');
 
 goog.requireType('Blockly.IASTNodeLocation');

--- a/core/keyboard_nav/navigation.js
+++ b/core/keyboard_nav/navigation.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.navigation');
 
 goog.require('Blockly.Action');
 goog.require('Blockly.ASTNode');
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.user.keyMap');
 

--- a/core/names.js
+++ b/core/names.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.Names');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Msg');
 
 

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.RenderedConnection');
 
 goog.require('Blockly.Connection');
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.blockRendering.ConstantProvider');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.dom');

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -20,6 +20,7 @@ goog.require('Blockly.blockRendering.Row');
 goog.require('Blockly.blockRendering.SpacerRow');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -29,6 +29,7 @@ goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.blockRendering.SquareCorner');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
+goog.require('Blockly.constants');
 
 
 /**

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -14,6 +14,7 @@
 goog.provide('Blockly.blockRendering.MarkerSvg');
 
 goog.require('Blockly.ASTNode');
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -18,6 +18,7 @@ goog.require('Blockly.blockRendering.Drawer');
 goog.require('Blockly.blockRendering.IPathObject');
 goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.blockRendering.RenderInfo');
+goog.require('Blockly.constants');
 goog.require('Blockly.InsertionMarkerManager');
 
 goog.requireType('Blockly.blockRendering.Debug');

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -29,6 +29,7 @@ goog.require('Blockly.blockRendering.OutputConnection');
 goog.require('Blockly.blockRendering.PreviousConnection');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.blockRendering.ExternalValueInput');
+goog.require('Blockly.constants');
 goog.require('Blockly.geras.InlineInput');
 goog.require('Blockly.geras.StatementInput');
 goog.require('Blockly.utils.object');

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -14,6 +14,7 @@
 goog.provide('Blockly.zelos.ConstantProvider');
 
 goog.require('Blockly.blockRendering.ConstantProvider');
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Svg');

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -29,6 +29,7 @@ goog.require('Blockly.blockRendering.SquareCorner');
 goog.require('Blockly.blockRendering.SpacerRow');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
+goog.require('Blockly.constants');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.zelos.BottomRow');
 goog.require('Blockly.zelos.RightConnectionShape');

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -14,6 +14,7 @@ goog.provide('Blockly.zelos.Renderer');
 
 goog.require('Blockly.blockRendering');
 goog.require('Blockly.blockRendering.Renderer');
+goog.require('Blockly.constants');
 goog.require('Blockly.InsertionMarkerManager');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.zelos.ConstantProvider');

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.Toolbox');
 
 goog.require('Blockly.CollapsibleToolboxCategory');
+goog.require('Blockly.constants');
 goog.require('Blockly.Css');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Ui');

--- a/core/touch.js
+++ b/core/touch.js
@@ -16,6 +16,7 @@
  */
 goog.provide('Blockly.Touch');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.global');
 goog.require('Blockly.utils.string');

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.Trashcan');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Scrollbar');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -12,11 +12,11 @@
 
 goog.provide('Blockly.utils.toolbox');
 
+goog.require('Blockly.constants');
 
 goog.requireType('Blockly.ToolboxCategory');
 goog.requireType('Blockly.ToolboxSeparator');
 
-goog.require("Blockly.constants");
 
 /**
  * The information needed to create a block in the toolbox.

--- a/core/variables.js
+++ b/core/variables.js
@@ -17,6 +17,7 @@
 goog.provide('Blockly.Variables');
 
 goog.require('Blockly.Blocks');
+goog.require('Blockly.constants');
 goog.require('Blockly.Msg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.xml');

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -13,6 +13,7 @@
 
 goog.provide('Blockly.WorkspaceAudio');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.global');
 goog.require('Blockly.utils.userAgent');

--- a/core/xml.js
+++ b/core/xml.js
@@ -16,6 +16,7 @@
  */
 goog.provide('Blockly.Xml');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.FinishedLoading');

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.ZoomControls');
 
+goog.require('Blockly.constants');
 goog.require('Blockly.Css');
 goog.require('Blockly.Scrollbar');
 goog.require('Blockly.Touch');


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

A number of missing `Blockly.constants` requires.

### Proposed Changes

Following on from https://github.com/google/blockly/pull/4360, adding missing Blockly.constants requires throughout Blockly.

### Reason for Changes

### Test Coverage

Tested with `npm run build:debug`.

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
