### PR TITLE
Set clang-format column limit to 100 instead of 80

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 Language:        JavaScript
 BasedOnStyle:    Google
-ColumnLimit:     80
+ColumnLimit:     100


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Match eslint, to avoid conflicts between our automated style tools.

### Proposed Changes

Set clang-format column limit to 100 instead of 80

