### PR TITLE
Fix serializing non-printable characters to XML

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -410,7 +410,8 @@ Blockly.Field.prototype.fromXml = function(fieldElement) {
  * @package
  */
 Blockly.Field.prototype.toXml = function(fieldElement) {
-  fieldElement.textContent = this.getValue();
+  fieldElement.appendChild(Blockly.utils.xml.createTextNode(
+      /** @type {string} */ (this.getValue())));
   return fieldElement;
 };
 

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -744,7 +744,8 @@ Blockly.Trashcan.prototype.cleanBlockXML_ = function(xml) {
       node.removeAttribute('y');
       node.removeAttribute('id');
       node.removeAttribute('disabled');
-      if (node.nodeName == 'comment') {  // Future proof just in case.
+      // Future proof just in case.
+      if (node.nodeName.toLowerCase() == 'comment') {
         node.removeAttribute('h');
         node.removeAttribute('w');
         node.removeAttribute('pinned');

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -93,20 +93,10 @@ Blockly.utils.xml.domToText = function(dom) {
  * reference).
  * @param {string} text The text to sanitize.
  * @return {string} The sanitized text.
+ * @public
  */
 Blockly.utils.xml.sanitizeText = function(text) {
-  if (!text.match(Blockly.utils.xml.INVALID_CONTROL_CHARS)) {
-    return text;
-  }
-  var match;
-  var newText = '';
-  while ((match = text.match(Blockly.utils.xml.INVALID_CONTROL_CHARS))) {
-    newText += text.substring(0, match.index);
-    newText += '&#x';
-    newText += text.charCodeAt(match.index).toString(16);
-    newText += ';';
-    text = text.substr(match.index + 1);
-  }
-  newText += text;
-  return newText;
+  return text.replace(Blockly.utils.xml.INVALID_CONTROL_CHARS, function(match) {
+    return '&#x' + match.charCodeAt(0).toString(16) + ';';
+  });
 };

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -29,7 +29,7 @@ Blockly.utils.xml.NAME_SPACE = 'https://developers.google.com/blockly/xml';
  * character references) before serializing to XML.
  */
 // eslint-disable-next-line no-control-regex
-Blockly.utils.xml.INVALID_CONTROL_CHARS = /[\u0000-\u0009\u000B\u000C\u000E-\u001F]/;
+Blockly.utils.xml.INVALID_CONTROL_CHARS = /[\x00-\x09\x0B\x0C\x0E-\x1F]/;
 
 /**
  * Get the document object.  This method is overridden in the Node.js build of
@@ -54,7 +54,6 @@ Blockly.utils.xml.createElement = function(tagName) {
 
 /**
  * Create text element for XML.
- * serialized to XML.
  * @param {string} text Text content.
  * @return {!Text} New DOM text node.
  * @public

--- a/core/xml.js
+++ b/core/xml.js
@@ -366,11 +366,11 @@ Blockly.Xml.textToDom = function(text) {
   if (!doc || !doc.documentElement ||
       doc.getElementsByTagName('parsererror').length) {
     var oParser = new DOMParser();
-    // Attempt to parse as html to deserialize control chars.
+    // Attempt to parse as HTML to deserialize control chars.
     doc = oParser.parseFromString(text, 'text/html');
     if (!doc || !doc.body.firstChild ||
         doc.body.firstChild.nodeName.toLowerCase() != 'xml') {
-      throw Error('textToDom was unable to parse: ' + text);
+      throw Error('DOMParser was unable to parse: ' + text);
     }
     return /** @type {!Element} */ (doc.body.firstChild);
   }

--- a/core/xml.js
+++ b/core/xml.js
@@ -278,7 +278,7 @@ Blockly.Xml.cloneShadow_ = function(shadow, opt_noId) {
   var node = shadow;
   var textNode;
   while (node) {
-    if (opt_noId && node.nodeName == 'shadow') {
+    if (opt_noId && node.nodeName.toLowerCase() == 'shadow') {
       // Strip off IDs from shadow blocks.  There should never be a 'block' as
       // a child of a 'shadow', so no need to check that.
       node.removeAttribute('id');

--- a/core/xml.js
+++ b/core/xml.js
@@ -365,7 +365,14 @@ Blockly.Xml.textToDom = function(text) {
   var doc = Blockly.utils.xml.textToDomDocument(text);
   if (!doc || !doc.documentElement ||
       doc.getElementsByTagName('parsererror').length) {
-    throw Error('textToDom was unable to parse: ' + text);
+    var oParser = new DOMParser();
+    // Attempt to parse as html to deserialize control chars.
+    doc = oParser.parseFromString(text, 'text/html');
+    if (!doc || !doc.body.firstChild ||
+        doc.body.firstChild.nodeName.toLowerCase() != 'xml') {
+      throw Error('textToDom was unable to parse: ' + text);
+    }
+    return /** @type {!Element} */ (doc.body.firstChild);
   }
   return doc.documentElement;
 };

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-suite.only('XML', function() {
+suite('XML', function() {
   var assertSimpleFieldDom = function(fieldDom, name, text) {
     chai.assert.equal(text, fieldDom.textContent);
     chai.assert.equal(name, fieldDom.getAttribute('name'));


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #4590

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that control chars are properly handled when serializing and deserializing XML.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Control chars would not be "escaped" (replaced with their numerical character reference) when serializing. And they would cause errors to be thrown when deserializing.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Now they are properly escaped (for XML 1.1) and properly deserialized.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) Accidentally typing a control char into your project should not brick your project.
2) Sometimes programmers need to interact with control chars, so Blockly should support that.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
Added tests for serialization and deserialization of control chars. Also added a test for escaping ampersands because I was in the area.

Manually tested that control chars can be serialized and deserialized when typed into a text input field using the steps from #4590.

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->


### Additional Information

<!-- Anything else we should know? -->
Based on @ewpatton's changes from https://github.com/mit-cml/appinventor-sources/pull/2370. I decided to do the escaping when serializing rather than deserializing to conform with XML 1.1.

I also attempted using an xml document for serialization as proposed [here](https://github.com/google/blockly/pull/1628#discussion_r168647450), but the built-in serializer does not properly escape control characters :/

And I also attempted to escape the control chars within `Blockly.utils.xml.createTextNode`, but this caused the `&` to be escaped to `&amp;` inside `domToText`, which is not what we wanted.
