### PR TITLE
Migrate core/keyboard_nav/basic_cursor.js to goog.module syntax

### DIFF
--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -43,11 +43,11 @@ Blockly.BasicCursor.registrationName = 'basicCursor';
  * @override
  */
 Blockly.BasicCursor.prototype.next = function() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = this.getNextNode_(curNode, this.validNode_);
+  const newNode = this.getNextNode_(curNode, this.validNode_);
 
   if (newNode) {
     this.setCurNode(newNode);
@@ -74,11 +74,11 @@ Blockly.BasicCursor.prototype.in = function() {
  * @override
  */
 Blockly.BasicCursor.prototype.prev = function() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = this.getPreviousNode_(curNode, this.validNode_);
+  const newNode = this.getPreviousNode_(curNode, this.validNode_);
 
   if (newNode) {
     this.setCurNode(newNode);
@@ -112,13 +112,13 @@ Blockly.BasicCursor.prototype.getNextNode_ = function(node, isValid) {
   if (!node) {
     return null;
   }
-  var newNode = node.in() || node.next();
+  const newNode = node.in() || node.next();
   if (isValid(newNode)) {
     return newNode;
   } else if (newNode) {
     return this.getNextNode_(newNode, isValid);
   }
-  var siblingOrParent = this.findSiblingOrParent_(node.out());
+  const siblingOrParent = this.findSiblingOrParent_(node.out());
   if (isValid(siblingOrParent)) {
     return siblingOrParent;
   } else if (siblingOrParent) {
@@ -142,7 +142,7 @@ Blockly.BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
   if (!node) {
     return null;
   }
-  var newNode = node.prev();
+  let newNode = node.prev();
 
   if (newNode) {
     newNode = this.getRightMostChild_(newNode);
@@ -165,8 +165,8 @@ Blockly.BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
  * @protected
  */
 Blockly.BasicCursor.prototype.validNode_ = function(node) {
-  var isValid = false;
-  var type = node && node.getType();
+  let isValid = false;
+  const type = node && node.getType();
   if (type == Blockly.ASTNode.types.OUTPUT ||
       type == Blockly.ASTNode.types.INPUT ||
       type == Blockly.ASTNode.types.FIELD ||
@@ -189,7 +189,7 @@ Blockly.BasicCursor.prototype.findSiblingOrParent_ = function(node) {
   if (!node) {
     return null;
   }
-  var nextNode = node.next();
+  const nextNode = node.next();
   if (nextNode) {
     return nextNode;
   }
@@ -208,7 +208,7 @@ Blockly.BasicCursor.prototype.getRightMostChild_ = function(node) {
   if (!node.in()) {
     return node;
   }
-  var newNode = node.in();
+  let newNode = node.in();
   while (newNode.next()) {
     newNode = newNode.next();
   }

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -14,9 +14,10 @@
 goog.module('Blockly.BasicCursor');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.ASTNode');
-goog.require('Blockly.Cursor');
-goog.require('Blockly.registry');
+const ASTNode = goog.require('Blockly.ASTNode');
+const Cursor = goog.require('Blockly.Cursor');
+const {register, Type} = goog.require('Blockly.registry');
+const {inherits} = goog.require('Blockly.utils.object');
 
 
 /**
@@ -24,12 +25,12 @@ goog.require('Blockly.registry');
  * This will allow the user to get to all nodes in the AST by hitting next or
  * previous.
  * @constructor
- * @extends {Blockly.Cursor}
+ * @extends {Cursor}
  */
 const BasicCursor = function() {
   BasicCursor.superClass_.constructor.call(this);
 };
-Blockly.utils.object.inherits(BasicCursor, Blockly.Cursor);
+inherits(BasicCursor, Cursor);
 
 /**
  * Name used for registering a basic cursor.
@@ -39,7 +40,7 @@ BasicCursor.registrationName = 'basicCursor';
 
 /**
  * Find the next node in the pre order traversal.
- * @return {Blockly.ASTNode} The next node, or null if the current node is
+ * @return {?ASTNode} The next node, or null if the current node is
  *     not set or there is no next value.
  * @override
  */
@@ -60,7 +61,7 @@ BasicCursor.prototype.next = function() {
  * For a basic cursor we only have the ability to go next and previous, so
  * in will also allow the user to get to the next node in the pre order
  * traversal.
- * @return {Blockly.ASTNode} The next node, or null if the current node is
+ * @return {?ASTNode} The next node, or null if the current node is
  *     not set or there is no next value.
  * @override
  */
@@ -70,7 +71,7 @@ BasicCursor.prototype.in = function() {
 
 /**
  * Find the previous node in the pre order traversal.
- * @return {Blockly.ASTNode} The previous node, or null if the current node
+ * @return {?ASTNode} The previous node, or null if the current node
  *     is not set or there is no previous value.
  * @override
  */
@@ -91,7 +92,7 @@ BasicCursor.prototype.prev = function() {
  * For a basic cursor we only have the ability to go next and previous, so
  * out will allow the user to get to the previous node in the pre order
  * traversal.
- * @return {Blockly.ASTNode} The previous node, or null if the current node is
+ * @return {?ASTNode} The previous node, or null if the current node is
  *     not set or there is no previous value.
  * @override
  */
@@ -103,10 +104,10 @@ BasicCursor.prototype.out = function() {
  * Uses pre order traversal to navigate the Blockly AST. This will allow
  * a user to easily navigate the entire Blockly AST without having to go in
  * and out levels on the tree.
- * @param {Blockly.ASTNode} node The current position in the AST.
- * @param {!function(Blockly.ASTNode) : boolean} isValid A function true/false
+ * @param {?ASTNode} node The current position in the AST.
+ * @param {!function(ASTNode) : boolean} isValid A function true/false
  *     depending on whether the given node should be traversed.
- * @return {Blockly.ASTNode} The next node in the traversal.
+ * @return {?ASTNode} The next node in the traversal.
  * @protected
  */
 BasicCursor.prototype.getNextNode_ = function(node, isValid) {
@@ -132,10 +133,10 @@ BasicCursor.prototype.getNextNode_ = function(node, isValid) {
  * Reverses the pre order traversal in order to find the previous node. This
  * will allow a user to easily navigate the entire Blockly AST without having to
  * go in and out levels on the tree.
- * @param {Blockly.ASTNode} node The current position in the AST.
- * @param {!function(Blockly.ASTNode) : boolean} isValid A function true/false
+ * @param {?ASTNode} node The current position in the AST.
+ * @param {!function(ASTNode) : boolean} isValid A function true/false
  *     depending on whether the given node should be traversed.
- * @return {Blockly.ASTNode} The previous node in the traversal or null if no
+ * @return {?ASTNode} The previous node in the traversal or null if no
  *     previous node exists.
  * @protected
  */
@@ -161,19 +162,19 @@ BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
 /**
  * Decides what nodes to traverse and which ones to skip. Currently, it
  * skips output, stack and workspace nodes.
- * @param {Blockly.ASTNode} node The AST node to check whether it is valid.
+ * @param {?ASTNode} node The AST node to check whether it is valid.
  * @return {boolean} True if the node should be visited, false otherwise.
  * @protected
  */
 BasicCursor.prototype.validNode_ = function(node) {
   let isValid = false;
   const type = node && node.getType();
-  if (type == Blockly.ASTNode.types.OUTPUT ||
-      type == Blockly.ASTNode.types.INPUT ||
-      type == Blockly.ASTNode.types.FIELD ||
-      type == Blockly.ASTNode.types.NEXT ||
-      type == Blockly.ASTNode.types.PREVIOUS ||
-      type == Blockly.ASTNode.types.WORKSPACE) {
+  if (type == ASTNode.types.OUTPUT ||
+      type == ASTNode.types.INPUT ||
+      type == ASTNode.types.FIELD ||
+      type == ASTNode.types.NEXT ||
+      type == ASTNode.types.PREVIOUS ||
+      type == ASTNode.types.WORKSPACE) {
     isValid = true;
   }
   return isValid;
@@ -181,8 +182,8 @@ BasicCursor.prototype.validNode_ = function(node) {
 
 /**
  * From the given node find either the next valid sibling or parent.
- * @param {Blockly.ASTNode} node The current position in the AST.
- * @return {Blockly.ASTNode} The parent AST node or null if there are no
+ * @param {?ASTNode} node The current position in the AST.
+ * @return {?ASTNode} The parent AST node or null if there are no
  *     valid parents.
  * @private
  */
@@ -200,8 +201,8 @@ BasicCursor.prototype.findSiblingOrParent_ = function(node) {
 
 /**
  * Get the right most child of a node.
- * @param {Blockly.ASTNode} node The node to find the right most child of.
- * @return {Blockly.ASTNode} The right most child of the given node, or the node
+ * @param {?ASTNode} node The node to find the right most child of.
+ * @return {?ASTNode} The right most child of the given node, or the node
  *     if no child exists.
  * @private
  */
@@ -216,8 +217,8 @@ BasicCursor.prototype.getRightMostChild_ = function(node) {
   return this.getRightMostChild_(newNode);
 };
 
-Blockly.registry.register(
-    Blockly.registry.Type.CURSOR, BasicCursor.registrationName,
+register(
+    Type.CURSOR, BasicCursor.registrationName,
     BasicCursor);
 
 exports = BasicCursor;

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -169,12 +169,9 @@ BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
 BasicCursor.prototype.validNode_ = function(node) {
   let isValid = false;
   const type = node && node.getType();
-  if (type == ASTNode.types.OUTPUT ||
-      type == ASTNode.types.INPUT ||
-      type == ASTNode.types.FIELD ||
-      type == ASTNode.types.NEXT ||
-      type == ASTNode.types.PREVIOUS ||
-      type == ASTNode.types.WORKSPACE) {
+  if (type == ASTNode.types.OUTPUT || type == ASTNode.types.INPUT ||
+      type == ASTNode.types.FIELD || type == ASTNode.types.NEXT ||
+      type == ASTNode.types.PREVIOUS || type == ASTNode.types.WORKSPACE) {
     isValid = true;
   }
   return isValid;
@@ -217,8 +214,6 @@ BasicCursor.prototype.getRightMostChild_ = function(node) {
   return this.getRightMostChild_(newNode);
 };
 
-register(
-    Type.CURSOR, BasicCursor.registrationName,
-    BasicCursor);
+register(Type.CURSOR, BasicCursor.registrationName, BasicCursor);
 
 exports = BasicCursor;

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.BasicCursor');
+goog.module('Blockly.BasicCursor');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.Cursor');
@@ -25,16 +26,16 @@ goog.require('Blockly.registry');
  * @constructor
  * @extends {Blockly.Cursor}
  */
-Blockly.BasicCursor = function() {
-  Blockly.BasicCursor.superClass_.constructor.call(this);
+const BasicCursor = function() {
+  BasicCursor.superClass_.constructor.call(this);
 };
-Blockly.utils.object.inherits(Blockly.BasicCursor, Blockly.Cursor);
+Blockly.utils.object.inherits(BasicCursor, Blockly.Cursor);
 
 /**
  * Name used for registering a basic cursor.
  * @const {string}
  */
-Blockly.BasicCursor.registrationName = 'basicCursor';
+BasicCursor.registrationName = 'basicCursor';
 
 /**
  * Find the next node in the pre order traversal.
@@ -42,7 +43,7 @@ Blockly.BasicCursor.registrationName = 'basicCursor';
  *     not set or there is no next value.
  * @override
  */
-Blockly.BasicCursor.prototype.next = function() {
+BasicCursor.prototype.next = function() {
   const curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -63,7 +64,7 @@ Blockly.BasicCursor.prototype.next = function() {
  *     not set or there is no next value.
  * @override
  */
-Blockly.BasicCursor.prototype.in = function() {
+BasicCursor.prototype.in = function() {
   return this.next();
 };
 
@@ -73,7 +74,7 @@ Blockly.BasicCursor.prototype.in = function() {
  *     is not set or there is no previous value.
  * @override
  */
-Blockly.BasicCursor.prototype.prev = function() {
+BasicCursor.prototype.prev = function() {
   const curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -94,7 +95,7 @@ Blockly.BasicCursor.prototype.prev = function() {
  *     not set or there is no previous value.
  * @override
  */
-Blockly.BasicCursor.prototype.out = function() {
+BasicCursor.prototype.out = function() {
   return this.prev();
 };
 
@@ -108,7 +109,7 @@ Blockly.BasicCursor.prototype.out = function() {
  * @return {Blockly.ASTNode} The next node in the traversal.
  * @protected
  */
-Blockly.BasicCursor.prototype.getNextNode_ = function(node, isValid) {
+BasicCursor.prototype.getNextNode_ = function(node, isValid) {
   if (!node) {
     return null;
   }
@@ -138,7 +139,7 @@ Blockly.BasicCursor.prototype.getNextNode_ = function(node, isValid) {
  *     previous node exists.
  * @protected
  */
-Blockly.BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
+BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
   if (!node) {
     return null;
   }
@@ -164,7 +165,7 @@ Blockly.BasicCursor.prototype.getPreviousNode_ = function(node, isValid) {
  * @return {boolean} True if the node should be visited, false otherwise.
  * @protected
  */
-Blockly.BasicCursor.prototype.validNode_ = function(node) {
+BasicCursor.prototype.validNode_ = function(node) {
   let isValid = false;
   const type = node && node.getType();
   if (type == Blockly.ASTNode.types.OUTPUT ||
@@ -185,7 +186,7 @@ Blockly.BasicCursor.prototype.validNode_ = function(node) {
  *     valid parents.
  * @private
  */
-Blockly.BasicCursor.prototype.findSiblingOrParent_ = function(node) {
+BasicCursor.prototype.findSiblingOrParent_ = function(node) {
   if (!node) {
     return null;
   }
@@ -204,7 +205,7 @@ Blockly.BasicCursor.prototype.findSiblingOrParent_ = function(node) {
  *     if no child exists.
  * @private
  */
-Blockly.BasicCursor.prototype.getRightMostChild_ = function(node) {
+BasicCursor.prototype.getRightMostChild_ = function(node) {
   if (!node.in()) {
     return node;
   }
@@ -216,5 +217,7 @@ Blockly.BasicCursor.prototype.getRightMostChild_ = function(node) {
 };
 
 Blockly.registry.register(
-    Blockly.registry.Type.CURSOR, Blockly.BasicCursor.registrationName,
-    Blockly.BasicCursor);
+    Blockly.registry.Type.CURSOR, BasicCursor.registrationName,
+    BasicCursor);
+
+exports = BasicCursor;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -88,7 +88,7 @@ goog.addDependency('../../core/interfaces/i_deletable.js', ['Blockly.IDeletable'
 goog.addDependency('../../core/interfaces/i_delete_area.js', ['Blockly.IDeleteArea'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarget'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_keyboard_accessible.js', ['Blockly.IKeyboardAccessible'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
@@ -97,10 +97,10 @@ goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistra
 goog.addDependency('../../core/interfaces/i_registrable_field.js', ['Blockly.IRegistrableField'], []);
 goog.addDependency('../../core/interfaces/i_selectable.js', ['Blockly.ISelectable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
-goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry'], {'lang': 'es5'});
+goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object']);

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -100,7 +100,7 @@ goog.addDependency('../../core/interfaces/i_styleable.js', ['Blockly.IStyleable'
 goog.addDependency('../../core/interfaces/i_toolbox.js', ['Blockly.IToolbox'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_toolbox_item.js', ['Blockly.ICollapsibleToolboxItem', 'Blockly.ISelectableToolboxItem', 'Blockly.IToolboxItem'], []);
 goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], ['Blockly.connectionTypes', 'Blockly.constants', 'Blockly.utils.Coordinate'], {'lang': 'es5'});
-goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es5'});
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/keyboard_nav/basic_cursor.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/keyboard_nav/basic_cursor.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
