### PR TITLE
Migrate core/interfaces/i_flyout.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_flyout.js
+++ b/core/interfaces/i_flyout.js
@@ -14,17 +14,17 @@
 goog.module('Blockly.IFlyout');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.BlockSvg');
-goog.requireType('Blockly.IRegistrable');
-goog.requireType('Blockly.utils.Coordinate');
-goog.requireType('Blockly.utils.Svg');
-goog.requireType('Blockly.utils.toolbox');
-goog.requireType('Blockly.WorkspaceSvg');
+const BlockSvg = goog.requireType('Blockly.BlockSvg');
+const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+const IRegistrable = goog.require('Blockly.IRegistrable');
+const Svg = goog.requireType('Blockly.utils.Svg');
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+const {FlyoutDefinition} = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
  * Interface for a flyout.
- * @extends {Blockly.IRegistrable}
+ * @extends {IRegistrable}
  * @interface
  */
 const IFlyout = function() {};
@@ -43,7 +43,7 @@ IFlyout.prototype.RTL;
 
 /**
  * The target workspace
- * @type {?Blockly.WorkspaceSvg}
+ * @type {?WorkspaceSvg}
  */
 IFlyout.prototype.targetWorkspace;
 
@@ -72,8 +72,8 @@ IFlyout.prototype.CORNER_RADIUS;
  * either exist as its own svg element or be a g element nested inside a
  * separate svg element.
  * @param {string|
- * !Blockly.utils.Svg<!SVGSVGElement>|
- * !Blockly.utils.Svg<!SVGGElement>} tagName The type of tag to
+ * !Svg<!SVGSVGElement>|
+ * !Svg<!SVGGElement>} tagName The type of tag to
  *     put the flyout in. This should be <svg> or <g>.
  * @return {!SVGElement} The flyout's SVG group.
  */
@@ -81,7 +81,7 @@ IFlyout.prototype.createDom;
 
 /**
  * Initializes the flyout.
- * @param {!Blockly.WorkspaceSvg} targetWorkspace The workspace in which to
+ * @param {!WorkspaceSvg} targetWorkspace The workspace in which to
  *     create new blocks.
  */
 IFlyout.prototype.init;
@@ -106,7 +106,7 @@ IFlyout.prototype.getHeight;
 
 /**
  * Get the workspace inside the flyout.
- * @return {!Blockly.WorkspaceSvg} The workspace inside the flyout.
+ * @return {!WorkspaceSvg} The workspace inside the flyout.
  */
 IFlyout.prototype.getWorkspace;
 
@@ -136,7 +136,7 @@ IFlyout.prototype.hide;
 
 /**
  * Show and populate the flyout.
- * @param {!Blockly.utils.toolbox.FlyoutDefinition|string} flyoutDef Contents to
+ * @param {!FlyoutDefinition|string} flyoutDef Contents to
  *     display in the flyout. This is either an array of Nodes, a NodeList, a
  *     toolbox definition, or a string with the name of the dynamic category.
  */
@@ -144,8 +144,8 @@ IFlyout.prototype.show;
 
 /**
  * Create a copy of this block on the workspace.
- * @param {!Blockly.BlockSvg} originalBlock The block to copy from the flyout.
- * @return {!Blockly.BlockSvg} The newly created block.
+ * @param {!BlockSvg} originalBlock The block to copy from the flyout.
+ * @return {!BlockSvg} The newly created block.
  * @throws {Error} if something went wrong with deserialization.
  */
 IFlyout.prototype.createBlock;
@@ -183,7 +183,7 @@ IFlyout.prototype.position;
  * Determine if a drag delta is toward the workspace, based on the position
  * and orientation of the flyout. This is used in determineDragIntention_ to
  * determine if a new block should be created or if the flyout should scroll.
- * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer has
+ * @param {!Coordinate} currentDragDeltaXY How far the pointer has
  *     moved from the position at mouse down, in pixel units.
  * @return {boolean} True if the drag is toward the workspace.
  */

--- a/core/interfaces/i_flyout.js
+++ b/core/interfaces/i_flyout.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IFlyout');
+goog.module('Blockly.IFlyout');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.IRegistrable');
@@ -26,45 +27,45 @@ goog.requireType('Blockly.WorkspaceSvg');
  * @extends {Blockly.IRegistrable}
  * @interface
  */
-Blockly.IFlyout = function() {};
+const IFlyout = function() {};
 
 /**
  * Whether the flyout is laid out horizontally or not.
  * @type {boolean}
  */
-Blockly.IFlyout.prototype.horizontalLayout;
+IFlyout.prototype.horizontalLayout;
 
 /**
  * Is RTL vs LTR.
  * @type {boolean}
  */
-Blockly.IFlyout.prototype.RTL;
+IFlyout.prototype.RTL;
 
 /**
  * The target workspace
  * @type {?Blockly.WorkspaceSvg}
  */
-Blockly.IFlyout.prototype.targetWorkspace;
+IFlyout.prototype.targetWorkspace;
 
 /**
  * Margin around the edges of the blocks in the flyout.
  * @type {number}
  * @const
  */
