### PR TITLE
Migrate core/interfaces/i_toolbox_item.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_collapsible_toolbox_item.js
+++ b/core/interfaces/i_collapsible_toolbox_item.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for a collapsible toolbox item.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+
+'use strict';
+
+goog.provide('Blockly.ICollapsibleToolboxItem');
+
+goog.require('Blockly.IToolboxItem');
+goog.requireType('Blockly.utils.toolbox');
+
+
+/**
+ * Interface for an item in the toolbox that can be collapsed.
+ * @extends {Blockly.ISelectableToolboxItem}
+ * @interface
+ */
+Blockly.ICollapsibleToolboxItem = function() {};
+
+/**
+ * Gets any children toolbox items. (ex. Gets the subcategories)
+ * @return {!Array<!Blockly.IToolboxItem>} The child toolbox items.
+ */
+Blockly.ICollapsibleToolboxItem.prototype.getChildToolboxItems;
+
+/**
+ * Whether the toolbox item is expanded to show its child subcategories.
+ * @return {boolean} True if the toolbox item shows its children, false if it
+ *     is collapsed.
+ * @public
+ */
+Blockly.ICollapsibleToolboxItem.prototype.isExpanded;
+
+/**
+ * Toggles whether or not the toolbox item is expanded.
+ * @public
+ */
+Blockly.ICollapsibleToolboxItem.prototype.toggleExpanded;

--- a/core/interfaces/i_collapsible_toolbox_item.js
+++ b/core/interfaces/i_collapsible_toolbox_item.js
@@ -11,10 +11,11 @@
 
 'use strict';
 
-goog.provide('Blockly.ICollapsibleToolboxItem');
+goog.module('Blockly.ICollapsibleToolboxItem');
+goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IToolboxItem');
-goog.requireType('Blockly.utils.toolbox');
+goog.require('Blockly.ISelectableToolboxItem');
+goog.requireType('Blockly.IToolboxItem');
 
 
 /**
@@ -22,13 +23,13 @@ goog.requireType('Blockly.utils.toolbox');
  * @extends {Blockly.ISelectableToolboxItem}
  * @interface
  */
-Blockly.ICollapsibleToolboxItem = function() {};
+const ICollapsibleToolboxItem = function() {};
 
 /**
  * Gets any children toolbox items. (ex. Gets the subcategories)
  * @return {!Array<!Blockly.IToolboxItem>} The child toolbox items.
  */
-Blockly.ICollapsibleToolboxItem.prototype.getChildToolboxItems;
+ICollapsibleToolboxItem.prototype.getChildToolboxItems;
 
 /**
  * Whether the toolbox item is expanded to show its child subcategories.
@@ -36,10 +37,12 @@ Blockly.ICollapsibleToolboxItem.prototype.getChildToolboxItems;
  *     is collapsed.
  * @public
  */
-Blockly.ICollapsibleToolboxItem.prototype.isExpanded;
+ICollapsibleToolboxItem.prototype.isExpanded;
 
 /**
  * Toggles whether or not the toolbox item is expanded.
  * @public
  */
-Blockly.ICollapsibleToolboxItem.prototype.toggleExpanded;
+ICollapsibleToolboxItem.prototype.toggleExpanded;
+
+exports = ICollapsibleToolboxItem;

--- a/core/interfaces/i_collapsible_toolbox_item.js
+++ b/core/interfaces/i_collapsible_toolbox_item.js
@@ -14,20 +14,20 @@
 goog.module('Blockly.ICollapsibleToolboxItem');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.ISelectableToolboxItem');
-goog.requireType('Blockly.IToolboxItem');
+const ISelectableToolboxItem = goog.require('Blockly.ISelectableToolboxItem');
+const IToolboxItem = goog.requireType('Blockly.IToolboxItem');
 
 
 /**
  * Interface for an item in the toolbox that can be collapsed.
- * @extends {Blockly.ISelectableToolboxItem}
+ * @extends {ISelectableToolboxItem}
  * @interface
  */
 const ICollapsibleToolboxItem = function() {};
 
 /**
  * Gets any children toolbox items. (ex. Gets the subcategories)
- * @return {!Array<!Blockly.IToolboxItem>} The child toolbox items.
+ * @return {!Array<!IToolboxItem>} The child toolbox items.
  */
 ICollapsibleToolboxItem.prototype.getChildToolboxItems;
 

