### PR TITLE
Fix flyout scrollbar reposition edge case

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -446,7 +446,8 @@ Blockly.Flyout.prototype.positionAt_ = function(width, height, x, y) {
     if (scrollbar.hScroll) {
       scrollbar.hScroll.setPosition(
           scrollbar.hScroll.position.x, scrollbar.hScroll.position.y);
-    } else if (scrollbar.vScroll) {
+    }
+    if (scrollbar.vScroll) {
       scrollbar.vScroll.setPosition(
           scrollbar.vScroll.position.x, scrollbar.vScroll.position.y);
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -441,6 +441,16 @@ Blockly.Flyout.prototype.positionAt_ = function(width, height, x, y) {
     // Set the scrollbars origin to be the top left of the flyout.
     scrollbar.setOrigin(x, y);
     scrollbar.resize();
+    // If origin changed and metrics haven't changed enough to trigger
+    // reposition in resize, we need to call setPosition. See issue #4692.
+    if (scrollbar.hScroll) {
+      scrollbar.hScroll.setPosition(
+          scrollbar.hScroll.position.x, scrollbar.hScroll.position.y);
+    } else if (scrollbar.vScroll) {
+      scrollbar.vScroll.setPosition(
+          scrollbar.vScroll.position.x, scrollbar.vScroll.position.y);
+
+    }
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4692
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds `setPosition` call inside of Flyout code to fix issues cause by scrollbar not repositioning correctly in certain edge cases.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Scrollbar was not repositioning correctly, as described in #4692
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Scrollbar positions correctly.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Bugfix
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manual testing in playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

This `setPosition` call was removed in #4607 because it was incorrectly assumed to be unnecessary. A comment has been added to reference why it's needed and the bug for additional repro of what it fixes.
<!-- Anything else we should know? -->
