### PR TITLE
Fix vertical button padding in horizontal flyout

### DIFF
--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -343,6 +343,10 @@ Blockly.HorizontalFlyout.prototype.reflowInternal_ = function() {
   for (var i = 0, block; (block = blocks[i]); i++) {
     flyoutHeight = Math.max(flyoutHeight, block.getHeightWidth().height);
   }
+  var buttons = this.buttons_;
+  for (var i = 0, button; (button = buttons[i]); i++) {
+    flyoutHeight = Math.max(flyoutHeight, button.height);
+  }
   flyoutHeight += this.MARGIN * 1.5;
   flyoutHeight *= this.workspace_.scale;
   flyoutHeight += Blockly.Scrollbar.scrollbarThickness;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4914.

### Proposed Changes

Uses the height of flyout buttons in the calculation to find the height of the flyout.

#### Behavior Before Change

![Screenshot from 2021-07-12 01-32-00](https://user-images.githubusercontent.com/57055412/125235774-fbb50c80-e2b0-11eb-9b51-d3702a1c0beb.png)

#### Behavior After Change

![Screenshot from 2021-07-12 01-00-32](https://user-images.githubusercontent.com/57055412/125235677-d6280300-e2b0-11eb-8fc7-1d8db572adb3.png)


<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

