### PR TITLE
Use Blockly.utils.toolbox.Position enum everywhere

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -571,3 +571,27 @@ Blockly.PREVIOUS_STATEMENT = Blockly.connectionTypes.PREVIOUS_STATEMENT;
  * @see Blockly.inputTypes.DUMMY_INPUT
  */
 Blockly.DUMMY_INPUT = Blockly.inputTypes.DUMMY;
+
+/**
+ * Aliases for toolbox positions.
+ */
+
+/**
+ * @see Blockly.constants.toolboxPosition.TOP
+ */
+Blockly.TOOLBOX_AT_TOP = Blockly.constants.toolboxPosition.TOP;
+
+/**
+ * @see Blockly.constants.toolboxPosition.BOTTOM
+ */
+Blockly.TOOLBOX_AT_BOTTOM = Blockly.constants.toolboxPosition.BOTTOM;
+
+/**
+ * @see Blockly.constants.toolboxPosition.LEFT
+ */
+Blockly.TOOLBOX_AT_LEFT = Blockly.constants.toolboxPosition.LEFT;
+
+/**
+ * @see Blockly.constants.toolboxPosition.RIGHT
+ */
+Blockly.TOOLBOX_AT_RIGHT = Blockly.constants.toolboxPosition.RIGHT;

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -44,6 +44,7 @@ goog.require('Blockly.utils');
 goog.require('Blockly.utils.colour');
 goog.require('Blockly.utils.deprecation');
 goog.require('Blockly.utils.Size');
+goog.require('Blockly.utils.toolbox');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Variables');
 goog.require('Blockly.WidgetDiv');
@@ -577,21 +578,21 @@ Blockly.DUMMY_INPUT = Blockly.inputTypes.DUMMY;
  */
 
 /**
- * @see Blockly.constants.toolboxPosition.TOP
+ * @see Blockly.utils.toolbox.Position.TOP
  */
-Blockly.TOOLBOX_AT_TOP = Blockly.constants.toolboxPosition.TOP;
+Blockly.TOOLBOX_AT_TOP = Blockly.utils.toolbox.Position.TOP;
 
 /**
- * @see Blockly.constants.toolboxPosition.BOTTOM
+ * @see Blockly.utils.toolbox.Position.BOTTOM
  */
-Blockly.TOOLBOX_AT_BOTTOM = Blockly.constants.toolboxPosition.BOTTOM;
+Blockly.TOOLBOX_AT_BOTTOM = Blockly.utils.toolbox.Position.BOTTOM;
 
 /**
- * @see Blockly.constants.toolboxPosition.LEFT
+ * @see Blockly.utils.toolbox.Position.LEFT
  */
-Blockly.TOOLBOX_AT_LEFT = Blockly.constants.toolboxPosition.LEFT;
+Blockly.TOOLBOX_AT_LEFT = Blockly.utils.toolbox.Position.LEFT;
 
 /**
- * @see Blockly.constants.toolboxPosition.RIGHT
+ * @see Blockly.utils.toolbox.Position.RIGHT
  */
-Blockly.TOOLBOX_AT_RIGHT = Blockly.constants.toolboxPosition.RIGHT;
+Blockly.TOOLBOX_AT_RIGHT = Blockly.utils.toolbox.Position.RIGHT;

--- a/core/constants.js
+++ b/core/constants.js
@@ -161,18 +161,6 @@ Blockly.OPPOSITE_TYPE[Blockly.connectionTypes.NEXT_STATEMENT] =
 Blockly.OPPOSITE_TYPE[Blockly.connectionTypes.PREVIOUS_STATEMENT] =
     Blockly.connectionTypes.NEXT_STATEMENT;
 
-
-/**
- * Enum for the position of the toolbox and/or flyout.
- * @enum {number}
- */
-Blockly.constants.toolboxPosition = {
-  TOP: 0,
-  BOTTOM: 1,
-  LEFT: 2,
-  RIGHT: 3
-};
-
 /**
  * ENUM representing that an event is not in any delete areas.
  * Null for backwards compatibility reasons.

--- a/core/constants.js
+++ b/core/constants.js
@@ -163,28 +163,15 @@ Blockly.OPPOSITE_TYPE[Blockly.connectionTypes.PREVIOUS_STATEMENT] =
 
 
 /**
- * ENUM for toolbox and flyout at top of screen.
- * @const
+ * Enum for the position of the toolbox and/or flyout.
+ * @enum {number}
  */
