### PR TITLE
Fixes mutators considering insertion markers during compose

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -176,7 +176,7 @@ Blockly.Blocks['lists_create_with'] = {
     var itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     var connections = [];
-    while (itemBlock) {
+    while (itemBlock && !itemBlock.isInsertionMarker()) {
       connections.push(itemBlock.valueConnection_);
       itemBlock = itemBlock.nextConnection &&
           itemBlock.nextConnection.targetBlock();

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -365,7 +365,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
     var valueConnections = [null];
     var statementConnections = [null];
     var elseStatementConnection = null;
-    while (clauseBlock) {
+    while (clauseBlock && !clauseBlock.isInsertionMarker()) {
       switch (clauseBlock.type) {
         case 'controls_if_elseif':
           this.elseifCount_++;

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -214,7 +214,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     this.paramIds_ = [];
     this.argumentVarModels_ = [];
     var paramBlock = containerBlock.getInputTargetBlock('STACK');
-    while (paramBlock) {
+    while (paramBlock && !paramBlock.isInsertionMarker()) {
       var varName = paramBlock.getFieldValue('NAME');
       this.arguments_.push(varName);
       var variable = this.workspace.getVariable(varName, '');

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -722,7 +722,7 @@ Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN = {
     var itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     var connections = [];
-    while (itemBlock) {
+    while (itemBlock && !itemBlock.isInsertionMarker()) {
       connections.push(itemBlock.valueConnection_);
       itemBlock = itemBlock.nextConnection &&
           itemBlock.nextConnection.targetBlock();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Part of #4448 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds checks for insertion markers to all compose functions.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Insertion markers should not be considered when doing composition, as they aren't actual blocks.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

![If](https://user-images.githubusercontent.com/25440652/99159939-a92a3e80-2696-11eb-800e-60ef2d873fc9.gif)
![list](https://user-images.githubusercontent.com/25440652/99159940-aa5b6b80-2696-11eb-962b-119cd83100c3.gif)
![text](https://user-images.githubusercontent.com/25440652/99159942-acbdc580-2696-11eb-8f8c-640bb3a08505.gif)
![procedure](https://user-images.githubusercontent.com/25440652/99159944-ad565c00-2696-11eb-841a-368d989d31cf.gif)

Note that the issue with all of the procedure args being 'x' is just because the UI events are still in flux (I think).

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
[Edit: Actually, might want to mention this under [compose and decompose](https://developers.google.com/blockly/guides/create-custom-blocks/extensions#compose_and_decompose)]

### Additional Information

<!-- Anything else we should know? -->
N/A
