### PR TITLE
Migrate core/interfaces/i_movable.js to goog.module

### DIFF
--- a/core/interfaces/i_movable.js
+++ b/core/interfaces/i_movable.js
@@ -11,17 +11,20 @@
 
 'use strict';
 
-goog.provide('Blockly.IMovable');
+goog.module('Blockly.IMovable');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * The interface for an object that is movable.
  * @interface
  */
-Blockly.IMovable = function() {};
+const IMovable = function() {};
 
 /**
  * Get whether this is movable or not.
  * @return {boolean} True if movable.
  */
-Blockly.IMovable.prototype.isMovable;
+IMovable.prototype.isMovable;
+
+exports = IMovable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -88,7 +88,7 @@ goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarg
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
-goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], []);
+goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent']);
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], []);
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_movable.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_movable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