-Blockly.TOOLBOX_AT_TOP = 0;
-
-/**
- * ENUM for toolbox and flyout at bottom of screen.
- * @const
- */
-Blockly.TOOLBOX_AT_BOTTOM = 1;
-
-/**
- * ENUM for toolbox and flyout at left of screen.
- * @const
- */
-Blockly.TOOLBOX_AT_LEFT = 2;
-
-/**
- * ENUM for toolbox and flyout at right of screen.
- * @const
- */
-Blockly.TOOLBOX_AT_RIGHT = 3;
+Blockly.constants.toolboxPosition = {
+  TOP: 0,
+  BOTTOM: 1,
+  LEFT: 2,
+  RIGHT: 3
+};
 
 /**
  * ENUM representing that an event is not in any delete areas.

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -78,11 +78,11 @@ Blockly.HorizontalFlyout.prototype.getMetrics_ = function() {
 
   var absoluteTop = this.SCROLLBAR_PADDING;
   var absoluteLeft = this.SCROLLBAR_PADDING;
-  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_BOTTOM) {
+  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.BOTTOM) {
     absoluteTop = 0;
   }
   var viewHeight = this.height_;
-  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP) {
     viewHeight -= this.SCROLLBAR_PADDING;
   }
   var viewWidth = this.width_ - 2 * this.SCROLLBAR_PADDING;
@@ -154,18 +154,19 @@ Blockly.HorizontalFlyout.prototype.getY = function() {
   }
 
   var y = 0;
+  var atTop = this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP;
   // If this flyout is not the trashcan flyout (e.g. toolbox or mutator).
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
     if (targetWorkspaceMetrics.toolboxHeight) {
-      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+      if (atTop) {
         y = targetWorkspaceMetrics.toolboxHeight;
       } else {
         y = targetWorkspaceMetrics.viewHeight - this.height_;
       }
       // Simple (flyout-only) toolbox.
     } else {
-      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+      if (atTop) {
         y = 0;
       } else {
         // The simple flyout does not cover the workspace.
@@ -174,7 +175,7 @@ Blockly.HorizontalFlyout.prototype.getY = function() {
     }
     // Trashcan flyout is opposite the main flyout.
   } else {
-    if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+    if (atTop) {
       y = 0;
     } else {
       // Because the anchor point of the flyout is on the top, but we want
@@ -220,9 +221,9 @@ Blockly.HorizontalFlyout.prototype.position = function() {
  *     rounded corners.
  * @private
  */
