### PR TITLE
Move deploy temp dir into the Blockly directory so that it can be use…

### DIFF
--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -17,8 +17,8 @@ var execSync = require('child_process').execSync;
 
 var packageJson = require('../../package.json');
 
-const demoTmpDir = '../_deploy';
-const demoStaticTmpDir = '../_deploy/static';
+const demoTmpDir = '_deploy';
+const demoStaticTmpDir = '_deploy/static';
 
 /**
  * Cleans and creates the tmp directory used for deploying.
@@ -47,8 +47,8 @@ function copyStaticSrc(done) {
  */
 function copyAppengineSrc() {
   const appengineSrc = [
-      `${demoStaticTmpDir}/appengine/**/*`,
-      `${demoStaticTmpDir}/appengine/.gcloudignore`,
+    path.join(demoStaticTmpDir, 'appengine/**/*'),
+    path.join(demoStaticTmpDir, 'appengine/.gcloudignore'),
   ];
   return gulp.src(appengineSrc).pipe(gulp.dest(demoTmpDir));
 }


### PR DESCRIPTION
…d from github actions

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #4988 

### Proposed Changes

Make the prepareDemos script put files in a `_deploy` directory in the repository instead of up a level. This is necessary because github actions cannot access outputs that are up a level.

This PR is deliberately against develop--changes to files other than the workflow itself can be on develop, because I can choose which branch to run the workflow against.

#### Behavior Before Change

Files were placed in `../_deploy`

#### Behavior After Change

Files are placed in `_deploy`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested by running `npm run prepareDemos` from the command line.