### PR TITLE
Refactor theme event

### DIFF
--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.Events.Ui');
 goog.provide('Blockly.Events.Click');
+goog.provide('Blockly.Events.ThemeChange');
 
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.Abstract');

--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -113,5 +113,25 @@ Blockly.Events.Click.prototype.fromJson = function(json) {
   this.blockId = json['blockId'];
 };
 
+/**
+ * Class for a theme change event.
+ * @param {string=} opt_workspaceId The workspace identifier for this event.
+ *    event. Undefined for a blank event.
+ * @extends {Blockly.Events.Ui}
+ * @constructor
+ */
+Blockly.Events.ThemeChange = function(opt_workspaceId) {
+  Blockly.Events.ThemeChange.superClass_.constructor.call(this, opt_workspaceId);
+};
+Blockly.utils.object.inherits(Blockly.Events.ThemeChange, Blockly.Events.Ui);
+
+/**
+ * Type of this event.
+ * @type {string}
+ */
+Blockly.Events.ThemeChange.prototype.type = Blockly.Events.THEME_CHANGE;
+
 Blockly.registry.register(Blockly.registry.Type.EVENT, Blockly.Events.CLICK,
     Blockly.Events.Click);
+Blockly.registry.register(Blockly.registry.Type.EVENT,
+    Blockly.Events.THEME_CHANGE, Blockly.Events.ThemeChange);

--- a/core/ui_events.js
+++ b/core/ui_events.js
@@ -115,13 +115,20 @@ Blockly.Events.Click.prototype.fromJson = function(json) {
 
 /**
  * Class for a theme change event.
+ * @param {string=} opt_themeName The theme name. Undefined for a blank event.
  * @param {string=} opt_workspaceId The workspace identifier for this event.
  *    event. Undefined for a blank event.
  * @extends {Blockly.Events.Ui}
  * @constructor
  */
-Blockly.Events.ThemeChange = function(opt_workspaceId) {
+Blockly.Events.ThemeChange = function(opt_themeName, opt_workspaceId) {
   Blockly.Events.ThemeChange.superClass_.constructor.call(this, opt_workspaceId);
+
+  /**
+   * The theme name.
+   * @type {string|undefined}
+   */
+  this.themeName = opt_themeName;
 };
 Blockly.utils.object.inherits(Blockly.Events.ThemeChange, Blockly.Events.Ui);
 
@@ -130,6 +137,25 @@ Blockly.utils.object.inherits(Blockly.Events.ThemeChange, Blockly.Events.Ui);
  * @type {string}
  */
 Blockly.Events.ThemeChange.prototype.type = Blockly.Events.THEME_CHANGE;
+
+/**
+ * Encode the event as JSON.
+ * @return {!Object} JSON representation.
+ */
+Blockly.Events.ThemeChange.prototype.toJson = function() {
+  var json = Blockly.Events.ThemeChange.superClass_.toJson.call(this);
+  json['themeName'] = this.themeName;
+  return json;
+};
+
+/**
+ * Decode the JSON event.
+ * @param {!Object} json JSON representation.
+ */
+Blockly.Events.ThemeChange.prototype.fromJson = function(json) {
+  Blockly.Events.ThemeChange.superClass_.fromJson.call(this, json);
+  this.themeName = json['themeName'];
+};
 
 Blockly.registry.register(Blockly.registry.Type.EVENT, Blockly.Events.CLICK,
     Blockly.Events.Click);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -577,7 +577,7 @@ Blockly.WorkspaceSvg.prototype.refreshTheme = function() {
     this.setVisible(true);
   }
 
-  var event = new Blockly.Events.ThemeChange(this.id);
+  var event = new Blockly.Events.ThemeChange(this.getTheme().name, this.id);
   Blockly.Events.fire(event);
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -19,6 +19,7 @@ goog.require('Blockly.constants');
 goog.require('Blockly.ContextMenuRegistry');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
+goog.require('Blockly.Events.ThemeChange');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Grid');
 goog.require('Blockly.MarkerManager');
@@ -576,8 +577,7 @@ Blockly.WorkspaceSvg.prototype.refreshTheme = function() {
     this.setVisible(true);
   }
 
-  var event = new Blockly.Events.OldUi(null, 'theme', null, null);
-  event.workspaceId = this.id;
+  var event = new Blockly.Events.ThemeChange(this.id);
   Blockly.Events.fire(event);
 };
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -144,8 +144,7 @@ suite('Theme', function() {
       sinon.assert.calledOnce(refreshToolboxSelectionStub);
 
       assertEventFired(
-          this.eventsFireStub, Blockly.Events.OldUi, {element: 'theme'},
-          workspace.id, null);
+          this.eventsFireStub, Blockly.Events.ThemeChange, {}, workspace.id);
     } finally {
       workspaceTeardown.call(this, workspace);
     }

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -120,6 +120,7 @@ suite('Theme', function() {
     defineThemeTestBlocks(this.sharedCleanup);
     try {
       var blockStyles = createBlockStyles();
+      var theme = new Blockly.Theme('themeName', blockStyles);
       var workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
       var blockA = workspace.newBlock('stack_block');
 
@@ -132,10 +133,10 @@ suite('Theme', function() {
       sinon.stub(Blockly, "getMainWorkspace").returns(workspace);
       sinon.stub(Blockly, "hideChaff");
 
-      workspace.setTheme(blockStyles);
+      workspace.setTheme(theme);
 
       // Checks that the theme was set correctly on Blockly namespace
-      stringifyAndCompare(workspace.getTheme(), blockStyles);
+      stringifyAndCompare(workspace.getTheme(), theme);
 
       // Checks that the setTheme function was called on the block
       chai.assert.equal(blockA.getStyleName(), 'styleTwo');
@@ -144,7 +145,8 @@ suite('Theme', function() {
       sinon.assert.calledOnce(refreshToolboxSelectionStub);
 
       assertEventFired(
-          this.eventsFireStub, Blockly.Events.ThemeChange, {}, workspace.id);
+          this.eventsFireStub, Blockly.Events.ThemeChange,
+          {themeName: 'themeName'}, workspace.id);
     } finally {
       workspaceTeardown.call(this, workspace);
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4203
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Creates dedicated class (`Blockly.Events.ThemeChange`) for theme update event.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

See issue, but generally motivated by:
- better typing
- clearer events
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested by logging events on playground and using the following code:
```
var ws = Blockly.getMainWorkspace();
ws.setTheme(ws.getTheme());
```
and observing logged event had expected properties. Also ran mocha tests.

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Previously theme events did not include theme name.

