### PR TITLE
Migrate core/keyboard_nav/cursor.js to goog.module syntax

### DIFF
--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -42,12 +42,12 @@ Blockly.utils.object.inherits(Blockly.Cursor, Blockly.Marker);
  * @public
  */
 Blockly.Cursor.prototype.next = function() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
 
-  var newNode = curNode.next();
+  let newNode = curNode.next();
   while (newNode && newNode.next() &&
          (newNode.getType() == Blockly.ASTNode.types.NEXT ||
           newNode.getType() == Blockly.ASTNode.types.BLOCK)) {
@@ -67,7 +67,7 @@ Blockly.Cursor.prototype.next = function() {
  * @public
  */
 Blockly.Cursor.prototype.in = function() {
-  var curNode = this.getCurNode();
+  let curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
@@ -77,7 +77,7 @@ Blockly.Cursor.prototype.in = function() {
       curNode.getType() == Blockly.ASTNode.types.OUTPUT) {
     curNode = curNode.next();
   }
-  var newNode = curNode.in();
+  const newNode = curNode.in();
 
   if (newNode) {
     this.setCurNode(newNode);
@@ -92,11 +92,11 @@ Blockly.Cursor.prototype.in = function() {
  * @public
  */
 Blockly.Cursor.prototype.prev = function() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.prev();
+  let newNode = curNode.prev();
 
   while (newNode && newNode.prev() &&
          (newNode.getType() == Blockly.ASTNode.types.NEXT ||
@@ -117,11 +117,11 @@ Blockly.Cursor.prototype.prev = function() {
  * @public
  */
 Blockly.Cursor.prototype.out = function() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.out();
+  let newNode = curNode.out();
 
   if (newNode && newNode.getType() == Blockly.ASTNode.types.BLOCK) {
     newNode = newNode.prev() || newNode;

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Cursor');
+goog.module('Blockly.Cursor');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.Marker');
@@ -25,15 +26,15 @@ goog.require('Blockly.utils.object');
  * @constructor
  * @extends {Blockly.Marker}
  */
-Blockly.Cursor = function() {
-  Blockly.Cursor.superClass_.constructor.call(this);
+const Cursor = function() {
+  Cursor.superClass_.constructor.call(this);
 
   /**
    * @override
    */
   this.type = 'cursor';
 };
-Blockly.utils.object.inherits(Blockly.Cursor, Blockly.Marker);
+Blockly.utils.object.inherits(Cursor, Blockly.Marker);
 
 /**
  * Find the next connection, field, or block.
@@ -41,7 +42,7 @@ Blockly.utils.object.inherits(Blockly.Cursor, Blockly.Marker);
  *     not set or there is no next value.
  * @public
  */
-Blockly.Cursor.prototype.next = function() {
+Cursor.prototype.next = function() {
   const curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -66,7 +67,7 @@ Blockly.Cursor.prototype.next = function() {
  *     not set or there is no in value.
  * @public
  */
-Blockly.Cursor.prototype.in = function() {
+Cursor.prototype.in = function() {
   let curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -91,7 +92,7 @@ Blockly.Cursor.prototype.in = function() {
  *     is not set or there is no previous value.
  * @public
  */
-Blockly.Cursor.prototype.prev = function() {
+Cursor.prototype.prev = function() {
   const curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -116,7 +117,7 @@ Blockly.Cursor.prototype.prev = function() {
  *     not set or there is no out value.
  * @public
  */
-Blockly.Cursor.prototype.out = function() {
+Cursor.prototype.out = function() {
   const curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -134,4 +135,6 @@ Blockly.Cursor.prototype.out = function() {
 };
 
 Blockly.registry.register(
-    Blockly.registry.Type.CURSOR, Blockly.registry.DEFAULT, Blockly.Cursor);
+    Blockly.registry.Type.CURSOR, Blockly.registry.DEFAULT, Cursor);
+
+exports = Cursor;

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -14,17 +14,17 @@
 goog.module('Blockly.Cursor');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.ASTNode');
-goog.require('Blockly.Marker');
-goog.require('Blockly.registry');
-goog.require('Blockly.utils.object');
+const ASTNode = goog.require('Blockly.ASTNode');
+const Marker = goog.require('Blockly.Marker');
+const {DEFAULT, register, Type} = goog.require('Blockly.registry');
+const {inherits} = goog.require('Blockly.utils.object');
 
 
 /**
  * Class for a cursor.
  * A cursor controls how a user navigates the Blockly AST.
  * @constructor
- * @extends {Blockly.Marker}
+ * @extends {Marker}
  */
 const Cursor = function() {
   Cursor.superClass_.constructor.call(this);
@@ -34,11 +34,11 @@ const Cursor = function() {
    */
   this.type = 'cursor';
 };
-Blockly.utils.object.inherits(Cursor, Blockly.Marker);
+inherits(Cursor, Marker);
 
 /**
  * Find the next connection, field, or block.
- * @return {Blockly.ASTNode} The next element, or null if the current node is
+ * @return {ASTNode} The next element, or null if the current node is
  *     not set or there is no next value.
  * @public
  */
@@ -50,8 +50,8 @@ Cursor.prototype.next = function() {
 
   let newNode = curNode.next();
   while (newNode && newNode.next() &&
-         (newNode.getType() == Blockly.ASTNode.types.NEXT ||
-          newNode.getType() == Blockly.ASTNode.types.BLOCK)) {
+         (newNode.getType() == ASTNode.types.NEXT ||
+          newNode.getType() == ASTNode.types.BLOCK)) {
     newNode = newNode.next();
   }
 
@@ -63,7 +63,7 @@ Cursor.prototype.next = function() {
 
 /**
  * Find the in connection or field.
- * @return {Blockly.ASTNode} The in element, or null if the current node is
+ * @return {ASTNode} The in element, or null if the current node is
  *     not set or there is no in value.
  * @public
  */
@@ -74,8 +74,8 @@ Cursor.prototype.in = function() {
   }
   // If we are on a previous or output connection, go to the block level before
   // performing next operation.
-  if (curNode.getType() == Blockly.ASTNode.types.PREVIOUS ||
-      curNode.getType() == Blockly.ASTNode.types.OUTPUT) {
+  if (curNode.getType() == ASTNode.types.PREVIOUS ||
+      curNode.getType() == ASTNode.types.OUTPUT) {
     curNode = curNode.next();
   }
   const newNode = curNode.in();
@@ -88,7 +88,7 @@ Cursor.prototype.in = function() {
 
 /**
  * Find the previous connection, field, or block.
- * @return {Blockly.ASTNode} The previous element, or null if the current node
+ * @return {ASTNode} The previous element, or null if the current node
  *     is not set or there is no previous value.
  * @public
  */
@@ -100,8 +100,8 @@ Cursor.prototype.prev = function() {
   let newNode = curNode.prev();
 
   while (newNode && newNode.prev() &&
-         (newNode.getType() == Blockly.ASTNode.types.NEXT ||
-          newNode.getType() == Blockly.ASTNode.types.BLOCK)) {
+         (newNode.getType() == ASTNode.types.NEXT ||
+          newNode.getType() == ASTNode.types.BLOCK)) {
     newNode = newNode.prev();
   }
 
@@ -113,7 +113,7 @@ Cursor.prototype.prev = function() {
 
 /**
  * Find the out connection, field, or block.
- * @return {Blockly.ASTNode} The out element, or null if the current node is
+ * @return {ASTNode} The out element, or null if the current node is
  *     not set or there is no out value.
  * @public
  */
@@ -124,7 +124,7 @@ Cursor.prototype.out = function() {
   }
   let newNode = curNode.out();
 
-  if (newNode && newNode.getType() == Blockly.ASTNode.types.BLOCK) {
+  if (newNode && newNode.getType() == ASTNode.types.BLOCK) {
     newNode = newNode.prev() || newNode;
   }
 
@@ -134,7 +134,6 @@ Cursor.prototype.out = function() {
   return newNode;
 };
 
-Blockly.registry.register(
-    Blockly.registry.Type.CURSOR, Blockly.registry.DEFAULT, Cursor);
+register(Type.CURSOR, DEFAULT, Cursor);
 
 exports = Cursor;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -101,7 +101,7 @@ goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], [
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es5'});
+goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object']);
 goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/keyboard_nav/cursor.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/keyboard_nav/cursor.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->