### PR TITLE
Enforce connection preconditions for setParent

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -766,7 +766,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
     // This block hasn't actually moved on-screen, so there's no need to update
     //     its connection locations.
   } else {
-    // New parent must be non-null so remove this block from the workspace's 
+    // New parent must be non-null so remove this block from the workspace's
     //     list of top-most blocks.
     this.workspace.removeTopBlock(this);
   }

--- a/core/block.js
+++ b/core/block.js
@@ -747,7 +747,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
 
   // Check that block is connected to new parent if new parent is not null.
   //    After todo is addressed, throw error if block is not disconnected from
-  //    superior block when setting newParent to null. 
+  //    superior block when setting newParent to null.
   var connection = this.previousConnection || this.outputConnection;
   var isConnected = !!(connection && connection.targetBlock());
 
@@ -756,8 +756,8 @@ Blockly.Block.prototype.setParent = function(newParent) {
   } else if (!isConnected && newParent) {
     throw Error('Block not connected to new parent.');
   } else if (isConnected && !newParent) {
-    throw Error('Cannot set parent to null while block is still connected to'
-        + ' superior block.');
+    throw Error('Cannot set parent to null while block is still connected to' +
+        ' superior block.');
   }
 
   if (this.parentBlock_) {

--- a/core/block.js
+++ b/core/block.js
@@ -745,9 +745,8 @@ Blockly.Block.prototype.setParent = function(newParent) {
     return;
   }
 
-  // Check that block is connected to new parent if new parent is not null.
-  //    After todo is addressed, throw error if block is not disconnected from
-  //    superior block when setting newParent to null.
+  // Check that block is connected to new parent if new parent is not null and
+  //    that block is not connected to superior one if new parent is null.
   var connection = this.previousConnection || this.outputConnection;
   var isConnected = !!(connection && connection.targetBlock());
 

--- a/core/block.js
+++ b/core/block.js
@@ -755,11 +755,9 @@ Blockly.Block.prototype.setParent = function(newParent) {
     throw Error('Block connected to superior one that is not new parent.');
   } else if (!isConnected && newParent) {
     throw Error('Block not connected to new parent.');
-  } else if (connection && !newParent) {
-    // TODO #4989: Clean up code so that error can be thrown in this case 
-    //     without breaking things.
-    // throw Error('Cannot set parent to null while block is still connected
-    //    to superior block.');
+  } else if (isConnected && !newParent) {
+    throw Error('Cannot set parent to null while block is still connected to'
+        + ' superior block.');
   }
 
   if (this.parentBlock_) {

--- a/core/block.js
+++ b/core/block.js
@@ -763,13 +763,11 @@ Blockly.Block.prototype.setParent = function(newParent) {
     // Remove this block from the old parent's child list.
     Blockly.utils.arrayRemove(this.parentBlock_.childBlocks_, this);
 
-    // Reflect disconnection from superior blocks.
-    this.parentBlock_ = null;
-
     // This block hasn't actually moved on-screen, so there's no need to update
-    // its connection locations.
+    //     its connection locations.
   } else {
-    // Remove this block from the workspace's list of top-most blocks.
+    // New parent must be non-null so remove this block from the workspace's 
+    //     list of top-most blocks.
     this.workspace.removeTopBlock(this);
   }
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -901,8 +901,8 @@ suite('Blocks', function() {
             '        <block type="text">' +
             '        </block>' +
             '      </value>' +
-            '    </block>' + 
-            '  </value>' + 
+            '    </block>' +
+            '  </value>' +
             '</block>'
         ), this.workspace);
         this.textJoinBlock = this.printBlock.getInputTargetBlock('TEXT');

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -938,11 +938,11 @@ suite('Blocks', function() {
         assertBlockIsOnlyChild(this.printBlock, this.textBlock, 'TEXT');
       });
       test('Setting to new parent while connected to other block', function() {
-        // setting to grandparent with no available input connection
+        // Setting to grandparent with no available input connection.
         chai.assert.throws(this.textBlock.setParent
             .bind(this.textBlock, this.printBlock));
         this.textJoinBlock.outputConnection.disconnect();
-        // setting to block with available input connection
+        // Setting to block with available input connection.
         chai.assert.throws(this.textBlock.setParent
             .bind(this.textBlock, this.printBlock));
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
@@ -956,11 +956,11 @@ suite('Blocks', function() {
       });
       test('Setting to new parent when orphan', function() {
         this.textBlock.outputConnection.disconnect();
-        // when new parent has no available input connection
+        // When new parent has no available input connection.
         chai.assert.throws(this.textBlock.setParent
             .bind(this.textBlock, this.printBlock));
         this.textJoinBlock.outputConnection.disconnect();
-        // when new parent has available input connection
+        // When new parent has available input connection.
         chai.assert.throws(this.textBlock.setParent
             .bind(this.textBlock, this.printBlock));
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -890,6 +890,97 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
     });
+    suite('Setting Parent Block', function() {
+      setup(function() {
+        this.printBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            '<block type="text_print">' +
+            '  <value name="TEXT">' +
+            '    <block type="text_join">' +
+            '      <mutation items="2"></mutation>' +
+            '      <value name="ADD0">' +
+            '        <block type="text">' +
+            '        </block>' +
+            '      </value>' +
+            '    </block>' + 
+            '  </value>' + 
+            '</block>'
+        ), this.workspace);
+        this.textJoinBlock = this.printBlock.getInputTargetBlock('TEXT');
+        this.textBlock = this.textJoinBlock.getInputTargetBlock('ADD0');
+      });
+
+      function assertBlockIsOnlyChild(parent, child, inputName) {
+        chai.assert.equal(parent.getChildren().length, 1);
+        chai.assert.equal(parent.getInputTargetBlock(inputName), child);
+        chai.assert.equal(child.getParent(), parent);
+      }
+      function assertNonParentAndOrphan(nonParent, orphan, inputName) {
+        chai.assert.equal(nonParent.getChildren().length, 0);
+        chai.assert.isNull(nonParent.getInputTargetBlock('TEXT'));
+        chai.assert.isNull(orphan.getParent());
+      }
+      function assertOriginalSetup() {
+        assertBlockIsOnlyChild(this.printBlock, this.textJoinBlock, 'TEXT');
+        assertBlockIsOnlyChild(this.textJoinBlock, this.textBlock, 'ADD0');
+      }
+
+      test('Setting to connected parent', function() {
+        chai.assert.doesNotThrow(this.textJoinBlock.setParent
+            .bind(this.textJoinBlock, this.printBlock));
+        assertOriginalSetup.call(this);
+      });
+      test('Setting to new parent after connecting to it', function() {
+        this.textJoinBlock.outputConnection.disconnect();
+        this.textBlock.outputConnection
+            .connect(this.printBlock.getInput('TEXT').connection);
+        chai.assert.doesNotThrow(this.textBlock.setParent
+            .bind(this.textBlock, this.printBlock));
+        assertBlockIsOnlyChild(this.printBlock, this.textBlock, 'TEXT');
+      });
+      test('Setting to new parent while connected to other block', function() {
+        // setting to grandparent with no available input connection
+        chai.assert.throws(this.textBlock.setParent
+            .bind(this.textBlock, this.printBlock));
+        this.textJoinBlock.outputConnection.disconnect();
+        // setting to block with available input connection
+        chai.assert.throws(this.textBlock.setParent
+            .bind(this.textBlock, this.printBlock));
+        assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
+        // assertNonParentAndOrphan(this.printBlock, this.textBlock, 'TEXT');
+        assertBlockIsOnlyChild(this.textJoinBlock, this.textBlock, 'ADD0');
+      });
+      test('Setting to same parent after disconnecting from it', function() {
+        this.textJoinBlock.outputConnection.disconnect();
+        chai.assert.throws(this.textJoinBlock.setParent
+            .bind(this.textJoinBlock, this.printBlock));
+        assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
+      });
+      test('Setting to new parent when orphan', function() {
+        this.textBlock.outputConnection.disconnect();
+        // when new parent has no available input connection
+        chai.assert.throws(this.textBlock.setParent
+            .bind(this.textBlock, this.printBlock));
+        this.textJoinBlock.outputConnection.disconnect();
+        // when new parent has available input connection
+        chai.assert.throws(this.textBlock.setParent
+            .bind(this.textBlock, this.printBlock));
+
+        assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
+        assertNonParentAndOrphan(this.printBlock, this.textBlock, 'TEXT');
+        assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
+      });
+      test('Setting parent to null after disconnecting', function() {
+        this.textBlock.outputConnection.disconnect();
+        chai.assert.doesNotThrow(this.textBlock.setParent
+            .bind(this.textBlock, null));
+        assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
+      });
+      test('Setting parent to null without disconnecting', function() {
+        chai.assert.throws(this.textBlock.setParent
+            .bind(this.textBlock, null));
+        assertOriginalSetup.call(this);
+      });
+    });
     suite('Remove Connections Programmatically', function() {
       test('Output', function() {
         var block = createRenderedBlock(this.workspace, 'row_block');
@@ -1106,9 +1197,14 @@ suite('Blocks', function() {
   });
   suite('Getting/Setting Field (Values)', function() {
     setup(function() {
+      this.workspace = Blockly.inject('blocklyDiv');
       this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
           '<block type="text"><field name = "TEXT">test</field></block>'
       ), this.workspace);
+    });
+
+    teardown(function() {
+      workspaceTeardown.call(this, this.workspace);
     });
 
     test('Getting Field', function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -946,7 +946,6 @@ suite('Blocks', function() {
         chai.assert.throws(this.textBlock.setParent
             .bind(this.textBlock, this.printBlock));
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
-        // assertNonParentAndOrphan(this.printBlock, this.textBlock, 'TEXT');
         assertBlockIsOnlyChild(this.textJoinBlock, this.textBlock, 'ADD0');
       });
       test('Setting to same parent after disconnecting from it', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves #4989 

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Throws error when attempting to set a block's parent to a non-null block `b` if `b` is `not` properly connected to it without changing state (i.e., if its previous/output connection is *not* connected to one of `b`'s input/next connections or when it doesn't have such connections).  Also throws error when attempting to set a block's parent to `null` if it has a connection to a superior block.

#### Behavior Before Change

Setting a parent of a block already connected to some other superior block would remove the block from that old parent's child list before throwing, leading to potential rendering issues.  Setting the parent of a disconnected block could cause rendering issues and errors when attempting to delete that parent.

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

Errors are thrown in these cases without changing state so none of these problems ensue.

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

To enforce the desired precondition for `setParent` that a non-`null` inputted parent should already be a superior block via the proper connections and that a block should not be connected to a superior one when attempting to set its new parent to `null`.

### Test Coverage

Tested on Blockly Playground to make sure that it resolved the desired bugs.

### Documentation

No additional documentation required.