--- a/core/interfaces/i_selectable_toolbox_item.js
+++ b/core/interfaces/i_selectable_toolbox_item.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.ISelectableToolboxItem');
+goog.module('Blockly.ISelectableToolboxItem');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IToolboxItem');
 goog.requireType('Blockly.utils.toolbox');
@@ -22,14 +23,14 @@ goog.requireType('Blockly.utils.toolbox');
  * @extends {Blockly.IToolboxItem}
  * @interface
  */
-Blockly.ISelectableToolboxItem = function() {};
+const ISelectableToolboxItem = function() {};
 
 /**
  * Gets the name of the toolbox item. Used for emitting events.
  * @return {string} The name of the toolbox item.
  * @public
  */
-Blockly.ISelectableToolboxItem.prototype.getName;
+ISelectableToolboxItem.prototype.getName;
 
 /**
  * Gets the contents of the toolbox item. These are items that are meant to be
@@ -38,7 +39,7 @@ Blockly.ISelectableToolboxItem.prototype.getName;
  *     of items to be displayed in the flyout.
  * @public
  */
-Blockly.ISelectableToolboxItem.prototype.getContents;
+ISelectableToolboxItem.prototype.getContents;
 
 /**
  * Sets the current toolbox item as selected.
@@ -46,7 +47,7 @@ Blockly.ISelectableToolboxItem.prototype.getContents;
  *     otherwise.
  * @public
  */
-Blockly.ISelectableToolboxItem.prototype.setSelected;
+ISelectableToolboxItem.prototype.setSelected;
 
 /**
  * Gets the HTML element that is clickable.
@@ -55,11 +56,13 @@ Blockly.ISelectableToolboxItem.prototype.setSelected;
  * @return {!Element} The HTML element that receives clicks.
  * @public
  */
-Blockly.ISelectableToolboxItem.prototype.getClickTarget;
+ISelectableToolboxItem.prototype.getClickTarget;
 
 /**
  * Handles when the toolbox item is clicked.
  * @param {!Event} _e Click event to handle.
  * @public
  */
-Blockly.ISelectableToolboxItem.prototype.onClick;
+ISelectableToolboxItem.prototype.onClick;
+
+exports = ISelectableToolboxItem;

--- a/core/interfaces/i_selectable_toolbox_item.js
+++ b/core/interfaces/i_selectable_toolbox_item.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview The interface for a selectable toolbox item.
+ * @author aschmiedt@google.com (Abby Schmiedt)
+ */
+
+'use strict';
+
+goog.provide('Blockly.ISelectableToolboxItem');
+
+goog.require('Blockly.IToolboxItem');
+goog.requireType('Blockly.utils.toolbox');
+
+
+/**
+ * Interface for an item in the toolbox that can be selected.
+ * @extends {Blockly.IToolboxItem}
+ * @interface
+ */
+Blockly.ISelectableToolboxItem = function() {};
+
+/**
+ * Gets the name of the toolbox item. Used for emitting events.
+ * @return {string} The name of the toolbox item.
+ * @public
+ */
+Blockly.ISelectableToolboxItem.prototype.getName;
+
+/**
+ * Gets the contents of the toolbox item. These are items that are meant to be
+ * displayed in the flyout.
+ * @return {!Blockly.utils.toolbox.FlyoutItemInfoArray|string} The definition
+ *     of items to be displayed in the flyout.
+ * @public
+ */
+Blockly.ISelectableToolboxItem.prototype.getContents;
+
+/**
+ * Sets the current toolbox item as selected.
+ * @param {boolean} _isSelected True if this category is selected, false
+ *     otherwise.
+ * @public
+ */
+Blockly.ISelectableToolboxItem.prototype.setSelected;
+
+/**
+ * Gets the HTML element that is clickable.
+ * The parent toolbox element receives clicks. The parent toolbox will add an ID
+ * to this element so it can pass the onClick event to the correct toolboxItem.
+ * @return {!Element} The HTML element that receives clicks.
+ * @public
+ */
+Blockly.ISelectableToolboxItem.prototype.getClickTarget;
+
+/**
+ * Handles when the toolbox item is clicked.
+ * @param {!Event} _e Click event to handle.
+ * @public
+ */
+Blockly.ISelectableToolboxItem.prototype.onClick;

