### PR TITLE
Refactor field_variable_tests to use dev-tools

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -65,7 +65,8 @@ Blockly.FieldVariable = function(varName, opt_validator, opt_variableTypes,
    * variable.
    * @type {string}
    */
-  this.defaultVariableName = varName || '';
+  this.defaultVariableName =
+      typeof varName === 'string' || varName instanceof String ? varName : '';
 
   /**
    * The size of the area rendered by the field.

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -65,8 +65,7 @@ Blockly.FieldVariable = function(varName, opt_validator, opt_variableTypes,
    * variable.
    * @type {string}
    */
-  this.defaultVariableName =
-      typeof varName === 'string' || varName instanceof String ? varName : '';
+  this.defaultVariableName = typeof varName === 'string' ? varName : '';
 
   /**
    * The size of the area rendered by the field.

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -529,7 +529,12 @@ function createTestBlock() {
     rendered: false,
     workspace: {
       rendered: false
-    }
+    },
+    'isShadow': function() {
+      return false;
+    },
+    'renameVarById': Blockly.Block.prototype.renameVarById,
+    'updateVarName': Blockly.Block.prototype.updateVarName,
   };
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
 Part of #4260
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Refactors `FieldVariable` tests to use dev-tools helpers
- Modifies handling of invalid values passed to `FieldVariable` constructor (for truthy non-string values like number or true)
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Expands coverage
- Better handling of invalid values (to use default value rather than causing error later down the line.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests (using local version of dev-tools).
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Depends on change https://github.com/google/blockly-samples/pull/428

Old tests:
![image](https://user-images.githubusercontent.com/6621618/97620859-59cde800-19df-11eb-8b5b-090c3708cdad.png)


New tests:
![image](https://user-images.githubusercontent.com/6621618/97620833-50dd1680-19df-11eb-8c9a-3165cf98e5a1.png)



<!-- Anything else we should know? -->
