### PR TITLE
Remove unused parameters from test helpers

### DIFF
--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -45,7 +45,7 @@ suite('Gesture', function() {
 
   setup(function() {
     sharedTestSetup.call(this);
-    defineBasicBlockWithField(this.sharedCleanup);
+    defineBasicBlockWithField();
     var toolbox = document.getElementById('gesture-test-toolbox');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
   });

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -18,7 +18,7 @@ suite('Key Down', function() {
    * @param {Blockly.Workspace} workspace The workspace to create a new block on.
    */
   function setSelectedBlock(workspace) {
-    defineStackBlock(this.sharedCleanup);
+    defineStackBlock();
     Blockly.selected = workspace.newBlock('stack_block');
   }
 

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -456,7 +456,7 @@ function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
   assertXmlProperties_(eventArg, xmlProperties);
 }
 
-function defineStackBlock(sharedCleanupObj) {
+function defineStackBlock() {
   Blockly.defineBlocksWithJsonArray([{
     "type": "stack_block",
     "message0": "",
@@ -465,7 +465,7 @@ function defineStackBlock(sharedCleanupObj) {
   }]);
 }
 
-function defineRowBlock(sharedCleanupObj) {
+function defineRowBlock() {
   Blockly.defineBlocksWithJsonArray([{
     "type": "row_block",
     "message0": "%1",
@@ -479,7 +479,7 @@ function defineRowBlock(sharedCleanupObj) {
   }]);
 }
 
-function defineStatementBlock(sharedCleanupObj) {
+function defineStatementBlock() {
   Blockly.defineBlocksWithJsonArray([{
     "type": "statement_block",
     "message0": "%1",
@@ -496,7 +496,7 @@ function defineStatementBlock(sharedCleanupObj) {
     "helpUrl": ""
   }]);
 }
-function defineBasicBlockWithField(sharedCleanupObj) {
+function defineBasicBlockWithField() {
   Blockly.defineBlocksWithJsonArray([{
     "type": "test_field_block",
     "message0": "%1",

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -20,7 +20,7 @@ suite('Theme', function() {
     Blockly.registry.typeMap_['theme'] = {};
   });
 
-  function defineThemeTestBlocks(sharedCleanupObj) {
+  function defineThemeTestBlocks() {
     Blockly.defineBlocksWithJsonArray([{
       "type": "stack_block",
       "message0": "",
@@ -117,7 +117,7 @@ suite('Theme', function() {
   });
 
   test('Set Theme', function() {
-    defineThemeTestBlocks(this.sharedCleanup);
+    defineThemeTestBlocks();
     try {
       var blockStyles = createBlockStyles();
       var theme = new Blockly.Theme('themeName', blockStyles);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

n/a
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Removes unused param `sharedCleanupObj` from test helpers. This parameter used to be necessary before `Blockly.defineBlocksWithJsonArray` was stubbed in tests.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Reduce confusion in test helpers and correct incorrect call in `keydown_test.js`.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Ran mocha tests.
<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

One of the calls was also passing the incorrect object (in `keydown_test.js` undefined was being passed due to an incorrect assumption of scope). However, removing this param bypasses the need to fix that call.
<!-- Anything else we should know? -->
