### PR TITLE
Fix windows path separator in uncompressed build

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -391,8 +391,9 @@ return gulp.src(maybeAddClosureLibrary(['core/**/**/*.js']))
       dep.setClosurePath(closurePath);
     }
 
-    const addDependency = closureDeps.depFile.getDepFileText(closurePath, deps)
-      .replace(/\\/g, '\/');
+    const addDependency = closureDeps.depFile
+        .getDepFileText(closurePath, deps)
+        .replace(/\\/g, '\/');
 
     const requires = `goog.addDependency("base.js", [], []);
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -391,7 +391,8 @@ return gulp.src(maybeAddClosureLibrary(['core/**/**/*.js']))
       dep.setClosurePath(closurePath);
     }
 
-    const addDependency = closureDeps.depFile.getDepFileText(closurePath, deps);
+    const addDependency = closureDeps.depFile.getDepFileText(closurePath, deps)
+      .replace(/\\/g, '\/');
 
     const requires = `goog.addDependency("base.js", [], []);
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/4433

### Proposed Changes

Replaces windows path separator with the browser path separator.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
