### PR TITLE
Use selenium-standalone-service to automatically start and stop Selenium when running the test suite.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       run: source ./tests/scripts/setup_osx_env.sh
 
     - name: Run
-      run: npm run test:run
+      run: npm run test
 
       env:
         CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,12 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # TODO (#2114): re-enable osx build.
+        # os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,10 @@ on: [pull_request]
 
 jobs:
   build:
-    # TODO (#2114): re-enable osx build.
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -414,6 +414,15 @@
       "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
+      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
@@ -451,6 +460,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/selenium-standalone": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/@types/selenium-standalone/-/selenium-standalone-6.15.2.tgz",
+      "integrity": "sha512-Jnt4AHHcUOPGuZ5cJRYfP3IpPalNc/o1BmFvuFFmLtU2PtvEGvyyJPdpErqzZDxsP8E4yjTst0GL+QMJiEWuBA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -591,6 +609,121 @@
       "dev": true,
       "requires": {
         "@wdio/utils": "7.6.0"
+      }
+    },
+    "@wdio/selenium-standalone-service": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-6.12.1.tgz",
+      "integrity": "sha512-9R5iTAb5p7XEWfn9WkiH8K3tgArmUJ0U3CcOQCeaHQBZks5DhNQv6ZQIodnIDyWHjoEfwnF9n+/UKsfPOk4rCQ==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^9.0.1",
+        "@types/selenium-standalone": "^6.15.2",
+        "@wdio/config": "6.12.1",
+        "@wdio/logger": "6.10.10",
+        "fs-extra": "^9.0.1",
+        "selenium-standalone": "^6.22.1"
+      },
+      "dependencies": {
+        "@wdio/config": {
+          "version": "6.12.1",
+          "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.12.1.tgz",
+          "integrity": "sha512-V5hTIW5FNlZ1W33smHF4Rd5BKjGW2KeYhyXDQfXHjqLCeRiirZ9fABCo9plaVQDnwWSUMWYaAaIAifV82/oJCQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.10.10",
+            "deepmerge": "^4.0.0",
+            "glob": "^7.1.2"
+          }
+        },
+        "@wdio/logger": {
+          "version": "6.10.10",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.10.tgz",
+          "integrity": "sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "loglevel": "^1.6.0",
+            "loglevel-plugin-prefix": "^0.8.4",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@wdio/types": {
@@ -1145,6 +1278,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -8538,6 +8677,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
     },
     "typescript-closure-tools": {
       "version": "0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8681,7 +8681,8 @@
     "typescript": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true
     },
     "typescript-closure-tools": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
     "rimraf": "^3.0.2",
     "selenium-standalone": "^6.17.0",
     "through2": "^4.0.2",
+    "typescript": "^4.3.2",
     "typescript-closure-tools": "^0.0.7",
     "webdriverio": "^7.0.3",
     "yargs": "^16.0.3"
   },
   "dependencies": {
-    "jsdom": "15.2.1",
-    "typescript": "^4.3.2"
+    "jsdom": "15.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,12 +40,8 @@
     "publish:beta": "gulp publishBeta",
     "recompile": "gulp recompile",
     "release": "gulp gitCreateRC",
-    "test": "concurrently 'npm run test:prepare' 'sleep 5 && npm run test:run'",
-    "test:generators": "concurrently 'npm run test:prepare' 'sleep 5 && tests/scripts/run_generators.sh'",
-    "test:prepare": "npm run test:setupselenium && npm run test:startselenium",
-    "test:run": "tests/run_all_tests.sh",
-    "test:setupselenium": "selenium-standalone install --config=./tests/scripts/selenium-config.js",
-    "test:startselenium": "selenium-standalone start --config=./tests/scripts/selenium-config.js",
+    "test": "tests/run_all_tests.sh",
+    "test:generators": "tests/scripts/run_generators.sh",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest",
     "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"
@@ -65,6 +61,7 @@
     "@blockly/dev-tools": "^2.0.1",
     "@blockly/theme-dark": "^1.0.0",
     "@blockly/theme-modern": "^2.1.1",
+    "@wdio/selenium-standalone-service": "^6.11.0",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "clang-format": "^1.5.0",
@@ -92,6 +89,7 @@
     "yargs": "^16.0.3"
   },
   "dependencies": {
-    "jsdom": "15.2.1"
+    "jsdom": "15.2.1",
+    "typescript": "^4.3.2"
   }
 }

--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -32,8 +32,8 @@ async function runLangGeneratorInBrowser(browser, filename, codegenFn) {
 }
 
 /**
- * Runs the generator tests in Firefox. It uses webdriverio to
- * launch Firefox and load index.html. Outputs a summary of the test results
+ * Runs the generator tests in Chrome. It uses webdriverio to
+ * launch Chrome and load index.html. Outputs a summary of the test results
  * to the console and outputs files for later validation.
  * @return the Thenable managing the processing of the browser tests.
  */

--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -40,14 +40,18 @@ async function runLangGeneratorInBrowser(browser, filename, codegenFn) {
 async function runGeneratorsInBrowser() {
   var options = {
     capabilities: {
-      browserName: 'firefox'
+      browserName: 'chrome',
     },
-    path: '/wd/hub'
+    services: ['selenium-standalone']
   };
   // Run in headless mode on Github Actions.
   if (process.env.CI) {
-    options.capabilities['moz:firefoxOptions'] = {
-      args: ['-headless']
+    options.capabilities['goog:chromeOptions'] = {
+      args: ['--headless', '--no-sandbox', '--disable-dev-shm-usage', '--allow-file-access-from-files']
+    };
+  } else {
+    options.capabilities['goog:chromeOptions'] = {
+      args: ['--allow-file-access-from-files']
     };
   }
 

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -22,7 +22,9 @@ async function runMochaTestsInBrowser() {
     capabilities: {
       browserName: 'chrome'
     },
-    path: '/wd/hub'
+    services: [
+      ['selenium-standalone']
+    ]
   };
   // Run in headless mode on Github Actions.
   if (process.env.CI) {

--- a/tests/scripts/setup_osx_env.sh
+++ b/tests/scripts/setup_osx_env.sh
@@ -2,8 +2,6 @@
   
 if [ "${RUNNER_OS}" == "macOS" ]
   then
-    brew install google-chrome 
-    sudo Xvfb :99 -ac -screen 0 1024x768x8 &
     export CHROME_BIN="/Applications/Google Chrome.app"
     npm run test:prepare > /dev/null &
 fi

--- a/tests/scripts/setup_osx_env.sh
+++ b/tests/scripts/setup_osx_env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
   
-if [ "${TRAVIS_OS_NAME}" == "osx" ]
+if [ "${RUNNER_OS}" == "macOS" ]
   then
-    brew cask install google-chrome 
+    brew install google-chrome 
     sudo Xvfb :99 -ac -screen 0 1024x768x8 &
     export CHROME_BIN="/Applications/Google Chrome.app"
     npm run test:prepare > /dev/null &


### PR DESCRIPTION
This change also migrates the generator tests to run in Chrome instead of Firefox.

## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

This PR uses the selenium-standalone-service module to automatically start and stop Selenium when running test cases, instead of the old commands in package.json to coordinate doing so. It also uses Chrome to run the generator tests (consistent with the Mocha tests) instead of Firefox.

#### Behavior Before Change

`npm run test` would run the test suite, but hang and never terminate since it was blocking on a child Selenium process.

#### Behavior After Change

`npm run test` runs the test suite and terminates when it is done.

### Reason for Changes

The test suite had to be manually stopped with ^C.

### Test Coverage

Change is to the test suite itself; ran the test suite and confirmed that all tests pass.
