### PR TITLE
Fix flyout scroll metrics

### DIFF
--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -541,16 +541,19 @@ Blockly.FlyoutMetricsManager.prototype.getContentMetrics = function(
 Blockly.FlyoutMetricsManager.prototype.getScrollMetrics = function(
     opt_getWorkspaceCoordinates, opt_viewMetrics, opt_contentMetrics) {
   var contentMetrics = opt_contentMetrics || this.getContentMetrics();
-  var absoluteMetrics = this.getAbsoluteMetrics();
-  var margin = this.flyout_.MARGIN;
+  var margin = this.flyout_.MARGIN * this.workspace_.scale;
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
-  var leftPadding = contentMetrics.left - absoluteMetrics.left + margin;
+
+  // The left padding isn't just the margin. Some blocks are also offset by
+  // tabWidth so that value and statement blocks line up.
+  // The contentMetrics.left value is equivalent to the variable left padding.
+  var leftPadding = contentMetrics.left;
 
   return {
     height: (contentMetrics.height + 2 * margin) / scale,
     width: (contentMetrics.width + leftPadding + margin) / scale,
-    top: absoluteMetrics.top / scale,
-    left: absoluteMetrics.left / scale,
+    top: 0,
+    left: 0,
   };
 };
 
@@ -561,16 +564,9 @@ Blockly.FlyoutMetricsManager.prototype.getViewMetrics = function(
     opt_getWorkspaceCoordinates) {
   var svgMetrics = this.getSvgMetrics();
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
-  if (this.flyout_.horizontalLayout) {
-    var viewWidth = svgMetrics.width - 2 * this.flyout_.SCROLLBAR_PADDING;
-    var viewHeight = svgMetrics.height - this.flyout_.SCROLLBAR_PADDING;
-  } else {
-    var viewWidth = svgMetrics.width - this.flyout_.SCROLLBAR_PADDING;
-    var viewHeight = svgMetrics.height - 2 * this.flyout_.SCROLLBAR_PADDING;
-  }
   return {
-    height: viewHeight / scale,
-    width: viewWidth / scale,
+    height: svgMetrics.height / scale,
+    width: svgMetrics.width / scale,
     top: -this.workspace_.scrollY / scale,
     left: -this.workspace_.scrollX / scale,
   };
@@ -580,15 +576,5 @@ Blockly.FlyoutMetricsManager.prototype.getViewMetrics = function(
  * @override
  */
 Blockly.FlyoutMetricsManager.prototype.getAbsoluteMetrics = function() {
-  var scrollbarPadding = this.flyout_.SCROLLBAR_PADDING;
-
-  if (this.flyout_.horizontalLayout) {
-    // The viewWidth is svgWidth - 2 * scrollbarPadding. We want to put half
-    // of that padding to the left of the blocks.
-    return {top: 0, left: scrollbarPadding};
-  } else {
-    // The viewHeight is svgHeight - 2 * scrollbarPadding. We want to put half
-    // of that padding to the top of the blocks.
-    return {top: scrollbarPadding, left: 0};
-  }
+  return {top: 0, left: 0};
 };

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -544,16 +544,11 @@ Blockly.FlyoutMetricsManager.prototype.getScrollMetrics = function(
   var absoluteMetrics = this.getAbsoluteMetrics();
   var margin = this.flyout_.MARGIN;
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
-
-  var widthAdjustment = 0;
-  if (contentMetrics.left - margin !== absoluteMetrics.left) {
-    // Blocks without a tab are offset to the right and we need to add to width.
-    widthAdjustment = contentMetrics.left;
-  }
+  var leftPadding = contentMetrics.left - absoluteMetrics.left + margin;
 
   return {
     height: (contentMetrics.height + 2 * margin) / scale,
-    width: (contentMetrics.width + 2 * margin + widthAdjustment) / scale,
+    width: (contentMetrics.width + leftPadding + margin) / scale,
     top: absoluteMetrics.top / scale,
     left: absoluteMetrics.left / scale,
   };

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -541,14 +541,15 @@ Blockly.FlyoutMetricsManager.prototype.getContentMetrics = function(
 Blockly.FlyoutMetricsManager.prototype.getScrollMetrics = function(
     opt_getWorkspaceCoordinates, opt_viewMetrics, opt_contentMetrics) {
   var contentMetrics = opt_contentMetrics || this.getContentMetrics();
+  var absoluteMetrics = this.getAbsoluteMetrics();
   var margin = this.flyout_.MARGIN;
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
 
   return {
     height: (contentMetrics.height + 2 * margin) / scale,
     width: (contentMetrics.width + 2 * margin) / scale,
-    top: contentMetrics.top - margin / scale,
-    left: contentMetrics.left - margin / scale,
+    top: absoluteMetrics.top / scale,
+    left: absoluteMetrics.left / scale,
   };
 };
 

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -545,9 +545,15 @@ Blockly.FlyoutMetricsManager.prototype.getScrollMetrics = function(
   var margin = this.flyout_.MARGIN;
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
 
+  var widthAdjustment = 0;
+  if (contentMetrics.left - margin !== absoluteMetrics.left) {
+    // Blocks without a tab are offset to the right and we need to add to width.
+    widthAdjustment = contentMetrics.left;
+  }
+
   return {
     height: (contentMetrics.height + 2 * margin) / scale,
-    width: (contentMetrics.width + 2 * margin) / scale,
+    width: (contentMetrics.width + 2 * margin + widthAdjustment) / scale,
     top: absoluteMetrics.top / scale,
     left: absoluteMetrics.left / scale,
   };

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -564,9 +564,16 @@ Blockly.FlyoutMetricsManager.prototype.getViewMetrics = function(
     opt_getWorkspaceCoordinates) {
   var svgMetrics = this.getSvgMetrics();
   var scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
+  if (this.flyout_.horizontalLayout) {
+    var viewWidth = svgMetrics.width - 2 * this.flyout_.SCROLLBAR_PADDING;
+    var viewHeight = svgMetrics.height - this.flyout_.SCROLLBAR_PADDING;
+  } else {
+    var viewWidth = svgMetrics.width - this.flyout_.SCROLLBAR_PADDING;
+    var viewHeight = svgMetrics.height - 2 * this.flyout_.SCROLLBAR_PADDING;
+  }
   return {
-    height: svgMetrics.height / scale,
-    width: svgMetrics.width / scale,
+    height: viewHeight / scale,
+    width: viewWidth / scale,
     top: -this.workspace_.scrollY / scale,
     left: -this.workspace_.scrollX / scale,
   };
@@ -576,5 +583,15 @@ Blockly.FlyoutMetricsManager.prototype.getViewMetrics = function(
  * @override
  */
 Blockly.FlyoutMetricsManager.prototype.getAbsoluteMetrics = function() {
-  return {top: 0, left: 0};
+  var scrollbarPadding = this.flyout_.SCROLLBAR_PADDING;
+
+  if (this.flyout_.horizontalLayout) {
+    // The viewWidth is svgWidth - 2 * scrollbarPadding. We want to put half
+    // of that padding to the left of the blocks.
+    return {top: 0, left: scrollbarPadding};
+  } else {
+    // The viewHeight is svgHeight - 2 * scrollbarPadding. We want to put half
+    // of that padding to the top of the blocks.
+    return {top: scrollbarPadding, left: 0};
+  }
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Updates flyout metrics computation.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

1. Switching between text and logic category flyouts in the playground and scrolling in them caused a weird "bump" behavior.

![f52f29e7-1e0a-44f8-a04e-6bc87b014f97](https://user-images.githubusercontent.com/6621618/112211517-3a776780-8bd9-11eb-80f8-75ecb124cd8b.gif)

2. The horizontal scrollbar did not have enough padding to the left of the first block in the flyout, if that block was not a value block, when compared to master.

Expected:
![4H7P2UATEfQAoo3](https://user-images.githubusercontent.com/6621618/112212678-824abe80-8bda-11eb-9865-57659964197d.png)

Actual:
![BTjdHbESghsJWsT](https://user-images.githubusercontent.com/6621618/112212690-8545af00-8bda-11eb-9548-09fe940b7564.png)

3. (on master) The left edge padding for a horizontal flyout is not adjusted if the first block is not a value block. 
![BhUwdWpYwQzsibK](https://user-images.githubusercontent.com/6621618/112217068-78778a00-8bdf-11eb-8c1b-b05e5a9a971a.png)

4. (on master) The bottom edge padding for a vertical flyout and the left edge padding for a horizontal flyout is not scaled with zoom as it should.


<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

1. Flyout scrolling now behaves as expected, without "bump" behavior.

2. Padding to the left of the first block in a horizontal flyout on develop is adjusted so that blocks with and without an output connection are aligned.

3. Padding to the right of blocks in horizontal flyout is now adjusted so that there is the expected padding if the first block  had an output connection.
![9E4qcA6PeBWLZZE](https://user-images.githubusercontent.com/6621618/112217187-93e29500-8bdf-11eb-88fc-a8536dea31d5.png)

4. The bottom and right edge padding of flyouts now scale with zoom.

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Bugfix.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on multi_playground.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
