### PR TITLE
Use null-prototype objects for maps

### DIFF
--- a/build.py
+++ b/build.py
@@ -135,7 +135,7 @@ this.BLOCKLY_BOOT = function(root) {
 
     f.write('\n')
     f.write('// Load Blockly.\n')
-    f.write('goog.require(\'Blockly.requires\')\n')
+    f.write('goog.require(\'Blockly.requires\');\n')
 
     f.write("""
 delete root.BLOCKLY_DIR;

--- a/core/block.js
+++ b/core/block.js
@@ -509,7 +509,7 @@ Blockly.Block.prototype.getOnlyValueConnection_ = function() {
         thisConnection.type == Blockly.connectionTypes.INPUT_VALUE &&
         thisConnection.targetConnection) {
       if (connection) {
-        return null; // More than one value input found.
+        return null;  // More than one value input found.
       }
       connection = thisConnection;
     }
@@ -1700,7 +1700,7 @@ Blockly.Block.prototype.validateTokens_ = function(tokens, argsCount) {
 };
 
 /**
- * Inserts args in place of numerical tokens. String args are converted to json
+ * Inserts args in place of numerical tokens. String args are converted to JSON
  * that defines a label field. If necessary an extra dummy input is added to
  * the end of the elements.
  * @param {!Array<!string|number>} tokens The tokens to interpolate
@@ -1742,9 +1742,9 @@ Blockly.Block.prototype.interpolateArguments_ =
     };
 
 /**
- * Creates a field from the json definition of a field. If a field with the
+ * Creates a field from the JSON definition of a field. If a field with the
  * given type cannot be found, this attempts to create a different field using
- * the 'alt' property of the json definition (if it exists).
+ * the 'alt' property of the JSON definition (if it exists).
  * @param {{alt:(string|undefined)}} element The element to try to turn into a
  *     field.
  * @return {?Blockly.Field} The field defined by the JSON, or null if one
@@ -1764,7 +1764,7 @@ Blockly.Block.prototype.fieldFromJson_ = function(element) {
 };
 
 /**
- * Creates an input from the json definition of an input. Sets the input's check
+ * Creates an input from the JSON definition of an input. Sets the input's check
  * and alignment if they are provided.
  * @param {!Object} element The JSON to turn into an input.
  * @param {string} warningPrefix The prefix to add to warnings to help the

--- a/core/block.js
+++ b/core/block.js
@@ -1949,9 +1949,8 @@ Blockly.Block.prototype.removeInput = function(name, opt_quiet) {
   }
   if (opt_quiet) {
     return false;
-  } else {
-    throw Error('Input not found: ' + name);
   }
+  throw Error('Input not found: ' + name);
 };
 
 /**

--- a/core/component_manager.js
+++ b/core/component_manager.js
@@ -28,14 +28,14 @@ Blockly.ComponentManager = function() {
    * @type {!Object<string, !Blockly.ComponentManager.ComponentDatum>}
    * @private
    */
-  this.componentData_ = {};
+  this.componentData_ = Object.create(null);
 
   /**
-   * A map of capabilities to component ids.
-   * @type {!Object<string, Array<string>>}
+   * A map of capabilities to component IDs.
+   * @type {!Object<string, !Array<string>>}
    * @private
    */
-  this.capabilityToComponentIds_ = {};
+  this.capabilityToComponentIds_ = Object.create(null);
 };
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -493,8 +493,7 @@ Blockly.Connection.prototype.respawnShadow_ = function() {
   var parentBlock = this.getSourceBlock();
   var shadow = this.getShadowDom();
   if (parentBlock.workspace && shadow) {
-    var blockShadow =
-        Blockly.Xml.domToBlock(shadow, parentBlock.workspace);
+    var blockShadow = Blockly.Xml.domToBlock(shadow, parentBlock.workspace);
     if (blockShadow.outputConnection) {
       this.connect(blockShadow.outputConnection);
     } else if (blockShadow.previousConnection) {
@@ -646,11 +645,10 @@ Blockly.Connection.prototype.neighbours = function(_maxLimit) {
  */
 Blockly.Connection.prototype.getParentInput = function() {
   var parentInput = null;
-  var block = this.sourceBlock_;
-  var inputs = block.inputList;
-  for (var idx = 0; idx < block.inputList.length; idx++) {
-    if (inputs[idx].connection === this) {
-      parentInput = inputs[idx];
+  var inputs = this.sourceBlock_.inputList;
+  for (var i = 0; i < inputs.length; i++) {
+    if (inputs[i].connection === this) {
+      parentInput = inputs[i];
       break;
     }
   }
@@ -663,11 +661,12 @@ Blockly.Connection.prototype.getParentInput = function() {
  * @return {string} The description.
  */
 Blockly.Connection.prototype.toString = function() {
-  var msg;
   var block = this.sourceBlock_;
   if (!block) {
     return 'Orphan Connection';
-  } else if (block.outputConnection == this) {
+  }
+  var msg;
+  if (block.outputConnection == this) {
     msg = 'Output Connection of ';
   } else if (block.previousConnection == this) {
     msg = 'Previous Connection of ';

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -31,11 +31,11 @@ Blockly.ContextMenuRegistry = function() {
   Blockly.ContextMenuRegistry.registry = this;
 
   /**
-   * Registry of all registered RegistryItems, keyed by id.
-   * @type {!Object<string, Blockly.ContextMenuRegistry.RegistryItem>}
+   * Registry of all registered RegistryItems, keyed by ID.
+   * @type {!Object<string, !Blockly.ContextMenuRegistry.RegistryItem>}
    * @private
    */
-  this.registry_ = {};
+  this.registry_ = Object.create(null);
 };
 
 /**
@@ -97,7 +97,7 @@ Blockly.ContextMenuRegistry.registry = null;
  */
 Blockly.ContextMenuRegistry.prototype.register = function(item) {
   if (this.registry_[item.id]) {
-    throw Error('Menu item with id "' + item.id + '" is already registered.');
+    throw Error('Menu item with ID "' + item.id + '" is already registered.');
   }
   this.registry_[item.id] = item;
 };
@@ -108,11 +108,10 @@ Blockly.ContextMenuRegistry.prototype.register = function(item) {
  * @throws {Error} if an item with the given ID does not exist.
  */
 Blockly.ContextMenuRegistry.prototype.unregister = function(id) {
-  if (this.registry_[id]) {
-    delete this.registry_[id];
-  } else {
-    throw new Error('Menu item with id "' + id + '" not found.');
+  if (!this.registry_[id]) {
+    throw new Error('Menu item with ID "' + id + '" not found.');
   }
+  delete this.registry_[id];
 };
 
 /**
@@ -120,10 +119,7 @@ Blockly.ContextMenuRegistry.prototype.unregister = function(id) {
  * @return {?Blockly.ContextMenuRegistry.RegistryItem} RegistryItem or null if not found
  */
 Blockly.ContextMenuRegistry.prototype.getItem = function(id) {
-  if (this.registry_[id]) {
-    return this.registry_[id];
-  }
-  return null;
+  return this.registry_[id] || null;
 };
 
 /**

--- a/core/css.js
+++ b/core/css.js
@@ -88,13 +88,13 @@ Blockly.Css.CONTENT = [
   '.blocklyWidgetDiv {',
     'display: none;',
     'position: absolute;',
-    'z-index: 99999;', /* big value for bootstrap3 compatibility */
+    'z-index: 99999;',  /* big value for bootstrap3 compatibility */
   '}',
 
   '.injectionDiv {',
     'height: 100%;',
     'position: relative;',
-    'overflow: hidden;', /* So blocks in drag surface disappear at edges */
+    'overflow: hidden;',  /* So blocks in drag surface disappear at edges */
     'touch-action: none;',
   '}',
 
@@ -125,7 +125,7 @@ Blockly.Css.CONTENT = [
     'right: 0;',
     'bottom: 0;',
     'overflow: visible !important;',
-    'z-index: 50;', /* Display below toolbox, but above everything else. */
+    'z-index: 50;',  /* Display below toolbox, but above everything else. */
   '}',
 
   '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
@@ -143,7 +143,7 @@ Blockly.Css.CONTENT = [
     'opacity: .9;',
     'padding: 2px;',
     'position: absolute;',
-    'z-index: 100000;', /* big value for bootstrap3 compatibility */
+    'z-index: 100000;',  /* big value for bootstrap3 compatibility */
   '}',
 
   '.blocklyDropDownDiv {',
@@ -165,7 +165,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownContent {',
-    'max-height: 300px;', // @todo: spec for maximum height.
+    'max-height: 300px;',  // @todo: spec for maximum height.
     'overflow: auto;',
     'overflow-x: hidden;',
     'position: relative;',
@@ -498,11 +498,11 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyDropDownDiv .blocklyMenu {',
-    'background: inherit;', /* Compatibility with gapi, reset from goog-menu */
-    'border: inherit;', /* Compatibility with gapi, reset from goog-menu */
+    'background: inherit;',  /* Compatibility with gapi, reset from goog-menu */
+    'border: inherit;',  /* Compatibility with gapi, reset from goog-menu */
     'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
     'outline: none;',
-    'position: relative;', /* Compatibility with gapi, reset from goog-menu */
+    'position: relative;',  /* Compatibility with gapi, reset from goog-menu */
     'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
   '}',
 
@@ -541,7 +541,7 @@ Blockly.Css.CONTENT = [
     'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
     'float: left;',
     'margin-left: -24px;',
-    'position: static;', /* Scroll with the menu. */
+    'position: static;',  /* Scroll with the menu. */
   '}',
 
   '.blocklyMenuItemRtl .blocklyMenuItemCheckbox {',

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -493,7 +493,7 @@ Blockly.DropDownDiv.getPositionBelowMetrics_ = function(
   return {
     initialX: xCoords.divX,
     initialY : primaryY,
-    finalX: xCoords.divX, // X position remains constant during animation.
+    finalX: xCoords.divX,  // X position remains constant during animation.
     finalY: finalY,
     arrowX: xCoords.arrowX,
     arrowY: arrowY,
@@ -525,12 +525,12 @@ Blockly.DropDownDiv.getPositionAboveMetrics_ = function(
   var arrowY = divSize.height - (Blockly.DropDownDiv.BORDER_SIZE * 2) -
       (Blockly.DropDownDiv.ARROW_SIZE / 2);
   var finalY = secondaryY - divSize.height - Blockly.DropDownDiv.PADDING_Y;
-  var initialY = secondaryY - divSize.height; // No padding on Y
+  var initialY = secondaryY - divSize.height;  // No padding on Y.
 
   return {
     initialX: xCoords.divX,
     initialY : initialY,
-    finalX: xCoords.divX, // X position remains constant during animation.
+    finalX: xCoords.divX,  // X position remains constant during animation.
     finalY: finalY,
     arrowX: xCoords.arrowX,
     arrowY: arrowY,
@@ -560,8 +560,8 @@ Blockly.DropDownDiv.getPositionTopOfPageMetrics_ = function(
   return {
     initialX: xCoords.divX,
     initialY : 0,
-    finalX: xCoords.divX, // X position remains constant during animation.
-    finalY: 0,            // Y position remains constant during animation.
+    finalX: xCoords.divX,  // X position remains constant during animation.
+    finalY: 0,             // Y position remains constant during animation.
     arrowAtTop: null,
     arrowX: null,
     arrowY: null,

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -281,7 +281,7 @@ Blockly.Events.filter = function(queueIn, forward) {
   // Merge duplicates.
   for (var i = 0, event; (event = queue[i]); i++) {
     if (!event.isNull()) {
-      // Treat all ui events as the same type in hash table.
+      // Treat all UI events as the same type in hash table.
       var eventType = event.isUiEvent ? Blockly.Events.UI : event.type;
       var key = [eventType, event.blockId, event.workspaceId].join(' ');
 

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -227,10 +227,9 @@ Blockly.Extensions.checkMutatorDialog_ = function(object, errorPrefix) {
     return true;
   } else if (!hasCompose && !hasDecompose) {
     return false;
-  } else {
-    throw Error(errorPrefix +
-        'Must have both or neither of "compose" and "decompose"');
   }
+  throw Error(errorPrefix +
+      'Must have both or neither of "compose" and "decompose"');
 };
 
 /**

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -28,7 +28,7 @@ goog.requireType('Blockly.Block');
  * The set of all registered extensions, keyed by extension name/id.
  * @private
  */
-Blockly.Extensions.ALL_ = {};
+Blockly.Extensions.ALL_ = Object.create(null);
 
 /**
  * Registers a new extension function. Extensions are functions that help

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -337,8 +337,8 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
   var options = this.getOptions(false);
   this.selectedMenuItem_ = null;
   for (var i = 0; i < options.length; i++) {
-    var content = options[i][0]; // Human-readable text or image.
-    var value = options[i][1];   // Language-neutral value.
+    var content = options[i][0];  // Human-readable text or image.
+    var value = options[i][1];    // Language-neutral value.
     if (typeof content == 'object') {
       // An image, not text.
       var image = new Image(content['width'], content['height']);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -100,8 +100,8 @@ Blockly.FieldMultilineInput.fromJson = function(options) {
  * @package
  */
 Blockly.FieldMultilineInput.prototype.toXml = function(fieldElement) {
-  // Replace '\n' characters with html-escaped equivalent '&#10'. This is
-  // needed so the plain-text representation of the xml produced by
+  // Replace '\n' characters with HTML-escaped equivalent '&#10'. This is
+  // needed so the plain-text representation of the XML produced by
   // `Blockly.Xml.domToText` will appear on a single line (this is a limitation
   // of the plain-text format).
   fieldElement.textContent = this.getValue().replace(/\n/g, '&#10;');

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -547,7 +547,7 @@ Blockly.FieldTextInput.prototype.isTabNavigable = function() {
  */
 Blockly.FieldTextInput.prototype.getText_ = function() {
   if (this.isBeingEdited_ && this.htmlInput_) {
-    // We are currently editing, return the html input value instead.
+    // We are currently editing, return the HTML input value instead.
     return this.htmlInput_.value;
   }
   return null;

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -129,7 +129,7 @@ Blockly.FieldVariable.prototype.configure_ = function(config) {
  */
 Blockly.FieldVariable.prototype.initModel = function() {
   if (this.variable_) {
-    return; // Initialization already happened.
+    return;  // Initialization already happened.
   }
   var variable = Blockly.Variables.getOrCreateVariablePackage(
       this.sourceBlock_.workspace, null,
@@ -300,7 +300,7 @@ Blockly.FieldVariable.prototype.doValueUpdate_ = function(newId) {
 Blockly.FieldVariable.prototype.typeIsAllowed_ = function(type) {
   var typeList = this.getVariableTypes_();
   if (!typeList) {
-    return true; // If it's null, all types are valid.
+    return true;  // If it's null, all types are valid.
   }
   for (var i = 0; i < typeList.length; i++) {
     if (type == typeList[i]) {

--- a/core/generator.js
+++ b/core/generator.js
@@ -219,9 +219,8 @@ Blockly.Generator.prototype.blockToCode = function(block, opt_thisOnly) {
   } else if (code === null) {
     // Block has handled code generation itself.
     return '';
-  } else {
-    throw SyntaxError('Invalid code generated: ' + code);
   }
+  throw SyntaxError('Invalid code generated: ' + code);
 };
 
 /**

--- a/core/inject.js
+++ b/core/inject.js
@@ -166,7 +166,7 @@ Blockly.createMainWorkspace_ = function(svg, options, blockDragSurface,
       mainWorkspace.getTheme().getClassName());
 
   if (!wsOptions.hasCategories && wsOptions.languageTree) {
-    // Add flyout as an <svg> that is a sibling of the workspace svg.
+    // Add flyout as an <svg> that is a sibling of the workspace SVG.
     var flyout = mainWorkspace.addFlyout(Blockly.utils.Svg.SVG);
     Blockly.utils.dom.insertAfter(flyout, svg);
   }

--- a/core/input.js
+++ b/core/input.js
@@ -168,9 +168,8 @@ Blockly.Input.prototype.removeField = function(name, opt_quiet) {
   }
   if (opt_quiet) {
     return false;
-  } else {
-    throw Error('Field "' + name + '" not found.');
   }
+  throw Error('Field "' + name + '" not found.');
 };
 
 /**

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -384,7 +384,7 @@ Blockly.InsertionMarkerManager.prototype.shouldUpdatePreviews_ = function(
     } else {
       console.error('Only one of localConnection_ and closestConnection_ was set.');
     }
-  } else { // No connection found.
+  } else {  // No connection found.
     // Only need to update if we were showing a preview before.
     return !!(this.localConnection_ && this.closestConnection_);
   }

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -196,9 +196,9 @@ Blockly.Mutator.prototype.createEditor_ = function() {
   this.workspace_.addChangeListener(Blockly.Events.disableOrphans);
 
   // Mutator flyouts go inside the mutator workspace's <g> rather than in
-  // a top level svg. Instead of handling scale themselves, mutators
+  // a top level SVG. Instead of handling scale themselves, mutators
   // inherit scale from the parent workspace.
-  // To fix this, scale needs to be applied at a different level in the dom.
+  // To fix this, scale needs to be applied at a different level in the DOM.
   var flyoutSvg = hasFlyout ?
       this.workspace_.addFlyout(Blockly.utils.Svg.G) : null;
   var background = this.workspace_.createDom('blocklyMutatorBackground');

--- a/core/names.js
+++ b/core/names.js
@@ -95,9 +95,8 @@ Blockly.Names.prototype.getNameForUserVariable_ = function(id) {
   var variable = this.variableMap_.getVariableById(id);
   if (variable) {
     return variable.name;
-  } else {
-    return null;
   }
+  return null;
 };
 
 /**

--- a/core/names.js
+++ b/core/names.js
@@ -228,5 +228,6 @@ Blockly.Names.prototype.safeName_ = function(name) {
  * @return {boolean} True if names are the same.
  */
 Blockly.Names.equals = function(name1, name2) {
+  // name1.localeCompare(name2) is slower.
   return name1.toLowerCase() == name2.toLowerCase();
 };

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -404,7 +404,7 @@ Blockly.Procedures.getDefinition = function(name, workspace) {
         blocks[i]);
       var tuple = procedureBlock.getProcedureDef();
       if (tuple && Blockly.Names.equals(tuple[0], name)) {
-        return blocks[i];
+        return procedureBlock;
       }
     }
   }

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -404,7 +404,7 @@ Blockly.Procedures.getDefinition = function(name, workspace) {
         blocks[i]);
       var tuple = procedureBlock.getProcedureDef();
       if (tuple && Blockly.Names.equals(tuple[0], name)) {
-        return procedureBlock;
+        return blocks[i];  // Can't use procedureBlock var due to type check.
       }
     }
   }

--- a/core/registry.js
+++ b/core/registry.js
@@ -33,7 +33,7 @@ goog.requireType('Blockly.ToolboxItem');
  *
  * @type {Object<string, Object<string, function(new:?)>>}
  */
-Blockly.registry.typeMap_ = {};
+Blockly.registry.typeMap_ = Object.create(null);
 
 /**
  * The string used to register the default class for a type of plugin.
@@ -137,7 +137,7 @@ Blockly.registry.register = function(
   var typeRegistry = Blockly.registry.typeMap_[type];
   // If the type registry has not been created, create it.
   if (!typeRegistry) {
-    typeRegistry = Blockly.registry.typeMap_[type] = {};
+    typeRegistry = Blockly.registry.typeMap_[type] = Object.create(null);
   }
 
   // Validate that the given class has all the required properties.

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -587,10 +587,10 @@ Blockly.blockRendering.ConstantProvider.prototype.setTheme = function(
 
   /**
    * The block styles map.
-   * @type {Object<string, Blockly.Theme.BlockStyle>}
+   * @type {Object<string, !Blockly.Theme.BlockStyle>}
    * @package
    */
-  this.blockStyles = {};
+  this.blockStyles = Object.create(null);
 
   var blockStyles = theme.blockStyles;
   for (var key in blockStyles) {

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -261,14 +261,14 @@ Blockly.blockRendering.ConstantProvider = function() {
    * to be the height of the text based on the font used.
    * @type {number}
    */
-  this.FIELD_TEXT_HEIGHT = -1; // Dynamically set
+  this.FIELD_TEXT_HEIGHT = -1;  // Dynamically set.
 
   /**
    * Text baseline.  This constant is dynamically set in ``setFontConstants_``
    * to be the baseline of the text based on the font used.
    * @type {number}
    */
-  this.FIELD_TEXT_BASELINE = -1; // Dynamically set
+  this.FIELD_TEXT_BASELINE = -1;  // Dynamically set.
 
   /**
    * A field's border rect corner radius.
@@ -855,7 +855,7 @@ Blockly.blockRendering.ConstantProvider.prototype.makePuzzleTab = function() {
     var halfHeight = height / 2;
     var control1Y = halfHeight + overlap;
     var control2Y = halfHeight + 0.5;
-    var control3Y = overlap; // 2.5
+    var control3Y = overlap;  // 2.5
 
     var endPoint1 = Blockly.utils.svgPaths.point(-width, forward * halfHeight);
     var endPoint2 = Blockly.utils.svgPaths.point(width, forward * halfHeight);

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -227,7 +227,7 @@ Blockly.blockRendering.Drawer.prototype.drawRightSideRow_ = function(row) {
 
 /**
  * Add steps for the bottom edge of a block, possibly including a notch
- * for the next connection
+ * for the next connection.
  * @protected
  */
 Blockly.blockRendering.Drawer.prototype.drawBottom_ = function() {
@@ -449,7 +449,7 @@ Blockly.blockRendering.Drawer.prototype.positionNextConnection_ = function() {
 
   if (bottomRow.connection) {
     var connInfo = bottomRow.connection;
-    var x = connInfo.xPos; // Already contains info about startX
+    var x = connInfo.xPos;  // Already contains info about startX.
     var connX = (this.info_.RTL ? -x : x);
     connInfo.connectionModel.setOffsetInBlock(connX, bottomRow.baseline);
   }

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -197,7 +197,7 @@ Blockly.geras.Drawer.prototype.positionNextConnection_ = function() {
 
   if (bottomRow.connection) {
     var connInfo = bottomRow.connection;
-    var x = connInfo.xPos; // Already contains info about startX
+    var x = connInfo.xPos;  // Already contains info about startX.
     var connX = (this.info_.RTL ? -x : x) +
         (this.constants_.DARK_PATH_OFFSET / 2);
     connInfo.connectionModel.setOffsetInBlock(

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -214,23 +214,23 @@ Blockly.zelos.ConstantProvider = function() {
    * @package
    */
   this.SHAPE_IN_SHAPE_PADDING = {
-    1: { // Outer shape: hexagon.
-      0: 5 * this.GRID_UNIT, // Field in hexagon.
-      1: 2 * this.GRID_UNIT, // Hexagon in hexagon.
-      2: 5 * this.GRID_UNIT, // Round in hexagon.
-      3: 5 * this.GRID_UNIT  // Square in hexagon.
+    1: {  // Outer shape: hexagon.
+      0: 5 * this.GRID_UNIT,  // Field in hexagon.
+      1: 2 * this.GRID_UNIT,  // Hexagon in hexagon.
+      2: 5 * this.GRID_UNIT,  // Round in hexagon.
+      3: 5 * this.GRID_UNIT   // Square in hexagon.
     },
-    2: { // Outer shape: round.
-      0: 3 * this.GRID_UNIT, // Field in round.
-      1: 3 * this.GRID_UNIT, // Hexagon in round.
-      2: 1 * this.GRID_UNIT, // Round in round.
-      3: 2 * this.GRID_UNIT  // Square in round.
+    2: {  // Outer shape: round.
+      0: 3 * this.GRID_UNIT,  // Field in round.
+      1: 3 * this.GRID_UNIT,  // Hexagon in round.
+      2: 1 * this.GRID_UNIT,  // Round in round.
+      3: 2 * this.GRID_UNIT   // Square in round.
     },
-    3: { // Outer shape: square.
-      0: 2 * this.GRID_UNIT, // Field in square.
-      1: 2 * this.GRID_UNIT, // Hexagon in square.
-      2: 2 * this.GRID_UNIT, // Round in square.
-      3: 2 * this.GRID_UNIT  // Square in square.
+    3: {  // Outer shape: square.
+      0: 2 * this.GRID_UNIT,  // Field in square.
+      1: 2 * this.GRID_UNIT,  // Hexagon in square.
+      2: 2 * this.GRID_UNIT,  // Round in square.
+      3: 2 * this.GRID_UNIT   // Square in square.
     }
   };
 

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -45,17 +45,17 @@ Blockly.zelos.PathObject = function(root, style, constants) {
 
   /**
    * The selected path of the block.
-   * @type {SVGElement}
+   * @type {?SVGElement}
    * @private
    */
   this.svgPathSelected_ = null;
 
   /**
    * The outline paths on the block.
-   * @type {!Object<string,!SVGElement>}
+   * @type {!Object<string, !SVGElement>}
    * @private
    */
-  this.outlines_ = {};
+  this.outlines_ = Object.create(null);
 
   /**
    * A set used to determine which outlines were used during a draw pass.  The
@@ -98,8 +98,7 @@ Blockly.zelos.PathObject.prototype.applyColour = function(block) {
   }
 
   // Apply colour to outlines.
-  for (var i = 0, keys = Object.keys(this.outlines_),
-    key; (key = keys[i]); i++) {
+  for (var key in this.outlines_) {
     this.outlines_[key].setAttribute('fill', this.style.colourTertiary);
   }
 };
@@ -110,8 +109,7 @@ Blockly.zelos.PathObject.prototype.applyColour = function(block) {
 Blockly.zelos.PathObject.prototype.flipRTL = function() {
   Blockly.zelos.PathObject.superClass_.flipRTL.call(this);
   // Mirror each input outline path.
-  for (var i = 0, keys = Object.keys(this.outlines_),
-    key; (key = keys[i]); i++) {
+  for (var key in this.outlines_) {
     this.outlines_[key].setAttribute('transform', 'scale(-1 1)');
   }
 };
@@ -175,9 +173,8 @@ Blockly.zelos.PathObject.prototype.updateShapeForInputHighlight = function(
  * @package
  */
 Blockly.zelos.PathObject.prototype.beginDrawing = function() {
-  this.remainingOutlines_ = {};
-  for (var i = 0, keys = Object.keys(this.outlines_),
-    key; (key = keys[i]); i++) {
+  this.remainingOutlines_ = Object.create(null);
+  for (var key in this.outlines_) {
     // The value set here isn't used anywhere, we are just using the
     // object as a Set data structure.
     this.remainingOutlines_[key] = 1;
@@ -192,8 +189,7 @@ Blockly.zelos.PathObject.prototype.endDrawing = function() {
   // Go through all remaining outlines that were not used this draw pass, and
   // remove them.
   if (this.remainingOutlines_) {
-    for (var i = 0, keys = Object.keys(this.remainingOutlines_),
-      key; (key = keys[i]); i++) {
+    for (var key in this.remainingOutlines_) {
       this.removeOutlinePath_(key);
     }
   }

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -165,11 +165,10 @@ Blockly.ShortcutRegistry.prototype.removeKeyMapping = function(
       delete this.keyMap_[keyCode];
     }
     return true;
-  } else if (!opt_quiet) {
-    console.warn(
-        'No keyboard shortcut with name "' + shortcutName +
+  }
+  if (!opt_quiet) {
+    console.warn('No keyboard shortcut with name "' + shortcutName +
         '" registered with key code "' + keyCode + '"');
-    return false;
   }
   return false;
 };

--- a/core/theme/highcontrast.js
+++ b/core/theme/highcontrast.js
@@ -113,7 +113,7 @@ Blockly.Themes.HighContrast.setComponentStyle('selectedGlowSize', 1);
 Blockly.Themes.HighContrast.setComponentStyle('replacementGlowColour', '#000000');
 
 Blockly.Themes.HighContrast.setFontStyle({
-  'family': null, // Use default font-family
-  'weight': null, // Use default font-weight
+  'family': null,  // Use default font-family.
+  'weight': null,  // Use default font-weight.
   'size': 16
 });

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -125,10 +125,10 @@ Blockly.Toolbox = function(workspace) {
 
   /**
    * A map from toolbox item IDs to toolbox items.
-   * @type {!Object<string, Blockly.IToolboxItem>}
+   * @type {!Object<string, !Blockly.IToolboxItem>}
    * @protected
    */
-  this.contentMap_ = {};
+  this.contentMap_ = Object.create(null);
 
   /**
    * Position of the toolbox and flyout relative to the workspace.
@@ -393,7 +393,7 @@ Blockly.Toolbox.prototype.render = function(toolboxDef) {
     }
   }
   this.contents_ = [];
-  this.contentMap_ = {};
+  this.contentMap_ = Object.create(null);
   this.renderContents_(toolboxDef['contents']);
   this.position();
 };
@@ -537,7 +537,7 @@ Blockly.Toolbox.prototype.getClientRect = function() {
  * @public
  */
 Blockly.Toolbox.prototype.getToolboxItemById = function(id) {
-  return this.contentMap_[id];
+  return this.contentMap_[id] || null;
 };
 
 /**

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -406,7 +406,7 @@ Blockly.Toolbox.prototype.render = function(toolboxDef) {
  */
 Blockly.Toolbox.prototype.renderContents_ = function(toolboxDef) {
   // This is for performance reasons. By using document fragment we only have to
-  // add to the dom once.
+  // add to the DOM once.
   var fragment = document.createDocumentFragment();
   for (var i = 0, toolboxItemDef; (toolboxItemDef = toolboxDef[i]); i++) {
     this.createToolboxItem_(toolboxItemDef, fragment);
@@ -426,7 +426,7 @@ Blockly.Toolbox.prototype.createToolboxItem_ = function(toolboxItemDef, fragment
   var registryName = toolboxItemDef['kind'];
 
   // Categories that are collapsible are created using a class registered under
-  // a diffferent name.
+  // a different name.
   if (registryName.toUpperCase() == 'CATEGORY' &&
       Blockly.utils.toolbox.isCategoryCollapsible(
       /** @type {!Blockly.utils.toolbox.CategoryInfo} */(toolboxItemDef))) {
@@ -443,7 +443,7 @@ Blockly.Toolbox.prototype.createToolboxItem_ = function(toolboxItemDef, fragment
     if (toolboxItemDom) {
       fragment.appendChild(toolboxItemDom);
     }
-    // Adds the id to the html element that can receive a click.
+    // Adds the ID to the HTML element that can receive a click.
     // This is used in onClick_ to find the toolboxItem that was clicked.
     if (toolboxItem.getClickTarget) {
       toolboxItem.getClickTarget().setAttribute('id', toolboxItem.getId());

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -411,11 +411,7 @@ Blockly.Trashcan.prototype.openFlyout = function() {
   if (this.contentsIsOpen()) {
     return;
   }
-
-  var xml = [];
-  for (var i = 0, text; (text = this.contents_[i]); i++) {
-    xml[i] = Blockly.Xml.textToDom(text);
-  }
+  var xml = this.contents_.map(Blockly.Xml.textToDom);
   this.flyout.show(xml);
   this.fireUiEvent_(true);
 };
@@ -427,7 +423,6 @@ Blockly.Trashcan.prototype.closeFlyout = function() {
   if (!this.contentsIsOpen()) {
     return;
   }
-
   this.flyout.hide();
   this.fireUiEvent_(false);
 };

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -232,7 +232,7 @@ Blockly.utils.dom.setCssTransform = function(element, transform) {
 Blockly.utils.dom.startTextWidthCache = function() {
   Blockly.utils.dom.cacheReference_++;
   if (!Blockly.utils.dom.cacheWidths_) {
-    Blockly.utils.dom.cacheWidths_ = {};
+    Blockly.utils.dom.cacheWidths_ = Object.create(null);
   }
 };
 

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -353,7 +353,7 @@ Blockly.utils.toolbox.xmlToJsonArray_ = function(toolboxDef) {
       obj['contents'] = Blockly.utils.toolbox.xmlToJsonArray_(child);
     }
 
-    // Add xml attributes to object
+    // Add XML attributes to object
     Blockly.utils.toolbox.addAttributes_(child, obj);
     arr.push(obj);
   }

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -345,7 +345,7 @@ Blockly.utils.toolbox.xmlToJsonArray_ = function(toolboxDef) {
     var tagName = child.tagName.toUpperCase();
     obj['kind'] = tagName;
 
-    // Store the xml for a block
+    // Store the XML for a block.
     if (tagName == 'BLOCK') {
       obj['blockxml'] = child;
     } else if (child.childNodes && child.childNodes.length > 0) {

--- a/core/warning.js
+++ b/core/warning.js
@@ -36,7 +36,7 @@ Blockly.Warning = function(block) {
   Blockly.Warning.superClass_.constructor.call(this, block);
   this.createIcon();
   // The text_ object can contain multiple warnings.
-  this.text_ = {};
+  this.text_ = Object.create(null);
 };
 Blockly.utils.object.inherits(Blockly.Warning, Blockly.Icon);
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -169,7 +169,7 @@ Blockly.WorkspaceSvg = function(
   * @type {!Object<string, ?function(!Blockly.Workspace):!Array<!Element>>}
   * @private
   */
-  this.toolboxCategoryCallbacks_ = {};
+  this.toolboxCategoryCallbacks_ = Object.create(null);
 
   /**
   * Map from function names to callbacks, for deciding what to do when a button
@@ -177,7 +177,7 @@ Blockly.WorkspaceSvg = function(
   * @type {!Object<string, ?function(!Blockly.FlyoutButton)>}
   * @private
   */
-  this.flyoutButtonCallbacks_ = {};
+  this.flyoutButtonCallbacks_ = Object.create(null);
 
   if (Blockly.Variables && Blockly.Variables.flyoutCategory) {
     this.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME,

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1787,7 +1787,7 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
       // This is needed as for some browser/system combinations which do not
       // set deltaX.
       x = this.scrollX - scrollDelta.y;
-      y = this.scrollY; // Don't scroll vertically
+      y = this.scrollY;  // Don't scroll vertically.
     }
     this.scroll(x, y);
   }
@@ -2213,8 +2213,8 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
 
   this.scrollX -= metrics.absoluteLeft;
   this.scrollY -= metrics.absoluteTop;
-  // // The scroll values and the view values are additive inverses of
-  // // each other, so when we subtract from one we have to add to the other.
+  // The scroll values and the view values are additive inverses of
+  // each other, so when we subtract from one we have to add to the other.
   metrics.viewLeft += metrics.absoluteLeft;
   metrics.viewTop += metrics.absoluteTop;
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -166,7 +166,7 @@ Blockly.Xml.blockToDom = function(block, opt_noId) {
   element.setAttribute('type', block.type);
   if (!opt_noId) {
     // It's important to use setAttribute here otherwise IE11 won't serialize
-    // the block's id when domToText is called.
+    // the block's ID when domToText is called.
     element.setAttribute('id', block.id);
   }
   if (block.mutationToDom) {
@@ -637,7 +637,7 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
 Blockly.Xml.childNodeTagMap;
 
 /**
- * Creates a mapping of childNodes for each supported xml tag for the provided
+ * Creates a mapping of childNodes for each supported XML tag for the provided
  * xmlBlock. Logs a warning for any encountered unsupported tags.
  * @param {!Element} xmlBlock XML block element.
  * @return {!Blockly.Xml.childNodeTagMap} The childNode map from nodeName to
@@ -765,8 +765,8 @@ Blockly.Xml.applyFieldTagNodes_ = function(xmlChildren, block) {
 };
 
 /**
- * Finds any enclosed blocks or shadows within this xml node.
- * @param {!Element} xmlNode The xml node to extract child block info from.
+ * Finds any enclosed blocks or shadows within this XML node.
+ * @param {!Element} xmlNode The XML node to extract child block info from.
  * @return {{childBlockElement: ?Element, childShadowElement: ?Element}} Any
  *    found child block.
  * @private

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -887,7 +887,6 @@ WorkspaceFactoryController.prototype.clearAll = function() {
   if (!confirm(msg)) {
     return;
   }
-  var hasCategories = this.model.hasElements();
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.model.savePreloadXml(Blockly.utils.xml.createElement('xml'));
@@ -1209,9 +1208,9 @@ WorkspaceFactoryController.prototype.importBlocks = function(file, format) {
       // If an imported block type is already defined, check if the user wants
       // to override the current block definition.
       if (controller.model.hasDefinedBlockTypes(blockTypes)) {
-        var msg = 'An imported block uses the same name as a block '
-          + 'already in your toolbox. Are you sure you want to override the '
-          + 'currently defined block?';
+        var msg = 'An imported block uses the same name as a block ' +
+          'already in your toolbox. Are you sure you want to override the ' +
+          'currently defined block?';
         var continueAnyway = confirm(msg);
         BlocklyDevTools.Analytics.onWarning(msg);
         if (!continueAnyway) {

--- a/demos/blockfactory/workspacefactory/wfactory_model.js
+++ b/demos/blockfactory/workspacefactory/wfactory_model.js
@@ -360,7 +360,7 @@ WorkspaceFactoryModel.prototype.addCustomTag = function(category, tag) {
  * @param {!Element} xml The XML to be saved.
  */
 WorkspaceFactoryModel.prototype.savePreloadXml = function(xml) {
-  this.preloadXml = xml
+  this.preloadXml = xml;
 };
 
 /**
@@ -445,8 +445,8 @@ WorkspaceFactoryModel.prototype.updateLibBlockTypes = function(blockTypes) {
  * @return {boolean} True if blockType is defined, false otherwise.
  */
 WorkspaceFactoryModel.prototype.isDefinedBlockType = function(blockType) {
-  var isStandardBlock = StandardCategories.coreBlockTypes.indexOf(blockType)
-      != -1;
+  var isStandardBlock =
+      StandardCategories.coreBlockTypes.indexOf(blockType) != -1;
   var isLibBlock = this.libBlockTypes.indexOf(blockType) != -1;
   var isImportedBlock = this.importedBlockTypes.indexOf(blockType) != -1;
   return (isStandardBlock || isLibBlock || isImportedBlock);

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -14,12 +14,12 @@ goog.provide('Blockly.PHP.procedures');
 
 goog.require('Blockly.PHP');
 
+
 Blockly.PHP['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   // First, add a 'global' statement for every variable that is not shadowed by
   // a local parameter.
   var globals = [];
-  var varName;
   var workspace = block.workspace;
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
   for (var i = 0, variable; variable = variables[i]; i++) {

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -23,7 +23,7 @@ Blockly.PHP['procedures_defreturn'] = function(block) {
   var workspace = block.workspace;
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
   for (var i = 0, variable; variable = variables[i]; i++) {
-    varName = variable.name;
+    var varName = variable.name;
     if (block.getVars().indexOf(varName) == -1) {
       globals.push(Blockly.PHP.nameDB_.getName(varName,
           Blockly.VARIABLE_CATEGORY_NAME));

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -22,8 +22,8 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   var globals = [];
   var workspace = block.workspace;
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
-  for (var i = 0, variable; variable = variables[i]; i++) {
-    varName = variable.name;
+  for (var i = 0, variable; (variable = variables[i]); i++) {
+    var varName = variable.name;
     if (block.getVars().indexOf(varName) == -1) {
       globals.push(Blockly.Python.nameDB_.getName(varName,
           Blockly.VARIABLE_CATEGORY_NAME));

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -20,7 +20,6 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   // First, add a 'global' statement for every variable that is not shadowed by
   // a local parameter.
   var globals = [];
-  var varName;
   var workspace = block.workspace;
   var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
   for (var i = 0, variable; variable = variables[i]; i++) {

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -398,7 +398,7 @@ return gulp.src(maybeAddClosureLibrary(['core/**/**/*.js']))
     const requires = `goog.addDependency("base.js", [], []);
 
 // Load Blockly.
-goog.require('Blockly.requires')
+goog.require('Blockly.requires');
 `;
     fs.writeFileSync('blockly_uncompressed.js',
       header +


### PR DESCRIPTION
A {} has a bunch of names already defined on it (like ‘toString’).  When using an object as a map with arbitrary keys, it should not inherit from Object.prototype.