### PR TITLE
Get deploy files from the correct directory

### DIFF
--- a/.github/workflows/appengine_deploy.yml
+++ b/.github/workflows/appengine_deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: appengine_files
-          path: _deploy/
+          path: ../_deploy/
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Previous path was `_deploy/`. New path is `../_deploy`.

The alternative is to change where the prepareDemos action places the files.