### PR TITLE
Remove deprecated field functions

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -19,7 +19,6 @@ goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Gesture');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.utils');
-goog.require('Blockly.utils.deprecation');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.utils.Size');
@@ -534,54 +533,6 @@ Blockly.Field.prototype.getValidator = function() {
 };
 
 /**
- * Validates a change.  Does nothing.  Subclasses may override this.
- * @param {string} text The user's text.
- * @return {string} No change needed.
- * @deprecated May 2019. Override doClassValidation and other relevant 'do'
- *  functions instead.
- */
-Blockly.Field.prototype.classValidator = function(text) {
-  Blockly.utils.deprecation.warn(
-      'Field.prototype.classValidator',
-      'May 2019',
-      'December 2020',
-      'Blockly.Field.prototype.doClassValidation_');
-  return text;
-};
-
-/**
- * Calls the validation function for this field, as well as all the validation
- * function for the field's class and its parents.
- * @param {string} text Proposed text.
- * @return {?string} Revised text, or null if invalid.
- * @deprecated May 2019. setValue now contains all relevant logic.
- */
-Blockly.Field.prototype.callValidator = function(text) {
-  Blockly.utils.deprecation.warn(
-      'Field.prototype.callValidator',
-      'May 2019',
-      'December 2020');
-  var classResult = this.classValidator(text);
-  if (classResult === null) {
-    // Class validator rejects value.  Game over.
-    return null;
-  } else if (classResult !== undefined) {
-    text = classResult;
-  }
-  var userValidator = this.getValidator();
-  if (userValidator) {
-    var userResult = userValidator.call(this, text);
-    if (userResult === null) {
-      // User validator rejects value.  Game over.
-      return null;
-    } else if (userResult !== undefined) {
-      text = userResult;
-    }
-  }
-  return text;
-};
-
-/**
  * Gets the group element for this editable field.
  * Used for measuring the size and for positioning.
  * @return {!SVGGElement} The group element.
@@ -623,22 +574,6 @@ Blockly.Field.prototype.showEditor = function(opt_e) {
   if (this.isClickable()) {
     this.showEditor_(opt_e);
   }
-};
-
-/**
- * Updates the width of the field. Redirects to updateSize_().
- * @deprecated May 2019  Use Blockly.Field.updateSize_() to force an update
- * to the size of the field, or Blockly.utils.dom.getTextWidth() to
- * check the size of the field.
- */
-Blockly.Field.prototype.updateWidth = function() {
-
-  Blockly.utils.deprecation.warn(
-      'Field.prototype.updateWidth',
-      'May 2019',
-      'December 2020',
-      'Blockly.Field.prototype.updateSize_ or Blockly.utils.dom.getTextWidth');
-  this.updateSize_();
 };
 
 /**
@@ -819,20 +754,6 @@ Blockly.Field.prototype.getText = function() {
 };
 
 /**
- * Set the text in this field.  Trigger a rerender of the source block.
- * @param {*} _newText New text.
- * @deprecated 2019 setText should not be used directly. Use setValue instead.
- */
-Blockly.Field.prototype.setText = function(_newText) {
-  Blockly.utils.deprecation.warn(
-      'Field.prototype.setText',
-      'May 2019',
-      'December 2020',
-      'Blockly.Field.prototype.setValue');
-  throw Error('setText method is deprecated');
-};
-
-/**
  * Force a rerender of the block that this field is installed on, which will
  * rerender this field and adjust for any sizing changes.
  * Other fields on the same block will not rerender, because their sizes have
@@ -951,14 +872,11 @@ Blockly.Field.prototype.getValue = function() {
  * @param {*=} opt_newValue The value to be validated.
  * @return {*} The validated value, same as input by default.
  * @protected
- * @suppress {deprecated} Suppress deprecated this.classValidator call.
  */
 Blockly.Field.prototype.doClassValidation_ = function(opt_newValue) {
   if (opt_newValue === null || opt_newValue === undefined) {
     return null;
   }
-  // For backwards compatibility.
-  opt_newValue = this.classValidator(/** @type {string} */ (opt_newValue));
   return opt_newValue;
 };
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -524,45 +524,6 @@ Blockly.FieldTextInput.prototype.resizeEditor_ = function() {
 };
 
 /**
- * Ensure that only a number may be entered.
- * @param {string} text The user's text.
- * @return {?string} A string representing a valid number, or null if invalid.
- * @deprecated
- */
-Blockly.FieldTextInput.numberValidator = function(text) {
-  Blockly.utils.deprecation.warn(
-      'FieldTextInput.numberValidator',
-      'May 2019',
-      'December 2020',
-      'Blockly.FieldNumber');
-  if (text === null) {
-    return null;
-  }
-  text = String(text);
-  // TODO: Handle cases like 'ten', '1.203,14', etc.
-  // 'O' is sometimes mistaken for '0' by inexperienced users.
-  text = text.replace(/O/ig, '0');
-  // Strip out thousands separators.
-  text = text.replace(/,/g, '');
-  var n = Number(text || 0);
-  return isNaN(n) ? null : String(n);
-};
-
-/**
- * Ensure that only a non-negative integer may be entered.
- * @param {string} text The user's text.
- * @return {?string} A string representing a valid int, or null if invalid.
- * @deprecated
- */
-Blockly.FieldTextInput.nonnegativeIntegerValidator = function(text) {
-  var n = Blockly.FieldTextInput.numberValidator(text);
-  if (n) {
-    n = String(Math.max(0, Math.floor(n)));
-  }
-  return n;
-};
-
-/**
  * Returns whether or not the field is tab navigable.
  * @return {boolean} True if the field is tab navigable.
  * @override

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -115,15 +115,6 @@ suite('Image Fields', function() {
         });
         chai.assert.equal(field.altText_, 'alt');
       });
-      test('Deprecated - setText', function() {
-        var deprecateWarnSpy = createDeprecationWarningStub();
-        var field = new Blockly.FieldImage('src', 10, 10, 'alt');
-        chai.assert.throws(function() {
-          field.setText('newAlt');
-        });
-        assertSingleDeprecationWarningCall(deprecateWarnSpy,
-            'Field.prototype.setText');
-      });
       suite('SetAlt', function() {
         setup(function() {
           this.imageField = new Blockly.FieldImage('src', 10, 10, 'alt');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Part of #4481
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Removes all deprecated functions in fields.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
`Blockly.FieldTextInput.nonnegativeIntegerValidator` doesn't look like it ever got a `Blockly.utils.deprecation.warn`. So we can either: 
- Add the deprecation warning now, and add back `Blockly.FieldTextInput.numberValidator` since `nonnegativeIntegerValidator`  relies on it.
- Just remove it now without the deprecation warning. 
- Add a deprecate warn to `nonnegativeIntegerValidator` now, and remove all the functions together when they have been deleted.

I prefer option 2 or 3, so that people only have to go through and update their fields once. 

<!-- Anything else we should know? -->
