### PR TITLE
Migrate core/utils/idgenerator.js to goog.module syntax

### DIFF
--- a/core/utils/idgenerator.js
+++ b/core/utils/idgenerator.js
@@ -16,7 +16,8 @@
  * @name Blockly.utils.IdGenerator
  * @namespace
  */
-goog.provide('Blockly.utils.IdGenerator');
+goog.module('Blockly.utils.IdGenerator');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -24,7 +25,7 @@ goog.provide('Blockly.utils.IdGenerator');
  * @type {number}
  * @private
  */
-Blockly.utils.IdGenerator.nextId_ = 0;
+let nextId = 0;
 
 /**
  * Gets the next unique ID.
@@ -32,6 +33,8 @@ Blockly.utils.IdGenerator.nextId_ = 0;
  * Use only ASCII letters, digits, '_', '-' and '.'
  * @return {string} The next unique identifier.
  */
-Blockly.utils.IdGenerator.getNextUniqueId = function() {
-  return 'blockly-' + (Blockly.utils.IdGenerator.nextId_++).toString(36);
+const getNextUniqueId = function() {
+  return 'blockly-' + (nextId++).toString(36);
 };
+
+exports = {getNextUniqueId};

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -4,6 +4,7 @@ goog.addDependency('../../blocks/logic.js', ['Blockly.Blocks.logic', 'Blockly.Co
 goog.addDependency('../../blocks/loops.js', ['Blockly.Blocks.loops', 'Blockly.Constants.Loops'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldLabel', 'Blockly.FieldNumber', 'Blockly.FieldVariable', 'Blockly.Warning']);
 goog.addDependency('../../blocks/math.js', ['Blockly.Blocks.math', 'Blockly.Constants.Math'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldLabel', 'Blockly.FieldNumber', 'Blockly.FieldVariable']);
 goog.addDependency('../../blocks/procedures.js', ['Blockly.Blocks.procedures'], ['Blockly', 'Blockly.Blocks', 'Blockly.Comment', 'Blockly.FieldCheckbox', 'Blockly.FieldLabel', 'Blockly.FieldTextInput', 'Blockly.Mutator', 'Blockly.Warning'], {'lang': 'es5'});
+goog.addDependency('../../blocks/test_blocks.js', ['Blockly.TestBlocks'], ['Blockly', 'Blockly.Blocks'], {'lang': 'es5'});
 goog.addDependency('../../blocks/text.js', ['Blockly.Blocks.texts', 'Blockly.Constants.Text'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldDropdown', 'Blockly.FieldImage', 'Blockly.FieldMultilineInput', 'Blockly.FieldTextInput', 'Blockly.FieldVariable', 'Blockly.Mutator']);
 goog.addDependency('../../blocks/variables.js', ['Blockly.Blocks.variables', 'Blockly.Constants.Variables'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldLabel', 'Blockly.FieldVariable']);
 goog.addDependency('../../blocks/variables_dynamic.js', ['Blockly.Constants.VariablesDynamic'], ['Blockly', 'Blockly.Blocks', 'Blockly.FieldLabel', 'Blockly.FieldVariable']);
@@ -175,7 +176,7 @@ goog.addDependency('../../core/utils/coordinate.js', ['Blockly.utils.Coordinate'
 goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], []);
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.Svg', 'Blockly.utils.userAgent']);
 goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
-goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], []);
+goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], []);
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog.module`
- [x] My pull request is against `goog.module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Additional Information

<!-- Anything else we should know? -->