### PR TITLE
Migrate core/interfaces/i_autohideable.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_autohideable.js
+++ b/core/interfaces/i_autohideable.js
@@ -15,12 +15,12 @@
 goog.module('Blockly.IAutoHideable');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IComponent');
+const IComponent = goog.require('Blockly.IComponent');
 
 
 /**
  * Interface for a component that can be automatically hidden.
- * @extends {Blockly.IComponent}
+ * @extends {IComponent}
  * @interface
  */
 const IAutoHideable = function() {};

--- a/core/interfaces/i_autohideable.js
+++ b/core/interfaces/i_autohideable.js
@@ -12,7 +12,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IAutoHideable');
+goog.module('Blockly.IAutoHideable');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IComponent');
 
@@ -22,11 +23,13 @@ goog.require('Blockly.IComponent');
  * @extends {Blockly.IComponent}
  * @interface
  */
-Blockly.IAutoHideable = function() {};
+const IAutoHideable = function() {};
 
 /**
  * Hides the component. Called in Blockly.hideChaff.
  * @param {boolean} onlyClosePopups Whether only popups should be closed.
  *   Flyouts should not be closed if this is true.
  */
-Blockly.IAutoHideable.prototype.autoHide;
+IAutoHideable.prototype.autoHide;
+
+exports = IAutoHideable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -76,7 +76,7 @@ goog.addDependency('../../core/insertion_marker_manager.js', ['Blockly.Insertion
 goog.addDependency('../../core/interfaces/i_ast_node_location.js', ['Blockly.IASTNodeLocation'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_ast_node_location_svg.js', ['Blockly.IASTNodeLocationSvg'], ['Blockly.IASTNodeLocation'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_ast_node_location_with_block.js', ['Blockly.IASTNodeLocationWithBlock'], ['Blockly.IASTNodeLocation'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHideable'], ['Blockly.IComponent']);
+goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHideable'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_autohideable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
