### PR TITLE
Temporarily disable strict require compiler errors

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -74,7 +74,8 @@ var JSCOMP_ERROR = [
   'missingPolyfill',
   'missingProperties',
   'missingProvide',
-  'missingRequire',
+  // 'missingRequire', As of Jan 8 2020, this enables the strict require check.
+  // Disabling this until we have fixed all the require issues. 
   'missingReturn',
   // 'missingSourcesWarnings',
   'moduleLoad',

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -74,7 +74,7 @@ var JSCOMP_ERROR = [
   'missingPolyfill',
   'missingProperties',
   'missingProvide',
-  // 'missingRequire', As of Jan 8 2020, this enables the strict require check.
+  // 'missingRequire', As of Jan 8 2021, this enables the strict require check.
   // Disabling this until we have fixed all the require issues. 
   'missingReturn',
   // 'missingSourcesWarnings',


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

In preparation for https://github.com/google/blockly/pull/4580
Temporarily disable strict require compiler errors, as the new closure compiler uses `missingRequire` to flip them on.

### Proposed Changes

Temporarily disable strict require compiler errors until we have resolved the missing require checks in https://github.com/google/blockly/issues/4457

### Reason for Changes

Preparation for the new closure compiler update.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
