### PR TITLE
Move typings output into their own directory under `build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ tests/screenshot/outputs/*
 local_build/*compiler*.jar
 local_build/local_*_compressed.js
 chromedriver
-typings/tmp/*
 build/
 dist/

--- a/scripts/gulpfiles/config.js
+++ b/scripts/gulpfiles/config.js
@@ -25,4 +25,7 @@ module.exports = {
   // Directory in which to assemble (and from which to publish) the
   // blockly npm package.
   RELEASE_DIR: 'dist',
+
+  // Directory to write typings output to.
+  TYPINGS_BUILD_DIR: path.join('build', 'typings'),
 };

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -19,7 +19,7 @@ var path = require('path');
 var fs = require('fs');
 var rimraf = require('rimraf');
 var {getPackageJson} = require('./helper_tasks');
-var {BUILD_DIR, RELEASE_DIR} = require('./config');
+var {BUILD_DIR, RELEASE_DIR, TYPINGS_BUILD_DIR} = require('./config');
 
 // Path to template files for gulp-umd.
 const TEMPLATE_DIR = 'scripts/package/templates';
@@ -77,9 +77,9 @@ function checkBuildDir(done) {
   }
   // Check files built by typings.typings exist in BUILD_DIR.
   for (const fileName of ['blockly.d.ts', 'msg/en.d.ts']) {
-    if (!fs.existsSync(`${BUILD_DIR}/${fileName}`)) {
+    if (!fs.existsSync(`${TYPINGS_BUILD_DIR}/${fileName}`)) {
       done(new Error(
-          `Your ${BUILD_DIR} directory does not contain ${fileName}.  ` +
+          `Your ${TYPINGS_BUILD_DIR} directory does not contain ${fileName}. ` +
           'Has typings.typings been run?  Try "npm run typings".'));
       return;
     }
@@ -403,11 +403,11 @@ function packageDTS() {
     'typings/msg/msg.d.ts',
   ];
   const builtSrcs = [
-    `${BUILD_DIR}/blockly.d.ts`,  // Use freshly-built one instead.
-    `${BUILD_DIR}/msg/*.d.ts`,
+    `${TYPINGS_BUILD_DIR}/blockly.d.ts`,  // Use freshly-built one instead.
+    `${TYPINGS_BUILD_DIR}/msg/*.d.ts`,
   ];
   return gulp.src(handwrittenSrcs, {base: 'typings'})
-      .pipe(gulp.src(builtSrcs, {base: BUILD_DIR}))
+      .pipe(gulp.src(builtSrcs, {base: TYPINGS_BUILD_DIR}))
       .pipe(gulp.dest(RELEASE_DIR));
 };
 

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -82,7 +82,7 @@ function typings() {
     if (file.indexOf('core/msg.js') > -1) {
       return;
     }
-    const cmd = `node ./node_modules/typescript-closure-tools/definition-generator/src/main.js ${file} ${typescriptFileName}`;
+    const cmd = `closure2ts ${file} ${typescriptFileName}`;
     console.log(`Generating typings for ${file}`);
     execSync(cmd, { stdio: 'inherit' });
   });
@@ -106,7 +106,8 @@ function typings() {
 
 // Generates the TypeScript definition files (d.ts) for Blockly locales.
 function msgTypings(cb) {
-  const template = fs.readFileSync(path.join('typings/templates/msg.template'), 'utf-8');
+  const template =
+      fs.readFileSync(path.join('typings/templates/msg.template'), 'utf-8');
   const msgFiles = fs.readdirSync(path.join('msg', 'json'));
   const msgDir = path.join(TYPINGS_BUILD_DIR, 'msg');
   if (!fs.existsSync(msgDir)) {
@@ -115,8 +116,9 @@ function msgTypings(cb) {
   msgFiles.forEach(msg => {
     const localeName = msg.substring(0, msg.indexOf('.json'));
     const msgTypings = template.slice().replace(/<%= locale %>/gi, localeName);
-    fs.writeFileSync(path.join(TYPINGS_BUILD_DIR, 'msg', localeName + '.d.ts'), msgTypings, 'utf-8');
-  })
+    fs.writeFileSync(path.join(TYPINGS_BUILD_DIR, 'msg', localeName + '.d.ts'),
+                     msgTypings, 'utf-8');
+  });
   cb();
 }
 

--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -16,7 +16,7 @@ var path = require('path');
 var fs = require('fs');
 var rimraf = require('rimraf');
 var execSync = require('child_process').execSync;
-var {BUILD_DIR} = require('./config');
+var {TYPINGS_BUILD_DIR} = require('./config');
 
 /**
  * Recursively generates a list of file paths with the specified extension
@@ -52,13 +52,13 @@ function getFilePath(basePath, filter, excludePaths) {
 // This includes the header (incl License), additional useful interfaces
 // including Blockly Options and Google Closure typings.
 function typings() {
-  const tmpDir = './typings/tmp';
+  const tmpDir = path.join(TYPINGS_BUILD_DIR, 'tmp');
 
   // Clean directory if exists.
   if (fs.existsSync(tmpDir)) {
     rimraf.sync(tmpDir);
   }
-  fs.mkdirSync(tmpDir);
+  fs.mkdirSync(tmpDir, {recursive: true});
 
   const excludePaths = [
     "core/renderers/geras",
@@ -95,7 +95,7 @@ function typings() {
   ];
   return gulp.src(srcs)
     .pipe(gulp.concat('blockly.d.ts'))
-    .pipe(gulp.dest(BUILD_DIR))
+    .pipe(gulp.dest(TYPINGS_BUILD_DIR))
     .on('end', function () {
       // Clean up tmp directory.
       if (fs.existsSync(tmpDir)) {
@@ -108,10 +108,14 @@ function typings() {
 function msgTypings(cb) {
   const template = fs.readFileSync(path.join('typings/templates/msg.template'), 'utf-8');
   const msgFiles = fs.readdirSync(path.join('msg', 'json'));
+  const msgDir = path.join(TYPINGS_BUILD_DIR, 'msg');
+  if (!fs.existsSync(msgDir)) {
+    fs.mkdirSync(msgDir, {recursive: true});
+  }
   msgFiles.forEach(msg => {
     const localeName = msg.substring(0, msg.indexOf('.json'));
     const msgTypings = template.slice().replace(/<%= locale %>/gi, localeName);
-    fs.writeFileSync(path.join(BUILD_DIR, 'msg', localeName + '.d.ts'), msgTypings, 'utf-8');
+    fs.writeFileSync(path.join(TYPINGS_BUILD_DIR, 'msg', localeName + '.d.ts'), msgTypings, 'utf-8');
   })
   cb();
 }
@@ -122,8 +126,8 @@ function msgTypings(cb) {
  */
 function checkinTypings() {
   return gulp.src([
-    `${BUILD_DIR}/**.d.ts`,
-    `${BUILD_DIR}/**/**.d.ts`,
+    `${TYPINGS_BUILD_DIR}/**.d.ts`,
+    `${TYPINGS_BUILD_DIR}/**/**.d.ts`,
   ]).pipe(gulp.dest('typings'));
 };
 

--- a/typings/msg/bs.d.ts
+++ b/typings/msg/bs.d.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Type definitions for the Blockly bs locale.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+/// <reference path="msg.d.ts" />
+
+import BlocklyMsg = Blockly.Msg;
+export = BlocklyMsg;
+


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

- Fixes issue with msgTypings script when the `build/msg` folder is not present.
- Move the typings temporary directory so that it's in the new`build` directory.
- Group all typings files in the build directory under their own directory: `build/typings`.
