### PR TITLE
Fix misplaced percent sign in css, close iframe html tag

### DIFF
--- a/tests/playgrounds/iframe.html
+++ b/tests/playgrounds/iframe.html
@@ -14,11 +14,11 @@
     border: 0;
     margin: 2px;
     padding: 0;
-    width: %100;
+    width: 100%;
   }
   #playground-iframe {
     border: 0;
-    width: %100;
+    width: 100%;
   }
 </style>
 <script type="text/javascript">
@@ -35,5 +35,6 @@
 <body>
   <h1 id="title">Outer Frame</h1>
   <iframe id="playground-iframe" src="../playground.html">
+  </iframe>
 </body>
 </html>


### PR DESCRIPTION
## The basics

- [ x] I branched from develop
- [ x] My pull request is against develop
- [ x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixed misplaced percent sign in css, close iframe html tag

### Proposed Changes

It fixes possible bugs.

### Reason for Changes

Missplaced "%" sign may cause css bugs.
Iframe tag must be closed.
