### PR TITLE
Make FieldDropdown menu_ field protected

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -108,7 +108,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
   /**
    * The dropdown menu.
    * @type {Blockly.Menu}
-   * @private
+   * @protected
    */
   this.menu_ = null;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Part of https://github.com/google/blockly-samples/issues/373
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Changed visibility of `FieldDropdown.menu_` from `private` to `protected`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Allows subclasses to access `menu_` property, which is useful to access the html element containing the menu. 
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Additional Information

Change needed for plugin feature: https://github.com/google/blockly-samples/pull/440.
<!-- Anything else we should know? -->
