### PR TITLE
feat: add deserialization of JSO block state

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -348,16 +348,17 @@ const loadExtraState = function(block, state) {
 };
 
 /**
- * Applies any extra state information available on the state object to the
- * block.
- * @param {!Block} block The block to set the extra state of.
+ * Applies any field information available on the state object to the block.
+ * @param {!Block} block The block to set the field state of.
  * @param {!State} state The state object to reference.
  */
 const loadFields = function(block, state) {
   if (!state['fields']) {
     return;
   }
-  for (const fieldName of Object.keys(state['fields'])) {
+  const keys = Object.keys(state['fields']);
+  for (let i = 0; i < keys.length; i++) {
+    const fieldName = keys[i];
     const fieldState = state['fields'][fieldName];
     const field = block.getField(fieldName);
     if (!field) {
@@ -379,7 +380,9 @@ const loadInputBlocks = function(block, state) {
   if (!state['inputs']) {
     return;
   }
-  for (const inputName of Object.keys(state['inputs'])) {
+  const keys = Object.keys(state['inputs']);
+  for (let i = 0; i < keys.length; i++) {
+    const inputName = keys[i];
     const input = block.getInput(inputName);
     if (input && input.connection) {
       loadConnection(input.connection, state['inputs'][inputName]);

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -1260,7 +1260,7 @@ Serializer.Connections.OverwrittenShadow.Row = new SerializerTestCase('Row',
     '</shadow>' +
     '</value>' +
     '</shadow>' +
-    '<block type="logic_boolean" id="id3*****************">' +
+    '<block type="logic_boolean" id="id4*****************">' +
     '<field name="BOOL">TRUE</field>' +
     '</block>' +
     '</value>' +
@@ -1276,7 +1276,7 @@ Serializer.Connections.OverwrittenShadow.Nested = new SerializerTestCase(
     '<shadow type="text_print" id="id3*****************"></shadow>' +
     '</statement>' +
     '</shadow>' +
-    '<block type="text_print" id="id3*****************"></block>' +
+    '<block type="text_print" id="id4*****************"></block>' +
     '</statement>' +
     '</block>' +
     '</xml>');
@@ -1284,10 +1284,10 @@ Serializer.Connections.OverwrittenShadow.Stack = new SerializerTestCase('Stack',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
     '<block type="text_print" id="id******************" x="42" y="42">' +
     '<next>' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '<shadow type="text_print" id="id2*****************">' +
+    '<block type="text_print" id="id2*****************"></block>' +
+    '<shadow type="text_print" id="id3*****************">' +
     '<next>' +
-    '<shadow type="text_print" id="id3*****************"></shadow>' +
+    '<shadow type="text_print" id="id4*****************"></shadow>' +
     '</next>' +
     '</shadow>' +
     '</next>' +
@@ -1768,5 +1768,5 @@ var runSerializerTestSuite = (serializer, deserializer, testSuite) => {
 };
 
 runSerializerTestSuite(null, null, Serializer);
-Serializer.skip = true;
+Serializer.Icons.skip = true;
 runSerializerTestSuite(state => state, state => state, Serializer);

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -1769,4 +1769,5 @@ var runSerializerTestSuite = (serializer, deserializer, testSuite) => {
 
 runSerializerTestSuite(null, null, Serializer);
 Serializer.Icons.skip = true;
+Serializer.Mutations.skip = true;
 runSerializerTestSuite(state => state, state => state, Serializer);


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on project cereal
Dependent on #5132 

### Proposed Changes

Adds deserialization of blocks. This handles everything except icons (ie comments), because I'm going to investigate their serialization and deserialization separately. Namely, type, id, coords, attributes, extra state, fields, and children.

Does not handle initialization of the deserialized blocks.

### Reason for Changes

Saving state is good.

### Test Coverage

Enabled all of the serializer tests for the JSO system except for icons, which aren't handled yet, and mutators, which aren't upgraded yet.