### PR TITLE
Only lint once in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,22 @@ jobs:
 
       env:
         CI: true
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+
+    - name: Npm Install
+      run: npm install
+
+    - name: Lint
+      run: npm run lint
+
+      env:
+        CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,3 @@ jobs:
 
     - name: Lint
       run: npm run lint
-
-      env:
-        CI: true

--- a/core/block.js
+++ b/core/block.js
@@ -47,8 +47,6 @@ goog.requireType('Blockly.Mutator');
 goog.requireType('Blockly.utils.Size');
 goog.requireType('Blockly.VariableModel');
 
-// This should be a lint error as the line is too long and it should show up as a lint error on GitHub.
-
 
 /**
  * Class for one block.

--- a/core/block.js
+++ b/core/block.js
@@ -47,6 +47,8 @@ goog.requireType('Blockly.Mutator');
 goog.requireType('Blockly.utils.Size');
 goog.requireType('Blockly.VariableModel');
 
+// This should be a lint error as the line is too long and it should show up as a lint error on GitHub.
+
 
 /**
  * Class for one block.

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -49,7 +49,10 @@ run_test_command () {
 }
 
 # Lint the codebase.
-run_test_command "eslint" "eslint ."
+# Skip for CI environments, because linting is run separately.
+if [ ! -z $CI ]; then
+  run_test_command "eslint" "eslint ."
+fi
 
 # Run the full usual build process.
 run_test_command "build" "npm run build"

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -50,7 +50,7 @@ run_test_command () {
 
 # Lint the codebase.
 # Skip for CI environments, because linting is run separately.
-if [ ! -z $CI ]; then
+if [ -z $CI ]; then
   run_test_command "eslint" "eslint ."
 fi
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Currently all lint errors show up 4x, one per each version of Node we test with. This causes spam.

### Proposed Changes

eslint will only be run if the CI environment variable is NOT set. When you run `npm run test` locally, linting will happen. When GitHub runs it in the build workflow, it will not be run. Instead, a separate action will run `npm run lint` and report lint errors only once.

#### Behavior Before Change

4x lint error messages per error on PRs. 

#### Behavior After Change

1 lint error message per error on PRs.

### Reason for Changes

Reduces lint spam.

### Test Coverage

Tested by adding and then reverting a lint error in this PR. Example run https://github.com/google/blockly/pull/5128/checks?sha=62affa59527dece39b22c6f657acaf1c96c7346c
