### PR TITLE
Add check for removing shadow

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -184,7 +184,11 @@ Blockly.Blocks['lists_create_with'] = {
     for (var i = 0; i < this.itemCount_; i++) {
       var connection = this.getInput('ADD' + i).connection.targetConnection;
       if (connection && connections.indexOf(connection) == -1) {
+        var childBlock = connection.getSourceBlock();
         connection.disconnect();
+        if (childBlock.isShadow()) {
+          childBlock.dispose(true);
+        }
       }
     }
     this.itemCount_ = connections.length;

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -731,7 +731,11 @@ Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN = {
     for (var i = 0; i < this.itemCount_; i++) {
       var connection = this.getInput('ADD' + i).connection.targetConnection;
       if (connection && connections.indexOf(connection) == -1) {
+        var childBlock = connection.getSourceBlock();
         connection.disconnect();
+        if (childBlock.isShadow()) {
+          childBlock.dispose(true);
+        }
       }
     }
     this.itemCount_ = connections.length;

--- a/core/connection.js
+++ b/core/connection.js
@@ -435,7 +435,7 @@ Blockly.Connection.prototype.disconnect = function() {
   this.disconnectInternal_(parentBlock, childBlock);
   if (childBlock.isShadow()) {
     // Displaced shadow blocks dissolve.
-    childBlock.dispose();
+    childBlock.dispose(true);
   } else {
     // If we were disconnecting a shadow, no need to spawn a new one.
     parentConnection.respawnShadow_();

--- a/core/connection.js
+++ b/core/connection.js
@@ -433,10 +433,7 @@ Blockly.Connection.prototype.disconnect = function() {
     Blockly.Events.setGroup(true);
   }
   this.disconnectInternal_(parentBlock, childBlock);
-  if (childBlock.isShadow()) {
-    // Displaced shadow blocks dissolve.
-    childBlock.dispose(true);
-  } else {
+  if (!childBlock.isShadow()) {
     // If we were disconnecting a shadow, no need to spawn a new one.
     parentConnection.respawnShadow_();
   }

--- a/core/connection.js
+++ b/core/connection.js
@@ -433,7 +433,10 @@ Blockly.Connection.prototype.disconnect = function() {
     Blockly.Events.setGroup(true);
   }
   this.disconnectInternal_(parentBlock, childBlock);
-  if (!childBlock.isShadow()) {
+  if (childBlock.isShadow()) {
+    // Displaced shadow blocks dissolve.
+    childBlock.dispose();
+  } else {
     // If we were disconnecting a shadow, no need to spawn a new one.
     parentConnection.respawnShadow_();
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4847
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Adds check in disconnect to dispose of shadow blocks that are disconnected in logic for list and test blocks.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

Shadow blocks are not disposed of when they are disconnected (triggered by mutator).
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Shadow blocks are not disposed of when they are disconnected (triggered by mutator).
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Fixes bug where workspace could get in invalid state with a shadow block with no parent.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

1. Added a `lists_create_with` block with shadow blocks attached.
```
<xml xmlns="https://developers.google.com/blockly/xml">
  <block type="lists_create_with" id="ValgeK+i,*14r-$Y/(Mf" x="137" y="288">
    <mutation items="3"></mutation>
    <value name="ADD0">
      <shadow type="text" id="$7.W0Q.$C0EN_gvhj!O1">
        <field name="TEXT"></field>
      </shadow>
    </value>
    <value name="ADD1">
      <shadow type="text_join" id="Y]Ey@~iE1)CyROK:2S;Y">
        <mutation items="2"></mutation>
        <value name="ADD0">
          <shadow type="text" id="8d.%rw85YL({LZTf5iR;">
            <field name="TEXT"></field>
          </shadow>
        </value>
      </shadow>
    </value>
    <value name="ADD2">
      <block type="text" id="PV!ud*`c-FK6?-|3$74o">
        <field name="TEXT"></field>
      </block>
    </value>
  </block>
</xml>
```
2. Try each of the following scenarios (recreating the above block before each attempt):
  - Remove the second connection on the outer list_create_with block (should dispose of the 2 shadow blocks connected)
  - Remove the first connection on the outer list_create_with block (should shift the shadow blocks connected in the second connections up one)
  - Removed the first connection on the inner list_create_with block (should dispose of the connected shadow block)
3. Observed that the shadow block(s) was/were properly disposed of.

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->


<!-- Anything else we should know? -->
