### PR TITLE
Renderer requires and requireTypes

### DIFF
--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -19,6 +19,9 @@ goog.provide('Blockly.blockRendering');
 goog.require('Blockly.registry');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.Renderer');
+goog.requireType('Blockly.Theme');
+
 
 /**
  * Whether or not the debugger is turned on.

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -21,7 +21,8 @@ goog.require('Blockly.utils.svgPaths');
 goog.require('Blockly.utils.userAgent');
 
 goog.requireType('Blockly.blockRendering.Debug');
-
+goog.requireType('Blockly.RenderedConnection');
+goog.requireType('Blockly.Theme');
 
 /**
  * An object that provides constants for rendering blocks.

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -24,6 +24,10 @@ goog.require('Blockly.constants');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.RenderedConnection');
+
 
 /**
  * An object that renders rectangles and dots for debugging rendering code.

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -22,6 +22,9 @@ goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.svgPaths');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+
 
 /**
  * An object that draws a block based on the given rendering information.

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -31,6 +31,11 @@ goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.constants');
 
+goog.requireType('Blockly.blockRendering.Renderer');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Input');
+goog.requireType('Blockly.RenderedConnection');
+
 
 /**
  * An object containing all sizing information needed to draw this block.

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -19,6 +19,14 @@ goog.require('Blockly.Events.MarkerMove');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Field');
+goog.requireType('Blockly.Marker');
+goog.requireType('Blockly.RenderedConnection');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class for a marker.

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -19,6 +19,9 @@ goog.require('Blockly.Theme');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.Connection');
+
 
 /**
  * An object that handles creating and setting each of the SVG elements

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -13,16 +13,23 @@
 goog.provide('Blockly.blockRendering.Renderer');
 
 goog.require('Blockly.blockRendering.ConstantProvider');
-goog.require('Blockly.blockRendering.MarkerSvg');
+goog.require('Blockly.blockRendering.Debug');
 goog.require('Blockly.blockRendering.Drawer');
+goog.require('Blockly.blockRendering.MarkerSvg');
 goog.require('Blockly.blockRendering.IPathObject');
 goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.blockRendering.RenderInfo');
 goog.require('Blockly.constants');
 goog.require('Blockly.InsertionMarkerManager');
+goog.require('Blockly.IRegistrable');
 
-goog.requireType('Blockly.blockRendering.Debug');
-goog.requireType('Blockly.IRegistrable');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Marker');
+goog.requireType('Blockly.RenderedConnection');
+goog.requireType('Blockly.Theme');
+goog.requireType('Blockly.utils.object');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -20,6 +20,7 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.svgPaths');
 
 goog.requireType('Blockly.geras.PathObject');
+goog.requireType('Blockly.BlockSvg');
 
 
 /**

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -23,6 +23,12 @@ goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.svgPaths');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.geras.ConstantProvider');
+goog.requireType('Blockly.geras.HighlightConstantProvider');
+goog.requireType('Blockly.geras.Renderer');
+goog.requireType('Blockly.geras.RenderInfo');
+
 
 /**
  * An object that adds highlights to a block based on the given rendering

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -16,6 +16,7 @@ goog.provide('Blockly.geras.RenderInfo');
 
 goog.require('Blockly.blockRendering.BottomRow');
 goog.require('Blockly.blockRendering.InputRow');
+goog.require('Blockly.blockRendering.InRowSpacer');
 goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.NextConnection');
 goog.require('Blockly.blockRendering.OutputConnection');
@@ -33,6 +34,10 @@ goog.require('Blockly.constants');
 goog.require('Blockly.geras.InlineInput');
 goog.require('Blockly.geras.StatementInput');
 goog.require('Blockly.utils.object');
+
+goog.requireType('Blockly.geras.Renderer');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.blockRendering.Field');
 
 
 /**

--- a/core/renderers/geras/measurables/inputs.js
+++ b/core/renderers/geras/measurables/inputs.js
@@ -15,6 +15,11 @@ goog.provide('Blockly.geras.InlineInput');
 goog.provide('Blockly.geras.StatementInput');
 
 goog.require('Blockly.utils.object');
+goog.require('Blockly.blockRendering.InlineInput');
+goog.require('Blockly.blockRendering.StatementInput');
+
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.Input');
 
 
 /**

--- a/core/renderers/geras/path_object.js
+++ b/core/renderers/geras/path_object.js
@@ -16,6 +16,7 @@ goog.provide('Blockly.geras.PathObject');
 goog.require('Blockly.blockRendering.PathObject');
 goog.require('Blockly.geras.ConstantProvider');
 goog.require('Blockly.Theme');
+goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Svg');

--- a/core/renderers/geras/renderer.js
+++ b/core/renderers/geras/renderer.js
@@ -21,6 +21,12 @@ goog.require('Blockly.geras.PathObject');
 goog.require('Blockly.geras.RenderInfo');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.RenderInfo');
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Theme');
+
+
 
 /**
  * The geras renderer.

--- a/core/renderers/measurables/base.js
+++ b/core/renderers/measurables/base.js
@@ -15,6 +15,8 @@ goog.provide('Blockly.blockRendering.Measurable');
 
 goog.require('Blockly.blockRendering.Types');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+
 
 /**
  * The base class to represent a part of a block that takes up space during

--- a/core/renderers/measurables/connections.js
+++ b/core/renderers/measurables/connections.js
@@ -18,6 +18,8 @@ goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.RenderedConnection');
 
 
 /**

--- a/core/renderers/measurables/inputs.js
+++ b/core/renderers/measurables/inputs.js
@@ -20,6 +20,9 @@ goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.Input');
+
 
 /**
  * The base class to represent an input that takes up space on a block

--- a/core/renderers/measurables/row_elements.js
+++ b/core/renderers/measurables/row_elements.js
@@ -22,6 +22,11 @@ goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.Field');
+goog.requireType('Blockly.Icon');
+goog.requireType('Blockly.Input');
+
 
 /**
  * An object containing information about the space an icon takes up during

--- a/core/renderers/measurables/rows.js
+++ b/core/renderers/measurables/rows.js
@@ -24,6 +24,9 @@ goog.require('Blockly.blockRendering.PreviousConnection');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+
 
 /**
  * An object representing a single row on a rendered block and all of its

--- a/core/renderers/measurables/types.js
+++ b/core/renderers/measurables/types.js
@@ -13,6 +13,10 @@
 
 goog.provide('Blockly.blockRendering.Types');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.blockRendering.Measurable');
+goog.requireType('Blockly.blockRendering.Row');
+
 
 /**
  * Types of rendering elements.

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -17,6 +17,7 @@ goog.provide('Blockly.thrasos.RenderInfo');
 goog.require('Blockly.blockRendering.BottomRow');
 goog.require('Blockly.blockRendering.ExternalValueInput');
 goog.require('Blockly.blockRendering.InlineInput');
+goog.require('Blockly.blockRendering.InRowSpacer');
 goog.require('Blockly.blockRendering.InputRow');
 goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.NextConnection');
@@ -29,6 +30,10 @@ goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
+
+goog.requireType('Blockly.blockRendering.Field');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.thrasos.Renderer');
 
 
 /**

--- a/core/renderers/thrasos/renderer.js
+++ b/core/renderers/thrasos/renderer.js
@@ -17,6 +17,9 @@ goog.require('Blockly.blockRendering.Renderer');
 goog.require('Blockly.thrasos.RenderInfo');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.BlockSvg');
+
+
 /**
  * The thrasos renderer.
  * @param {string} name The renderer name.

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.zelos.ConstantProvider');
 
 goog.require('Blockly.blockRendering.ConstantProvider');
 goog.require('Blockly.constants');
+goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Svg');

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -16,8 +16,11 @@ goog.require('Blockly.blockRendering.ConstantProvider');
 goog.require('Blockly.blockRendering.Drawer');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
+goog.require('Blockly.utils.svgPaths');
 goog.require('Blockly.zelos.RenderInfo');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.blockRendering.Row');
 goog.requireType('Blockly.zelos.PathObject');
 
 

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -18,6 +18,7 @@ goog.require('Blockly.blockRendering.BottomRow');
 goog.require('Blockly.blockRendering.ExternalValueInput');
 goog.require('Blockly.blockRendering.InlineInput');
 goog.require('Blockly.blockRendering.InputRow');
+goog.require('Blockly.blockRendering.InRowSpacer');
 goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.NextConnection');
 goog.require('Blockly.blockRendering.OutputConnection');
@@ -30,11 +31,18 @@ goog.require('Blockly.blockRendering.SpacerRow');
 goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.constants');
+goog.require('Blockly.FieldImage');
+goog.require('Blockly.FieldLabel');
+goog.require('Blockly.FieldTextInput');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.zelos.BottomRow');
 goog.require('Blockly.zelos.RightConnectionShape');
 goog.require('Blockly.zelos.StatementInput');
 goog.require('Blockly.zelos.TopRow');
+
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.zelos.ConstantProvider');
+goog.requireType('Blockly.zelos.Renderer');
 
 
 /**

--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -16,6 +16,12 @@ goog.require('Blockly.blockRendering.MarkerSvg');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Marker');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class to draw a marker.

--- a/core/renderers/zelos/measurables/inputs.js
+++ b/core/renderers/zelos/measurables/inputs.js
@@ -15,6 +15,9 @@ goog.provide('Blockly.zelos.StatementInput');
 goog.require('Blockly.blockRendering.StatementInput');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.Input');
+
 
 /**
  * An object containing information about the space a statement input takes up

--- a/core/renderers/zelos/measurables/row_elements.js
+++ b/core/renderers/zelos/measurables/row_elements.js
@@ -16,6 +16,8 @@ goog.require('Blockly.blockRendering.Measurable');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+
 
 /**
  * An object containing information about the space a right connection shape

--- a/core/renderers/zelos/measurables/rows.js
+++ b/core/renderers/zelos/measurables/rows.js
@@ -19,6 +19,8 @@ goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.SpacerRow');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+
 
 /**
  * An object containing information about what elements are in the top row of a

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -19,6 +19,8 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.Theme');
+
 
 /**
  * An object that handles creating and setting each of the SVG elements

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -23,6 +23,12 @@ goog.require('Blockly.zelos.PathObject');
 goog.require('Blockly.zelos.RenderInfo');
 goog.require('Blockly.zelos.MarkerSvg');
 
+goog.requireType('Blockly.blockRendering.MarkerSvg');
+goog.requireType('Blockly.blockRendering.RenderInfo');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Marker');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * The zelos renderer.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes missing calls to `goog.requireType`.

### Proposed Changes

Add calls to `goog.requireType` (and some calls to `goog.require`) in renderer files.

### Reason for Changes

Part of enabling the `stricterMissingRequires` closure compiler flag.
Part of cleaning up and making consistent our calls to require and provide, to make it easier to chunk output code correctly.

### Test Coverage

### Documentation
### Additional Information

This change is purely additive. In a later change I will look for unnecessary requires.