### PR TITLE
Migrate core/interfaces/i_draggable.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_draggable.js
+++ b/core/interfaces/i_draggable.js
@@ -14,12 +14,12 @@
 goog.module('Blockly.IDraggable');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IDeletable');
+const IDeletable = goog.require('Blockly.IDeletable');
 
 
 /**
  * The interface for an object that can be dragged.
- * @extends {Blockly.IDeletable}
+ * @extends {IDeletable}
  * @interface
  */
 const IDraggable = function() {};

--- a/core/interfaces/i_draggable.js
+++ b/core/interfaces/i_draggable.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IDraggable');
+goog.module('Blockly.IDraggable');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IDeletable');
 
@@ -21,4 +22,6 @@ goog.require('Blockly.IDeletable');
  * @extends {Blockly.IDeletable}
  * @interface
  */
-Blockly.IDraggable = function() {};
+const IDraggable = function() {};
+
+exports = IDraggable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -85,7 +85,7 @@ goog.addDependency('../../core/interfaces/i_copyable.js', ['Blockly.ICopyable'],
 goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget']);
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent']);
-goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable']);
+goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_draggable.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_draggable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
