### PR TITLE
Revert bubble dragger logic change and helper name change

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -290,7 +290,7 @@ Blockly.BlockDragger.prototype.endDrag = function(e, currentDragDeltaXY) {
   } else {
     this.draggingBlock_.setDragging(false);
     if (delta) { // !preventMove
-      this.updateBlockLocationAfterMove_(delta);
+      this.updateBlockAfterMove_(delta);
     } else {
       // Blocks dragged directly from a flyout may need to be bumped into
       // bounds.
@@ -313,7 +313,7 @@ Blockly.BlockDragger.prototype.endDrag = function(e, currentDragDeltaXY) {
  *     the block started the drag to where it ended the drag.
  * @protected
  */
-Blockly.BlockDragger.prototype.updateBlockLocationAfterMove_ = function(delta) {
+Blockly.BlockDragger.prototype.updateBlockAfterMove_ = function(delta) {
   this.draggingBlock_.moveConnections(delta.x, delta.y);
   this.fireMoveEvent_();
   if (this.draggedConnectionManager_.wouldConnectBlock()) {

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -217,7 +217,7 @@ Blockly.BubbleDragger.prototype.endBubbleDrag = function(
     if (this.dragSurface_) {
       this.dragSurface_.clearAndHide(this.workspace_.getBubbleCanvas());
     }
-    if (this.draggingBubble_) {
+    if (this.draggingBubble_.setDragging) {
       this.draggingBubble_.setDragging(false);
     }
     this.fireMoveEvent_();


### PR DESCRIPTION
Revert accidental change in bubble dragger logic and reverts name change in block dragger helper.
From: https://github.com/google/blockly/pull/4886