### PR TITLE
Update toolbox drag target when visibility changes

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -817,7 +817,7 @@ Blockly.Toolbox.prototype.refreshSelection = function() {
  * @public
  */
 Blockly.Toolbox.prototype.setVisible = function(isVisible) {
-  if (this.isVisible_ == isVisible) {
+  if (this.isVisible_ === isVisible) {
     return;
   }
 

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -100,6 +100,13 @@ Blockly.Toolbox = function(workspace) {
   this.contentsDiv_ = null;
 
   /**
+   * Whether the Toolbox is visible.
+   * @type {boolean}
+   * @protected
+   */
+  this.isVisible_ = false;
+
+  /**
    * The list of items in the toolbox.
    * @type {!Array<!Blockly.IToolboxItem>}
    * @protected
@@ -193,6 +200,7 @@ Blockly.Toolbox.prototype.init = function() {
 
   this.HtmlDiv = this.createDom_(this.workspace_);
   Blockly.utils.dom.insertAfter(this.flyout_.createDom('svg'), svg);
+  this.setVisible(true);
   this.flyout_.init(workspace);
 
   this.render(this.toolboxDef_);
@@ -513,7 +521,7 @@ Blockly.Toolbox.prototype.removeStyle = function(style) {
  *   target area should be ignored.
  */
 Blockly.Toolbox.prototype.getClientRect = function() {
-  if (!this.HtmlDiv) {
+  if (!this.HtmlDiv || !this.isVisible_) {
     return null;
   }
 
@@ -809,7 +817,15 @@ Blockly.Toolbox.prototype.refreshSelection = function() {
  * @public
  */
 Blockly.Toolbox.prototype.setVisible = function(isVisible) {
+  if (this.isVisible_ == isVisible) {
+    return;
+  }
+
   this.HtmlDiv.style.display = isVisible ? 'block' : 'none';
+  this.isVisible_ = isVisible;
+  // Invisible toolbox is ignored as drag targets and must have the drag target
+  // updated.
+  this.workspace_.recordDragTargets();
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/4811
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

- Adds property to toolbox to track visibility status.
- Checks if toolbox is visible in `getClientRect`
- Update drag targets when visibility changes
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Toolbox area is still a delete area when invisible.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Toolbox area is not a delete area when invisible.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

It is unexpected that the toolbox area is still a delete area when it is invisible.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Testing manually in playground by setting the toolbox visibility to false.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
 * Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


### Additional Information

This is a bug that already existed in master. So it's a great sign that we can now easily fix this.
<!-- Anything else we should know? -->
