### PR TITLE
Migrate core/connection_checker.js to goog.module

### DIFF
--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -64,14 +64,14 @@ Blockly.ConnectionChecker.prototype.canConnect = function(a, b,
  */
 Blockly.ConnectionChecker.prototype.canConnectWithReason = function(
     a, b, isDragging, opt_distance) {
-  var safety = this.doSafetyChecks(a, b);
+  const safety = this.doSafetyChecks(a, b);
   if (safety != Blockly.Connection.CAN_CONNECT) {
     return safety;
   }
 
   // If the safety checks passed, both connections are non-null.
-  var connOne = /** @type {!Blockly.Connection} **/ (a);
-  var connTwo = /** @type {!Blockly.Connection} **/ (b);
+  const connOne = /** @type {!Blockly.Connection} **/ (a);
+  const connTwo = /** @type {!Blockly.Connection} **/ (b);
   if (!this.doTypeChecks(connOne, connTwo)) {
     return Blockly.Connection.REASON_CHECKS_FAILED;
   }
@@ -108,12 +108,13 @@ Blockly.ConnectionChecker.prototype.getErrorMessage = function(errorCode,
       return 'Attempt to connect incompatible types.';
     case Blockly.Connection.REASON_TARGET_NULL:
       return 'Target connection is null.';
-    case Blockly.Connection.REASON_CHECKS_FAILED:
-      var connOne = /** @type {!Blockly.Connection} **/ (a);
-      var connTwo = /** @type {!Blockly.Connection} **/ (b);
-      var msg = 'Connection checks failed. ';
+    case Blockly.Connection.REASON_CHECKS_FAILED: {
+      const connOne = /** @type {!Blockly.Connection} **/ (a);
+      const connTwo = /** @type {!Blockly.Connection} **/ (b);
+      let msg = 'Connection checks failed. ';
       msg += connOne + ' expected ' + connOne.getCheck() + ', found ' + connTwo.getCheck();
       return msg;
+    }
     case Blockly.Connection.REASON_SHADOW_PARENT:
       return 'Connecting non-shadow to shadow block.';
     case Blockly.Connection.REASON_DRAG_CHECKS_FAILED:
@@ -135,12 +136,13 @@ Blockly.ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
   if (!a || !b) {
     return Blockly.Connection.REASON_TARGET_NULL;
   }
+  let blockA, blockB;
   if (a.isSuperior()) {
-    var blockA = a.getSourceBlock();
-    var blockB = b.getSourceBlock();
+    blockA = a.getSourceBlock();
+    blockB = b.getSourceBlock();
   } else {
-    var blockB = a.getSourceBlock();
-    var blockA = b.getSourceBlock();
+    blockB = a.getSourceBlock();
+    blockA = b.getSourceBlock();
   }
   if (blockA == blockB) {
     return Blockly.Connection.REASON_SELF_CONNECTION;
@@ -164,15 +166,15 @@ Blockly.ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
  * @public
  */
 Blockly.ConnectionChecker.prototype.doTypeChecks = function(a, b) {
-  var checkArrayOne = a.getCheck();
-  var checkArrayTwo = b.getCheck();
+  const checkArrayOne = a.getCheck();
+  const checkArrayTwo = b.getCheck();
 
   if (!checkArrayOne || !checkArrayTwo) {
     // One or both sides are promiscuous enough that anything will fit.
     return true;
   }
   // Find any intersection in the check lists.
-  for (var i = 0; i < checkArrayOne.length; i++) {
+  for (let i = 0; i < checkArrayOne.length; i++) {
     if (checkArrayTwo.indexOf(checkArrayOne[i]) != -1) {
       return true;
     }
@@ -274,7 +276,7 @@ Blockly.ConnectionChecker.prototype.canConnectToPrevious_ = function(a, b) {
     return true;
   }
 
-  var targetBlock = b.targetBlock();
+  const targetBlock = b.targetBlock();
   // If it is connected to a real block, game over.
   if (!targetBlock.isInsertionMarker()) {
     return false;

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -5,8 +5,8 @@
  */
 
 /**
- * @fileoverview An object that encapsulates logic for checking whether a potential
- * connection is safe and valid.
+ * @fileoverview An object that encapsulates logic for checking whether a
+ * potential connection is safe and valid.
  * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
@@ -28,8 +28,7 @@ goog.require('Blockly.constants');
  * @implements {IConnectionChecker}
  * @constructor
  */
-const ConnectionChecker = function() {
-};
+const ConnectionChecker = function() {};
 
 /**
  * Check whether the current connection can connect with the target
@@ -43,8 +42,8 @@ const ConnectionChecker = function() {
  * @return {boolean} Whether the connection is legal.
  * @public
  */
-ConnectionChecker.prototype.canConnect = function(a, b,
-    isDragging, opt_distance) {
+ConnectionChecker.prototype.canConnect = function(
+    a, b, isDragging, opt_distance) {
   return this.canConnectWithReason(a, b, isDragging, opt_distance) ==
       Connection.CAN_CONNECT;
 };
@@ -79,8 +78,7 @@ ConnectionChecker.prototype.canConnectWithReason = function(
   if (isDragging &&
       !this.doDragChecks(
           /** @type {!RenderedConnection} **/ (a),
-          /** @type {!RenderedConnection} **/ (b),
-          opt_distance || 0)) {
+          /** @type {!RenderedConnection} **/ (b), opt_distance || 0)) {
     return Connection.REASON_DRAG_CHECKS_FAILED;
   }
 
@@ -96,8 +94,7 @@ ConnectionChecker.prototype.canConnectWithReason = function(
  * @return {string} A developer-readable error string.
  * @public
  */
-ConnectionChecker.prototype.getErrorMessage = function(errorCode,
-    a, b) {
+ConnectionChecker.prototype.getErrorMessage = function(errorCode, a, b) {
   switch (errorCode) {
     case Connection.REASON_SELF_CONNECTION:
       return 'Attempted to connect a block to itself.';
@@ -112,7 +109,8 @@ ConnectionChecker.prototype.getErrorMessage = function(errorCode,
       const connOne = /** @type {!Connection} **/ (a);
       const connTwo = /** @type {!Connection} **/ (b);
       let msg = 'Connection checks failed. ';
-      msg += connOne + ' expected ' + connOne.getCheck() + ', found ' + connTwo.getCheck();
+      msg += connOne + ' expected ' + connOne.getCheck() + ', found ' +
+          connTwo.getCheck();
       return msg;
     }
     case Connection.REASON_SHADOW_PARENT:
@@ -207,8 +205,7 @@ ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
     case connectionTypes.OUTPUT_VALUE: {
       // Don't offer to connect an already connected left (male) value plug to
       // an available right (female) value plug.
-      if ((b.isConnected() &&
-          !b.targetBlock().isInsertionMarker()) ||
+      if ((b.isConnected() && !b.targetBlock().isInsertionMarker()) ||
           a.isConnected()) {
         return false;
       }
@@ -218,8 +215,7 @@ ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
       // Offering to connect the left (male) of a value block to an already
       // connected value pair is ok, we'll splice it in.
       // However, don't offer to splice into an immovable block.
-      if (b.isConnected() &&
-          !b.targetBlock().isMovable() &&
+      if (b.isConnected() && !b.targetBlock().isMovable() &&
           !b.targetBlock().isShadow()) {
         return false;
       }
@@ -230,10 +226,8 @@ ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
       // stack.  But covering up a shadow block or stack of shadow blocks is
       // fine.  Similarly, replacing a terminal statement with another terminal
       // statement is allowed.
-      if (b.isConnected() &&
-          !a.getSourceBlock().nextConnection &&
-          !b.targetBlock().isShadow() &&
-          b.targetBlock().nextConnection) {
+      if (b.isConnected() && !a.getSourceBlock().nextConnection &&
+          !b.targetBlock().isShadow() && b.targetBlock().nextConnection) {
         return false;
       }
       break;
@@ -287,7 +281,7 @@ ConnectionChecker.prototype.canConnectToPrevious_ = function(a, b) {
   return !targetBlock.getPreviousBlock();
 };
 
-registry.register(registry.Type.CONNECTION_CHECKER,
-    registry.DEFAULT, ConnectionChecker);
+registry.register(
+    registry.Type.CONNECTION_CHECKER, registry.DEFAULT, ConnectionChecker);
 
 exports = ConnectionChecker;

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -15,10 +15,10 @@ goog.module('Blockly.ConnectionChecker');
 goog.module.declareLegacyNamespace();
 
 const Connection = goog.require('Blockly.Connection');
-const connectionTypes = goog.require('Blockly.connectionTypes');
 const IConnectionChecker = goog.require('Blockly.IConnectionChecker');
-const registry = goog.require('Blockly.registry');
 const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
+const connectionTypes = goog.require('Blockly.connectionTypes');
+const registry = goog.require('Blockly.registry');
 /** @suppress {extraRequire} */
 goog.require('Blockly.constants');
 

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.ConnectionChecker');
+goog.module('Blockly.ConnectionChecker');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Connection');
 goog.require('Blockly.connectionTypes');
@@ -28,7 +29,7 @@ goog.requireType('Blockly.RenderedConnection');
  * @implements {Blockly.IConnectionChecker}
  * @constructor
  */
-Blockly.ConnectionChecker = function() {
+const ConnectionChecker = function() {
 };
 
 /**
@@ -43,7 +44,7 @@ Blockly.ConnectionChecker = function() {
  * @return {boolean} Whether the connection is legal.
  * @public
  */
-Blockly.ConnectionChecker.prototype.canConnect = function(a, b,
+ConnectionChecker.prototype.canConnect = function(a, b,
     isDragging, opt_distance) {
   return this.canConnectWithReason(a, b, isDragging, opt_distance) ==
       Blockly.Connection.CAN_CONNECT;
@@ -62,7 +63,7 @@ Blockly.ConnectionChecker.prototype.canConnect = function(a, b,
  *    an error code otherwise.
  * @public
  */
-Blockly.ConnectionChecker.prototype.canConnectWithReason = function(
+ConnectionChecker.prototype.canConnectWithReason = function(
     a, b, isDragging, opt_distance) {
   const safety = this.doSafetyChecks(a, b);
   if (safety != Blockly.Connection.CAN_CONNECT) {
@@ -96,7 +97,7 @@ Blockly.ConnectionChecker.prototype.canConnectWithReason = function(
  * @return {string} A developer-readable error string.
  * @public
  */
-Blockly.ConnectionChecker.prototype.getErrorMessage = function(errorCode,
+ConnectionChecker.prototype.getErrorMessage = function(errorCode,
     a, b) {
   switch (errorCode) {
     case Blockly.Connection.REASON_SELF_CONNECTION:
@@ -132,7 +133,7 @@ Blockly.ConnectionChecker.prototype.getErrorMessage = function(errorCode,
  * @return {number} An enum with the reason this connection is safe or unsafe.
  * @public
  */
-Blockly.ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
+ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
   if (!a || !b) {
     return Blockly.Connection.REASON_TARGET_NULL;
   }
@@ -165,7 +166,7 @@ Blockly.ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
  * @return {boolean} True if the connections share a type.
  * @public
  */
-Blockly.ConnectionChecker.prototype.doTypeChecks = function(a, b) {
+ConnectionChecker.prototype.doTypeChecks = function(a, b) {
   const checkArrayOne = a.getCheck();
   const checkArrayTwo = b.getCheck();
 
@@ -191,7 +192,7 @@ Blockly.ConnectionChecker.prototype.doTypeChecks = function(a, b) {
  * @return {boolean} True if the connection is allowed during a drag.
  * @public
  */
-Blockly.ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
+ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
   if (a.distanceFrom(b) > distance) {
     return false;
   }
@@ -260,7 +261,7 @@ Blockly.ConnectionChecker.prototype.doDragChecks = function(a, b, distance) {
  * @return {boolean} True if the connection is allowed, false otherwise.
  * @protected
  */
-Blockly.ConnectionChecker.prototype.canConnectToPrevious_ = function(a, b) {
+ConnectionChecker.prototype.canConnectToPrevious_ = function(a, b) {
   if (a.targetConnection) {
     // This connection is already occupied.
     // A next connection will never disconnect itself mid-drag.
@@ -288,4 +289,6 @@ Blockly.ConnectionChecker.prototype.canConnectToPrevious_ = function(a, b) {
 };
 
 Blockly.registry.register(Blockly.registry.Type.CONNECTION_CHECKER,
-    Blockly.registry.DEFAULT, Blockly.ConnectionChecker);
+    Blockly.registry.DEFAULT, ConnectionChecker);
+
+exports = ConnectionChecker;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -20,7 +20,7 @@ goog.addDependency('../../core/bubble_dragger.js', ['Blockly.BubbleDragger'], ['
 goog.addDependency('../../core/comment.js', ['Blockly.Comment'], ['Blockly.Bubble', 'Blockly.Css', 'Blockly.Events', 'Blockly.Events.BlockChange', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.Warning', 'Blockly.browserEvents', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.userAgent']);
 goog.addDependency('../../core/component_manager.js', ['Blockly.ComponentManager'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/connection.js', ['Blockly.Connection'], ['Blockly.Events', 'Blockly.Events.BlockMove', 'Blockly.IASTNodeLocationWithBlock', 'Blockly.Xml', 'Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.deprecation']);
-goog.addDependency('../../core/connection_checker.js', ['Blockly.ConnectionChecker'], ['Blockly.Connection', 'Blockly.IConnectionChecker', 'Blockly.connectionTypes', 'Blockly.constants', 'Blockly.registry']);
+goog.addDependency('../../core/connection_checker.js', ['Blockly.ConnectionChecker'], ['Blockly.Connection', 'Blockly.IConnectionChecker', 'Blockly.connectionTypes', 'Blockly.constants', 'Blockly.registry'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/connection_db.js', ['Blockly.ConnectionDB'], ['Blockly.RenderedConnection', 'Blockly.connectionTypes', 'Blockly.constants']);
 goog.addDependency('../../core/connection_types.js', ['Blockly.connectionTypes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/constants.js', ['Blockly.constants'], ['Blockly.connectionTypes']);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026