### PR TITLE
Connecting block to parent in domToBlockHeadless_

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -158,6 +158,20 @@ Blockly.FieldDropdown.fromJson = function(options) {
 };
 
 /**
+ * Sets the field's value based on the given XML element. Should only be
+ * called by Blockly.Xml.
+ * @param {!Element} fieldElement The element containing info about the
+ *    field's state.
+ * @package
+ */
+Blockly.FieldDropdown.prototype.fromXml = function(fieldElement) {
+  if (this.isOptionListDynamic()) {
+    this.getOptions(false);
+  }
+  this.setValue(fieldElement.textContent);
+};
+
+/**
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}

--- a/core/xml.js
+++ b/core/xml.js
@@ -797,9 +797,11 @@ Blockly.Xml.applyInputTagNodes_ = function(xmlChildren, workspace, block,
     }
     var childBlockInfo = Blockly.Xml.findChildBlocks_(xmlChild);
     if (childBlockInfo.childBlockElement) {
+      if (!input.connection) {
+        throw TypeError('Input connection does not exist.');
+      }
       Blockly.Xml.domToBlockHeadless_(childBlockInfo.childBlockElement,
-          workspace, /** @type {!Blockly.Connection} */ (input.connection),
-          false);
+          workspace, input.connection, false);
     }
     // Set shadow after so we don't create a shadow we delete immediately.
     if (childBlockInfo.childShadowElement) {
@@ -829,7 +831,7 @@ Blockly.Xml.applyNextTagNodes_ = function(xmlChildren, workspace, block) {
       }
       // Create child block.
       Blockly.Xml.domToBlockHeadless_(childBlockInfo.childBlockElement,
-          workspace, /** @type {!Blockly.Connection} */ (block.nextConnection),
+          workspace, block.nextConnection,
           true);
     }
     // Set shadow after so we don't create a shadow we delete immediately.

--- a/core/xml.js
+++ b/core/xml.js
@@ -845,7 +845,7 @@ Blockly.Xml.applyNextTagNodes_ = function(xmlChildren, workspace, block) {
  * @param {!Blockly.Workspace} workspace The workspace.
  * @param {!Blockly.Connection=} parentConnection The parent connection to
  *    to connect this block to after instantiating.
- * @param {boolean} connectedToParentNext Whether the provided parent connection
+ * @param {boolean=} connectedToParentNext Whether the provided parent connection
  *    is a next connection, rather than output or statement.
  * @return {!Blockly.Block} The root block created.
  * @private

--- a/core/xml.js
+++ b/core/xml.js
@@ -798,7 +798,8 @@ Blockly.Xml.applyInputTagNodes_ = function(xmlChildren, workspace, block,
     var childBlockInfo = Blockly.Xml.findChildBlocks_(xmlChild);
     if (childBlockInfo.childBlockElement) {
       Blockly.Xml.domToBlockHeadless_(childBlockInfo.childBlockElement,
-          workspace, input.connection, false);
+          workspace, /** @type {!Blockly.Connection} */ (input.connection),
+          false);
     }
     // Set shadow after so we don't create a shadow we delete immediately.
     if (childBlockInfo.childShadowElement) {
@@ -828,7 +829,8 @@ Blockly.Xml.applyNextTagNodes_ = function(xmlChildren, workspace, block) {
       }
       // Create child block.
       Blockly.Xml.domToBlockHeadless_(childBlockInfo.childBlockElement,
-          workspace, block.nextConnection, true);
+          workspace, /** @type {!Blockly.Connection} */ (block.nextConnection),
+          true);
     }
     // Set shadow after so we don't create a shadow we delete immediately.
     if (childBlockInfo.childShadowElement && block.nextConnection) {
@@ -843,7 +845,7 @@ Blockly.Xml.applyNextTagNodes_ = function(xmlChildren, workspace, block) {
  * workspace.
  * @param {!Element} xmlBlock XML block element.
  * @param {!Blockly.Workspace} workspace The workspace.
- * @param {?Blockly.Connection=} parentConnection The parent connection to
+ * @param {!Blockly.Connection=} parentConnection The parent connection to
  *    to connect this block to after instantiating.
  * @param {boolean=} connectedToParentNext Whether the provided parent connection
  *    is a next connection, rather than output or statement.

--- a/core/xml.js
+++ b/core/xml.js
@@ -843,7 +843,7 @@ Blockly.Xml.applyNextTagNodes_ = function(xmlChildren, workspace, block) {
  * workspace.
  * @param {!Element} xmlBlock XML block element.
  * @param {!Blockly.Workspace} workspace The workspace.
- * @param {!Blockly.Connection=} parentConnection The parent connection to
+ * @param {?Blockly.Connection=} parentConnection The parent connection to
  *    to connect this block to after instantiating.
  * @param {boolean=} connectedToParentNext Whether the provided parent connection
  *    is a next connection, rather than output or statement.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #2135
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Connects block to it's parent in domToBlockHeadless_ rather than in the parent block's instantiation (allows for parent to be connected before field tag is processed)
  - Before: Block was connected it it's parent after it was fully loaded (which caused issues with fields validators that depended on the connected state of the block)
  - After: Block is connected to parent as it is being loaded, before it's field values are loaded
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Solves issues with loading blocks with field validators that depend on the parent being connected (and accessing parent fields) from xml
- Solves issues with loading dynamic dropdowns that depend on a connected parent from xml
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran tests and tested in advanced playground with the following block:
```
<xml xmlns="https://developers.google.com/blockly/xml">
  <variables>
    <variable>list</variable>
  </variables>
  <block type="controls_repeat_ext">
    <value name="TIMES">
      <block type="math_number">
        <field name="NUM">123</field>
      </block>
    </value>
    <statement name="DO">
      <block type="test_dropdowns_dynamic_connect_dependant">
        <field name="OPTIONS">wcjS31{oxnJqsPUgQ+_m_type_key</field>
        <next>
          <block type="lists_getIndex">
            <mutation statement="true" at="true"></mutation>
            <field name="MODE">REMOVE</field>
            <field name="WHERE">FROM_START</field>
            <value name="VALUE">
              <block type="variables_get">
                <field name="VAR">list</field>
              </block>
            </value>
            <value name="AT">
              <block type="lists_getIndex">
                <mutation statement="false" at="true"></mutation>
                <field name="MODE">GET</field>
                <field name="WHERE">FROM_START</field>
                <value name="VALUE">
                  <block type="variables_get">
                    <field name="VAR">list</field>
                  </block>
                </value>
                <value name="AT">
                  <block type="math_number">
                    <field name="NUM">123</field>
                  </block>
                </value>
              </block>
            </value>
            <next>
              <block type="test_dropdowns_dynamic_connect_dependant">
                <field name="OPTIONS">T1_y8l67gg$DXQ=u8Q~2_type_key</field>
              </block>
            </next>
          </block>
        </next>
      </block>
    </statement>
  </block>
</xml>
```
### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

The generator tests were very helpful for testing this change as it caught many edge cases of xml generation.

Depends on https://github.com/google/blockly/pull/4571
<!-- Anything else we should know? -->
