### PR TITLE
Add better error messages to insertion marker

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -155,7 +155,7 @@ Blockly.InsertionMarkerManager.PREVIEW_TYPE = {
  * @const
  */
 Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
-    'manager tried to create a marker but the result is missing {0}. If ' +
+    'manager tried to create a marker but the result is missing %1. If ' +
     'you are using a mutator, make sure your domToMutation method is ' +
     'properly defined.';
 
@@ -292,14 +292,14 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
       var resultInput = result.inputList[i];
       if (!resultInput) {
         throw new Error(Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR
-            .replace('{0}', 'an input'));
+            .replace('%1', 'an input'));
       }
       for (var j = 0; j < sourceInput.fieldRow.length; j++) {
         var sourceField = sourceInput.fieldRow[j];
         var resultField = resultInput.fieldRow[j];
         if (!resultField) {
           throw new Error(Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR
-              .replace('{0}', 'a field'));
+              .replace('%1', 'a field'));
         }
         resultField.setValue(sourceField.getValue());
       }

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -149,6 +149,17 @@ Blockly.InsertionMarkerManager.PREVIEW_TYPE = {
 };
 
 /**
+ * An error message to throw if the block created by createMarkerBlock_ is
+ * missing any components.
+ * @type {string}
+ * @const
+ */
+Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
+    'manager tried to create a marker but the result is missing {0}. If ' +
+    'you are using a mutator, make sure your domToMutation method is ' +
+    'properly defined.';
+
+/**
  * Sever all links from this object.
  * @package
  */
@@ -279,9 +290,17 @@ Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function(sourceBlo
         continue;  // Ignore the collapsed input.
       }
       var resultInput = result.inputList[i];
+      if (!resultInput) {
+        throw new Error(Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR
+            .replace('{0}', 'an input'));
+      }
       for (var j = 0; j < sourceInput.fieldRow.length; j++) {
         var sourceField = sourceInput.fieldRow[j];
         var resultField = resultInput.fieldRow[j];
+        if (!resultField) {
+          throw new Error(Blockly.InsertionMarkerManager.DUPLICATE_BLOCK_ERROR
+              .replace('{0}', 'a field'));
+        }
         resultField.setValue(sourceField.getValue());
       }
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#4485

### Proposed Changes

Adds better errors to the insertion marker managers so that people can figure out why their blocks are breaking.

### Reason for Changes

Blockly should, in general, throw informative errors so that developers can have a smooth experience debugging their code.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1) Modified the controls_if block by removing the updateShape_ call from rebuildBlock_ and replacing it with the code from updateShape_
2) Modified the duplicated code to not create inputs/fields properly.
3) Observed how before uninformative errors were thrown, and now informative errors are thrown.

Tested on:
* Desktop Chrome
