### PR TITLE
Migrate core/interfaces/i_drag_target.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_drag_target.js
+++ b/core/interfaces/i_drag_target.js
@@ -15,15 +15,15 @@
 goog.module('Blockly.IDragTarget');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IComponent');
+const IComponent = goog.require('Blockly.IComponent');
+const IDraggable = goog.requireType('Blockly.IDraggable');
+const Rect = goog.requireType('Blockly.utils.Rect');
 
-goog.requireType('Blockly.IDraggable');
-goog.requireType('Blockly.utils.Rect');
 
 /**
  * Interface for a component with custom behaviour when a block or bubble is
  * dragged over or dropped on top of it.
- * @extends {Blockly.IComponent}
+ * @extends {IComponent}
  * @interface
  */
 const IDragTarget = function() {};
@@ -31,14 +31,14 @@ const IDragTarget = function() {};
 /**
  * Returns the bounding rectangle of the drag target area in pixel units
  * relative to viewport.
- * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
+ * @return {?Rect} The component's bounding box. Null if drag
  *   target area should be ignored.
  */
 IDragTarget.prototype.getClientRect;
 
 /**
  * Handles when a cursor with a block or bubble enters this drag target.
- * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
+ * @param {!IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
 IDragTarget.prototype.onDragEnter;
@@ -46,7 +46,7 @@ IDragTarget.prototype.onDragEnter;
 /**
  * Handles when a cursor with a block or bubble is dragged over this drag
  * target.
- * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
+ * @param {!IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
 IDragTarget.prototype.onDragOver;
@@ -54,7 +54,7 @@ IDragTarget.prototype.onDragOver;
 
 /**
  * Handles when a cursor with a block or bubble exits this drag target.
- * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
+ * @param {!IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
 IDragTarget.prototype.onDragExit;
@@ -62,7 +62,7 @@ IDragTarget.prototype.onDragExit;
 /**
  * Handles when a block or bubble is dropped on this component.
  * Should not handle delete here.
- * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
+ * @param {!IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
 IDragTarget.prototype.onDrop;
@@ -71,7 +71,7 @@ IDragTarget.prototype.onDrop;
  * Returns whether the provided block or bubble should not be moved after being
  * dropped on this component. If true, the element will return to where it was
  * when the drag started.
- * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
+ * @param {!IDraggable} dragElement The block or bubble currently being
  *   dragged.
  * @return {boolean} Whether the block or bubble provided should be returned to
  *     drag start.

--- a/core/interfaces/i_drag_target.js
+++ b/core/interfaces/i_drag_target.js
@@ -12,7 +12,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IDragTarget');
+goog.module('Blockly.IDragTarget');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IComponent');
 
@@ -25,7 +26,7 @@ goog.requireType('Blockly.utils.Rect');
  * @extends {Blockly.IComponent}
  * @interface
  */
-Blockly.IDragTarget = function() {};
+const IDragTarget = function() {};
 
 /**
  * Returns the bounding rectangle of the drag target area in pixel units
@@ -33,14 +34,14 @@ Blockly.IDragTarget = function() {};
  * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
  *   target area should be ignored.
  */
-Blockly.IDragTarget.prototype.getClientRect;
+IDragTarget.prototype.getClientRect;
 
 /**
  * Handles when a cursor with a block or bubble enters this drag target.
  * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.IDragTarget.prototype.onDragEnter;
+IDragTarget.prototype.onDragEnter;
 
 /**
  * Handles when a cursor with a block or bubble is dragged over this drag
@@ -48,7 +49,7 @@ Blockly.IDragTarget.prototype.onDragEnter;
  * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.IDragTarget.prototype.onDragOver;
+IDragTarget.prototype.onDragOver;
 
 
 /**
@@ -56,7 +57,7 @@ Blockly.IDragTarget.prototype.onDragOver;
  * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.IDragTarget.prototype.onDragExit;
+IDragTarget.prototype.onDragExit;
 
 /**
  * Handles when a block or bubble is dropped on this component.
@@ -64,7 +65,7 @@ Blockly.IDragTarget.prototype.onDragExit;
  * @param {!Blockly.IDraggable} dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.IDragTarget.prototype.onDrop;
+IDragTarget.prototype.onDrop;
 
 /**
  * Returns whether the provided block or bubble should not be moved after being
@@ -75,4 +76,6 @@ Blockly.IDragTarget.prototype.onDrop;
  * @return {boolean} Whether the block or bubble provided should be returned to
  *     drag start.
  */
-Blockly.IDragTarget.prototype.shouldPreventMove;
+IDragTarget.prototype.shouldPreventMove;
+
+exports = IDragTarget;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -84,7 +84,7 @@ goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextM
 goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent']);
+goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_drag_target.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_drag_target.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
