### PR TITLE
Align constants -> Blockly.constants.ALIGN enum

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1765,10 +1765,10 @@ Blockly.Block.prototype.fieldFromJson_ = function(element) {
  */
 Blockly.Block.prototype.inputFromJson_ = function(element, warningPrefix) {
   var alignmentLookup = {
-    'LEFT': Blockly.ALIGN_LEFT,
-    'RIGHT': Blockly.ALIGN_RIGHT,
-    'CENTRE': Blockly.ALIGN_CENTRE,
-    'CENTER': Blockly.ALIGN_CENTRE
+    'LEFT': Blockly.constants.ALIGN.LEFT,
+    'RIGHT': Blockly.constants.ALIGN.RIGHT,
+    'CENTRE': Blockly.constants.ALIGN.CENTRE,
+    'CENTER': Blockly.constants.ALIGN.CENTRE
   };
 
   var input = null;

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -503,3 +503,18 @@ Blockly.unbindEvent_ = Blockly.browserEvents.unbind;
  * @see Blockly.browserEvents.conditionalBind
  */
 Blockly.bindEventWithChecks_ = Blockly.browserEvents.conditionalBind;
+
+/**
+ * @see Blockly.constants.ALIGN.LEFT
+ */
+Blockly.ALIGN_LEFT = Blockly.constants.ALIGN.LEFT;
+
+/**
+ * @see Blockly.constants.ALIGN.CENTRE
+ */
+Blockly.ALIGN_CENTRE = Blockly.constants.ALIGN.CENTRE;
+
+/**
+ * @see Blockly.constants.ALIGN.RIGHT
+ */
+Blockly.ALIGN_RIGHT = Blockly.constants.ALIGN.RIGHT;

--- a/core/constants.js
+++ b/core/constants.js
@@ -140,22 +140,14 @@ Blockly.PREVIOUS_STATEMENT = 4;
 Blockly.DUMMY_INPUT = 5;
 
 /**
- * ENUM for left alignment.
- * @const
+ * Enum for alignment of inputs.
+ * @enum {number}
  */
-Blockly.ALIGN_LEFT = -1;
-
-/**
- * ENUM for centre alignment.
- * @const
- */
-Blockly.ALIGN_CENTRE = 0;
-
-/**
- * ENUM for right alignment.
- * @const
- */
-Blockly.ALIGN_RIGHT = 1;
+Blockly.constants.ALIGN = {
+  LEFT: -1,
+  CENTRE: 0,
+  RIGHT: 1
+};
 
 /**
  * ENUM for no drag operation.

--- a/core/input.js
+++ b/core/input.js
@@ -55,7 +55,7 @@ Blockly.Input = function(type, name, block, connection) {
  * Alignment of input's fields (left, right or centre).
  * @type {number}
  */
-Blockly.Input.prototype.align = Blockly.ALIGN_LEFT;
+Blockly.Input.prototype.align = Blockly.constants.ALIGN.LEFT;
 
 /**
  * Is the input visible?
@@ -242,8 +242,8 @@ Blockly.Input.prototype.setCheck = function(check) {
 
 /**
  * Change the alignment of the connection's field(s).
- * @param {number} align One of Blockly.ALIGN_LEFT, ALIGN_CENTRE, ALIGN_RIGHT.
- *   In RTL mode directions are reversed, and ALIGN_RIGHT aligns to the left.
+ * @param {number} align One of the values of Blockly.constants.ALIGN.
+ *   In RTL mode directions are reversed, and ALIGN.RIGHT aligns to the left.
  * @return {!Blockly.Input} The input being modified (to allow chaining).
  */
 Blockly.Input.prototype.setAlign = function(align) {

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -591,14 +591,14 @@ Blockly.blockRendering.RenderInfo.prototype.addAlignmentPadding_ = function(row,
   }
 
   // Decide where the extra padding goes.
-  if (row.align == Blockly.ALIGN_LEFT) {
+  if (row.align == Blockly.constants.ALIGN.LEFT) {
     // Add padding to the end of the row.
     lastSpacer.width += missingSpace;
-  } else if (row.align == Blockly.ALIGN_CENTRE) {
+  } else if (row.align == Blockly.constants.ALIGN.CENTRE) {
     // Split the padding between the beginning and end of the row.
     firstSpacer.width += missingSpace / 2;
     lastSpacer.width += missingSpace / 2;
-  } else if (row.align == Blockly.ALIGN_RIGHT) {
+  } else if (row.align == Blockly.constants.ALIGN.RIGHT) {
     // Add padding at the beginning of the row.
     firstSpacer.width += missingSpace;
   } else {

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -277,8 +277,8 @@ Blockly.zelos.RenderInfo.prototype.addInput_ = function(input, activeRow) {
   // right, keep track of the right aligned dummy input so we can add padding
   // later.
   if (input.type == Blockly.DUMMY_INPUT && activeRow.hasDummyInput &&
-      activeRow.align == Blockly.ALIGN_LEFT &&
-      input.align == Blockly.ALIGN_RIGHT) {
+      activeRow.align == Blockly.constants.ALIGN.LEFT &&
+      input.align == Blockly.constants.ALIGN.RIGHT) {
     activeRow.rightAlignedDummyInput = input;
   }
   Blockly.zelos.RenderInfo.superClass_.addInput_.call(this, input, activeRow);

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -561,9 +561,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'LEFT',
           },
-          'input_dummy',
-          undefined,
-          Blockly.ALIGN_LEFT);
+          'input_dummy', undefined, Blockly.constants.ALIGN.LEFT);
     });
 
     test('"Right" align', function() {
@@ -572,9 +570,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'RIGHT',
           },
-          'input_dummy',
-          undefined,
-          Blockly.ALIGN_RIGHT);
+          'input_dummy', undefined, Blockly.constants.ALIGN);
     });
 
     test('"Center" align', function() {
@@ -583,9 +579,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'CENTER',
           },
-          'input_dummy',
-          undefined,
-          Blockly.ALIGN_CENTRE);
+          'input_dummy', undefined, Blockly.constants..);
     });
 
     test('"Centre" align', function() {
@@ -594,9 +588,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'CENTRE',
           },
-          'input_dummy',
-          undefined,
-          Blockly.ALIGN_CENTRE);
+          'input_dummy', undefined, Blockly.constants.ALIGN.CENTRE);
     });
   });
 });

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -570,7 +570,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'RIGHT',
           },
-          'input_dummy', undefined, Blockly.constants.ALIGN);
+          'input_dummy', undefined, Blockly.constants.ALIGN.RIGHT);
     });
 
     test('"Center" align', function() {
@@ -579,7 +579,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'align': 'CENTER',
           },
-          'input_dummy', undefined, Blockly.constants..);
+          'input_dummy', undefined, Blockly.constants.ALIGN.CENTRE);
     });
 
     test('"Centre" align', function() {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes 16 warnings.

### Proposed Changes

Move the align constants into an enum on the Blockly.constants namespace, and then add aliases in blockly.js.

### Reason for Changes

Resolves compiler warnings related to setting properties on `Blockly` from `constants.js`.
Allows files to require `constants` rather than `blockly` to get the correct values, to reduce circular dependencies.

### Test Coverage

### Documentation

- Will need to make sure the jsdoc is correct.
- Constants are referenced in the [define blocks page](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks)

### Additional Information

There are still uses of the old names in demos and in samples.
We will likely never get rid of the old constants for external use, because they are part of block definitions. But all internal uses should now use the constants file.