### PR TITLE
Fix code in code demo executing twice on mobile

### DIFF
--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -187,7 +187,7 @@ Code.bindClick = function(el, func) {
   if (typeof el == 'string') {
     el = document.getElementById(el);
   }
-  if (Blockly.utils.userAgent.MOBILE) {
+  if (Blockly.utils.userAgent.MOBILE || Blockly.utils.userAgent.TABLET) {
     el.addEventListener('touchend', func, true);
   } else {
     el.addEventListener('click', func, true);

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -549,7 +549,7 @@ Code.initLanguage = function() {
 /**
  * Execute the user's code.
  * Just a quick and dirty eval.  Catch infinite loops.
- * @param {UIEvent} event Event created from listener bound to the function.
+ * @param {Event} event Event created from listener bound to the function.
  */
 Code.runJS = function(event) {
   // Prevent code from being executed twice on touchscreens.

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -187,11 +187,8 @@ Code.bindClick = function(el, func) {
   if (typeof el == 'string') {
     el = document.getElementById(el);
   }
-  if (Blockly.utils.userAgent.MOBILE || Blockly.utils.userAgent.TABLET) {
-    el.addEventListener('touchend', func, true);
-  } else {
-    el.addEventListener('click', func, true);
-  }
+  el.addEventListener('click', func, true);
+  el.addEventListener('touchend', func, true);
 };
 
 /**
@@ -552,8 +549,14 @@ Code.initLanguage = function() {
 /**
  * Execute the user's code.
  * Just a quick and dirty eval.  Catch infinite loops.
+ * @param {UIEvent} event Event created from listener bound to the function
  */
-Code.runJS = function() {
+Code.runJS = function(event) {
+  // Prevent code from being executed twice on touchscreens.
+  if (event.type == 'touchend') {
+    event.preventDefault();
+  }
+
   Blockly.JavaScript.INFINITE_LOOP_TRAP = 'checkTimeout();\n';
   var timeouts = 0;
   var checkTimeout = function() {

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -187,8 +187,11 @@ Code.bindClick = function(el, func) {
   if (typeof el == 'string') {
     el = document.getElementById(el);
   }
-  el.addEventListener('click', func, true);
-  el.addEventListener('touchend', func, true);
+  if (Blockly.utils.userAgent.MOBILE) {
+    el.addEventListener('touchend', func, true);
+  } else {
+    el.addEventListener('click', func, true);
+  }
 };
 
 /**

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -549,7 +549,7 @@ Code.initLanguage = function() {
 /**
  * Execute the user's code.
  * Just a quick and dirty eval.  Catch infinite loops.
- * @param {UIEvent} event Event created from listener bound to the function
+ * @param {UIEvent} event Event created from listener bound to the function.
  */
 Code.runJS = function(event) {
   // Prevent code from being executed twice on touchscreens.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #1949

### Proposed Changes

Only bind one event listener depending on platform.

#### Behavior Before Change

Code executes twice, one after the other because of the two event listeners bound to the "run" button.

#### Behavior After Change

Code executes only once.

### Test Coverage

Tested on chromium devtools mobile viewport mode, where the bug was also present.
