### PR TITLE
Adjust block positions when the bounds of blocks in a flyout change.

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -123,6 +123,15 @@ Blockly.constants.ALIGN = {
 };
 
 /**
+ * Enum for axes.
+ * @enum {string}
+ */
+Blockly.constants.AXIS = {
+  X: 'x',
+  Y: 'y',
+};
+
+/**
  * ENUM for no drag operation.
  * @const
  */

--- a/core/constants.js
+++ b/core/constants.js
@@ -123,15 +123,6 @@ Blockly.constants.ALIGN = {
 };
 
 /**
- * Enum for axes.
- * @enum {string}
- */
-Blockly.constants.AXIS = {
-  X: 'x',
-  Y: 'y',
-};
-
-/**
  * ENUM for no drag operation.
  * @const
  */

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -405,6 +405,7 @@ Blockly.Flyout.prototype.getWorkspace = function() {
  */
 Blockly.Flyout.prototype.positionContents = function(primaryAxis) {
   this.workspace_.setResizesEnabled(false);
+  this.reflow();
   var margin = this.MARGIN;
   var cursorX = margin + this.tabWidth_;
   var cursorY = margin;
@@ -453,6 +454,9 @@ Blockly.Flyout.prototype.positionContents = function(primaryAxis) {
 
       if (this.RTL && primaryAxis === Blockly.constants.AXIS.X) {
         destinationX += dimensions.width;
+      } else if (this.RTL && primaryAxis === Blockly.constants.AXIS.Y) {
+        destinationX = (this.width_ / this.workspace_.scale) - (margin * 2) +
+            (block.outputConnection ? this.tabWidth_ : 0);
       }
       var destinationY = cursorY;
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -151,6 +151,7 @@ Blockly.HorizontalFlyout.prototype.position = function() {
   var y = this.getY();
 
   this.positionAt_(this.width_, this.height_, x, y);
+  this.positionContents(Blockly.constants.AXIS.X);
 };
 
 /**
@@ -250,6 +251,23 @@ Blockly.HorizontalFlyout.prototype.layout_ = function(contents, gaps) {
 Blockly.HorizontalFlyout.prototype.handleBlockChange_ = function(event) {
   if (event.type === Blockly.Events.BLOCK_CHANGE) {
     this.positionContents(Blockly.constants.AXIS.X);
+    
+    // If we're RTL, rerender the text fields on this block (which were being
+    // edited to trigger this event) to fix their alignment relative to their
+    // parent block, which was just moved in the call to positionContents above.
+    // This avoids the editing field falling out of alignment with the field
+    // rendered on the block itself.
+    if (this.RTL) {
+      var block = this.workspace_.getBlockById(event.blockId);
+      for (var i = 0; i < block.inputList.length; i++) {
+        for (var j = 0; j < block.inputList[i].fieldRow.length; j++) {
+          var field = block.inputList[i].fieldRow[j];
+          if (field instanceof Blockly.FieldTextInput) {
+            field.forceRerender();
+          }
+        }
+      }
+    }
   }
 };
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -40,6 +40,8 @@ goog.requireType('Blockly.utils.Coordinate');
 Blockly.HorizontalFlyout = function(workspaceOptions) {
   Blockly.HorizontalFlyout.superClass_.constructor.call(this, workspaceOptions);
   this.horizontalLayout = true;
+  var blockChangeHandler = this.handleBlockChange_.bind(this);
+  this.workspace_.addChangeListener(blockChangeHandler);
 };
 Blockly.utils.object.inherits(Blockly.HorizontalFlyout, Blockly.Flyout);
 
@@ -236,45 +238,13 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
  * @protected
  */
 Blockly.HorizontalFlyout.prototype.layout_ = function(contents, gaps) {
-  this.workspace_.scale = this.targetWorkspace.scale;
-  var margin = this.MARGIN;
-  var cursorX = margin + this.tabWidth_;
-  var cursorY = margin;
-  if (this.RTL) {
-    contents = contents.reverse();
-  }
+  Blockly.Flyout.prototype.layout_.call(this, contents, gaps);
+  this.positionContents('x');
+};
 
-  for (var i = 0, item; (item = contents[i]); i++) {
-    if (item.type == 'block') {
-      var block = item.block;
-      var allBlocks = block.getDescendants(false);
-      for (var j = 0, child; (child = allBlocks[j]); j++) {
-        // Mark blocks as being inside a flyout.  This is used to detect and
-        // prevent the closure of the flyout if the user right-clicks on such a
-        // block.
-        child.isInFlyout = true;
-      }
-      block.render();
-      var root = block.getSvgRoot();
-      var blockHW = block.getHeightWidth();
-
-      // Figure out where to place the block.
-      var tab = block.outputConnection ? this.tabWidth_ : 0;
-      if (this.RTL) {
-        var moveX = cursorX + blockHW.width;
-      } else {
-        var moveX = cursorX - tab;
-      }
-      block.moveBy(moveX, cursorY);
-
-      var rect = this.createRect_(block, moveX, cursorY, blockHW, i);
-      cursorX += (blockHW.width + gaps[i]);
-
-      this.addBlockListeners_(root, block, rect);
-    } else if (item.type == 'button') {
-      this.initFlyoutButton_(item.button, cursorX, cursorY);
-      cursorX += (item.button.width + gaps[i]);
-    }
+Blockly.HorizontalFlyout.prototype.handleBlockChange_ = function(event) {
+  if (event.type === Blockly.Events.BLOCK_CHANGE) {
+    this.positionContents('x');
   }
 };
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -239,12 +239,17 @@ Blockly.HorizontalFlyout.prototype.wheel_ = function(e) {
  */
 Blockly.HorizontalFlyout.prototype.layout_ = function(contents, gaps) {
   Blockly.Flyout.prototype.layout_.call(this, contents, gaps);
-  this.positionContents('x');
+  this.positionContents(Blockly.constants.AXIS.X);
 };
 
+/**
+ * Respond to changes in the dimensions of blocks by repositioning the contents
+ * of the flyout.
+ * @param {!Blockly.Events.BlockChange} event The block change event.
+ */
 Blockly.HorizontalFlyout.prototype.handleBlockChange_ = function(event) {
   if (event.type === Blockly.Events.BLOCK_CHANGE) {
-    this.positionContents('x');
+    this.positionContents(Blockly.constants.AXIS.X);
   }
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -230,13 +230,17 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
  */
 Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
   Blockly.Flyout.prototype.layout_.call(this, contents, gaps);
-  this.positionContents('y');
+  this.positionContents(Blockly.constants.AXIS.Y);
 };
 
-
+/**
+ * Respond to changes in the dimensions of blocks by repositioning the contents
+ * of the flyout.
+ * @param {!Blockly.Events.BlockChange} event The block change event.
+ */
 Blockly.VerticalFlyout.prototype.handleBlockChange_ = function(event) {
   if (event.type === Blockly.Events.BLOCK_CHANGE) {
-    this.positionContents('y');
+    this.positionContents(Blockly.constants.AXIS.Y);
   }
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -241,6 +241,15 @@ Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
 Blockly.VerticalFlyout.prototype.handleBlockChange_ = function(event) {
   if (event.type === Blockly.Events.BLOCK_CHANGE) {
     this.positionContents(Blockly.constants.AXIS.Y);
+    var block = this.workspace_.getBlockById(event.blockId);
+    for (var i = 0; i < block.inputList.length; i++) {
+      for (var j = 0; j < block.inputList[i].fieldRow.length; j++) {
+        var field = block.inputList[i].fieldRow[j];
+        if (field instanceof Blockly.FieldTextInput) {
+          field.forceRerender();
+        }
+      }
+    }
   }
 };
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -39,6 +39,8 @@ goog.requireType('Blockly.utils.Coordinate');
  */
 Blockly.VerticalFlyout = function(workspaceOptions) {
   Blockly.VerticalFlyout.superClass_.constructor.call(this, workspaceOptions);
+  var blockChangeHandler = this.handleBlockChange_.bind(this);
+  this.workspace_.addChangeListener(blockChangeHandler);
 };
 Blockly.utils.object.inherits(Blockly.VerticalFlyout, Blockly.Flyout);
 
@@ -227,37 +229,14 @@ Blockly.VerticalFlyout.prototype.wheel_ = function(e) {
  * @protected
  */
 Blockly.VerticalFlyout.prototype.layout_ = function(contents, gaps) {
-  this.workspace_.scale = this.targetWorkspace.scale;
-  var margin = this.MARGIN;
-  var cursorX = this.RTL ? margin : margin + this.tabWidth_;
-  var cursorY = margin;
+  Blockly.Flyout.prototype.layout_.call(this, contents, gaps);
+  this.positionContents('y');
+};
 
-  for (var i = 0, item; (item = contents[i]); i++) {
-    if (item.type == 'block') {
-      var block = item.block;
-      var allBlocks = block.getDescendants(false);
-      for (var j = 0, child; (child = allBlocks[j]); j++) {
-        // Mark blocks as being inside a flyout.  This is used to detect and
-        // prevent the closure of the flyout if the user right-clicks on such a
-        // block.
-        child.isInFlyout = true;
-      }
-      block.render();
-      var root = block.getSvgRoot();
-      var blockHW = block.getHeightWidth();
-      var moveX = block.outputConnection ? cursorX - this.tabWidth_ : cursorX;
-      block.moveBy(moveX, cursorY);
 
-      var rect = this.createRect_(block,
-          this.RTL ? moveX - blockHW.width : moveX, cursorY, blockHW, i);
-
-      this.addBlockListeners_(root, block, rect);
-
-      cursorY += blockHW.height + gaps[i];
-    } else if (item.type == 'button') {
-      this.initFlyoutButton_(item.button, cursorX, cursorY);
-      cursorY += item.button.height + gaps[i];
-    }
+Blockly.VerticalFlyout.prototype.handleBlockChange_ = function(event) {
+  if (event.type === Blockly.Events.BLOCK_CHANGE) {
+    this.positionContents('y');
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4913

### Proposed Changes
This PR listens for block change events and repositions blocks in the flyout to accomodate the block's new size. It also refactors some shared logic for initial layout and subsequent block repositioning. into flyout_base

#### Behavior Before Change
Blocks that grew in height or width (e.g. because of typing into a text field) would overlap adjacent blocks in the toolbox.

#### Behavior After Change
Adjacent and subsequent blocks have their bounds adjusted to maintain constant inter-block spacing.