### PR TITLE
Localization for toolbox XML

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -400,7 +400,8 @@ Blockly.Field.prototype.bindEvents_ = function() {
  * @package
  */
 Blockly.Field.prototype.fromXml = function(fieldElement) {
-  this.setValue(fieldElement.textContent);
+  let value = Blockly.utils.replaceMessageReferences(fieldElement.textContent);
+  this.setValue(value);
 };
 
 /**

--- a/core/xml.js
+++ b/core/xml.js
@@ -617,7 +617,7 @@ Blockly.Xml.domToVariables = function(xmlVariables, workspace) {
     }
     var type = xmlChild.getAttribute('type');
     var id = xmlChild.getAttribute('id');
-    var name = xmlChild.textContent;
+    var name = Blockly.utils.replaceMessageReferences(xmlChild.textContent);
 
     workspace.createVariable(name, type, id);
   }
@@ -720,7 +720,7 @@ Blockly.Xml.applyMutationTagNodes_ = function(xmlChildren, block) {
  */
 Blockly.Xml.applyCommentTagNodes_ = function(xmlChildren, block) {
   for (var i = 0, xmlChild; (xmlChild = xmlChildren[i]); i++) {
-    var text = xmlChild.textContent;
+    var text = Blockly.utils.replaceMessageReferences(xmlChild.textContent);
     var pinned = xmlChild.getAttribute('pinned') == 'true';
     var width = parseInt(xmlChild.getAttribute('w'), 10);
     var height = parseInt(xmlChild.getAttribute('h'), 10);
@@ -747,7 +747,7 @@ Blockly.Xml.applyCommentTagNodes_ = function(xmlChildren, block) {
  */
 Blockly.Xml.applyDataTagNodes_ = function(xmlChildren, block) {
   for (var i = 0, xmlChild; (xmlChild = xmlChildren[i]); i++) {
-    block.data = xmlChild.textContent;
+    block.data = Blockly.utils.replaceMessageReferences(xmlChild.textContent);
   }
 };
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

[#4492](https://github.com/google/blockly/issues/4992)

### Proposed Changes

Allows to use the %{BKY_*} message reference system for field values when loading a toolbox XML. The second (actually first) commit also allows localization for block comments, variable names and block data.

#### Behavior Before Change

Field values, comments, variable names and block data could not be localized.

#### Behavior After Change

Field values, comments, variable names and block data can now be localized.

### Reason for Changes

When adding example programs to the toolbox these may often contain field values, comments, variable names, etc. to make the program easier to follow. It would be at least odd if these were not localized in a multi-lingual application.

### Test Coverage

<!-- Tested on: -->
<!-- * Desktop Chrome -->
* Desktop Firefox
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: Samsung Galaxy M31
  * OS: Android 11
  * Browser Chrome / Firefox
  * Version 91.0.4472.164 / 90.1.1


### Documentation

No additional documentation is required as this was (to me) expected behavior and is kind of covered in the localization guide.

### Additional Information

That's it :)
