### PR TITLE
Initial commit for appengine deploy action

### DIFF
--- a/.github/workflows/appengine_deploy.yml
+++ b/.github/workflows/appengine_deploy.yml
@@ -1,0 +1,54 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Deploy to App Engine
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  prepare:
+    name: Prepare
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Prepare demo files
+        run: |
+          npm install
+          npm run prepareDemos
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: appengine_files
+          path: _deploy/
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Download prepared files
+        uses: actions/download-artifact@v2
+        with:
+          name: appengine_files
+          path: _deploy/
+
+      - name: Deploy to App Engine
+        uses: google-github-actions/deploy-appengine@v0.2.0
+        with:
+          deliverables: app.yaml
+          working_directory: _deploy/
+          # TODO: Set up project id and credentials secrets
+          project_id: ${{ secrets.GCP_PROJECT }}
+          credentials: ${{ secrets.GCP_SA_KEY }}
+          promote: false
+          # TODO: Generate a version string based on package.json
+          version: vtest

--- a/.github/workflows/appengine_deploy.yml
+++ b/.github/workflows/appengine_deploy.yml
@@ -1,4 +1,4 @@
-# This is a basic workflow to help you get started with Actions
+# Workflow that prepares files and deploys to appengine
 
 name: Deploy to App Engine
 
@@ -7,19 +7,18 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   prepare:
     name: Prepare
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out the repository under $GITHUB_WORKSPACE.
+      # When running manually this checks out the master branch.
       - uses: actions/checkout@v2
 
       - name: Prepare demo files
+        # Install all dependencies, then copy all the files needed for demos.
         run: |
           npm install
           npm run prepareDemos
@@ -33,6 +32,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    # The prepare step must succeed for this step to run.
     needs: prepare
     steps:
       - name: Download prepared files
@@ -43,12 +43,12 @@ jobs:
 
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v0.2.0
+        # For parameters see:
+        # https://github.com/google-github-actions/deploy-appengine#inputs
         with:
-          deliverables: app.yaml
           working_directory: _deploy/
-          # TODO: Set up project id and credentials secrets
+          deliverables: app.yaml
           project_id: ${{ secrets.GCP_PROJECT }}
           credentials: ${{ secrets.GCP_SA_KEY }}
           promote: false
-          # TODO: Generate a version string based on package.json
           version: vtest

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,7 @@ module.exports = {
   package: packageTasks.package,
   checkLicenses: licenseTasks.checkLicenses,
   recompile: releaseTasks.recompile,
+  prepareDemos: appengineTasks.prepareDemos,
   publish: releaseTasks.publish,
   publishBeta: releaseTasks.publishBeta,
   sortRequires: cleanupTasks.sortRequires,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint": "eslint .",
     "package": "gulp package",
     "prepare": "npm run package",
+    "prepareDemos": "gulp prepareDemos",
     "publish": "gulp publish",
     "publish:beta": "gulp publishBeta",
     "recompile": "gulp recompile",

--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -88,16 +88,18 @@ function deployAndClean(done) {
 }
 
 /**
+ * Prepares demos.
+ */
+const prepareDemos = gulp.series(
+    prepareDeployDir, copyStaticSrc, copyAppengineSrc, copyPlaygroundDeps);
+
+
+/**
  * Deploys demos.
  */
-const deployDemos = gulp.series(
-    prepareDeployDir,
-    copyStaticSrc,
-    copyAppengineSrc,
-    copyPlaygroundDeps,
-    deployAndClean
-);
+const deployDemos = gulp.series(prepareDemos, deployAndClean);
 
 module.exports = {
   deployDemos: deployDemos,
+  prepareDemos: prepareDemos
 }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/4988

### Proposed Changes

- Adds a gulp action that prepares the demos but doesn't deploy or delete the directory
- Adds a github workflow with steps to prepare and deploy demos

#### Behavior Before Change

Deploying had to be done manually.

#### Behavior After Change

Deploying will be done by clicking a button in github.

### Reason for Changes

Automate tasks

### Test Coverage

Not yet tested

### Documentation

Internal documentation on how to release will need to be updated.

### Additional Information

- I'm following [these steps](https://github.com/google-github-actions/deploy-appengine#setup) to use the deploy-appengine action. I need to set up a service account and some secrets before I can actually run this.
- I still need to set the version number based on package.json
- @cpcallen after your build changes are merged, I'll need to use them and make sure that I'm copying over the correct built files
- I'm using [uploading and downloading artifacts](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow) to share information between steps
- I could pass in a flag to determine whether to switch over traffic to the new version or not (`promote: false` or `promote: true`)
- The prepare step puts files in `../_deploy`. I don't know if that's actually accessible from a workflow

