### PR TITLE
Migrate core/interfaces/i_copyable.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.ICopyable');
+goog.module('Blockly.ICopyable');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.ISelectable');
 goog.requireType('Blockly.WorkspaceSvg');
@@ -21,13 +22,13 @@ goog.requireType('Blockly.WorkspaceSvg');
  * @extends {Blockly.ISelectable}
  * @interface
  */
-Blockly.ICopyable = function() {};
+const ICopyable = function() {};
 
 /**
  * Encode for copying.
- * @return {?Blockly.ICopyable.CopyData} Copy metadata.
+ * @return {?ICopyable.CopyData} Copy metadata.
  */
-Blockly.ICopyable.prototype.toCopyData;
+ICopyable.prototype.toCopyData;
 
 /**
  * Copy Metadata.
@@ -37,4 +38,6 @@ Blockly.ICopyable.prototype.toCopyData;
  *            typeCounts:?Object
  *          }}
  */
-Blockly.ICopyable.CopyData;
+ICopyable.CopyData;
+
+exports = ICopyable;

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -14,12 +14,12 @@
 goog.module('Blockly.ICopyable');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.ISelectable');
-goog.requireType('Blockly.WorkspaceSvg');
+const ISelectable = goog.requireType('Blockly.ISelectable');
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**
- * @extends {Blockly.ISelectable}
+ * @extends {ISelectable}
  * @interface
  */
 const ICopyable = function() {};
@@ -34,7 +34,7 @@ ICopyable.prototype.toCopyData;
  * Copy Metadata.
  * @typedef {{
  *            xml:!Element,
- *            source:Blockly.WorkspaceSvg,
+ *            source:WorkspaceSvg,
  *            typeCounts:?Object
  *          }}
  */

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -81,7 +81,7 @@ goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['B
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);
-goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], []);
+goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_copyable.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_copyable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
