### PR TITLE
Adds automated release note generation

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,39 @@
+name: 'Release'
+on: workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get Npm Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+
+      - name: Push tag
+        uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.package-version.outputs.current-version }}
+          message: 'Release'
+
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v1
+        with:
+          configuration: ".github/workflows/release_config.json"
+          toTag: ${{ steps.package-version.outputs.current-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.package-version.outputs.current-version }}
+          release_name: ${{ steps.package-version.outputs.current-version }}
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_config.json
+++ b/.github/workflows/release_config.json
@@ -1,0 +1,35 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test"]
+    },
+    {
+      "title": "## 📓 Documentation",
+      "labels": ["docs"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+  "pr_template": "- ${{TITLE}} #${{NUMBER}}",
+  "empty_template": "- no changes",
+  "max_tags_to_fetch": 200,
+  "max_back_track_time_days": 365,
+  "tag_resolver": {
+    "method": "sort"
+  },
+  "base_branches": [
+    "master"
+  ]
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
**This action will:** 
- Get the npm version in the package json.
- Push a tag so that we can use it later on when creating the release notes.
- Build our release notes by looking at PRs between the current tag and the tag before it. ([github action](https://github.com/marketplace/actions/release-changelog-builder))
- Creates a release with the tag we just pushed and the generated release notes.

**When would it get run?** 
This would get run after we have finished all of the merges into master. 

**How would we run it?**
It is `on:workflow` so it would have to be run by hitting a button in the `Actions` tab.

**How it works?**
It uses labels on PRs to organize our release notes.

**What do we get out of it?**
I think the biggest benefit is we can easily configure what categories we want in the release notes and what labels should go under each category. With our current release note generation we have to go in and change a script to get this to work.

**Alternatives?**
We could adapt our internal release notes generator to be used in a github action. We would still use the create release action, but we could get rid of the tag action.

We could use [release-please](https://github.com/google-github-actions/release-please-action). However, they use formatted commits to organize their release notes. We could decide to adopt this, but I thought it would be a bit of a pain to have to communicate this to external contributors.

**Any cons?**
This only works once we merge master into core. So we would still need to use our old release notes generator if we want to get release notes before that. 

If this is a big enough con, we could also look into the [release drafter action](https://github.com/marketplace/actions/release-drafter) that keeps a PR around with the updated changelog throughout the quarter.

### Test Coverage
Tried it out on my branch. [Release it created.](https://github.com/alschmiedt/blockly/releases/tag/6.20210701.4)

If we decide this is the direction we want, I will probably test a bit more before merging.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
