### PR TITLE
Migrate object.js to goog.module syntax

### DIFF
--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -46,7 +46,7 @@ Blockly.utils.object.inherits = function(childCtor, parentCtor) {
  * @param {!Object} source Source.
  */
 Blockly.utils.object.mixin = function(target, source) {
-  for (var x in source) {
+  for (const x in source) {
     target[x] = source[x];
   }
 };
@@ -58,7 +58,7 @@ Blockly.utils.object.mixin = function(target, source) {
  * @return {!Object} The resulting object.
  */
 Blockly.utils.object.deepMerge = function(target, source) {
-  for (var x in source) {
+  for (const x in source) {
     if (source[x] != null && typeof source[x] === 'object') {
       target[x] = Blockly.utils.object.deepMerge(
           target[x] || Object.create(null), source[x]);

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -89,4 +89,4 @@ exports = {
   mixin,
   deepMerge,
   values,
-}
+};

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -14,7 +14,8 @@
  * @name Blockly.utils.object
  * @namespace
  */
-goog.provide('Blockly.utils.object');
+goog.module('Blockly.utils.object');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -23,7 +24,7 @@ goog.provide('Blockly.utils.object');
  * @param {!Function} parentCtor Parent class.
  * @suppress {strictMissingProperties} superClass_ is not defined on Function.
  */
-Blockly.utils.object.inherits = function(childCtor, parentCtor) {
+const inherits = function(childCtor, parentCtor) {
   // Set a .superClass_ property so that methods can call parent methods
   // without hard-coding the parent class name.
   // Could be replaced by ES6's super().
@@ -45,7 +46,7 @@ Blockly.utils.object.inherits = function(childCtor, parentCtor) {
  * @param {!Object} target Target.
  * @param {!Object} source Source.
  */
-Blockly.utils.object.mixin = function(target, source) {
+const mixin = function(target, source) {
   for (const x in source) {
     target[x] = source[x];
   }
@@ -57,11 +58,10 @@ Blockly.utils.object.mixin = function(target, source) {
  * @param {!Object} source Source.
  * @return {!Object} The resulting object.
  */
-Blockly.utils.object.deepMerge = function(target, source) {
+const deepMerge = function(target, source) {
   for (const x in source) {
     if (source[x] != null && typeof source[x] === 'object') {
-      target[x] = Blockly.utils.object.deepMerge(
-          target[x] || Object.create(null), source[x]);
+      target[x] = deepMerge(target[x] || Object.create(null), source[x]);
     } else {
       target[x] = source[x];
     }
@@ -74,7 +74,7 @@ Blockly.utils.object.deepMerge = function(target, source) {
  * @param {!Object} obj Object containing values.
  * @return {!Array} Array of values.
  */
-Blockly.utils.object.values = function(obj) {
+const values = function(obj) {
   if (Object.values) {
     return Object.values(obj);
   }
@@ -83,3 +83,10 @@ Blockly.utils.object.values = function(obj) {
     return obj[e];
   });
 };
+
+exports = {
+  inherits,
+  mixin,
+  deepMerge,
+  values,
+}

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -179,7 +179,7 @@ goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerato
 goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], []);
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], []);
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);
-goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], []);
+goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], []);
 goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], []);
 goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], []);


### PR DESCRIPTION
## The basics
- ~~[ ] I branched from develop~~
- ~~[ ] My pull request is against develop~~
- [X] I branched from goog_module
- [X] My pull request is against goog_module
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5026

### Proposed Changes

Converts `object.js` to `goog.module` syntax. 

### Test Coverage

Ran `npm run start` and `npm run test`
