### PR TITLE
Fix advanced comp

### DIFF
--- a/core/input.js
+++ b/core/input.js
@@ -21,7 +21,6 @@ goog.require('Blockly.inputTypes');
 goog.requireType('Blockly.Block');
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.Field');
-goog.requireType('Blockly.FieldDropdown');
 goog.requireType('Blockly.RenderedConnection');
 
 
@@ -122,17 +121,16 @@ Blockly.Input.prototype.insertFieldAt = function(index, field, opt_name) {
   field.name = opt_name;
   field.setVisible(this.isVisible());
 
-  var fieldDropdown = /** @type {Blockly.FieldDropdown} */ (field);
-  if (fieldDropdown.prefixField) {
+  if (field.prefixField) {
     // Add any prefix.
-    index = this.insertFieldAt(index, fieldDropdown.prefixField);
+    index = this.insertFieldAt(index, field.prefixField);
   }
   // Add the field to the field row.
   this.fieldRow.splice(index, 0, field);
   ++index;
-  if (fieldDropdown.suffixField) {
+  if (field.suffixField) {
     // Add any suffix.
-    index = this.insertFieldAt(index, fieldDropdown.suffixField);
+    index = this.insertFieldAt(index, field.suffixField);
   }
 
   if (this.sourceBlock_.rendered) {

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -449,6 +449,7 @@ function buildAdvancedCompilationTest() {
     'tests/compile/main.js',
     'core/**/**/*.js',
     'blocks/*.js',
+    'tests/compile/test_blocks.js',
     'generators/**/*.js'];
   return gulp.src(maybeAddClosureLibrary(srcs), {base: './'})
     .pipe(stripApacheLicense())

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -447,9 +447,9 @@ function buildLangfiles(done) {
 function buildAdvancedCompilationTest() {
   const srcs = [
     'tests/compile/main.js',
+    'tests/compile/test_blocks.js',
     'core/**/**/*.js',
     'blocks/*.js',
-    'tests/compile/test_blocks.js',
     'generators/**/*.js'];
   return gulp.src(maybeAddClosureLibrary(srcs), {base: './'})
     .pipe(stripApacheLicense())

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -14,6 +14,7 @@ goog.require('Blockly.VerticalFlyout');
 goog.require('Blockly.Constants.Logic');
 goog.require('Blockly.Constants.Loops');
 goog.require('Blockly.Constants.Math');
+goog.require('Blockly.Constants.TestBlocks');
 goog.require('Blockly.Constants.Text');
 goog.require('Blockly.Constants.Lists');
 goog.require('Blockly.Constants.Colour');

--- a/tests/compile/test_blocks.js
+++ b/tests/compile/test_blocks.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Test blocks for advanced compilation.
+ */
+'use strict';
+
+goog.provide('Blockly.Constants.TestBlocks');
+
+goog.require('Blockly');
+goog.require('Blockly.Blocks');
+
+
+Blockly.defineBlocksWithJsonArray([
+    {
+      'type': 'test_style_hex1',
+      'message0': 'Block color: Bright purple %1 %2 %3 %4',
+      'args0': [
+        {
+          'type': 'field_input',
+          'name': 'TEXT',
+          'text': '#992aff',
+        },
+        {
+          'type': 'field_dropdown',
+          'name': 'DROPDOWN',
+          'options': [
+            ['option', 'ONE'],
+            ['option', 'TWO'],
+          ],
+        },
+        {
+          'type': 'field_checkbox',
+          'name': 'NAME',
+          'checked': true,
+        },
+        {
+          'type': 'input_value',
+          'name': 'NAME',
+        },
+      ],
+      'previousStatement': null,
+      'nextStatement': null,
+      'colour': '#992aff',
+    }
+]);
+  

--- a/tests/compile/test_blocks.js
+++ b/tests/compile/test_blocks.js
@@ -48,4 +48,3 @@ Blockly.defineBlocksWithJsonArray([
       'colour': '#992aff',
     }
 ]);
-  


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Advanced compilation test was failing due to 
- Us moving the "test_style_hex1" block out of core
- Because of a type cast to `Blockly.FieldDropdown`.

This bug was a bit weird and I am not entirely sure I understand what is happening but I will try to document at least what I know:
- We were getting an error because somehow [field.suffixField](https://github.com/google/blockly/blob/d7e9eaff0fd533e8bfda905c8eb02a16722af89d/core/input.js#L122) was getting set to true when it shouldn't be(only in advanced compilation).
- We do not get the error when we remove the [type cast](https://github.com/google/blockly/blob/d7e9eaff0fd533e8bfda905c8eb02a16722af89d/core/input.js#L114) OR when we remove [these three lines](https://github.com/google/blockly/blob/82a2dd90a7f965205882875bf7325dd4428fd0e9/core/field_dropdown.js#L162) in FieldDropdown.fromXml.
- I have no idea why, removing those three lines in fromXml works since I put console logs there, and it doesn't look like we actually ever get to that code.
### Proposed Changes
- Add back in the test block. 
- Remove the cast to a field dropdown. From what I can tell this does not break the compiler, and it seems similar to what we do when we check for an optional method on a class before calling it.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
The [original comment](https://github.com/google/blockly/pull/3912/files#r428912607) discussing this.
Alternatives: 
1. Create an interface for prefixField and suffixField
2. Check the field is an instance of Blockly.FieldDropdown. (I tried this and the compiler complained. I can look more into this, however in the comment we say that Blockly.FieldDropdown isn't a required field so we shouldn't assume it is available?)
3. Leave as is.
<!-- Anything else we should know? -->
