### PR TITLE
Change compilation language_in to STABLE

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -116,8 +116,6 @@ function compile(compilerOptions, opt_verbose, opt_warnings_as_error,
   const options = {};
   options.compilation_level = 'SIMPLE_OPTIMIZATIONS';
   options.warning_level = opt_verbose ? 'VERBOSE' : 'DEFAULT';
-  // Use stable, regardless of what was passed in.
-  options.language_in = 'STABLE';
   options.language_out = 'ECMASCRIPT5_STRICT';
   options.rewrite_polyfills = false;
   options.hide_warnings_for = 'node_modules';


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Sets the input language for the closure compiler to STABLE rather than pinning it to ES5.

#### Behavior Before Change

Uncompiled code had to be written in ES5. 
The uncompressed library could be used in IE10 and IE11.

#### Behavior After Change

Uncompiled code can be written in ES6. 
The uncompressed library may not be loadable in IE10 and IE11.

### Reason for Changes

Library modernization/catching up with the world.

### Test Coverage
Ran `npm test` and `npm test:compile:advanced`

### Documentation

Related doc changes that should follow on:

- [ ] Style guide (no longer prohibit ES6, possibly note if there are still parts of ES6 that should be avoided)
- [ ] [Building blockly](https://developers.google.com/blockly/guides/modify/web/building) page (change in progress)

### Additional Information

Clang-format made this a bit hard to read.

Lines I actually changed:
- In `compile`, `options.language_in = 'STABLE'`, instead of `ECMASCRIPT5_STRICT`.
- In `buildCompressed`. removed `language_in` from `options`
- In `buildAdvancedCompilationTest`, removed `language_in` from `options`.

This may also be the right time to remove the `build.py` script entirely. Otherwise I will need to update it as well.