### PR TITLE
Add exclude paths as config for typings

### DIFF
--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -24,6 +24,14 @@ var execSync = require('child_process').execSync;
 // including Blockly Options and Google Closure typings.
 function typings() {
   const tmpDir = './typings/tmp';
+  const excludeDirs = [
+    "core/renderers/geras",
+    "core/renderers/minimalist",
+    "core/renderers/thrasos",
+    "core/renderers/zelos"
+  ];
+  // blocklySrcs should include everything under msg and core (except excludes)
+  // TODO generate blockySrcs
   const blocklySrcs = [
     "core/",
     "core/events",

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -90,15 +90,7 @@ function typings() {
   const srcs = [
     'typings/templates/blockly-header.template',
     'typings/templates/blockly-interfaces.template',
-    `${tmpDir}/core/**`,
-    `${tmpDir}/core/interfaces/**`,
-    `${tmpDir}/core/events/**`,
-    `${tmpDir}/core/keyboard_nav/**`,
-    `${tmpDir}/core/renderers/common/**`,
-    `${tmpDir}/core/renderers/measurables/**`,
-    `${tmpDir}/core/utils/**`,
-    `${tmpDir}/core/toolbox/**`,
-    `${tmpDir}/core/theme/**`,
+    `${tmpDir}/core/**/*`,
     `${tmpDir}/msg/**`
   ];
   return gulp.src(srcs)

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -19,19 +19,18 @@ var execSync = require('child_process').execSync;
 
 /**
  * Recursively generates a list of file paths with the specified extension
- * contained within the specified startPath.
- * @param {string} startPath The base path to use.
+ * contained within the specified basePath.
+ * @param {string} basePath The base path to use.
  * @param {string} filter The extension name to filter for.
  * @param {Array<string>} excludePaths The paths to exclude from search.
  * @return {Array<string>} The generated file paths.
  */
-function getFilePath(startPath, filter, excludePaths) {
+function getFilePath(basePath, filter, excludePaths) {
   const files = [];
-  const dirContents = fs.readdirSync(startPath);
+  const dirContents = fs.readdirSync(basePath);
   dirContents.forEach((fn) => {
-    const filePath = path.join(startPath, fn);
+    const filePath = path.join(basePath, fn);
     const excluded =
-        !excludePaths.every((exPath) => !filePath.startsWith(exPath));
         !excludePaths.every((exPath) => !filePath.startsWith(exPath));
     if (excluded) {
       return;
@@ -72,8 +71,8 @@ function typings() {
   ]
   // Find all files that will be included in the typings file.
   let files = [];
-  blocklySrcs.forEach((startPath) => {
-    files.push(...getFilePath(startPath, '.js', excludePaths));
+  blocklySrcs.forEach((basePath) => {
+    files.push(...getFilePath(basePath, '.js', excludePaths));
   });
 
   // Generate typings file for each file.

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -17,6 +17,35 @@ var fs = require('fs');
 var rimraf = require('rimraf');
 var execSync = require('child_process').execSync;
 
+/**
+ * Recursively generates a list of file paths with the specified extension
+ * contained within the specified startPath.
+ * @param {string} startPath The base path to use.
+ * @param {string} filter The extension name to filter for.
+ * @param {Array<string>} excludePaths The paths to exclude from search.
+ * @return {Array<string>} The generated file paths.
+ */
+function getFilePath(startPath, filter, excludePaths) {
+  const files = [];
+  const dirContents = fs.readdirSync(startPath);
+  dirContents.forEach((fn) => {
+    const filePath = path.join(startPath, fn);
+    const excluded =
+        !excludePaths.every((exPath) => !filePath.startsWith(exPath));
+        !excludePaths.every((exPath) => !filePath.startsWith(exPath));
+    if (excluded) {
+      return;
+    }
+    const stat = fs.lstatSync(filePath);
+    if (stat.isDirectory()) {
+      files.push(...getFilePath(filePath, filter, excludePaths));
+    } else if (filePath.endsWith(filter)) {
+      files.push(filePath);
+    }
+  });
+  return files;
+}
+
 // Generates the TypeScript definition file (d.ts) for Blockly.
 // As well as generating the typings of each of the files under core/ and msg/,
 // the script also pulls in a number of part files from typings/parts.
@@ -24,38 +53,27 @@ var execSync = require('child_process').execSync;
 // including Blockly Options and Google Closure typings.
 function typings() {
   const tmpDir = './typings/tmp';
-  const excludeDirs = [
-    "core/renderers/geras",
-    "core/renderers/minimalist",
-    "core/renderers/thrasos",
-    "core/renderers/zelos"
-  ];
-  // blocklySrcs should include everything under msg and core (except excludes)
-  // TODO generate blockySrcs
-  const blocklySrcs = [
-    "core/",
-    "core/events",
-    "core/keyboard_nav",
-    "core/renderers/common",
-    "core/renderers/measurables",
-    "core/theme",
-    "core/toolbox",
-    "core/interfaces",
-    "core/utils",
-    "msg/"
-  ];
+
   // Clean directory if exists.
   if (fs.existsSync(tmpDir)) {
     rimraf.sync(tmpDir);
   }
   fs.mkdirSync(tmpDir);
 
+  const excludePaths = [
+    "core/renderers/geras",
+    "core/renderers/minimalist",
+    "core/renderers/thrasos",
+    "core/renderers/zelos",
+  ];
+  const blocklySrcs = [
+      'core',
+      'msg'
+  ]
   // Find all files that will be included in the typings file.
   let files = [];
-  blocklySrcs.forEach((src) => {
-    files = files.concat(fs.readdirSync(src)
-      .filter(fn => fn.endsWith('.js'))
-      .map(fn => path.join(src, fn)));
+  blocklySrcs.forEach((startPath) => {
+    files.push(...getFilePath(startPath, '.js', excludePaths));
   });
 
   // Generate typings file for each file.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4546
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Changes logic in typing script to check all directories in core and msg and use exclude paths instead of a list of include paths that need to be manually updated.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

If a new folder was added to core, then this file would need to be updated manually.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

If a new folder is added to core, the typing script does not need to be updated.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Reduces overhead for committing changes that edit the directory structure of source code in the repo.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran typings and checked the console output.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

