### PR TITLE
Update appengine_tasks to include playground dependencies

### DIFF
--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -62,7 +62,7 @@ function copyPlaygroundDeps() {
       './node_modules/@blockly/theme-modern/dist/index.js',
       './node_modules/@blockly/block-test/dist/index.js',
   ];
-  return gulp.src(playgroundDeps).pipe(gulp.dest(demoStaticTmpDir));
+  return gulp.src(playgroundDeps, {base: '.'}).pipe(gulp.dest(demoStaticTmpDir));
 }
 
 /**

--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -54,6 +54,18 @@ function copyAppengineSrc() {
 }
 
 /**
+ * Copies playground deps into deploy directory.
+ */
+function copyPlaygroundDeps() {
+  const playgroundDeps = [
+      './node_modules/@blockly/dev-tools/dist/index.js',
+      './node_modules/@blockly/theme-modern/dist/index.js',
+      './node_modules/@blockly/block-test/dist/index.js',
+  ];
+  return gulp.src(playgroundDeps).pipe(gulp.dest(demoStaticTmpDir));
+}
+
+/**
  * Deploys files from tmp directory to appengine to version based on the version
  * specified in package.json and then cleans the tmp directory.
  */
@@ -82,6 +94,7 @@ const deployDemos = gulp.series(
     prepareDeployDir,
     copyStaticSrc,
     copyAppengineSrc,
+    copyPlaygroundDeps,
     deployAndClean
 );
 


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/4567

### Proposed Changes

Include playground deps from node_modules in the set of files deployed to appengine.

### Reason for Changes

Fix deployed playgrounds.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
