### PR TITLE
Fix event related missing requires

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -226,8 +226,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 
     // Fire a create event.
     if (Blockly.Events.isEnabled()) {
-      Blockly.Events.fire(
-          new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(this));
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(
+          this));
     }
 
   } finally {
@@ -366,8 +366,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
 
   this.unplug(healStack);
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(
-        new (Blockly.Events.get(Blockly.Events.BLOCK_DELETE))(this));
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_DELETE))(
+        this));
   }
   Blockly.Events.disable();
 

--- a/core/block.js
+++ b/core/block.js
@@ -226,7 +226,8 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 
     // Fire a create event.
     if (Blockly.Events.isEnabled()) {
-      Blockly.Events.fire(new Blockly.Events.BlockCreate(this));
+      Blockly.Events.fire(
+          new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(this));
     }
 
   } finally {
@@ -365,7 +366,8 @@ Blockly.Block.prototype.dispose = function(healStack) {
 
   this.unplug(healStack);
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new Blockly.Events.BlockDelete(this));
+    Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.BLOCK_DELETE))(this));
   }
   Blockly.Events.disable();
 
@@ -1217,7 +1219,7 @@ Blockly.Block.prototype.setOutput = function(newBoolean, opt_check) {
  */
 Blockly.Block.prototype.setInputsInline = function(newBoolean) {
   if (this.inputsInline != newBoolean) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
         this, 'inline', null, this.inputsInline, newBoolean));
     this.inputsInline = newBoolean;
   }
@@ -1280,7 +1282,7 @@ Blockly.Block.prototype.isEnabled = function() {
  */
 Blockly.Block.prototype.setEnabled = function(enabled) {
   if (this.isEnabled() != enabled) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
         this, 'disabled', null, this.disabled, !enabled));
     this.disabled = !enabled;
   }
@@ -1317,7 +1319,7 @@ Blockly.Block.prototype.isCollapsed = function() {
  */
 Blockly.Block.prototype.setCollapsed = function(collapsed) {
   if (this.collapsed_ != collapsed) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
         this, 'collapsed', null, this.collapsed_, collapsed));
     this.collapsed_ = collapsed;
   }
