### PR TITLE
Prevent an error beep when copying blocks in Safari.

### DIFF
--- a/core/shortcut_items.js
+++ b/core/shortcut_items.js
@@ -99,7 +99,10 @@ Blockly.ShortcutItems.registerCopy = function() {
         Blockly.selected.isDeletable() &&
         Blockly.selected.isMovable();
     },
-    callback: function() {
+    callback: function(workspace, e) {
+      // Prevent the default copy behavior, which may beep or otherwise indicate
+      // an error due to the lack of a selection.
+      e.preventDefault();
       Blockly.hideChaff();
       Blockly.copy(/** @type {!Blockly.ICopyable} */ (Blockly.selected));
       return true;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4537

### Proposed Changes
Prevents the default copy behavior when a block is copied; the default behavior caused Safari to beep due to the lack of a text selection.

#### Behavior Before Change

Safari would beep when copying a block with Command C.

#### Behavior After Change

Safari copies the block silently.

### Test Coverage
Confirmed that entire test suite passes and that blocks can be copied/pasted using command/control C and V in Safari, Chrome and Firefox.