### PR TITLE
Preventing workspace click when trashcan is clicked

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -313,9 +313,13 @@ Blockly.Trashcan.prototype.createDom = function() {
   this.svgLid_.setAttributeNS(Blockly.utils.dom.XLINK_NS, 'xlink:href',
       this.workspace_.options.pathToMedia + Blockly.SPRITE.url);
 
-  Blockly.bindEventWithChecks_(this.svgGroup_, 'mouseup', this, this.click);
   // bindEventWithChecks_ quashes events too aggressively. See:
   // https://groups.google.com/forum/#!topic/blockly/QF4yB9Wx00s
+  // Using bindEventWithChecks_ for blocking mousedown causes issue in mobile.
+  // See #4303
+  Blockly.bindEvent_(
+      this.svgGroup_, 'mousedown', this, this.blockMouseDownWhenOpenable_);
+  Blockly.bindEvent_(this.svgGroup_, 'mouseup', this, this.click);
   // Bind to body instead of this.svgGroup_ so that we don't get lid jitters
   Blockly.bindEvent_(body, 'mouseover', this, this.mouseOver_);
   Blockly.bindEvent_(body, 'mouseout', this, this.mouseOut_);
@@ -564,6 +568,17 @@ Blockly.Trashcan.prototype.fireUiEvent_ = function(trashcanOpen) {
   var uiEvent =
       new Blockly.Events.TrashcanOpen(trashcanOpen,this.workspace_.id);
   Blockly.Events.fire(uiEvent);
+};
+
+/**
+ * Prevents a workspace scroll and click event if the trashcan has blocks.
+ * @param {!Event} e A mouse down event.
+ * @private
+ */
+Blockly.Trashcan.prototype.blockMouseDownWhenOpenable_ = function(e) {
+  if (!this.contentsIsOpen() && this.hasContents_()) {
+    e.stopPropagation();  // Don't start a workspace scroll.
+  }
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #3975
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
 
Binds mousedown event on trashcan to prevent event propagation if opening flyout using `bindEvent_`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This change prevents a workspace click event from emitting if trashcan click opens the flyout and otherwise emits workspace click if trashcan click does nothing (happens when trashcan contents are empty).
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested event logging on web and mobile (using browserstack) using playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Previously a similar solution was attempted using `bindEventWithChecks_` which caused bug on mobile (#4303).
<!-- Anything else we should know? -->
