### PR TITLE
Migrate core/interfaces/i_bubble.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IBubble');
+goog.module('Blockly.IBubble');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IContextMenu');
 goog.require('Blockly.IDraggable');
@@ -26,20 +27,20 @@ goog.requireType('Blockly.utils.Coordinate');
  * @extends {Blockly.IDraggable}
  * @extends {Blockly.IContextMenu}
  */
-Blockly.IBubble = function() {};
+const IBubble = function() {};
 
 /**
  * Return the coordinates of the top-left corner of this bubble's body relative
  * to the drawing surface's origin (0,0), in workspace units.
  * @return {!Blockly.utils.Coordinate} Object with .x and .y properties.
  */
-Blockly.IBubble.prototype.getRelativeToSurfaceXY;
+IBubble.prototype.getRelativeToSurfaceXY;
 
 /**
  * Return the root node of the bubble's SVG group.
  * @return {!SVGElement} The root SVG node of the bubble's group.
  */
-Blockly.IBubble.prototype.getSvgRoot;
+IBubble.prototype.getSvgRoot;
 
 /**
  * Set whether auto-layout of this bubble is enabled.  The first time a bubble
@@ -48,13 +49,13 @@ Blockly.IBubble.prototype.getSvgRoot;
  * @param {boolean} enable True if auto-layout should be enabled, false
  *     otherwise.
  */
-Blockly.IBubble.prototype.setAutoLayout;
+IBubble.prototype.setAutoLayout;
 
 /**
  * Triggers a move callback if one exists at the end of a drag.
  * @param {boolean} adding True if adding, false if removing.
  */
-Blockly.IBubble.prototype.setDragging;
+IBubble.prototype.setDragging;
 
 /**
  * Move this bubble during a drag, taking into account whether or not there is
@@ -64,23 +65,25 @@ Blockly.IBubble.prototype.setDragging;
  * @param {!Blockly.utils.Coordinate} newLoc The location to translate to, in
  *     workspace coordinates.
  */
-Blockly.IBubble.prototype.moveDuringDrag;
+IBubble.prototype.moveDuringDrag;
 
 /**
  * Move the bubble to the specified location in workspace coordinates.
  * @param {number} x The x position to move to.
  * @param {number} y The y position to move to.
  */
-Blockly.IBubble.prototype.moveTo;
+IBubble.prototype.moveTo;
 
 /**
  * Update the style of this bubble when it is dragged over a delete area.
  * @param {boolean} enable True if the bubble is about to be deleted, false
  *     otherwise.
  */
-Blockly.IBubble.prototype.setDeleteStyle;
+IBubble.prototype.setDeleteStyle;
 
 /**
  * Dispose of this bubble.
  */
-Blockly.IBubble.prototype.dispose;
+IBubble.prototype.dispose;
+
+exports = IBubble;

--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -14,25 +14,24 @@
 goog.module('Blockly.IBubble');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IContextMenu');
-goog.require('Blockly.IDraggable');
-
-goog.requireType('Blockly.BlockDragSurfaceSvg');
-goog.requireType('Blockly.utils.Coordinate');
+const BlockDragSurfaceSvg = goog.requireType('Blockly.BlockDragSurfaceSvg');
+const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+const IContextMenu = goog.require('Blockly.IContextMenu');
+const IDraggable = goog.require('Blockly.IDraggable');
 
 
 /**
  * A bubble interface.
  * @interface
- * @extends {Blockly.IDraggable}
- * @extends {Blockly.IContextMenu}
+ * @extends {IDraggable}
+ * @extends {IContextMenu}
  */
 const IBubble = function() {};
 
 /**
  * Return the coordinates of the top-left corner of this bubble's body relative
  * to the drawing surface's origin (0,0), in workspace units.
- * @return {!Blockly.utils.Coordinate} Object with .x and .y properties.
+ * @return {!Coordinate} Object with .x and .y properties.
  */
 IBubble.prototype.getRelativeToSurfaceXY;
 
@@ -60,9 +59,9 @@ IBubble.prototype.setDragging;
 /**
  * Move this bubble during a drag, taking into account whether or not there is
  * a drag surface.
- * @param {Blockly.BlockDragSurfaceSvg} dragSurface The surface that carries
+ * @param {BlockDragSurfaceSvg} dragSurface The surface that carries
  *     rendered items during a drag, or null if no drag surface is in use.
- * @param {!Blockly.utils.Coordinate} newLoc The location to translate to, in
+ * @param {!Coordinate} newLoc The location to translate to, in
  *     workspace coordinates.
  */
 IBubble.prototype.moveDuringDrag;

--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -59,7 +59,7 @@ IBubble.prototype.setDragging;
 /**
  * Move this bubble during a drag, taking into account whether or not there is
  * a drag surface.
- * @param {BlockDragSurfaceSvg} dragSurface The surface that carries
+ * @param {?BlockDragSurfaceSvg} dragSurface The surface that carries
  *     rendered items during a drag, or null if no drag surface is in use.
  * @param {!Coordinate} newLoc The location to translate to, in
  *     workspace coordinates.

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -77,7 +77,7 @@ goog.addDependency('../../core/interfaces/i_accessibility.js', ['Blockly.IASTNod
 goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHideable'], ['Blockly.IComponent']);
 goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable']);
+goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_bubble.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_bubble.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