@@ -1984,7 +1986,7 @@ Blockly.Block.prototype.setCommentText = function(text) {
   if (this.commentModel.text == text) {
     return;
   }
-  Blockly.Events.fire(new Blockly.Events.BlockChange(
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
       this, 'comment', null, this.commentModel.text, text));
   this.commentModel.text = text;
   this.comment = text;  // For backwards compatibility.
@@ -2027,7 +2029,7 @@ Blockly.Block.prototype.moveBy = function(dx, dy) {
   if (this.parentBlock_) {
     throw Error('Block has parent.');
   }
-  var event = new Blockly.Events.BlockMove(this);
+  var event = new (Blockly.Events.get(Blockly.Events.BLOCK_MOVE))(this);
   this.xy_.translate(dx, dy);
   event.recordNew();
   Blockly.Events.fire(event);

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -187,8 +187,8 @@ Blockly.BlockDragger.prototype.startBlockDrag = function(currentDragDeltaXY,
  * @private
  */
 Blockly.BlockDragger.prototype.fireDragStartEvent_ = function() {
-  var event = new Blockly.Events.BlockDrag(this.draggingBlock_, true,
-      this.draggingBlock_.getDescendants(false));
+  var event = new (Blockly.Events.get(Blockly.Events.BLOCK_DRAG))(
+      this.draggingBlock_, true, this.draggingBlock_.getDescendants(false));
   Blockly.Events.fire(event);
 };
 
@@ -264,8 +264,8 @@ Blockly.BlockDragger.prototype.endBlockDrag = function(e, currentDragDeltaXY) {
  * @private
  */
 Blockly.BlockDragger.prototype.fireDragEndEvent_ = function() {
-  var event = new Blockly.Events.BlockDrag(this.draggingBlock_, false,
-      this.draggingBlock_.getDescendants(false));
+  var event = new (Blockly.Events.get(Blockly.Events.BLOCK_DRAG))(
+      this.draggingBlock_, false, this.draggingBlock_.getDescendants(false));
   Blockly.Events.fire(event);
 };
 
@@ -274,7 +274,8 @@ Blockly.BlockDragger.prototype.fireDragEndEvent_ = function() {
  * @private
  */
 Blockly.BlockDragger.prototype.fireMoveEvent_ = function() {
-  var event = new Blockly.Events.BlockMove(this.draggingBlock_);
+  var event = new (Blockly.Events.get(Blockly.Events.BLOCK_MOVE))(
+      this.draggingBlock_);
   event.oldCoordinate = this.startXY_;
   event.recordNew();
   Blockly.Events.fire(event);

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -34,6 +34,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.utils.userAgent');
+goog.require('Blockly.Xml');
 
 goog.requireType('Blockly.blockRendering.Debug');
 goog.requireType('Blockly.Comment');
@@ -309,7 +310,8 @@ Blockly.BlockSvg.prototype.select = function() {
       Blockly.Events.enable();
     }
   }
-  var event = new Blockly.Events.Selected(oldId, this.id, this.workspace.id);
+  var event = new (Blockly.Events.get(Blockly.Events.SELECTED))(oldId, this.id,
+      this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = this;
   this.addSelect();
@@ -322,7 +324,8 @@ Blockly.BlockSvg.prototype.unselect = function() {
   if (Blockly.selected != this) {
     return;
   }
-  var event = new Blockly.Events.Selected(this.id, null, this.workspace.id);
+  var event = new (Blockly.Events.get(Blockly.Events.SELECTED))(this.id, null,
+      this.workspace.id);
   event.workspaceId = this.workspace.id;
   Blockly.Events.fire(event);
   Blockly.selected = null;
@@ -463,7 +466,7 @@ Blockly.BlockSvg.prototype.moveBy = function(dx, dy) {
   }
   var eventsEnabled = Blockly.Events.isEnabled();
   if (eventsEnabled) {
-    var event = new Blockly.Events.BlockMove(this);
+    var event = new (Blockly.Events.get(Blockly.Events.BLOCK_MOVE))(this);
   }
   var xy = this.getRelativeToSurfaceXY();
   this.translate(xy.x + dx, xy.y + dy);

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -18,6 +18,9 @@ goog.provide('Blockly');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
+goog.require('Blockly.Events.BlockCreate');
+goog.require('Blockly.Events.FinishedLoading');
+goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.Events.Ui');
 goog.require('Blockly.Events.UiBase');
 goog.require('Blockly.inject');

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -229,7 +229,7 @@ Blockly.BubbleDragger.prototype.endBubbleDrag = function(
  */
 Blockly.BubbleDragger.prototype.fireMoveEvent_ = function() {
   if (this.draggingBubble_.isComment) {
-    var event = new Blockly.Events.CommentMove(
+    var event = new (Blockly.Events.get(Blockly.Events.COMMENT_MOVE))(
         /** @type {!Blockly.WorkspaceCommentSvg} */ (this.draggingBubble_));
     event.setOldCoordinate(this.startXY_);
     event.recordNew();

--- a/core/comment.js
+++ b/core/comment.js
@@ -179,7 +179,8 @@ Blockly.Comment.prototype.createEditor_ = function() {
         if (this.cachedText_ != this.model_.text) {
           Blockly.Events.fire(
               new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
-              this.block_, 'comment', null, this.cachedText_, this.model_.text));
+                  this.block_, 'comment', null, this.cachedText_,
+                  this.model_.text));
         }
       });
   this.onInputWrapper_ = Blockly.bindEventWithChecks_(

--- a/core/comment.js
+++ b/core/comment.js
@@ -177,7 +177,8 @@ Blockly.Comment.prototype.createEditor_ = function() {
   this.onChangeWrapper_ = Blockly.bindEventWithChecks_(
       textarea, 'change', this, function(_e) {
         if (this.cachedText_ != this.model_.text) {
-          Blockly.Events.fire(new Blockly.Events.BlockChange(
+          Blockly.Events.fire(
+              new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
               this.block_, 'comment', null, this.cachedText_, this.model_.text));
         }
       });
@@ -241,8 +242,8 @@ Blockly.Comment.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
     return;
   }
-  Blockly.Events.fire(
-      new Blockly.Events.BubbleOpen(this.block_, visible, 'comment'));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BUBBLE_OPEN))(
+      this.block_, visible, 'comment'));
   this.model_.pinned = visible;
   if (visible) {
     this.createBubble_();

--- a/core/connection.js
+++ b/core/connection.js
@@ -188,7 +188,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
 
   var event;
   if (Blockly.Events.isEnabled()) {
-    event = new Blockly.Events.BlockMove(childBlock);
+    event = new (Blockly.Events.get(Blockly.Events.BLOCK_MOVE))(childBlock);
   }
   // Establish the connections.
   Blockly.Connection.connectReciprocally_(parentConnection, childConnection);
@@ -466,7 +466,7 @@ Blockly.Connection.prototype.disconnectInternal_ = function(parentBlock,
     childBlock) {
   var event;
   if (Blockly.Events.isEnabled()) {
-    event = new Blockly.Events.BlockMove(childBlock);
+    event = new (Blockly.Events.get(Blockly.Events.BLOCK_MOVE))(childBlock);
   }
   var otherConnection = this.targetConnection;
   otherConnection.targetConnection = null;

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -18,6 +18,7 @@ goog.provide('Blockly.ContextMenu');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
+goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Menu');
 goog.require('Blockly.MenuItem');
 goog.require('Blockly.Msg');
@@ -199,7 +200,7 @@ Blockly.ContextMenu.callbackFactory = function(block, xml) {
     } finally {
       Blockly.Events.enable();
     }
-    if (Blockly.Events.isEnabled() && !newBlock.isShadow()) {;
+    if (Blockly.Events.isEnabled() && !newBlock.isShadow()) {
       Blockly.Events.fire(
           new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock));
     }

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -18,7 +18,6 @@ goog.provide('Blockly.ContextMenu');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Menu');
 goog.require('Blockly.MenuItem');
 goog.require('Blockly.Msg');
@@ -200,8 +199,9 @@ Blockly.ContextMenu.callbackFactory = function(block, xml) {
     } finally {
       Blockly.Events.enable();
     }
-    if (Blockly.Events.isEnabled() && !newBlock.isShadow()) {
-      Blockly.Events.fire(new Blockly.Events.BlockCreate(newBlock));
+    if (Blockly.Events.isEnabled() && !newBlock.isShadow()) {;
+      Blockly.Events.fire(
+          new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock));
     }
     newBlock.select();
   };

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -17,6 +17,7 @@
 goog.provide('Blockly.ContextMenuItems');
 
 goog.require('Blockly.constants');
+goog.require('Blockly.Events');
 
 goog.requireType('Blockly.BlockSvg');
 

--- a/core/events/block_events.js
+++ b/core/events/block_events.js
@@ -26,8 +26,7 @@ goog.require('Blockly.registry');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.xml');
-// TODO: Fix recursive dependency.
-// goog.require('Blockly.Xml');
+goog.require('Blockly.Xml');
 
 goog.requireType('Blockly.Block');
 
@@ -202,7 +201,7 @@ Blockly.Events.Change.prototype.run = function(forward) {
         var dom = Blockly.Xml.textToDom(/** @type {string} */ (value) || '<mutation/>');
         block.domToMutation(dom);
       }
-      Blockly.Events.fire(new Blockly.Events.Change(
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.CHANGE))(
           block, 'mutation', null, oldMutation, value));
       break;
     default:

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -412,8 +412,8 @@ Blockly.Events.fromJson = function(json, workspace) {
 /**
  * Gets the class for a specific event type from the registry.
  * @param {string} eventType The type of the event to get.
- * @return {?function(new:T, ...?)} The event class with the given type or null
- *     if none exists.
+ * @return {?function(new:Blockly.Events.Abstract, ...?)} The event class with
+ *     the given type or null if none exists.
  */
 Blockly.Events.get = function(eventType) {
   return Blockly.registry.getClass(Blockly.registry.Type.EVENT, eventType);

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -412,6 +412,8 @@ Blockly.Events.fromJson = function(json, workspace) {
 /**
  * Gets the class for a specific event type from the registry.
  * @param {string} eventType The type of the event to get.
+ * @return {?function(new:T, ...?)} The event class with the given type or null
+ *     if none exists.
  */
 Blockly.Events.get = function(eventType) {
   return Blockly.registry.getClass(Blockly.registry.Type.EVENT, eventType);

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -399,8 +399,7 @@ Blockly.Events.getDescendantIds = function(block) {
  * @throws {Error} if an event type is not found in the registry.
  */
 Blockly.Events.fromJson = function(json, workspace) {
-  var eventClass = Blockly.registry.getClass(Blockly.registry.Type.EVENT,
-      json.type);
+  var eventClass = Blockly.Events.get(json.type);
   if (!eventClass) {
     throw Error('Unknown event type.');
   }
@@ -408,6 +407,14 @@ Blockly.Events.fromJson = function(json, workspace) {
   event.fromJson(json);
   event.workspaceId = workspace.id;
   return event;
+};
+
+/**
+ * Gets the class for a specific event type from the registry.
+ * @param {string} eventType The type of the event to get.
+ */
+Blockly.Events.get = function(eventType) {
+  return Blockly.registry.getClass(Blockly.registry.Type.EVENT, eventType);
 };
 
 /**

--- a/core/events/ws_comment_events.js
+++ b/core/events/ws_comment_events.js
@@ -22,8 +22,7 @@ goog.require('Blockly.registry');
 goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.xml');
-// TODO: Fix recursive dependency.
-// goog.require('Blockly.Xml');
+goog.require('Blockly.Xml');
 
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -831,7 +831,7 @@ Blockly.Field.prototype.setValue = function(newValue) {
   }
 
   if (source && Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new Blockly.Events.BlockChange(
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
         source, 'field', this.name || null, oldValue, newValue));
   }
   this.doValueUpdate_(newValue);

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.FieldCheckbox');
 
 goog.require('Blockly.Events');
+goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.utils.dom');

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -13,7 +13,6 @@
 goog.provide('Blockly.FieldCheckbox');
 
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.utils.dom');

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -15,7 +15,6 @@ goog.provide('Blockly.FieldColour');
 goog.require('Blockly.Css');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.utils.aria');

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.FieldColour');
 goog.require('Blockly.Css');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events');
+goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.utils.aria');

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -15,7 +15,6 @@
 goog.provide('Blockly.FieldDropdown');
 
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.Field');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.Menu');

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -202,7 +202,7 @@ Blockly.FieldTextInput.prototype.doValueInvalid_ = function(_invalidValue) {
     // Revert value when the text becomes invalid.
     this.value_ = this.htmlInput_.untypedDefaultValue_;
     if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
-      Blockly.Events.fire(new Blockly.Events.BlockChange(
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
           this.sourceBlock_, 'field', this.name || null, oldValue, this.value_));
     }
   }

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -14,7 +14,6 @@ goog.provide('Blockly.FieldVariable');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.FieldDropdown');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.Msg');

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -14,6 +14,7 @@ goog.provide('Blockly.FieldVariable');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
+goog.require('Blockly.Events.BlockChange');
 goog.require('Blockly.FieldDropdown');
 goog.require('Blockly.fieldRegistry');
 goog.require('Blockly.Msg');

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -27,6 +27,7 @@ goog.require('Blockly.utils.Coordinate');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 goog.require('Blockly.utils.toolbox');
+goog.require('Blockly.utils.xml');
 goog.require('Blockly.WorkspaceSvg');
 goog.require('Blockly.Xml');
 
@@ -796,12 +797,14 @@ Blockly.Flyout.prototype.createBlock = function(originalBlock) {
     // Fire a VarCreate event for each (if any) new variable created.
     for (var i = 0; i < newVariables.length; i++) {
       var thisVariable = newVariables[i];
-      Blockly.Events.fire(new Blockly.Events.VarCreate(thisVariable));
+      Blockly.Events.fire(
+          new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(thisVariable));
     }
 
     // Block events come after var events, in case they refer to newly created
     // variables.
-    Blockly.Events.fire(new Blockly.Events.Create(newBlock));
+    Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(newBlock));
   }
   if (this.autoClose) {
     this.hide();

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -653,8 +653,8 @@ Blockly.Gesture.prototype.handleWsStart = function(e, ws) {
  * @private
  */
 Blockly.Gesture.prototype.fireWorkspaceClick_ = function(ws) {
-  var clickEvent = new Blockly.Events.Click(null, ws.id, 'workspace');
-  Blockly.Events.fire(clickEvent);
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.CLICK))(
+      null, ws.id, 'workspace'));
 };
 
 /**
@@ -744,7 +744,7 @@ Blockly.Gesture.prototype.doBlockClick_ = function() {
     }
   } else {
     // Clicks events are on the start block, even if it was a shadow.
-    var event = new Blockly.Events.Click(
+    var event = new (Blockly.Events.get(Blockly.Events.CLICK))(
         this.startBlock_, this.startWorkspace_.id, 'block');
     Blockly.Events.fire(event);
   }

--- a/core/inject.js
+++ b/core/inject.js
@@ -22,6 +22,7 @@ goog.require('Blockly.Options');
 goog.require('Blockly.ScrollbarPair');
 goog.require('Blockly.Tooltip');
 goog.require('Blockly.utils');
+goog.require('Blockly.utils.aria');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
 goog.require('Blockly.utils.userAgent');

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.BasicCursor');
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.Cursor');
+goog.require('Blockly.registry');
 
 
 /**

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.Cursor');
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.Marker');
+goog.require('Blockly.registry');
 goog.require('Blockly.utils.object');
 
 goog.requireType('Blockly.ShortcutRegistry');

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.MetricsManager');
 
 goog.require('Blockly.IMetricsManager');
+goog.require('Blockly.registry');
 goog.require('Blockly.utils.Size');
 
 goog.requireType('Blockly.IFlyout');

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -290,8 +290,8 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // No change.
     return;
   }
-  Blockly.Events.fire(
-      new Blockly.Events.BubbleOpen(this.block_, visible, 'mutator'));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BUBBLE_OPEN))(
+      this.block_, visible, 'mutator'));
   if (visible) {
     // Create the bubble.
     this.bubble_ = new Blockly.Bubble(
@@ -426,7 +426,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
     var newMutationDom = block.mutationToDom();
     var newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
     if (oldMutation != newMutation) {
-      Blockly.Events.fire(new Blockly.Events.BlockChange(
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
           block, 'mutation', null, oldMutation, newMutation));
       // Ensure that any bump is part of this mutation's event group.
       var group = Blockly.Events.getGroup();

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -378,7 +378,7 @@ Blockly.Procedures.mutateCallers = function(defBlock) {
       // undo action since it is deterministically tied to the procedure's
       // definition mutation.
       Blockly.Events.recordUndo = false;
-      Blockly.Events.fire(new Blockly.Events.BlockChange(
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
           caller, 'mutation', null, oldMutation, newMutation));
       Blockly.Events.recordUndo = oldRecordUndo;
     }

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.blockRendering.MarkerSvg');
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.constants');
+goog.require('Blockly.Events');
 goog.require('Blockly.Events.MarkerMove');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Svg');
@@ -561,7 +562,7 @@ Blockly.blockRendering.MarkerSvg.prototype.hide = function() {
 Blockly.blockRendering.MarkerSvg.prototype.fireMarkerEvent_ = function(
     oldNode, curNode) {
   var curBlock = curNode.getSourceBlock();
-  var event = new Blockly.Events.MarkerMove(
+  var event = new (Blockly.Events.get(Blockly.Events.MARKER_MOVE))(
       curBlock, this.isCursor(), oldNode, curNode);
   Blockly.Events.fire(event);
 };

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.Scrollbar');
 goog.provide('Blockly.ScrollbarPair');
 
+goog.require('Blockly.Events');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.Coordinate');

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -815,7 +815,7 @@ Blockly.Toolbox.prototype.fireSelectEvent_ = function(oldItem, newItem) {
   if (oldItem == newItem) {
     newElement = null;
   }
-  var event = new Blockly.Events.ToolboxItemSelect(
+  var event = new (Blockly.Events.get(Blockly.Events.TOOLBOX_ITEM_SELECT))(
       oldElement, newElement, this.workspace_.id);
   Blockly.Events.fire(event);
 };

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.Trashcan');
 
 goog.require('Blockly.constants');
+goog.require('Blockly.Events');
 goog.require('Blockly.Events.TrashcanOpen');
 goog.require('Blockly.Scrollbar');
 goog.require('Blockly.utils.dom');
@@ -567,8 +568,8 @@ Blockly.Trashcan.prototype.click = function() {
  * @private
  */
 Blockly.Trashcan.prototype.fireUiEvent_ = function(trashcanOpen) {
-  var uiEvent =
-      new Blockly.Events.TrashcanOpen(trashcanOpen,this.workspace_.id);
+  var uiEvent = new (Blockly.Events.get(Blockly.Events.TRASHCAN_OPEN))(
+      trashcanOpen,this.workspace_.id);
   Blockly.Events.fire(uiEvent);
 };
 

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -13,6 +13,7 @@
 goog.provide('Blockly.utils.toolbox');
 
 goog.require('Blockly.constants');
+goog.require('Blockly.Xml');
 
 goog.requireType('Blockly.ToolboxCategory');
 goog.requireType('Blockly.ToolboxSeparator');

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -106,7 +106,8 @@ Blockly.VariableMap.prototype.renameVariableById = function(id, newName) {
  */
 Blockly.VariableMap.prototype.renameVariableAndUses_ = function(variable,
     newName, blocks) {
-  Blockly.Events.fire(new Blockly.Events.VarRename(variable, newName));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_RENAME))(
+      variable, newName));
   variable.name = newName;
   for (var i = 0; i < blocks.length; i++) {
     blocks[i].updateVarName(variable);
@@ -143,7 +144,8 @@ Blockly.VariableMap.prototype.renameVariableWithConflict_ = function(variable,
   }
 
   // Finally delete the original variable, which is now unreferenced.
-  Blockly.Events.fire(new Blockly.Events.VarDelete(variable));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_DELETE))(
+      variable));
   // And remove it from the list.
   var variableList = this.getVariablesOfType(type);
   var variableIndex = variableList.indexOf(variable);
@@ -205,7 +207,8 @@ Blockly.VariableMap.prototype.deleteVariable = function(variable) {
   for (var i = 0, tempVar; (tempVar = variableList[i]); i++) {
     if (tempVar.getId() == variable.getId()) {
       variableList.splice(i, 1);
-      Blockly.Events.fire(new Blockly.Events.VarDelete(variable));
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_DELETE))(
+          variable));
       return;
     }
   }

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -66,7 +66,8 @@ Blockly.VariableModel = function(workspace, name, opt_type, opt_id) {
    */
   this.id_ = opt_id || Blockly.utils.genUid();
 
-  Blockly.Events.fire(new Blockly.Events.VarCreate(this));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(
+      this));
 };
 
 /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -86,8 +86,8 @@ Blockly.Warning.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
     return;
   }
-  Blockly.Events.fire(
-      new Blockly.Events.BubbleOpen(this.block_, visible, 'warning'));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BUBBLE_OPEN))(
+      this.block_, visible, 'warning'));
   if (visible) {
     this.createBubble_();
   } else {

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -15,6 +15,7 @@ goog.provide('Blockly.Workspace');
 goog.require('Blockly.ConnectionChecker');
 goog.require('Blockly.Events');
 goog.require('Blockly.Options');
+goog.require('Blockly.registry');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.math');
 goog.require('Blockly.VariableMap');

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -116,7 +116,8 @@ Blockly.WorkspaceComment.prototype.dispose = function() {
   }
 
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new Blockly.Events.CommentDelete(this));
+    Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.COMMENT_DELETE))(this));
   }
 
   // Remove from the list of top comments and the comment database.