--- a/core/interfaces/i_selectable_toolbox_item.js
+++ b/core/interfaces/i_selectable_toolbox_item.js
@@ -14,13 +14,13 @@
 goog.module('Blockly.ISelectableToolboxItem');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IToolboxItem');
-goog.requireType('Blockly.utils.toolbox');
+const IToolboxItem = goog.require('Blockly.IToolboxItem');
+const {FlyoutItemInfoArray} = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
  * Interface for an item in the toolbox that can be selected.
- * @extends {Blockly.IToolboxItem}
+ * @extends {IToolboxItem}
  * @interface
  */
 const ISelectableToolboxItem = function() {};
@@ -35,7 +35,7 @@ ISelectableToolboxItem.prototype.getName;
 /**
  * Gets the contents of the toolbox item. These are items that are meant to be
  * displayed in the flyout.
- * @return {!Blockly.utils.toolbox.FlyoutItemInfoArray|string} The definition
+ * @return {!FlyoutItemInfoArray|string} The definition
  *     of items to be displayed in the flyout.
  * @public
  */

--- a/core/interfaces/i_toolbox_item.js
+++ b/core/interfaces/i_toolbox_item.js
@@ -11,16 +11,15 @@
 
 'use strict';
 
-goog.provide('Blockly.IToolboxItem');
-
-goog.requireType('Blockly.utils.toolbox');
+goog.module('Blockly.IToolboxItem');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * Interface for an item in the toolbox.
  * @interface
  */
-Blockly.IToolboxItem = function() {};
+const IToolboxItem = function() {};
 
 /**
  * Initializes the toolbox item.
@@ -29,21 +28,21 @@ Blockly.IToolboxItem = function() {};
  * @return {void}
  * @public
  */
-Blockly.IToolboxItem.prototype.init;
+IToolboxItem.prototype.init;
 
 /**
  * Gets the div for the toolbox item.
  * @return {?Element} The div for the toolbox item.
  * @public
  */
-Blockly.IToolboxItem.prototype.getDiv;
+IToolboxItem.prototype.getDiv;
 
 /**
  * Gets a unique identifier for this toolbox item.
  * @return {string} The ID for the toolbox item.
  * @public
  */
-Blockly.IToolboxItem.prototype.getId;
+IToolboxItem.prototype.getId;
 
 /**
  * Gets the parent if the toolbox item is nested.
@@ -51,31 +50,33 @@ Blockly.IToolboxItem.prototype.getId;
  *     this toolbox item is not nested.
  * @public
  */
-Blockly.IToolboxItem.prototype.getParent;
+IToolboxItem.prototype.getParent;
 
 /**
  * Gets the nested level of the category.
  * @return {number} The nested level of the category.
  * @package
  */
-Blockly.IToolboxItem.prototype.getLevel;
+IToolboxItem.prototype.getLevel;
 
 /**
  * Whether the toolbox item is selectable.
  * @return {boolean} True if the toolbox item can be selected.
  * @public
  */
-Blockly.IToolboxItem.prototype.isSelectable;
+IToolboxItem.prototype.isSelectable;
 
 /**
  * Whether the toolbox item is collapsible.
  * @return {boolean} True if the toolbox item is collapsible.
  * @public
  */
-Blockly.IToolboxItem.prototype.isCollapsible;
+IToolboxItem.prototype.isCollapsible;
 
 /**
  * Dispose of this toolbox item. No-op by default.
  * @public
  */
-Blockly.IToolboxItem.prototype.dispose;
+IToolboxItem.prototype.dispose;
+
+exports = IToolboxItem;

