### PR TITLE
Allow .js script files to refer to Blockly global from blockly.d.ts

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -11,6 +11,8 @@
 
 export = Blockly;
 
+export as namespace Blockly;
+
 declare module Blockly {
 
   interface BlocklyOptions {

--- a/typings/templates/blockly-header.template
+++ b/typings/templates/blockly-header.template
@@ -10,3 +10,5 @@
  */
 
 export = Blockly;
+
+export as namespace Blockly;


### PR DESCRIPTION
It is now possible to use tsc to typecheck a .js file such as:

    // @ts-check
    Blockly.inject('blocklyDiv', {});

if tsconfig.json is configured with:

    {
        "compilerOptions": {
            "allowJs": true,
        }
    }

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
(No issue was created)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
It is now possible to use tsc to typecheck a .js file such as:

    // @ts-check
    Blockly.inject('blocklyDiv', {});

if tsconfig.json is configured with:

    {
        "compilerOptions": {
            "allowJs": true,
        }
    }

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Previously it was impossible to typecheck .js files with tsc which assume that Blockly is imported to the global scope via a script tag. With this PR it is now possible to typecheck such .js files.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Manually tested by running `tsc` in a directory with the following files:

```
// index.js
// @ts-check
Blockly.inject('blocklyDiv', {});

// tsconfig.json
{
    "include": [
        "./index.js",
        "./node_modules/blockly/blockly.d.ts",
    ],
    "compilerOptions": {
        "outDir": "./.tsc_cache",
        "incremental": true,
        "allowJs": true,
        "target": "ES2017",
    },
}
```

I was not able to locate any automated tests that ensure TypeScript definitions work as expected, so I didn't update any such tests.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
This PR makes no change to how Blockly's type definitions are imported normally, so it didn't seem like there were any user-visible changes to document.

I **do** think this change should be mentioned in release notes. I was not able to locate if/where the release notes are checked in.

### Additional Information

<!-- Anything else we should know? -->
n/a
