### PR TITLE
Migrate core/interfaces/i_component.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_component.js
+++ b/core/interfaces/i_component.js
@@ -12,7 +12,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IComponent');
+goog.module('Blockly.IComponent');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -20,11 +21,13 @@ goog.provide('Blockly.IComponent');
  * ComponentManager.
  * @interface
  */
-Blockly.IComponent = function() {};
+const IComponent = function() {};
 
 /**
  * The unique id for this component that is used to register with the
  * ComponentManager.
  * @type {string}
  */
-Blockly.IComponent.id;
+IComponent.id;
+
+exports = IComponent;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -78,7 +78,7 @@ goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHid
 goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], []);
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], []);
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable']);
-goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], []);
+goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_component.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->