### PR TITLE
Remove useless variable declarations in PHP.

### DIFF
--- a/generators/php.js
+++ b/generators/php.js
@@ -144,23 +144,6 @@ Blockly.PHP.init = function(workspace) {
 
   Blockly.PHP.variableDB_.setVariableMap(workspace.getVariableMap());
 
-  var defvars = [];
-  // Add developer variables (not created or named by the user).
-  var devVarList = Blockly.Variables.allDeveloperVariables(workspace);
-  for (var i = 0; i < devVarList.length; i++) {
-    defvars.push(Blockly.PHP.variableDB_.getName(devVarList[i],
-        Blockly.Names.DEVELOPER_VARIABLE_TYPE) + ';');
-  }
-
-  // Add user variables, but only ones that are being used.
-  var variables = Blockly.Variables.allUsedVarModels(workspace);
-  for (var i = 0, variable; variable = variables[i]; i++) {
-    defvars.push(Blockly.PHP.variableDB_.getName(variable.getId(),
-        Blockly.VARIABLE_CATEGORY_NAME) + ';');
-  }
-
-  // Declare all of the variables.
-  Blockly.PHP.definitions_['variables'] = defvars.join('\n');
   this.isInitialized = true;
 };
 

--- a/tests/generators/golden/generated.php
+++ b/tests/generators/golden/generated.php
@@ -1,32 +1,3 @@
-$unittestResults;
-$test_name;
-$naked;
-$proc_x;
-$proc_y;
-$func_x;
-$func_y;
-$func_a;
-$n;
-$ok;
-$log;
-$count;
-$varToChange;
-$rand;
-$item;
-$text;
-$number_of_calls;
-$list2;
-$proc_z;
-$func_z;
-$x;
-$proc_w;
-$func_c;
-$if2;
-$i;
-$loglist;
-$changing_list;
-$list_copy;
-
 function unittest_report() {
   global $unittestResults;
   // Create test report.


### PR DESCRIPTION
As far as I can tell, these are 100% pointless.