### PR TITLE
update event type in blockly developer tools

### DIFF
--- a/demos/blockfactory/workspacefactory/wfactory_init.js
+++ b/demos/blockfactory/workspacefactory/wfactory_init.js
@@ -346,7 +346,7 @@ WorkspaceFactoryInit.addWorkspaceFactoryEventListeners_ = function(controller) {
     // surrounding parent, meaning it is nested in another block (blocks that
     // are not nested in parents cannot be shadow blocks).
     if (e.type == Blockly.Events.BLOCK_MOVE ||
-        e.type == Blockly.Event.SELECTED) {
+        e.type == Blockly.Events.SELECTED) {
       var selected = Blockly.selected;
 
       // Show shadow button if a block is selected. Show "Add Shadow" if


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

See image. In the workspace factory in developer tools, when you select a block, the "make shadow" button should be enabled. it is not, because the event listener gives up because "Blockly.Event.Selected" does not exist.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

See image. "make shadow" button does not work

#### Behavior After Change

"make shadow" button enables correctly

### Additional Information

This behavior is also present on master, so this isn't a recent regression. The rest of developer tools still works fine.


![image](https://user-images.githubusercontent.com/8573958/112400757-3f661500-8cc6-11eb-8800-71f58b9bdd88.png)

