### PR TITLE
Fix missing require in contextmenu items

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -20,6 +20,7 @@ goog.require('Blockly.browserEvents');
 goog.require('Blockly.constants');
 goog.require('Blockly.ContextMenu');
 goog.require('Blockly.ContextMenuRegistry');
+goog.require('Blockly.ContextMenuItems');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockMove');
 goog.require('Blockly.Events.Selected');

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -17,6 +17,7 @@
 goog.provide('Blockly.ContextMenuItems');
 
 goog.require('Blockly.constants');
+goog.require('Blockly.ContextMenuRegistry');
 goog.require('Blockly.Events');
 
 goog.requireType('Blockly.BlockSvg');

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -536,4 +536,5 @@ Blockly.ContextMenuItems.registerDefaultOptions = function() {
   Blockly.ContextMenuItems.registerWorkspaceOptions_();
   Blockly.ContextMenuItems.registerBlockOptions_();
 };
-  
+
+Blockly.ContextMenuItems.registerDefaultOptions();

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -16,8 +16,6 @@
  */
 goog.provide('Blockly.ContextMenuRegistry');
 
-goog.require('Blockly.ContextMenuItems');
-
 /**
  * Class for the registry of context menu items. This is intended to be a singleton. You should
  * not create a new instance, and only access this class from Blockly.ContextMenuRegistry.registry.
@@ -34,7 +32,6 @@ Blockly.ContextMenuRegistry = function() {
    * @private
    */
   this.registry_ = {};
-  Blockly.ContextMenuItems.registerDefaultOptions();
 };
 
 /**

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -18,6 +18,7 @@ goog.require('Blockly.browserEvents');
 goog.require('Blockly.ConnectionDB');
 goog.require('Blockly.constants');
 goog.require('Blockly.ContextMenuRegistry');
+goog.require('Blockly.ContextMenuItems');
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.BlockCreate');
 goog.require('Blockly.Events.ThemeChange');


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes 71 warnings (Big win)

### Proposed Changes

Fix circular dependency between context menu registry and context menu registry items.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
