### PR TITLE
Add option to hide the inline/external menu option

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -523,7 +523,8 @@ Blockly.BlockSvg.prototype.moveToDragSurface = function() {
 
 /**
  * Move a block to a position.
- * @param {Blockly.utils.Coordinate} xy The position to move to in workspace units.
+ * @param {!Blockly.utils.Coordinate} xy The position to move to in workspace
+ *     units.
  */
 Blockly.BlockSvg.prototype.moveTo = function(xy) {
   var curXY = this.getRelativeToSurfaceXY();

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -340,8 +340,9 @@ Blockly.ContextMenuItems.registerComment = function() {
     preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       var block = scope.block;
       // IE doesn't support necessary features for comment editing.
-      if (!Blockly.utils.userAgent.IE && !block.isInFlyout && block.workspace.options.comments &&
-        !block.isCollapsed() && block.isEditable()) {
+      if (!Blockly.utils.userAgent.IE && !block.isInFlyout &&
+          block.workspace.options.comments && !block.isCollapsed() &&
+          block.isEditable()) {
         return 'enabled';
       }
       return 'hidden';
@@ -361,7 +362,7 @@ Blockly.ContextMenuItems.registerComment = function() {
   Blockly.ContextMenuRegistry.registry.register(commentOption);
 };
 
-/** Option to inline variables. */
+/** Option to inline values. */
 Blockly.ContextMenuItems.registerInline = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   var inlineOption = {
@@ -371,7 +372,8 @@ Blockly.ContextMenuItems.registerInline = function() {
     },
     preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       var block = scope.block;
-      if (!block.isInFlyout && block.isMovable() && !block.isCollapsed()) {
+      if (!block.isInFlyout && block.isMovable() && !block.isCollapsed() &&
+          block.workspace.options.inlineExternal) {
         for (var i = 1; i < block.inputList.length; i++) {
           // Only display this option if there are two value or dummy inputs next to each other.
           if (block.inputList[i - 1].type != Blockly.inputTypes.STATEMENT &&

--- a/core/options.js
+++ b/core/options.js
@@ -66,6 +66,10 @@ Blockly.Options = function(options) {
     if (hasDisable === undefined) {
       hasDisable = hasCategories;
     }
+    var hasInlineExternal = options['inlineExternal'];
+    if (hasInlineExternal === undefined) {
+      hasInlineExternal = hasCategories;
+    }
     var hasSounds = options['sounds'];
     if (hasSounds === undefined) {
       hasSounds = true;
@@ -119,6 +123,8 @@ Blockly.Options = function(options) {
   this.comments = hasComments;
   /** @type {boolean} */
   this.disable = hasDisable;
+  /** @type {boolean} */
+  this.inlineExternal = hasInlineExternal;
   /** @type {boolean} */
   this.readOnly = readOnly;
   /** @type {number} */

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -102,6 +102,7 @@ function start() {
             snap: true
           },
         horizontalLayout: false,
+        inlineExternal: true,
         maxBlocks: Infinity,
         maxInstances: {'test_basic_limit_instances': 3},
         maxTrashcanContents: 256,


### PR DESCRIPTION
Fixes #3077

New option will need to be added to this page upon release:
https://developers.google.com/blockly/guides/configure/web/configuration_struct

```
inlineExternal
boolean
Allows block inputs to be toggled between inline or external. Defaults to `true` if the toolbox has categories, `false` otherwise.
```
