### PR TITLE
Erratic scroll fix

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1726,6 +1726,9 @@ Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
 
   // Start at 1 since the 0th block was used for initialization.
   for (var i = 1; i < topElements.length; i++) {
+    if (topElements[i].isInsertionMarker_) {
+      continue;
+    }
     var blockBoundary = topElements[i].getBoundingRectangle();
     if (blockBoundary.top < boundary.top) {
       boundary.top = blockBoundary.top;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1726,10 +1726,11 @@ Blockly.WorkspaceSvg.prototype.getBlocksBoundingBox = function() {
 
   // Start at 1 since the 0th block was used for initialization.
   for (var i = 1; i < topElements.length; i++) {
-    if (topElements[i].isInsertionMarker_) {
+    var topElement = topElements[i];
+    if (topElement.isInsertionMarker && topElement.isInsertionMarker()) {
       continue;
     }
-    var blockBoundary = topElements[i].getBoundingRectangle();
+    var blockBoundary = topElement.getBoundingRectangle();
     if (blockBoundary.top < boundary.top) {
       boundary.top = blockBoundary.top;
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4636
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Removes insertion marker from content size computation (cause of erratic scroll bug)

#### Behavior Before Change

Erratic scroll behavior in `contentResize` logic, as described in #4636, where no scroll was expected.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

No erratic jump in scenario described by #4636.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Fixes incorrect behavior (insertion marker was causing issues in the math for scrolling)

### Test Coverage

Extensive manual testing in playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Broken off from #4643
This was a tricky change.
<!-- Anything else we should know? -->
