### PR TITLE
Merge consecutive viewport change events

### DIFF
--- a/core/events/events.js
+++ b/core/events/events.js
@@ -307,7 +307,10 @@ Blockly.Events.filter = function(queueIn, forward) {
         lastEvent.newValue = event.newValue;
       } else if (event.type == Blockly.Events.VIEWPORT_CHANGE) {
         // Merge viewport change events.
-        lastEvent.newValue = event.newValue;
+        lastEvent.viewTop = event.viewTop;
+        lastEvent.viewLeft = event.viewLeft;
+        lastEvent.scale = event.scale;
+        lastEvent.oldScale = event.oldScale;
       } else if (event.type == Blockly.Events.CLICK &&
           lastEvent.type == Blockly.Events.BUBBLE_OPEN) {
         // Drop click events caused by opening/closing bubbles.

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -305,6 +305,9 @@ Blockly.Events.filter = function(queueIn, forward) {
           event.name == lastEvent.name) {
         // Merge change events.
         lastEvent.newValue = event.newValue;
+      } else if (event.type == Blockly.Events.VIEWPORT_CHANGE) {
+        // Merge viewport change events.
+        lastEvent.newValue = event.newValue;
       } else if (event.type == Blockly.Events.CLICK &&
           lastEvent.type == Blockly.Events.BUBBLE_OPEN) {
         // Drop click events caused by opening/closing bubbles.

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -910,6 +910,19 @@ suite('Events', function() {
       chai.assert.equal(filteredEvents[0].newValue, 'item2');
     });
 
+    test('Merge viewport change events', function() {
+      var events = [
+        new Blockly.Events.ViewportChange(1, 2, 3, this.workspace, 4),
+        new Blockly.Events.ViewportChange(5, 6, 7, this.workspace, 8)
+      ];
+      var filteredEvents = Blockly.Events.filter(events, true);
+      chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
+      chai.assert.equal(filteredEvents[0].viewTop, 5);
+      chai.assert.equal(filteredEvents[0].viewLeft, 6);
+      chai.assert.equal(filteredEvents[0].scale, 7);
+      chai.assert.equal(filteredEvents[0].oldScale, 8);
+    });
+
     test('Merge ui events', function() {
       var block1 = this.workspace.newBlock('field_variable_test_block', '1');
       var block2 = this.workspace.newBlock('field_variable_test_block', '2');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Updates event filter code to merge consecutive viewport change events.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

ViewportChange events are not filtered.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

VIewportChange events that happen quickly after each other are merged together.  
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

This filtering helps improve performance when workspace change listeners are listening for viewport change events.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested locally by linking to content-highlight plugin demo.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

PR created to improve performance of content-highlight plugin created in https://github.com/google/blockly-samples/pull/675.
<!-- Anything else we should know? -->
