### PR TITLE
Migrate core/interfaces/i_positionable.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IPositionable');
+goog.module('Blockly.IPositionable');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IComponent');
 
@@ -24,7 +25,7 @@ goog.requireType('Blockly.utils.Rect');
  * @extends {Blockly.IComponent}
  * @interface
  */
-Blockly.IPositionable = function() {};
+const IPositionable = function() {};
 
 /**
  * Positions the element. Called when the window is resized.
@@ -32,7 +33,7 @@ Blockly.IPositionable = function() {};
  * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
  *     are already on the workspace.
  */
-Blockly.IPositionable.prototype.position;
+IPositionable.prototype.position;
 
 /**
  * Returns the bounding rectangle of the UI element in pixel units relative to
@@ -40,4 +41,6 @@ Blockly.IPositionable.prototype.position;
  * @return {?Blockly.utils.Rect} The UI elements’s bounding box. Null if
  *   bounding box should be ignored by other UI elements.
  */
-Blockly.IPositionable.prototype.getBoundingRectangle;
+IPositionable.prototype.getBoundingRectangle;
+
+exports = IPositionable;

--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -14,23 +14,22 @@
 goog.module('Blockly.IPositionable');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IComponent');
-
-goog.requireType('Blockly.MetricsManager');
-goog.requireType('Blockly.utils.Rect');
+const IComponent = goog.require('Blockly.IComponent');
+const Rect = goog.requireType('Blockly.utils.Rect');
+const {UiMetrics} = goog.requireType('Blockly.MetricsManager');
 
 
 /**
  * Interface for a component that is positioned on top of the workspace.
- * @extends {Blockly.IComponent}
+ * @extends {IComponent}
  * @interface
  */
 const IPositionable = function() {};
 
 /**
  * Positions the element. Called when the window is resized.
- * @param {!Blockly.MetricsManager.UiMetrics} metrics The workspace metrics.
- * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
+ * @param {!UiMetrics} metrics The workspace metrics.
+ * @param {!Array<!Rect>} savedPositions List of rectangles that
  *     are already on the workspace.
  */
 IPositionable.prototype.position;
@@ -38,7 +37,7 @@ IPositionable.prototype.position;
 /**
  * Returns the bounding rectangle of the UI element in pixel units relative to
  * the Blockly injection div.
- * @return {?Blockly.utils.Rect} The UI elements’s bounding box. Null if
+ * @return {?Rect} The UI elements’s bounding box. Null if
  *   bounding box should be ignored by other UI elements.
  */
 IPositionable.prototype.getBoundingRectangle;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -89,7 +89,7 @@ goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], []);
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent']);
+goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], []);
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_positionable.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_positionable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
