### PR TITLE
Add old and new type info to select event

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -289,9 +289,9 @@ Blockly.BlockSvg.prototype.select = function() {
   if (Blockly.selected == this) {
     return;
   }
-  var oldId = null;
+  var oldSelected = null;
   if (Blockly.selected) {
-    oldId = Blockly.selected.id;
+    oldSelected = Blockly.selected;
     // Unselect any previously selected block.
     Blockly.Events.disable();
     try {
@@ -300,7 +300,7 @@ Blockly.BlockSvg.prototype.select = function() {
       Blockly.Events.enable();
     }
   }
-  var event = new Blockly.Events.Selected(oldId, this.id, this.workspace.id);
+  var event = new Blockly.Events.Selected(oldSelected, this, this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = this;
   this.addSelect();
@@ -313,7 +313,7 @@ Blockly.BlockSvg.prototype.unselect = function() {
   if (Blockly.selected != this) {
     return;
   }
-  var event = new Blockly.Events.Selected(this.id, null, this.workspace.id);
+  var event = new Blockly.Events.Selected(this, null, this.workspace.id);
   event.workspaceId = this.workspace.id;
   Blockly.Events.fire(event);
   Blockly.selected = null;

--- a/core/events/events_selected.js
+++ b/core/events/events_selected.js
@@ -16,33 +16,67 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.UiBase');
 goog.require('Blockly.registry');
 goog.require('Blockly.utils.object');
+goog.require('Blockly.ISelectable');
+goog.require('Blockly.BlockSvg');
+goog.require('Blockly.WorkspaceCommentSvg');
 
 /**
  * Class for a selected event.
- * @param {?string=} opt_oldElementId The id of the previously selected
+ * @param {?Blockly.ISelectable=} opt_oldElement The previously selected
  *    element. Null if no element last selected. Undefined for a blank event.
- * @param {?string=} opt_newElementId The id of the selected element. Null if no
- *    element currently selected (deselect). Undefined for a blank event.
+ * @param {?Blockly.ISelectable=} opt_newElement The selected element. Null if
+ *    no element currently selected (deselect). Undefined for a blank event.
  * @param {string=} opt_workspaceId The workspace identifier for this event.
  *    Null if no element previously selected. Undefined for a blank event.
  * @extends {Blockly.Events.UiBase}
  * @constructor
  */
-Blockly.Events.Selected = function(opt_oldElementId, opt_newElementId,
-    opt_workspaceId) {
+Blockly.Events.Selected = function(opt_oldElement, opt_newElement, opt_workspaceId) {
   Blockly.Events.Selected.superClass_.constructor.call(this, opt_workspaceId);
+  function getSelectedId(selectedElement) {
+    if (selectedElement === undefined) {
+      return undefined;
+    } else if (selectedElement) {
+      return selectedElement.id;
+    }
+    return null;
+  }
 
   /**
    * The id of the last selected element.
    * @type {?string|undefined}
    */
-  this.oldElementId = opt_oldElementId;
+  this.oldElementId = getSelectedId(opt_oldElement);
 
   /**
    * The id of the selected element.
    * @type {?string|undefined}
    */
-  this.newElementId = opt_newElementId;
+  this.newElementId = getSelectedId(opt_newElement);
+
+  function getSelectedType(selectedElement) {
+    if (selectedElement === undefined) {
+      return undefined;
+    }
+    if (selectedElement instanceof Blockly.BlockSvg) {
+      return 'block';
+    } else if (selectedElement instanceof Blockly.WorkspaceCommentSvg) {
+      return 'workspace_comment';
+    }
+    return null;
+  }
+
+  /**
+   * The type of the last selected element.
+   * @type {?string|undefined}
+   */
+  this.oldElementType = getSelectedType(opt_oldElement);
+
+  /**
+   * The type of the current selected element.
+   * @type {?string|undefined}
+   */
+  this.newElementType = getSelectedType(opt_newElement);
 };
 Blockly.utils.object.inherits(Blockly.Events.Selected, Blockly.Events.UiBase);
 
@@ -60,6 +94,8 @@ Blockly.Events.Selected.prototype.toJson = function() {
   var json = Blockly.Events.Selected.superClass_.toJson.call(this);
   json['oldElementId'] = this.oldElementId;
   json['newElementId'] = this.newElementId;
+  json['oldElementType'] = this.oldElementType;
+  json['newElementType'] = this.newElementType;
   return json;
 };
 
@@ -71,6 +107,8 @@ Blockly.Events.Selected.prototype.fromJson = function(json) {
   Blockly.Events.Selected.superClass_.fromJson.call(this, json);
   this.oldElementId = json['oldElementId'];
   this.newElementId = json['newElementId'];
+  this.oldElementType = json['oldElementType'];
+  this.newElementType = json['newElementType'];
 };
 
 Blockly.registry.register(Blockly.registry.Type.EVENT, Blockly.Events.SELECTED,

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -213,9 +213,9 @@ Blockly.WorkspaceCommentSvg.prototype.select = function() {
   if (Blockly.selected == this) {
     return;
   }
-  var oldId = null;
+  var oldSelected = null;
   if (Blockly.selected) {
-    oldId = Blockly.selected.id;
+    oldSelected = Blockly.selected;
     // Unselect any previously selected block.
     Blockly.Events.disable();
     try {
@@ -224,7 +224,7 @@ Blockly.WorkspaceCommentSvg.prototype.select = function() {
       Blockly.Events.enable();
     }
   }
-  var event = new Blockly.Events.Selected(oldId, this.id, this.workspace.id);
+  var event = new Blockly.Events.Selected(oldSelected, this, this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = this;
   this.addSelect();
@@ -238,7 +238,8 @@ Blockly.WorkspaceCommentSvg.prototype.unselect = function() {
   if (Blockly.selected != this) {
     return;
   }
-  var event = new Blockly.Events.Selected(this.id, null, this.workspace.id);
+  var event = new Blockly.Events.Selected(
+      this, null, this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = null;
   this.removeSelect();

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -35,7 +35,8 @@ suite('Gesture', function() {
 
 
     assertEventFired(eventsFireStub, Blockly.Events.Selected,
-        {oldElementId: null, newElementId: block.id}, fieldWorkspace.id);
+        {oldElementId: null, newElementId: block.id, oldElementType: null,
+          newElementType: 'block'}, fieldWorkspace.id);
     assertEventNotFired(eventsFireStub, Blockly.Events.Click, {});
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4513
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Add logic to enable differentiating what kind of element was newly and previously selected.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Before this change, there was no clear way how to check what kind of element was selected based on selected event.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

Will require updates to event documentation
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
<!-- Anything else we should know? -->
