### PR TITLE
Refactor interpolate_ into multiple functions & remove direct new Field call

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1641,6 +1641,7 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
       case 'input_statement':
       case 'input_dummy':
         var input = this.inputFromJson_(element, warningPrefix);
+        // Should never be null, but just in case.
         if (input) {
           for (var j = 0, tuple; (tuple = fieldStack[j]); j++) {
             input.appendField(tuple[0], tuple[1]);
@@ -1658,6 +1659,14 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
   }
 };
 
+/**
+ * Validates that the tokens are within the correct bounds, with no duplicates,
+ * and that all of the arguments are referred to. Throws errors if any of these
+ * things are not true.
+ * @param {!Array<string|number>} tokens An array of tokens to validate
+ * @param {number} argsCount The number of args that need to be referred to.
+ * @private
+ */
 Blockly.Block.prototype.validateTokens_ = function(tokens, argsCount) {
   var visitedArgsHash = [];
   var visitedArgsCount = 0;
@@ -1683,6 +1692,18 @@ Blockly.Block.prototype.validateTokens_ = function(tokens, argsCount) {
   }
 };
 
+/**
+ * Inserts args in place of numerical tokens. String args are converted to json
+ * that defines a label field. If necessary an extra dummy input is added to
+ * the end of the elements.
+ * @param {!Array<!string|number>} tokens The tokens to interpolate
+ * @param {!Array<!Object|string>} args The arguments to insert.
+ * @param {string} lastDummyAlign The alignment the added dummy input should
+ *     have, if we are required to add one.
+ * @return {!Array<!Object>} The JSON definitions of field and inputs to add
+ *     to the block.
+ * @private
+ */
 Blockly.Block.prototype.interpolateArguments_ =
     function(tokens, args, lastDummyAlign) {
       var elements = [];
@@ -1716,6 +1737,16 @@ Blockly.Block.prototype.interpolateArguments_ =
       return elements;
     };
 
