### PR TITLE
Fix #4830 for getting/setting unnamed fields

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1126,7 +1126,7 @@ Blockly.Block.prototype.getFieldValue = function(name) {
  */
 Blockly.Block.prototype.setFieldValue = function(newValue, name) {
   if (typeof name === "undefined") {
-    throw Error("Call to Blockly.Block.prototype.setFieldValue without " + 
+    throw Error("Call to Blockly.Block.prototype.setFieldValue without " +
         "required second argument of field name.");
   }
   var field = this.getField(name);

--- a/core/block.js
+++ b/core/block.js
@@ -1022,9 +1022,15 @@ Blockly.Block.prototype.setOnChange = function(onchangeFn) {
  * @return {?Blockly.Field} Named field, or null if field does not exist.
  */
 Blockly.Block.prototype.getField = function(name) {
+  if (typeof name !== 'string') {
+    throw TypeError('Blockly.Block.prototype.getField expects a string ' +
+      'with the field name but received ' +
+      (name === undefined ? 'nothing' : name + ' of type ' + typeof name) +
+      ' instead');
+  }
   for (var i = 0, input; (input = this.inputList[i]); i++) {
     for (var j = 0, field; (field = input.fieldRow[j]); j++) {
-      if (typeof field.name !== "undefined" && field.name == name) {
+      if (field.name === name) {
         return field;
       }
     }
@@ -1122,13 +1128,9 @@ Blockly.Block.prototype.getFieldValue = function(name) {
 /**
  * Sets the value of the given field for this block.
  * @param {*} newValue The value to set.
- * @param {!string} name The name of the field to set the value of.
+ * @param {string} name The name of the field to set the value of.
  */
 Blockly.Block.prototype.setFieldValue = function(newValue, name) {
-  if (typeof name === "undefined") {
-    throw Error("Call to Blockly.Block.prototype.setFieldValue without " +
-        "required second argument of field name.");
-  }
   var field = this.getField(name);
   if (!field) {
     throw Error('Field "' + name + '" not found.');

--- a/core/block.js
+++ b/core/block.js
@@ -1125,6 +1125,10 @@ Blockly.Block.prototype.getFieldValue = function(name) {
  * @param {!string} name The name of the field to set the value of.
  */
 Blockly.Block.prototype.setFieldValue = function(newValue, name) {
+  if (typeof name === "undefined") {
+    throw Error("Call to Blockly.Block.prototype.setFieldValue without " + 
+        "required second argument of field name.");
+  }
   var field = this.getField(name);
   if (!field) {
     throw Error('Field "' + name + '" not found.');

--- a/core/block.js
+++ b/core/block.js
@@ -1024,7 +1024,7 @@ Blockly.Block.prototype.setOnChange = function(onchangeFn) {
 Blockly.Block.prototype.getField = function(name) {
   for (var i = 0, input; (input = this.inputList[i]); i++) {
     for (var j = 0, field; (field = input.fieldRow[j]); j++) {
-      if (field.name == name) {
+      if (typeof field.name !== "undefined" && field.name == name) {
         return field;
       }
     }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1104,6 +1104,31 @@ suite('Blocks', function() {
       });
     });
   });
+  suite('Getting/Setting Field (Values)', function() {
+    setup(function() {
+      this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          '<block type="text"><field name = "TEXT">test</field></block>'
+      ), this.workspace);
+    });
+
+    test('Getting Field', function() {
+      chai.assert.instanceOf(this.block.getField("TEXT"), Blockly.Field);
+    });
+    test('Getting Field without Name', function() {
+      chai.assert.isNull(this.block.getField());
+    });
+    test('Getting Value of Field without Name', function() {
+      chai.assert.isNull(this.block.getFieldValue());
+    });
+    test('Getting/Setting Field Value', function() {
+      chai.assert.equal(this.block.getFieldValue("TEXT"), "test");
+      this.block.setFieldValue("abc", "TEXT");
+      chai.assert.equal(this.block.getFieldValue("TEXT"), "abc");
+    });
+    test('Setting Field without Name', function() {
+      chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test'));
+    });
+  });
   suite('Icon Management', function() {
     suite('Bubbles and Collapsing', function() {
       setup(function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1112,21 +1112,51 @@ suite('Blocks', function() {
     });
 
     test('Getting Field', function() {
-      chai.assert.instanceOf(this.block.getField("TEXT"), Blockly.Field);
+      chai.assert.instanceOf(this.block.getField('TEXT'), Blockly.Field);
     });
     test('Getting Field without Name', function() {
-      chai.assert.isNull(this.block.getField());
+      chai.assert.throws(this.block.getField.bind(this.block), TypeError);
     });
     test('Getting Value of Field without Name', function() {
-      chai.assert.isNull(this.block.getFieldValue());
+      chai.assert.throws(this.block.getFieldValue.bind(this.block), TypeError);
+    });
+    test('Getting Field with Wrong Type', function() {
+      var testFunction = function() {
+        return 'TEXT';
+      };
+      var inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      for (var i = 0; i < inputs.length; i++) {
+        chai.assert.throws(this.block.getField.bind(this.block, inputs[i]),
+            TypeError);
+      }
+    });
+    test('Getting Value of Field with Wrong Type', function() {
+      var testFunction = function() {
+        return 'TEXT';
+      };
+      var inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      for (var i = 0; i < inputs.length; i++) {
+        chai.assert.throws(
+            this.block.getFieldValue.bind(this.block, inputs[i]), TypeError);
+      }
     });
     test('Getting/Setting Field Value', function() {
-      chai.assert.equal(this.block.getFieldValue("TEXT"), "test");
-      this.block.setFieldValue("abc", "TEXT");
-      chai.assert.equal(this.block.getFieldValue("TEXT"), "abc");
+      chai.assert.equal(this.block.getFieldValue('TEXT'), 'test');
+      this.block.setFieldValue('abc', 'TEXT');
+      chai.assert.equal(this.block.getFieldValue('TEXT'), 'abc');
     });
     test('Setting Field without Name', function() {
       chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test'));
+    });
+    test('Setting Field with Wrong Type', function() {
+      var testFunction = function() {
+        return 'TEXT';
+      };
+      var inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      for (var i = 0; i < inputs.length; i++) {
+        chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test',
+            inputs[i]), TypeError);
+      }
     });
   });
   suite('Icon Management', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

#4830 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Calling [`block.setFieldValue`](https://github.com/google/blockly/blob/master/core/block.js#L1121) without supplying the field name for the required second parameter results in the block's first unnamed field being set to the value of the first argument.  For example, calling it on a built-in `text_print` block replaces `print` with whatever the new value that's passed is.  Connected to this, calling [`block.getField`](https://github.com/google/blockly/blob/master/core/block.js#L1023) or [`block.getFieldValue`](https://github.com/google/blockly/blob/master/core/block.js#L1113) without supplying a name of the field (whose value) to get returns the block's first unnamed field (value). 

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

Calling [`block.getField`](https://github.com/google/blockly/blob/master/core/block.js#L1023) or [`block.getFieldValue`](https://github.com/google/blockly/blob/master/core/block.js#L1113) without supplying a name of the field (whose value) to get will now result in a return value of `null`, which is consistent with the documentation that this is what should be produced when the field with that name doesn't exist.  Attempting to set a field without providing a name throws an error `Field "undefined" not found.`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

These changes put these methods in line with their specification.  I.e., `name` is listed as a required argument for `setFieldValue` and `getField` and `getFieldValue` are supposed to return `null` when the field with the given name (no name here!) is not found.  This also provides the developer with some information that they're probably doing something unintended such as changing the text on the block itself.

### Test Coverage

Tested locally.  Add test to https://github.com/google/blockly/blob/master/tests/mocha/block_test.js? 

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

No additional documentation required.

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

#4830 : In this issue I filed, I mentioned that we should provide a warning or throw an error when getting (the value of) an unnamed field.  Should I provide a warning or is returning `null` suffcient?  Also, should we throw a perhaps more friendly error when the field name wasn't passed to `setFieldValue` such as missing required argument of name of field to set?