### PR TITLE
Add overrideable function to get flyout scale

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -337,6 +337,15 @@ Blockly.Flyout.prototype.getHeight = function() {
 };
 
 /**
+ * Get the scale (zoom level) of the flyout. By default,
+ * this matches the target workspace scale, but this can be overridden.
+ * @return {number} Flyout workspace scale.
+ */
+Blockly.Flyout.prototype.getFlyoutScale = function() {
+  return this.targetWorkspace.scale;
+};
+
+/**
  * Get the workspace inside the flyout.
  * @return {!Blockly.WorkspaceSvg} The workspace inside the flyout.
  * @package

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -384,7 +384,7 @@ Blockly.HorizontalFlyout.prototype.getClientRect = function() {
  * @protected
  */
 Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
-  this.workspace_.scale = this.targetWorkspace.scale;
+  this.workspace_.scale = this.getFlyoutScale();
   var flyoutHeight = 0;
   var blocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; (block = blocks[i]); i++) {

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -368,7 +368,7 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
  * @protected
  */
 Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
-  this.workspace_.scale = this.targetWorkspace.scale;
+  this.workspace_.scale = this.getFlyoutScale();
   var flyoutWidth = 0;
   var blocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; (block = blocks[i]); i++) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Addresses #4038 but it doesn't change anything about the block dragging / adjust block position relative to cursor.

### Proposed Changes

Adds an overrideable function to get the flyout scale. By default, it has the exact same behavior as before, as in it just returns the target workspace scale. But now the behavior is customizable, for example you can override the function to return a constant value if you never want the flyout to zoom. You could also do something more complex such as implement independent zoom controls for the flyout.

#### Behavior Before Change

The flyout zoom level always matches the target workspace zoom level.

#### Behavior After Change

The behavior is customizable. For example, I added the following code:

```
/**
 * @override
 */
Blockly.VerticalFlyout.prototype.getFlyoutScale = function() {
  return 1;
};
```

and you get the result shown in the attached video. The flyout zoom level never changes now.

### Reason for Changes

Adds customizability.

### Test Coverage

All existing tests pass.

### Documentation

Could add some info to the flyout page. I might also implement this in the continuous toolbox so we have an example of it.

https://user-images.githubusercontent.com/8573958/108761856-3d146d80-7504-11eb-8559-5db1c6fb7ddf.mov


