### PR TITLE
Fix missing requireTypes

### DIFF
--- a/core/extensions.js
+++ b/core/extensions.js
@@ -21,6 +21,8 @@ goog.provide('Blockly.Extensions');
 
 goog.require('Blockly.utils');
 
+goog.requireType('Blockly.Block');
+
 
 /**
  * The set of all registered extensions, keyed by extension name/id.

--- a/core/field.js
+++ b/core/field.js
@@ -26,12 +26,17 @@ goog.require('Blockly.utils.style');
 goog.require('Blockly.utils.Svg');
 goog.require('Blockly.utils.userAgent');
 
+goog.requireType('Blockly.Block');
 goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.IASTNodeLocationSvg');
 goog.requireType('Blockly.IASTNodeLocationWithBlock');
 goog.requireType('Blockly.IKeyboardAccessible');
+goog.requireType('Blockly.Input');
 goog.requireType('Blockly.IRegistrable');
 goog.requireType('Blockly.ShortcutRegistry');
+goog.requireType('Blockly.utils.Coordinate');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -16,6 +16,7 @@ goog.provide('Blockly.fieldRegistry');
 
 goog.require('Blockly.registry');
 
+goog.requireType('Blockly.Field');
 goog.requireType('Blockly.IRegistrableField');
 
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -26,6 +26,9 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Size');
 goog.require('Blockly.utils.userAgent');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class for an editable text field.

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -25,6 +25,9 @@ goog.require('Blockly.VariableModel');
 goog.require('Blockly.Variables');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.Menu');
+goog.requireType('Blockly.MenuItem');
 
 
 /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -30,10 +30,14 @@ goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.FlyoutButton');
 goog.requireType('Blockly.IDeleteArea');
 goog.requireType('Blockly.IFlyout');
+goog.requireType('Blockly.Options');
 goog.requireType('Blockly.ShortcutRegistry');
 goog.requireType('Blockly.utils.Metrics');
+goog.requireType('Blockly.utils.Rect');
 
 
 /**

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -18,6 +18,9 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.utils.toolbox');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class for a button in the flyout.

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -22,7 +22,10 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.WidgetDiv');
 
+goog.requireType('Blockly.Options');
+goog.requireType('Blockly.utils.Coordinate');
 goog.requireType('Blockly.utils.Metrics');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**
@@ -195,7 +198,7 @@ Blockly.HorizontalFlyout.prototype.position = function() {
 
   var x = this.getX();
   var y = this.getY();
-  
+
   this.positionAt_(this.width_, this.height_, x, y);
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -23,6 +23,8 @@ goog.require('Blockly.utils.Rect');
 goog.require('Blockly.utils.userAgent');
 goog.require('Blockly.WidgetDiv');
 
+goog.requireType('Blockly.Options');
+goog.requireType('Blockly.utils.Coordinate');
 goog.requireType('Blockly.utils.Metrics');
 
 
@@ -199,7 +201,7 @@ Blockly.VerticalFlyout.prototype.position = function() {
 
   var x = this.getX();
   var y = this.getY();
-  
+
   this.positionAt_(this.width_, this.height_, x, y);
 };
 

--- a/core/generator.js
+++ b/core/generator.js
@@ -16,6 +16,9 @@ goog.provide('Blockly.Generator');
 goog.require('Blockly.constants');
 goog.require('Blockly.Block');
 
+goog.requireType('Blockly.Names');
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Class for a code generator that translates the blocks into a language.

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -26,8 +26,11 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.WorkspaceDragger');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Field');
 goog.requireType('Blockly.IBubble');
 goog.requireType('Blockly.IFlyout');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/icon.js
+++ b/core/icon.js
@@ -18,6 +18,9 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Size');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Bubble');
+
 
 /**
  * Class for an icon.

--- a/core/inject.js
+++ b/core/inject.js
@@ -29,6 +29,7 @@ goog.require('Blockly.WorkspaceDragSurfaceSvg');
 goog.require('Blockly.WorkspaceSvg');
 
 goog.requireType('Blockly.utils.Metrics');
+goog.requireType('Blockly.Workspace');
 
 
 /**

--- a/core/interfaces/i_accessibility.js
+++ b/core/interfaces/i_accessibility.js
@@ -15,7 +15,10 @@ goog.provide('Blockly.IASTNodeLocation');
 goog.provide('Blockly.IASTNodeLocationSvg');
 goog.provide('Blockly.IASTNodeLocationWithBlock');
 goog.provide('Blockly.IKeyboardAccessible');
+
+goog.requireType('Blockly.Block');
 goog.requireType('Blockly.ShortcutRegistry');
+
 
 /**
  * An AST node location interface.

--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -13,8 +13,10 @@
 
 goog.provide('Blockly.IBubble');
 
+goog.requireType('Blockly.BlockDragSurfaceSvg');
 goog.requireType('Blockly.IContextMenu');
 goog.requireType('Blockly.IDeletable');
+goog.requireType('Blockly.utils.Coordinate');
 
 
 /**

--- a/core/interfaces/i_connection_checker.js
+++ b/core/interfaces/i_connection_checker.js
@@ -14,6 +14,7 @@
 goog.provide('Blockly.IConnectionChecker');
 
 goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.RenderedConnection');
 
 
 /**

--- a/core/interfaces/i_deletearea.js
+++ b/core/interfaces/i_deletearea.js
@@ -14,6 +14,8 @@
 
 goog.provide('Blockly.IDeleteArea');
 
+goog.requireType('Blockly.utils.Rect');
+
 
 /**
  * Interface for a component that can delete a block that is dropped on top of it.

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -19,6 +19,7 @@ goog.requireType('Blockly.MetricsManager');
 goog.requireType('Blockly.utils.Metrics');
 goog.requireType('Blockly.utils.toolbox');
 
+goog.requireType('Blockly.utils.Size');
 
 /**
  * Interface for a metrics manager.

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -15,8 +15,13 @@ goog.provide('Blockly.ASTNode');
 goog.require('Blockly.constants');
 goog.require('Blockly.utils.Coordinate');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Field');
 goog.requireType('Blockly.IASTNodeLocation');
 goog.requireType('Blockly.IASTNodeLocationWithBlock');
+goog.requireType('Blockly.Input');
+goog.requireType('Blockly.Workspace');
 
 
 /**

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -15,6 +15,8 @@ goog.provide('Blockly.Marker');
 
 goog.require('Blockly.ASTNode');
 
+goog.requireType('Blockly.blockRendering.MarkerSvg');
+
 
 /**
  * Class for a marker.

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -17,6 +17,9 @@ goog.require('Blockly.ASTNode');
 goog.require('Blockly.BasicCursor');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.Field');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * A cursor for navigating between tab navigable fields.

--- a/core/menu.js
+++ b/core/menu.js
@@ -18,6 +18,9 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.KeyCodes');
 goog.require('Blockly.utils.style');
 
+goog.requireType('Blockly.MenuItem');
+goog.requireType('Blockly.utils.Size');
+
 
 /**
  * A basic menu class.

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -19,6 +19,7 @@ goog.requireType('Blockly.IFlyout');
 goog.requireType('Blockly.IToolbox');
 goog.requireType('Blockly.utils.Metrics');
 goog.requireType('Blockly.utils.toolbox');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -28,7 +28,13 @@ goog.require('Blockly.utils.xml');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.Connection');
+goog.requireType('Blockly.Events.Abstract');
+goog.requireType('Blockly.utils.Coordinate');
 goog.requireType('Blockly.utils.Metrics');
+goog.requireType('Blockly.Workspace');
 
 
 /**

--- a/core/names.js
+++ b/core/names.js
@@ -15,6 +15,8 @@ goog.provide('Blockly.Names');
 goog.require('Blockly.constants');
 goog.require('Blockly.Msg');
 
+goog.requireType('Blockly.VariableMap');
+
 
 /**
  * Class for a database of entity names (variables, functions, etc).

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -27,6 +27,10 @@ goog.require('Blockly.utils.xml');
 goog.require('Blockly.Workspace');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.Events.Abstract');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Constant to separate procedure names from variables and generated functions

--- a/core/registry.js
+++ b/core/registry.js
@@ -21,6 +21,11 @@ goog.requireType('Blockly.IFlyout');
 goog.requireType('Blockly.IToolbox');
 goog.requireType('Blockly.Theme');
 
+goog.requireType('Blockly.Cursor');
+goog.requireType('Blockly.MetricsManager');
+goog.requireType('Blockly.Options');
+goog.requireType('Blockly.ToolboxItem');
+
 
 /**
  * A map of maps. With the keys being the type and name of the class we are

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -22,6 +22,10 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.ConnectionDB');
+
 
 /**
  * Class for a connection between blocks that may be rendered on screen.

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -25,6 +25,8 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
 goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.blockRendering.InlineInput');
+goog.requireType('Blockly.blockRendering.InRowSpacer');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.RenderedConnection');
 

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -23,6 +23,9 @@ goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.utils.svgPaths');
 
 goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.blockRendering.Icon');
+goog.requireType('Blockly.blockRendering.InlineInput');
+goog.requireType('Blockly.blockRendering.Field');
 goog.requireType('Blockly.BlockSvg');
 
 

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -16,6 +16,7 @@ goog.provide('Blockly.blockRendering.IPathObject');
 
 goog.requireType('Blockly.blockRendering.ConstantProvider');
 goog.requireType('Blockly.Theme');
+goog.requireType('Blockly.Block');
 
 
 /**

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -31,6 +31,8 @@ goog.require('Blockly.blockRendering.TopRow');
 goog.require('Blockly.blockRendering.Types');
 goog.require('Blockly.constants');
 
+goog.requireType('Blockly.blockRendering.ConstantProvider');
+goog.requireType('Blockly.blockRendering.Icon');
 goog.requireType('Blockly.blockRendering.Renderer');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Input');

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -23,6 +23,7 @@ goog.requireType('Blockly.blockRendering.ConstantProvider');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Connection');
 goog.requireType('Blockly.Field');
+goog.requireType('Blockly.IASTNodeLocationSvg');
 goog.requireType('Blockly.Marker');
 goog.requireType('Blockly.RenderedConnection');
 goog.requireType('Blockly.WorkspaceSvg');

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -23,6 +23,7 @@ goog.require('Blockly.constants');
 goog.require('Blockly.InsertionMarkerManager');
 goog.require('Blockly.IRegistrable');
 
+goog.requireType('Blockly.Block');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Connection');
 goog.requireType('Blockly.Marker');

--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -16,6 +16,7 @@ goog.require('Blockly.blockRendering.MarkerSvg');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.ASTNode');
 goog.requireType('Blockly.blockRendering.ConstantProvider');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Connection');

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -27,6 +27,7 @@ goog.requireType('Blockly.blockRendering.MarkerSvg');
 goog.requireType('Blockly.blockRendering.RenderInfo');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Marker');
+goog.requireType('Blockly.Theme');
 goog.requireType('Blockly.WorkspaceSvg');
 
 

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -20,6 +20,8 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Metrics');
 goog.require('Blockly.utils.Svg');
 
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * A note on units: most of the numbers that are in CSS pixels are scaled if the

--- a/core/shortcut_items.js
+++ b/core/shortcut_items.js
@@ -18,6 +18,10 @@ goog.provide('Blockly.ShortcutItems');
 
 goog.require('Blockly.utils.KeyCodes');
 
+goog.requireType('Blockly.BlockSvg');
+goog.requireType('Blockly.ICopyable');
+goog.requireType('Blockly.ShortcutRegistry');
+
 
 /**
  * Object holding the names of the default shortcut items.

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -16,6 +16,9 @@ goog.provide('Blockly.ShortcutRegistry');
 goog.require('Blockly.ShortcutItems');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.utils.KeyCodes');
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Class for the registry of keyboard shortcuts. This is intended to be a

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -16,6 +16,9 @@ goog.provide('Blockly.ThemeManager');
 
 goog.require('Blockly.Theme');
 
+goog.requireType('Blockly.Workspace');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Class for storing and updating a workspace's theme and UI components.

--- a/core/toolbox/toolbox_item.js
+++ b/core/toolbox/toolbox_item.js
@@ -12,6 +12,7 @@
 
 goog.provide('Blockly.ToolboxItem');
 
+goog.requireType('Blockly.ICollapsibleToolboxItem');
 goog.requireType('Blockly.IToolbox');
 goog.requireType('Blockly.IToolboxItem');
 goog.requireType('Blockly.utils.toolbox');

--- a/core/touch.js
+++ b/core/touch.js
@@ -21,6 +21,8 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.global');
 goog.require('Blockly.utils.string');
 
+goog.requireType('Blockly.Gesture');
+
 
 /**
   * Whether touch is enabled in the browser.

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -18,6 +18,8 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /*
  * Note: In this file "start" refers to touchstart, mousedown, and pointerstart

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -21,8 +21,10 @@ goog.require('Blockly.utils.Svg');
 goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.Events.Abstract');
 goog.requireType('Blockly.IDeleteArea');
 goog.requireType('Blockly.IFlyout');
+goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**

--- a/core/utils.js
+++ b/core/utils.js
@@ -28,6 +28,9 @@ goog.require('Blockly.utils.string');
 goog.require('Blockly.utils.style');
 goog.require('Blockly.utils.userAgent');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.WorkspaceSvg');
+
 
 /**
  * Don't do anything for this event, just halt propagation.

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -19,6 +19,10 @@ goog.require('Blockly.Msg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.object');
 
+goog.requireType('Blockly.Block');
+goog.requireType('Blockly.VariableModel');
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Class for a variable map.  This contains a dictionary data structure with

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -16,6 +16,8 @@ goog.require('Blockly.Events');
 goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.utils');
 
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Class for a variable model.

--- a/core/variables.js
+++ b/core/variables.js
@@ -24,6 +24,8 @@ goog.require('Blockly.utils.xml');
 goog.require('Blockly.VariableModel');
 goog.require('Blockly.Xml');
 
+goog.requireType('Blockly.Workspace');
+
 
 /**
  * Constant to separate variable names from procedures and generated functions


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes missing require types

### Proposed Changes

Adds calls to goog.requireType where missing

#### Behavior Before Change

No change

#### Behavior After Change

No change

### Reason for Changes

More accurate dependencies -> better compiler support.
