### PR TITLE
Migrate core/utils/svg_paths.js to goog.module syntax

### DIFF
--- a/core/utils/svg_paths.js
+++ b/core/utils/svg_paths.js
@@ -39,9 +39,9 @@ const point = function(x, y) {
  * These coordinates are unitless and hence in the user coordinate system.
  * @param {string} command The command to use.
  *     Should be one of: c, C, s, S, q, Q.
- * @param {!Array<string>} points  An array containing all of the points to pass to the
- *     curve command, in order.  The points are represented as strings of the
- *     format ' x, y '.
+ * @param {!Array<string>} points  An array containing all of the points to pass
+ *     to the curve command, in order.  The points are represented as strings of
+ *     the format ' x, y '.
  * @return {string} A string defining one or more Bezier curves.  See the MDN
  *     documentation for exact format.
  * @public

--- a/core/utils/svg_paths.js
+++ b/core/utils/svg_paths.js
@@ -15,7 +15,8 @@
  * @name Blockly.utils.svgPaths
  * @namespace
  */
-goog.provide('Blockly.utils.svgPaths');
+goog.module('Blockly.utils.svgPaths');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -28,7 +29,7 @@ goog.provide('Blockly.utils.svgPaths');
  * @return {string} A string of the format ' x,y '
  * @public
  */
-Blockly.utils.svgPaths.point = function(x, y) {
+const point = function(x, y) {
   return ' ' + x + ',' + y + ' ';
 };
 
@@ -45,7 +46,7 @@ Blockly.utils.svgPaths.point = function(x, y) {
  *     documentation for exact format.
  * @public
  */
-Blockly.utils.svgPaths.curve = function(command, points) {
+const curve = function(command, points) {
   return ' ' + command + points.join('');
 };
 
@@ -59,7 +60,7 @@ Blockly.utils.svgPaths.curve = function(command, points) {
  * @return {string} A string of the format ' M x,y '
  * @public
  */
-Blockly.utils.svgPaths.moveTo = function(x, y) {
+const moveTo = function(x, y) {
   return ' M ' + x + ',' + y + ' ';
 };
 
@@ -73,7 +74,7 @@ Blockly.utils.svgPaths.moveTo = function(x, y) {
  * @return {string} A string of the format ' m dx,dy '
  * @public
  */
-Blockly.utils.svgPaths.moveBy = function(dx, dy) {
+const moveBy = function(dx, dy) {
   return ' m ' + dx + ',' + dy + ' ';
 };
 
@@ -87,7 +88,7 @@ Blockly.utils.svgPaths.moveBy = function(dx, dy) {
  * @return {string} A string of the format ' l dx,dy '
  * @public
  */
-Blockly.utils.svgPaths.lineTo = function(dx, dy) {
+const lineTo = function(dx, dy) {
   return ' l ' + dx + ',' + dy + ' ';
 };
 
@@ -102,7 +103,7 @@ Blockly.utils.svgPaths.lineTo = function(dx, dy) {
  * @return {string} A string of the format ' l (dx,dy)+ '
  * @public
  */
-Blockly.utils.svgPaths.line = function(points) {
+const line = function(points) {
   return ' l' + points.join('');
 };
 
@@ -119,7 +120,7 @@ Blockly.utils.svgPaths.line = function(points) {
  * @return {string} A string of the format ' command val '
  * @public
  */
-Blockly.utils.svgPaths.lineOnAxis = function(command, val) {
+const lineOnAxis = function(command, val) {
   return ' ' + command + ' ' + val + ' ';
 };
 
@@ -137,6 +138,17 @@ Blockly.utils.svgPaths.lineOnAxis = function(command, val) {
  * @return {string} A string of the format 'command radius radius flags point'
  * @public
  */
-Blockly.utils.svgPaths.arc = function(command, flags, radius, point) {
+const arc = function(command, flags, radius, point) {
   return command + ' ' + radius + ' ' + radius + ' ' + flags + point;
+};
+
+exports = {
+  point,
+  curve,
+  moveTo,
+  moveBy,
+  lineTo,
+  line,
+  lineOnAxis,
+  arc,
 };

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -185,7 +185,7 @@ goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], []);
 goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], []);
 goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Blockly.utils.Coordinate', 'Blockly.utils.Size']);
 goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], []);
-goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], []);
+goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/toolbox.js', ['Blockly.utils.toolbox'], ['Blockly.Xml', 'Blockly.constants']);
 goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global']);
 goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026