### PR TITLE
Don’t hide insertion marker if it’s already gone

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -674,7 +674,10 @@ Blockly.InsertionMarkerManager.prototype.hideInsertionMarker_ = function() {
   }
 
   this.markerConnection_ = null;
-  imBlock.getSvgRoot().setAttribute('visibility', 'hidden');
+  var svg = imBlock.getSvgRoot();
+  if (svg) {
+    svg.setAttribute('visibility', 'hidden');
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes #2338.

I also looked at having workspace.clear delete any insertion marker, but there doesn’t appear to be a public API for this.  Shouldn’t matter, this should be sufficient.
