### PR TITLE
Migrate core/css.js to goog.module syntax

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -77,7 +77,7 @@ const inject = function(hasCss, pathToMedia) {
  * Array making up the CSS content for Blockly.
  */
 const CONTENT = [
-`.blocklySvg {
+  `.blocklySvg {
   background-color: #fff;
   outline: none;
   overflow: hidden;  /* IE overflows by default. */
@@ -85,26 +85,26 @@ const CONTENT = [
   display: block;
 }`,
 
-`.blocklyWidgetDiv {
+  `.blocklyWidgetDiv {
   display: none;
   position: absolute;
   z-index: 99999;  /* big value for bootstrap3 compatibility */
 }`,
 
-`.injectionDiv {
+  `.injectionDiv {
   height: 100%;
   position: relative;
   overflow: hidden;  /* So blocks in drag surface disappear at edges */
   touch-action: none;
 }`,
 
-`.blocklyNonSelectable {
+  `.blocklyNonSelectable {
   user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
 }`,
 
-`.blocklyWsDragSurface {
+  `.blocklyWsDragSurface {
   display: none;
   position: absolute;
   top: 0;
@@ -114,11 +114,11 @@ const CONTENT = [
   /* Added as a separate rule with multiple classes to make it more specific
      than a bootstrap rule that selects svg:root. See issue #1275 for context.
   */
-`.blocklyWsDragSurface.blocklyOverflowVisible {
+  `.blocklyWsDragSurface.blocklyOverflowVisible {
   overflow: visible;
 }`,
 
-`.blocklyBlockDragSurface {
+  `.blocklyBlockDragSurface {
   display: none;
   position: absolute;
   top: 0;
@@ -129,12 +129,12 @@ const CONTENT = [
   z-index: 50;',  /* Display below toolbox, but above everything else. */
 }`,
 
-`.blocklyBlockCanvas.blocklyCanvasTransitioning,
+  `.blocklyBlockCanvas.blocklyCanvasTransitioning,
 .blocklyBubbleCanvas.blocklyCanvasTransitioning {
   transition: transform .5s;
 }`,
 
-`.blocklyTooltipDiv {
+  `.blocklyTooltipDiv {
   background-color: #ffffc7;
   border: 1px solid #ddc;
   box-shadow: 4px 4px 20px 1px rgba(0,0,0,.15);
@@ -147,7 +147,7 @@ const CONTENT = [
   z-index: 100000;',  /* big value for bootstrap3 compatibility */
 }`,
 
-`.blocklyDropDownDiv {
+  `.blocklyDropDownDiv {
   position: absolute;
   left: 0;
   top: 0;
@@ -161,18 +161,18 @@ const CONTENT = [
   box-shadow: 0 0 3px 1px rgba(0,0,0,.3);
 }`,
 
-`.blocklyDropDownDiv.blocklyFocused {
+  `.blocklyDropDownDiv.blocklyFocused {
   box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
 }`,
 
-`.blocklyDropDownContent {
+  `.blocklyDropDownContent {
   max-height: 300px;',  // @todo: spec for maximum height.
   overflow: auto;
   overflow-x: hidden;
   position: relative;
 }`,
 
-`.blocklyDropDownArrow {
+  `.blocklyDropDownArrow {
   position: absolute;
   left: 0;
   top: 0;
@@ -183,7 +183,7 @@ const CONTENT = [
   border-color: inherit;
 }`,
 
-`.blocklyDropDownButton {
+  `.blocklyDropDownButton {
   display: inline-block;
   float: left;
   padding: 0;
@@ -195,52 +195,52 @@ const CONTENT = [
   cursor: pointer;
 }`,
 
-`.blocklyArrowTop {
+  `.blocklyArrowTop {
   border-top: 1px solid;
   border-left: 1px solid;
   border-top-left-radius: 4px;
   border-color: inherit;
 }`,
 
-`.blocklyArrowBottom {
+  `.blocklyArrowBottom {
   border-bottom: 1px solid;
   border-right: 1px solid;
   border-bottom-right-radius: 4px;
   border-color: inherit;
 }`,
 
-`.blocklyResizeSE {
+  `.blocklyResizeSE {
   cursor: se-resize;
   fill: #aaa;
 }`,
 
-`.blocklyResizeSW {
+  `.blocklyResizeSW {
   cursor: sw-resize;
   fill: #aaa;
 }`,
 
-`.blocklyResizeLine {
+  `.blocklyResizeLine {
   stroke: #515A5A;
   stroke-width: 1;
 }`,
 
-`.blocklyHighlightedConnectionPath {
+  `.blocklyHighlightedConnectionPath {
   fill: none;
   stroke: #fc3;
   stroke-width: 4px;
 }`,
 
-`.blocklyPathLight {
+  `.blocklyPathLight {
   fill: none;
   stroke-linecap: round;
   stroke-width: 1;
 }`,
 
-`.blocklySelected>.blocklyPathLight {
+  `.blocklySelected>.blocklyPathLight {
   display: none;
 }`,
 
-`.blocklyDraggable {
+  `.blocklyDraggable {
   /* backup for browsers (e.g. IE11) that don't support grab */
   cursor: url("<<<PATH>>>/handopen.cur"), auto;
   cursor: grab;
@@ -248,7 +248,7 @@ const CONTENT = [
 }`,
 
   /* backup for browsers (e.g. IE11) that don't support grabbing */
-`.blocklyDragging {
+  `.blocklyDragging {
   /* backup for browsers (e.g. IE11) that don't support grabbing */
   cursor: url("<<<PATH>>>/handclosed.cur"), auto;
   cursor: grabbing;
@@ -257,7 +257,7 @@ const CONTENT = [
 
   /* Changes cursor on mouse down. Not effective in Firefox because of
      https://bugzilla.mozilla.org/show_bug.cgi?id=771241 */
-`.blocklyDraggable:active {
+  `.blocklyDraggable:active {
   /* backup for browsers (e.g. IE11) that don't support grabbing */
   cursor: url("<<<PATH>>>/handclosed.cur"), auto;
   cursor: grabbing;
@@ -267,58 +267,58 @@ const CONTENT = [
   /* Change the cursor on the whole drag surface in case the mouse gets
      ahead of block during a drag. This way the cursor is still a closed hand.
    */
-`.blocklyBlockDragSurface .blocklyDraggable {
+  `.blocklyBlockDragSurface .blocklyDraggable {
   /* backup for browsers (e.g. IE11) that don't support grabbing */
   cursor: url("<<<PATH>>>/handclosed.cur"), auto;
   cursor: grabbing;
   cursor: -webkit-grabbing;
 }`,
 
-`.blocklyDragging.blocklyDraggingDelete {
+  `.blocklyDragging.blocklyDraggingDelete {
   cursor: url("<<<PATH>>>/handdelete.cur"), auto;
 }`,
 
-`.blocklyDragging>.blocklyPath,
+  `.blocklyDragging>.blocklyPath,
 .blocklyDragging>.blocklyPathLight {
   fill-opacity: .8;
   stroke-opacity: .8;
 }`,
 
-`.blocklyDragging>.blocklyPathDark {
+  `.blocklyDragging>.blocklyPathDark {
   display: none;
 }`,
 
-`.blocklyDisabled>.blocklyPath {
+  `.blocklyDisabled>.blocklyPath {
   fill-opacity: .5;
   stroke-opacity: .5;
 }`,
 
-`.blocklyDisabled>.blocklyPathLight,
+  `.blocklyDisabled>.blocklyPathLight,
 .blocklyDisabled>.blocklyPathDark {
   display: none;
 }`,
 
-`.blocklyInsertionMarker>.blocklyPath,
+  `.blocklyInsertionMarker>.blocklyPath,
 .blocklyInsertionMarker>.blocklyPathLight,
 .blocklyInsertionMarker>.blocklyPathDark {
   fill-opacity: .2;
   stroke: none;
 }`,
 
-`.blocklyMultilineText {
+  `.blocklyMultilineText {
   font-family: monospace;
 }`,
 
-`.blocklyNonEditableText>text {
+  `.blocklyNonEditableText>text {
   pointer-events: none;
 }`,
 
-`.blocklyFlyout {
+  `.blocklyFlyout {
   position: absolute;
   z-index: 20;
 }`,
 
-`.blocklyText text {
+  `.blocklyText text {
   cursor: default;
 }`,
 
@@ -326,7 +326,7 @@ const CONTENT = [
     Don't allow users to select text.  It gets annoying when trying to
     drag a block and selected text moves instead.
   */
-`.blocklySvg text,
+  `.blocklySvg text,
 .blocklyBlockDragSurface text {
   user-select: none;
   -ms-user-select: none;
@@ -334,39 +334,39 @@ const CONTENT = [
   cursor: inherit;
 }`,
 
-`.blocklyHidden {
+  `.blocklyHidden {
   display: none;
 }`,
 
-`.blocklyFieldDropdown:not(.blocklyHidden) {
+  `.blocklyFieldDropdown:not(.blocklyHidden) {
   display: block;
 }`,
 
-`.blocklyIconGroup {
+  `.blocklyIconGroup {
   cursor: default;
 }`,
 
-`.blocklyIconGroup:not(:hover),
+  `.blocklyIconGroup:not(:hover),
 .blocklyIconGroupReadonly {
   opacity: .6;
 }`,
 
-`.blocklyIconShape {
+  `.blocklyIconShape {
   fill: #00f;
   stroke: #fff;
   stroke-width: 1px;
 }`,
 
-`.blocklyIconSymbol {
+  `.blocklyIconSymbol {
   fill: #fff;
 }`,
 
-`.blocklyMinimalBody {
+  `.blocklyMinimalBody {
   margin: 0;
   padding: 0;
 }`,
 
-`.blocklyHtmlInput {
+  `.blocklyHtmlInput {
   border: none;
   border-radius: 4px;
   height: 100%;
@@ -382,107 +382,107 @@ const CONTENT = [
   /* Edge and IE introduce a close icon when the input value is longer than a
      certain length. This affects our sizing calculations of the text input.
      Hiding the close icon to avoid that. */
-`.blocklyHtmlInput::-ms-clear {
+  `.blocklyHtmlInput::-ms-clear {
   display: none;
 }`,
 
-`.blocklyMainBackground {
+  `.blocklyMainBackground {
   stroke-width: 1;
   stroke: #c6c6c6;',  /* Equates to #ddd due to border being off-pixel. */
 }`,
 
-`.blocklyMutatorBackground {
+  `.blocklyMutatorBackground {
   fill: #fff;
   stroke: #ddd;
   stroke-width: 1;
 }`,
 
-`.blocklyFlyoutBackground {
+  `.blocklyFlyoutBackground {
   fill: #ddd;
   fill-opacity: .8;
 }`,
 
-`.blocklyMainWorkspaceScrollbar {
+  `.blocklyMainWorkspaceScrollbar {
   z-index: 20;
 }`,
 
-`.blocklyFlyoutScrollbar {
+  `.blocklyFlyoutScrollbar {
   z-index: 30;
 }`,
 
-`.blocklyScrollbarHorizontal,
+  `.blocklyScrollbarHorizontal,
 .blocklyScrollbarVertical {
   position: absolute;
   outline: none;
 }`,
 
-`.blocklyScrollbarBackground {
+  `.blocklyScrollbarBackground {
   opacity: 0;
 }`,
 
-`.blocklyScrollbarHandle {
+  `.blocklyScrollbarHandle {
   fill: #ccc;
 }`,
 
-`.blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
+  `.blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
 .blocklyScrollbarHandle:hover {
   fill: #bbb;
 }`,
 
   /* Darken flyout scrollbars due to being on a grey background. */
   /* By contrast, workspace scrollbars are on a white background. */
-`.blocklyFlyout .blocklyScrollbarHandle {
+  `.blocklyFlyout .blocklyScrollbarHandle {
   fill: #bbb;
 }`,
 
-`.blocklyFlyout .blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
+  `.blocklyFlyout .blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
 .blocklyFlyout .blocklyScrollbarHandle:hover {
   fill: #aaa;
 }`,
 
-`.blocklyInvalidInput {
+  `.blocklyInvalidInput {
   background: #faa;
 }`,
 
-`.blocklyVerticalMarker {
+  `.blocklyVerticalMarker {
   stroke-width: 3px;
   fill: rgba(255,255,255,.5);
   pointer-events: none;
 }`,
 
-`.blocklyComputeCanvas {
+  `.blocklyComputeCanvas {
   position: absolute;
   width: 0;
   height: 0;
 }`,
 
-`.blocklyNoPointerEvents {
+  `.blocklyNoPointerEvents {
   pointer-events: none;
 }`,
 
-`.blocklyContextMenu {
+  `.blocklyContextMenu {
   border-radius: 4px;
   max-height: 100%;
 }`,
 
-`.blocklyDropdownMenu {
+  `.blocklyDropdownMenu {
   border-radius: 2px;
   padding: 0 !important;
 }`,
 
-`.blocklyDropdownMenu .blocklyMenuItem {
+  `.blocklyDropdownMenu .blocklyMenuItem {
   /* 28px on the left for icon or checkbox. */
   padding-left: 28px;
 }`,
 
   /* BiDi override for the resting state. */
-`.blocklyDropdownMenu .blocklyMenuItemRtl {
+  `.blocklyDropdownMenu .blocklyMenuItemRtl {
   /* Flip left/right padding for BiDi. */
   padding-left: 5px;
   padding-right: 28px;
 }`,
 
-`.blocklyWidgetDiv .blocklyMenu {
+  `.blocklyWidgetDiv .blocklyMenu {
   background: #fff;
   border: 1px solid transparent;
   box-shadow: 0 0 3px 1px rgba(0,0,0,.3);
@@ -497,11 +497,11 @@ const CONTENT = [
   z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
 }`,
 
-`.blocklyWidgetDiv .blocklyMenu.blocklyFocused {
+  `.blocklyWidgetDiv .blocklyMenu.blocklyFocused {
   box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
 }`,
 
-`.blocklyDropDownDiv .blocklyMenu {
+  `.blocklyDropDownDiv .blocklyMenu {
   background: inherit;',  /* Compatibility with gapi, reset from goog-menu */
   border: inherit;',  /* Compatibility with gapi, reset from goog-menu */
   font: normal 13px "Helvetica Neue", Helvetica, sans-serif;
@@ -511,7 +511,7 @@ const CONTENT = [
 }`,
 
   /* State: resting. */
-`.blocklyMenuItem {
+  `.blocklyMenuItem {
   border: none;
   color: #000;
   cursor: pointer;
@@ -524,34 +524,38 @@ const CONTENT = [
 }`,
 
   /* State: disabled. */
-`.blocklyMenuItemDisabled {
+  `.blocklyMenuItemDisabled {
   color: #ccc;
   cursor: inherit;
 }`,
 
   /* State: hover. */
-`.blocklyMenuItemHighlight {
+  `.blocklyMenuItemHighlight {
   background-color: rgba(0,0,0,.1);
 }`,
 
   /* State: selected/checked. */
-`.blocklyMenuItemCheckbox {
+  `.blocklyMenuItemCheckbox {
   height: 16px;
   position: absolute;
   width: 16px;
 }`,
 
-`.blocklyMenuItemSelected .blocklyMenuItemCheckbox {
+  `.blocklyMenuItemSelected .blocklyMenuItemCheckbox {
   background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;
   float: left;
   margin-left: -24px;
   position: static;',  /* Scroll with the menu. */
 }`,
 
-`.blocklyMenuItemRtl .blocklyMenuItemCheckbox {
+  `.blocklyMenuItemRtl .blocklyMenuItemCheckbox {
   float: right;
   margin-right: -24px;
 }`,
 ];
 
-exports = {register, inject, CONTENT};
+exports = {
+  register,
+  inject,
+  CONTENT
+};

--- a/core/css.js
+++ b/core/css.js
@@ -14,7 +14,8 @@
  * @name Blockly.Css
  * @namespace
  */
-goog.provide('Blockly.Css');
+goog.module('Blockly.Css');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -22,7 +23,7 @@ goog.provide('Blockly.Css');
  * @type {boolean}
  * @private
  */
-Blockly.Css.injected_ = false;
+let injected = false;
 
 /**
  * Add some CSS to the blob that will be injected later.  Allows optional
@@ -30,12 +31,12 @@ Blockly.Css.injected_ = false;
  * The provided array of CSS will be destroyed by this function.
  * @param {!Array<string>} cssArray Array of CSS strings.
  */
-Blockly.Css.register = function(cssArray) {
-  if (Blockly.Css.injected_) {
+const register = function(cssArray) {
+  if (injected) {
     throw Error('CSS already injected');
   }
-  // Concatenate cssArray onto Blockly.Css.CONTENT.
-  Array.prototype.push.apply(Blockly.Css.CONTENT, cssArray);
+  // Concatenate cssArray onto CONTENT.
+  Array.prototype.push.apply(CONTENT, cssArray);
   cssArray.length = 0;  // Garbage collect provided CSS content.
 };
 
@@ -49,14 +50,14 @@ Blockly.Css.register = function(cssArray) {
  *     (providing CSS becomes the document's responsibility).
  * @param {string} pathToMedia Path from page to the Blockly media directory.
  */
-Blockly.Css.inject = function(hasCss, pathToMedia) {
+const inject = function(hasCss, pathToMedia) {
   // Only inject the CSS once.
-  if (Blockly.Css.injected_) {
+  if (injected) {
     return;
   }
-  Blockly.Css.injected_ = true;
-  let text = Blockly.Css.CONTENT.join('\n');
-  Blockly.Css.CONTENT.length = 0;  // Garbage collect CSS content.
+  injected = true;
+  let text = CONTENT.join('\n');
+  CONTENT.length = 0;  // Garbage collect CSS content.
   if (!hasCss) {
     return;
   }
@@ -75,7 +76,7 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
 /**
  * Array making up the CSS content for Blockly.
  */
-Blockly.Css.CONTENT = [
+const CONTENT = [
 `.blocklySvg {
   background-color: #fff;
   outline: none;
@@ -552,3 +553,5 @@ Blockly.Css.CONTENT = [
   margin-right: -24px;
 }`,
 ];
+
+exports = {register, inject, CONTENT};

--- a/core/css.js
+++ b/core/css.js
@@ -76,477 +76,479 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
  * Array making up the CSS content for Blockly.
  */
 Blockly.Css.CONTENT = [
-  /* eslint-disable indent */
-  '.blocklySvg {',
-    'background-color: #fff;',
-    'outline: none;',
-    'overflow: hidden;',  /* IE overflows by default. */
-    'position: absolute;',
-    'display: block;',
-  '}',
+`.blocklySvg {
+  background-color: #fff;
+  outline: none;
+  overflow: hidden;  /* IE overflows by default. */
+  position: absolute;
+  display: block;
+}`,
 
-  '.blocklyWidgetDiv {',
-    'display: none;',
-    'position: absolute;',
-    'z-index: 99999;',  /* big value for bootstrap3 compatibility */
-  '}',
+`.blocklyWidgetDiv {
+  display: none;
+  position: absolute;
+  z-index: 99999;  /* big value for bootstrap3 compatibility */
+}`,
 
-  '.injectionDiv {',
-    'height: 100%;',
-    'position: relative;',
-    'overflow: hidden;',  /* So blocks in drag surface disappear at edges */
-    'touch-action: none;',
-  '}',
+`.injectionDiv {
+  height: 100%;
+  position: relative;
+  overflow: hidden;  /* So blocks in drag surface disappear at edges */
+  touch-action: none;
+}`,
 
-  '.blocklyNonSelectable {',
-    'user-select: none;',
-    '-ms-user-select: none;',
-    '-webkit-user-select: none;',
-  '}',
+`.blocklyNonSelectable {
+  user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+}`,
 
-  '.blocklyWsDragSurface {',
-    'display: none;',
-    'position: absolute;',
-    'top: 0;',
-    'left: 0;',
-  '}',
+`.blocklyWsDragSurface {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}`,
+
   /* Added as a separate rule with multiple classes to make it more specific
      than a bootstrap rule that selects svg:root. See issue #1275 for context.
   */
-  '.blocklyWsDragSurface.blocklyOverflowVisible {',
-    'overflow: visible;',
-  '}',
+`.blocklyWsDragSurface.blocklyOverflowVisible {
+  overflow: visible;
+}`,
 
-  '.blocklyBlockDragSurface {',
-    'display: none;',
-    'position: absolute;',
-    'top: 0;',
-    'left: 0;',
-    'right: 0;',
-    'bottom: 0;',
-    'overflow: visible !important;',
-    'z-index: 50;',  /* Display below toolbox, but above everything else. */
-  '}',
+`.blocklyBlockDragSurface {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: visible !important;
+  z-index: 50;',  /* Display below toolbox, but above everything else. */
+}`,
 
-  '.blocklyBlockCanvas.blocklyCanvasTransitioning,',
-  '.blocklyBubbleCanvas.blocklyCanvasTransitioning {',
-    'transition: transform .5s;',
-  '}',
+`.blocklyBlockCanvas.blocklyCanvasTransitioning,
+.blocklyBubbleCanvas.blocklyCanvasTransitioning {
+  transition: transform .5s;
+}`,
 
-  '.blocklyTooltipDiv {',
-    'background-color: #ffffc7;',
-    'border: 1px solid #ddc;',
-    'box-shadow: 4px 4px 20px 1px rgba(0,0,0,.15);',
-    'color: #000;',
-    'display: none;',
-    'font: 9pt sans-serif;',
-    'opacity: .9;',
-    'padding: 2px;',
-    'position: absolute;',
-    'z-index: 100000;',  /* big value for bootstrap3 compatibility */
-  '}',
+`.blocklyTooltipDiv {
+  background-color: #ffffc7;
+  border: 1px solid #ddc;
+  box-shadow: 4px 4px 20px 1px rgba(0,0,0,.15);
+  color: #000;
+  display: none;
+  font: 9pt sans-serif;
+  opacity: .9;
+  padding: 2px;
+  position: absolute;
+  z-index: 100000;',  /* big value for bootstrap3 compatibility */
+}`,
 
-  '.blocklyDropDownDiv {',
-    'position: absolute;',
-    'left: 0;',
-    'top: 0;',
-    'z-index: 1000;',
-    'display: none;',
-    'border: 1px solid;',
-    'border-color: #dadce0;',
-    'background-color: #fff;',
-    'border-radius: 2px;',
-    'padding: 4px;',
-    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
-  '}',
+`.blocklyDropDownDiv {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  display: none;
+  border: 1px solid;
+  border-color: #dadce0;
+  background-color: #fff;
+  border-radius: 2px;
+  padding: 4px;
+  box-shadow: 0 0 3px 1px rgba(0,0,0,.3);
+}`,
 
-  '.blocklyDropDownDiv.blocklyFocused {',
-    'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
-  '}',
+`.blocklyDropDownDiv.blocklyFocused {
+  box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
+}`,
 
-  '.blocklyDropDownContent {',
-    'max-height: 300px;',  // @todo: spec for maximum height.
-    'overflow: auto;',
-    'overflow-x: hidden;',
-    'position: relative;',
-  '}',
+`.blocklyDropDownContent {
+  max-height: 300px;',  // @todo: spec for maximum height.
+  overflow: auto;
+  overflow-x: hidden;
+  position: relative;
+}`,
 
-  '.blocklyDropDownArrow {',
-    'position: absolute;',
-    'left: 0;',
-    'top: 0;',
-    'width: 16px;',
-    'height: 16px;',
-    'z-index: -1;',
-    'background-color: inherit;',
-    'border-color: inherit;',
-  '}',
+`.blocklyDropDownArrow {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  z-index: -1;
+  background-color: inherit;
+  border-color: inherit;
+}`,
 
-  '.blocklyDropDownButton {',
-    'display: inline-block;',
-    'float: left;',
-    'padding: 0;',
-    'margin: 4px;',
-    'border-radius: 4px;',
-    'outline: none;',
-    'border: 1px solid;',
-    'transition: box-shadow .1s;',
-    'cursor: pointer;',
-  '}',
+`.blocklyDropDownButton {
+  display: inline-block;
+  float: left;
+  padding: 0;
+  margin: 4px;
+  border-radius: 4px;
+  outline: none;
+  border: 1px solid;
+  transition: box-shadow .1s;
+  cursor: pointer;
+}`,
 
-  '.blocklyArrowTop {',
-    'border-top: 1px solid;',
-    'border-left: 1px solid;',
-    'border-top-left-radius: 4px;',
-    'border-color: inherit;',
-  '}',
+`.blocklyArrowTop {
+  border-top: 1px solid;
+  border-left: 1px solid;
+  border-top-left-radius: 4px;
+  border-color: inherit;
+}`,
 
-  '.blocklyArrowBottom {',
-    'border-bottom: 1px solid;',
-    'border-right: 1px solid;',
-    'border-bottom-right-radius: 4px;',
-    'border-color: inherit;',
-  '}',
+`.blocklyArrowBottom {
+  border-bottom: 1px solid;
+  border-right: 1px solid;
+  border-bottom-right-radius: 4px;
+  border-color: inherit;
+}`,
 
-  '.blocklyResizeSE {',
-    'cursor: se-resize;',
-    'fill: #aaa;',
-  '}',
+`.blocklyResizeSE {
+  cursor: se-resize;
+  fill: #aaa;
+}`,
 
-  '.blocklyResizeSW {',
-    'cursor: sw-resize;',
-    'fill: #aaa;',
-  '}',
+`.blocklyResizeSW {
+  cursor: sw-resize;
+  fill: #aaa;
+}`,
 
-  '.blocklyResizeLine {',
-    'stroke: #515A5A;',
-    'stroke-width: 1;',
-  '}',
+`.blocklyResizeLine {
+  stroke: #515A5A;
+  stroke-width: 1;
+}`,
 
-  '.blocklyHighlightedConnectionPath {',
-    'fill: none;',
-    'stroke: #fc3;',
-    'stroke-width: 4px;',
-  '}',
+`.blocklyHighlightedConnectionPath {
+  fill: none;
+  stroke: #fc3;
+  stroke-width: 4px;
+}`,
 
-  '.blocklyPathLight {',
-    'fill: none;',
-    'stroke-linecap: round;',
-    'stroke-width: 1;',
-  '}',
+`.blocklyPathLight {
+  fill: none;
+  stroke-linecap: round;
+  stroke-width: 1;
+}`,
 
-  '.blocklySelected>.blocklyPathLight {',
-    'display: none;',
-  '}',
+`.blocklySelected>.blocklyPathLight {
+  display: none;
+}`,
 
-  '.blocklyDraggable {',
-    /* backup for browsers (e.g. IE11) that don't support grab */
-    'cursor: url("<<<PATH>>>/handopen.cur"), auto;',
-    'cursor: grab;',
-    'cursor: -webkit-grab;',
-  '}',
+`.blocklyDraggable {
+  /* backup for browsers (e.g. IE11) that don't support grab */
+  cursor: url("<<<PATH>>>/handopen.cur"), auto;
+  cursor: grab;
+  cursor: -webkit-grab;
+}`,
 
-  '.blocklyDragging {',
-    /* backup for browsers (e.g. IE11) that don't support grabbing */
-    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
-    'cursor: grabbing;',
-    'cursor: -webkit-grabbing;',
-  '}',
+  /* backup for browsers (e.g. IE11) that don't support grabbing */
+`.blocklyDragging {
+  /* backup for browsers (e.g. IE11) that don't support grabbing */
+  cursor: url("<<<PATH>>>/handclosed.cur"), auto;
+  cursor: grabbing;
+  cursor: -webkit-grabbing;
+}`,
+
   /* Changes cursor on mouse down. Not effective in Firefox because of
-    https://bugzilla.mozilla.org/show_bug.cgi?id=771241 */
-  '.blocklyDraggable:active {',
-    /* backup for browsers (e.g. IE11) that don't support grabbing */
-    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
-    'cursor: grabbing;',
-    'cursor: -webkit-grabbing;',
-  '}',
+     https://bugzilla.mozilla.org/show_bug.cgi?id=771241 */
+`.blocklyDraggable:active {
+  /* backup for browsers (e.g. IE11) that don't support grabbing */
+  cursor: url("<<<PATH>>>/handclosed.cur"), auto;
+  cursor: grabbing;
+  cursor: -webkit-grabbing;
+}`,
+
   /* Change the cursor on the whole drag surface in case the mouse gets
      ahead of block during a drag. This way the cursor is still a closed hand.
    */
-  '.blocklyBlockDragSurface .blocklyDraggable {',
-    /* backup for browsers (e.g. IE11) that don't support grabbing */
-    'cursor: url("<<<PATH>>>/handclosed.cur"), auto;',
-    'cursor: grabbing;',
-    'cursor: -webkit-grabbing;',
-  '}',
+`.blocklyBlockDragSurface .blocklyDraggable {
+  /* backup for browsers (e.g. IE11) that don't support grabbing */
+  cursor: url("<<<PATH>>>/handclosed.cur"), auto;
+  cursor: grabbing;
+  cursor: -webkit-grabbing;
+}`,
 
-  '.blocklyDragging.blocklyDraggingDelete {',
-    'cursor: url("<<<PATH>>>/handdelete.cur"), auto;',
-  '}',
+`.blocklyDragging.blocklyDraggingDelete {
+  cursor: url("<<<PATH>>>/handdelete.cur"), auto;
+}`,
 
-  '.blocklyDragging>.blocklyPath,',
-  '.blocklyDragging>.blocklyPathLight {',
-    'fill-opacity: .8;',
-    'stroke-opacity: .8;',
-  '}',
+`.blocklyDragging>.blocklyPath,
+.blocklyDragging>.blocklyPathLight {
+  fill-opacity: .8;
+  stroke-opacity: .8;
+}`,
 
-  '.blocklyDragging>.blocklyPathDark {',
-    'display: none;',
-  '}',
+`.blocklyDragging>.blocklyPathDark {
+  display: none;
+}`,
 
-  '.blocklyDisabled>.blocklyPath {',
-    'fill-opacity: .5;',
-    'stroke-opacity: .5;',
-  '}',
+`.blocklyDisabled>.blocklyPath {
+  fill-opacity: .5;
+  stroke-opacity: .5;
+}`,
 
-  '.blocklyDisabled>.blocklyPathLight,',
-  '.blocklyDisabled>.blocklyPathDark {',
-    'display: none;',
-  '}',
+`.blocklyDisabled>.blocklyPathLight,
+.blocklyDisabled>.blocklyPathDark {
+  display: none;
+}`,
 
-  '.blocklyInsertionMarker>.blocklyPath,',
-  '.blocklyInsertionMarker>.blocklyPathLight,',
-  '.blocklyInsertionMarker>.blocklyPathDark {',
-    'fill-opacity: .2;',
-    'stroke: none;',
-  '}',
+`.blocklyInsertionMarker>.blocklyPath,
+.blocklyInsertionMarker>.blocklyPathLight,
+.blocklyInsertionMarker>.blocklyPathDark {
+  fill-opacity: .2;
+  stroke: none;
+}`,
 
-  '.blocklyMultilineText {',
-    'font-family: monospace;',
-  '}',
+`.blocklyMultilineText {
+  font-family: monospace;
+}`,
 
-  '.blocklyNonEditableText>text {',
-    'pointer-events: none;',
-  '}',
+`.blocklyNonEditableText>text {
+  pointer-events: none;
+}`,
 
-  '.blocklyFlyout {',
-    'position: absolute;',
-    'z-index: 20;',
-  '}',
+`.blocklyFlyout {
+  position: absolute;
+  z-index: 20;
+}`,
 
-  '.blocklyText text {',
-    'cursor: default;',
-  '}',
+`.blocklyText text {
+  cursor: default;
+}`,
 
   /*
     Don't allow users to select text.  It gets annoying when trying to
     drag a block and selected text moves instead.
   */
-  '.blocklySvg text,',
-  '.blocklyBlockDragSurface text {',
-    'user-select: none;',
-    '-ms-user-select: none;',
-    '-webkit-user-select: none;',
-    'cursor: inherit;',
-  '}',
+`.blocklySvg text,
+.blocklyBlockDragSurface text {
+  user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  cursor: inherit;
+}`,
 
-  '.blocklyHidden {',
-    'display: none;',
-  '}',
+`.blocklyHidden {
+  display: none;
+}`,
 
-  '.blocklyFieldDropdown:not(.blocklyHidden) {',
-    'display: block;',
-  '}',
+`.blocklyFieldDropdown:not(.blocklyHidden) {
+  display: block;
+}`,
 
-  '.blocklyIconGroup {',
-    'cursor: default;',
-  '}',
+`.blocklyIconGroup {
+  cursor: default;
+}`,
 
-  '.blocklyIconGroup:not(:hover),',
-  '.blocklyIconGroupReadonly {',
-    'opacity: .6;',
-  '}',
+`.blocklyIconGroup:not(:hover),
+.blocklyIconGroupReadonly {
+  opacity: .6;
+}`,
 
-  '.blocklyIconShape {',
-    'fill: #00f;',
-    'stroke: #fff;',
-    'stroke-width: 1px;',
-  '}',
+`.blocklyIconShape {
+  fill: #00f;
+  stroke: #fff;
+  stroke-width: 1px;
+}`,
 
-  '.blocklyIconSymbol {',
-    'fill: #fff;',
-  '}',
+`.blocklyIconSymbol {
+  fill: #fff;
+}`,
 
-  '.blocklyMinimalBody {',
-    'margin: 0;',
-    'padding: 0;',
-  '}',
+`.blocklyMinimalBody {
+  margin: 0;
+  padding: 0;
+}`,
 
-  '.blocklyHtmlInput {',
-    'border: none;',
-    'border-radius: 4px;',
-    'height: 100%;',
-    'margin: 0;',
-    'outline: none;',
-    'padding: 0;',
-    'width: 100%;',
-    'text-align: center;',
-    'display: block;',
-    'box-sizing: border-box;',
-  '}',
+`.blocklyHtmlInput {
+  border: none;
+  border-radius: 4px;
+  height: 100%;
+  margin: 0;
+  outline: none;
+  padding: 0;
+  width: 100%;
+  text-align: center;
+  display: block;
+  box-sizing: border-box;
+}`,
 
   /* Edge and IE introduce a close icon when the input value is longer than a
      certain length. This affects our sizing calculations of the text input.
      Hiding the close icon to avoid that. */
-  '.blocklyHtmlInput::-ms-clear {',
-    'display: none;',
-  '}',
+`.blocklyHtmlInput::-ms-clear {
+  display: none;
+}`,
 
-  '.blocklyMainBackground {',
-    'stroke-width: 1;',
-    'stroke: #c6c6c6;',  /* Equates to #ddd due to border being off-pixel. */
-  '}',
+`.blocklyMainBackground {
+  stroke-width: 1;
+  stroke: #c6c6c6;',  /* Equates to #ddd due to border being off-pixel. */
+}`,
 
-  '.blocklyMutatorBackground {',
-    'fill: #fff;',
-    'stroke: #ddd;',
-    'stroke-width: 1;',
-  '}',
+`.blocklyMutatorBackground {
+  fill: #fff;
+  stroke: #ddd;
+  stroke-width: 1;
+}`,
 
-  '.blocklyFlyoutBackground {',
-    'fill: #ddd;',
-    'fill-opacity: .8;',
-  '}',
+`.blocklyFlyoutBackground {
+  fill: #ddd;
+  fill-opacity: .8;
+}`,
 
-  '.blocklyMainWorkspaceScrollbar {',
-    'z-index: 20;',
-  '}',
+`.blocklyMainWorkspaceScrollbar {
+  z-index: 20;
+}`,
 
-  '.blocklyFlyoutScrollbar {',
-    'z-index: 30;',
-  '}',
+`.blocklyFlyoutScrollbar {
+  z-index: 30;
+}`,
 
-  '.blocklyScrollbarHorizontal,',
-  '.blocklyScrollbarVertical {',
-    'position: absolute;',
-    'outline: none;',
-  '}',
+`.blocklyScrollbarHorizontal,
+.blocklyScrollbarVertical {
+  position: absolute;
+  outline: none;
+}`,
 
-  '.blocklyScrollbarBackground {',
-    'opacity: 0;',
-  '}',
+`.blocklyScrollbarBackground {
+  opacity: 0;
+}`,
 
-  '.blocklyScrollbarHandle {',
-    'fill: #ccc;',
-  '}',
+`.blocklyScrollbarHandle {
+  fill: #ccc;
+}`,
 
-  '.blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,',
-  '.blocklyScrollbarHandle:hover {',
-    'fill: #bbb;',
-  '}',
+`.blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
+.blocklyScrollbarHandle:hover {
+  fill: #bbb;
+}`,
 
   /* Darken flyout scrollbars due to being on a grey background. */
   /* By contrast, workspace scrollbars are on a white background. */
-  '.blocklyFlyout .blocklyScrollbarHandle {',
-    'fill: #bbb;',
-  '}',
+`.blocklyFlyout .blocklyScrollbarHandle {
+  fill: #bbb;
+}`,
 
-  '.blocklyFlyout .blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,',
-  '.blocklyFlyout .blocklyScrollbarHandle:hover {',
-    'fill: #aaa;',
-  '}',
+`.blocklyFlyout .blocklyScrollbarBackground:hover+.blocklyScrollbarHandle,
+.blocklyFlyout .blocklyScrollbarHandle:hover {
+  fill: #aaa;
+}`,
 
-  '.blocklyInvalidInput {',
-    'background: #faa;',
-  '}',
+`.blocklyInvalidInput {
+  background: #faa;
+}`,
 
-  '.blocklyVerticalMarker {',
-    'stroke-width: 3px;',
-    'fill: rgba(255,255,255,.5);',
-    'pointer-events: none;',
-  '}',
+`.blocklyVerticalMarker {
+  stroke-width: 3px;
+  fill: rgba(255,255,255,.5);
+  pointer-events: none;
+}`,
 
-  '.blocklyComputeCanvas {',
-    'position: absolute;',
-    'width: 0;',
-    'height: 0;',
-  '}',
+`.blocklyComputeCanvas {
+  position: absolute;
+  width: 0;
+  height: 0;
+}`,
 
-  '.blocklyNoPointerEvents {',
-    'pointer-events: none;',
-  '}',
+`.blocklyNoPointerEvents {
+  pointer-events: none;
+}`,
 
-  '.blocklyContextMenu {',
-    'border-radius: 4px;',
-    'max-height: 100%;',
-  '}',
+`.blocklyContextMenu {
+  border-radius: 4px;
+  max-height: 100%;
+}`,
 
-  '.blocklyDropdownMenu {',
-    'border-radius: 2px;',
-    'padding: 0 !important;',
-  '}',
+`.blocklyDropdownMenu {
+  border-radius: 2px;
+  padding: 0 !important;
+}`,
 
-  '.blocklyDropdownMenu .blocklyMenuItem {',
-    /* 28px on the left for icon or checkbox. */
-    'padding-left: 28px;',
-  '}',
+`.blocklyDropdownMenu .blocklyMenuItem {
+  /* 28px on the left for icon or checkbox. */
+  padding-left: 28px;
+}`,
 
   /* BiDi override for the resting state. */
-  '.blocklyDropdownMenu .blocklyMenuItemRtl {',
-     /* Flip left/right padding for BiDi. */
-    'padding-left: 5px;',
-    'padding-right: 28px;',
-  '}',
+`.blocklyDropdownMenu .blocklyMenuItemRtl {
+  /* Flip left/right padding for BiDi. */
+  padding-left: 5px;
+  padding-right: 28px;
+}`,
 
-  '.blocklyWidgetDiv .blocklyMenu {',
-    'background: #fff;',
-    'border: 1px solid transparent;',
-    'box-shadow: 0 0 3px 1px rgba(0,0,0,.3);',
-    'font: normal 13px Arial, sans-serif;',
-    'margin: 0;',
-    'outline: none;',
-    'padding: 4px 0;',
-    'position: absolute;',
-    'overflow-y: auto;',
-    'overflow-x: hidden;',
-    'max-height: 100%;',
-    'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
-  '}',
+`.blocklyWidgetDiv .blocklyMenu {
+  background: #fff;
+  border: 1px solid transparent;
+  box-shadow: 0 0 3px 1px rgba(0,0,0,.3);
+  font: normal 13px Arial, sans-serif;
+  margin: 0;
+  outline: none;
+  padding: 4px 0;
+  position: absolute;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 100%;
+  z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
+}`,
 
-  '.blocklyWidgetDiv .blocklyMenu.blocklyFocused {',
-    'box-shadow: 0 0 6px 1px rgba(0,0,0,.3);',
-  '}',
+`.blocklyWidgetDiv .blocklyMenu.blocklyFocused {
+  box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
+}`,
 
-  '.blocklyDropDownDiv .blocklyMenu {',
-    'background: inherit;',  /* Compatibility with gapi, reset from goog-menu */
-    'border: inherit;',  /* Compatibility with gapi, reset from goog-menu */
-    'font: normal 13px "Helvetica Neue", Helvetica, sans-serif;',
-    'outline: none;',
-    'position: relative;',  /* Compatibility with gapi, reset from goog-menu */
-    'z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
-  '}',
+`.blocklyDropDownDiv .blocklyMenu {
+  background: inherit;',  /* Compatibility with gapi, reset from goog-menu */
+  border: inherit;',  /* Compatibility with gapi, reset from goog-menu */
+  font: normal 13px "Helvetica Neue", Helvetica, sans-serif;
+  outline: none;
+  position: relative;',  /* Compatibility with gapi, reset from goog-menu */
+  z-index: 20000;',  /* Arbitrary, but some apps depend on it... */
+}`,
 
   /* State: resting. */
-  '.blocklyMenuItem {',
-    'border: none;',
-    'color: #000;',
-    'cursor: pointer;',
-    'list-style: none;',
-    'margin: 0;',
-     /* 7em on the right for shortcut. */
-    'min-width: 7em;',
-    'padding: 6px 15px;',
-    'white-space: nowrap;',
-  '}',
+`.blocklyMenuItem {
+  border: none;
+  color: #000;
+  cursor: pointer;
+  list-style: none;
+  margin: 0;
+  /* 7em on the right for shortcut. */
+  min-width: 7em;
+  padding: 6px 15px;
+  white-space: nowrap;
+}`,
 
   /* State: disabled. */
-  '.blocklyMenuItemDisabled {',
-    'color: #ccc;',
-    'cursor: inherit;',
-  '}',
+`.blocklyMenuItemDisabled {
+  color: #ccc;
+  cursor: inherit;
+}`,
 
   /* State: hover. */
-  '.blocklyMenuItemHighlight {',
-    'background-color: rgba(0,0,0,.1);',
-  '}',
+`.blocklyMenuItemHighlight {
+  background-color: rgba(0,0,0,.1);
+}`,
 
   /* State: selected/checked. */
-  '.blocklyMenuItemCheckbox {',
-    'height: 16px;',
-    'position: absolute;',
-    'width: 16px;',
-  '}',
+`.blocklyMenuItemCheckbox {
+  height: 16px;
+  position: absolute;
+  width: 16px;
+}`,
 
-  '.blocklyMenuItemSelected .blocklyMenuItemCheckbox {',
-    'background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;',
-    'float: left;',
-    'margin-left: -24px;',
-    'position: static;',  /* Scroll with the menu. */
-  '}',
+`.blocklyMenuItemSelected .blocklyMenuItemCheckbox {
+  background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;
+  float: left;
+  margin-left: -24px;
+  position: static;',  /* Scroll with the menu. */
+}`,
 
-  '.blocklyMenuItemRtl .blocklyMenuItemCheckbox {',
-    'float: right;',
-    'margin-right: -24px;',
-  '}',
-  /* eslint-enable indent */
+`.blocklyMenuItemRtl .blocklyMenuItemCheckbox {
+  float: right;
+  margin-right: -24px;
+}`,
 ];

--- a/core/css.js
+++ b/core/css.js
@@ -55,19 +55,19 @@ Blockly.Css.inject = function(hasCss, pathToMedia) {
     return;
   }
   Blockly.Css.injected_ = true;
-  var text = Blockly.Css.CONTENT.join('\n');
+  let text = Blockly.Css.CONTENT.join('\n');
   Blockly.Css.CONTENT.length = 0;  // Garbage collect CSS content.
   if (!hasCss) {
     return;
   }
   // Strip off any trailing slash (either Unix or Windows).
-  var mediaPath = pathToMedia.replace(/[\\/]$/, '');
+  const mediaPath = pathToMedia.replace(/[\\/]$/, '');
   text = text.replace(/<<<PATH>>>/g, mediaPath);
 
   // Inject CSS tag at start of head.
-  var cssNode = document.createElement('style');
+  const cssNode = document.createElement('style');
   cssNode.id = 'blockly-common-style';
-  var cssTextNode = document.createTextNode(text);
+  const cssTextNode = document.createTextNode(text);
   cssNode.appendChild(cssTextNode);
   document.head.insertBefore(cssNode, document.head.firstChild);
 };

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -27,7 +27,7 @@ goog.addDependency('../../core/constants.js', ['Blockly.constants'], ['Blockly.c
 goog.addDependency('../../core/contextmenu.js', ['Blockly.ContextMenu'], ['Blockly.Events', 'Blockly.Events.BlockCreate', 'Blockly.Menu', 'Blockly.MenuItem', 'Blockly.Msg', 'Blockly.WidgetDiv', 'Blockly.Xml', 'Blockly.browserEvents', 'Blockly.constants', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.userAgent']);
 goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems'], ['Blockly.ContextMenuRegistry', 'Blockly.Events', 'Blockly.constants', 'Blockly.inputTypes'], {'lang': 'es5'});
 goog.addDependency('../../core/contextmenu_registry.js', ['Blockly.ContextMenuRegistry'], [], {'lang': 'es5'});
-goog.addDependency('../../core/css.js', ['Blockly.Css'], [], {'lang': 'es5'});
+goog.addDependency('../../core/css.js', ['Blockly.Css'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/delete_area.js', ['Blockly.DeleteArea'], ['Blockly.BlockSvg', 'Blockly.DragTarget', 'Blockly.IDeleteArea']);
 goog.addDependency('../../core/drag_target.js', ['Blockly.DragTarget'], ['Blockly.IDragTarget']);
 goog.addDependency('../../core/dropdowndiv.js', ['Blockly.DropDownDiv'], ['Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.math', 'Blockly.utils.style']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/css.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
