### PR TITLE
Fix Jsdoc by removing trailing comma

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -238,7 +238,7 @@ Blockly.WorkspaceSvg = function(
    * @type {!Array<
    * {
    *   component: !Blockly.IDragTarget,
-   *   clientRect: !Blockly.utils.Rect,
+   *   clientRect: !Blockly.utils.Rect
    * }>}
    * @private
    */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Problems with JsDoc generation. Trailing comma breaks everything.

### Test Coverage

Tested with `jsdoc core/workspace_svg.js` and no errors.

### Additional Information

This needs to go in this release so that JsDocs can be generated correctly.
