### PR TITLE
Make sure el can be blurred before doing so

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1814,7 +1814,10 @@ Blockly.WorkspaceSvg.prototype.markFocused = function() {
 Blockly.WorkspaceSvg.prototype.setBrowserFocus = function() {
   // Blur whatever was focused since explicitly grabbing focus below does not
   // work in Edge.
-  if (document.activeElement) {
+  // In IE, SVGs can't be blurred or focused. Check to make sure the current
+  // focus can be blurred before doing so.
+  // See https://github.com/google/blockly/issues/4440
+  if (document.activeElement && document.activeElement.blur) {
     document.activeElement.blur();
   }
   try {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4440 

### Proposed Changes

Checks that `blur` function exists before calling it.

### Reason for Changes

In IE, svg elements cannot be blurred or focused, so IE users see a console error on this line as blur function does not exist.  Of course, this begs the question of how such an element became focused in the first place... I couldn't figure that out. I did some playing around in win-ie11 and couldn't ever reproduce the linked bug. The activeElement was always the svg's parent element, exactly what the code in line 1830 is doing. Perhaps there is some client code that is causing this as opposed to something in Blockly, I'm not sure, but either way since having the svg be focused in IE is unexpected behavior, and there's no way to blur it, I can't think of anything else we need to do here.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
Desktop Chrome
Windows Internet Explorer 11

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
