### PR TITLE
Fix conflict in background CSS for dropdown div

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -498,7 +498,8 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownDiv .blocklyMenu {',
-    'background: #fff;', /* Compatibility with gapi, resting from goog-menu */
+    'background: inherit;', /* Compatibility with gapi, resting from goog-menu */
+    'border: inherit;', /* Compatibility with gapi, resting from goog-menu */
     'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
     'outline: none;',
     'position: relative;', /* Compatibility with gapi, resting from goog-menu */

--- a/core/css.js
+++ b/core/css.js
@@ -498,11 +498,11 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownDiv .blocklyMenu {',
-    'background: inherit;', /* Compatibility with gapi, resting from goog-menu */
-    'border: inherit;', /* Compatibility with gapi, resting from goog-menu */
+    'background: inherit;', /* Compatibility with gapi, reset from goog-menu */
+    'border: inherit;', /* Compatibility with gapi, reset from goog-menu */
     'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
     'outline: none;',
-    'position: relative;', /* Compatibility with gapi, resting from goog-menu */
+    'position: relative;', /* Compatibility with gapi, reset from goog-menu */
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fix conflict of background in dropdown div.

### Proposed Changes

Make it inherit the background so that the .goog-menu selector setting the background doesn't conflict with the zelos renderer.
In addition, make it so we're not explicitly setting the background so we don't conflict with other field dropdown subclasses.

### Reason for Changes

Bug fix.

### Test Coverage


Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
