### PR TITLE
Remove rules forbidding es6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,8 +72,7 @@
                 "balanced": true
             },
             "exceptions": ["*"]
-        }],
-        "es5/no-es6-methods": ["warn"]
+        }]
     },
     "env": {
         "browser": true
@@ -83,7 +82,6 @@
         "goog": true
     },
     "extends": [
-        "eslint:recommended",
-        "plugin:es5/no-es2015"
+        "eslint:recommended"
     ]
 }

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -62,9 +62,7 @@ Blockly.utils.object.deepMerge = function(target, source) {
  */
 Blockly.utils.object.values = function(obj) {
   if (Object.values) {
-    /* eslint-disable es5/no-es6-methods */
     return Object.values(obj);
-    /* eslint-enable es5/no-es6-methods */
   }
   // Fallback for IE.
   return Object.keys(obj).map(function(e) {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "clang-format": "^1.5.0",
     "concurrently": "^6.0.0",
     "eslint": "^7.6.0",
-    "eslint-plugin-es5": "^1.5.0",
     "google-closure-compiler": "^20210302.0.0",
     "google-closure-deps": "^20210202.0.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Gets rid of (erroneous) lint warnings about es6 methods.

### Proposed Changes

- Stop using [eslint-plugin-es5](https://www.npmjs.com/package/eslint-plugin-es5)
- Remove from eslintrc
- Remove from package.json


#### Behavior Before Change

- Warnings for use of es6 language constructs
- Erroneous warnings for use of Blockly's internal `startsWith` method.

#### Behavior After Change

No warnings for use of es6.

### Reason for Changes

Prompted by #4764

The input language is now es6, compiled down to es5 in the build/compress pass.

### Test Coverage

Ran `npm run lint` locally.

### Documentation

Possibly need to change the style guide.

### Additional Information

Another option is to turn off *some* of the rules that this plugin gives us (e.g. no-es6-methods) but leave others on. Here's the [list of rules](https://www.npmjs.com/package/eslint-plugin-es5#list-of-supported-rules).

We currently have the compiler set to not add polyfills for es6 features (`rewrite_polyfills=false`). Some options here:
- Try not to use anything that requires polyfilling (if we want this one, we should have rules to help enforce it, but we *probably* can make this work as long as we always test on IE).
- Include polyfills. This would bloat our compressed file.
- Don't include polyfills (current state) and rely on anyone using the library in IE to pull in whatever polyfill libraries they need.

More links:
- Closure-compiler [polyfill](https://github.com/google/closure-compiler/wiki/Polyfills#polyfills) documentation.
- Closure-compiler [list of supported features](https://github.com/google/closure-compiler/wiki/Supported-features), which says which features are supported through polyfills and which language version they are from.
- eslint-plugin-es5 [list of supported rules](https://www.npmjs.com/package/eslint-plugin-es5#list-of-supported-rules).
- eslint-plugin-es5 [issue](https://github.com/nkt/eslint-plugin-es5/issues/12) for the plugin being too strict, and matching on function names with no escape hatch.