### PR TITLE
Migrate core/interfaces/i_block_dragger.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_block_dragger.js
+++ b/core/interfaces/i_block_dragger.js
@@ -14,8 +14,8 @@
 goog.module('Blockly.IBlockDragger');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.BlockSvg');
-goog.requireType('Blockly.utils.Coordinate');
+const BlockSvg = goog.requireType('Blockly.BlockSvg');
+const Coordinate = goog.requireType('Blockly.utils.Coordinate');
 
 
 /**
@@ -26,7 +26,7 @@ const IBlockDragger = function() {};
 
 /**
  * Start dragging a block.  This includes moving it to the drag surface.
- * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
+ * @param {!Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at mouse down, in pixel units.
  * @param {boolean} healStack Whether or not to heal the stack after
  *     disconnecting.
@@ -37,7 +37,7 @@ IBlockDragger.prototype.startDrag;
  * Execute a step of block dragging, based on the given event.  Update the
  * display accordingly.
  * @param {!Event} e The most recent move event.
- * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
+ * @param {!Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at the start of the drag, in pixel units.
  */
 IBlockDragger.prototype.drag;
@@ -45,7 +45,7 @@ IBlockDragger.prototype.drag;
 /**
  * Finish a block drag and put the block back on the workspace.
  * @param {!Event} e The mouseup/touchend event.
- * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
+ * @param {!Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at the start of the drag, in pixel units.
  */
 IBlockDragger.prototype.endDrag;
@@ -53,7 +53,7 @@ IBlockDragger.prototype.endDrag;
 /**
  * Get a list of the insertion markers that currently exist.  Drags have 0, 1,
  * or 2 insertion markers.
- * @return {!Array.<!Blockly.BlockSvg>} A possibly empty list of insertion
+ * @return {!Array.<!BlockSvg>} A possibly empty list of insertion
  *     marker blocks.
  */
 IBlockDragger.prototype.getInsertionMarkers;

--- a/core/interfaces/i_block_dragger.js
+++ b/core/interfaces/i_block_dragger.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IBlockDragger');
+goog.module('Blockly.IBlockDragger');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.utils.Coordinate');
@@ -21,7 +22,7 @@ goog.requireType('Blockly.utils.Coordinate');
  * A block dragger interface.
  * @interface
  */
-Blockly.IBlockDragger = function() {};
+const IBlockDragger = function() {};
 
 /**
  * Start dragging a block.  This includes moving it to the drag surface.
@@ -30,7 +31,7 @@ Blockly.IBlockDragger = function() {};
  * @param {boolean} healStack Whether or not to heal the stack after
  *     disconnecting.
  */
-Blockly.IBlockDragger.prototype.startDrag;
+IBlockDragger.prototype.startDrag;
 
 /**
  * Execute a step of block dragging, based on the given event.  Update the
@@ -39,7 +40,7 @@ Blockly.IBlockDragger.prototype.startDrag;
  * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at the start of the drag, in pixel units.
  */
-Blockly.IBlockDragger.prototype.drag;
+IBlockDragger.prototype.drag;
 
 /**
  * Finish a block drag and put the block back on the workspace.
@@ -47,7 +48,7 @@ Blockly.IBlockDragger.prototype.drag;
  * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at the start of the drag, in pixel units.
  */
-Blockly.IBlockDragger.prototype.endDrag;
+IBlockDragger.prototype.endDrag;
 
 /**
  * Get a list of the insertion markers that currently exist.  Drags have 0, 1,
@@ -55,4 +56,6 @@ Blockly.IBlockDragger.prototype.endDrag;
  * @return {!Array.<!Blockly.BlockSvg>} A possibly empty list of insertion
  *     marker blocks.
  */
-Blockly.IBlockDragger.prototype.getInsertionMarkers;
+IBlockDragger.prototype.getInsertionMarkers;
+
+exports = IBlockDragger;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -75,7 +75,7 @@ goog.addDependency('../../core/input_types.js', ['Blockly.inputTypes'], ['Blockl
 goog.addDependency('../../core/insertion_marker_manager.js', ['Blockly.InsertionMarkerManager'], ['Blockly.ComponentManager', 'Blockly.Events', 'Blockly.blockAnimations', 'Blockly.connectionTypes', 'Blockly.constants'], {'lang': 'es5'});
 goog.addDependency('../../core/interfaces/i_accessibility.js', ['Blockly.IASTNodeLocation', 'Blockly.IASTNodeLocationSvg', 'Blockly.IASTNodeLocationWithBlock', 'Blockly.IKeyboardAccessible'], []);
 goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHideable'], ['Blockly.IComponent']);
-goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], []);
+goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], []);
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable']);
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_block_dragger.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
