### PR TITLE
Migrate core/interfaces/i_bounded_element.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_bounded_element.js
+++ b/core/interfaces/i_bounded_element.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IBoundedElement');
+goog.module('Blockly.IBoundedElement');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.utils.Rect');
 
@@ -20,7 +21,7 @@ goog.requireType('Blockly.utils.Rect');
  * A bounded element interface.
  * @interface
  */
-Blockly.IBoundedElement = function() {};
+const IBoundedElement = function() {};
 
 /**
  * Returns the coordinates of a bounded element describing the dimensions of the
@@ -28,11 +29,13 @@ Blockly.IBoundedElement = function() {};
  * Coordinate system: workspace coordinates.
  * @return {!Blockly.utils.Rect} Object with coordinates of the bounded element.
  */
-Blockly.IBoundedElement.prototype.getBoundingRectangle;
+IBoundedElement.prototype.getBoundingRectangle;
 
 /**
  * Move the element by a relative offset.
  * @param {number} dx Horizontal offset in workspace units.
  * @param {number} dy Vertical offset in workspace units.
  */
-Blockly.IBoundedElement.prototype.moveBy;
+IBoundedElement.prototype.moveBy;
+
+exports = IBoundedElement;

--- a/core/interfaces/i_bounded_element.js
+++ b/core/interfaces/i_bounded_element.js
@@ -14,7 +14,7 @@
 goog.module('Blockly.IBoundedElement');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.utils.Rect');
+const Rect = goog.requireType('Blockly.utils.Rect');
 
 
 /**
@@ -27,7 +27,7 @@ const IBoundedElement = function() {};
  * Returns the coordinates of a bounded element describing the dimensions of the
  * element.
  * Coordinate system: workspace coordinates.
- * @return {!Blockly.utils.Rect} Object with coordinates of the bounded element.
+ * @return {!Rect} Object with coordinates of the bounded element.
  */
 IBoundedElement.prototype.getBoundingRectangle;
 

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -76,7 +76,7 @@ goog.addDependency('../../core/insertion_marker_manager.js', ['Blockly.Insertion
 goog.addDependency('../../core/interfaces/i_accessibility.js', ['Blockly.IASTNodeLocation', 'Blockly.IASTNodeLocationSvg', 'Blockly.IASTNodeLocationWithBlock', 'Blockly.IKeyboardAccessible'], []);
 goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHideable'], ['Blockly.IComponent']);
 goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], []);
+goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable']);
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], []);
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate path/to/file.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_bounded_element.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
