### PR TITLE
Migrate core/utils/rect.js to goog.module syntax

### DIFF
--- a/core/utils/rect.js
+++ b/core/utils/rect.js
@@ -16,7 +16,8 @@
  * @name Blockly.utils.Rect
  * @namespace
  */
-goog.provide('Blockly.utils.Rect');
+goog.module('Blockly.utils.Rect');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -28,7 +29,7 @@ goog.provide('Blockly.utils.Rect');
  * @struct
  * @constructor
  */
-Blockly.utils.Rect = function(top, bottom, left, right) {
+const Rect = function(top, bottom, left, right) {
   /** @type {number} */
   this.top = top;
 
@@ -49,7 +50,7 @@ Blockly.utils.Rect = function(top, bottom, left, right) {
  * @param {number} y The y coordinate to test for containment.
  * @return {boolean} Whether this rectangle contains given coordinate.
  */
-Blockly.utils.Rect.prototype.contains = function(x, y) {
+Rect.prototype.contains = function(x, y) {
   return x >= this.left && x <= this.right && y >= this.top && y <= this.bottom;
 };
 
@@ -60,7 +61,9 @@ Blockly.utils.Rect.prototype.contains = function(x, y) {
  *    intersection with.
  * @return {boolean} Whether this rectangle intersects the provided rectangle.
  */
-Blockly.utils.Rect.prototype.intersects = function(other) {
+Rect.prototype.intersects = function(other) {
   return !(this.left > other.right || this.right < other.left ||
       this.top > other.bottom || this.bottom < other.top);
 };
+
+exports = Rect;

--- a/core/utils/rect.js
+++ b/core/utils/rect.js
@@ -62,7 +62,8 @@ Rect.prototype.contains = function(x, y) {
  * @return {boolean} Whether this rectangle intersects the provided rectangle.
  */
 Rect.prototype.intersects = function(other) {
-  return !(this.left > other.right || this.right < other.left ||
+  return !(
+      this.left > other.right || this.right < other.left ||
       this.top > other.bottom || this.bottom < other.top);
 };
 

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -180,7 +180,7 @@ goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], []);
+goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], []);
 goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], []);
 goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Blockly.utils.Coordinate', 'Blockly.utils.Size']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog.module`
- [x] My pull request is against `goog.module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `FILENAME` to `goog.module` syntax. 

### Test Coverage

Ran `npm run start` and `npm run test`

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
