### PR TITLE
Work around WebKit bug that prevents scrolling/zooming the workspace.

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -877,6 +877,10 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   if (!this.isFlyout) {
     Blockly.browserEvents.conditionalBind(
         this.svgGroup_, 'mousedown', this, this.onMouseDown_, false, true);
+    // This no-op works around https://bugs.webkit.org/show_bug.cgi?id=226683,
+    // which otherwise prevents zoom/scroll events from being observed in
+    // Safari. Once that bug is fixed it should be removed.
+    document.body.addEventListener('wheel', function(e) {});
     Blockly.browserEvents.conditionalBind(
         this.svgGroup_, 'wheel', this, this.onMouseWheel_);
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -880,7 +880,7 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
     // This no-op works around https://bugs.webkit.org/show_bug.cgi?id=226683,
     // which otherwise prevents zoom/scroll events from being observed in
     // Safari. Once that bug is fixed it should be removed.
-    document.body.addEventListener('wheel', function(e) {});
+    document.body.addEventListener('wheel', function() {});
     Blockly.browserEvents.conditionalBind(
         this.svgGroup_, 'wheel', this, this.onMouseWheel_);
   }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4957

### Proposed Changes
Adds a no-op event listener that works around a WebKit bug preventing listening to wheel events on an SVG <g> element.

#### Behavior Before Change
The workspace could not be zoomed or scrolled in Safari.

#### Behavior After Change
Workspace zooming and scrolling works as expected in Safari.

### Test Coverage
Manually verified the fix in Safari and confirmed that behavior was unaffected in Firefox and Chrome.