### PR TITLE
Fix menu setHighlighted not scrolling to the menuItem

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -165,9 +165,6 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownContent {',
-    'max-height: 300px;', // @todo: spec for maximum height.
-    'overflow: auto;',
-    'overflow-x: hidden;',
     'position: relative;',
   '}',
 
@@ -462,6 +459,9 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropdownMenu {',
+    'max-height: 300px;', // @todo: spec for maximum height.
+    'overflow-y: auto;',
+    'overflow-x: hidden;',
     'border-radius: 2px;',
     'padding: 0 !important;',
   '}',
@@ -515,7 +515,8 @@ Blockly.Css.CONTENT = [
     'margin: 0;',
      /* 7em on the right for shortcut. */
     'min-width: 7em;',
-    'padding: 6px 15px;',
+    'padding: 5px 15px;',
+    'margin-bottom: 2px;',
     'white-space: nowrap;',
   '}',
 

--- a/core/menu.js
+++ b/core/menu.js
@@ -102,13 +102,6 @@ Blockly.Menu = function() {
    * @private
    */
   this.roleName_ = null;
-
-  /**
-   * The menu parent's DOM element.
-   * @type {Element}
-   * @private
-   */
-  this.parentElement_ = null;
 };
 
 
@@ -132,7 +125,6 @@ Blockly.Menu.prototype.render = function(container) {
   if (this.roleName_) {
     Blockly.utils.aria.setRole(element, this.roleName_);
   }
-  this.parentElement_ = container;
   this.element_ = element;
 
   // Add menu items.
@@ -277,7 +269,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
     this.highlightedItem_ = item;
     // Bring the highlighted item into view. This has no effect if the menu is
     // not scrollable.
-    var el = /** @type {!Element} */ (this.parentElement_);
+    var el = /** @type {!Element} */ (this.getElement());
     Blockly.utils.style.scrollIntoContainerView(
         /** @type {!Element} */ (item.getElement()), el);
 

--- a/core/menu.js
+++ b/core/menu.js
@@ -102,6 +102,13 @@ Blockly.Menu = function() {
    * @private
    */
   this.roleName_ = null;
+
+  /**
+   * The menu parent's DOM element.
+   * @type {Element}
+   * @private
+   */
+  this.parentElement_ = null;
 };
 
 
@@ -125,6 +132,7 @@ Blockly.Menu.prototype.render = function(container) {
   if (this.roleName_) {
     Blockly.utils.aria.setRole(element, this.roleName_);
   }
+  this.parentElement_ = container;
   this.element_ = element;
 
   // Add menu items.
@@ -269,7 +277,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
     this.highlightedItem_ = item;
     // Bring the highlighted item into view. This has no effect if the menu is
     // not scrollable.
-    var el = /** @type {!Element} */ (this.getElement());
+    var el = /** @type {!Element} */ (this.parentElement_);
     Blockly.utils.style.scrollIntoContainerView(
         /** @type {!Element} */ (item.getElement()), el);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes menu scrolling to item when highlighted

### Proposed Changes
Menu root element doesn't have scroll because `.blocklyMenu` has auto height but parent element of menu has fixed `max-height: 300px`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change
After menu opened you can navigate through it items using DOWN and UP keys. 
If menu has scroll it's not scrolling to the hidden items on highlight.
![image](https://user-images.githubusercontent.com/903622/113131180-90758c00-9225-11eb-8f44-098440953427.png)

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

### Reason for Changes
Bug fix.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested on:
* Desktop Chrome

### Documentation
Nothing to do.

### Additional Information

<!-- Anything else we should know? -->