+/**
+ * Creates a field from the json definition of a field. If a field with the
+ * given type cannot be found, this attempts to create a different field using
+ * the 'alt' property of the json definition (if it exists).
+ * @param {{alt:(string|undefined)}} element The element to try to turn into a
+ *     field.
+ * @return {!Blockly.Field|null} The field defined by the JSON, or null if one
+ *     couldn't be created.
+ * @private
+ */
 Blockly.Block.prototype.fieldFromJson_ = function(element) {
   var field = Blockly.fieldRegistry.fromJson(element);
   if (!field && element['alt']) {
@@ -1728,6 +1759,16 @@ Blockly.Block.prototype.fieldFromJson_ = function(element) {
   return field;
 };
 
+/**
+ * Creates an input from the json definition of an input. Sets the input's check
+ * and alignment if they are provided.
+ * @param {!Object} element The JSON to turn into an input.
+ * @param {string} warningPrefix The prefix to add to warnings to help the
+ *     developer debug.
+ * @return {!Blockly.Input|null} The input that has been created, or null if one
+ *     could not be created for some reason (should never happen).
+ * @private
+ */
 Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
   var alignmentLookup = {
     'LEFT': Blockly.ALIGN_LEFT,
@@ -1748,6 +1789,7 @@ Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
       input = this.appendDummyInput(element['name']);
       break;
   }
+  // Should never be hit because of interpolate_'s checks, but just in case.
   if (!input) {
     return null;
   }
@@ -1767,6 +1809,13 @@ Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
   return input;
 };
 
+/**
+ * Turns a string into the JSON definition of a label field. If the string
+ * becomes an empty string when trimmed, this returns null.
+ * @param {string} str String to turn into the JSON definition of a label field.
+ * @return {null|{text: *, type: string}} The JSON definition or null.
+ * @private
+ */
 Blockly.Block.prototype.stringToFieldJson_ = function(str) {
   str = str.trim();
   if (str) {

--- a/core/block.js
+++ b/core/block.js
@@ -1743,7 +1743,7 @@ Blockly.Block.prototype.interpolateArguments_ =
  * the 'alt' property of the json definition (if it exists).
  * @param {{alt:(string|undefined)}} element The element to try to turn into a
  *     field.
- * @return {!Blockly.Field|null} The field defined by the JSON, or null if one
+ * @return {?Blockly.Field} The field defined by the JSON, or null if one
  *     couldn't be created.
  * @private
  */
@@ -1765,7 +1765,7 @@ Blockly.Block.prototype.fieldFromJson_ = function(element) {
  * @param {!Object} element The JSON to turn into an input.
  * @param {string} warningPrefix The prefix to add to warnings to help the
  *     developer debug.
- * @return {!Blockly.Input|null} The input that has been created, or null if one
+ * @return {?Blockly.Input} The input that has been created, or null if one
  *     could not be created for some reason (should never happen).
  * @private
  */
@@ -1813,7 +1813,7 @@ Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
  * Turns a string into the JSON definition of a label field. If the string
  * becomes an empty string when trimmed, this returns null.
  * @param {string} str String to turn into the JSON definition of a label field.
- * @return {null|{text: *, type: string}} The JSON definition or null.
+ * @return {?{text: string, type: string}} The JSON definition or null.
  * @private
  */
 Blockly.Block.prototype.stringToFieldJson_ = function(str) {

--- a/core/block.js
+++ b/core/block.js
@@ -1630,111 +1630,152 @@ Blockly.Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
 Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
     warningPrefix) {
   var tokens = Blockly.utils.tokenizeInterpolation(message);
-  // Interpolate the arguments.  Build a list of elements.
-  var indexDup = [];
-  var indexCount = 0;
-  var elements = [];
+  this.validateTokens_(tokens, args.length);
+  var elements = this.interpolateArguments_(tokens, args, lastDummyAlign);
+
+  // An array of [field, fieldName] tuples.
+  var fieldStack = [];
+  for (var i = 0, element; (element = elements[i]); i++) {
+    switch (element['type']) {
+      case 'input_value':
+      case 'input_statement':
+      case 'input_dummy':
+        var input = this.inputFromJson_(element, warningPrefix);
+        if (input) {
+          for (var j = 0, tuple; (tuple = fieldStack[j]); j++) {
+            input.appendField(tuple[0], tuple[1]);
+          }
+          fieldStack.length = 0;
+        }
+        break;
+      // All other types, including ones starting with 'input_' get routed here.
+      default:
+        var field = this.fieldFromJson_(element);
+        if (field) {
+          fieldStack.push([field, element['name']]);
+        }
+    }
+  }
+};
+
+Blockly.Block.prototype.validateTokens_ = function(tokens, argsCount) {
+  var visitedArgsHash = [];
+  var visitedArgsCount = 0;
   for (var i = 0; i < tokens.length; i++) {
     var token = tokens[i];
-    if (typeof token == 'number') {
-      if (token <= 0 || token > args.length) {
-        throw Error('Block "' + this.type + '": ' +
-            'Message index %' + token + ' out of range.');
-      }
-      if (indexDup[token]) {
-        throw Error('Block "' + this.type + '": ' +
-            'Message index %' + token + ' duplicated.');
-      }
-      indexDup[token] = true;
-      indexCount++;
-      elements.push(args[token - 1]);
-    } else {
-      token = token.trim();
-      if (token) {
-        elements.push(token);
-      }
+    if (typeof token != 'number') {
+      continue;
     }
+    if (token < 1 || token > argsCount) {
+      throw Error('Block "' + this.type + '": ' +
+          'Message index %' + token + ' out of range.');
+    }
+    if (visitedArgsHash[token]) {
+      throw Error('Block "' + this.type + '": ' +
+          'Message index %' + token + ' duplicated.');
+    }
+    visitedArgsHash[token] = true;
+    visitedArgsCount++;
   }
-  if (indexCount != args.length) {
+  if (visitedArgsCount != argsCount) {
     throw Error('Block "' + this.type + '": ' +
-        'Message does not reference all ' + args.length + ' arg(s).');
+        'Message does not reference all ' + argsCount + ' arg(s).');
   }
-  // Add last dummy input if needed.
-  if (elements.length && (typeof elements[elements.length - 1] == 'string' ||
-      Blockly.utils.string.startsWith(
-          elements[elements.length - 1]['type'], 'field_'))) {
-    var dummyInput = {type: 'input_dummy'};
-    if (lastDummyAlign) {
-      dummyInput['align'] = lastDummyAlign;
+};
+
+Blockly.Block.prototype.interpolateArguments_ =
+    function(tokens, args, lastDummyAlign) {
+      var elements = [];
+      for (var i = 0; i < tokens.length; i++) {
+        var element = tokens[i];
+        if (typeof element == 'number') {
+          element = args[element - 1];
+        }
+        // Args can be strings, which is why this isn't elseif.
+        if (typeof element == 'string') {
+          element = this.stringToFieldJson_(element);
+          if (!element) {
+            continue;
+          }
+        }
+        elements.push(element);
+      }
+
+      var length = elements.length;
+      var startsWith = Blockly.utils.string.startsWith;
+      // TODO: This matches the old behavior, but it doesn't work for fields
+      //   that don't start with 'field_'.
+      if (length && startsWith(elements[length - 1]['type'], 'field_')) {
+        var dummyInput = {'type': 'input_dummy'};
+        if (lastDummyAlign) {
+          dummyInput['align'] = lastDummyAlign;
+        }
+        elements.push(dummyInput);
+      }
+
+      return elements;
+    };
+
+Blockly.Block.prototype.fieldFromJson_ = function(element) {
+  var field = Blockly.fieldRegistry.fromJson(element);
+  if (!field && element['alt']) {
+    if (typeof element['alt'] == 'string') {
+      var json = this.stringToFieldJson_(element['alt']);
+      return json ? this.fieldFromJson_(json) : null;
     }
-    elements.push(dummyInput);
+    return this.fieldFromJson_(element['alt']);
   }
-  // Lookup of alignment constants.
+  return field;
+};
+
+Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
   var alignmentLookup = {
     'LEFT': Blockly.ALIGN_LEFT,
     'RIGHT': Blockly.ALIGN_RIGHT,
     'CENTRE': Blockly.ALIGN_CENTRE,
     'CENTER': Blockly.ALIGN_CENTRE
   };
-  // Populate block with inputs and fields.
-  var fieldStack = [];
-  for (var i = 0; i < elements.length; i++) {
-    var element = elements[i];
-    if (typeof element == 'string') {
-      fieldStack.push([element, undefined]);
-    } else {
-      var field = null;
-      var input = null;
-      do {
-        var altRepeat = false;
-        if (typeof element == 'string') {
-          field = new Blockly.FieldLabel(element);
-        } else {
-          switch (element['type']) {
-            case 'input_value':
-              input = this.appendValueInput(element['name']);
-              break;
-            case 'input_statement':
-              input = this.appendStatementInput(element['name']);
-              break;
-            case 'input_dummy':
-              input = this.appendDummyInput(element['name']);
-              break;
-            default:
-              // This should handle all field JSON parsing, including
-              // options that can be applied to any field type.
-              field = Blockly.fieldRegistry.fromJson(element);
 
-              // Unknown field.
-              if (!field && element['alt']) {
-                element = element['alt'];
-                altRepeat = true;
-              }
-          }
-        }
-      } while (altRepeat);
-      if (field) {
-        fieldStack.push([field, element['name']]);
-      } else if (input) {
-        if (element['check']) {
-          input.setCheck(element['check']);
-        }
-        if (element['align']) {
-          var alignment = alignmentLookup[element['align'].toUpperCase()];
-          if (alignment === undefined) {
-            console.warn(warningPrefix + 'Illegal align value: ',
-                element['align']);
-          } else {
-            input.setAlign(alignment);
-          }
-        }
-        for (var j = 0; j < fieldStack.length; j++) {
-          input.appendField(fieldStack[j][0], fieldStack[j][1]);
-        }
-        fieldStack.length = 0;
-      }
+  var input = null;
+  switch (element['type']) {
+    case 'input_value':
+      input = this.appendValueInput(element['name']);
+      break;
+    case 'input_statement':
+      input = this.appendStatementInput(element['name']);
+      break;
+    case 'input_dummy':
+      input = this.appendDummyInput(element['name']);
+      break;
+  }
+  if (!input) {
+    return null;
+  }
+
+  if (element['check']) {
+    input.setCheck(element['check']);
+  }
+  if (element['align']) {
+    var alignment = alignmentLookup[element['align'].toUpperCase()];
+    if (alignment === undefined) {
+      console.warn(warningPrefix + 'Illegal align value: ',
+          element['align']);
+    } else {
+      input.setAlign(alignment);
     }
   }
+  return input;
+};
+
+Blockly.Block.prototype.stringToFieldJson_ = function(str) {
+  str = str.trim();
+  if (str) {
+    return {
+      'type': 'field_label',
+      'text': str,
+    };
+  }
+  return null;
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -1698,8 +1698,8 @@ Blockly.Block.prototype.validateTokens_ = function(tokens, argsCount) {
  * the end of the elements.
  * @param {!Array<!string|number>} tokens The tokens to interpolate
  * @param {!Array<!Object|string>} args The arguments to insert.
- * @param {string} lastDummyAlign The alignment the added dummy input should
- *     have, if we are required to add one.
+ * @param {string|undefined} lastDummyAlign The alignment the added dummy input
+ *     should have, if we are required to add one.
  * @return {!Array<!Object>} The JSON definitions of field and inputs to add
  *     to the block.
  * @private

--- a/package-lock.json
+++ b/package-lock.json
@@ -8173,7 +8173,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -8396,6 +8396,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "typescript-closure-tools": {
       "version": "0.0.7",

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -217,6 +217,25 @@ suite('Block JSON initialization', function() {
           ]);
     });
 
+    test.skip('Add last dummy for no_field_prefix_field', function() {
+      this.assertInterpolation(
+          [
+            {
+              'type': 'no_field_prefix_field',
+            }
+          ],
+          [],
+          undefined,
+          [
+            {
+              'type': 'no_field_prefix_field',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
     test('Set last dummy alignment', function() {
       this.assertInterpolation(
           ['test1', 'test2', 'test3'],

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -1,0 +1,563 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+suite('Block JSON initialization', function() {
+  suite('validateTokens_', function() {
+    setup(function() {
+      this.assertError = function(tokens, count, error) {
+        var block = {
+          type: 'test',
+          validateTokens_: Blockly.Block.prototype.validateTokens_,
+        };
+        chai.assert.throws(function() {
+          block.validateTokens_(tokens, count);
+        }, error);
+      };
+
+      this.assertNoError = function(tokens, count) {
+        var block = {
+          type: 'test',
+          validateTokens_: Blockly.Block.prototype.validateTokens_,
+        };
+        chai.assert.doesNotThrow(function() {
+          block.validateTokens_(tokens, count);
+        });
+      };
+    });
+
+    test('0 args, 0 tokens', function() {
+      this.assertNoError(['test', 'test'], 0);
+    });
+
+    test('0 args, 1 token', function() {
+      this.assertError(['test', 1, 'test'], 0,
+          'Block "test": Message index %1 out of range.');
+    });
+
+    test('1 arg, 0 tokens', function() {
+      this.assertError(['test', 'test'], 1,
+          'Block "test": Message does not reference all 1 arg(s).');
+    });
+
+    test('1 arg, 1 token', function() {
+      this.assertNoError(['test', 1, 'test'], 1);
+    });
+
+    test('1 arg, 2 tokens', function() {
+      this.assertError(['test', 1, 1, 'test'], 1,
+          'Block "test": Message index %1 duplicated.');
+    });
+
+    test('Token out of lower bound', function() {
+      this.assertError(['test', 0, 'test'], 1,
+          'Block "test": Message index %0 out of range.');
+    });
+
+    test('Token out of upper bound', function() {
+      this.assertError(['test', 2, 'test'], 1,
+          'Block "test": Message index %2 out of range.');
+    });
+  });
+
+  suite('interpolateArguments_', function() {
+    setup(function() {
+      this.assertInterpolation = function(tokens, args, lastAlign, elements) {
+        var block = {
+          type: 'test',
+          interpolateArguments_: Blockly.Block.prototype.interpolateArguments_,
+          stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
+        };
+        chai.assert.deepEqual(
+            block.interpolateArguments_(tokens, args, lastAlign),
+            elements);
+      };
+    });
+
+    test('Strings to labels', function() {
+      this.assertInterpolation(
+          ['test1', 'test2', 'test3', { 'type': 'input_dummy'}],
+          [],
+          undefined,
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test2',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test3',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Ignore empty strings', function() {
+      this.assertInterpolation(
+          ['test1', '', '    ', { 'type': 'input_dummy'}],
+          [],
+          undefined,
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Insert args', function() {
+      this.assertInterpolation(
+          [1, 2, 3, { 'type': 'input_dummy'}],
+          [
+            {
+              'type': 'field_number',
+              'name': 'test1',
+            },
+            {
+              'type': 'field_number',
+              'name': 'test2',
+            },
+            {
+              'type': 'field_number',
+              'name': 'test3',
+            },
+          ],
+          undefined,
+          [
+            {
+              'type': 'field_number',
+              'name': 'test1',
+            },
+            {
+              'type': 'field_number',
+              'name': 'test2',
+            },
+            {
+              'type': 'field_number',
+              'name': 'test3',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('String args to labels', function() {
+      this.assertInterpolation(
+          [1, 2, 3, { 'type': 'input_dummy'}],
+          ['test1', 'test2', 'test3'],
+          undefined,
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test2',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test3',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Ignore empty string args', function() {
+      this.assertInterpolation(
+          [1, 2, 3, { 'type': 'input_dummy'}],
+          ['test1', '     ', '     '],
+          undefined,
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Add last dummy', function() {
+      this.assertInterpolation(
+          ['test1', 'test2', 'test3'],
+          [],
+          undefined,
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test2',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test3',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Set last dummy alignment', function() {
+      this.assertInterpolation(
+          ['test1', 'test2', 'test3'],
+          [],
+          'CENTER',
+          [
+            {
+              'type': 'field_label',
+              'text': 'test1',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test2',
+            },
+            {
+              'type': 'field_label',
+              'text': 'test3',
+            },
+            {
+              'type': 'input_dummy',
+              'align': 'CENTER',
+            }
+          ]);
+    });
+  });
+
+  suite('fieldFromJson_', function() {
+    setup(function() {
+      this.stub = sinon.stub(Blockly.fieldRegistry, 'fromJson')
+          .callsFake(function(elem) {
+            switch (elem['type']) {
+              case 'field_label':
+                return 'field_label';
+              case 'field_number':
+                return 'field_number';
+              case 'no_field_prefix_field':
+                return 'no_field_prefix_field';
+              case 'input_prefix_field':
+                return 'input_prefix_field';
+              default:
+                return null;
+            }
+          });
+
+      this.assertField = function(json, expectedType) {
+        var block = {
+          type: 'test',
+          fieldFromJson_: Blockly.Block.prototype.fieldFromJson_,
+          stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
+        };
+        chai.assert.strictEqual(block.fieldFromJson_(json), expectedType);
+      };
+    });
+
+    teardown(function() {
+      this.stub.restore();
+    });
+
+    test('Simple field', function() {
+      this.assertField({
+        'type': 'field_label',
+        'text': 'text',
+      }, 'field_label');
+    });
+
+    test('Bad field', function() {
+      this.assertField({
+        'type': 'field_bad',
+      }, null);
+    });
+
+    test('no_field_prefix_field', function() {
+      this.assertField({
+        'type': 'no_field_prefix_field',
+      }, 'no_field_prefix_field');
+    });
+
+    test('input_prefix_field', function() {
+      this.assertField({
+        'type': 'input_prefix_field',
+      }, 'input_prefix_field');
+    });
+
+    test('Alt string', function() {
+      this.assertField({
+        'type': 'field_undefined',
+        'alt': 'alt text',
+      }, 'field_label');
+    });
+
+    test('input_prefix_bad w/ alt string', function() {
+      this.assertField({
+        'type': 'input_prefix_bad',
+        'alt': 'alt string',
+      }, 'field_label');
+    });
+
+    test('Alt other field', function() {
+      this.assertField({
+        'type': 'field_undefined',
+        'alt': {
+          'type': 'field_number',
+          'name': 'FIELDNAME'
+        },
+      }, 'field_number');
+    });
+
+    test('Deep alt string', function() {
+      this.assertField({
+        'type': 'field_undefined1',
+        'alt': {
+          'type': 'field_undefined2',
+          'alt': {
+            'type': 'field_undefined3',
+            'alt': {
+              'type': 'field_undefined4',
+              'alt': {
+                'type': 'field_undefined5',
+                'alt': 'text',
+              },
+            },
+          },
+        },
+      }, 'field_label');
+    });
+
+    test('Deep alt other field', function() {
+      this.assertField({
+        'type': 'field_undefined1',
+        'alt': {
+          'type': 'field_undefined2',
+          'alt': {
+            'type': 'field_undefined3',
+            'alt': {
+              'type': 'field_undefined4',
+              'alt': {
+                'type': 'field_undefined5',
+                'alt': {
+                  'type': 'field_number',
+                  'name': 'FIELDNAME'
+                },
+              },
+            },
+          },
+        },
+      }, 'field_number');
+    });
+
+    test('No alt', function() {
+      this.assertField({
+        'type': 'field_undefined'
+      }, null);
+    });
+
+    test('Bad alt', function() {
+      this.assertField({
+        'type': 'field_undefined',
+        'alt': {
+          'type': 'field_undefined',
+        }
+      }, null);
+    });
+
+    test('Spaces string alt', function() {
+      this.assertField({
+        'type': 'field_undefined',
+        'alt': '        ',
+      }, null);
+    });
+  });
+
+  suite('inputFromJson_', function() {
+    setup(function() {
+      var Input = function(type) {
+        this.type = type;
+        this.setCheck = sinon.fake();
+        this.setAlign = sinon.fake();
+      };
+      var Block = function() {
+        this.type = 'test';
+        this.appendDummyInput = sinon.fake.returns(new Input());
+        this.appendValueInput = sinon.fake.returns(new Input());
+        this.appendStatementInput = sinon.fake.returns(new Input());
+        this.inputFromJson_ = Blockly.Block.prototype.inputFromJson_;
+      };
+
+      this.assertInput = function(json, type, check, align) {
+        var block = new Block();
+        var input = block.inputFromJson_(json);
+        switch (type) {
+          case 'input_dummy':
+            chai.assert.isTrue(block.appendDummyInput.calledOnce,
+                'Expected a dummy input to be created.');
+            break;
+          case 'input_value':
+            chai.assert.isTrue(block.appendValueInput.calledOnce,
+                'Expected a value input to be created.');
+            break;
+          case 'input_statement':
+            chai.assert.isTrue(block.appendStatementInput.calledOnce,
+                'Expected a statement input to be created.');
+            break;
+          default:
+            chai.assert.isNull(input, 'Expected input to be null');
+            chai.assert.isTrue(block.appendDummyInput.notCalled,
+                'Expected no input to be created');
+            chai.assert.isTrue(block.appendValueInput.notCalled,
+                'Expected no input to be created');
+            chai.assert.isTrue(block.appendStatementInput.notCalled,
+                'Expected no input to be created');
+            return;
+        }
+        if (check) {
+          chai.assert.isTrue(input.setCheck.calledWith(check),
+              'Expected setCheck to be called with', check);
+        } else {
+          chai.assert.isTrue(input.setCheck.notCalled,
+              'Expected setCheck to not be called');
+        }
+        if (align !== undefined) {
+          chai.assert.isTrue(input.setAlign.calledWith(align),
+              'Expected setAlign to be called with', align);
+        } else {
+          chai.assert.isTrue(input.setAlign.notCalled,
+              'Expected setAlign to not be called');
+        }
+      };
+    });
+
+    test('Dummy', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+          },
+          'input_dummy');
+    });
+
+    test('Value', function() {
+      this.assertInput(
+          {
+            'type': 'input_value',
+          },
+          'input_value');
+    });
+
+    test('Statement', function() {
+      this.assertInput(
+          {
+            'type': 'input_statement',
+          },
+          'input_statement');
+    });
+
+    test('Bad input type', function() {
+      this.assertInput(
+          {
+            'type': 'input_bad',
+          },
+          'input_bad');
+    });
+
+    test('String Check', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'check': 'Integer'
+          },
+          'input_dummy',
+          'Integer');
+    });
+
+    test('Array check', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'check': ['Integer', 'Number']
+          },
+          'input_dummy',
+          ['Integer', 'Number']);
+    });
+
+    test('Empty check', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'check': ''
+          },
+          'input_dummy');
+    });
+
+    test('Null check', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'check': null,
+          },
+          'input_dummy');
+    });
+
+    test('"Left" align', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'align': 'LEFT',
+          },
+          'input_dummy',
+          undefined,
+          Blockly.ALIGN_LEFT);
+    });
+
+    test('"Right" align', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'align': 'RIGHT',
+          },
+          'input_dummy',
+          undefined,
+          Blockly.ALIGN_RIGHT);
+    });
+
+    test('"Center" align', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'align': 'CENTER',
+          },
+          'input_dummy',
+          undefined,
+          Blockly.ALIGN_CENTRE);
+    });
+
+    test('"Centre" align', function() {
+      this.assertInput(
+          {
+            'type': 'input_dummy',
+            'align': 'CENTRE',
+          },
+          'input_dummy',
+          undefined,
+          Blockly.ALIGN_CENTRE);
+    });
+  });
+});

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -52,6 +52,7 @@
     <script src="toolbox_helper.js"></script>
 
     <script src="astnode_test.js"></script>
+    <script src="block_json_test.js"></script>
     <script src="block_test.js"></script>
     <script src="comment_test.js"></script>
     <script src="connection_db_test.js"></script>

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -23,45 +23,54 @@ suite('Utils', function() {
   });
 
   suite('tokenizeInterpolation', function() {
-    setup(function() {
-      this.assertInterpolation = function(string, tokens) {
-        chai.assert.deepEqual(
-            Blockly.utils.tokenizeInterpolation(string), tokens);
-      };
-    });
-
     suite('Basic', function() {
       test('Empty string', function() {
-        this.assertInterpolation('', []);
+        chai.assert.deepEqual(Blockly.utils.tokenizeInterpolation(''), []);
       });
 
       test('No interpolation', function() {
-        this.assertInterpolation('Hello', ['Hello']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('Hello'), ['Hello']);
       });
 
       test('Unescaped %', function() {
-        this.assertInterpolation('Hello%World', ['Hello%World']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('Hello%World'),
+            ['Hello%World']);
       });
 
-      test('Escaped percent', function() {
-        this.assertInterpolation('Hello%%World', ['Hello%World']);
+      test('Escaped %', function() {
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('Hello%%World'),
+            ['Hello%World']);
       });
     });
 
     suite('Number interpolation', function() {
       test('Single-digit number interpolation', function() {
-        this.assertInterpolation('Hello%1World', ['Hello', 1, 'World']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('Hello%1World'),
+            ['Hello', 1, 'World']);
       });
 
       test('Multi-digit number interpolation', function() {
-        this.assertInterpolation(
-            '%123Hello%456World%789', [123, 'Hello', 456, 'World', 789]);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%123Hello%456World%789'),
+            [123, 'Hello', 456, 'World', 789]);
+      });
+
+      test('Escaped number', function() {
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('Hello %%1 World'),
+            ['Hello %1 World']);
       });
 
       test('Crazy interpolation', function() {
         // No idea what this is supposed to tell you if it breaks. But might
         // as well keep it.
-        this.assertInterpolation('%%%x%%0%00%01%', ['%%x%0', 0, 1, '%']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%%%x%%0%00%01%'),
+            ['%%x%0', 0, 1, '%']);
       });
     });
 
@@ -72,74 +81,100 @@ suite('Utils', function() {
 
       test('Simple interpolation', function() {
         Blockly.Msg.STRING_REF = 'test string';
-        this.assertInterpolation('%{bky_string_ref}', ['test string']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_string_ref}'),
+            ['test string']);
       });
 
       test('Case', function() {
         Blockly.Msg.STRING_REF = 'test string';
-        this.assertInterpolation('%{BkY_StRiNg_ReF}', ['test string']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{BkY_StRiNg_ReF}'),
+            ['test string']);
       });
 
       test('Surrounding text', function() {
         Blockly.Msg.STRING_REF = 'test string';
-        this.assertInterpolation(
-            'before %{bky_string_ref} after', ['before test string after']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation(
+                'before %{bky_string_ref} after'),
+            ['before test string after']);
       });
 
       test('With param', function() {
         Blockly.Msg.WITH_PARAM = 'before %1 after';
-        this.assertInterpolation('%{bky_with_param}', ['before ', 1, ' after']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_with_param}'),
+            ['before ', 1, ' after']);
       });
 
       test('Recursive reference', function() {
         Blockly.Msg.STRING_REF = 'test string';
         Blockly.Msg.RECURSE = 'before %{bky_string_ref} after';
-        this.assertInterpolation(
-            '%{bky_recurse}', ['before test string after']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_recurse}'),
+            ['before test string after']);
       });
 
       test('Number reference', function() {
         Blockly.Msg['1'] = 'test string';
-        this.assertInterpolation('%{bky_1}', ['test string']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_1}'), ['test string']);
       });
 
       test('Undefined reference', function() {
-        this.assertInterpolation('%{bky_undefined}', ['%{bky_undefined}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_undefined}'),
+            ['%{bky_undefined}']);
       });
 
       test('Not prefixed', function() {
         Blockly.Msg.STRING_REF = 'test string';
-        this.assertInterpolation('%{string_ref}', ['%{string_ref}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{string_ref}'),
+            ['%{string_ref}']);
       });
 
       test('Not prefixed, number', function() {
         Blockly.Msg['1'] = 'test string';
-        this.assertInterpolation('%{1}', ['%{1}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{1}'),
+            ['%{1}']);
       });
 
       test('Space in ref', function() {
         Blockly.Msg['string ref'] = 'test string';
-        this.assertInterpolation('%{bky_string ref}', ['%{bky_string ref}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_string ref}'),
+            ['%{bky_string ref}']);
       });
 
       test('Dash in ref', function() {
         Blockly.Msg['string-ref'] = 'test string';
-        this.assertInterpolation('%{bky_string-ref}', ['%{bky_string-ref}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_string-ref}'),
+            ['%{bky_string-ref}']);
       });
 
       test('Period in ref', function() {
         Blockly.Msg['string.ref'] = 'test string';
-        this.assertInterpolation('%{bky_string.ref}', ['%{bky_string.ref}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_string.ref}'),
+            ['%{bky_string.ref}']);
       });
 
       test('Ampersand in ref', function() {
         Blockly.Msg['string&ref'] = 'test string';
-        this.assertInterpolation('%{bky_string&ref}', ['%{bky_string&ref}']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_string&ref}'),
+            ['%{bky_string&ref}']);
       });
 
       test('Unclosed reference', function() {
         Blockly.Msg.UNCLOSED = 'test string';
-        this.assertInterpolation('%{bky_unclosed', ['%{bky_unclosed']);
+        chai.assert.deepEqual(
+            Blockly.utils.tokenizeInterpolation('%{bky_unclosed'),
+            ['%{bky_unclosed']);
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #4575

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Refactors the interpolate_ function to be more testable and consistent. Removes the call to new Blockly.FieldLabel() in the process.

This PR breaks the interpolate_ function into 5 new functions, so that each piece can be tested individually:
  * validateTokens_(): Ensures that all of the args are referenced, that all references are in the correct range, and that there are no duplicate references.
  * interpolateArgs_(): Replaces all arg references and strings with field/input json definitions. This means that `interpolate_` can invariantly expect all elements of the `elements` array to be objects, which simplifies the logic in `interpolate_` greatly.
  * inputFromJson_(): Appends an input to the block and returns it, given a json representation of an input. 
  * fieldFromJson_(): Returns a field instance given a json representation of a field. Note that every element whose type is not one of the hard-coded input types gets routed here. In the case that a field of the given `element['type']` is not registered it calls, itself recursively with the `element['alt']` value to try to create a field. If a field cannot be created, this returns null.
  * stringToFieldJson_(): Returns a JSON representation of a label field, with the given string as its text. If when `trim()`ed the string evaluates to an empty string, this returns null. The null value works its way back up to `interpolate_` where the element is ignored.

### Reason for Changes

After looking at #4575 I realized that the `interpolate_` function could use some serious cleanup.

Firstly the original function was very hard to read. For example the original call pointed out by the issue isn't even the real place that strings were being handled. That location was only handling strings in `'alt'` properties. Normally strings were being handled by [input.insertFieldAt](https://github.com/google/blockly/blob/edd475f37b02888819b87ddfca1d6eeebe68898a/core/input.js#L103) (which still needs to be fixed) via the logic [here](https://github.com/google/blockly/blob/edd475f37b02888819b87ddfca1d6eeebe68898a/core/block.js#L1677) and [here](https://github.com/google/blockly/blob/edd475f37b02888819b87ddfca1d6eeebe68898a/core/block.js#L1725). This is just one example of the logic being messy, but the whole thing was basically a rats-nest of nesting that needed to be detangled.

And secondly, the entire function was based on changing state, which made it very hard to test. Breaking the large function up in to smaller stateless functions makes it unit-testable.

### Breaking Changes

I did an intense review over two days to make sure I didn't make any changes that would break block initialization unintentionally.

Here is a list of the things I *intentionally* broke:
1) **You can no longer create inputs as alts.** I believe this is fine because the [documentation](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#args) only refers to fields as alts, not inputs, so there is no "contract" between us and the developer to support this.
```
  {
    'type': 'test1',
    'message0': 'test: %1',
    'args0': [
      {
        'type': 'field_undefined',
        'alt': {
          'type': 'input_value',
          'name': 'ALT_INPUT'
        },
      }
    ]
  },
```

Before:
![alt-input](https://user-images.githubusercontent.com/25440652/104391181-34d41600-54f4-11eb-8afb-19bd3c22ff5f.png)

After:
![no-alt-input](https://user-images.githubusercontent.com/25440652/104391187-38679d00-54f4-11eb-8146-f11937abee2e.png)


2) **String args are now trimmed.** I believe this is fine because it makes them more consistent with normal strings in the message.

```
  {
    'type': 'test2',
    'message0': 'test: %1',
    'args0': [
      '    arg string    '
    ]
  },
```

Before:
![string-no-trimming](https://user-images.githubusercontent.com/25440652/104390609-f9851780-54f2-11eb-8301-247e59b40a2c.png)

After:
![string-trimming](https://user-images.githubusercontent.com/25440652/104390647-07d33380-54f3-11eb-9c3e-8c8807c4dccb.png)

3) **If a string arg evaluates to the null string after being trimmed it is ignored.** Again this aids in consistency.
```
  {
    'type': 'test3',
    'message0': 'test: %1',
    'args0': [
      '        '
    ]
  },
```

Before:
![string-no-eliminating](https://user-images.githubusercontent.com/25440652/104390663-0f92d800-54f3-11eb-85f6-b61d89d7bf7a.png)

After:
![string-eliminating](https://user-images.githubusercontent.com/25440652/104390704-26d1c580-54f3-11eb-86e9-be1041923673.png)

4) **Field alt strings are now trimmed.** Again this aids in consistency.
```
  {
    'type': 'test4',
    'message0': 'test: %1',
    'args0': [
      {
        'type': 'field_undefined',
        'alt': '    arg string    ',
      }
    ]
  },
```

Before:
![alt-no-trimming](https://user-images.githubusercontent.com/25440652/104391233-5208e480-54f4-11eb-96cd-deaec113f341.png)

After:
![alt-trimming](https://user-images.githubusercontent.com/25440652/104391245-57662f00-54f4-11eb-96ef-7a563ad5a22f.png)

5) **If a field alt string evaluates to the null string after being trimmed it is ignored.** Again this aids in consistency.
```
  {
    'type': 'test5',
    'message0': 'test: %1',
    'args0': [
      {
        'type': 'field_undefined',
        'alt': '        ',
      }
    ]
  }
```

Before:
![alt-no-eliminating](https://user-images.githubusercontent.com/25440652/104391254-5cc37980-54f4-11eb-97cd-495ee864660c.png)

After:
![alt-eliminating](https://user-images.githubusercontent.com/25440652/104391267-62b95a80-54f4-11eb-8a16-57f7c19fbc6f.png)

6) **The call to new Blockly.FieldLabel() has been removed.** This was the intention of the original issue, but could cause problems if someone is relying on this behavior to get the default label implementation instead of their custom one in the case of an alt-field specifically. However I believe this is fine because that use-case is extremely unlikely.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
I wrote tests for all of the new functions, excepting stringToFieldJson, because that is covered by the other tests =)

I also went through all the test blocks and built-in blocks and made sure they intialized themselves correctly.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

There is still a call in [insertFieldAt](https://github.com/google/blockly/blob/edd475f37b02888819b87ddfca1d6eeebe68898a/core/input.js#L103) that needs to be changed to use the field registry.

There is a bug where registered fields that don't begin with the `'field_'` prefix will not make the block add a dummy input at the end of the block. This obviously isn't affecting anyone currently, because they would have figured it out when their fields didn't show up, but it would be good to fix. I've created a skipped test to document this.
