### PR TITLE
Update Blockly Games URL.

### DIFF
--- a/appengine/redirect.html
+++ b/appengine/redirect.html
@@ -49,13 +49,13 @@ if (loc.match('/apps/plane/plane.html')) {
 
 if (loc.match('/apps/puzzle/')) {
   // Puzzle moved to Blockly Games on 15 Oct 2014.
-  loc = 'https://blockly-games.appspot.com/puzzle';
+  loc = 'https://blockly.games/puzzle';
 } else if (loc.match('/apps/maze/')) {
   // Maze moved to Blockly Games on 10 Nov 2014.
-  loc = 'https://blockly-games.appspot.com/maze';
+  loc = 'https://blockly.games/maze';
 } else if (loc.match('/apps/turtle/')) {
   // Turtle moved to Blockly Games on 10 Nov 2014.
-  loc = 'https://blockly-games.appspot.com/turtle';
+  loc = 'https://blockly.games/turtle';
 } else if (loc.match('/apps/')) {
   // Remaining apps moved to demos on 20 Nov 2014.
   loc = loc.replace('/apps/', '/demos/');


### PR DESCRIPTION
Currently there's a double-redirect (Blockly sends the user to appspot, Blockly Games then sends the user to its own domain).