### PR TITLE
Configure eslint and Closure Compiler to accept ES6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,6 +75,7 @@
         }]
     },
     "env": {
+        "es6": true,
         "browser": true
     },
     "globals": {

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -118,6 +118,7 @@ function compile(compilerOptions, opt_verbose, opt_warnings_as_error,
   const options = {};
   options.compilation_level = 'SIMPLE_OPTIMIZATIONS';
   options.warning_level = opt_verbose ? 'VERBOSE' : 'DEFAULT';
+  options.language_in = 'ECMASCRIPT6_STRICT',
   options.language_out = 'ECMASCRIPT5_STRICT';
   options.rewrite_polyfills = false;
   options.hide_warnings_for = 'node_modules';


### PR DESCRIPTION
## The basics

- ~~[ ] I branched from develop~~
- ~~[ ] My pull request is against develop~~
- [X] I branched from goog_module
- [X] My pull request is against goog_module
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Configure eslint and Closure Compiler to accept ES6 input.

### Reason for Changes

We are beginning the migration to ES6.
