### PR TITLE
Migrate core/interfaces/i_selectable.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_selectable.js
+++ b/core/interfaces/i_selectable.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.ISelectable');
+goog.module('Blockly.ISelectable');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.IDeletable');
 goog.requireType('Blockly.IMovable');
@@ -23,21 +24,23 @@ goog.requireType('Blockly.IMovable');
  * @extends {Blockly.IMovable}
  * @interface
  */
-Blockly.ISelectable = function() {};
+const ISelectable = function() {};
 
 /**
  * @type {string}
  */
-Blockly.ISelectable.prototype.id;
+ISelectable.prototype.id;
 
 /**
  * Select this.  Highlight it visually.
  * @return {void}
  */
-Blockly.ISelectable.prototype.select;
+ISelectable.prototype.select;
 
 /**
  * Unselect this.  Unhighlight it visually.
  * @return {void}
  */
-Blockly.ISelectable.prototype.unselect;
+ISelectable.prototype.unselect;
+
+exports = ISelectable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -92,7 +92,7 @@ goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [
 goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], []);
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
-goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], []);
+goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], []);
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_selectable.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_selectable.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
