### PR TITLE
Migrate core/interfaces/i_contextmenu.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_contextmenu.js
+++ b/core/interfaces/i_contextmenu.js
@@ -11,16 +11,19 @@
 
 'use strict';
 
-goog.provide('Blockly.IContextMenu');
+goog.module('Blockly.IContextMenu');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @interface
  */
-Blockly.IContextMenu = function() {};
+const IContextMenu = function() {};
 
 /**
  * Show the context menu for this object.
  * @param {!Event} e Mouse event.
  */
-Blockly.IContextMenu.prototype.showContextMenu;
+IContextMenu.prototype.showContextMenu;
+
+exports = IContextMenu;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -80,7 +80,7 @@ goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoun
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
-goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);
+goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_contextmenu.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
