### PR TITLE
Migrate core/interfaces/i_delete_area.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_delete_area.js
+++ b/core/interfaces/i_delete_area.js
@@ -12,7 +12,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IDeleteArea');
+goog.module('Blockly.IDeleteArea');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IDragTarget');
 
@@ -25,7 +26,7 @@ goog.requireType('Blockly.IDraggable');
  * @extends {Blockly.IDragTarget}
  * @interface
  */
-Blockly.IDeleteArea = function() {};
+const IDeleteArea = function() {};
 
 /**
  * Returns whether the provided block or bubble would be deleted if dropped on
@@ -39,4 +40,6 @@ Blockly.IDeleteArea = function() {};
  * @return {boolean} Whether the element provided would be deleted if dropped on
  *     this area.
  */
-Blockly.IDeleteArea.prototype.wouldDelete;
+IDeleteArea.prototype.wouldDelete;
+
+exports = IDeleteArea;

--- a/core/interfaces/i_delete_area.js
+++ b/core/interfaces/i_delete_area.js
@@ -15,15 +15,14 @@
 goog.module('Blockly.IDeleteArea');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IDragTarget');
-
-goog.requireType('Blockly.IDraggable');
+const IDraggable = goog.requireType('Blockly.IDraggable');
+const IDragTarget = goog.require('Blockly.IDragTarget');
 
 
 /**
  * Interface for a component that can delete a block or bubble that is dropped
  * on top of it.
- * @extends {Blockly.IDragTarget}
+ * @extends {IDragTarget}
  * @interface
  */
 const IDeleteArea = function() {};
@@ -33,7 +32,7 @@ const IDeleteArea = function() {};
  * this area.
  * This method should check if the element is deletable and is always called
  * before onDragEnter/onDragOver/onDragExit.
- * @param {!Blockly.IDraggable} element The block or bubble currently being
+ * @param {!IDraggable} element The block or bubble currently being
  *   dragged.
  * @param {boolean} couldConnect Whether the element could could connect to
  *     another.

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -83,7 +83,7 @@ goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IC
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], []);
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], []);
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget']);
+goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent']);
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable']);
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_delete_area.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_delete_area.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
