### PR TITLE
Migrate core/keyboard_nav/marker.js to goog.module syntax

### DIFF
--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -14,7 +14,9 @@
 goog.module('Blockly.Marker');
 goog.module.declareLegacyNamespace();
 
-const ASTNode = goog.require('Blockly.ASTNode');
+/* eslint-disable-next-line no-unused-vars */
+const ASTNode = goog.requireType('Blockly.ASTNode');
+/* eslint-disable-next-line no-unused-vars */
 const MarkerSvg = goog.requireType('Blockly.blockRendering.MarkerSvg');
 
 

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -38,7 +38,8 @@ const Marker = function() {
   this.curNode_ = null;
 
   /**
-   * The object in charge of drawing the visual representation of the current node.
+   * The object in charge of drawing the visual representation of the current
+   * node.
    * @type {MarkerSvg}
    * @private
    */

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -85,7 +85,7 @@ Blockly.Marker.prototype.getCurNode = function() {
  * @param {Blockly.ASTNode} newNode The new location of the marker.
  */
 Blockly.Marker.prototype.setCurNode = function(newNode) {
-  var oldNode = this.curNode_;
+  const oldNode = this.curNode_;
   this.curNode_ = newNode;
   if (this.drawer_) {
     this.drawer_.draw(oldNode, this.curNode_);

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Marker');
+goog.module('Blockly.Marker');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.ASTNode');
 
@@ -23,7 +24,7 @@ goog.requireType('Blockly.blockRendering.MarkerSvg');
  * This is used in keyboard navigation to save a location in the Blockly AST.
  * @constructor
  */
-Blockly.Marker = function() {
+const Marker = function() {
   /**
    * The colour of the marker.
    * @type {?string}
@@ -56,7 +57,7 @@ Blockly.Marker = function() {
  * @param {Blockly.blockRendering.MarkerSvg} drawer The object in charge of
  *     drawing the marker.
  */
-Blockly.Marker.prototype.setDrawer = function(drawer) {
+Marker.prototype.setDrawer = function(drawer) {
   this.drawer_ = drawer;
 };
 
@@ -65,7 +66,7 @@ Blockly.Marker.prototype.setDrawer = function(drawer) {
  * @return {Blockly.blockRendering.MarkerSvg} The object in charge of drawing
  *     the marker.
  */
-Blockly.Marker.prototype.getDrawer = function() {
+Marker.prototype.getDrawer = function() {
   return this.drawer_;
 };
 
@@ -74,7 +75,7 @@ Blockly.Marker.prototype.getDrawer = function() {
  * @return {Blockly.ASTNode} The current field, connection, or block the marker
  *     is on.
  */
-Blockly.Marker.prototype.getCurNode = function() {
+Marker.prototype.getCurNode = function() {
   return this.curNode_;
 };
 
@@ -84,7 +85,7 @@ Blockly.Marker.prototype.getCurNode = function() {
  * output or previous connection on a stack.
  * @param {Blockly.ASTNode} newNode The new location of the marker.
  */
-Blockly.Marker.prototype.setCurNode = function(newNode) {
+Marker.prototype.setCurNode = function(newNode) {
   const oldNode = this.curNode_;
   this.curNode_ = newNode;
   if (this.drawer_) {
@@ -96,7 +97,7 @@ Blockly.Marker.prototype.setCurNode = function(newNode) {
  * Redraw the current marker.
  * @package
  */
-Blockly.Marker.prototype.draw = function() {
+Marker.prototype.draw = function() {
   if (this.drawer_) {
     this.drawer_.draw(this.curNode_, this.curNode_);
   }
@@ -105,7 +106,7 @@ Blockly.Marker.prototype.draw = function() {
 /**
  * Hide the marker SVG.
  */
-Blockly.Marker.prototype.hide = function() {
+Marker.prototype.hide = function() {
   if (this.drawer_) {
     this.drawer_.hide();
   }
@@ -114,8 +115,10 @@ Blockly.Marker.prototype.hide = function() {
 /**
  * Dispose of this marker.
  */
-Blockly.Marker.prototype.dispose = function() {
+Marker.prototype.dispose = function() {
   if (this.getDrawer()) {
     this.getDrawer().dispose();
   }
 };
+
+exports = Marker;

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -14,9 +14,8 @@
 goog.module('Blockly.Marker');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.ASTNode');
-
-goog.requireType('Blockly.blockRendering.MarkerSvg');
+const ASTNode = goog.require('Blockly.ASTNode');
+const MarkerSvg = goog.requireType('Blockly.blockRendering.MarkerSvg');
 
 
 /**
@@ -33,14 +32,14 @@ const Marker = function() {
 
   /**
    * The current location of the marker.
-   * @type {Blockly.ASTNode}
+   * @type {ASTNode}
    * @private
    */
   this.curNode_ = null;
 
   /**
    * The object in charge of drawing the visual representation of the current node.
-   * @type {Blockly.blockRendering.MarkerSvg}
+   * @type {MarkerSvg}
    * @private
    */
   this.drawer_ = null;
@@ -54,7 +53,7 @@ const Marker = function() {
 
 /**
  * Sets the object in charge of drawing the marker.
- * @param {Blockly.blockRendering.MarkerSvg} drawer The object in charge of
+ * @param {MarkerSvg} drawer The object in charge of
  *     drawing the marker.
  */
 Marker.prototype.setDrawer = function(drawer) {
@@ -63,7 +62,7 @@ Marker.prototype.setDrawer = function(drawer) {
 
 /**
  * Get the current drawer for the marker.
- * @return {Blockly.blockRendering.MarkerSvg} The object in charge of drawing
+ * @return {MarkerSvg} The object in charge of drawing
  *     the marker.
  */
 Marker.prototype.getDrawer = function() {
@@ -72,7 +71,7 @@ Marker.prototype.getDrawer = function() {
 
 /**
  * Gets the current location of the marker.
- * @return {Blockly.ASTNode} The current field, connection, or block the marker
+ * @return {ASTNode} The current field, connection, or block the marker
  *     is on.
  */
 Marker.prototype.getCurNode = function() {
@@ -83,7 +82,7 @@ Marker.prototype.getCurNode = function() {
  * Set the location of the marker and call the update method.
  * Setting isStack to true will only work if the newLocation is the top most
  * output or previous connection on a stack.
- * @param {Blockly.ASTNode} newNode The new location of the marker.
+ * @param {ASTNode} newNode The new location of the marker.
  */
 Marker.prototype.setCurNode = function(newNode) {
   const oldNode = this.curNode_;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -105,7 +105,7 @@ goog.addDependency('../../core/internal_constants.js', ['Blockly.internalConstan
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style']);

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -105,7 +105,7 @@ goog.addDependency('../../core/internal_constants.js', ['Blockly.internalConstan
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
+goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/keyboard_nav/marker.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/keyboard_nav/marker.js` to `goog.module` syntax. 

### Additional Information

This PR also adds missing nullability modifier to JsDoc, according to the [style guide](https://google.github.io/styleguide/jsguide.html#jsdoc-nullability).
