### PR TITLE
Migrate core/interfaces/i_registrable_field.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_registrable_field.js
+++ b/core/interfaces/i_registrable_field.js
@@ -11,21 +11,25 @@
 
 'use strict';
 
-goog.provide('Blockly.IRegistrableField');
+goog.module('Blockly.IRegistrableField');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.Field');
+
 
 /**
  * A registrable field.
  * Note: We are not using an interface here as we are interested in defining the
  * static methods of a field rather than the instance methods.
  * @typedef {{
- *     fromJson:Blockly.IRegistrableField.fromJson
+ *     fromJson:IRegistrableField.fromJson
  * }}
  */
-Blockly.IRegistrableField;
+let IRegistrableField;
 
 /**
  * @typedef {function(!Object): Blockly.Field}
  */
-Blockly.IRegistrableField.fromJson;
+IRegistrableField.fromJson;
+
+exports = IRegistrableField;

--- a/core/interfaces/i_registrable_field.js
+++ b/core/interfaces/i_registrable_field.js
@@ -14,7 +14,7 @@
 goog.module('Blockly.IRegistrableField');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.Field');
+const Field = goog.requireType('Blockly.Field');
 
 
 /**
@@ -28,7 +28,7 @@ goog.requireType('Blockly.Field');
 let IRegistrableField;
 
 /**
- * @typedef {function(!Object): Blockly.Field}
+ * @typedef {function(!Object): Field}
  */
 IRegistrableField.fromJson;
 

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -95,7 +95,7 @@ goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetr
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
+goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_selectable_toolbox_item.js', ['Blockly.ISelectableToolboxItem'], ['Blockly.IToolboxItem'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_registrable_field.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_registrable_field.js` to `goog.module` syntax. 


### Additional Information

https://github.com/google/blockly/issues/5124