### PR TITLE
Use pull request target trigger for tagging cleanup

### DIFF
--- a/.github/workflows/tag_module_cleanup.yml
+++ b/.github/workflows/tag_module_cleanup.yml
@@ -4,8 +4,9 @@
 name: Tag module cleanup
 
 # Trigger on pull requests against goog_module branch only
+# Uses pull_request_target to get write permissions so that it can write labels.
 on: 
-  pull_request:
+  pull_request_target:
     branches:
       - goog_module
 


### PR DESCRIPTION
Uses the `pull_request_target` trigger instead of `pull_request`, in order to acquire the write permission to add labels.

References:
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://github.com/actions/labeler/issues/12