### PR TITLE
Add mutator bump back in

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -428,6 +428,13 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     if (oldMutation != newMutation) {
       Blockly.Events.fire(new Blockly.Events.BlockChange(
           block, 'mutation', null, oldMutation, newMutation));
+      // Ensure that any bump is part of this mutation's event group.
+      var group = Blockly.Events.getGroup();
+      setTimeout(function() {
+        Blockly.Events.setGroup(group);
+        block.bumpNeighbours();
+        Blockly.Events.setGroup(false);
+      }, Blockly.BUMP_DELAY);
     }
 
     // Don't update the bubble until the drag has ended, to avoid moving blocks


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Rest of #4448

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Reverts #3783. 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
At the time, that PR was fine, but in combination with setting `rendered` to false to address #4175 it now causes mutations to not bump blocks, as documented by #4448

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
![BumpOnMutate](https://user-images.githubusercontent.com/25440652/99161061-d1b83580-26a2-11eb-919a-744ac98e2584.gif)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Nope

### Additional Information

<!-- Anything else we should know? -->
N/A
