### PR TITLE
CI updates: bump node, prepare to reenable macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,12 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # TODO (#2114): re-enable osx build.
+        # os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,10 @@ on: [pull_request]
 
 jobs:
   build:
-    # TODO (#2114): re-enable osx build.
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/tests/scripts/setup_osx_env.sh
+++ b/tests/scripts/setup_osx_env.sh
@@ -2,8 +2,6 @@
   
 if [ "${RUNNER_OS}" == "macOS" ]
   then
-    brew install google-chrome 
-    sudo Xvfb :99 -ac -screen 0 1024x768x8 &
     export CHROME_BIN="/Applications/Google Chrome.app"
     npm run test:prepare > /dev/null &
 fi

--- a/tests/scripts/setup_osx_env.sh
+++ b/tests/scripts/setup_osx_env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
   
-if [ "${TRAVIS_OS_NAME}" == "osx" ]
+if [ "${RUNNER_OS}" == "macOS" ]
   then
-    brew cask install google-chrome 
+    brew install google-chrome 
     sudo Xvfb :99 -ac -screen 0 1024x768x8 &
     export CHROME_BIN="/Applications/Google Chrome.app"
     npm run test:prepare > /dev/null &


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

~~This should fix the CI issue with PR #4812~~, and also does some preparatory work for #2114.

### Proposed Changes

Update our CI configuration:

- Bump node.js versions: ~~remove v10 and~~ add v16, per https://nodejs.org/en/about/releases/
- Update the configuration for macOS, but leave it disabled for now.

### Test Coverage

Will be improved.

