### PR TITLE
Move where a non editable bubble is created

### DIFF
--- a/core/bubble.js
+++ b/core/bubble.js
@@ -917,7 +917,7 @@ Blockly.Bubble.createNonEditableBubble = function(paragraphElement, block, iconX
       /** @type {!Blockly.WorkspaceSvg} */ (block.workspace),
       paragraphElement, block.pathObject.svgPath,
       /** @type {!Blockly.utils.Coordinate} */ (iconXY), null, null);
-  // Expose this warning's block's ID on its top-level SVG group.
+  // Expose this bubble's block's ID on its top-level SVG group.
   bubble.setSvgId(block.id);
   if (block.RTL) {
     // Right-align the paragraph.

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -878,3 +878,57 @@ Blockly.Bubble.prototype.getRelativeToSurfaceXY = function() {
 Blockly.Bubble.prototype.setAutoLayout = function(enable) {
   this.autoLayout_ = enable;
 };
+
+/**
+ * Create the text for a non editable bubble.
+ * @param {string} text The text to display.
+ * @return {!SVGTextElement} The top-level node of the text.
+ * @package
+ */
+Blockly.Bubble.textToDom = function(text) {
+  var paragraph = Blockly.utils.dom.createSvgElement(
+      Blockly.utils.Svg.TEXT,
+      {
+        'class': 'blocklyText blocklyBubbleText blocklyNoPointerEvents',
+        'y': Blockly.Bubble.BORDER_WIDTH
+      },
+      null);
+  var lines = text.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    var tspanElement = Blockly.utils.dom.createSvgElement(
+        Blockly.utils.Svg.TSPAN,
+        {'dy': '1em', 'x': Blockly.Bubble.BORDER_WIDTH}, paragraph);
+    var textNode = document.createTextNode(lines[i]);
+    tspanElement.appendChild(textNode);
+  }
+  return paragraph;
+};
+
+/**
+ * Creates a bubble that can not be edited.
+ * @param {!SVGTextElement} paragraphElement The text element for the non editable bubble.
+ * @param {!Blockly.BlockSvg} block The block that the bubble is attached to.
+ * @param {!Blockly.utils.Coordinate} iconXY The coordinate of the icon.
+ * @return {!Blockly.Bubble} The non editable bubble.
+ * @package
+ */
+Blockly.Bubble.createNonEditableBubble = function(paragraphElement, block, iconXY) {
+  var bubble = new Blockly.Bubble(
+      /** @type {!Blockly.WorkspaceSvg} */ (block.workspace),
+      paragraphElement, block.pathObject.svgPath,
+      /** @type {!Blockly.utils.Coordinate} */ (iconXY), null, null);
+  // Expose this warning's block's ID on its top-level SVG group.
+  bubble.setSvgId(block.id);
+  if (block.RTL) {
+    // Right-align the paragraph.
+    // This cannot be done until the bubble is rendered on screen.
+    var maxWidth = this.paragraphElement_.getBBox().width;
+    for (var i = 0, textElement;
+      (textElement = this.paragraphElement_.childNodes[i]); i++) {
+
+      textElement.setAttribute('text-anchor', 'end');
+      textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);
+    }
+  }
+  return bubble;
+};

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -922,9 +922,9 @@ Blockly.Bubble.createNonEditableBubble = function(paragraphElement, block, iconX
   if (block.RTL) {
     // Right-align the paragraph.
     // This cannot be done until the bubble is rendered on screen.
-    var maxWidth = this.paragraphElement_.getBBox().width;
+    var maxWidth = paragraphElement.getBBox().width;
     for (var i = 0, textElement;
-      (textElement = this.paragraphElement_.childNodes[i]); i++) {
+      (textElement = paragraphElement.childNodes[i]); i++) {
 
       textElement.setAttribute('text-anchor', 'end');
       textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);

--- a/core/comment.js
+++ b/core/comment.js
@@ -284,7 +284,10 @@ Blockly.Comment.prototype.createEditableBubble_ = function() {
  */
 Blockly.Comment.prototype.createNonEditableBubble_ = function() {
   // TODO (#2917): It would be great if the comment could support line breaks.
-  Blockly.Warning.prototype.createBubble.call(this);
+  this.paragraphElement_ = Blockly.Bubble.textToDom(this.block_.getCommentText());
+  this.bubble_ = Blockly.Bubble.createNonEditableBubble(
+      this.paragraphElement_, this.block_, this.iconXY_);
+  this.applyColour();
 };
 
 /**
@@ -293,11 +296,6 @@ Blockly.Comment.prototype.createNonEditableBubble_ = function() {
  * @suppress {checkTypes} Suppress `this` type mismatch.
  */
 Blockly.Comment.prototype.disposeBubble_ = function() {
-  if (this.paragraphElement_) {
-    // We're using the warning UI so we have to let it dispose.
-    Blockly.Warning.prototype.disposeBubble.call(this);
-    return;
-  }
   if (this.onMouseUpWrapper_) {
     Blockly.unbindEvent_(this.onMouseUpWrapper_);
     this.onMouseUpWrapper_ = null;
@@ -318,6 +316,7 @@ Blockly.Comment.prototype.disposeBubble_ = function() {
   this.bubble_ = null;
   this.textarea_ = null;
   this.foreignObject_ = null;
+  this.paragraphElement_ = null;
 };
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -251,7 +251,6 @@ Blockly.Comment.prototype.setVisible = function(visible) {
  */
 Blockly.Comment.prototype.createBubble_ = function() {
   if (!this.block_.isEditable() || Blockly.utils.userAgent.IE) {
-    // Steal the code from warnings to make an uneditable text bubble.
     // MSIE does not support foreignobject; textareas are impossible.
     // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
     // Always treat comments in IE as uneditable.
@@ -286,7 +285,8 @@ Blockly.Comment.prototype.createNonEditableBubble_ = function() {
   // TODO (#2917): It would be great if the comment could support line breaks.
   this.paragraphElement_ = Blockly.Bubble.textToDom(this.block_.getCommentText());
   this.bubble_ = Blockly.Bubble.createNonEditableBubble(
-      this.paragraphElement_, this.block_, this.iconXY_);
+      this.paragraphElement_, /** @type {!Blockly.BlockSvg} */ (this.block_),
+      /** @type {!Blockly.utils.Coordinate} */ (this.iconXY_));
   this.applyColour();
 };
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -98,7 +98,8 @@ Blockly.Warning.prototype.setVisible = function(visible) {
 Blockly.Warning.prototype.createBubble_ = function() {
   this.paragraphElement_ = Blockly.Bubble.textToDom(this.getText());
   this.bubble_ = Blockly.Bubble.createNonEditableBubble(
-      this.paragraphElement_, this.block_, this.iconXY_);
+      this.paragraphElement_, /** @type {!Blockly.BlockSvg} */ (this.block_),
+      /** @type {!Blockly.utils.Coordinate} */ (this.iconXY_));
   this.applyColour();
 };
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -75,31 +75,6 @@ Blockly.Warning.prototype.drawIcon_ = function(group) {
 };
 
 /**
- * Create the text for the warning's bubble.
- * @param {string} text The text to display.
- * @return {!SVGTextElement} The top-level node of the text.
- * @private
- */
-Blockly.Warning.textToDom_ = function(text) {
-  var paragraph = Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.TEXT,
-      {
-        'class': 'blocklyText blocklyBubbleText blocklyNoPointerEvents',
-        'y': Blockly.Bubble.BORDER_WIDTH
-      },
-      null);
-  var lines = text.split('\n');
-  for (var i = 0; i < lines.length; i++) {
-    var tspanElement = Blockly.utils.dom.createSvgElement(
-        Blockly.utils.Svg.TSPAN,
-        {'dy': '1em', 'x': Blockly.Bubble.BORDER_WIDTH}, paragraph);
-    var textNode = document.createTextNode(lines[i]);
-    tspanElement.appendChild(textNode);
-  }
-  return paragraph;
-};
-
-/**
  * Show or hide the warning bubble.
  * @param {boolean} visible True if the bubble should be visible.
  */
@@ -110,50 +85,30 @@ Blockly.Warning.prototype.setVisible = function(visible) {
   Blockly.Events.fire(
       new Blockly.Events.BubbleOpen(this.block_, visible, 'warning'));
   if (visible) {
-    this.createBubble();
+    this.createBubble_();
   } else {
-    this.disposeBubble();
+    this.disposeBubble_();
   }
 };
 
 /**
  * Show the bubble.
- * @package
+ * @private
  */
-Blockly.Warning.prototype.createBubble = function() {
-  // TODO (#2943): This is package because comments steal this UI for
-  //  non-editable comments, but really this should be private.
-  this.paragraphElement_ = Blockly.Warning.textToDom_(this.getText());
-  this.bubble_ = new Blockly.Bubble(
-      /** @type {!Blockly.WorkspaceSvg} */ (this.block_.workspace),
-      this.paragraphElement_, this.block_.pathObject.svgPath,
-      /** @type {!Blockly.utils.Coordinate} */ (this.iconXY_), null, null);
-  // Expose this warning's block's ID on its top-level SVG group.
-  this.bubble_.setSvgId(this.block_.id);
-  if (this.block_.RTL) {
-    // Right-align the paragraph.
-    // This cannot be done until the bubble is rendered on screen.
-    var maxWidth = this.paragraphElement_.getBBox().width;
-    for (var i = 0, textElement;
-      (textElement = this.paragraphElement_.childNodes[i]); i++) {
-
-      textElement.setAttribute('text-anchor', 'end');
-      textElement.setAttribute('x', maxWidth + Blockly.Bubble.BORDER_WIDTH);
-    }
-  }
+Blockly.Warning.prototype.createBubble_ = function() {
+  this.paragraphElement_ = Blockly.Bubble.textToDom(this.getText());
+  this.bubble_ = Blockly.Bubble.createNonEditableBubble(
+      this.paragraphElement_, this.block_, this.iconXY_);
   this.applyColour();
 };
 
 /**
  * Dispose of the bubble and references to it.
- * @package
+ * @private
  */
-Blockly.Warning.prototype.disposeBubble = function() {
-  // TODO (#2943): This is package because comments steal this UI for
-  //  non-editable comments, but really this should be private.
+Blockly.Warning.prototype.disposeBubble_ = function() {
   this.bubble_.dispose();
   this.bubble_ = null;
-  this.body_ = null;
   this.paragraphElement_ = null;
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes: #4186 and #2943.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
There are two methods in warning that comments need in order to create a non editable bubble. Since these methods primary goal is to create a bubble this moves those methods on to the Bubble class. 

#2943 says that the comments should have their own UI which I agree with. However, since we can not use `<foreignobject>` to create a non editable bubble (see [here](https://github.com/google/blockly/blob/85874cd6962d6baf81c806a190a05be0b45f2838/core/comment.js#L254)) then whatever UI we create will most likely rely on these methods in some capacity.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
1. We want to be able to remove `getText` on the comment. We can't do that if the warning UI is using getText. (#4186)
2. General cleanup. (#2943)
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
<!-- Anything else we should know? -->
