### PR TITLE
Migrate core/utils/keycodes.js to goog.module

### DIFF
--- a/core/utils/keycodes.js
+++ b/core/utils/keycodes.js
@@ -16,7 +16,8 @@
  * @name Blockly.utils.KeyCodes
  * @namespace
  */
-goog.provide('Blockly.utils.KeyCodes');
+goog.module('Blockly.utils.KeyCodes');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -29,7 +30,7 @@ goog.provide('Blockly.utils.KeyCodes');
  *
  * @enum {number}
  */
-Blockly.utils.KeyCodes = {
+const KeyCodes = {
   WIN_KEY_FF_LINUX: 0,
   MAC_ENTER: 3,
   BACKSPACE: 8,
@@ -166,3 +167,5 @@ Blockly.utils.KeyCodes = {
   // http://en.community.dell.com/support-forums/laptop/f/3518/p/19285957/19523128.aspx
   PHANTOM: 255
 };
+
+exports = KeyCodes;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -176,7 +176,7 @@ goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecatio
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.Svg', 'Blockly.utils.userAgent']);
 goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], []);
-goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], []);
+goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], []);
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], []);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- ~~[ ] I branched from develop~~
- ~~[ ] My pull request is against develop~~
- [X] I branched from goog_module
- [X] My pull request is against goog_module
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5026
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Converts `core/utils/keycodes.js` to `goog.module` syntax. 
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Test Coverage

Ran `npm run start` and `npm run test`

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

No instances of var to update.
No changes to the file after running clang-format.