### PR TITLE
Add warning to blockToCode

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -78,6 +78,12 @@ Blockly.Generator.prototype.COMMENT_WRAP = 60;
 Blockly.Generator.prototype.ORDER_OVERRIDES = [];
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.Generator.prototype.isInitialized = null;
+
+/**
  * Generate code for all blocks in the workspace to the specified language.
  * @param {Blockly.Workspace} workspace Workspace to generate code from.
  * @return {string} Generated code.
@@ -167,6 +173,10 @@ Blockly.Generator.prototype.allNestedComments = function(block) {
  *     operator order value.  Returns '' if block is null.
  */
 Blockly.Generator.prototype.blockToCode = function(block, opt_thisOnly) {
+  if (this.isInitialized === false) {
+    console.warn(
+        'Generator init was not called before blockToCode was called.');
+  }
   if (!block) {
     return '';
   }

--- a/core/generator.js
+++ b/core/generator.js
@@ -79,6 +79,9 @@ Blockly.Generator.prototype.ORDER_OVERRIDES = [];
 
 /**
  * Whether the init method has been called.
+ * Generators that set this flag to false after creation and true in init
+ * will cause blockToCode to emit a warning if the generator has not been
+ * initialized. If this flag is untouched, it will have no effect.
  * @type {?boolean}
  */
 Blockly.Generator.prototype.isInitialized = null;

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -82,7 +82,6 @@ Blockly.Dart.isInitialized = false;
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.Dart.init = function(workspace) {
-  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.Dart.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_
@@ -118,6 +117,7 @@ Blockly.Dart.init = function(workspace) {
     Blockly.Dart.definitions_['variables'] =
         'var ' + defvars.join(', ') + ';';
   }
+  this.isInitialized = true;
 };
 
 /**

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -72,10 +72,17 @@ Blockly.Dart.ORDER_ASSIGNMENT = 16;    // = *= /= ~/= %= += -= <<= >>= &= ^= |=
 Blockly.Dart.ORDER_NONE = 99;          // (...)
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.Dart.isInitialized = false;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.Dart.init = function(workspace) {
+  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.Dart.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -114,10 +114,17 @@ Blockly.JavaScript.ORDER_OVERRIDES = [
 ];
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.JavaScript.isInitialized = false;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.JavaScript.init = function(workspace) {
+  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.JavaScript.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -124,7 +124,6 @@ Blockly.JavaScript.isInitialized = false;
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.JavaScript.init = function(workspace) {
-  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.JavaScript.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_
@@ -160,6 +159,7 @@ Blockly.JavaScript.init = function(workspace) {
     Blockly.JavaScript.definitions_['variables'] =
         'var ' + defvars.join(', ') + ';';
   }
+  this.isInitialized = true;
 };
 
 /**

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -80,10 +80,17 @@ Blockly.Lua.ORDER_NONE = 99;
  */
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.Lua.isInitialized = false;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.Lua.init = function(workspace) {
+  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.Lua.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -90,7 +90,6 @@ Blockly.Lua.isInitialized = false;
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.Lua.init = function(workspace) {
-  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.Lua.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_
@@ -104,6 +103,7 @@ Blockly.Lua.init = function(workspace) {
     Blockly.Lua.variableDB_.reset();
   }
   Blockly.Lua.variableDB_.setVariableMap(workspace.getVariableMap());
+  this.isInitialized = true;
 };
 
 /**

--- a/generators/php.js
+++ b/generators/php.js
@@ -128,7 +128,6 @@ Blockly.PHP.isInitialized = false;
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.PHP.init = function(workspace) {
-  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.PHP.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_
@@ -161,6 +160,7 @@ Blockly.PHP.init = function(workspace) {
 
   // Declare all of the variables.
   Blockly.PHP.definitions_['variables'] = defvars.join('\n');
+  this.isInitialized = true;
 };
 
 /**

--- a/generators/php.js
+++ b/generators/php.js
@@ -118,10 +118,17 @@ Blockly.PHP.ORDER_OVERRIDES = [
 ];
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.PHP.isInitialized = false;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  */
 Blockly.PHP.init = function(workspace) {
+  this.isInitialized = true;
   // Create a dictionary of definitions to be printed before the code.
   Blockly.PHP.definitions_ = Object.create(null);
   // Create a dictionary mapping desired function names in definitions_

--- a/generators/python.js
+++ b/generators/python.js
@@ -137,7 +137,6 @@ Blockly.Python.isInitialized = false;
  * @this {Blockly.Generator}
  */
 Blockly.Python.init = function(workspace) {
-  this.isInitialized = true;
   /**
    * Empty loops or conditionals are not allowed in Python.
    */
@@ -173,6 +172,7 @@ Blockly.Python.init = function(workspace) {
   }
 
   Blockly.Python.definitions_['variables'] = defvars.join('\n');
+  this.isInitialized = true;
 };
 
 /**

--- a/generators/python.js
+++ b/generators/python.js
@@ -126,11 +126,18 @@ Blockly.Python.ORDER_OVERRIDES = [
 ];
 
 /**
+ * Whether the init method has been called.
+ * @type {?boolean}
+ */
+Blockly.Python.isInitialized = false;
+
+/**
  * Initialise the database of variable names.
  * @param {!Blockly.Workspace} workspace Workspace to generate code from.
  * @this {Blockly.Generator}
  */
 Blockly.Python.init = function(workspace) {
+  this.isInitialized = true;
   /**
    * Empty loops or conditionals are not allowed in Python.
    */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/2153
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds property to `Generator` to allow for checking whether it has been initialized and logging a warning in `blockToCode` if `init` was not called.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Provides developers with a helpful warning when `blockToCode` is called before `init`.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually on playground with repro steps described in bug.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

`isInitialized` is set to `null` so that it does not affect custom generators (and incorrectly log a warning when `blockToCode` is called).
<!-- Anything else we should know? -->
