### PR TITLE
update break block even if it's not the dragged block

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -334,9 +334,8 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
     // Don't change state if:
     //   * It's at the start of a drag.
     //   * It's not a move event.
-    //   * Or the moving block is not this block.
     if (!this.workspace.isDragging || this.workspace.isDragging() ||
-        e.type != Blockly.Events.BLOCK_MOVE || e.blockId != this.id) {
+        e.type != Blockly.Events.BLOCK_MOVE) {
       return;
     }
     var enabled = Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#4500 

### Proposed Changes

break block onchange handler acts even if the moved block is not the break block. 

### Reason for Changes

See #4500 

### Test Coverage

This was added in #3697 to fix #2321 so I double checked against the scenario in the original bug. Undo still works (thanks to the group id being set) and now the break block updates state correctly even if you are e.g. dragging a parent or a stack it's a part of. checked many variations of this to make sure.
