### PR TITLE
Fixed bug that prevented delete areas from updating when flyout width changed.

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -367,6 +367,7 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
     // Record the height for workspace metrics and .position.
     this.height_ = flyoutHeight;
     this.position();
+    this.targetWorkspace.recordDragTargets();
   }
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -375,6 +375,7 @@ Blockly.VerticalFlyout.prototype.reflowInternal_ = function() {
     // Record the width for workspace metrics and .position.
     this.width_ = flyoutWidth;
     this.position();
+    this.targetWorkspace.recordDragTargets();
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4912

### Proposed Changes
Updates the delete areas when the flyout width changes.

#### Behavior Before Change
Delete area bounds were not updated, so the width of the delete area did not align with the width of the flyout.

#### Behavior After Change
Delete area and flyout bounds are kept in sync.

### Test Coverage
Manually tested and confirmed all test suites pass.
