### PR TITLE
Always have npm start serve the repository root

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "publish:beta": "gulp publishBeta",
     "recompile": "gulp recompile",
     "release": "gulp gitCreateRC",
-    "start": "http-server -o /tests/playground.html",
+    "start": "http-server ./ -o /tests/playground.html",
     "test": "tests/run_all_tests.sh",
     "test:generators": "tests/scripts/run_generators.sh",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest",


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Problem observed when existence of a `public/` subdirectory in the repository root causes `http-server` to serve `./public` instead of `./`, resulting in `npm start` opening a browser window that immediately displays a 404 error.

### Proposed Changes

Explicitly specify directory to be served by `http-server` in response to `npm start`.
