### PR TITLE
Migrate core/interfaces/i_toolbox.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_toolbox.js
+++ b/core/interfaces/i_toolbox.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IToolbox');
+goog.module('Blockly.IToolbox');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.IFlyout');
 goog.requireType('Blockly.IRegistrable');
@@ -25,76 +26,76 @@ goog.requireType('Blockly.WorkspaceSvg');
  * @extends {Blockly.IRegistrable}
  * @interface
  */
-Blockly.IToolbox = function() {};
+const IToolbox = function() {};
 
 /**
  * Initializes the toolbox.
  * @return {void}
  */
-Blockly.IToolbox.prototype.init;
+IToolbox.prototype.init;
 
 /**
  * Fills the toolbox with new toolbox items and removes any old contents.
  * @param {!Blockly.utils.toolbox.ToolboxInfo} toolboxDef Object holding information
  *     for creating a toolbox.
  */
-Blockly.IToolbox.prototype.render;
+IToolbox.prototype.render;
 
 /**
  * Gets the width of the toolbox.
  * @return {number} The width of the toolbox.
  */
-Blockly.IToolbox.prototype.getWidth;
+IToolbox.prototype.getWidth;
 
 /**
  * Gets the height of the toolbox.
  * @return {number} The width of the toolbox.
  */
-Blockly.IToolbox.prototype.getHeight;
+IToolbox.prototype.getHeight;
 
 /**
  * Gets the toolbox flyout.
  * @return {?Blockly.IFlyout} The toolbox flyout.
  */
-Blockly.IToolbox.prototype.getFlyout;
+IToolbox.prototype.getFlyout;
 
 /**
  * Gets the workspace for the toolbox.
  * @return {!Blockly.WorkspaceSvg} The parent workspace for the toolbox.
  */
-Blockly.IToolbox.prototype.getWorkspace;
+IToolbox.prototype.getWorkspace;
 
 /**
  * Gets whether or not the toolbox is horizontal.
  * @return {boolean} True if the toolbox is horizontal, false if the toolbox is
  *     vertical.
  */
-Blockly.IToolbox.prototype.isHorizontal;
+IToolbox.prototype.isHorizontal;
 
 /**
  * Positions the toolbox based on whether it is a horizontal toolbox and whether
  * the workspace is in rtl.
  * @return {void}
  */
-Blockly.IToolbox.prototype.position;
+IToolbox.prototype.position;
 
 /**
  * Handles resizing the toolbox when a toolbox item resizes.
  * @return {void}
  */
-Blockly.IToolbox.prototype.handleToolboxItemResize;
+IToolbox.prototype.handleToolboxItemResize;
 
 /**
  * Unhighlights any previously selected item.
  * @return {void}
  */
-Blockly.IToolbox.prototype.clearSelection;
+IToolbox.prototype.clearSelection;
 
 /**
  * Updates the category colours and background colour of selected categories.
  * @return {void}
  */
-Blockly.IToolbox.prototype.refreshTheme;
+IToolbox.prototype.refreshTheme;
 
 /**
  * Updates the flyout's content without closing it.  Should be used in response
@@ -102,30 +103,32 @@ Blockly.IToolbox.prototype.refreshTheme;
  * procedures.
  * @return {void}
  */
-Blockly.IToolbox.prototype.refreshSelection;
+IToolbox.prototype.refreshSelection;
 
 /**
  * Sets the visibility of the toolbox.
  * @param {boolean} isVisible True if toolbox should be visible.
  */
-Blockly.IToolbox.prototype.setVisible;
+IToolbox.prototype.setVisible;
 
 /**
  * Selects the toolbox item by it's position in the list of toolbox items.
  * @param {number} position The position of the item to select.
  * @return {void}
  */
-Blockly.IToolbox.prototype.selectItemByPosition;
+IToolbox.prototype.selectItemByPosition;
 
 /**
  * Gets the selected item.
  * @return {?Blockly.IToolboxItem} The selected item, or null if no item is
  *     currently selected.
  */
-Blockly.IToolbox.prototype.getSelectedItem;
+IToolbox.prototype.getSelectedItem;
 
 /**
  * Disposes of this toolbox.
  * @return {void}
  */
-Blockly.IToolbox.prototype.dispose;
+IToolbox.prototype.dispose;
+
+exports = IToolbox;

--- a/core/interfaces/i_toolbox.js
+++ b/core/interfaces/i_toolbox.js
@@ -14,16 +14,16 @@
 goog.module('Blockly.IToolbox');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.IFlyout');
-goog.requireType('Blockly.IRegistrable');
-goog.requireType('Blockly.IToolboxItem');
-goog.requireType('Blockly.utils.toolbox');
-goog.requireType('Blockly.WorkspaceSvg');
+const IFlyout = goog.requireType('Blockly.IFlyout');
+const IRegistrable = goog.require('Blockly.IRegistrable');
+const IToolboxItem = goog.requireType('Blockly.IToolboxItem');
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+const {ToolboxInfo} = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
  * Interface for a toolbox.
- * @extends {Blockly.IRegistrable}
+ * @extends {IRegistrable}
  * @interface
  */
 const IToolbox = function() {};
@@ -36,7 +36,7 @@ IToolbox.prototype.init;
 
 /**
  * Fills the toolbox with new toolbox items and removes any old contents.
- * @param {!Blockly.utils.toolbox.ToolboxInfo} toolboxDef Object holding information
+ * @param {!ToolboxInfo} toolboxDef Object holding information
  *     for creating a toolbox.
  */
 IToolbox.prototype.render;
@@ -55,13 +55,13 @@ IToolbox.prototype.getHeight;
 
 /**
  * Gets the toolbox flyout.
- * @return {?Blockly.IFlyout} The toolbox flyout.
+ * @return {?IFlyout} The toolbox flyout.
  */
 IToolbox.prototype.getFlyout;
 
 /**
  * Gets the workspace for the toolbox.
- * @return {!Blockly.WorkspaceSvg} The parent workspace for the toolbox.
+ * @return {!WorkspaceSvg} The parent workspace for the toolbox.
  */
 IToolbox.prototype.getWorkspace;
 
@@ -120,7 +120,7 @@ IToolbox.prototype.selectItemByPosition;
 
 /**
  * Gets the selected item.
- * @return {?Blockly.IToolboxItem} The selected item, or null if no item is
+ * @return {?IToolboxItem} The selected item, or null if no item is
  *     currently selected.
  */
 IToolbox.prototype.getSelectedItem;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -97,7 +97,7 @@ goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistra
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], []);
+goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry'], {'lang': 'es5'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_toolbox.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_toolbox.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
