### PR TITLE
Reflow flyouts when zoom level changes to keep block zoom level in sync.

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -296,9 +296,6 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
     this.targetWorkspace.addChangeListener(this.filterWrapper_);
   }
 
-  var zoomHandler = this.handleZoom_.bind(this);
-  this.targetWorkspace.addChangeListener(zoomHandler);
-
   // Dragging the flyout up and down.
   Array.prototype.push.apply(
       this.eventWrappers_,
@@ -960,19 +957,6 @@ Blockly.Flyout.prototype.filterForCapacity_ = function() {
         block = block.getNextBlock();
       }
     }
-  }
-};
-
-/**
- * Responds to workplace zoom events by reflowing the flyout to ensure that
- * blocks in the flyout adjust to the new zoom level.
- * @param {!Blockly.Events.Abstract} event The Blockly event that was fired.
- * @private
- */
-Blockly.Flyout.prototype.handleZoom_ = function(event) {
-  if (event.type === Blockly.Events.CLICK &&
-      event.targetType === 'zoom_controls') {
-    this.reflow();
   }
 };
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -296,6 +296,9 @@ Blockly.Flyout.prototype.init = function(targetWorkspace) {
     this.targetWorkspace.addChangeListener(this.filterWrapper_);
   }
 
+  var zoomHandler = this.handleZoom_.bind(this);
+  this.targetWorkspace.addChangeListener(zoomHandler);
+
   // Dragging the flyout up and down.
   Array.prototype.push.apply(
       this.eventWrappers_,
@@ -957,6 +960,19 @@ Blockly.Flyout.prototype.filterForCapacity_ = function() {
         block = block.getNextBlock();
       }
     }
+  }
+};
+
+/**
+ * Responds to workplace zoom events by reflowing the flyout to ensure that
+ * blocks in the flyout adjust to the new zoom level.
+ * @param {!Blockly.Events.Abstract} event The Blockly event that was fired.
+ * @private
+ */
+Blockly.Flyout.prototype.handleZoom_ = function(event) {
+  if (event.type === Blockly.Events.CLICK &&
+      event.targetType === 'zoom_controls') {
+    this.reflow();
   }
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2225,9 +2225,10 @@ Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
   this.scale = newScale;
 
   Blockly.hideChaff(false);
-  if (this.flyout_) {
-    // No toolbox, resize flyout.
-    this.flyout_.reflow();
+  // Get the flyout, if any, whether our own or owned by the toolbox.
+  var flyout = this.getFlyout(false);
+  if (flyout && flyout.isVisible()) {
+    flyout.reflow();
     this.recordDragTargets();
   }
   if (this.grid_) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4931

### Proposed Changes
Updates flyouts to listen for zoom events and re-render themselves so that their blocks reflect the new zoom level.

#### Behavior Before Change
Zoom level changes are not reflected in an open flyout until a click occurs inside the flyout itself.

#### Behavior After Change
Zoom level changes are immediately reflected in an open flyout.

### Test Coverage
Manually verified and ensured all test suites pass.