@@ -180,7 +181,7 @@ Blockly.WorkspaceComment.prototype.getXY = function() {
  * @package
  */
 Blockly.WorkspaceComment.prototype.moveBy = function(dx, dy) {
-  var event = new Blockly.Events.CommentMove(this);
+  var event = new (Blockly.Events.get(Blockly.Events.COMMENT_MOVE))(this);
   this.xy_.translate(dx, dy);
   event.recordNew();
   Blockly.Events.fire(event);
@@ -257,8 +258,8 @@ Blockly.WorkspaceComment.prototype.getContent = function() {
  */
 Blockly.WorkspaceComment.prototype.setContent = function(content) {
   if (this.content_ != content) {
-    Blockly.Events.fire(
-        new Blockly.Events.CommentChange(this, this.content_, content));
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.COMMENT_CHANGE))(
+        this, this.content_, content));
     this.content_ = content;
   }
 };
@@ -307,7 +308,8 @@ Blockly.WorkspaceComment.fireCreateEvent = function(comment) {
       Blockly.Events.setGroup(true);
     }
     try {
-      Blockly.Events.fire(new Blockly.Events.CommentCreate(comment));
+      Blockly.Events.fire(
+          new (Blockly.Events.get(Blockly.Events.COMMENT_CREATE))(comment));
     } finally {
       if (!existingGroup) {
         Blockly.Events.setGroup(false);

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -127,7 +127,8 @@ Blockly.WorkspaceCommentSvg.prototype.dispose = function() {
   }
 
   if (Blockly.Events.isEnabled()) {
-    Blockly.Events.fire(new Blockly.Events.CommentDelete(this));
+    Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.COMMENT_DELETE))(this));
   }
 
   Blockly.utils.dom.removeNode(this.svgGroup_);
