### PR TITLE
Reorganize README.md and add more links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Want to make Blockly better? We welcome contributions to Blockly in the form of 
 
 The next major release will be **March 25th, 2021**.
 
-We release by pushing the latest code to the master branch, followed by updating the npm package, our [docs](https://developers.google.com/blockly), and [demo pages](https://blockly-demo.appspot.com). We typically release a new version of Blockly once a quarter (every 3 months). If there are breaking bugs, such as a crash when performing a standard action or a rendering issue that makes Blockly unusable, we will cherry-pick fixes to master between releases to fix them. The [releases page](https://github.com/google/blockly/releases) has a list of all releases.
+We release by pushing the latest code to the master branch, followed by updating the npm package, our [docs](https://developers.google.com/blockly), and [demo pages](https://google.github.io/blockly-samples/). We typically release a new version of Blockly once a quarter (every 3 months). If there are breaking bugs, such as a crash when performing a standard action or a rendering issue that makes Blockly unusable, we will cherry-pick fixes to master between releases to fix them. The [releases page](https://github.com/google/blockly/releases) has a list of all releases.
 
 Releases are tagged by the release date (YYYYMMDD) with a leading '4.' and a trailing '.0' in case we ever need a major or patch version (such as [2.20190722.1](https://github.com/google/blockly/tree/2.20190722.1)). Releases that have breaking changes or are otherwise not backwards compatible will have a new major version. Patch versions are reserved for bug-fix patches between scheduled releases.
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,58 @@
 # Blockly [![Build Status]( https://travis-ci.org/google/blockly.svg?branch=master)](https://travis-ci.org/google/blockly)
 
-
-Google's Blockly is a web-based, visual programming editor.  Users can drag
-blocks together to build programs.  All code is free and open source.
-
-**The project page is https://developers.google.com/blockly/**
+Google's Blockly is a library that adds a visual code editor to web and mobile apps. The Blockly editor uses interlocking, graphical blocks to represent code concepts like variables, logical expressions, loops, and more. It allows users to apply programming principles without having to worry about syntax or the intimidation of a blinking cursor on the command line.  All code is free and open source.
 
 ![](https://developers.google.com/blockly/images/sample.png)
 
-Blockly has an active [developer forum](https://groups.google.com/forum/#!forum/blockly).  Please drop by and say hello. Show us your prototypes early; collectively we have a lot of experience and can offer hints which will save you time. We actively monitor the forums and typically respond to questions within 2 working days.
+## Getting Started with Blockly
+
+Blockly has many resources for learning how to use the library. Start at our [Google Developers Site](https://developers.google.com/blockly) to read the documentation on how to get started, configure Blockly, and integrate it into your application. The developers site also contains links to:
+
+* [Getting Started article](https://developers.google.com/blockly/guides/get-started/web)
+* [Getting Started codelab](https://blocklycodelabs.dev/codelabs/getting-started/index.html#0)
+* [More codelabs](https://blocklycodelabs.dev/)
+* [Demos and plugins](https://google.github.io/blockly-samples/)
 
 Help us focus our development efforts by telling us [what you are doing with
 Blockly](https://developers.google.com/blockly/registration).  The questionnaire only takes
 a few minutes and will help us better support the Blockly community.
 
-Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https://saucelabs.com)
+### Installing Blockly
 
-We support IE11 and test it using [BrowserStack](https://browserstack.com)
+Blockly is [available on npm](https://www.npmjs.com/package/blockly).
 
-Want to contribute? Great! First, read [our guidelines for contributors](https://developers.google.com/blockly/guides/modify/contributing).
-
-## Releases
-
-The next major release will be **December 17th, 2020**.
-
-We release by pushing the latest code to the master branch, followed by updating our [docs](https://developers.google.com/blockly) and [demo pages](https://blockly-demo.appspot.com). We typically release a new version of Blockly once a quarter (every 3 months). If there are breaking bugs, such as a crash when performing a standard action or a rendering issue that makes Blockly unusable, we will cherry-pick fixes to master between releases to fix them. The [releases page](https://github.com/google/blockly/releases) has a list of all releases.
-
-Releases are tagged by the release date (YYYYMMDD) with a leading '2.' and a trailing '.0' in case we ever need a major or minor version (such as [2.20190722.1](https://github.com/google/blockly/tree/2.20190722.1)). If you're using npm, you can install the ``blockly`` package on npm: 
 ```bash
 npm install blockly
 ```
 
-### New APIs
+For more information on installing and using Blockly, see the [Getting Started article](https://developers.google.com/blockly/guides/get-started/web).
 
-Once a new API is merged into master it is considered beta until the following release. We generally try to avoid changing an API after it has been merged to master, but sometimes we need to make changes after seeing how an API is used. If an API has been around for at least two releases we'll do our best to avoid breaking it.
+### Getting Help
+* [Report a bug](https://developers.google.com/blockly/guides/modify/contribute/write_a_good_issue) or file a feature request on GitHub
+* Ask a question, or search others' questions, on our [developer forum](https://groups.google.com/forum/#!forum/blockly). You can also drop by to say hello and show us your prototypes; collectively we have a lot of experience and can offer hints which will save you time. We actively monitor the forums and typically respond to questions within 2 working days.
 
-Unreleased APIs may change radically. Anything that is in `develop` but not `master` is subject to change without warning.
+### blockly-samples
+
+We have a number of resources such as example code, demos, and plugins in another repository called [blockly-samples](https://github.com/google/blockly-samples/). A plugin is a self-contained piece of code that adds functionality to Blockly. Plugins can add fields, define themes, create renderers, and much more. For more information, see the [Plugins documentation](https://developers.google.com/blockly/guides/plugins/overview).
+
+## Contributing to Blockly
+
+Want to make Blockly better? We welcome contributions to Blockly in the form of pull requests, bug reports, documentation, answers on the forum, and more! Check out our [Contributing Guidelines](https://developers.google.com/blockly/guides/modify/contributing) for more information. You might also want to look for issues tagged "[Help Wanted](https://github.com/google/blockly/labels/help%20wanted)" which are issues we think would be great for external contributors to help with.
+
+## Releases
+
+The next major release will be **March 25th, 2021**.
+
+We release by pushing the latest code to the master branch, followed by updating the npm package, our [docs](https://developers.google.com/blockly), and [demo pages](https://blockly-demo.appspot.com). We typically release a new version of Blockly once a quarter (every 3 months). If there are breaking bugs, such as a crash when performing a standard action or a rendering issue that makes Blockly unusable, we will cherry-pick fixes to master between releases to fix them. The [releases page](https://github.com/google/blockly/releases) has a list of all releases.
+
+Releases are tagged by the release date (YYYYMMDD) with a leading '4.' and a trailing '.0' in case we ever need a major or patch version (such as [2.20190722.1](https://github.com/google/blockly/tree/2.20190722.1)). Releases that have breaking changes or are otherwise not backwards compatible will have a new major version. Patch versions are reserved for bug-fix patches between scheduled releases.
+
+We now have a [beta release on npm](https://www.npmjs.com/package/blockly?activeTab=versions). If you'd like to test the upcoming release, or try out a not-yet-released new API, you can use the beta channel with:
+
+```bash
+npm install blockly@beta
+```
+As it is a beta channel, it may be less stable, and the APIs there are subject to change.
 
 ### Branches
 
@@ -46,6 +63,12 @@ There are two main branches for Blockly.
 **[develop](https://github.com/google/blockly/tree/develop)** - This is where most of our work happens. Pull requests should always be made against develop. This branch will generally be usable, but may be less stable than the master branch. Once something is in develop we expect it to merge to master in the next release.
 
 **other branches:** - Larger changes may have their own branches until they are good enough for people to try out. These will be developed separately until we think they are almost ready for release. These branches typically get merged into develop immediately after a release to allow extra time for testing.
+
+### New APIs
+
+Once a new API is merged into master it is considered beta until the following release. We generally try to avoid changing an API after it has been merged to master, but sometimes we need to make changes after seeing how an API is used. If an API has been around for at least two releases we'll do our best to avoid breaking it.
+
+Unreleased APIs may change radically. Anything that is in `develop` but not `master` is subject to change without warning.
 
 ## Issues and Milestones
 
@@ -58,3 +81,8 @@ We typically triage all bugs within 2 working days, which includes adding any ap
 **Bug Bash Backlog** - These are bugs that we're still prioritizing. They haven't been added to a specific release yet, but we'll consider them for each release depending on relative priority and available time.
 
 **Icebox** - These are bugs that we do not intend to spend time on. They are either too much work or minor enough that we don't expect them to ever take priority. We are still happy to accept pull requests for these bugs.
+
+## Good to Know
+
+* Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https://saucelabs.com)
+* We support IE11 and test it using [BrowserStack](https://browserstack.com)


### PR DESCRIPTION
* Copied the introductory statement from the dev site. The devsite introduction makes it more clear that Blockly is a library, not a standalone application. but I can change this back if we are attached to the original statement.
* Kept the image at the top, despite it not showing in the diff preview
* Added an explicit Getting Started section with links to the main resources and where to get help
* Added info on blockly-samples
* Fleshed out the Contributing section
* Added info on beta channel
* Updated date of next release, definition of major and patch update, and some other minor release info (it said we were on major version 2)
* Switched the order of "branches" and "new APIs" so they reference each other in a logical order

I filled in all the links afterward, please help me double check I actually added a url everywhere I added the link.


