### PR TITLE
Added script and workflow to automatically update build artifact sizes in check_metadata.sh

### DIFF
--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -6,13 +6,8 @@ name: Update Metadata
 on: [workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node-version: [16.x]        
+  update-metadata:
+    runs-on: ubuntu-latest        
 
     steps:
     - name: Check Out Blockly
@@ -20,10 +15,22 @@ jobs:
       with:
         ref: 'develop'
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}        
+        node-version: 16.x
+
+    - name: Build Blockly
+      run: npm run build:compressed
+
+    - name: Build Blockly blocks
+      run: npm run build:blocks
+
+    - name: Gzip Blockly
+      run: gzip -k build/blockly_compressed.js
+
+    - name: Gzip Blockly blocks
+      run: gzip -k build/blocks_compressed.js
 
     - name: Update Metadata
       run: source ./tests/scripts/update_metadata.sh
@@ -31,9 +38,9 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
       with:
-        commit-message: Updated build artifact sizes in check_metadata.sh
+        commit-message: Update build artifact sizes in check_metadata.sh
         delete-branch: true
-        title: Updated build artifact sizes in check_metadata.sh
+        title: Update build artifact sizes in check_metadata.sh
 
     - name: View Pull Request
       run: echo "View Pull Request - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -1,0 +1,39 @@
+# This workflow updates the check_metadata.sh script, which compares the current
+# size of build artifacts against their size in the previous version of Blockly.
+
+name: Update Metadata
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]        
+
+    steps:
+    - name: Check Out Blockly
+      uses: actions/checkout@v2
+      with:
+        ref: 'develop'
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}        
+
+    - name: Update Metadata
+      run: source ./tests/scripts/update_metadata.sh
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
+      with:
+        commit-message: Updated build artifact sizes in check_metadata.sh
+        delete-branch: true
+        title: Updated build artifact sizes in check_metadata.sh
+
+    - name: View Pull Request
+      run: echo "View Pull Request - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -26,12 +26,6 @@ jobs:
     - name: Build Blockly blocks
       run: npm run build:blocks
 
-    - name: Gzip Blockly
-      run: gzip -k build/blockly_compressed.js
-
-    - name: Gzip Blockly blocks
-      run: gzip -k build/blocks_compressed.js
-
     - name: Update Metadata
       run: source ./tests/scripts/update_metadata.sh
 

--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Determines the size of generated files and updates check_metadata.sh to
+# reflect the new values.
+
+blockly_size=$(wc -c < "blockly_compressed.js")
+blocks_size=$(wc -c < "blocks_compressed.js")
+blockly_gz_size=$(wc -c < "blockly_compressed.js.gz")
+blocks_gz_size=$(wc -c < "blocks_compressed.js.gz")
+quarter=$(date "+Q%q %Y")
+version=$(npx -c 'echo "$npm_package_version"')
+
+replacement="# ${quarter}\t${version}\t${blockly_size}\n"
+replacement+="readonly BLOCKLY_SIZE_EXPECTED=${blockly_size}"
+sed -ri "s/readonly BLOCKLY_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+  tests/scripts/check_metadata.sh
+
+replacement="# ${quarter}\t${version}\t${blocks_size}\n"
+replacement+="readonly BLOCKS_SIZE_EXPECTED=${blocks_size}"
+sed -ri "s/readonly BLOCKS_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+  tests/scripts/check_metadata.sh
+
+replacement="# ${quarter}\t${version}\t${blockly_gz_size}\n"
+replacement+="readonly BLOCKLY_GZ_SIZE_EXPECTED=${blockly_gz_size}"
+sed -ri "s/readonly BLOCKLY_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+  tests/scripts/check_metadata.sh
+
+replacement="# ${quarter}\t${version}\t${blocks_gz_size}\n"
+replacement+="readonly BLOCKS_GZ_SIZE_EXPECTED=${blocks_gz_size}"
+sed -ri "s/readonly BLOCKS_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+  tests/scripts/check_metadata.sh

--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -3,6 +3,9 @@
 # Determines the size of generated files and updates check_metadata.sh to
 # reflect the new values.
 
+gzip -k build/blockly_compressed.js
+gzip -k build/blocks_compressed.js
+
 blockly_size=$(wc -c < "build/blockly_compressed.js")
 blocks_size=$(wc -c < "build/blocks_compressed.js")
 blockly_gz_size=$(wc -c < "build/blockly_compressed.js.gz")

--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -3,10 +3,10 @@
 # Determines the size of generated files and updates check_metadata.sh to
 # reflect the new values.
 
-blockly_size=$(wc -c < "blockly_compressed.js")
-blocks_size=$(wc -c < "blocks_compressed.js")
-blockly_gz_size=$(wc -c < "blockly_compressed.js.gz")
-blocks_gz_size=$(wc -c < "blocks_compressed.js.gz")
+blockly_size=$(wc -c < "build/blockly_compressed.js")
+blocks_size=$(wc -c < "build/blocks_compressed.js")
+blockly_gz_size=$(wc -c < "build/blockly_compressed.js.gz")
+blocks_gz_size=$(wc -c < "build/blocks_compressed.js.gz")
 quarter=$(date "+Q%q %Y")
 version=$(npx -c 'echo "$npm_package_version"')
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
https://github.com/google/blockly/issues/4977

### Proposed Changes
Adds a script that calculates the size of the various Blockly JS files and updates check_metadata.sh with the new values.

#### Behavior Before Change
As part of the release process, a developer would need to manually determine the build artifact sizes and update the check_metadata.sh script.

#### Behavior After Change
Running the workflow will automatically calculate the new build artifact sizes, update the script, and create a PR with the updated script.

### Reason for Changes
Makes this step in the release process more reliable and reduces the effort on the part of the dev team.