### PR TITLE
Remove return value from Field dropdownCreate_

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -78,14 +78,21 @@ Blockly.FieldAngle = function(opt_value, opt_validator, opt_config) {
       this, opt_value, opt_validator, opt_config);
 
   /**
+   * The angle picker's SVG element.
+   * @type {?SVGElement}
+   * @private
+   */
+  this.editor_ = null;
+
+  /**
    * The angle picker's gauge path depending on the value.
-   * @type {SVGElement}
+   * @type {?SVGElement}
    */
   this.gauge_ = null;
 
   /**
    * The angle picker's line drawn representing the value's angle.
-   * @type {SVGElement}
+   * @type {?SVGElement}
    */
   this.line_ = null;
 
@@ -271,8 +278,8 @@ Blockly.FieldAngle.prototype.showEditor_ = function(opt_e) {
       Blockly.utils.userAgent.IPAD;
   Blockly.FieldAngle.superClass_.showEditor_.call(this, opt_e, noFocus);
 
-  var editor = this.dropdownCreate_();
-  Blockly.DropDownDiv.getContentDiv().appendChild(editor);
+  this.dropdownCreate_();
+  Blockly.DropDownDiv.getContentDiv().appendChild(this.editor_);
 
   Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
       this.sourceBlock_.style.colourTertiary);
@@ -285,7 +292,6 @@ Blockly.FieldAngle.prototype.showEditor_ = function(opt_e) {
 
 /**
  * Create the angle dropdown editor.
- * @return {!SVGElement} The newly created angle picker.
  * @private
  */
 Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
@@ -343,7 +349,7 @@ Blockly.FieldAngle.prototype.dropdownCreate_ = function() {
       circle, 'click', this, this.onMouseMove_, true, true);
   this.moveSurfaceWrapper_ = Blockly.browserEvents.conditionalBind(
       circle, 'mousemove', this, this.onMouseMove_, true, true);
-  return svg;
+  this.editor_ = svg;
 };
 
 /**

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -47,7 +47,7 @@ Blockly.FieldColour = function(opt_value, opt_validator, opt_config) {
 
   /**
    * The field's colour picker element.
-   * @type {Element}
+   * @type {?Element}
    * @private
    */
   this.picker_ = null;
@@ -321,7 +321,7 @@ Blockly.FieldColour.prototype.setColumns = function(columns) {
  * @protected
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-  this.picker_ = this.dropdownCreate_();
+  this.dropdownCreate_();
   Blockly.DropDownDiv.getContentDiv().appendChild(this.picker_);
 
   Blockly.DropDownDiv.showPositionedByField(
@@ -512,7 +512,6 @@ Blockly.FieldColour.prototype.setHighlightedCell_ = function(cell, index) {
 
 /**
  * Create a colour picker dropdown editor.
- * @return {!Element} The newly created colour picker.
  * @private
  */
 Blockly.FieldColour.prototype.dropdownCreate_ = function() {
@@ -568,7 +567,7 @@ Blockly.FieldColour.prototype.dropdownCreate_ = function() {
   this.onKeyDownWrapper_ = Blockly.browserEvents.conditionalBind(
       table, 'keydown', this, this.onKeyDown_);
 
-  return table;
+  this.picker_ = table;
 };
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -95,35 +95,35 @@ Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
 
   /**
    * A reference to the currently selected menu item.
-   * @type {Blockly.MenuItem}
+   * @type {?Blockly.MenuItem}
    * @private
    */
   this.selectedMenuItem_ = null;
 
   /**
    * The dropdown menu.
-   * @type {Blockly.Menu}
+   * @type {?Blockly.Menu}
    * @protected
    */
   this.menu_ = null;
 
   /**
    * SVG image element if currently selected option is an image, or null.
-   * @type {SVGImageElement}
+   * @type {?SVGImageElement}
    * @private
    */
   this.imageElement_ = null;
 
   /**
    * Tspan based arrow element.
-   * @type {SVGTSpanElement}
+   * @type {?SVGTSpanElement}
    * @private
    */
   this.arrow_ = null;
 
   /**
    * SVG based arrow element.
-   * @type {SVGElement}
+   * @type {?SVGElement}
    * @private
    */
   this.svgArrow_ = null;
@@ -288,7 +288,7 @@ Blockly.FieldDropdown.prototype.createSVGArrow_ = function() {
  * @protected
  */
 Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
-  this.menu_ = this.dropdownCreate_();
+  this.dropdownCreate_();
   if (opt_e && typeof opt_e.clientX === 'number') {
     this.menu_.openingCoords =
         new Blockly.utils.Coordinate(opt_e.clientX, opt_e.clientY);
@@ -327,12 +327,12 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
 
 /**
  * Create the dropdown editor.
- * @return {!Blockly.Menu} The newly created dropdown menu.
  * @private
  */
 Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
   var menu = new Blockly.Menu();
   menu.setRole(Blockly.utils.aria.Role.LISTBOX);
+  this.menu_ = menu;
 
   var options = this.getOptions(false);
   this.selectedMenuItem_ = null;
@@ -357,8 +357,6 @@ Blockly.FieldDropdown.prototype.dropdownCreate_ = function() {
     }
     menuItem.onAction(this.handleMenuActionEvent_, this);
   }
-
-  return menu;
 };
 
 /**

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -101,7 +101,7 @@ suite('Colour Fields', function() {
   testHelpers.runFromJsonSuiteTests(
       Blockly.FieldColour, validValueTestCases,invalidValueTestCases,
       validTestCaseAssertField, assertFieldDefault);
-  
+
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
       setup(function() {
@@ -165,9 +165,9 @@ suite('Colour Fields', function() {
   suite('Customizations', function() {
     suite('Colours and Titles', function() {
       function assertColoursAndTitles(field, colours, titles) {
-        var editor = field.dropdownCreate_();
+        field.dropdownCreate_();
         var index = 0;
-        var node = editor.firstChild.firstChild;
+        var node = field.picker_.firstChild.firstChild;
         while (node) {
           chai.assert.equal(node.getAttribute('title'), titles[index]);
           chai.assert.equal(
@@ -243,8 +243,8 @@ suite('Colour Fields', function() {
     });
     suite('Columns', function() {
       function assertColumns(field, columns) {
-        var editor = field.dropdownCreate_();
-        chai.assert.equal(editor.firstChild.children.length, columns);
+        field.dropdownCreate_();
+        chai.assert.equal(field.picker_.firstChild.children.length, columns);
       }
       test('Constants', function() {
         var columns = Blockly.FieldColour.COLUMNS;


### PR DESCRIPTION
These functions have side effects and set all kinds of private fields.  It is misleading for them to do all that, then return the top-level element, for the caller to assign to a private field.
