### PR TITLE
Add JSO hooks for blocks and fields.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -328,17 +328,33 @@ Blockly.Block.prototype.onchange;
 
 /**
  * An optional serialization method for defining how to serialize the
- * mutation state. This must be coupled with defining `domToMutation`.
+ * mutation state to XML. This must be coupled with defining `domToMutation`.
  * @type {?function(...):!Element}
  */
 Blockly.Block.prototype.mutationToDom;
 
 /**
  * An optional deserialization method for defining how to deserialize the
- * mutation state. This must be coupled with defining `mutationToDom`.
+ * mutation state from XML. This must be coupled with defining `mutationToDom`.
  * @type {?function(!Element)}
  */
 Blockly.Block.prototype.domToMutation;
+
+/**
+ * An optional serialization method for defining how to serialize the block's
+ * extra state (eg mutation state) to something JSON compatible. This must be
+ * coupled with defining `loadExtraState`.
+ * @type {?function(): *}
+ */
+Blockly.Block.prototype.saveExtraState;
+
+/**
+ * An optional serialization method for defining how to deserialize the block's
+ * extra state (eg mutation state) from something JSON compatible. This must be
+ * coupled with defining `saveExtraState`.
+ * @type {?function(*)}
+ */
+Blockly.Block.prototype.loadExtraState;
 
 /**
  * An optional property for suppressing adding STATEMENT_PREFIX and

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -265,7 +265,7 @@ Blockly.Extensions.checkHasFunctionPair_ =
       if (typeof object[name1] != 'function') {
         throw Error(errorPrefix + name1 + ' must be a function.');
       } else if (typeof object[name2] != 'function') {
-        throw Error(errorPrefix + name2 + 'must be a function.');
+        throw Error(errorPrefix + name2 + ' must be a function.');
       }
       return true;
     } else if (!has1 && !has2) {
@@ -286,7 +286,7 @@ Blockly.Extensions.checkHasMutatorProperties_ = function(errorPrefix, object) {
   var hasJsonHooks = Blockly.Extensions.checkJsonHooks_(object, errorPrefix);
   if (!hasXmlHooks && !hasJsonHooks) {
     throw Error(errorPrefix +
-        'Mutations must contain either XML hooks or JSON hooks');
+        'Mutations must contain either XML hooks, or JSON hooks, or both');
   }
   // A block with a mutator isn't required to have a mutation dialog, but
   // it should still have both or neither of compose and decompose.

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -284,10 +284,7 @@ Blockly.Extensions.checkHasFunctionPair_ =
 Blockly.Extensions.checkHasMutatorProperties_ = function(errorPrefix, object) {
   var hasXmlHooks = Blockly.Extensions.checkXmlHooks_(object, errorPrefix);
   var hasJsonHooks = Blockly.Extensions.checkJsonHooks_(object, errorPrefix);
-  if (hasXmlHooks && hasJsonHooks) {
-    throw Error(errorPrefix +
-        'Mutations should only contain either XML hooks, or JSON hooks');
-  } else if (!hasXmlHooks && !hasJsonHooks) {
+  if (!hasXmlHooks && !hasJsonHooks) {
     throw Error(errorPrefix +
         'Mutations must contain either XML hooks or JSON hooks');
   }

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -86,20 +86,11 @@ Blockly.Extensions.registerMutator = function(name, mixinObj, opt_helperFn,
     opt_blockList) {
   var errorPrefix = 'Error when registering mutator "' + name + '": ';
 
-  var hasXmlHooks = Blockly.Extensions.checkXmlHooks_(mixinObj, errorPrefix);
-  var hasJsonHooks = Blockly.Extensions.checkXmlHooks_(mixinObj, errorPrefix);
-  if (hasXmlHooks && hasJsonHooks) {
-    throw Error(
-        'Mutations should only contain either XML hooks, or JSON hooks');
-  } else if (!hasXmlHooks && !hasJsonHooks) {
-    throw Error('Mutations must contain either XML hooks or JSON hooks');
-  }
-
+  Blockly.Extensions.checkHasMutatorProperties_(errorPrefix, mixinObj);
   var hasMutatorDialog =
       Blockly.Extensions.checkMutatorDialog_(mixinObj, errorPrefix);
-
   if (opt_helperFn && (typeof opt_helperFn != 'function')) {
-    throw Error('Extension "' + name + '" is not a function');
+    throw Error(errorPrefix + 'Extension "' + name + '" is not a function');
   }
 
   // Sanity checks passed.
@@ -157,7 +148,7 @@ Blockly.Extensions.apply = function(name, block, isMutator) {
 
   if (isMutator) {
     var errorPrefix = 'Error after applying mutator "' + name + '": ';
-    Blockly.Extensions.checkBlockHasMutatorProperties_(errorPrefix, block);
+    Blockly.Extensions.checkHasMutatorProperties_(errorPrefix, block);
   } else {
     if (!Blockly.Extensions.mutatorPropertiesMatch_(
         /** @type {!Array<Object>} */ (mutatorProperties), block)) {
@@ -285,24 +276,24 @@ Blockly.Extensions.checkHasFunctionPair_ =
   };
 
 /**
- * Check that a block has required mutator properties.  This should be called
- * after applying a mutation extension.
+ * Checks that the given object required mutator properties.
  * @param {string} errorPrefix The string to prepend to any error message.
- * @param {!Blockly.Block} block The block to inspect.
+ * @param {!Object} object The object to inspect.
  * @private
  */
