### PR TITLE
Migrate core/utils/string.js to goog.module syntax

### DIFF
--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -64,7 +64,8 @@ const commonWordPrefix = function(array, opt_shortest) {
   }
   let wordPrefix = 0;
   const max = opt_shortest || shortestStringLength(array);
-  for (var len = 0; len < max; len++) {
+  let len;
+  for (len = 0; len < max; len++) {
     const letter = array[0][len];
     for (let i = 1; i < array.length; i++) {
       if (letter != array[i][len]) {
@@ -100,7 +101,8 @@ const commonWordSuffix = function(array, opt_shortest) {
   }
   let wordPrefix = 0;
   const max = opt_shortest || shortestStringLength(array);
-  for (var len = 0; len < max; len++) {
+  let len;
+  for (len = 0; len < max; len++) {
     const letter = array[0].substr(-len - 1, 1);
     for (let i = 1; i < array.length; i++) {
       if (letter != array[i].substr(-len - 1, 1)) {

--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -40,9 +40,11 @@ const shortestStringLength = function(array) {
   if (!array.length) {
     return 0;
   }
-  return array.reduce(function(a, b) {
-    return a.length < b.length ? a : b;
-  }).length;
+  return array
+      .reduce(function(a, b) {
+        return a.length < b.length ? a : b;
+      })
+      .length;
 };
 
 /**
@@ -223,8 +225,9 @@ const wrapScore = function(words, wordBreaks, limit) {
   // previous line.  For example, this looks wrong:
   // aaa bbb
   // ccc ddd eee
-  if (lineLengths.length > 1 && lineLengths[lineLengths.length - 1] <=
-      lineLengths[lineLengths.length - 2]) {
+  if (lineLengths.length > 1 &&
+      lineLengths[lineLengths.length - 1] <=
+          lineLengths[lineLengths.length - 2]) {
     score += 0.5;
   }
   return score;
@@ -250,8 +253,7 @@ const wrapMutate = function(words, wordBreaks, limit) {
     const mutatedWordBreaks = [].concat(wordBreaks);
     mutatedWordBreaks[i] = !mutatedWordBreaks[i];
     mutatedWordBreaks[i + 1] = !mutatedWordBreaks[i + 1];
-    const mutatedScore =
-        wrapScore(words, mutatedWordBreaks, limit);
+    const mutatedScore = wrapScore(words, mutatedWordBreaks, limit);
     if (mutatedScore > bestScore) {
       bestScore = mutatedScore;
       bestBreaks = mutatedWordBreaks;
@@ -290,4 +292,3 @@ exports = {
   commonWordSuffix,
   wrap,
 };
-

--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -16,7 +16,8 @@
  * @name Blockly.utils.string
  * @namespace
  */
-goog.provide('Blockly.utils.string');
+goog.module('Blockly.utils.string');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -26,7 +27,7 @@ goog.provide('Blockly.utils.string');
  * @param {string} prefix A string to look for at the start of `str`.
  * @return {boolean} True if `str` begins with `prefix`.
  */
-Blockly.utils.string.startsWith = function(str, prefix) {
+const startsWith = function(str, prefix) {
   return str.lastIndexOf(prefix, 0) == 0;
 };
 
@@ -35,7 +36,7 @@ Blockly.utils.string.startsWith = function(str, prefix) {
  * @param {!Array<string>} array Array of strings.
  * @return {number} Length of shortest string.
  */
-Blockly.utils.string.shortestStringLength = function(array) {
+const shortestStringLength = function(array) {
   if (!array.length) {
     return 0;
   }
@@ -51,14 +52,14 @@ Blockly.utils.string.shortestStringLength = function(array) {
  * @param {number=} opt_shortest Length of shortest string.
  * @return {number} Length of common prefix.
  */
-Blockly.utils.string.commonWordPrefix = function(array, opt_shortest) {
+const commonWordPrefix = function(array, opt_shortest) {
   if (!array.length) {
     return 0;
   } else if (array.length == 1) {
     return array[0].length;
   }
   let wordPrefix = 0;
-  const max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
+  const max = opt_shortest || shortestStringLength(array);
   for (var len = 0; len < max; len++) {
     const letter = array[0][len];
     for (let i = 1; i < array.length; i++) {
@@ -86,14 +87,14 @@ Blockly.utils.string.commonWordPrefix = function(array, opt_shortest) {
  * @param {number=} opt_shortest Length of shortest string.
  * @return {number} Length of common suffix.
  */
-Blockly.utils.string.commonWordSuffix = function(array, opt_shortest) {
+const commonWordSuffix = function(array, opt_shortest) {
   if (!array.length) {
     return 0;
   } else if (array.length == 1) {
     return array[0].length;
   }
   let wordPrefix = 0;
-  const max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
+  const max = opt_shortest || shortestStringLength(array);
   for (var len = 0; len < max; len++) {
     const letter = array[0].substr(-len - 1, 1);
     for (let i = 1; i < array.length; i++) {
@@ -120,10 +121,10 @@ Blockly.utils.string.commonWordSuffix = function(array, opt_shortest) {
  * @param {number} limit Width to wrap each line.
  * @return {string} Wrapped text.
  */
-Blockly.utils.string.wrap = function(text, limit) {
+const wrap = function(text, limit) {
   const lines = text.split('\n');
   for (let i = 0; i < lines.length; i++) {
-    lines[i] = Blockly.utils.string.wrapLine_(lines[i], limit);
+    lines[i] = wrapLine(lines[i], limit);
   }
   return lines.join('\n');
 };
@@ -135,7 +136,7 @@ Blockly.utils.string.wrap = function(text, limit) {
  * @return {string} Wrapped text.
  * @private
  */
-Blockly.utils.string.wrapLine_ = function(text, limit) {
+const wrapLine = function(text, limit) {
   if (text.length <= limit) {
     // Short text, no need to wrap.
     return text;
@@ -170,9 +171,9 @@ Blockly.utils.string.wrapLine_ = function(text, limit) {
         wordBreaks[i] = false;
       }
     }
-    wordBreaks = Blockly.utils.string.wrapMutate_(words, wordBreaks, limit);
-    score = Blockly.utils.string.wrapScore_(words, wordBreaks, limit);
-    text = Blockly.utils.string.wrapToText_(words, wordBreaks);
+    wordBreaks = wrapMutate(words, wordBreaks, limit);
+    score = wrapScore(words, wordBreaks, limit);
+    text = wrapToText(words, wordBreaks);
     lineCount++;
   } while (score > lastScore);
   return lastText;
@@ -186,7 +187,7 @@ Blockly.utils.string.wrapLine_ = function(text, limit) {
  * @return {number} Larger the better.
  * @private
  */
-Blockly.utils.string.wrapScore_ = function(words, wordBreaks, limit) {
+const wrapScore = function(words, wordBreaks, limit) {
   // If this function becomes a performance liability, add caching.
   // Compute the length of each line.
   const lineLengths = [0];
@@ -238,8 +239,8 @@ Blockly.utils.string.wrapScore_ = function(words, wordBreaks, limit) {
  * @return {!Array<boolean>} New array of optimal line breaks.
  * @private
  */
-Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
-  let bestScore = Blockly.utils.string.wrapScore_(words, wordBreaks, limit);
+const wrapMutate = function(words, wordBreaks, limit) {
+  let bestScore = wrapScore(words, wordBreaks, limit);
   let bestBreaks;
   // Try shifting every line break forward or backward.
   for (let i = 0; i < wordBreaks.length - 1; i++) {
@@ -250,7 +251,7 @@ Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
     mutatedWordBreaks[i] = !mutatedWordBreaks[i];
     mutatedWordBreaks[i + 1] = !mutatedWordBreaks[i + 1];
     const mutatedScore =
-        Blockly.utils.string.wrapScore_(words, mutatedWordBreaks, limit);
+        wrapScore(words, mutatedWordBreaks, limit);
     if (mutatedScore > bestScore) {
       bestScore = mutatedScore;
       bestBreaks = mutatedWordBreaks;
@@ -258,7 +259,7 @@ Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
   }
   if (bestBreaks) {
     // Found an improvement.  See if it may be improved further.
-    return Blockly.utils.string.wrapMutate_(words, bestBreaks, limit);
+    return wrapMutate(words, bestBreaks, limit);
   }
   // No improvements found.  Done.
   return wordBreaks;
@@ -271,7 +272,7 @@ Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
  * @return {string} Plain text.
  * @private
  */
-Blockly.utils.string.wrapToText_ = function(words, wordBreaks) {
+const wrapToText = function(words, wordBreaks) {
   const text = [];
   for (let i = 0; i < words.length; i++) {
     text.push(words[i]);
@@ -280,5 +281,13 @@ Blockly.utils.string.wrapToText_ = function(words, wordBreaks) {
     }
   }
   return text.join('');
+};
+
+exports = {
+  startsWith,
+  shortestStringLength,
+  commonWordPrefix,
+  commonWordSuffix,
+  wrap,
 };
 

--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -57,11 +57,11 @@ Blockly.utils.string.commonWordPrefix = function(array, opt_shortest) {
   } else if (array.length == 1) {
     return array[0].length;
   }
-  var wordPrefix = 0;
-  var max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
+  let wordPrefix = 0;
+  const max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
   for (var len = 0; len < max; len++) {
-    var letter = array[0][len];
-    for (var i = 1; i < array.length; i++) {
+    const letter = array[0][len];
+    for (let i = 1; i < array.length; i++) {
       if (letter != array[i][len]) {
         return wordPrefix;
       }
@@ -70,8 +70,8 @@ Blockly.utils.string.commonWordPrefix = function(array, opt_shortest) {
       wordPrefix = len + 1;
     }
   }
-  for (var i = 1; i < array.length; i++) {
-    var letter = array[i][len];
+  for (let i = 1; i < array.length; i++) {
+    const letter = array[i][len];
     if (letter && letter != ' ') {
       return wordPrefix;
     }
@@ -92,11 +92,11 @@ Blockly.utils.string.commonWordSuffix = function(array, opt_shortest) {
   } else if (array.length == 1) {
     return array[0].length;
   }
-  var wordPrefix = 0;
-  var max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
+  let wordPrefix = 0;
+  const max = opt_shortest || Blockly.utils.string.shortestStringLength(array);
   for (var len = 0; len < max; len++) {
-    var letter = array[0].substr(-len - 1, 1);
-    for (var i = 1; i < array.length; i++) {
+    const letter = array[0].substr(-len - 1, 1);
+    for (let i = 1; i < array.length; i++) {
       if (letter != array[i].substr(-len - 1, 1)) {
         return wordPrefix;
       }
@@ -105,8 +105,8 @@ Blockly.utils.string.commonWordSuffix = function(array, opt_shortest) {
       wordPrefix = len + 1;
     }
   }
-  for (var i = 1; i < array.length; i++) {
-    var letter = array[i].charAt(array[i].length - len - 1);
+  for (let i = 1; i < array.length; i++) {
+    const letter = array[i].charAt(array[i].length - len - 1);
     if (letter && letter != ' ') {
       return wordPrefix;
     }
@@ -121,8 +121,8 @@ Blockly.utils.string.commonWordSuffix = function(array, opt_shortest) {
  * @return {string} Wrapped text.
  */
 Blockly.utils.string.wrap = function(text, limit) {
-  var lines = text.split('\n');
-  for (var i = 0; i < lines.length; i++) {
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
     lines[i] = Blockly.utils.string.wrapLine_(lines[i], limit);
   }
   return lines.join('\n');
@@ -141,28 +141,28 @@ Blockly.utils.string.wrapLine_ = function(text, limit) {
     return text;
   }
   // Split the text into words.
-  var words = text.trim().split(/\s+/);
+  const words = text.trim().split(/\s+/);
   // Set limit to be the length of the largest word.
-  for (var i = 0; i < words.length; i++) {
+  for (let i = 0; i < words.length; i++) {
     if (words[i].length > limit) {
       limit = words[i].length;
     }
   }
 
-  var lastScore;
-  var score = -Infinity;
-  var lastText;
-  var lineCount = 1;
+  let lastScore;
+  let score = -Infinity;
+  let lastText;
+  let lineCount = 1;
   do {
     lastScore = score;
     lastText = text;
     // Create a list of booleans representing if a space (false) or
     // a break (true) appears after each word.
-    var wordBreaks = [];
+    let wordBreaks = [];
     // Seed the list with evenly spaced linebreaks.
-    var steps = words.length / lineCount;
-    var insertedBreaks = 1;
-    for (var i = 0; i < words.length - 1; i++) {
+    const steps = words.length / lineCount;
+    let insertedBreaks = 1;
+    for (let i = 0; i < words.length - 1; i++) {
       if (insertedBreaks < (i + 1.5) / steps) {
         insertedBreaks++;
         wordBreaks[i] = true;
@@ -189,9 +189,9 @@ Blockly.utils.string.wrapLine_ = function(text, limit) {
 Blockly.utils.string.wrapScore_ = function(words, wordBreaks, limit) {
   // If this function becomes a performance liability, add caching.
   // Compute the length of each line.
-  var lineLengths = [0];
-  var linePunctuation = [];
-  for (var i = 0; i < words.length; i++) {
+  const lineLengths = [0];
+  const linePunctuation = [];
+  for (let i = 0; i < words.length; i++) {
     lineLengths[lineLengths.length - 1] += words[i].length;
     if (wordBreaks[i] === true) {
       lineLengths.push(0);
@@ -200,10 +200,10 @@ Blockly.utils.string.wrapScore_ = function(words, wordBreaks, limit) {
       lineLengths[lineLengths.length - 1]++;
     }
   }
-  var maxLength = Math.max.apply(Math, lineLengths);
+  const maxLength = Math.max.apply(Math, lineLengths);
 
-  var score = 0;
-  for (var i = 0; i < lineLengths.length; i++) {
+  let score = 0;
+  for (let i = 0; i < lineLengths.length; i++) {
     // Optimize for width.
     // -2 points per char over limit (scaled to the power of 1.5).
     score -= Math.pow(Math.abs(limit - lineLengths[i]), 1.5) * 2;
@@ -239,17 +239,17 @@ Blockly.utils.string.wrapScore_ = function(words, wordBreaks, limit) {
  * @private
  */
 Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
-  var bestScore = Blockly.utils.string.wrapScore_(words, wordBreaks, limit);
-  var bestBreaks;
+  let bestScore = Blockly.utils.string.wrapScore_(words, wordBreaks, limit);
+  let bestBreaks;
   // Try shifting every line break forward or backward.
-  for (var i = 0; i < wordBreaks.length - 1; i++) {
+  for (let i = 0; i < wordBreaks.length - 1; i++) {
     if (wordBreaks[i] == wordBreaks[i + 1]) {
       continue;
     }
-    var mutatedWordBreaks = [].concat(wordBreaks);
+    const mutatedWordBreaks = [].concat(wordBreaks);
     mutatedWordBreaks[i] = !mutatedWordBreaks[i];
     mutatedWordBreaks[i + 1] = !mutatedWordBreaks[i + 1];
-    var mutatedScore =
+    const mutatedScore =
         Blockly.utils.string.wrapScore_(words, mutatedWordBreaks, limit);
     if (mutatedScore > bestScore) {
       bestScore = mutatedScore;
@@ -272,8 +272,8 @@ Blockly.utils.string.wrapMutate_ = function(words, wordBreaks, limit) {
  * @private
  */
 Blockly.utils.string.wrapToText_ = function(words, wordBreaks) {
-  var text = [];
-  for (var i = 0; i < words.length; i++) {
+  const text = [];
+  for (let i = 0; i < words.length; i++) {
     text.push(words[i]);
     if (wordBreaks[i] !== undefined) {
       text.push(wordBreaks[i] ? '\n' : ' ');

--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -30,6 +30,7 @@ goog.module.declareLegacyNamespace();
 const startsWith = function(str, prefix) {
   return str.lastIndexOf(prefix, 0) == 0;
 };
+exports.startsWith = startsWith;
 
 /**
  * Given an array of strings, return the length of the shortest one.
@@ -46,6 +47,7 @@ const shortestStringLength = function(array) {
       })
       .length;
 };
+exports.shortestStringLength = shortestStringLength;
 
 /**
  * Given an array of strings, return the length of the common prefix.
@@ -81,6 +83,7 @@ const commonWordPrefix = function(array, opt_shortest) {
   }
   return max;
 };
+exports.commonWordPrefix = commonWordPrefix;
 
 /**
  * Given an array of strings, return the length of the common suffix.
@@ -116,6 +119,7 @@ const commonWordSuffix = function(array, opt_shortest) {
   }
   return max;
 };
+exports.commonWordSuffix = commonWordSuffix;
 
 /**
  * Wrap text to the specified width.
@@ -130,13 +134,13 @@ const wrap = function(text, limit) {
   }
   return lines.join('\n');
 };
+exports.wrap = wrap;
 
 /**
  * Wrap single line of text to the specified width.
  * @param {string} text Text to wrap.
  * @param {number} limit Width to wrap each line.
  * @return {string} Wrapped text.
- * @private
  */
 const wrapLine = function(text, limit) {
   if (text.length <= limit) {
@@ -187,7 +191,6 @@ const wrapLine = function(text, limit) {
  * @param {!Array<boolean>} wordBreaks Array of line breaks.
  * @param {number} limit Width to wrap each line.
  * @return {number} Larger the better.
- * @private
  */
 const wrapScore = function(words, wordBreaks, limit) {
   // If this function becomes a performance liability, add caching.
@@ -240,7 +243,6 @@ const wrapScore = function(words, wordBreaks, limit) {
  * @param {!Array<boolean>} wordBreaks Array of line breaks.
  * @param {number} limit Width to wrap each line.
  * @return {!Array<boolean>} New array of optimal line breaks.
- * @private
  */
 const wrapMutate = function(words, wordBreaks, limit) {
   let bestScore = wrapScore(words, wordBreaks, limit);
@@ -272,7 +274,6 @@ const wrapMutate = function(words, wordBreaks, limit) {
  * @param {!Array<string>} words Array of each word.
  * @param {!Array<boolean>} wordBreaks Array of line breaks.
  * @return {string} Plain text.
- * @private
  */
 const wrapToText = function(words, wordBreaks) {
   const text = [];
@@ -283,12 +284,4 @@ const wrapToText = function(words, wordBreaks) {
     }
   }
   return text.join('');
-};
-
-exports = {
-  startsWith,
-  shortestStringLength,
-  commonWordPrefix,
-  commonWordSuffix,
-  wrap,
 };

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -204,7 +204,7 @@ goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], [],
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], []);
+goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Blockly.utils.Coordinate', 'Blockly.utils.Size'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], []);
 goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], [], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026