### PR TITLE
Add a remove key map function

### DIFF
--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -104,10 +104,7 @@ Blockly.ShortcutRegistry.prototype.unregister = function(shortcutName) {
     return false;
   }
 
-  // Remove all key mappings with this shortcut.
-  for (var keyCode in this.keyMap_) {
-    this.removeKeyMapping(keyCode, shortcutName, true);
-  }
+  this.removeAllKeyMappings(shortcutName);
 
   delete this.registry_[shortcutName];
   return true;

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -179,6 +179,17 @@ Blockly.ShortcutRegistry.prototype.removeKeyMapping = function(
 };
 
 /**
+ * Removes all the key mappings for a shortcut with the given name.
+ * @param {string} shortcutName The name of the shortcut to remove from the key map.
+ * @public
+ */
+Blockly.ShortcutRegistry.prototype.removeAllKeyMappings = function(shortcutName) {
+  for (var keyCode in this.keyMap_) {
+    this.removeKeyMapping(keyCode, shortcutName, true);
+  }
+};
+
+/**
  * Sets the key map. Setting the key map will override any default key mappings.
  * @param {!Object<string, !Array<string>>} keyMap The object with key code to
  *     shortcut names.

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -177,6 +177,8 @@ Blockly.ShortcutRegistry.prototype.removeKeyMapping = function(
 
 /**
  * Removes all the key mappings for a shortcut with the given name.
+ * Useful when changing the default key mappings and the key codes registered to the shortcut are
+ * unknown.
  * @param {string} shortcutName The name of the shortcut to remove from the key map.
  * @public
  */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Adds a function to remove key maps without needing to know the key code for the shortcut.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
