### PR TITLE
Fix serialization of workspace comment events and add tests

### DIFF
--- a/core/events/ws_comment_events.js
+++ b/core/events/ws_comment_events.js
@@ -137,7 +137,7 @@ Blockly.Events.CommentChange.prototype.toJson = function() {
  */
 Blockly.Events.CommentChange.prototype.fromJson = function(json) {
   Blockly.Events.CommentChange.superClass_.fromJson.call(this, json);
-  this.newContents_ = json['newValue'];
+  this.newContents_ = json['newContents'];
 };
 
 /**

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -438,7 +438,7 @@ suite('Events', function() {
     });
   });
 
-  suite.only('Serialization', function() {
+  suite('Serialization', function() {
     var safeStringify = (json) => {
       let cache = [];
       return JSON.stringify(json, (key, value) => {

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -593,7 +593,7 @@ suite('Events', function() {
           oldXml: '<shadow xmlns="https://developers.google.com/blockly/xml"' +
               ' type="simple_test_block" id="testBlockId2"></shadow>',
           ids: [thisObj.shadowBlock.id], recordUndo: false})},
-      // TODO(4577) Test serialization of move event coordinate properties.
+      // TODO(#4577) Test serialization of move event coordinate properties.
       {title: 'Block move', class: Blockly.Events.BlockMove,
         getArgs: (thisObj) => [thisObj.block],
         getExpectedJson: (thisObj) => ({type: 'move',
@@ -623,7 +623,7 @@ suite('Events', function() {
         getArgs: (thisObj) => [thisObj.comment],
         getExpectedJson: (thisObj) => ({type: 'comment_delete',
           commentId: thisObj.comment.id})},
-      // TODO(4577) Test serialization of move event coordinate properties.
+      // TODO(#4577) Test serialization of move event coordinate properties.
       {title: 'Comment move', class: Blockly.Events.CommentMove,
         getArgs: (thisObj) => [thisObj.comment],
         getExpectedJson: (thisObj) => ({type: 'comment_move',

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -438,7 +438,7 @@ suite('Events', function() {
     });
   });
 
-  suite('Serialization', function() {
+  suite.only('Serialization', function() {
     var safeStringify = (json) => {
       let cache = [];
       return JSON.stringify(json, (key, value) => {
@@ -593,6 +593,7 @@ suite('Events', function() {
           oldXml: '<shadow xmlns="https://developers.google.com/blockly/xml"' +
               ' type="simple_test_block" id="testBlockId2"></shadow>',
           ids: [thisObj.shadowBlock.id], recordUndo: false})},
+      // TODO(4577) Test serialization of move event coordinate properties.
       {title: 'Block move', class: Blockly.Events.BlockMove,
         getArgs: (thisObj) => [thisObj.block],
         getExpectedJson: (thisObj) => ({type: 'move',
@@ -601,6 +602,32 @@ suite('Events', function() {
         getArgs: (thisObj) => [thisObj.shadowBlock],
         getExpectedJson: (thisObj) => ({type: 'move',
           blockId: thisObj.shadowBlock.id, recordUndo: false})},
+    ];
+    var workspaceEventTestCases = [
+      {title: 'Finished Loading', class: Blockly.Events.FinishedLoading,
+        getArgs: (thisObj) => [thisObj.workspace],
+        getExpectedJson: (thisObj) => ({type: 'finished_loading',
+          workspaceId: thisObj.workspace.id})},
+    ];
+    var workspaceCommentEventTestCases = [
+      {title: 'Comment change', class: Blockly.Events.CommentChange,
+        getArgs: (thisObj) => [thisObj.comment, '', 'words'],
+        getExpectedJson: (thisObj) => ({type: 'comment_change',
+          commentId: thisObj.comment.id, newContents: 'words'})},
+      {title: 'Comment create', class: Blockly.Events.CommentCreate,
+        getArgs: (thisObj) => [thisObj.comment],
+        getExpectedJson: (thisObj) => ({type: 'comment_create',
+          commentId: thisObj.comment.id,
+          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())})},
+      {title: 'Comment delete', class: Blockly.Events.CommentDelete,
+        getArgs: (thisObj) => [thisObj.comment],
+        getExpectedJson: (thisObj) => ({type: 'comment_delete',
+          commentId: thisObj.comment.id})},
+      // TODO(4577) Test serialization of move event coordinate properties.
+      {title: 'Comment move', class: Blockly.Events.CommentMove,
+        getArgs: (thisObj) => [thisObj.comment],
+        getExpectedJson: (thisObj) => ({type: 'comment_move',
+          commentId: thisObj.comment.id})},
     ];
     var testSuites = [
       {title: 'Variable events', testCases: variableEventTestCases,
@@ -618,7 +645,16 @@ suite('Events', function() {
           thisObj.block = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock.setShadow(true);
-        }}
+        }},
+      {title: 'Workspace events',
+        testCases: workspaceEventTestCases,
+        setup: (_) => {}},
+      {title: 'WorkspaceComment events',
+        testCases: workspaceCommentEventTestCases,
+        setup: (thisObj) => {
+          thisObj.comment = new Blockly.WorkspaceComment(
+              thisObj.workspace, 'comment text', 0, 0, 'comment id');
+        }},
     ];
     testSuites.forEach((testSuite) => {
       suite(testSuite.title, function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4527
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Updates logic in serialization of methods of workspace comment events to be consistent.
- Adds tests for workspace comment events and finished loading event
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

- Workspace comment events were not serializing/deserializing properly.
- Tests are good.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Filed #4577 to track adding more complex tests for testing coordinate properties of move events (for block move and comment move).
<!-- Anything else we should know? -->
