### PR TITLE
Group field edits together for undo/redo

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -159,7 +159,7 @@ Blockly.BlockDragSurfaceSvg.prototype.translateSurfaceInternal_ = function() {
   this.SVG_.style.display = 'block';
 
   Blockly.utils.dom.setCssTransform(
-      this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0px)');
+      this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
 };
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -340,6 +340,7 @@ Blockly.FieldTextInput.prototype.showInlineEditor_ = function(quietInput) {
  * @protected
  */
 Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
+  Blockly.Events.setGroup(true);
   var div = Blockly.WidgetDiv.DIV;
 
   Blockly.utils.dom.addClass(this.getClickTarget_(), 'editing');
@@ -368,8 +369,8 @@ Blockly.FieldTextInput.prototype.widgetCreate_ = function() {
     div.style.borderRadius = borderRadius;
     div.style.transition = 'box-shadow 0.25s ease 0s';
     if (this.getConstants().FIELD_TEXTINPUT_BOX_SHADOW) {
-      div.style.boxShadow = 'rgba(255, 255, 255, 0.3) 0px 0px 0px ' +
-          4 * scale + 'px';
+      div.style.boxShadow = 'rgba(255, 255, 255, 0.3) 0 0 0 ' +
+          (4 * scale) + 'px';
     }
   }
   htmlInput.style.borderRadius = borderRadius;
@@ -402,6 +403,7 @@ Blockly.FieldTextInput.prototype.widgetDispose_ = function() {
   if (this.onFinishEditing_) {
     this.onFinishEditing_(this.value_);
   }
+  Blockly.Events.setGroup(false);
 
   // Actual disposal.
   this.unbindInputEvents_();
@@ -477,15 +479,10 @@ Blockly.FieldTextInput.prototype.onHtmlInputChange_ = function(_e) {
   if (text !== this.htmlInput_.oldValue_) {
     this.htmlInput_.oldValue_ = text;
 
-    // TODO(#2169): Once issue is fixed the setGroup functionality could be
-    //              moved up to the Field setValue method. This would create a
-    //              broader fix for all field types.
-    Blockly.Events.setGroup(true);
     var value = this.getValueFromEditorText_(text);
     this.setValue(value);
     this.forceRerender();
     this.resizeEditor_();
-    Blockly.Events.setGroup(false);
   }
 };
 

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -652,7 +652,7 @@ Blockly.Css.register([
 
   '.blocklyToolboxDiv[dir="RTL"] .blocklyTreeRow {',
     'margin-left: 8px;',
-    'padding-right: 0px',
+    'padding-right: 0',
   '}',
 
   '.blocklyTreeIcon {',

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -370,7 +370,7 @@ Blockly.utils.dom.measureFontMetrics = function(text, fontSize, fontWeight,
 
   var block = document.createElement('div');
   block.style.width = '1px';
-  block.style.height = '0px';
+  block.style.height = 0;
 
   var div = document.createElement('div');
   div.setAttribute('style', 'position: fixed; top: 0; left: 0; display: flex;');

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -94,7 +94,7 @@ Blockly.WorkspaceDragSurfaceSvg.prototype.translateSurface = function(x, y) {
 
   this.SVG_.style.display = 'block';
   Blockly.utils.dom.setCssTransform(
-      this.SVG_, 'translate3d(' + fixedX + 'px, ' + fixedY + 'px, 0px)');
+      this.SVG_, 'translate3d(' + fixedX + 'px, ' + fixedY + 'px, 0)');
 };
 
 /**


### PR DESCRIPTION
Fixes #4189.
Also use 0 instead of 0px, in accordance with the rest of Blockly and Google’s CSS style guide.
