### PR TITLE
Add serialization of mutators

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -127,6 +127,7 @@ function addExtraState(block, state) {
   if (block.saveExtraState) {
     state['extra-state'] = block.saveExtraState();
   } else if (block.mutationToDom) {  // Backwards compatibility.
-    state['extra-state'] = Blockly.Xml.domToText(block.mutationToDom());
+    state['extra-state'] = Blockly.Xml.domToText(block.mutationToDom())
+        .replace('xmlns="https://developers.google.com/blockly/xml"', '');
   }
 }

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -129,12 +129,5 @@ const addExtraState = function(block, state) {
     if (extraState !== null) {
       state['extraState'] = extraState;
     }
-  } else if (block.mutationToDom) {  // Backwards compatibility.
-    const mutation = block.mutationToDom();
-    if (mutation !== null) {
-      state['extraState'] = Blockly.Xml.domToText(mutation)
-          .replace('xmlns="https://developers.google.com/blockly/xml"', '');
- 
-    }
   }
 };

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -123,11 +123,11 @@ const addCoords = function(block, state) {
  * @param {!Blockly.serialization.blocks.State} state The state object to append
  *     to.
  */
-function addExtraState(block, state) {
+const addExtraState = function(block, state) {
   if (block.saveExtraState) {
     state['extra-state'] = block.saveExtraState();
   } else if (block.mutationToDom) {  // Backwards compatibility.
     state['extra-state'] = Blockly.Xml.domToText(block.mutationToDom())
         .replace('xmlns="https://developers.google.com/blockly/xml"', '');
   }
-}
+};

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -13,8 +13,6 @@
 goog.module('Blockly.serialization.blocks');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Xml');
-
 
 // TODO: Remove this once lint is fixed.
 /* eslint-disable no-use-before-define */
@@ -120,7 +118,7 @@ const addCoords = function(block, state) {
 /**
  * Adds any extra state the block may provide to the given state object.
  * @param {!Blockly.Block} block The block to serialize the extra state of.
- * @param {!Blockly.serialization.blocks.State} state The state object to append
+ * @param {!State} state The state object to append
  *     to.
  */
 const addExtraState = function(block, state) {

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -13,12 +13,11 @@
 goog.module('Blockly.serialization.blocks');
 goog.module.declareLegacyNamespace();
 
+goog.require('Blockly.Xml');
+
 
 // TODO: Remove this once lint is fixed.
 /* eslint-disable no-use-before-define */
-
-// IMPORTANT: Use train-case for all property names to ensure compatibility
-//     with caseless formats.
 
 /**
  * Represents the state of a given block.
@@ -34,6 +33,7 @@ goog.module.declareLegacyNamespace();
  *     movable: (boolean|undefined),
  *     inline: (boolean|undefined),
  *     data: (string|undefined),
+ *     extra-state: *
  * }}
  */
 var State;
@@ -63,6 +63,7 @@ const save = function(block, {addCoordinates = false} = {}) {
     addCoords(block, state);
   }
   addAttributes(block, state);
+  addExtraState(block, state);
 
   return state;
 };
@@ -115,3 +116,17 @@ const addCoords = function(block, state) {
   state['x'] = Math.round(workspace.RTL ? workspace.getWidth() - xy.x : xy.x);
   state['y'] = Math.round(xy.y);
 };
+
+/**
+ * Adds any extra state the block may provide to the given state object.
+ * @param {!Blockly.Block} block The block to serialize the extra state of.
+ * @param {!Blockly.serialization.blocks.State} state The state object to append
+ *     to.
+ */
+function addExtraState(block, state) {
+  if (block.saveExtraState) {
+    state['extra-state'] = block.saveExtraState();
+  } else if (block.mutationToDom) {  // Backwards compatibility.
+    state['extra-state'] = Blockly.Xml.domToText(block.mutationToDom());
+  }
+}

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -17,6 +17,9 @@ goog.module.declareLegacyNamespace();
 // TODO: Remove this once lint is fixed.
 /* eslint-disable no-use-before-define */
 
+// IMPORTANT: Use train-case for all property names to ensure compatibility
+//     with caseless formats.
+
 /**
  * Represents the state of a given block.
  * @typedef {{

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -125,9 +125,16 @@ const addCoords = function(block, state) {
  */
 const addExtraState = function(block, state) {
   if (block.saveExtraState) {
-    state['extra-state'] = block.saveExtraState();
+    const extraState = block.saveExtraState();
+    if (extraState !== null) {
+      state['extraState'] = extraState;
+    }
   } else if (block.mutationToDom) {  // Backwards compatibility.
-    state['extra-state'] = Blockly.Xml.domToText(block.mutationToDom())
-        .replace('xmlns="https://developers.google.com/blockly/xml"', '');
+    const mutation = block.mutationToDom();
+    if (mutation !== null) {
+      state['extraState'] = Blockly.Xml.domToText(mutation)
+          .replace('xmlns="https://developers.google.com/blockly/xml"', '');
+ 
+    }
   }
 };

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -71,8 +71,7 @@ exports.save = save;
  * Adds attributes to the given state object based on the state of the block.
  * Eg collapsed, disabled, editable, etc.
  * @param {!Blockly.Block} block The block to base the attributes on.
- * @param {!State} state The state object to append
- *     to.
+ * @param {!State} state The state object to append to.
  */
 const addAttributes = function(block, state) {
   if (block.isCollapsed()) {
@@ -105,8 +104,7 @@ const addAttributes = function(block, state) {
 /**
  * Adds the coordinates of the given block to the given state object.
  * @param {!Blockly.Block} block The block to base the coordinates on
- * @param {!State} state The state object to append
- *     to
+ * @param {!State} state The state object to append to
  */
 const addCoords = function(block, state) {
   const workspace = block.workspace;
@@ -118,8 +116,7 @@ const addCoords = function(block, state) {
 /**
  * Adds any extra state the block may provide to the given state object.
  * @param {!Blockly.Block} block The block to serialize the extra state of.
- * @param {!State} state The state object to append
- *     to.
+ * @param {!State} state The state object to append to.
  */
 const addExtraState = function(block, state) {
   if (block.saveExtraState) {

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -271,12 +271,14 @@ suite('JSO', function() {
 
         test('XML backwards compat', function() {
           const block = this.workspace.newBlock('row_block');
-          block.mutationToDom = function(container) {
+          block.mutationToDom = function() {
+            const container = Blockly.utils.xml.createElement('mutation');
             container.setAttribute('extra1', 'state1');
+            return container;
           };
           const jso = Blockly.serialization.blocks.save(block);
           assertProperty(
-              jso, 'extra-state', '<mutation extra1="state1"></mutation>');
+              jso, 'extra-state', '<mutation  extra1="state1"></mutation>');
         });
       });
     });

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -32,7 +32,7 @@ suite('JSO', function() {
     suite('Save Single Block', function() {
 
       function assertProperty(obj, property, value) {
-        chai.assert.equal(obj[property], value);
+        chai.assert.deepEqual(obj[property], value);
       }
 
       function assertNoProperty(obj, property) {
@@ -229,6 +229,54 @@ suite('JSO', function() {
               Blockly.serialization.blocks.save(block, {addCoordinates: true});
           assertProperty(jso, 'x', 0);
           assertProperty(jso, 'y', 0);
+        });
+      });
+
+      // Mutators.
+      suite('Extra state', function() {
+        test('Simple value', function() {
+          const block = this.workspace.newBlock('row_block');
+          block.saveExtraState = function() {
+            return 'some extra state';
+          };
+          const jso = Blockly.serialization.blocks.save(block);
+          assertProperty(jso, 'extra-state', 'some extra state');
+        });
+
+        test('Object', function() {
+          const block = this.workspace.newBlock('row_block');
+          block.saveExtraState = function() {
+            return {
+              'extra1': 'state1',
+              'extra2': 42,
+              'extra3': true,
+            };
+          };
+          const jso = Blockly.serialization.blocks.save(block);
+          assertProperty(jso, 'extra-state', {
+            'extra1': 'state1',
+            'extra2': 42,
+            'extra3': true,
+          });
+        });
+
+        test('Array', function() {
+          const block = this.workspace.newBlock('row_block');
+          block.saveExtraState = function() {
+            return ['state1', 42, true];
+          };
+          const jso = Blockly.serialization.blocks.save(block);
+          assertProperty(jso, 'extra-state', ['state1', 42, true]);
+        });
+
+        test('XML backwards compat', function() {
+          const block = this.workspace.newBlock('row_block');
+          block.mutationToDom = function(container) {
+            container.setAttribute('extra1', 'state1');
+          };
+          const jso = Blockly.serialization.blocks.save(block);
+          assertProperty(
+              jso, 'extra-state', '<mutation extra1="state1"></mutation>');
         });
       });
     });

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -240,7 +240,7 @@ suite('JSO', function() {
             return 'some extra state';
           };
           const jso = Blockly.serialization.blocks.save(block);
-          assertProperty(jso, 'extra-state', 'some extra state');
+          assertProperty(jso, 'extraState', 'some extra state');
         });
 
         test('Object', function() {
@@ -253,7 +253,7 @@ suite('JSO', function() {
             };
           };
           const jso = Blockly.serialization.blocks.save(block);
-          assertProperty(jso, 'extra-state', {
+          assertProperty(jso, 'extraState', {
             'extra1': 'state1',
             'extra2': 42,
             'extra3': true,
@@ -266,19 +266,7 @@ suite('JSO', function() {
             return ['state1', 42, true];
           };
           const jso = Blockly.serialization.blocks.save(block);
-          assertProperty(jso, 'extra-state', ['state1', 42, true]);
-        });
-
-        test('XML backwards compat', function() {
-          const block = this.workspace.newBlock('row_block');
-          block.mutationToDom = function() {
-            const container = Blockly.utils.xml.createElement('mutation');
-            container.setAttribute('extra1', 'state1');
-            return container;
-          };
-          const jso = Blockly.serialization.blocks.save(block);
-          assertProperty(
-              jso, 'extra-state', '<mutation  extra1="state1"></mutation>');
+          assertProperty(jso, 'extraState', ['state1', 42, true]);
         });
       });
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->


- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

Link for Diff: https://github.com/BeksOmega/blockly/compare/cereal/block-serialization...BeksOmega:cereal/mutator-serialization

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on project cereal.
Dependent on #5053 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds serialization of mutators on blocks. ~~Handles backwards compatibility with the XML hooks by converting them to a string before appending them to the JSO.~~ That was removed in favor of investigating upgrading developers' files directly using a script.

Does not handle deserialization.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Serializing state is good.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Added tests for the different categories of objects the save function could return. Also added a test for wrapping the `mutationToDom` hook.

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
