### PR TITLE
Remove last FieldLabel call and fix adding dummy inputs to json

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1635,25 +1635,21 @@ Blockly.Block.prototype.interpolate_ = function(message, args, lastDummyAlign,
   // An array of [field, fieldName] tuples.
   var fieldStack = [];
   for (var i = 0, element; (element = elements[i]); i++) {
-    switch (element['type']) {
-      case 'input_value':
-      case 'input_statement':
-      case 'input_dummy':
-        var input = this.inputFromJson_(element, warningPrefix);
-        // Should never be null, but just in case.
-        if (input) {
-          for (var j = 0, tuple; (tuple = fieldStack[j]); j++) {
-            input.appendField(tuple[0], tuple[1]);
-          }
-          fieldStack.length = 0;
+    if (this.isInputKeyword_(element['type'])) {
+      var input = this.inputFromJson_(element, warningPrefix);
+      // Should never be null, but just in case.
+      if (input) {
+        for (var j = 0, tuple; (tuple = fieldStack[j]); j++) {
+          input.appendField(tuple[0], tuple[1]);
         }
-        break;
+        fieldStack.length = 0;
+      }
+    } else {
       // All other types, including ones starting with 'input_' get routed here.
-      default:
-        var field = this.fieldFromJson_(element);
-        if (field) {
-          fieldStack.push([field, element['name']]);
-        }
+      var field = this.fieldFromJson_(element);
+      if (field) {
+        fieldStack.push([field, element['name']]);
+      }
     }
   }
 };
@@ -1722,10 +1718,7 @@ Blockly.Block.prototype.interpolateArguments_ =
       }
 
       var length = elements.length;
-      var startsWith = Blockly.utils.string.startsWith;
-      // TODO: This matches the old behavior, but it doesn't work for fields
-      //   that don't start with 'field_'.
-      if (length && startsWith(elements[length - 1]['type'], 'field_')) {
+      if (length && !this.isInputKeyword_(elements[length - 1]['type'])) {
         var dummyInput = {'type': 'input_dummy'};
         if (lastDummyAlign) {
           dummyInput['align'] = lastDummyAlign;
@@ -1806,6 +1799,19 @@ Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
     }
   }
   return input;
+};
+
+/**
+ * Returns true if the given string matches one of the input keywords.
+ * @param {string} str The string to check.
+ * @return {boolean} True if the given string matches one of the input keywords,
+ *     false otherwise.
+ * @private
+ */
+Blockly.Block.prototype.isInputKeyword_ = function(str) {
+  return str == 'input_value' ||
+      str == 'input_statement' ||
+      str == 'input_dummy';
 };
 
 /**

--- a/core/input.js
+++ b/core/input.js
@@ -100,10 +100,10 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
 
   // Generate a FieldLabel when given a plain text field.
   if (typeof field == 'string') {
-    field = Blockly.fieldRegistry.fromJson({
+    field = /** @type {!Blockly.Field} **/ (Blockly.fieldRegistry.fromJson({
       'type': 'field_label',
       'text': field,
-    });
+    }));
   }
 
   field.setSourceBlock(this.sourceBlock_);

--- a/core/input.js
+++ b/core/input.js
@@ -14,7 +14,7 @@ goog.provide('Blockly.Input');
 
 goog.require('Blockly.Connection');
 goog.require('Blockly.constants');
-goog.require('Blockly.FieldLabel');
+goog.require('Blockly.fieldRegistry');
 
 
 /**
@@ -100,7 +100,10 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
 
   // Generate a FieldLabel when given a plain text field.
   if (typeof field == 'string') {
-    field = new Blockly.FieldLabel(/** @type {string} */ (field));
+    field = new Blockly.fieldRegistry.fromJson({
+      'type': 'field_label',
+      'text': field,
+    });
   }
 
   field.setSourceBlock(this.sourceBlock_);

--- a/core/input.js
+++ b/core/input.js
@@ -100,7 +100,7 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
 
   // Generate a FieldLabel when given a plain text field.
   if (typeof field == 'string') {
-    field = new Blockly.fieldRegistry.fromJson({
+    field = Blockly.fieldRegistry.fromJson({
       'type': 'field_label',
       'text': field,
     });

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -69,6 +69,7 @@ suite('Block JSON initialization', function() {
           type: 'test',
           interpolateArguments_: Blockly.Block.prototype.interpolateArguments_,
           stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
+          isInputKeyword_: Blockly.Block.prototype.isInputKeyword_,
         };
         chai.assert.deepEqual(
             block.interpolateArguments_(tokens, args, lastAlign),
@@ -217,7 +218,7 @@ suite('Block JSON initialization', function() {
           ]);
     });
 
-    test.skip('Add last dummy for no_field_prefix_field', function() {
+    test('Add last dummy for no_field_prefix_field', function() {
       this.assertInterpolation(
           [
             {
@@ -229,6 +230,25 @@ suite('Block JSON initialization', function() {
           [
             {
               'type': 'no_field_prefix_field',
+            },
+            {
+              'type': 'input_dummy',
+            }
+          ]);
+    });
+
+    test('Add last dummy for input_prefix_field', function() {
+      this.assertInterpolation(
+          [
+            {
+              'type': 'input_prefix_field',
+            }
+          ],
+          [],
+          undefined,
+          [
+            {
+              'type': 'input_prefix_field',
             },
             {
               'type': 'input_dummy',

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -57,6 +57,16 @@ suite('Inputs', function() {
         this.dummy.insertFieldAt(0, 'field');
         chai.assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldLabel);
       });
+      test('String w/ field_label overwritten', function() {
+        Blockly.fieldRegistry.unregister('field_label');
+        Blockly.fieldRegistry.register('field_label', Blockly.FieldNumber);
+
+        this.dummy.insertFieldAt(0, '1');
+        chai.assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldNumber);
+
+        Blockly.fieldRegistry.unregister('field_label');
+        Blockly.fieldRegistry.register('field_label', Blockly.FieldLabel);
+      });
       test('Empty String', function() {
         this.dummy.insertFieldAt(0, '');
         chai.assert.isEmpty(this.dummy.fieldRow);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #4575 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1) Changes input.insertFieldAt to use the field registry.
2) Fixes last dummy inputs only being added for fields where the key is prefixed with 'field_'

Changes are kept in separate commits to make reviewing easier =)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) Using the registry allows people to override the default field for strings, as referenced in #4575 
2) Not all fields are prefixed with 'field_' but we should add the last dummy input regardless.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Most of the tests were already written :D But for insertFieldAt I made a test to make sure if field_label gets overwritten in the registry, the new field gets used. And for interpolation I added a test that fields prefixed with input_ also force dummy inputs to be created.

Again, I went through and checked all of the core blocks and test blocks to make sure they get created correctly.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
