### PR TITLE
Pull Request template for goog.module PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/goog_module.md
+++ b/.github/PULL_REQUEST_TEMPLATE/goog_module.md
@@ -1,0 +1,20 @@
+<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->
+
+## The basics
+
+- [ ] I branched from `goog.module`
+- [ ] My pull request is against `goog.module`
+- [ ] My code follows the [style guide](
+      https://developers.google.com/blockly/guides/modify/web/style-guide)
+- [ ] My code is presented in the form suggeseted in the [module
+      conversion guide](https://github.com/google/blockly/issues/5026)
+- [ ] I have run `npm test` locally already.
+
+## The details
+### Resolves
+
+Part of #5026
+
+### Additional Information
+
+<!-- Anything else we should know? -->

--- a/.github/PULL_REQUEST_TEMPLATE/goog_module.md
+++ b/.github/PULL_REQUEST_TEMPLATE/goog_module.md
@@ -1,19 +1,23 @@
-<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->
+<!-- Suggested PR title: Migrate PATH/TO/FILE.js to goog.module syntax -->
 
 ## The basics
 
-- [ ] I branched from `goog.module`
-- [ ] My pull request is against `goog.module`
+- [ ] I branched from `goog_module`
+- [ ] My pull request is against `goog_module`
 - [ ] My code follows the [style guide](
       https://developers.google.com/blockly/guides/modify/web/style-guide)
-- [ ] My code is presented in the form suggeseted in the [module
+- [ ] My code is presented in the form suggested in the [module
       conversion guide](https://github.com/google/blockly/issues/5026)
-- [ ] I have run `npm test` locally already.
+- [ ] I have run `npm test`.
 
 ## The details
 ### Resolves
 
 Part of #5026
+
+### Proposed Changes
+
+Converts `PATH/TO/FILE.js` to `goog.module` with ES6 `const`/`let`.
 
 ### Additional Information
 


### PR DESCRIPTION

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from **master**
- [X] My pull request is against **master**, because issue and PR templates must live in default branch.

## The details

### Proposed Changes

Provide a standard pull request template more suited to PRs doing
goog.module conversions.

### Reason for Changes

Facilitate standardised PRs.

### Documentation

Migration guide in #5026 will be updated with instructions.

### Additional Information

There's no way to pick a non-default template when creating a PR manually, but this one can be used by adding `&?template=goog_module.md` to the `https://github.com/cpcallen/bugs/compare/` URL.
