### PR TITLE
Stop overriding @protected methods with @private

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1380,7 +1380,8 @@ Blockly.BlockSvg.prototype.moveNumberedInputBefore = function(
  * @param {string} name Language-neutral identifier which may used to find this
  *     input again.  Should be unique to this block.
  * @return {!Blockly.Input} The input object created.
- * @private
+ * @protected
+ * @override
  */
 Blockly.BlockSvg.prototype.appendInput_ = function(type, name) {
   var input = Blockly.BlockSvg.superClass_.appendInput_.call(this, type, name);

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -181,7 +181,8 @@ Blockly.FieldAngle.RADIUS = Blockly.FieldAngle.HALF - 1;
 /**
  * Configure the field based on the given map of options.
  * @param {!Object} config A map of options to configure the field based on.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldAngle.prototype.configure_ = function(config) {
   Blockly.FieldAngle.superClass_.configure_.call(this, config);
@@ -246,7 +247,7 @@ Blockly.FieldAngle.prototype.initView = function() {
 
 /**
  * Updates the graph when the field rerenders.
- * @private
+ * @protected
  * @override
  */
 Blockly.FieldAngle.prototype.render_ = function() {

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -88,7 +88,8 @@ Blockly.FieldCheckbox.prototype.CURSOR = 'default';
 /**
  * Configure the field based on the given map of options.
  * @param {!Object} config A map of options to configure the field based on.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldCheckbox.prototype.configure_ = function(config) {
   Blockly.FieldCheckbox.superClass_.configure_.call(this, config);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -153,7 +153,8 @@ Blockly.FieldColour.prototype.columns_ = 0;
 /**
  * Configure the field based on the given map of options.
  * @param {!Object} config A map of options to configure the field based on.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldColour.prototype.configure_ = function(config) {
   Blockly.FieldColour.superClass_.configure_.call(this, config);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -164,7 +164,8 @@ Blockly.FieldImage.prototype.isDirty_ = false;
 /**
  * Configure the field based on the given map of options.
  * @param {!Object} config A map of options to configure the field based on.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldImage.prototype.configure_ = function(config) {
   Blockly.FieldImage.superClass_.configure_.call(this, config);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -132,7 +132,8 @@ Blockly.FieldMultilineInput.prototype.initView = function() {
  * Get the text from this field as displayed on screen.  May differ from getText
  * due to ellipsis, and other formatting.
  * @return {string} Currently displayed text.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldMultilineInput.prototype.getDisplayText_ = function() {
   var textLines = this.getText();

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -105,7 +105,8 @@ Blockly.FieldNumber.prototype.SERIALIZABLE = true;
 /**
  * Configure the field based on the given map of options.
  * @param {!Object} config A map of options to configure the field based on.
- * @private
+ * @protected
+ * @override
  */
 Blockly.FieldNumber.prototype.configure_ = function(config) {
   Blockly.FieldNumber.superClass_.configure_.call(this, config);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -127,7 +127,7 @@ Blockly.Mutator.prototype.drawIcon_ = function(group) {
  * Clicking on the icon toggles if the mutator bubble is visible.
  * Disable if block is uneditable.
  * @param {!Event} e Mouse click event.
- * @private
+ * @protected
  * @override
  */
 Blockly.Mutator.prototype.iconClick_ = function(e) {

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -463,7 +463,8 @@ Blockly.RenderedConnection.prototype.onFailedConnect = function(
  * Disconnect two blocks that are connected by this connection.
  * @param {!Blockly.Block} parentBlock The superior block.
  * @param {!Blockly.Block} childBlock The inferior block.
- * @private
+ * @protected
+ * @override
  */
 Blockly.RenderedConnection.prototype.disconnectInternal_ = function(parentBlock,
     childBlock) {
@@ -484,7 +485,8 @@ Blockly.RenderedConnection.prototype.disconnectInternal_ = function(parentBlock,
 /**
  * Respawn the shadow block if there was one connected to the this connection.
  * Render/rerender blocks as needed.
- * @private
+ * @protected
+ * @override
  */
 Blockly.RenderedConnection.prototype.respawnShadow_ = function() {
   Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -120,7 +120,8 @@ Blockly.geras.Drawer.prototype.drawBottom_ = function() {
 /**
  * Add steps for the left side of the block, which may include an output
  * connection
- * @private
+ * @protected
+ * @override
  */
 Blockly.geras.Drawer.prototype.drawLeft_ = function() {
   this.highlighter_.drawLeft();


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This resolves an issue tracked internally in Google, since it relies on https://github.com/angular/clutz which is no longer kept up-to-date on GitHub.

### Proposed Changes

Replace @private on overrides of @protected methods with @protected.

### Reason for Changes

An upcoming change to emit private properties in Google's internal version of https://github.com/angular/clutz will otherwise break any TypeScript depending on these types. This is because TypeScript errors on overriding protected with private while Closure Compiler does not.

I believe this change is also generally reasonable to make since it doesn't make sense to narrow the visibility of a method when overridding.

### Test Coverage

none; this does not affect behavior.

### Documentation

no doc updates needed.

### Additional Information

n/a