-Blockly.Extensions.checkBlockHasMutatorProperties_ = function(errorPrefix,
-    block) {
-  if (typeof block.domToMutation != 'function') {
-    throw Error(errorPrefix + 'Applying a mutator didn\'t add "domToMutation"');
+Blockly.Extensions.checkHasMutatorProperties_ = function(errorPrefix, object) {
+  var hasXmlHooks = Blockly.Extensions.checkXmlHooks_(object, errorPrefix);
+  var hasJsonHooks = Blockly.Extensions.checkJsonHooks_(object, errorPrefix);
+  if (hasXmlHooks && hasJsonHooks) {
+    throw Error(errorPrefix +
+        'Mutations should only contain either XML hooks, or JSON hooks');
+  } else if (!hasXmlHooks && !hasJsonHooks) {
+    throw Error(errorPrefix +
+        'Mutations must contain either XML hooks or JSON hooks');
   }
-  if (typeof block.mutationToDom != 'function') {
-    throw Error(errorPrefix + 'Applying a mutator didn\'t add "mutationToDom"');
-  }
-
   // A block with a mutator isn't required to have a mutation dialog, but
   // it should still have both or neither of compose and decompose.
-  Blockly.Extensions.checkMutatorDialog_(block, errorPrefix);
+  Blockly.Extensions.checkMutatorDialog_(object, errorPrefix);
 };
 
 /**
@@ -321,6 +312,12 @@ Blockly.Extensions.getMutatorProperties_ = function(block) {
   }
   if (block.mutationToDom !== undefined) {
     result.push(block.mutationToDom);
+  }
+  if (block.saveExtraState !== undefined) {
+    result.push(block.saveExtraState);
+  }
+  if (block.loadExtraState !== undefined) {
+    result.push(block.loadExtraState);
   }
   if (block.compose !== undefined) {
     result.push(block.compose);

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -210,7 +210,7 @@ Blockly.Extensions.checkNoMutatorProperties_ = function(mutationName, block) {
 Blockly.Extensions.checkXmlHooks_ = function(object, errorPrefix) {
   return Blockly.Extensions.checkHasFunctionPair_(
       object, 'mutationToDom', 'domToMutation', errorPrefix);
-}
+};
 
 /**
  * Checks if the given object has both the 'saveExtraState' and 'loadExtraState'
@@ -226,7 +226,7 @@ Blockly.Extensions.checkXmlHooks_ = function(object, errorPrefix) {
 Blockly.Extensions.checkJsonHooks_ = function(object, errorPrefix) {
   return Blockly.Extensions.checkHasFunctionPair_(
       object, 'saveExtraState', 'loadExtraState', errorPrefix);
-}
+};
 
 /**
  * Checks if the given object has both the 'compose' and 'decompose' functions.

--- a/core/field.js
+++ b/core/field.js
@@ -425,9 +425,9 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 Blockly.Field.prototype.saveState = function() {
   // Default backwards-compatible implementation.
   var container = Blockly.utils.xml.createElement('field');
-  container.setAttribute('name', field.name || '');
+  container.setAttribute('name', this.name || '');
   return Blockly.Xml.domToText(this.toXml(container));
-}
+};
 
 /**
  * Sets the field's state based on the given state value. Should only be called

--- a/core/field.js
+++ b/core/field.js
@@ -418,27 +418,21 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 /**
  * Saves this fields value as something which can be serialized to JSON. Should
  * only be called by the serialization system.
- * Default implementation calls the XML versions for backwards compatibility.
  * @return {*} JSON serializable state.
  * @package
  */
 Blockly.Field.prototype.saveState = function() {
-  // Default backwards-compatible implementation.
-  var container = Blockly.utils.xml.createElement('field');
-  container.setAttribute('name', this.name || '');
-  return Blockly.Xml.domToText(this.toXml(container));
+  return this.getValue();
 };
 
 /**
  * Sets the field's state based on the given state value. Should only be called
  * by the serialization system.
- * Default implementation calls the XLM versions for backwards compatibility.
  * @param {*} state The state we want to apply to the field.
  * @package
  */
 Blockly.Field.prototype.loadState = function(state) {
-  // Default backwards-compatible implementation.
-  this.fromXml(Blockly.Xml.textToDom(/** @type{string} */ (state)));
+  this.setValue(state);
 };
 
 /**

--- a/core/field.js
+++ b/core/field.js
@@ -416,6 +416,32 @@ Blockly.Field.prototype.toXml = function(fieldElement) {
 };
 
 /**
+ * Saves this fields value as something which can be serialized to JSON. Should
+ * only be called by the serialization system.
+ * Default implementation calls the XML versions for backwards compatibility.
+ * @return {*} JSON serializable state.
+ * @package
+ */
+Blockly.Field.prototype.saveState = function() {
+  // Default backwards-compatible implementation.
+  var container = Blockly.utils.xml.createElement('field');
+  container.setAttribute('name', field.name || '');
+  return Blockly.Xml.domToText(this.toXml(container));
+}
+
+/**
+ * Sets the field's state based on the given state value. Should only be called
+ * by the serialization system.
+ * Default implementation calls the XLM versions for backwards compatibility.
+ * @param {*} state The state we want to apply to the field.
+ * @package
+ */
+Blockly.Field.prototype.loadState = function(state) {
+  // Default backwards-compatible implementation.
+  this.fromXml(Blockly.Xml.textToDom(/** @type{string} */ (state)));
+};
+
+/**
  * Dispose of all DOM objects and events belonging to this editable field.
  * @package
  */

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -448,6 +448,57 @@ suite('Extensions', function() {
         }, /mutationToDom/);
       });
 
