### PR TITLE
Revert "Get deploy files from the correct directory"

### DIFF
--- a/.github/workflows/appengine_deploy.yml
+++ b/.github/workflows/appengine_deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: appengine_files
-          path: ../_deploy/
+          path: _deploy/
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Reverts google/blockly#5010

Relative locations are not allowed, so I'll need to change where the prepareDemos script puts files.