### PR TITLE
Migrate core/interfaces/i_deletable.js to goog.module

### DIFF
--- a/core/interfaces/i_deletable.js
+++ b/core/interfaces/i_deletable.js
@@ -11,17 +11,20 @@
 
 'use strict';
 
-goog.provide('Blockly.IDeletable');
+goog.module('Blockly.IDeletable');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * The interface for an object that can be deleted.
  * @interface
  */
-Blockly.IDeletable = function() {};
+const IDeletable = function() {};
 
 /**
  * Get whether this object is deletable or not.
  * @return {boolean} True if deletable.
  */
-Blockly.IDeletable.prototype.isDeletable;
+IDeletable.prototype.isDeletable;
+
+exports = IDeletable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -82,7 +82,7 @@ goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], []);
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], []);
-goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], []);
+goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget']);
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent']);
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_deletable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