--- a/core/interfaces/i_toolbox_item.js
+++ b/core/interfaces/i_toolbox_item.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-goog.provide('Blockly.ICollapsibleToolboxItem');
-goog.provide('Blockly.ISelectableToolboxItem');
 goog.provide('Blockly.IToolboxItem');
 
 goog.requireType('Blockly.utils.toolbox');
@@ -81,77 +79,3 @@ Blockly.IToolboxItem.prototype.isCollapsible;
  * @public
  */
 Blockly.IToolboxItem.prototype.dispose;
-
-/**
- * Interface for an item in the toolbox that can be selected.
- * @extends {Blockly.IToolboxItem}
- * @interface
- */
-Blockly.ISelectableToolboxItem = function() {};
-
-/**
- * Gets the name of the toolbox item. Used for emitting events.
- * @return {string} The name of the toolbox item.
- * @public
- */
-Blockly.ISelectableToolboxItem.prototype.getName;
-
-/**
- * Gets the contents of the toolbox item. These are items that are meant to be
- * displayed in the flyout.
- * @return {!Blockly.utils.toolbox.FlyoutItemInfoArray|string} The definition
- *     of items to be displayed in the flyout.
- * @public
- */
-Blockly.ISelectableToolboxItem.prototype.getContents;
-
-/**
- * Sets the current toolbox item as selected.
- * @param {boolean} _isSelected True if this category is selected, false
- *     otherwise.
- * @public
- */
-Blockly.ISelectableToolboxItem.prototype.setSelected;
-
-/**
- * Gets the HTML element that is clickable.
- * The parent toolbox element receives clicks. The parent toolbox will add an ID
- * to this element so it can pass the onClick event to the correct toolboxItem.
- * @return {!Element} The HTML element that receives clicks.
- * @public
- */
-Blockly.ISelectableToolboxItem.prototype.getClickTarget;
-
-/**
- * Handles when the toolbox item is clicked.
- * @param {!Event} _e Click event to handle.
- * @public
- */
-Blockly.ISelectableToolboxItem.prototype.onClick;
-
-/**
- * Interface for an item in the toolbox that can be collapsed.
- * @extends {Blockly.ISelectableToolboxItem}
- * @interface
- */
-Blockly.ICollapsibleToolboxItem = function() {};
-
-/**
- * Gets any children toolbox items. (ex. Gets the subcategories)
- * @return {!Array<!Blockly.IToolboxItem>} The child toolbox items.
- */
-Blockly.ICollapsibleToolboxItem.prototype.getChildToolboxItems;
-
-/**
- * Whether the toolbox item is expanded to show its child subcategories.
- * @return {boolean} True if the toolbox item shows its children, false if it
- *     is collapsed.
- * @public
- */
-Blockly.ICollapsibleToolboxItem.prototype.isExpanded;
-
-/**
- * Toggles whether or not the toolbox item is expanded.
- * @public
- */
-Blockly.ICollapsibleToolboxItem.prototype.toggleExpanded;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -80,6 +80,7 @@ goog.addDependency('../../core/interfaces/i_autohideable.js', ['Blockly.IAutoHid
 goog.addDependency('../../core/interfaces/i_block_dragger.js', ['Blockly.IBlockDragger'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bounded_element.js', ['Blockly.IBoundedElement'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_bubble.js', ['Blockly.IBubble'], ['Blockly.IContextMenu', 'Blockly.IDraggable'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_collapsible_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem'], ['Blockly.ISelectableToolboxItem'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_component.js', ['Blockly.IComponent'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_connection_checker.js', ['Blockly.IConnectionChecker'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_contextmenu.js', ['Blockly.IContextMenu'], [], {'lang': 'es6', 'module': 'goog'});
@@ -96,9 +97,10 @@ goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositio
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], []);
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_selectable_toolbox_item.js', ['Blockly.ISelectableToolboxItem'], ['Blockly.IToolboxItem'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
+goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.IToolboxItem'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_toolbox_item.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_toolbox_item.js` to `goog.module` syntax. 

### Additional Information

This PR splits up `core/interfaces/i_toolbox_item.js` into multiple files for each interface that it provided.