### PR TITLE
Set data-id on block svgs for IE11

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -34,6 +34,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.userAgent');
 
 goog.requireType('Blockly.IASTNodeLocationSvg');
 goog.requireType('Blockly.IBoundedElement');
@@ -117,6 +118,10 @@ Blockly.BlockSvg = function(workspace, prototypeName, opt_id) {
   // Expose this block's ID on its top-level SVG group.
   if (this.svgGroup_.dataset) {
     this.svgGroup_.dataset['id'] = this.id;
+  } else if (Blockly.utils.userAgent.IE) {
+    // SVGElement.dataset is not available on IE11, but data-* properties
+    // can be set with setAttribute().
+    this.svgGroup_.setAttribute('data-id', this.id);
   }
 };
 Blockly.utils.object.inherits(Blockly.BlockSvg, Blockly.Block);


### PR DESCRIPTION
Set `data-id` on blocks' svg groups using `setAttribute()`, not `dataset` for IE. 
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4419
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Sets the `data-id` using `setAttribute` for IE

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
We use the data-id from the SVG group to interact with blocks in UI tests, so this is needed to be able to test in IE
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
Tested in the playground

Tested on:
* Desktop Chrome
![image](https://user-images.githubusercontent.com/8787187/97923255-8dc44880-1d12-11eb-9675-939285f08270.png)


* Windows IE 11
![blockly](https://user-images.githubusercontent.com/8787187/97923159-6a999900-1d12-11eb-99e5-73d9c5658608.PNG)

<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
