### PR TITLE
Use String() over toLocaleString when possible

### DIFF
--- a/core/field_number.js
+++ b/core/field_number.js
@@ -223,7 +223,13 @@ Blockly.FieldNumber.prototype.setPrecision = function(precision) {
  */
 Blockly.FieldNumber.prototype.setPrecisionInternal_ = function(precision) {
   this.precision_ = Number(precision) || 0;
-  var precisionString = this.precision_.toLocaleString('en-US', {maximumFractionDigits: 20});
+  var precisionString = String(this.precision_);
+  if (precisionString.indexOf('e') != -1) {
+    // String() is fast.  But it turns .0000001 into '1e-7'.
+    // Use the much slower toLocaleString to access all the digits.
+    precisionString =
+        this.precision_.toLocaleString('en-US', {maximumFractionDigits: 20});
+  }
   var decimalIndex = precisionString.indexOf('.');
   if (decimalIndex == -1) {
     // If the precision is 0 (float) allow any number of decimals,

--- a/demos/code/msg/en.js
+++ b/demos/code/msg/en.js
@@ -17,7 +17,7 @@ var MSG = {
   listVariable: "list",
   textVariable: "text",
   httpRequestError: "There was a problem with the request.",
-  linkAlert: "Share your blocks with this public link. We\'ll delete them if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.:\n\n%1",
+  linkAlert: "Share your blocks with this public link. We\'ll delete them if not used for a year. They are not associated with your account and handled as per Google\'s Privacy Policy. Please be sure not to include any private information.\n\n%1",
   hashError: "Sorry, '%1' doesn't correspond with any saved program.",
   xmlError: "Could not load your saved file. Perhaps it was created with a different version of Blockly?",
   badXml: "Error parsing XML:\n%1\n\nSelect 'OK' to abandon your changes or 'Cancel' to further edit the XML."


### PR DESCRIPTION
toLocaleString results in a 4.6% performance penalty when loading the Spaghetti test in Playground.
This relates to issue #4105