### PR TITLE
Migrate core/interfaces/i_connection_checker.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_connection_checker.js
+++ b/core/interfaces/i_connection_checker.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.IConnectionChecker');
+goog.module('Blockly.IConnectionChecker');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.Connection');
 goog.requireType('Blockly.RenderedConnection');
@@ -21,7 +22,7 @@ goog.requireType('Blockly.RenderedConnection');
  * Class for connection type checking logic.
  * @interface
  */
-Blockly.IConnectionChecker = function() {};
+const IConnectionChecker = function() {};
 
 /**
  * Check whether the current connection can connect with the target
@@ -35,7 +36,7 @@ Blockly.IConnectionChecker = function() {};
  * @return {boolean} Whether the connection is legal.
  * @public
  */
-Blockly.IConnectionChecker.prototype.canConnect;
+IConnectionChecker.prototype.canConnect;
 
 /**
  * Checks whether the current connection can connect with the target
@@ -50,7 +51,7 @@ Blockly.IConnectionChecker.prototype.canConnect;
  *    an error code otherwise.
  * @public
  */
-Blockly.IConnectionChecker.prototype.canConnectWithReason;
+IConnectionChecker.prototype.canConnectWithReason;
 
 /**
  * Helper method that translates a connection error code into a string.
@@ -61,7 +62,7 @@ Blockly.IConnectionChecker.prototype.canConnectWithReason;
  * @return {string} A developer-readable error string.
  * @public
  */
-Blockly.IConnectionChecker.prototype.getErrorMessage;
+IConnectionChecker.prototype.getErrorMessage;
 
 /**
  * Check that connecting the given connections is safe, meaning that it would
@@ -71,7 +72,7 @@ Blockly.IConnectionChecker.prototype.getErrorMessage;
  * @return {number} An enum with the reason this connection is safe or unsafe.
  * @public
  */
-Blockly.IConnectionChecker.prototype.doSafetyChecks;
+IConnectionChecker.prototype.doSafetyChecks;
 
 /**
  * Check whether this connection is compatible with another connection with
@@ -82,7 +83,7 @@ Blockly.IConnectionChecker.prototype.doSafetyChecks;
  * @return {boolean} True if the connections share a type.
  * @public
  */
-Blockly.IConnectionChecker.prototype.doTypeChecks;
+IConnectionChecker.prototype.doTypeChecks;
 
 /**
  * Check whether this connection can be made by dragging.
@@ -92,4 +93,6 @@ Blockly.IConnectionChecker.prototype.doTypeChecks;
  * @return {boolean} True if the connection is allowed during a drag.
  * @public
  */
-Blockly.IConnectionChecker.prototype.doDragChecks;
+IConnectionChecker.prototype.doDragChecks;
+
+exports = IConnectionChecker;

--- a/core/interfaces/i_connection_checker.js
+++ b/core/interfaces/i_connection_checker.js
@@ -14,8 +14,8 @@
 goog.module('Blockly.IConnectionChecker');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.Connection');
-goog.requireType('Blockly.RenderedConnection');
+const Connection = goog.requireType('Blockly.Connection');
+const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
 
 
 /**
@@ -27,8 +27,8 @@ const IConnectionChecker = function() {};
 /**
  * Check whether the current connection can connect with the target
  * connection.
- * @param {Blockly.Connection} a Connection to check compatibility with.
- * @param {Blockly.Connection} b Connection to check compatibility with.
+ * @param {Connection} a Connection to check compatibility with.
+ * @param {Connection} b Connection to check compatibility with.
  * @param {boolean} isDragging True if the connection is being made by dragging
  *     a block.
  * @param {number=} opt_distance The max allowable distance between the
@@ -41,13 +41,13 @@ IConnectionChecker.prototype.canConnect;
 /**
  * Checks whether the current connection can connect with the target
  * connection, and return an error code if there are problems.
- * @param {Blockly.Connection} a Connection to check compatibility with.
- * @param {Blockly.Connection} b Connection to check compatibility with.
+ * @param {Connection} a Connection to check compatibility with.
+ * @param {Connection} b Connection to check compatibility with.
  * @param {boolean} isDragging True if the connection is being made by dragging
  *     a block.
  * @param {number=} opt_distance The max allowable distance between the
  *     connections for drag checks.
- * @return {number} Blockly.Connection.CAN_CONNECT if the connection is legal,
+ * @return {number} Connection.CAN_CONNECT if the connection is legal,
  *    an error code otherwise.
  * @public
  */
@@ -56,8 +56,8 @@ IConnectionChecker.prototype.canConnectWithReason;
 /**
  * Helper method that translates a connection error code into a string.
  * @param {number} errorCode The error code.
- * @param {Blockly.Connection} a One of the two connections being checked.
- * @param {Blockly.Connection} b The second of the two connections being
+ * @param {Connection} a One of the two connections being checked.
+ * @param {Connection} b The second of the two connections being
  *     checked.
  * @return {string} A developer-readable error string.
  * @public
@@ -67,8 +67,8 @@ IConnectionChecker.prototype.getErrorMessage;
 /**
  * Check that connecting the given connections is safe, meaning that it would
  * not break any of Blockly's basic assumptions (e.g. no self connections).
- * @param {Blockly.Connection} a The first of the connections to check.
- * @param {Blockly.Connection} b The second of the connections to check.
+ * @param {Connection} a The first of the connections to check.
+ * @param {Connection} b The second of the connections to check.
  * @return {number} An enum with the reason this connection is safe or unsafe.
  * @public
  */
@@ -78,8 +78,8 @@ IConnectionChecker.prototype.doSafetyChecks;
  * Check whether this connection is compatible with another connection with
  * respect to the value type system.  E.g. square_root("Hello") is not
  * compatible.
- * @param {!Blockly.Connection} a Connection to compare.
- * @param {!Blockly.Connection} b Connection to compare against.
+ * @param {!Connection} a Connection to compare.
+ * @param {!Connection} b Connection to compare against.
  * @return {boolean} True if the connections share a type.
  * @public
  */
@@ -87,8 +87,8 @@ IConnectionChecker.prototype.doTypeChecks;
 
 /**
  * Check whether this connection can be made by dragging.
- * @param {!Blockly.RenderedConnection} a Connection to compare.
- * @param {!Blockly.RenderedConnection} b Connection to compare against.
+ * @param {!RenderedConnection} a Connection to compare.
+ * @param {!RenderedConnection} b Connection to compare against.
  * @param {number} distance The maximum allowable distance between connections.
  * @return {boolean} True if the connection is allowed during a drag.
  * @public

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -81,14 +81,14 @@ goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockD
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
+goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_keyboard_accessible.js', ['Blockly.IKeyboardAccessible'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
@@ -97,7 +97,7 @@ goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistra
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry'], {'lang': 'es5'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_connection_checker.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_connection_checker.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