@@ -224,7 +225,8 @@ Blockly.WorkspaceCommentSvg.prototype.select = function() {
       Blockly.Events.enable();
     }
   }
-  var event = new Blockly.Events.Selected(oldId, this.id, this.workspace.id);
+  var event = new (Blockly.Events.get(Blockly.Events.SELECTED))(oldId, this.id,
+      this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = this;
   this.addSelect();
@@ -238,7 +240,8 @@ Blockly.WorkspaceCommentSvg.prototype.unselect = function() {
   if (Blockly.selected != this) {
     return;
   }
-  var event = new Blockly.Events.Selected(this.id, null, this.workspace.id);
+  var event = new (Blockly.Events.get(Blockly.Events.SELECTED))(this.id, null,
+      this.workspace.id);
   Blockly.Events.fire(event);
   Blockly.selected = null;
   this.removeSelect();
@@ -331,7 +334,7 @@ Blockly.WorkspaceCommentSvg.prototype.getRelativeToSurfaceXY = function() {
  * @package
  */
 Blockly.WorkspaceCommentSvg.prototype.moveBy = function(dx, dy) {
-  var event = new Blockly.Events.CommentMove(this);
+  var event = new (Blockly.Events.get(Blockly.Events.COMMENT_MOVE))(this);
   // TODO: Do I need to look up the relative to surface XY position here?
   var xy = this.getRelativeToSurfaceXY();
   this.translate(xy.x + dx, xy.y + dy);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -617,7 +617,8 @@ Blockly.WorkspaceSvg.prototype.refreshTheme = function() {
     this.setVisible(true);
   }
 
-  var event = new Blockly.Events.ThemeChange(this.getTheme().name, this.id);
+  var event = new (Blockly.Events.get(Blockly.Events.THEME_CHANGE))(
+      this.getTheme().name, this.id);
   Blockly.Events.fire(event);
 };
 
@@ -1161,7 +1162,8 @@ Blockly.WorkspaceSvg.prototype.maybeFireViewportChangeEvent = function() {
   this.oldScale_ = scale;
   this.oldTop_ = top;
   this.oldLeft_ = left;
-  var event = new Blockly.Events.ViewportChange(top, left, scale, this.id);
+  var event = new (Blockly.Events.get(Blockly.Events.VIEWPORT_CHANGE))(top,
+      left, scale, this.id);
   Blockly.Events.fire(event);
 };
 
@@ -1444,7 +1446,8 @@ Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
     Blockly.Events.enable();
   }
   if (Blockly.Events.isEnabled() && !block.isShadow()) {
-    Blockly.Events.fire(new Blockly.Events.BlockCreate(block));
+    Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(block));
   }
   block.select();
 };

