### PR TITLE
Fix error caused by extra teardown call

### DIFF
--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -1249,10 +1249,6 @@ suite('Connection', function() {
       };
     });
 
-    teardown(function() {
-      sharedTestTeardown.call(this);
-    });
-
     suite('Disconnect from old parent', function() {
       test('Value', function() {
         var oldParent = this.workspace.newBlock('row_block');

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+goog.require('Blockly.WorkspaceComment');
+
 suite('Events', function() {
   setup(function() {
     sharedTestSetup.call(this, {fireEventsNow: false});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Removes extra teardown call in test
- Adds require to event test
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

- Console fills with logged errors from second teardown call when connection test is run
- event test throws error if `workspace_comment_test.js` is commented out in index.html
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

- no errors from connection test
- no errors from event test
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Cleans up console log for mocha tests.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

Extra teardown call was introduced in https://github.com/google/blockly/pull/4853 but the automated tests check doesn't fail when there are `console.error` calls in teardown.
<!-- Anything else we should know? -->
