### PR TITLE
Update positionable jsdoc

### DIFF
--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -37,6 +37,7 @@ Blockly.IPositionable.prototype.position;
 /**
  * Returns the bounding rectangle of the UI element in pixel units relative to
  * the Blockly injection div.
- * @return {!Blockly.utils.Rect} The UI elements’s bounding box.
+ * @return {?Blockly.utils.Rect} The UI elements’s bounding box. Null if
+ *   bounding box should be ignored by other UI elements.
  */
 Blockly.IPositionable.prototype.getBoundingRectangle;

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -506,7 +506,8 @@ Blockly.Trashcan.prototype.position = function(metrics, savedPositions) {
 /**
  * Returns the bounding rectangle of the UI element in pixel units relative to
  * the Blockly injection div.
- * @return {!Blockly.utils.Rect} The UI elements’s bounding box.
+ * @return {?Blockly.utils.Rect} The UI elements’s bounding box. Null if
+ *   bounding box should be ignored by other UI elements.
  */
 Blockly.Trashcan.prototype.getBoundingRectangle = function() {
   var bottom = this.top_ + this.BODY_HEIGHT_ + this.LID_HEIGHT_;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1148,7 +1148,10 @@ Blockly.WorkspaceSvg.prototype.resize = function() {
   var savedPositions = [];
   for (var i = 0, positionable; (positionable = positionables[i]); i++) {
     positionable.position(metrics, savedPositions);
-    savedPositions.push(positionable.getBoundingRectangle());
+    var clientRect = positionable.getBoundingRectangle();
+    if (clientRect) {
+      savedPositions.push(clientRect);
+    }
   }
 
   if (this.scrollbar) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1148,9 +1148,9 @@ Blockly.WorkspaceSvg.prototype.resize = function() {
   var savedPositions = [];
   for (var i = 0, positionable; (positionable = positionables[i]); i++) {
     positionable.position(metrics, savedPositions);
-    var clientRect = positionable.getBoundingRectangle();
-    if (clientRect) {
-      savedPositions.push(clientRect);
+    var boundingRect = positionable.getBoundingRectangle();
+    if (boundingRect) {
+      savedPositions.push(boundingRect);
     }
   }
 

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -228,7 +228,8 @@ Blockly.ZoomControls.prototype.dispose = function() {
 /**
  * Returns the bounding rectangle of the UI element in pixel units relative to
  * the Blockly injection div.
- * @return {!Blockly.utils.Rect} The UI elements’s bounding box.
+ * @return {?Blockly.utils.Rect} The UI elements’s bounding box. Null if
+ *   bounding box should be ignored by other UI elements.
  */
 Blockly.ZoomControls.prototype.getBoundingRectangle = function() {
   var height = this.SMALL_SPACING_ + 2 * this.HEIGHT_;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Makes the jsdoc type for `getBoundingRect` more accurate.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Adds support for other use cases:
- support of positionables that can be hidden (such as the `Flyout`, which is not yet a positionable).
- support for positionables that are meant to overlay the workspace and not affect the positioning of other positionables, such as `@blockly/workspace-search`.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested manually by making the `Trashcan` return `null` in `getBoundingRectangle` and observing how the zoom controls ignore the trashcan placment.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