-Blockly.IFlyout.prototype.MARGIN;
+IFlyout.prototype.MARGIN;
 
 /**
  * Does the flyout automatically close when a block is created?
  * @type {boolean}
  */
-Blockly.IFlyout.prototype.autoClose;
+IFlyout.prototype.autoClose;
 
 /**
  * Corner radius of the flyout background.
  * @type {number}
  * @const
  */
-Blockly.IFlyout.prototype.CORNER_RADIUS;
+IFlyout.prototype.CORNER_RADIUS;
 
 /**
  * Creates the flyout's DOM.  Only needs to be called once.  The flyout can
@@ -76,62 +77,62 @@ Blockly.IFlyout.prototype.CORNER_RADIUS;
  *     put the flyout in. This should be <svg> or <g>.
  * @return {!SVGElement} The flyout's SVG group.
  */
-Blockly.IFlyout.prototype.createDom;
+IFlyout.prototype.createDom;
 
 /**
  * Initializes the flyout.
  * @param {!Blockly.WorkspaceSvg} targetWorkspace The workspace in which to
  *     create new blocks.
  */
-Blockly.IFlyout.prototype.init;
+IFlyout.prototype.init;
 
 /**
  * Dispose of this flyout.
  * Unlink from all DOM elements to prevent memory leaks.
  */
-Blockly.IFlyout.prototype.dispose;
+IFlyout.prototype.dispose;
 
 /**
  * Get the width of the flyout.
  * @return {number} The width of the flyout.
  */
-Blockly.IFlyout.prototype.getWidth;
+IFlyout.prototype.getWidth;
 
 /**
  * Get the height of the flyout.
  * @return {number} The width of the flyout.
  */
-Blockly.IFlyout.prototype.getHeight;
+IFlyout.prototype.getHeight;
 
 /**
  * Get the workspace inside the flyout.
  * @return {!Blockly.WorkspaceSvg} The workspace inside the flyout.
  */
-Blockly.IFlyout.prototype.getWorkspace;
+IFlyout.prototype.getWorkspace;
 
 /**
  * Is the flyout visible?
  * @return {boolean} True if visible.
  */
-Blockly.IFlyout.prototype.isVisible;
+IFlyout.prototype.isVisible;
 
 /**
  * Set whether the flyout is visible. A value of true does not necessarily mean
  * that the flyout is shown. It could be hidden because its container is hidden.
  * @param {boolean} visible True if visible.
  */
-Blockly.IFlyout.prototype.setVisible;
+IFlyout.prototype.setVisible;
 
 /**
  * Set whether this flyout's container is visible.
  * @param {boolean} visible Whether the container is visible.
  */
-Blockly.IFlyout.prototype.setContainerVisible;
+IFlyout.prototype.setContainerVisible;
 
 /**
  * Hide and empty the flyout.
  */
-Blockly.IFlyout.prototype.hide;
+IFlyout.prototype.hide;
 
 /**
  * Show and populate the flyout.
@@ -139,7 +140,7 @@ Blockly.IFlyout.prototype.hide;
  *     display in the flyout. This is either an array of Nodes, a NodeList, a
  *     toolbox definition, or a string with the name of the dynamic category.
  */
-Blockly.IFlyout.prototype.show;
+IFlyout.prototype.show;
 
 /**
  * Create a copy of this block on the workspace.
@@ -147,36 +148,36 @@ Blockly.IFlyout.prototype.show;
  * @return {!Blockly.BlockSvg} The newly created block.
  * @throws {Error} if something went wrong with deserialization.
  */
-Blockly.IFlyout.prototype.createBlock;
+IFlyout.prototype.createBlock;
 
 /**
  * Reflow blocks and their mats.
  */
-Blockly.IFlyout.prototype.reflow;
+IFlyout.prototype.reflow;
 
 /**
  * @return {boolean} True if this flyout may be scrolled with a scrollbar or by
  *     dragging.
  */
-Blockly.IFlyout.prototype.isScrollable;
+IFlyout.prototype.isScrollable;
 
 /**
  * Calculates the x coordinate for the flyout position.
  * @return {number} X coordinate.
  */
-Blockly.IFlyout.prototype.getX;
+IFlyout.prototype.getX;
 
 /**
  * Calculates the y coordinate for the flyout position.
  * @return {number} Y coordinate.
  */
-Blockly.IFlyout.prototype.getY;
+IFlyout.prototype.getY;
 
 /**
  * Position the flyout.
  * @return {void}
  */
-Blockly.IFlyout.prototype.position;
+IFlyout.prototype.position;
 
 /**
  * Determine if a drag delta is toward the workspace, based on the position
@@ -186,4 +187,6 @@ Blockly.IFlyout.prototype.position;
  *     moved from the position at mouse down, in pixel units.
  * @return {boolean} True if the drag is toward the workspace.
  */
-Blockly.IFlyout.prototype.isDragTowardWorkspace;
+IFlyout.prototype.isDragTowardWorkspace;
+
+exports = IFlyout;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -88,7 +88,7 @@ goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);
+goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_keyboard_accessible.js', ['Blockly.IKeyboardAccessible'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_flyout.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_flyout.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
