### PR TITLE
Migrate core/utils/metrics.js to goog.module syntax

### DIFF
--- a/core/utils/metrics.js
+++ b/core/utils/metrics.js
@@ -14,139 +14,142 @@
  * @name Blockly.utils.Metrics
  * @namespace
  */
-goog.provide('Blockly.utils.Metrics');
+goog.module('Blockly.utils.Metrics');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @record
  */
-Blockly.utils.Metrics = function() {};
+const Metrics = function() {};
 
 /**
  * Height of the visible portion of the workspace.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.viewHeight;
+Metrics.prototype.viewHeight;
 
 /**
  * Width of the visible portion of the workspace.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.viewWidth;
+Metrics.prototype.viewWidth;
 
 /**
  * Height of the content.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.contentHeight;
+Metrics.prototype.contentHeight;
 
 /**
  * Width of the content.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.contentWidth;
+Metrics.prototype.contentWidth;
 
 /**
  * Height of the scroll area.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.scrollHeight;
+Metrics.prototype.scrollHeight;
 
 /**
  * Width of the scroll area.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.scrollWidth;
+Metrics.prototype.scrollWidth;
 
 /**
  * Top-edge of the visible portion of the workspace, relative to the workspace
  * origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.viewTop;
+Metrics.prototype.viewTop;
 
 /**
  * Left-edge of the visible portion of the workspace, relative to the workspace
  * origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.viewLeft;
+Metrics.prototype.viewLeft;
 
 /**
  * Top-edge of the content, relative to the workspace origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.contentTop;
+Metrics.prototype.contentTop;
 
 /**
  * Left-edge of the content relative to the workspace origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.contentLeft;
+Metrics.prototype.contentLeft;
 
 /**
  * Top-edge of the scroll area, relative to the workspace origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.scrollTop;
+Metrics.prototype.scrollTop;
 
 /**
  * Left-edge of the scroll area relative to the workspace origin.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.scrollLeft;
+Metrics.prototype.scrollLeft;
 
 /**
  * Top-edge of the visible portion of the workspace, relative to the blocklyDiv.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.absoluteTop;
+Metrics.prototype.absoluteTop;
 
 /**
  * Left-edge of the visible portion of the workspace, relative to the
  * blocklyDiv.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.absoluteLeft;
+Metrics.prototype.absoluteLeft;
 
 /**
  * Height of the Blockly div (the view + the toolbox, simple of otherwise).
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.svgHeight;
+Metrics.prototype.svgHeight;
 
 /**
  * Width of the Blockly div (the view + the toolbox, simple or otherwise).
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.svgWidth;
+Metrics.prototype.svgWidth;
 
 /**
  * Width of the toolbox, if it exists.  Otherwise zero.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.toolboxWidth;
+Metrics.prototype.toolboxWidth;
 
 /**
  * Height of the toolbox, if it exists.  Otherwise zero.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.toolboxHeight;
+Metrics.prototype.toolboxHeight;
 
 /**
  * Top, bottom, left or right. Use TOOLBOX_AT constants to compare.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.toolboxPosition;
+Metrics.prototype.toolboxPosition;
 
 /**
  * Width of the flyout if it is always open.  Otherwise zero.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.flyoutWidth;
+Metrics.prototype.flyoutWidth;
 
 /**
  * Height of the flyout if it is always open.  Otherwise zero.
  * @type {number}
  */
-Blockly.utils.Metrics.prototype.flyoutHeight;
+Metrics.prototype.flyoutHeight;
+
+exports = Metrics;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -178,7 +178,7 @@ goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], []);
+goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], []);
 goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog.module`
- [x] My pull request is against `goog.module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggeseted in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/metrics.js` to `goog.module` syntax. 

### Additional Information

No changes after running clang-format