### PR TITLE
Use captureWarning helper from dev-tools instead of mocha/test_helpers.js implementation

### DIFF
--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -21,7 +21,7 @@
         "assertVariableValues": true,
         "assertNoWarnings": true,
         "assertWarnings": true,
-        "captureWarnings": true,
+        "captureWarnings": false,
         "createDeprecationWarningStub": true,
         "createKeyDownEvent": true,
         "createRenderedBlock": true,

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -85,7 +85,7 @@ suite('Registry', function() {
     test('Incorrect Plugin Name', function() {
       this.options['plugins']['test'] = 'random';
       var testClass;
-      var warnings = captureWarnings(() => {
+      var warnings = testHelpers.captureWarnings(() => {
         testClass = Blockly.registry.getClassFromOptions('test', this.options);
       });
       chai.assert.isNull(testClass);

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -21,25 +21,6 @@ function assertVariableValues(container, name, type, id) {
 }
 
 /**
- * Captures the strings sent to console.warn() when calling a function.
- * @param {function} innerFunc The function where warnings may called.
- * @return {string[]} The warning messages (only the first arguments).
- */
-function captureWarnings(innerFunc) {
-  var msgs = [];
-  var nativeConsoleWarn = console.warn;
-  try {
-    console.warn = function(msg) {
-      msgs.push(msg);
-    };
-    innerFunc();
-  } finally {
-    console.warn = nativeConsoleWarn;
-  }
-  return msgs;
-}
-
-/**
  * Asserts that the given function logs the provided warning messages.
  * @param {function} innerFunc The function to call.
  * @param {Array<!RegExp>|!RegExp} messages A list of regex for the expected
@@ -49,7 +30,7 @@ function assertWarnings(innerFunc, messages) {
   if (!Array.isArray(messages)) {
     messages = [messages];
   }
-  var warnings = captureWarnings(innerFunc);
+  var warnings = testHelpers.captureWarnings(innerFunc);
   chai.assert.lengthOf(warnings, messages.length);
   messages.forEach((message, i) => {
     chai.assert.match(warnings[i], message);

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -1303,7 +1303,7 @@ function testAWorkspace() {
           this.workspace.createVariable('name1', 'type1', 'id1');
           this.workspace.deleteVariableById('id1');
           var workspace = this.workspace;
-          var warnings = captureWarnings(function() {
+          var warnings = testHelpers.captureWarnings(function() {
             workspace.deleteVariableById('id1');
           });
           chai.assert.equal(warnings.length, 1,
@@ -1332,7 +1332,7 @@ function testAWorkspace() {
           createVarBlocksNoEvents(this.workspace, ['id1']);
           this.workspace.deleteVariableById('id1');
           var workspace = this.workspace;
-          var warnings = captureWarnings(function() {
+          var warnings = testHelpers.captureWarnings(function() {
             workspace.deleteVariableById('id1');
           });
           chai.assert.equal(warnings.length, 1,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/4761

### Proposed Changes

Refactors Mocha tests to use captureWarnings method from dev-tools instead of the old implementation in mocha/test_helpers.js

#### Behavior Before Change

Mocha tests used their own version of the method.

#### Behavior After Change

Mocha tests use a common, shared version of the method.

### Test Coverage
Verified that all tests continue to pass.