### PR TITLE
Include oldCoordinate and oldContents in ws comment event serialization

### DIFF
--- a/core/events/ws_comment_events.js
+++ b/core/events/ws_comment_events.js
@@ -360,7 +360,7 @@ Blockly.Events.CommentMove.prototype.setOldCoordinate = function(xy) {
 // TODO (#1266): "Full" and "minimal" serialization.
 Blockly.Events.CommentMove.prototype.toJson = function() {
   var json = Blockly.Events.CommentMove.superClass_.toJson.call(this);
-  if (this.newCoordinate_) {
+  if (this.oldCoordinate_) {
     json['oldCoordinate'] = Math.round(this.oldCoordinate_.x) + ',' +
         Math.round(this.oldCoordinate_.y);
   }

--- a/core/events/ws_comment_events.js
+++ b/core/events/ws_comment_events.js
@@ -126,6 +126,7 @@ Blockly.Events.CommentChange.prototype.type = Blockly.Events.COMMENT_CHANGE;
  */
 Blockly.Events.CommentChange.prototype.toJson = function() {
   var json = Blockly.Events.CommentChange.superClass_.toJson.call(this);
+  json['oldContents'] = this.oldContents_;
   json['newContents'] = this.newContents_;
   return json;
 };
@@ -136,6 +137,7 @@ Blockly.Events.CommentChange.prototype.toJson = function() {
  */
 Blockly.Events.CommentChange.prototype.fromJson = function(json) {
   Blockly.Events.CommentChange.superClass_.fromJson.call(this, json);
+  this.oldContents_ = json['oldContents'];
   this.newContents_ = json['newContents'];
 };
 
@@ -359,6 +361,10 @@ Blockly.Events.CommentMove.prototype.setOldCoordinate = function(xy) {
 Blockly.Events.CommentMove.prototype.toJson = function() {
   var json = Blockly.Events.CommentMove.superClass_.toJson.call(this);
   if (this.newCoordinate_) {
+    json['oldCoordinate'] = Math.round(this.oldCoordinate_.x) + ',' +
+        Math.round(this.oldCoordinate_.y);
+  }
+  if (this.newCoordinate_) {
     json['newCoordinate'] = Math.round(this.newCoordinate_.x) + ',' +
         Math.round(this.newCoordinate_.y);
   }
@@ -372,6 +378,11 @@ Blockly.Events.CommentMove.prototype.toJson = function() {
 Blockly.Events.CommentMove.prototype.fromJson = function(json) {
   Blockly.Events.CommentMove.superClass_.fromJson.call(this, json);
 
+  if (json['oldCoordinate']) {
+    var xy = json['oldCoordinate'].split(',');
+    this.oldCoordinate_ =
+        new Blockly.utils.Coordinate(Number(xy[0]), Number(xy[1]));
+  }
   if (json['newCoordinate']) {
     var xy = json['newCoordinate'].split(',');
     this.newCoordinate_ =

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -628,7 +628,7 @@ suite('Events', function() {
       {title: 'Comment move', class: Blockly.Events.CommentMove,
         getArgs: (thisObj) => [thisObj.comment],
         getExpectedJson: (thisObj) => ({type: 'comment_move',
-          commentId: thisObj.comment.id})},
+          commentId: thisObj.comment.id, oldCoordinate: '0,0'})},
     ];
     var testSuites = [
       {title: 'Variable events', testCases: variableEventTestCases,

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -611,9 +611,10 @@ suite('Events', function() {
     ];
     var workspaceCommentEventTestCases = [
       {title: 'Comment change', class: Blockly.Events.CommentChange,
-        getArgs: (thisObj) => [thisObj.comment, '', 'words'],
+        getArgs: (thisObj) => [thisObj.comment, 'bar', 'foo'],
         getExpectedJson: (thisObj) => ({type: 'comment_change',
-          commentId: thisObj.comment.id, newContents: 'words'})},
+          commentId: thisObj.comment.id, oldContents: 'bar',
+          newContents: 'foo'})},
       {title: 'Comment create', class: Blockly.Events.CommentCreate,
         getArgs: (thisObj) => [thisObj.comment],
         getExpectedJson: (thisObj) => ({type: 'comment_create',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4527
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Includes `oldContents` and `oldCoodinate` in serialization/deserialization of workspace comment events
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Workspace comment change events did not serialize the `oldContents` property and workspace comment move events did not serialize the `oldCoordinate` property.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Workspace comment change events serializes `oldContents` property and workspace comment move events serializes the `oldCoordinate` property.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

Adding comment move event tests tracked as part of #4577.
<!-- Anything else we should know? -->
