### PR TITLE
Add some missing requires and requireTypes

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -30,10 +30,17 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.deprecation');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
+goog.require('Blockly.utils.Size');
 goog.require('Blockly.utils.string');
 goog.require('Blockly.Workspace');
 
+goog.requireType('Blockly.Comment');
+goog.requireType('Blockly.Events.Abstract');
+goog.requireType('Blockly.Field');
 goog.requireType('Blockly.IASTNodeLocation');
+goog.requireType('Blockly.Mutator');
+goog.requireType('Blockly.utils.Size');
+goog.requireType('Blockly.VariableModel');
 
 
 /**

--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.blockAnimations');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.BlockSvg');
 
 /**
  * PID of disconnect UI animation.  There can only be one at a time.

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -21,6 +21,9 @@ goog.require('Blockly.InsertionMarkerManager');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class for a block dragger.  It moves blocks around the workspace when they

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -36,9 +36,16 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.utils.userAgent');
 
+goog.requireType('Blockly.Comment');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Field');
 goog.requireType('Blockly.IASTNodeLocationSvg');
 goog.requireType('Blockly.IBoundedElement');
 goog.requireType('Blockly.ICopyable');
+goog.requireType('Blockly.Input');
+goog.requireType('Blockly.ShortcutRegistry');
+goog.requireType('Blockly.Warning');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -33,6 +33,11 @@ goog.require('Blockly.WidgetDiv');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.ICopyable');
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Blockly core version.

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -24,6 +24,7 @@ goog.require('Blockly.Workspace');
 
 goog.requireType('Blockly.IBubble');
 goog.requireType('Blockly.utils.Metrics');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Resolves some compiler errors that show up when I enable the `'stricterMissingRequire'` flag.

I ran `npm run build:strict:log` with that flag set, and looked for `Please add a goog.requireType`.


### Additional Information

The new warning surfaced https://github.com/google/blockly/issues/4575