### PR TITLE
Auto-tag and add milestones for cleanup PRs

### DIFF
--- a/.github/workflows/tag_module_cleanup.yml
+++ b/.github/workflows/tag_module_cleanup.yml
@@ -1,0 +1,34 @@
+# For new pull requests against the goog_module branch, adds the 'type: cleanup'
+# label and sets the milestone to q3 2021 release.
+
+name: Tag module cleanup
+
+# Trigger on pull requests against goog_module branch only
+on: 
+  pull_request:
+    branches:
+      - goog_module
+
+jobs:
+  tag-module-cleanup:
+  
+    # Add the type: cleanup label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@a3e7071
+        with:
+          script: |
+            // 2021 q3 release milestone.
+            // https://github.com/google/blockly/milestone/18
+            const milestoneNumber = 18;
+            // Note that pull requests are accessed through the issues API.
+            const issuesUpdateParams = { 
+              owner: context.repo.owner, 
+              repo: context.repo.repo, 
+              // Adds the milestone
+              milestone: milestoneNumber, 
+              issue_number: context.issue.number,
+              // Sets the labels
+              labels: ['type: cleanup']
+            }
+            await github.issues.update(issuesUpdateParams)

--- a/.github/workflows/tag_module_cleanup.yml
+++ b/.github/workflows/tag_module_cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     # Add the type: cleanup label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@a3e7071
+      - uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
         with:
           script: |
             // 2021 q3 release milestone.


### PR DESCRIPTION
## The basics
**Branched from goog_module because this is a workflow and that's where I want it to run.
- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
Automates tagging and adding milestones. 

I looked into adding to the cleanup project but that API is less well specified.

I believe that this workflow should run against this PR when I create it.