### PR TITLE
Fix escape key on all fields.

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -456,7 +456,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == Blockly.utils.KeyCodes.ESC) {
-    this.setValue(this.htmlInput_.defaultValue);
+    this.setValue(this.htmlInput_.untypedDefaultValue_);
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == Blockly.utils.KeyCodes.TAB) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -456,7 +456,7 @@ Blockly.FieldTextInput.prototype.onHtmlInputKeyDown_ = function(e) {
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == Blockly.utils.KeyCodes.ESC) {
-    this.htmlInput_.value = this.htmlInput_.defaultValue;
+    this.setValue(this.htmlInput_.defaultValue);
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();
   } else if (e.keyCode == Blockly.utils.KeyCodes.TAB) {


### PR DESCRIPTION
Currently the escape key fails to revert the value.  This is the inherited root of all type-in fields, including number and angle.

Fixes #4910