### PR TITLE
Migrate core/interfaces/i_styleable.js to goog.module

### DIFF
--- a/core/interfaces/i_styleable.js
+++ b/core/interfaces/i_styleable.js
@@ -11,23 +11,26 @@
 
 'use strict';
 
-goog.provide('Blockly.IStyleable');
+goog.module('Blockly.IStyleable');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * Interface for an object that a style can be added to.
  * @interface
  */
-Blockly.IStyleable = function() {};
+const IStyleable = function() {};
 
 /**
  * Adds a style on the toolbox. Usually used to change the cursor.
  * @param {string} style The name of the class to add.
  */
-Blockly.IStyleable.prototype.addStyle;
+IStyleable.prototype.addStyle;
 
 /**
  * Removes a style from the toolbox. Usually used to change the cursor.
  * @param {string} style The name of the class to remove.
  */
-Blockly.IStyleable.prototype.removeStyle;
+IStyleable.prototype.removeStyle;
+
+exports = IStyleable;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -93,7 +93,7 @@ goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositio
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], []);
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], []);
-goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], []);
+goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], []);
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `FILEPATH` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
