### PR TITLE
Update the registered component ids

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -72,7 +72,8 @@ Blockly.Flyout = function(workspaceOptions) {
   this.workspace_.setVisible(this.isVisible_);
 
   /**
-   * The unique id for this component.
+   * The unique id for this component that is used to register with the
+   * ComponentManager.
    * @type {string}
    */
   this.id = Blockly.utils.genUid();

--- a/core/interfaces/i_component.js
+++ b/core/interfaces/i_component.js
@@ -23,7 +23,8 @@ goog.provide('Blockly.IComponent');
 Blockly.IComponent = function() {};
 
 /**
- * The unique id for this component.
+ * The unique id for this component that is used to register with the
+ * ComponentManager.
  * @type {string}
  */
 Blockly.IComponent.id;

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -65,7 +65,8 @@ Blockly.Toolbox = function(workspace) {
   this.workspace_ = workspace;
 
   /**
-   * The unique id for this component.
+   * The unique id for this component that is used to register with the
+   * ComponentManager.
    * @type {string}
    */
   this.id = 'toolbox';

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -68,7 +68,7 @@ Blockly.Toolbox = function(workspace) {
    * The unique id for this component.
    * @type {string}
    */
-  this.id = Blockly.utils.genUid();
+  this.id = 'toolbox';
 
   /**
    * The JSON describing the contents of this toolbox.

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -55,7 +55,8 @@ Blockly.Trashcan = function(workspace) {
   this.workspace_ = workspace;
 
   /**
-   * The unique id for this component.
+   * The unique id for this component that is used to register with the
+   * ComponentManager.
    * @type {string}
    */
   this.id = 'trashcan';

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -58,7 +58,7 @@ Blockly.Trashcan = function(workspace) {
    * The unique id for this component.
    * @type {string}
    */
-  this.id = Blockly.utils.genUid();
+  this.id = 'trashcan';
 
   /**
    * A list of XML (stored as strings) representing blocks in the trashcan.

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -48,7 +48,7 @@ Blockly.ZoomControls = function(workspace) {
    * The unique id for this component.
    * @type {string}
    */
-  this.id = Blockly.utils.genUid();
+  this.id = 'zoomControls';
 
   /**
    * A handle to use to unbind the mouse down event handler for zoom reset

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -45,7 +45,8 @@ Blockly.ZoomControls = function(workspace) {
   this.workspace_ = workspace;
 
   /**
-   * The unique id for this component.
+   * The unique id for this component that is used to register with the
+   * ComponentManager.
    * @type {string}
    */
   this.id = 'zoomControls';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Updates the registered component id for `zoom_controls`, `trashcan` and `toolbox`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Since there is only ever one of each of these kinds of components, these ids do not need to be generated. 
These ids are easier to use to get the component by an external developer.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This change would mean that if someone wanted to have multiple of these kind of components, then they would need to change the ids of the two instances so that they would be unique (ids must be unique).

It might make sense to also add a constant for a default id for developers to use to get these components from the `ComponentManager`.

<!-- Anything else we should know? -->
