### PR TITLE
Migrate core/utils/deprecation.js to goog.module syntax

### DIFF
--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -30,8 +30,7 @@ goog.module.declareLegacyNamespace();
  *     if any.
  * @package
  */
-const warn = function(
-    name, deprecationDate, deletionDate, opt_use) {
+const warn = function(name, deprecationDate, deletionDate, opt_use) {
   let msg = name + ' was deprecated on ' + deprecationDate +
       ' and will be deleted on ' + deletionDate + '.';
   if (opt_use) {

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -31,8 +31,8 @@ goog.provide('Blockly.utils.deprecation');
  */
 Blockly.utils.deprecation.warn = function(
     name, deprecationDate, deletionDate, opt_use) {
-  var msg = name + ' was deprecated on ' + deprecationDate +
-        ' and will be deleted on ' + deletionDate + '.';
+  let msg = name + ' was deprecated on ' + deprecationDate +
+      ' and will be deleted on ' + deletionDate + '.';
   if (opt_use) {
     msg += '\nUse ' + opt_use + ' instead.';
   }

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -15,7 +15,8 @@
  * @name Blockly.utils.deprecation
  * @namespace
  */
-goog.provide('Blockly.utils.deprecation');
+goog.module('Blockly.utils.deprecation');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -29,7 +30,7 @@ goog.provide('Blockly.utils.deprecation');
  *     if any.
  * @package
  */
-Blockly.utils.deprecation.warn = function(
+const warn = function(
     name, deprecationDate, deletionDate, opt_use) {
   let msg = name + ' was deprecated on ' + deprecationDate +
       ' and will be deleted on ' + deletionDate + '.';
@@ -38,3 +39,5 @@ Blockly.utils.deprecation.warn = function(
   }
   console.warn(msg);
 };
+
+exports = {warn};

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -172,7 +172,7 @@ goog.addDependency('../../core/utils.js', ['Blockly.utils'], ['Blockly.Msg', 'Bl
 goog.addDependency('../../core/utils/aria.js', ['Blockly.utils.aria'], []);
 goog.addDependency('../../core/utils/colour.js', ['Blockly.utils.colour'], []);
 goog.addDependency('../../core/utils/coordinate.js', ['Blockly.utils.Coordinate'], []);
-goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], []);
+goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.Svg', 'Blockly.utils.userAgent']);
 goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], []);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- ~~[ ] I branched from develop~~
- ~~[ ] My pull request is against develop~~
- [X] I branched from goog_module
- [X] My pull request is against goog_module
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5026
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Converts `core/utils/deprecation.js` to `goog.module` syntax. 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Test Coverage

Ran `npm run start` and `npm run test`

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
