### PR TITLE
Revert "Allow .js script files to refer to Blockly global from blockly.d.ts"

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -11,8 +11,6 @@
 
 export = Blockly;
 
-export as namespace Blockly;
-
 declare module Blockly {
 
   interface BlocklyOptions {

--- a/typings/templates/blockly-header.template
+++ b/typings/templates/blockly-header.template
@@ -10,5 +10,3 @@
  */
 
 export = Blockly;
-
-export as namespace Blockly;


### PR DESCRIPTION
Reverts google/blockly#4434

This was causing the following issue:
```
node_modules/blockly/msg/msg.d.ts:13:1 - error TS6200: Definitions of the following identifiers conflict with those in another file: ADD_COMMENT, CANNOT_DELETE_VARIABLE_PROCEDURE
```
It looks like messages are getting defined twice, which is causing problems. 
This can be seen by running this version of blockly with our angular example.

Opening #4544 to look into this more next release.