### PR TITLE
Always scroll center on zoom reset

### DIFF
--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -456,19 +456,15 @@ Blockly.ZoomControls.prototype.resetZoom_ = function(e) {
   // targetScale = currentScale * Math.pow(speed, amount)
   var targetScale = this.workspace_.options.zoomOptions.startScale;
   var currentScale = this.workspace_.scale;
-  if (targetScale !== currentScale) {
-    var speed = this.workspace_.options.zoomOptions.scaleSpeed;
-    // To compute amount:
-    // amount = log(speed, (targetScale / currentScale))
-    // Math.log computes natural logarithm (ln), to change the base, use formula:
-    // log(base, value) = ln(value) / ln(base)
-    var amount = Math.log(targetScale / currentScale) / Math.log(speed);
-    this.workspace_.beginCanvasTransition();
-    this.workspace_.zoomCenter(amount);
-  } else {
-    this.workspace_.beginCanvasTransition();
-    this.workspace_.scrollCenter();
-  }
+  var speed = this.workspace_.options.zoomOptions.scaleSpeed;
+  // To compute amount:
+  // amount = log(speed, (targetScale / currentScale))
+  // Math.log computes natural logarithm (ln), to change the base, use formula:
+  // log(base, value) = ln(value) / ln(base)
+  var amount = Math.log(targetScale / currentScale) / Math.log(speed);
+  this.workspace_.beginCanvasTransition();
+  this.workspace_.zoomCenter(amount);
+  this.workspace_.scrollCenter();
 
   setTimeout(this.workspace_.endCanvasTransition.bind(this.workspace_), 500);
   this.fireZoomEvent_();

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -456,15 +456,19 @@ Blockly.ZoomControls.prototype.resetZoom_ = function(e) {
   // targetScale = currentScale * Math.pow(speed, amount)
   var targetScale = this.workspace_.options.zoomOptions.startScale;
   var currentScale = this.workspace_.scale;
-  var speed = this.workspace_.options.zoomOptions.scaleSpeed;
-  // To compute amount:
-  // amount = log(speed, (targetScale / currentScale))
-  // Math.log computes natural logarithm (ln), to change the base, use formula:
-  // log(base, value) = ln(value) / ln(base)
-  var amount = Math.log(targetScale / currentScale) / Math.log(speed);
-
-  this.workspace_.beginCanvasTransition();
-  this.workspace_.zoomCenter(amount);
+  if (targetScale !== currentScale) {
+    var speed = this.workspace_.options.zoomOptions.scaleSpeed;
+    // To compute amount:
+    // amount = log(speed, (targetScale / currentScale))
+    // Math.log computes natural logarithm (ln), to change the base, use formula:
+    // log(base, value) = ln(value) / ln(base)
+    var amount = Math.log(targetScale / currentScale) / Math.log(speed);
+    this.workspace_.beginCanvasTransition();
+    this.workspace_.zoomCenter(amount);
+  } else {
+    this.workspace_.beginCanvasTransition();
+    this.workspace_.scrollCenter();
+  }
 
   setTimeout(this.workspace_.endCanvasTransition.bind(this.workspace_), 500);
   this.fireZoomEvent_();

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -110,7 +110,9 @@ function start() {
         readOnly: false,
         rtl: rtl,
         move: {
-          scrollbars: true,
+          scrollbars: {
+            vertical: true
+          },
           drag: true,
           wheel: false,
         },

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -110,9 +110,7 @@ function start() {
         readOnly: false,
         rtl: rtl,
         move: {
-          scrollbars: {
-            vertical: true
-          },
+          scrollbars: true,
           drag: true,
           wheel: false,
         },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Updates zoom reset logic to scroll to center after resetting zoom level.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Workspace doesn't scroll to center when zoom reset control is clicked.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Workspace scrolla to center when zoom reset control is clicked.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

This behavior is consistent with how the zoom controls worked in previous releases.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


