### PR TITLE
Fix ios12 bug

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -236,7 +236,7 @@ Blockly.Toolbox.prototype.createContentsContainer_ = function() {
 Blockly.Toolbox.prototype.attachEvents_ = function(container,
     contentsContainer) {
   // Clicking on toolbox closes popups.
-  var clickEvent = Blockly.bindEventWithChecks_(container, 'mousedown', this,
+  var clickEvent = Blockly.bindEventWithChecks_(container, 'click', this,
       this.onClick_, /* opt_noCaptureIdentifier */ false,
       /* opt_noPreventDefault */ true);
   this.boundEvents_.push(clickEvent);

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -257,8 +257,8 @@ Blockly.Toolbox.prototype.onClick_ = function(e) {
     // Close flyout.
     Blockly.hideChaff(false);
   } else {
-    var srcElement = e.srcElement;
-    var itemId = srcElement.getAttribute('id');
+    var targetElement = e.target;
+    var itemId = targetElement.getAttribute('id');
     if (itemId) {
       var item = this.getToolboxItemById(itemId);
       if (item.isSelectable()) {

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -130,14 +130,14 @@ suite('Toolbox', function() {
 
     test('Toolbox clicked -> Should close flyout', function() {
       var hideChaffStub = sinon.stub(Blockly, "hideChaff");
-      var evt = new MouseEvent('pointerdown', {});
+      var evt = new MouseEvent('click', {});
       this.toolbox.HtmlDiv.dispatchEvent(evt);
       sinon.assert.calledOnce(hideChaffStub);
     });
     test('Category clicked -> Should select category', function() {
       var categoryXml = document.getElementsByClassName('blocklyTreeRow')[0];
       var evt = {
-        'srcElement': categoryXml
+        'target': categoryXml
       };
       var item = this.toolbox.contentMap_[categoryXml.getAttribute('id')];
       var setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #4510
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Changes 'mousedown' --> 'click'.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
**There were two problems for this bug:** 
1. [e.srcElement](https://github.com/google/blockly/blob/85874cd6962d6baf81c806a190a05be0b45f2838/core/toolbox/toolbox.js#L260) is undefined for a touchstart event. The [onClick_  method in toolbox](https://github.com/google/blockly/blob/85874cd6962d6baf81c806a190a05be0b45f2838/core/toolbox/toolbox.js#L255) relies on this and would therefore throw an error.
2. After this was fixed, the new bug became that the toolbox would close shortly after opening. 

**Why this bug was happening:**
1. We add a listener for a touchstart event when binding a mousedown event. 
2. Because we call [clearTouchIdentifier](https://github.com/google/blockly/blob/85874cd6962d6baf81c806a190a05be0b45f2838/core/toolbox/toolbox.js#L272) on the toolbox it does not throw out one of these as it should. 
3. The toolbox onClick_  method will therefore get called twice. The first event will open the category, the second will close it.

### Test Coverage
Tested on chrome.
Tested on ios12 using a simulator. 
Tested on ios14 using an iphone.

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
I'm not sure why we chose to use 'mousedown' but it looks like it has been that way from when the toolbox was first create. Changing this to 'click' will change the behavior slightly when someone clicks on the toolbox to close it. 
<!-- Anything else we should know? -->
