### PR TITLE
Migrate core/utils/math.js to goog.module syntax

### DIFF
--- a/core/utils/math.js
+++ b/core/utils/math.js
@@ -48,7 +48,7 @@ Blockly.utils.math.toDegrees = function(angleRadians) {
  */
 Blockly.utils.math.clamp = function(lowerBound, number, upperBound) {
   if (upperBound < lowerBound) {
-    var temp = upperBound;
+    const temp = upperBound;
     upperBound = lowerBound;
     lowerBound = temp;
   }

--- a/core/utils/math.js
+++ b/core/utils/math.js
@@ -56,4 +56,8 @@ const clamp = function(lowerBound, number, upperBound) {
   return Math.max(lowerBound, Math.min(number, upperBound));
 };
 
-exports = {toRadians, toDegrees, clamp};
+exports = {
+  toRadians,
+  toDegrees,
+  clamp
+};

--- a/core/utils/math.js
+++ b/core/utils/math.js
@@ -16,7 +16,8 @@
  * @name Blockly.utils.math
  * @namespace
  */
-goog.provide('Blockly.utils.math');
+goog.module('Blockly.utils.math');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -25,7 +26,7 @@ goog.provide('Blockly.utils.math');
  * @param {number} angleDegrees Angle in degrees.
  * @return {number} Angle in radians.
  */
-Blockly.utils.math.toRadians = function(angleDegrees) {
+const toRadians = function(angleDegrees) {
   return angleDegrees * Math.PI / 180;
 };
 
@@ -35,7 +36,7 @@ Blockly.utils.math.toRadians = function(angleDegrees) {
  * @param {number} angleRadians Angle in radians.
  * @return {number} Angle in degrees.
  */
-Blockly.utils.math.toDegrees = function(angleRadians) {
+const toDegrees = function(angleRadians) {
   return angleRadians * 180 / Math.PI;
 };
 
@@ -46,7 +47,7 @@ Blockly.utils.math.toDegrees = function(angleRadians) {
  * @param {number} upperBound The desired upper bound.
  * @return {number} The clamped number.
  */
-Blockly.utils.math.clamp = function(lowerBound, number, upperBound) {
+const clamp = function(lowerBound, number, upperBound) {
   if (upperBound < lowerBound) {
     const temp = upperBound;
     upperBound = lowerBound;
@@ -54,3 +55,5 @@ Blockly.utils.math.clamp = function(lowerBound, number, upperBound) {
   }
   return Math.max(lowerBound, Math.min(number, upperBound));
 };
+
+exports = {toRadians, toDegrees, clamp};

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -4,7 +4,6 @@ goog.addDependency('../../blocks/logic.js', ['Blockly.Blocks.logic', 'Blockly.Co
 goog.addDependency('../../blocks/loops.js', ['Blockly.Blocks.loops', 'Blockly.Constants.Loops'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldLabel', 'Blockly.FieldNumber', 'Blockly.FieldVariable', 'Blockly.Warning']);
 goog.addDependency('../../blocks/math.js', ['Blockly.Blocks.math', 'Blockly.Constants.Math'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldLabel', 'Blockly.FieldNumber', 'Blockly.FieldVariable']);
 goog.addDependency('../../blocks/procedures.js', ['Blockly.Blocks.procedures'], ['Blockly', 'Blockly.Blocks', 'Blockly.Comment', 'Blockly.FieldCheckbox', 'Blockly.FieldLabel', 'Blockly.FieldTextInput', 'Blockly.Mutator', 'Blockly.Warning'], {'lang': 'es5'});
-goog.addDependency('../../blocks/test_blocks.js', ['Blockly.TestBlocks'], ['Blockly', 'Blockly.Blocks'], {'lang': 'es5'});
 goog.addDependency('../../blocks/text.js', ['Blockly.Blocks.texts', 'Blockly.Constants.Text'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldImage', 'Blockly.FieldMultilineInput', 'Blockly.FieldTextInput', 'Blockly.FieldVariable', 'Blockly.Mutator']);
 goog.addDependency('../../blocks/variables.js', ['Blockly.Blocks.variables', 'Blockly.Constants.Variables'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldLabel', 'Blockly.FieldVariable']);
 goog.addDependency('../../blocks/variables_dynamic.js', ['Blockly.Constants.VariablesDynamic'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldLabel', 'Blockly.FieldVariable']);
@@ -178,7 +177,7 @@ goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.u
 goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], []);
+goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], []);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- ~~[ ] I branched from develop~~
- ~~[ ] My pull request is against develop~~
- [X] I branched from goog_module
- [X] My pull request is against goog_module
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5026

### Proposed Changes

Converts `core/utils/math.js` to `goog.module` syntax. 

### Test Coverage

Ran `npm run start` and `npm run test`

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->