### PR TITLE
Change lastConnectionInRow to getPlaceForOrphanedOutput

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -134,7 +134,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
       // Attempt to reattach the orphan at the end of the newly inserted
       // block.  Since this block may be a row, walk down to the end
       // or to the first (and only) shadow block.
-      var connection = Blockly.Connection.lastConnectionInRow(
+      var connection = Blockly.Connection.getPlaceForOrphanedOutput(
           childBlock, orphanBlock);
       if (connection) {
         orphanBlock.outputConnection.connect(connection);
@@ -372,30 +372,31 @@ Blockly.Connection.connectReciprocally_ = function(first, second) {
 };
 
 /**
- * Does the given block have one and only one connection point that will accept
- * an orphaned block?
+ * Returns the single connection on the block that will accept the orphaned
+ * block, if one can be found. If the block has multiple compatible connections
+ * (even if they are filled) this returns null. If the block has no compatible
+ * connections, this returns null.
  * @param {!Blockly.Block} block The superior block.
  * @param {!Blockly.Block} orphanBlock The inferior block.
  * @return {Blockly.Connection} The suitable connection point on 'block',
  *     or null.
  * @private
  */
-Blockly.Connection.singleConnection_ = function(block, orphanBlock) {
-  var connection = null;
+Blockly.Connection.getSingleConnection_ = function(block, orphanBlock) {
+  var foundConnection = null;
   var output = orphanBlock.outputConnection;
-  for (var i = 0; i < block.inputList.length; i++) {
-    var thisConnection = block.inputList[i].connection;
-    var typeChecker = output.getConnectionChecker();
-    if (thisConnection &&
-        thisConnection.type == Blockly.connectionTypes.INPUT_VALUE &&
-        typeChecker.canConnect(output, thisConnection, false)) {
-      if (connection) {
+  var typeChecker = output.getConnectionChecker();
+
+  for (var i = 0, input; (input = block.inputList[i]); i++) {
+    var connection = input.connection;
+    if (connection && typeChecker.canConnect(output, connection, false)) {
+      if (foundConnection) {
         return null;  // More than one connection.
       }
-      connection = thisConnection;
+      foundConnection = connection;
     }
   }
-  return connection;
+  return foundConnection;
 };
 
 /**
@@ -410,18 +411,19 @@ Blockly.Connection.singleConnection_ = function(block, orphanBlock) {
  *     of blocks, or null.
  * @package
  */
-Blockly.Connection.lastConnectionInRow = function(startBlock, orphanBlock) {
-  var newBlock = startBlock;
-  var connection;
-  while ((connection = Blockly.Connection.singleConnection_(
-      /** @type {!Blockly.Block} */ (newBlock), orphanBlock))) {
-    newBlock = connection.targetBlock();
-    if (!newBlock || newBlock.isShadow()) {
-      return connection;
-    }
-  }
-  return null;
-};
+Blockly.Connection.getPlaceForOrphanedOutput =
+    function(startBlock, orphanBlock) {
+      var newBlock = startBlock;
+      var connection;
+      while ((connection = Blockly.Connection.getSingleConnection_(
+          /** @type {!Blockly.Block} */ (newBlock), orphanBlock))) {
+        newBlock = connection.targetBlock();
+        if (!newBlock || newBlock.isShadow()) {
+          return connection;
+        }
+      }
+      return null;
+    };
 
 /**
  * Disconnect this connection.

--- a/core/connection.js
+++ b/core/connection.js
@@ -134,7 +134,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
       // Attempt to reattach the orphan at the end of the newly inserted
       // block.  Since this block may be a row, walk down to the end
       // or to the first (and only) shadow block.
-      var connection = Blockly.Connection.getPlaceForOrphanedOutput(
+      var connection = Blockly.Connection.getConnectionForOrphanedOutput(
           childBlock, orphanBlock);
       if (connection) {
         orphanBlock.outputConnection.connect(connection);
@@ -411,7 +411,7 @@ Blockly.Connection.getSingleConnection_ = function(block, orphanBlock) {
  *     of blocks, or null.
  * @package
  */
-Blockly.Connection.getPlaceForOrphanedOutput =
+Blockly.Connection.getConnectionForOrphanedOutput =
     function(startBlock, orphanBlock) {
       var newBlock = startBlock;
       var connection;

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -251,7 +251,7 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
       if (localType == Blockly.connectionTypes.OUTPUT_VALUE) {
         orphanConnection = orphanBlock.outputConnection;
         lastConnection =
-            Blockly.Connection.getPlaceForOrphanedOutput(
+            Blockly.Connection.getConnectionForOrphanedOutput(
                 /** @type {!Blockly.Block} **/ (topBlock), orphanBlock);
       } else {
         orphanConnection = orphanBlock.previousConnection;

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -248,19 +248,13 @@ Blockly.blockRendering.Renderer.prototype.orphanCanConnectAtEnd =
     function(topBlock, orphanBlock, localType) {
       var orphanConnection = null;
       var lastConnection = null;
-      if (localType ==
-          Blockly.connectionTypes
-              .OUTPUT_VALUE) {  // We are replacing an output.
+      if (localType == Blockly.connectionTypes.OUTPUT_VALUE) {
         orphanConnection = orphanBlock.outputConnection;
-        // TODO:  I don't think this function necessarily has the correct logic,
-        //  but for now it is being kept for behavioral backwards-compat.
-        lastConnection = Blockly.Connection
-            .lastConnectionInRow(
+        lastConnection =
+            Blockly.Connection.getPlaceForOrphanedOutput(
                 /** @type {!Blockly.Block} **/ (topBlock), orphanBlock);
-      } else {  // We are replacing a previous.
+      } else {
         orphanConnection = orphanBlock.previousConnection;
-        // TODO: This lives on the block while lastConnectionInRow lives on
-        //  on the connection. Something is fishy.
         lastConnection = topBlock.lastConnectionInStack();
       }
 

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -156,9 +156,6 @@ suite('Connection', function() {
 
         teardown(function() {
           workspaceTeardown.call(this, this.workspace);
-          delete Blockly.Blocks['stack_block'];
-          delete Blockly.Blocks['row_block'];
-          delete Blockly.Blocks['statement_block'];
         });
 
         suite('Add - No Block Connected', function() {
@@ -785,7 +782,7 @@ suite('Connection', function() {
     });
   });
 
-  suite('getPlaceForOrphanedOutput', function() {
+  suite('getConnectionForOrphanedOutput', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
 
@@ -811,8 +808,6 @@ suite('Connection', function() {
 
     teardown(function() {
       workspaceTeardown.call(this, this.workspace);
-      delete Blockly.Blocks['input'];
-      delete Blockly.Blocks['output'];
     });
 
     suite('No available spots', function() {
@@ -879,11 +874,6 @@ suite('Connection', function() {
         ]);
       });
 
-      teardown(function() {
-        delete Blockly.Blocks['output_and_statements'];
-        delete Blockly.Blocks['output_and_inputs'];
-      });
-
       test('No connection', function() {
         const parent = this.workspace.newBlock('input');
         const oldChild = this.workspace.newBlock('output');
@@ -891,7 +881,7 @@ suite('Connection', function() {
 
         parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
         chai.assert.notExists(
-            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+            Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
       });
 
       test('All statements', function() {
@@ -901,7 +891,7 @@ suite('Connection', function() {
 
         parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
         chai.assert.notExists(
-            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+            Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
       });
 
       test('Bad checks', function() {
@@ -911,7 +901,7 @@ suite('Connection', function() {
 
         parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
         chai.assert.notExists(
-            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+            Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
       });
 
       test('Through different types', function() {
@@ -926,7 +916,7 @@ suite('Connection', function() {
             .connect(otherChild.outputConnection);
 
         chai.assert.notExists(
-            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+            Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
       });
     });
 
@@ -965,11 +955,6 @@ suite('Connection', function() {
         ]);
       });
 
-      teardown(function() {
-        delete Blockly.Blocks['multiple_inputs'];
-        delete Blockly.Blocks['single_input'];
-      });
-
       suite('No shadows', function() {
         test('Top block', function() {
           const parent = this.workspace.newBlock('input');
@@ -978,7 +963,7 @@ suite('Connection', function() {
 
           parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
 
         test('Child blocks', function() {
@@ -993,7 +978,7 @@ suite('Connection', function() {
           oldChild.getInput('INPUT2').connection.connect(childY.outputConnection);
 
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
 
         test('Spots filled', function() {
@@ -1008,7 +993,7 @@ suite('Connection', function() {
               .connect(otherChild.outputConnection);
 
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
       });
 
@@ -1027,7 +1012,7 @@ suite('Connection', function() {
                   .firstChild);
 
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
 
         test('Child blocks', function() {
@@ -1048,7 +1033,7 @@ suite('Connection', function() {
                   .firstChild);
 
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
 
         test('Spots filled', function() {
@@ -1066,7 +1051,7 @@ suite('Connection', function() {
                   .firstChild);
 
           chai.assert.notExists(
-              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+              Blockly.Connection.getConnectionForOrphanedOutput(oldChild, newChild));
         });
       });
     });
@@ -1089,13 +1074,6 @@ suite('Connection', function() {
         ]);
       });
 
-      teardown(function() {
-        delete Blockly.Blocks['multiple_inputs'];
-        delete Blockly.Blocks['single_input'];
-        delete Blockly.Blocks['check_to_check2'];
-        delete Blockly.Blocks['check2_to_check'];
-      });
-
       test('No shadows', function() {
         const parent = this.workspace.newBlock('input');
         const oldChild = this.workspace.newBlock('single_input');
@@ -1104,7 +1082,7 @@ suite('Connection', function() {
         parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
 
         const result = Blockly.Connection
-            .getPlaceForOrphanedOutput(oldChild, newChild);
+            .getConnectionForOrphanedOutput(oldChild, newChild);
         chai.assert.exists(result);
         chai.assert.equal(result.getParentInput().name, 'INPUT');
       });
@@ -1119,10 +1097,8 @@ suite('Connection', function() {
             Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
                 .firstChild);
 
-        console.log(oldChild.getInput('INPUT').connection.isConnected());
-
         const result = Blockly.Connection
-            .getPlaceForOrphanedOutput(oldChild, newChild);
+            .getConnectionForOrphanedOutput(oldChild, newChild);
         chai.assert.exists(result);
         chai.assert.equal(result.getParentInput().name, 'INPUT');
       });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -784,4 +784,348 @@ suite('Connection', function() {
       });
     });
   });
+
+  suite('getPlaceForOrphanedOutput', function() {
+    setup(function() {
+      this.workspace = new Blockly.Workspace();
+
+      Blockly.defineBlocksWithJsonArray([
+        {
+          'type': 'input',
+          'message0': '%1',
+          'args0': [
+            {
+              'type': 'input_value',
+              'name': 'INPUT',
+              'check': 'check'
+            }
+          ],
+        },
+        {
+          'type': 'output',
+          'message0': '',
+          'output': 'check',
+        },
+      ]);
+    });
+
+    teardown(function() {
+      workspaceTeardown.call(this, this.workspace);
+      delete Blockly.Blocks['input'];
+      delete Blockly.Blocks['output'];
+    });
+
+    suite('No available spots', function() {
+      setup(function() {
+        Blockly.defineBlocksWithJsonArray([
+          {
+            'type': 'output_and_statements',
+            'message0': '%1 %2',
+            'args0': [
+              {
+                'type': 'input_statement',
+                'name': 'INPUT',
+                'check': 'check'
+              },
+              {
+                'type': 'input_statement',
+                'name': 'INPUT2',
+                'check': 'check'
+              }
+            ],
+            'output': 'check',
+          },
+          {
+            'type': 'output_and_inputs',
+            'message0': '%1 %2',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'INPUT',
+                'check': 'check2'
+              },
+              {
+                'type': 'input_value',
+                'name': 'INPUT2',
+                'check': 'check2'
+              }
+            ],
+            'output': 'check',
+          },
+          {
+            'type': 'check_to_check2',
+            'message0': '%1',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'INPUT',
+                'check': 'check2'
+              },
+            ],
+            'output': 'check',
+          },
+          {
+            'type': 'check2_to_check',
+            'message0': '%1',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'CHECK2TOCHECKINPUT',
+                'check': 'check'
+              },
+            ],
+            'output': 'check2',
+          },
+        ]);
+      });
+
+      teardown(function() {
+        delete Blockly.Blocks['output_and_statements'];
+        delete Blockly.Blocks['output_and_inputs'];
+      });
+
+      test('No connection', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('output');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+        chai.assert.notExists(
+            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+      });
+
+      test('All statements', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('output_and_statements');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+        chai.assert.notExists(
+            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+      });
+
+      test('Bad checks', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('output_and_inputs');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+        chai.assert.notExists(
+            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+      });
+
+      test('Through different types', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('check_to_check2');
+        const otherChild = this.workspace.newBlock('check2_to_check');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection
+            .connect(oldChild.outputConnection);
+        oldChild.getInput('INPUT').connection
+            .connect(otherChild.outputConnection);
+
+        chai.assert.notExists(
+            Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+      });
+    });
+
+    suite('Multiple available spots', function() {
+      setup(function() {
+        Blockly.defineBlocksWithJsonArray([
+          {
+            'type': 'multiple_inputs',
+            'message0': '%1 %2',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'INPUT',
+                'check': 'check'
+              },
+              {
+                'type': 'input_value',
+                'name': 'INPUT2',
+                'check': 'check'
+              },
+            ],
+            'output': 'check',
+          },
+          {
+            'type': 'single_input',
+            'message0': '%1',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'INPUT',
+                'check': 'check'
+              },
+            ],
+            'output': 'check',
+          },
+        ]);
+      });
+
+      teardown(function() {
+        delete Blockly.Blocks['multiple_inputs'];
+        delete Blockly.Blocks['single_input'];
+      });
+
+      suite('No shadows', function() {
+        test('Top block', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+
+        test('Child blocks', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const childX = this.workspace.newBlock('single_input');
+          const childY = this.workspace.newBlock('single_input');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+          oldChild.getInput('INPUT').connection.connect(childX.outputConnection);
+          oldChild.getInput('INPUT2').connection.connect(childY.outputConnection);
+
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+
+        test('Spots filled', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const otherChild = this.workspace.newBlock('output');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection
+              .connect(oldChild.outputConnection);
+          oldChild.getInput('INPUT').connection
+              .connect(otherChild.outputConnection);
+
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+      });
+
+      suite('Shadows', function() {
+        test('Top block', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+          oldChild.getInput('INPUT').connection.setShadowDom(
+              Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                  .firstChild);
+          oldChild.getInput('INPUT2').connection.setShadowDom(
+              Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                  .firstChild);
+
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+
+        test('Child blocks', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const childX = this.workspace.newBlock('single_input');
+          const childY = this.workspace.newBlock('single_input');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+          oldChild.getInput('INPUT').connection.connect(childX.outputConnection);
+          oldChild.getInput('INPUT2').connection.connect(childY.outputConnection);
+          childX.getInput('INPUT').connection.setShadowDom(
+              Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                  .firstChild);
+          childY.getInput('INPUT').connection.setShadowDom(
+              Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                  .firstChild);
+
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+
+        test('Spots filled', function() {
+          const parent = this.workspace.newBlock('input');
+          const oldChild = this.workspace.newBlock('multiple_inputs');
+          const otherChild = this.workspace.newBlock('output');
+          const newChild = this.workspace.newBlock('output');
+
+          parent.getInput('INPUT').connection
+              .connect(oldChild.outputConnection);
+          oldChild.getInput('INPUT').connection
+              .connect(otherChild.outputConnection);
+          oldChild.getInput('INPUT2').connection.setShadowDom(
+              Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                  .firstChild);
+
+          chai.assert.notExists(
+              Blockly.Connection.getPlaceForOrphanedOutput(oldChild, newChild));
+        });
+      });
+    });
+
+    suite('Single available spot', function() {
+      setup(function() {
+        Blockly.defineBlocksWithJsonArray([
+          {
+            'type': 'single_input',
+            'message0': '%1',
+            'args0': [
+              {
+                'type': 'input_value',
+                'name': 'INPUT',
+                'check': 'check'
+              },
+            ],
+            'output': 'check',
+          },
+        ]);
+      });
+
+      teardown(function() {
+        delete Blockly.Blocks['multiple_inputs'];
+        delete Blockly.Blocks['single_input'];
+        delete Blockly.Blocks['check_to_check2'];
+        delete Blockly.Blocks['check2_to_check'];
+      });
+
+      test('No shadows', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('single_input');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+
+        const result = Blockly.Connection
+            .getPlaceForOrphanedOutput(oldChild, newChild);
+        chai.assert.exists(result);
+        chai.assert.equal(result.getParentInput().name, 'INPUT');
+      });
+
+      test('Shadows', function() {
+        const parent = this.workspace.newBlock('input');
+        const oldChild = this.workspace.newBlock('single_input');
+        const newChild = this.workspace.newBlock('output');
+
+        parent.getInput('INPUT').connection.connect(oldChild.outputConnection);
+        oldChild.getInput('INPUT').connection.setShadowDom(
+            Blockly.Xml.textToDom('<xml><shadow type="output"/></xml>')
+                .firstChild);
+
+        console.log(oldChild.getInput('INPUT').connection.isConnected());
+
+        const result = Blockly.Connection
+            .getPlaceForOrphanedOutput(oldChild, newChild);
+        chai.assert.exists(result);
+        chai.assert.equal(result.getParentInput().name, 'INPUT');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Closes #3656

### Proposed Changes

Renames `lastConnectionInRow` and `singleConnection_` to better reflect what they're doing. But the main point of this was to add tests for `lastConnectionInRow`/`getPlaceForOrphanedOutput`.

No behavioral changes.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before I can tackle #4826 I need to write tests for everything, this is part of that.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Manually tested all of the behavior documented by #3658 to ensure nothing changed.

Tested on:
* Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
