### PR TITLE
Be consistent in how we access global properties on Blockly.utils.global

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -434,7 +434,7 @@ Blockly.utils.is3dSupported = function() {
   }
   // CC-BY-SA Lorenzo Polidori
   // stackoverflow.com/questions/5661671/detecting-transform-translate3d-support
-  if (!Blockly.utils.global.getComputedStyle) {
+  if (!Blockly.utils.global['getComputedStyle']) {
     return false;
   }
 
@@ -454,7 +454,7 @@ Blockly.utils.is3dSupported = function() {
   for (var t in transforms) {
     if (el.style[t] !== undefined) {
       el.style[t] = 'translate3d(1px,1px,1px)';
-      var computedStyle = Blockly.utils.global.getComputedStyle(el);
+      var computedStyle = Blockly.utils.global['getComputedStyle'](el);
       if (!computedStyle) {
         // getComputedStyle in Firefox returns null when Blockly is loaded
         // inside an iframe with display: none.  Returning false and not

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -107,4 +107,4 @@ Blockly.utils.userAgent.MOBILE;
   Blockly.utils.userAgent.MOBILE = !Blockly.utils.userAgent.TABLET &&
       (Blockly.utils.userAgent.IPOD || Blockly.utils.userAgent.IPHONE ||
        Blockly.utils.userAgent.ANDROID || has('IEMobile'));
-})((Blockly.utils.global.navigator && Blockly.utils.global.navigator.userAgent) || '');
+})((Blockly.utils.global['navigator'] && Blockly.utils.global['navigator']['userAgent']) || '');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This doesn't fix a specific problem per se, but it makes things consistent. This is ensuring we always access properties / methods on `Blockly.utils.global` using fully qualified strings (rather than dot syntax), that way the closure compiler will never rename these fields.

The reason these instances haven't caused an issue is:
- navigator: Elsewhere in the code we use the fully qualified name, so the closure compiler must pick up that that field shouldn't be renamed. 
- getComputedStyle: Unsure why that is. I would have expected it to but it didn't, maybe closure is doing something special for an object with the name `global`?

### Proposed Changes

Use fully qualified names.

### Reason for Changes

Consistency 

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