--- a/core/xml.js
+++ b/core/xml.js
@@ -18,9 +18,6 @@ goog.provide('Blockly.Xml');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Events');
-goog.require('Blockly.Events.BlockCreate');
-goog.require('Blockly.Events.FinishedLoading');
-goog.require('Blockly.Events.VarCreate');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.global');
@@ -481,7 +478,8 @@ Blockly.Xml.domToWorkspace = function(xml, workspace) {
   if (workspace.setResizesEnabled) {
     workspace.setResizesEnabled(true);
   }
-  Blockly.Events.fire(new Blockly.Events.FinishedLoading(workspace));
+  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.FINISHED_LOADING))(
+      workspace));
   return newBlockIds;
 };
 
@@ -593,11 +591,13 @@ Blockly.Xml.domToBlock = function(xmlBlock, workspace) {
     // Fire a VarCreate event for each (if any) new variable created.
     for (var i = 0; i < newVariables.length; i++) {
       var thisVariable = newVariables[i];
-      Blockly.Events.fire(new Blockly.Events.VarCreate(thisVariable));
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(
+          thisVariable));
     }
     // Block events come after var events, in case they refer to newly created
     // variables.
-    Blockly.Events.fire(new Blockly.Events.BlockCreate(topBlock));
+    Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.CREATE))(
+        topBlock));
   }
   return topBlock;
 };

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -14,6 +14,8 @@ goog.provide('Blockly.ZoomControls');
 
 goog.require('Blockly.constants');
 goog.require('Blockly.Css');
+goog.require('Blockly.Events');
+goog.require('Blockly.Events.Click');
 goog.require('Blockly.Scrollbar');
 goog.require('Blockly.Touch');
 goog.require('Blockly.utils.dom');
@@ -423,7 +425,7 @@ Blockly.ZoomControls.prototype.resetZoom_ = function(e) {
  * @private
  */
 Blockly.ZoomControls.prototype.fireZoomEvent_ = function() {
-  var uiEvent = new Blockly.Events.Click(
+  var uiEvent = new (Blockly.Events.get(Blockly.Events.CLICK))(
       null, this.workspace_.id, 'zoom_controls');
   Blockly.Events.fire(uiEvent);
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes circular dependency between `Blockly.Events` and `Blockly.Xml`.
Fix 46 warnings when `stringMissingRequires` is enabled related to events, registry and xml.

### Proposed Changes

Use the Blockly registry when instantiating a Blockly event.

### Reason for Changes

Path towards enabling strictMissingRequires

### Test Coverage

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
