### PR TITLE
Updated user agent parsing to detect iPads posing as desktop Safari.

### DIFF
--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -93,9 +93,11 @@ Blockly.utils.userAgent.MOBILE;
       !Blockly.utils.userAgent.EDGE;
 
   // Platforms.  Logic from:
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js
+  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
+  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
   Blockly.utils.userAgent.ANDROID = has('Android');
-  Blockly.utils.userAgent.IPAD = has('iPad');
+  Blockly.utils.userAgent.IPAD = has('iPad') ||
+      has('Macintosh') && navigator.maxTouchPoints > 0;
   Blockly.utils.userAgent.IPOD = has('iPod');
   Blockly.utils.userAgent.IPHONE = has('iPhone') &&
       !Blockly.utils.userAgent.IPAD && !Blockly.utils.userAgent.IPOD;

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -96,8 +96,8 @@ Blockly.utils.userAgent.MOBILE;
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
   Blockly.utils.userAgent.ANDROID = has('Android');
-  Blockly.utils.userAgent.IPAD = has('iPad') ||
-      has('Macintosh') && navigator.maxTouchPoints > 0;
+  var maxTouchPoints = Blockly.utils.global['navigator'] && Blockly.utils.global['navigator']['maxTouchPoints'];
+  Blockly.utils.userAgent.IPAD = has('iPad') || has('Macintosh') && maxTouchPoints > 0;
   Blockly.utils.userAgent.IPOD = has('iPod');
   Blockly.utils.userAgent.IPHONE = has('iPhone') &&
       !Blockly.utils.userAgent.IPAD && !Blockly.utils.userAgent.IPOD;

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -96,8 +96,10 @@ Blockly.utils.userAgent.MOBILE;
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
   Blockly.utils.userAgent.ANDROID = has('Android');
-  var maxTouchPoints = Blockly.utils.global['navigator'] && Blockly.utils.global['navigator']['maxTouchPoints'];
-  Blockly.utils.userAgent.IPAD = has('iPad') || has('Macintosh') && maxTouchPoints > 0;
+  var maxTouchPoints = Blockly.utils.global['navigator'] &&
+      Blockly.utils.global['navigator']['maxTouchPoints'];
+  Blockly.utils.userAgent.IPAD = has('iPad') ||
+      has('Macintosh') && maxTouchPoints > 0;
   Blockly.utils.userAgent.IPOD = has('iPod');
   Blockly.utils.userAgent.IPHONE = has('iPhone') &&
       !Blockly.utils.userAgent.IPAD && !Blockly.utils.userAgent.IPOD;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/4818

### Proposed Changes

Updates user agent parsing to detect iPads posing as desktop Safari. Since iOS 13, non-mini iPads use the same user agent as desktop Safari. This change checks for multitouch (which doesn't exist on Macs) to distinguish iPads. I looked into using the desktop behavior (inline fields instead of a modal text field), but that appears to be bordering on infeasible due to mobile Safari playing games with calls to focus().

#### Behavior Before Change
Editing values in text fields in blocks on an iPad running iOS 13 or greater with an external keyboard was not possible due to focus being lost as soon as the text field was tapped.

#### Behavior After Change
The standard modal text input dialog appears.

### Test Coverage
I have manually verified the fix on an iPad running iOS 14.6 with an external keyboard attached. I also verified that it still worked on desktop Safari and an iPhone.