+      test('No saveExtraState', function() {
+        this.extensionsCleanup_.push('mutator_test');
+        chai.assert.throws(function() {
+          Blockly.Extensions.registerMutator('mutator_test',
+              {
+                loadExtraState: function() {
+                  return 'loadExtraState';
+                },
+                compose: function() {
+                  return 'composeFn';
+                },
+                decompose: function() {
+                  return 'decomposeFn';
+                }
+              });
+        }, /saveExtraState/);
+      })
+
+      test('No loadExtraState', function() {
+        this.extensionsCleanup_.push('mutator_test');
+        chai.assert.throws(function() {
+          Blockly.Extensions.registerMutator('mutator_test',
+              {
+                saveExtraState: function() {
+                  return 'saveExtraState';
+                },
+                compose: function() {
+                  return 'composeFn';
+                },
+                decompose: function() {
+                  return 'decomposeFn';
+                }
+              });
+        }, /loadExtraState/);
+      })
+
+      test('No serialization hooks', function() {
+        this.extensionsCleanup_.push('mutator_test');
+        chai.assert.throws(function() {
+          Blockly.Extensions.registerMutator('mutator_test',
+              {
+                compose: function() {
+                  return 'composeFn';
+                },
+                decompose: function() {
+                  return 'decomposeFn';
+                }
+              });
+        }, 'Mutations must contain either XML hooks, or JSON hooks, or both');
+      })
+
       test('Has decompose but no compose', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -464,7 +464,7 @@ suite('Extensions', function() {
                 }
               });
         }, /saveExtraState/);
-      })
+      });
 
       test('No loadExtraState', function() {
         this.extensionsCleanup_.push('mutator_test');
@@ -482,7 +482,7 @@ suite('Extensions', function() {
                 }
               });
         }, /loadExtraState/);
-      })
+      });
 
       test('No serialization hooks', function() {
         this.extensionsCleanup_.push('mutator_test');
@@ -497,7 +497,7 @@ suite('Extensions', function() {
                 }
               });
         }, 'Mutations must contain either XML hooks, or JSON hooks, or both');
-      })
+      });
 
       test('Has decompose but no compose', function() {
         this.extensionsCleanup_.push('mutator_test');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

Link for Diff: https://github.com/BeksOmega/blockly/compare/tests/serialier...BeksOmega:cereal/basic-hooks

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on project cereal.
Dependent on #5034 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds `saveState` and `loadState` to fields. These functions wrap the old `toXml` and `fromXml` functions for backwards compatibility (as suggested by Sam).

Adds `saveExtraState` and `loadExtraState` to blocks. These functions do *not* wrap `mutationToDom` and `domToMutation` because mixins don't allow that.
  1) If we add default definitions to the block, the mixin function will throw errors when devs try to overwrite it.
  2) If we mixin default definitions via the extensions logic then we don't have wrappers for mutators defined via JavaScript.
As such handling backwards compatibility will need to be done in the JSO serializer itself.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
We want hooks specific to the JSO system.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests to make sure the extension system handles the new mutator mixins correctly. I'll add serialization testing when I actually write the serializer.

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
I have a  running docs task outside github.

### Additional Information

<!-- Anything else we should know? -->
I didn't add hooks for icons yet, because I think that will run into problems with icons not being added in headless mode. I'm going to worry about that after the rest of the serializer is built, because serializing icons is a comparatively small part of serialization.
