### PR TITLE
Add info to JsDoc for blockToCode

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -159,6 +159,7 @@ Blockly.Generator.prototype.allNestedComments = function(block) {
 
 /**
  * Generate code for the specified block (and attached blocks).
+ * The generator should be initialized before calling this function.
  * @param {Blockly.Block} block The block to generate code for.
  * @param {boolean=} opt_thisOnly True to generate code for only this statement.
  * @return {string|!Array} For statement blocks, the generated code.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/2153
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds " The generator should be initialized before calling this function." to the JsDoc fo `blockToCode`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Unlike `workspaceToCode`, `blockToCode` must have the generator initialized before calling it, otherwise there may be a nondescript error (depending on the generator). Adding this to the documentation can help developers to have an easier time with catching this mistake.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
