### PR TITLE
Add fix for display text on multiline text block

### DIFF
--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -116,13 +116,13 @@ Blockly.FieldMultilineInput.prototype.initView = function() {
  * @private
  */
 Blockly.FieldMultilineInput.prototype.getDisplayText_ = function() {
-  var value = this.value_;
-  if (!value) {
+  var textLines = this.getText();
+  if (!textLines) {
     // Prevent the field from disappearing if empty.
     return Blockly.Field.NBSP;
   }
-  var lines = value.split('\n');
-  value = '';
+  var lines = textLines.split('\n');
+  textLines = '';
   for (var i = 0; i < lines.length; i++) {
     var text = lines[i];
     if (text.length > this.maxDisplayLength) {
@@ -132,16 +132,16 @@ Blockly.FieldMultilineInput.prototype.getDisplayText_ = function() {
     // Replace whitespace with non-breaking spaces so the text doesn't collapse.
     text = text.replace(/\s/g, Blockly.Field.NBSP);
 
-    value += text;
+    textLines += text;
     if (i !== lines.length - 1) {
-      value += '\n';
+      textLines += '\n';
     }
   }
   if (this.sourceBlock_.RTL) {
     // The SVG is LTR, force value to be RTL.
-    value += '\u200F';
+    textLines += '\u200F';
   }
-  return value;
+  return textLines;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Fixed logic in `getDisplayText_` for `FieldMultilineText` to use `getText` rather than `this.value_` directly.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Due to the logic in `getDisplayText_`, rendering of editor text for `FieldMultilineText` was acting up in cases where the validator returned a string of different size. This is because there is extra logic in `getText` that returns the editor text if the field is currently being edited.

Before change:
![cfe96abb-4a24-4fe4-aaca-66e711c3efdf](https://user-images.githubusercontent.com/6621618/99326851-82ead700-282d-11eb-9f18-c8dbf4d79ea3.gif)

After change:
![d35ff7e9-e099-4213-a707-8d598f5922e4](https://user-images.githubusercontent.com/6621618/99326845-80887d00-282d-11eb-8b70-55b16296ea43.gif)


### Test Coverage

Tested block with `FieldMultilineInput` and custom validator before and after change:

```
Blockly.Blocks['text_multiline_validator'] = {
  init: function() {
    this.appendDummyInput()
        .appendField('multiline text input:')
        .appendField(
            new Blockly.FieldMultilineInput('default', this.validate), 'INPUT');
    this.setColour('#5ba58c');
  },

  validate: function(newValue) {
    return newValue.replace(/a/gm, '');
  },
};
```

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

Issue found while writing documentation for multiline text field
<!-- Anything else we should know? -->
