### PR TITLE
Remove undesirable \n from sv.json

### DIFF
--- a/msg/json/sv.json
+++ b/msg/json/sv.json
@@ -57,7 +57,7 @@
 	"COLOUR_RGB_RED": "röd",
 	"COLOUR_RGB_GREEN": "grön",
 	"COLOUR_RGB_BLUE": "blå",
-	"COLOUR_RGB_TOOLTIP": "Skapa en färg med det angivna mängden röd, grön och blå.\nAlla värden måste vara mellan 0 och 100.",
+	"COLOUR_RGB_TOOLTIP": "Skapa en färg med det angivna mängden röd, grön och blå. Alla värden måste vara mellan 0 och 100.",
 	"COLOUR_BLEND_HELPURL": "https://meyerweb.com/eric/tools/color-blend/#:::rgbp",
 	"COLOUR_BLEND_TITLE": "blanda",
 	"COLOUR_BLEND_COLOUR1": "färg 1",


### PR DESCRIPTION
Resolves #5017

Usually direct edits to the msg json files work just fine.  Occasionally such edits will get inadvertently reverted by translate wiki on their next push.  If this happens, then we make the edit again.  If it reverts a second time, then we ping them and ask them to pull it.

We have to reedit once every two years, and ping them about once every four years, so it's an acceptable solution in my opinion.  Not worth automating and creating more moving parts.