-Blockly.HorizontalFlyout.prototype.setBackgroundPath_ = function(width,
-    height) {
-  var atTop = this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP;
+Blockly.HorizontalFlyout.prototype.setBackgroundPath_ = function(
+    width, height) {
+  var atTop = this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP;
   // Start at top left.
   var path = ['M 0,' + (atTop ? 0 : this.CORNER_RADIUS)];
 
@@ -377,7 +378,7 @@ Blockly.HorizontalFlyout.prototype.getClientRect = function() {
   var BIG_NUM = 1000000000;
   var top = flyoutRect.top;
 
-  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP) {
+  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP) {
     var height = flyoutRect.height;
     return new Blockly.utils.Rect(-BIG_NUM, top + height, -BIG_NUM, BIG_NUM);
   } else {  // Bottom.
@@ -409,7 +410,7 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Blockly.TOOLBOX_AT_TOP &&
+        this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -22,6 +22,7 @@ goog.require('Blockly.Scrollbar');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.WidgetDiv');
 
 goog.requireType('Blockly.Options');
@@ -78,11 +79,11 @@ Blockly.HorizontalFlyout.prototype.getMetrics_ = function() {
 
   var absoluteTop = this.SCROLLBAR_PADDING;
   var absoluteLeft = this.SCROLLBAR_PADDING;
-  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.BOTTOM) {
+  if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.BOTTOM) {
     absoluteTop = 0;
   }
   var viewHeight = this.height_;
-  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP) {
+  if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.TOP) {
     viewHeight -= this.SCROLLBAR_PADDING;
   }
   var viewWidth = this.width_ - 2 * this.SCROLLBAR_PADDING;
@@ -154,7 +155,7 @@ Blockly.HorizontalFlyout.prototype.getY = function() {
   }
 
   var y = 0;
-  var atTop = this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP;
+  var atTop = this.toolboxPosition_ == Blockly.utils.toolbox.Position.TOP;
   // If this flyout is not the trashcan flyout (e.g. toolbox or mutator).
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
@@ -223,7 +224,7 @@ Blockly.HorizontalFlyout.prototype.position = function() {
  */
 Blockly.HorizontalFlyout.prototype.setBackgroundPath_ = function(
     width, height) {
-  var atTop = this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP;
+  var atTop = this.toolboxPosition_ == Blockly.utils.toolbox.Position.TOP;
   // Start at top left.
   var path = ['M 0,' + (atTop ? 0 : this.CORNER_RADIUS)];
 
@@ -378,7 +379,7 @@ Blockly.HorizontalFlyout.prototype.getClientRect = function() {
   var BIG_NUM = 1000000000;
   var top = flyoutRect.top;
 
-  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP) {
+  if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.TOP) {
     var height = flyoutRect.height;
     return new Blockly.utils.Rect(-BIG_NUM, top + height, -BIG_NUM, BIG_NUM);
   } else {  // Bottom.
@@ -410,7 +411,7 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Blockly.constants.toolboxPosition.TOP &&
+        this.toolboxPosition_ == Blockly.utils.toolbox.Position.TOP &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -22,6 +22,7 @@ goog.require('Blockly.Scrollbar');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.WidgetDiv');
 
 goog.requireType('Blockly.Options');
@@ -150,14 +151,14 @@ Blockly.VerticalFlyout.prototype.getX = function() {
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
     if (targetWorkspaceMetrics.toolboxWidth) {
-      if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
+      if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.LEFT) {
         x = targetWorkspaceMetrics.toolboxWidth;
       } else {
         x = targetWorkspaceMetrics.viewWidth - this.width_;
       }
       // Simple (flyout-only) toolbox.
     } else {
-      if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
+      if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.LEFT) {
         x = 0;
       } else {
         // The simple flyout does not cover the workspace.
@@ -166,7 +167,7 @@ Blockly.VerticalFlyout.prototype.getX = function() {
     }
     // Trashcan flyout is opposite the main flyout.
   } else {
-    if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
+    if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.LEFT) {
       x = 0;
     } else {
       // Because the anchor point of the flyout is on the left, but we want
@@ -222,8 +223,7 @@ Blockly.VerticalFlyout.prototype.position = function() {
  * @private
  */
 Blockly.VerticalFlyout.prototype.setBackgroundPath_ = function(width, height) {
-  var atRight =
-      this.toolboxPosition_ == Blockly.constants.toolboxPosition.RIGHT;
+  var atRight = this.toolboxPosition_ == Blockly.utils.toolbox.Position.RIGHT;
   var totalWidth = width + this.CORNER_RADIUS;
 
   // Decide whether to start on the left or right.
@@ -360,7 +360,7 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
   var BIG_NUM = 1000000000;
   var left = flyoutRect.left;
 
-  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
+  if (this.toolboxPosition_ == Blockly.utils.toolbox.Position.LEFT) {
     var width = flyoutRect.width;
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, left + width);
   } else {  // Right
@@ -417,7 +417,7 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT &&
+        this.toolboxPosition_ == Blockly.utils.toolbox.Position.LEFT &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -150,14 +150,14 @@ Blockly.VerticalFlyout.prototype.getX = function() {
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
     if (targetWorkspaceMetrics.toolboxWidth) {
-      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+      if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
         x = targetWorkspaceMetrics.toolboxWidth;
       } else {
         x = targetWorkspaceMetrics.viewWidth - this.width_;
       }
       // Simple (flyout-only) toolbox.
     } else {
-      if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+      if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
         x = 0;
       } else {
         // The simple flyout does not cover the workspace.
@@ -166,7 +166,7 @@ Blockly.VerticalFlyout.prototype.getX = function() {
     }
     // Trashcan flyout is opposite the main flyout.
   } else {
-    if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+    if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
       x = 0;
     } else {
       // Because the anchor point of the flyout is on the left, but we want
@@ -222,7 +222,8 @@ Blockly.VerticalFlyout.prototype.position = function() {
  * @private
  */
 Blockly.VerticalFlyout.prototype.setBackgroundPath_ = function(width, height) {
-  var atRight = this.toolboxPosition_ == Blockly.TOOLBOX_AT_RIGHT;
+  var atRight =
+      this.toolboxPosition_ == Blockly.constants.toolboxPosition.RIGHT;
   var totalWidth = width + this.CORNER_RADIUS;
 
   // Decide whether to start on the left or right.
@@ -359,7 +360,7 @@ Blockly.VerticalFlyout.prototype.getClientRect = function() {
   var BIG_NUM = 1000000000;
   var left = flyoutRect.left;
 
-  if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
+  if (this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT) {
     var width = flyoutRect.width;
     return new Blockly.utils.Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, left + width);
   } else {  // Right
@@ -416,7 +417,7 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT &&
+        this.toolboxPosition_ == Blockly.constants.toolboxPosition.LEFT &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -15,11 +15,11 @@ goog.provide('Blockly.MetricsManager');
 goog.require('Blockly.IMetricsManager');
 goog.require('Blockly.registry');
 goog.require('Blockly.utils.Size');
+goog.require('Blockly.utils.toolbox');
 
 goog.requireType('Blockly.IFlyout');
 goog.requireType('Blockly.IToolbox');
 goog.requireType('Blockly.utils.Metrics');
-goog.requireType('Blockly.utils.toolbox');
 goog.requireType('Blockly.WorkspaceSvg');
 
 
@@ -175,8 +175,8 @@ Blockly.MetricsManager.prototype.getAbsoluteMetrics = function() {
   var toolboxPosition =
       doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
-  var atLeft = toolboxPosition == Blockly.constants.toolboxPosition.LEFT;
-  var atTop = toolboxPosition == Blockly.constants.toolboxPosition.TOP;
+  var atLeft = toolboxPosition == Blockly.utils.toolbox.Position.LEFT;
+  var atTop = toolboxPosition == Blockly.utils.toolbox.Position.TOP;
   if (doesToolboxExist && atLeft) {
     absoluteLeft = toolboxMetrics.width;
   } else if (doesFlyoutExist && atLeft) {
@@ -216,21 +216,21 @@ Blockly.MetricsManager.prototype.getViewMetrics = function(
       doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
   if (this.workspace_.getToolbox()) {
-    if (toolboxPosition == Blockly.constants.toolboxPosition.TOP ||
-        toolboxPosition == Blockly.constants.toolboxPosition.BOTTOM) {
+    if (toolboxPosition == Blockly.utils.toolbox.Position.TOP ||
+        toolboxPosition == Blockly.utils.toolbox.Position.BOTTOM) {
       svgMetrics.height -= toolboxMetrics.height;
     } else if (
-        toolboxPosition == Blockly.constants.toolboxPosition.LEFT ||
-        toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
+        toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
+        toolboxPosition == Blockly.utils.toolbox.Position.RIGHT) {
       svgMetrics.width -= toolboxMetrics.width;
     }
   } else if (this.workspace_.getFlyout(true)) {
-    if (toolboxPosition == Blockly.constants.toolboxPosition.TOP ||
-        toolboxPosition == Blockly.constants.toolboxPosition.BOTTOM) {
+    if (toolboxPosition == Blockly.utils.toolbox.Position.TOP ||
+        toolboxPosition == Blockly.utils.toolbox.Position.BOTTOM) {
       svgMetrics.height -= flyoutMetrics.height;
     } else if (
-        toolboxPosition == Blockly.constants.toolboxPosition.LEFT ||
-        toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
+        toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
+        toolboxPosition == Blockly.utils.toolbox.Position.RIGHT) {
       svgMetrics.width -= flyoutMetrics.width;
     }
   }

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -219,8 +219,7 @@ Blockly.MetricsManager.prototype.getViewMetrics = function(
     if (toolboxPosition == Blockly.utils.toolbox.Position.TOP ||
         toolboxPosition == Blockly.utils.toolbox.Position.BOTTOM) {
       svgMetrics.height -= toolboxMetrics.height;
-    } else if (
-        toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
+    } else if (toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
         toolboxPosition == Blockly.utils.toolbox.Position.RIGHT) {
       svgMetrics.width -= toolboxMetrics.width;
     }
@@ -228,8 +227,7 @@ Blockly.MetricsManager.prototype.getViewMetrics = function(
     if (toolboxPosition == Blockly.utils.toolbox.Position.TOP ||
         toolboxPosition == Blockly.utils.toolbox.Position.BOTTOM) {
       svgMetrics.height -= flyoutMetrics.height;
-    } else if (
-        toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
+    } else if (toolboxPosition == Blockly.utils.toolbox.Position.LEFT ||
         toolboxPosition == Blockly.utils.toolbox.Position.RIGHT) {
       svgMetrics.width -= flyoutMetrics.width;
     }

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -175,15 +175,17 @@ Blockly.MetricsManager.prototype.getAbsoluteMetrics = function() {
   var toolboxPosition =
       doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
-  if (doesToolboxExist && toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+  var atLeft = toolboxPosition == Blockly.constants.toolboxPosition.LEFT;
+  var atTop = toolboxPosition == Blockly.constants.toolboxPosition.TOP;
+  if (doesToolboxExist && atLeft) {
     absoluteLeft = toolboxMetrics.width;
-  } else if (doesFlyoutExist && toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+  } else if (doesFlyoutExist && atLeft) {
     absoluteLeft = flyoutMetrics.width;
   }
   var absoluteTop = 0;
-  if (doesToolboxExist && toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+  if (doesToolboxExist && atTop) {
     absoluteTop = toolboxMetrics.height;
-  } else if (doesFlyoutExist && toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+  } else if (doesFlyoutExist && atTop) {
     absoluteTop = flyoutMetrics.height;
   }
 
@@ -214,19 +216,21 @@ Blockly.MetricsManager.prototype.getViewMetrics = function(
       doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
   if (this.workspace_.getToolbox()) {
-    if (toolboxPosition == Blockly.TOOLBOX_AT_TOP ||
-        toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
+    if (toolboxPosition == Blockly.constants.toolboxPosition.TOP ||
+        toolboxPosition == Blockly.constants.toolboxPosition.BOTTOM) {
       svgMetrics.height -= toolboxMetrics.height;
-    } else if (toolboxPosition == Blockly.TOOLBOX_AT_LEFT ||
-        toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
+    } else if (
+        toolboxPosition == Blockly.constants.toolboxPosition.LEFT ||
+        toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
       svgMetrics.width -= toolboxMetrics.width;
     }
   } else if (this.workspace_.getFlyout(true)) {
-    if (toolboxPosition == Blockly.TOOLBOX_AT_TOP ||
-        toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
+    if (toolboxPosition == Blockly.constants.toolboxPosition.TOP ||
+        toolboxPosition == Blockly.constants.toolboxPosition.BOTTOM) {
       svgMetrics.height -= flyoutMetrics.height;
-    } else if (toolboxPosition == Blockly.TOOLBOX_AT_LEFT ||
-        toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
+    } else if (
+        toolboxPosition == Blockly.constants.toolboxPosition.LEFT ||
+        toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
       svgMetrics.width -= flyoutMetrics.width;
     }
   }

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -611,13 +611,13 @@ Blockly.Toolbox.prototype.position = function() {
     toolboxDiv.style.height = 'auto';
     toolboxDiv.style.width = '100%';
     this.height_ = toolboxDiv.offsetHeight;
-    if (this.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {  // Top
+    if (this.toolboxPosition == Blockly.constants.toolboxPosition.TOP) {
       toolboxDiv.style.top = '0';
     } else {  // Bottom
       toolboxDiv.style.bottom = '0';
     }
   } else {
-    if (this.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {  // Right
+    if (this.toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
       toolboxDiv.style.right = '0';
     } else {  // Left
       toolboxDiv.style.left = '0';
@@ -636,10 +636,12 @@ Blockly.Toolbox.prototype.handleToolboxItemResize = function() {
   // to the new absolute edge (ie toolbox edge).
   var workspace = this.workspace_;
   var rect = this.HtmlDiv.getBoundingClientRect();
-  var newX = this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT ?
-      workspace.scrollX + rect.width : workspace.scrollX;
-  var newY = this.toolboxPosition == Blockly.TOOLBOX_AT_TOP ?
-      workspace.scrollY + rect.height : workspace.scrollY;
+  var newX = this.toolboxPosition == Blockly.constants.toolboxPosition.LEFT ?
+      workspace.scrollX + rect.width :
+      workspace.scrollX;
+  var newY = this.toolboxPosition == Blockly.constants.toolboxPosition.TOP ?
+      workspace.scrollY + rect.height :
+      workspace.scrollY;
   workspace.translate(newX, newY);
 
   // Even though the div hasn't changed size, the visible workspace

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -611,13 +611,13 @@ Blockly.Toolbox.prototype.position = function() {
     toolboxDiv.style.height = 'auto';
     toolboxDiv.style.width = '100%';
     this.height_ = toolboxDiv.offsetHeight;
-    if (this.toolboxPosition == Blockly.constants.toolboxPosition.TOP) {
+    if (this.toolboxPosition == Blockly.utils.toolbox.Position.TOP) {
       toolboxDiv.style.top = '0';
     } else {  // Bottom
       toolboxDiv.style.bottom = '0';
     }
   } else {
-    if (this.toolboxPosition == Blockly.constants.toolboxPosition.RIGHT) {
+    if (this.toolboxPosition == Blockly.utils.toolbox.Position.RIGHT) {
       toolboxDiv.style.right = '0';
     } else {  // Left
       toolboxDiv.style.left = '0';
@@ -636,10 +636,10 @@ Blockly.Toolbox.prototype.handleToolboxItemResize = function() {
   // to the new absolute edge (ie toolbox edge).
   var workspace = this.workspace_;
   var rect = this.HtmlDiv.getBoundingClientRect();
-  var newX = this.toolboxPosition == Blockly.constants.toolboxPosition.LEFT ?
+  var newX = this.toolboxPosition == Blockly.utils.toolbox.Position.LEFT ?
       workspace.scrollX + rect.width :
       workspace.scrollX;
-  var newY = this.toolboxPosition == Blockly.constants.toolboxPosition.TOP ?
+  var newY = this.toolboxPosition == Blockly.utils.toolbox.Position.TOP ?
       workspace.scrollY + rect.height :
       workspace.scrollY;
   workspace.translate(newX, newY);

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -446,8 +446,7 @@ Blockly.Trashcan.prototype.position = function(metrics, savedPositions) {
     return;
   }
 
-  if (metrics.toolboxMetrics.position ==
-          Blockly.constants.toolboxPosition.LEFT ||
+  if (metrics.toolboxMetrics.position == Blockly.utils.toolbox.Position.LEFT ||
       (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
     // Toolbox starts in the left corner.
     this.left_ = metrics.viewMetrics.width + metrics.absoluteMetrics.left -
@@ -463,8 +462,8 @@ Blockly.Trashcan.prototype.position = function(metrics, savedPositions) {
   // Bottom corner placement
   var maxTop = metrics.viewMetrics.height + metrics.absoluteMetrics.top -
       height - this.verticalSpacing_;
-  var placeBottom = metrics.toolboxMetrics.position !==
-      Blockly.constants.toolboxPosition.BOTTOM;
+  var placeBottom =
+      metrics.toolboxMetrics.position !== Blockly.utils.toolbox.Position.BOTTOM;
   this.top_ = placeBottom ? maxTop : minTop;
 
   // Check for collision and bump if needed.
@@ -563,8 +562,8 @@ Blockly.Trashcan.prototype.animateLid_ = function() {
  * @private
  */
 Blockly.Trashcan.prototype.setLidAngle_ = function(lidAngle) {
-  var openAtRight = this.workspace_.toolboxPosition ==
-          Blockly.constants.toolboxPosition.RIGHT ||
+  var openAtRight =
+      this.workspace_.toolboxPosition == Blockly.utils.toolbox.Position.RIGHT ||
       (this.workspace_.horizontalLayout && this.workspace_.RTL);
   this.svgLid_.setAttribute('transform', 'rotate(' +
       (openAtRight ? -lidAngle : lidAngle) + ',' +

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -446,7 +446,8 @@ Blockly.Trashcan.prototype.position = function(metrics, savedPositions) {
     return;
   }
 
-  if (metrics.toolboxMetrics.position == Blockly.TOOLBOX_AT_LEFT ||
+  if (metrics.toolboxMetrics.position ==
+          Blockly.constants.toolboxPosition.LEFT ||
       (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
     // Toolbox starts in the left corner.
     this.left_ = metrics.viewMetrics.width + metrics.absoluteMetrics.left -
@@ -462,8 +463,8 @@ Blockly.Trashcan.prototype.position = function(metrics, savedPositions) {
   // Bottom corner placement
   var maxTop = metrics.viewMetrics.height + metrics.absoluteMetrics.top -
       height - this.verticalSpacing_;
-  var placeBottom =
-      metrics.toolboxMetrics.position !== Blockly.TOOLBOX_AT_BOTTOM;
+  var placeBottom = metrics.toolboxMetrics.position !==
+      Blockly.constants.toolboxPosition.BOTTOM;
   this.top_ = placeBottom ? maxTop : minTop;
 
   // Check for collision and bump if needed.
@@ -562,7 +563,8 @@ Blockly.Trashcan.prototype.animateLid_ = function() {
  * @private
  */
 Blockly.Trashcan.prototype.setLidAngle_ = function(lidAngle) {
-  var openAtRight = this.workspace_.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT ||
+  var openAtRight = this.workspace_.toolboxPosition ==
+          Blockly.constants.toolboxPosition.RIGHT ||
       (this.workspace_.horizontalLayout && this.workspace_.RTL);
   this.svgLid_.setAttribute('transform', 'rotate(' +
       (openAtRight ? -lidAngle : lidAngle) + ',' +

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -177,12 +177,7 @@ Blockly.utils.toolbox.FLYOUT_TOOLBOX_KIND = 'flyoutToolbox';
  * Position of the the toolbox relative to the flyout.
  * @enum {number}
  */
-Blockly.utils.toolbox.Position = {
-  TOP: Blockly.TOOLBOX_AT_TOP,
-  BOTTOM: Blockly.TOOLBOX_AT_BOTTOM,
-  LEFT: Blockly.TOOLBOX_AT_LEFT,
-  RIGHT: Blockly.TOOLBOX_AT_RIGHT
-};
+Blockly.utils.toolbox.Position = Blockly.constants.toolboxPosition;
 
 /**
  * Converts the toolbox definition into toolbox JSON.

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -174,10 +174,15 @@ Blockly.utils.toolbox.CATEGORY_TOOLBOX_KIND = 'categoryToolbox';
 Blockly.utils.toolbox.FLYOUT_TOOLBOX_KIND = 'flyoutToolbox';
 
 /**
- * Position of the the toolbox relative to the flyout.
+ * Position of the the toolbox and/or flyout relative to the workspace.
  * @enum {number}
  */
-Blockly.utils.toolbox.Position = Blockly.constants.toolboxPosition;
+Blockly.utils.toolbox.Position = {
+  TOP: 0,
+  BOTTOM: 1,
+  LEFT: 2,
+  RIGHT: 3
+};
 
 /**
  * Converts the toolbox definition into toolbox JSON.

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -46,6 +46,7 @@ goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Metrics');
 goog.require('Blockly.utils.object');
 goog.require('Blockly.utils.Rect');
+goog.require('Blockly.utils.Size');
 goog.require('Blockly.utils.Svg');
 goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.Workspace');

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -224,7 +224,8 @@ Blockly.ZoomControls.prototype.position = function(metrics, savedPositions) {
   if (!this.verticalSpacing_) {
     return;
   }
-  if (metrics.toolboxMetrics.position == Blockly.TOOLBOX_AT_LEFT ||
+  if (metrics.toolboxMetrics.position ==
+          Blockly.constants.toolboxPosition.LEFT ||
       (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
     // Toolbox starts in the left corner.
     this.left_ = metrics.viewMetrics.width + metrics.absoluteMetrics.left -
@@ -239,8 +240,8 @@ Blockly.ZoomControls.prototype.position = function(metrics, savedPositions) {
   // Bottom corner placement
   var maxTop = metrics.viewMetrics.height + metrics.absoluteMetrics.top -
       this.HEIGHT_ - this.verticalSpacing_;
-  var placeBottom =
-      metrics.toolboxMetrics.position !== Blockly.TOOLBOX_AT_BOTTOM;
+  var placeBottom = metrics.toolboxMetrics.position !==
+      Blockly.constants.toolboxPosition.BOTTOM;
   this.top_ = placeBottom ? maxTop : minTop;
   if (placeBottom) {
     this.zoomInGroup_.setAttribute('transform', 'translate(0, 43)');

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -24,6 +24,7 @@ goog.require('Blockly.Touch');
 goog.require('Blockly.utils.dom');
 goog.require('Blockly.utils.Rect');
 goog.require('Blockly.utils.Svg');
+goog.require('Blockly.utils.toolbox');
 goog.require('Blockly.IPositionable');
 
 goog.requireType('Blockly.WorkspaceSvg');
@@ -224,8 +225,7 @@ Blockly.ZoomControls.prototype.position = function(metrics, savedPositions) {
   if (!this.verticalSpacing_) {
     return;
   }
-  if (metrics.toolboxMetrics.position ==
-          Blockly.constants.toolboxPosition.LEFT ||
+  if (metrics.toolboxMetrics.position == Blockly.utils.toolbox.Position.LEFT ||
       (this.workspace_.horizontalLayout && !this.workspace_.RTL)) {
     // Toolbox starts in the left corner.
     this.left_ = metrics.viewMetrics.width + metrics.absoluteMetrics.left -
@@ -240,8 +240,8 @@ Blockly.ZoomControls.prototype.position = function(metrics, savedPositions) {
   // Bottom corner placement
   var maxTop = metrics.viewMetrics.height + metrics.absoluteMetrics.top -
       this.HEIGHT_ - this.verticalSpacing_;
-  var placeBottom = metrics.toolboxMetrics.position !==
-      Blockly.constants.toolboxPosition.BOTTOM;
+  var placeBottom =
+      metrics.toolboxMetrics.position !== Blockly.utils.toolbox.Position.BOTTOM;
   this.top_ = placeBottom ? maxTop : minTop;
   if (placeBottom) {
     this.zoomInGroup_.setAttribute('transform', 'translate(0, 43)');

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -43,15 +43,14 @@ suite('Flyout', function() {
             viewWidth: 100,
           });
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.RIGHT;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.RIGHT;
+              Blockly.utils.toolbox.Position.RIGHT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
           chai.assert.equal(this.flyout.getX(), 100, 'x should be right of workspace');
         });
         test('x is 0 if flyout at left', function() {
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.LEFT;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
+              Blockly.utils.toolbox.Position.LEFT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
           chai.assert.equal(this.flyout.getX(), 0, 'x should be 0 if the flyout is on the left');
         });
       });
@@ -72,8 +71,8 @@ suite('Flyout', function() {
             toolboxWidth: 20,
           });
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.LEFT;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
+              Blockly.utils.toolbox.Position.LEFT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
           chai.assert.equal(this.flyout.getX(), 20, 'x should be aligned with toolbox');
         });
         test('x is aligned with toolbox at right', function() {
@@ -83,9 +82,8 @@ suite('Flyout', function() {
           });
           this.flyout.width_ = 10;
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.RIGHT;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.RIGHT;
+              Blockly.utils.toolbox.Position.RIGHT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
           chai.assert.equal(this.flyout.getX(), 90,'x + width should be aligned with toolbox');
         });
       });
@@ -100,8 +98,8 @@ suite('Flyout', function() {
             viewWidth: 100,
           });
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.RIGHT;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
+              Blockly.utils.toolbox.Position.RIGHT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
           chai.assert.equal(this.flyout.getX(), 0, 'x should be aligned with left edge');
         });
         test('trashcan on right covers right edge of workspace', function() {
@@ -111,9 +109,8 @@ suite('Flyout', function() {
             absoluteLeft: 10,
           });
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.LEFT;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.RIGHT;
+              Blockly.utils.toolbox.Position.LEFT;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
           chai.assert.equal(this.flyout.getX(), 90, 'x + width should be aligned with right edge');
         });
       });
@@ -139,15 +136,14 @@ suite('Flyout', function() {
         });
         test('y is 0 if flyout at top', function() {
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.TOP;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
+              Blockly.utils.toolbox.Position.TOP;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
           chai.assert.equal(this.flyout.getY(), 0, 'y should be 0 if flyout is at the top');
         });
         test('y is below workspace if flyout at bottom', function() {
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.BOTTOM;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.BOTTOM;
+              Blockly.utils.toolbox.Position.BOTTOM;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.BOTTOM;
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewHeight: 50,
           });
@@ -172,8 +168,8 @@ suite('Flyout', function() {
             toolboxHeight: 20,
           });
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.TOP;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
+              Blockly.utils.toolbox.Position.TOP;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
           chai.assert.equal(this.flyout.getY(), 20, 'y should be aligned with toolbox');
         });
         test('y is aligned with toolbox at bottom', function() {
@@ -183,9 +179,8 @@ suite('Flyout', function() {
           });
           this.flyout.height_ = 30;
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.BOTTOM;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.BOTTOM;
+              Blockly.utils.toolbox.Position.BOTTOM;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.BOTTOM;
           chai.assert.equal(this.flyout.getY(), 70, 'y + height should be aligned with toolbox');
         });
       });
@@ -197,15 +192,14 @@ suite('Flyout', function() {
         });
         test('y is 0 if trashcan at top', function() {
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.BOTTOM;
-          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
+              Blockly.utils.toolbox.Position.BOTTOM;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
           chai.assert.equal(this.flyout.getY(), 0, 'y should be aligned with top');
         });
         test('trashcan on bottom covers bottom of workspace', function() {
           this.flyout.targetWorkspace.toolboxPosition =
-              Blockly.constants.toolboxPosition.TOP;
-          this.flyout.toolboxPosition_ =
-              Blockly.constants.toolboxPosition.BOTTOM;
+              Blockly.utils.toolbox.Position.TOP;
+          this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.BOTTOM;
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewHeight: 50,
             absoluteTop: 10,

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -42,13 +42,16 @@ suite('Flyout', function() {
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewWidth: 100,
           });
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_RIGHT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_RIGHT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.RIGHT;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.RIGHT;
           chai.assert.equal(this.flyout.getX(), 100, 'x should be right of workspace');
         });
         test('x is 0 if flyout at left', function() {
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_LEFT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_LEFT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.LEFT;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
           chai.assert.equal(this.flyout.getX(), 0, 'x should be 0 if the flyout is on the left');
         });
       });
@@ -68,8 +71,9 @@ suite('Flyout', function() {
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             toolboxWidth: 20,
           });
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_LEFT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_LEFT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.LEFT;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
           chai.assert.equal(this.flyout.getX(), 20, 'x should be aligned with toolbox');
         });
         test('x is aligned with toolbox at right', function() {
@@ -78,8 +82,10 @@ suite('Flyout', function() {
             viewWidth: 100,
           });
           this.flyout.width_ = 10;
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_RIGHT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_RIGHT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.RIGHT;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.RIGHT;
           chai.assert.equal(this.flyout.getX(), 90,'x + width should be aligned with toolbox');
         });
       });
@@ -93,8 +99,9 @@ suite('Flyout', function() {
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewWidth: 100,
           });
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_RIGHT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_LEFT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.RIGHT;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.LEFT;
           chai.assert.equal(this.flyout.getX(), 0, 'x should be aligned with left edge');
         });
         test('trashcan on right covers right edge of workspace', function() {
@@ -103,8 +110,10 @@ suite('Flyout', function() {
             viewWidth: 100,
             absoluteLeft: 10,
           });
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_LEFT;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_RIGHT;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.LEFT;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.RIGHT;
           chai.assert.equal(this.flyout.getX(), 90, 'x + width should be aligned with right edge');
         });
       });
@@ -129,13 +138,16 @@ suite('Flyout', function() {
           chai.assert.equal(this.flyout.getX(), 0, 'x coordinate in horizontal flyout should be 0');
         });
         test('y is 0 if flyout at top', function() {
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_TOP;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_TOP;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.TOP;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
           chai.assert.equal(this.flyout.getY(), 0, 'y should be 0 if flyout is at the top');
         });
         test('y is below workspace if flyout at bottom', function() {
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_BOTTOM;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_BOTTOM;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.BOTTOM;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.BOTTOM;
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewHeight: 50,
           });
@@ -159,8 +171,9 @@ suite('Flyout', function() {
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             toolboxHeight: 20,
           });
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_TOP;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_TOP;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.TOP;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
           chai.assert.equal(this.flyout.getY(), 20, 'y should be aligned with toolbox');
         });
         test('y is aligned with toolbox at bottom', function() {
@@ -169,8 +182,10 @@ suite('Flyout', function() {
             viewHeight: 100,
           });
           this.flyout.height_ = 30;
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_BOTTOM;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_BOTTOM;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.BOTTOM;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.BOTTOM;
           chai.assert.equal(this.flyout.getY(), 70, 'y + height should be aligned with toolbox');
         });
       });
@@ -181,13 +196,16 @@ suite('Flyout', function() {
           this.flyout = this.workspace.getFlyout();
         });
         test('y is 0 if trashcan at top', function() {
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_BOTTOM;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_TOP;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.BOTTOM;
+          this.flyout.toolboxPosition_ = Blockly.constants.toolboxPosition.TOP;
           chai.assert.equal(this.flyout.getY(), 0, 'y should be aligned with top');
         });
         test('trashcan on bottom covers bottom of workspace', function() {
-          this.flyout.targetWorkspace.toolboxPosition = Blockly.TOOLBOX_AT_TOP;
-          this.flyout.toolboxPosition_ = Blockly.TOOLBOX_AT_BOTTOM;
+          this.flyout.targetWorkspace.toolboxPosition =
+              Blockly.constants.toolboxPosition.TOP;
+          this.flyout.toolboxPosition_ =
+              Blockly.constants.toolboxPosition.BOTTOM;
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
             viewHeight: 50,
             absoluteTop: 10,

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -444,7 +444,7 @@ suite('Toolbox', function() {
     });
     test('Horizontal toolbox at top -> Should anchor horizontal toolbox to top', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.TOP;
+      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.TOP;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
@@ -452,7 +452,7 @@ suite('Toolbox', function() {
     });
     test('Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.BOTTOM;
+      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.BOTTOM;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
@@ -460,7 +460,7 @@ suite('Toolbox', function() {
     });
     test('Vertical toolbox at right -> Should anchor to right', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.RIGHT;
+      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.RIGHT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
       chai.assert.equal(toolbox.HtmlDiv.style.right, '0px', 'Check right');
@@ -468,7 +468,7 @@ suite('Toolbox', function() {
     });
     test('Vertical toolbox at left -> Should anchor to left', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.LEFT;
+      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.LEFT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
       chai.assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left');

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -444,7 +444,7 @@ suite('Toolbox', function() {
     });
     test('Horizontal toolbox at top -> Should anchor horizontal toolbox to top', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.TOOLBOX_AT_TOP;
+      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.TOP;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
@@ -452,7 +452,7 @@ suite('Toolbox', function() {
     });
     test('Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.TOOLBOX_AT_BOTTOM;
+      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.BOTTOM;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
@@ -460,7 +460,7 @@ suite('Toolbox', function() {
     });
     test('Vertical toolbox at right -> Should anchor to right', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.TOOLBOX_AT_RIGHT;
+      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.RIGHT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
       chai.assert.equal(toolbox.HtmlDiv.style.right, '0px', 'Check right');
@@ -468,7 +468,7 @@ suite('Toolbox', function() {
     });
     test('Vertical toolbox at left -> Should anchor to left', function() {
       var toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.TOOLBOX_AT_LEFT;
+      toolbox.toolboxPosition = Blockly.constants.toolboxPosition.LEFT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
       chai.assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves ~40 missing require warnings.

### Proposed Changes

Replace uses of `Blockly.TOOLBOX_AT_TOP` and friends with uses of `Blockly.utils.toolbox.Position.TOP` and friends.

Leave the old names around as aliases in `blockly.js`.

No change in behaviour--just in types.
