### PR TITLE
Migrate core/keyboard_nav/tab_navigate_cursor.js to goog.module syntax

### DIFF
--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -14,26 +14,25 @@
 goog.module('Blockly.TabNavigateCursor');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.ASTNode');
-goog.require('Blockly.BasicCursor');
-goog.require('Blockly.utils.object');
-
-goog.requireType('Blockly.Field');
+const ASTNode = goog.require('Blockly.ASTNode');
+const BasicCursor = goog.require('Blockly.BasicCursor');
+const Field = goog.requireType('Blockly.Field');
+const {inherits} = goog.require('Blockly.utils.object');
 
 
 /**
  * A cursor for navigating between tab navigable fields.
  * @constructor
- * @extends {Blockly.BasicCursor}
+ * @extends {BasicCursor}
  */
 const TabNavigateCursor = function() {
   TabNavigateCursor.superClass_.constructor.call(this);
 };
-Blockly.utils.object.inherits(TabNavigateCursor, Blockly.BasicCursor);
+inherits(TabNavigateCursor, BasicCursor);
 
 /**
  * Skip all nodes except for tab navigable fields.
- * @param {Blockly.ASTNode} node The AST node to check whether it is valid.
+ * @param {?ASTNode} node The AST node to check whether it is valid.
  * @return {boolean} True if the node should be visited, false otherwise.
  * @override
  */
@@ -41,8 +40,8 @@ TabNavigateCursor.prototype.validNode_ = function(node) {
   let isValid = false;
   const type = node && node.getType();
   if (node) {
-    const location = /** @type {Blockly.Field} */ (node.getLocation());
-    if (type == Blockly.ASTNode.types.FIELD &&
+    const location = /** @type {Field} */ (node.getLocation());
+    if (type == ASTNode.types.FIELD &&
         location && location.isTabNavigable() && location.isClickable()) {
       isValid = true;
     }

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -41,8 +41,8 @@ TabNavigateCursor.prototype.validNode_ = function(node) {
   const type = node && node.getType();
   if (node) {
     const location = /** @type {Field} */ (node.getLocation());
-    if (type == ASTNode.types.FIELD &&
-        location && location.isTabNavigable() && location.isClickable()) {
+    if (type == ASTNode.types.FIELD && location && location.isTabNavigable() &&
+        location.isClickable()) {
       isValid = true;
     }
   }

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -37,10 +37,10 @@ Blockly.utils.object.inherits(Blockly.TabNavigateCursor, Blockly.BasicCursor);
  * @override
  */
 Blockly.TabNavigateCursor.prototype.validNode_ = function(node) {
-  var isValid = false;
-  var type = node && node.getType();
+  let isValid = false;
+  const type = node && node.getType();
   if (node) {
-    var location = /** @type {Blockly.Field} */ (node.getLocation());
+    const location = /** @type {Blockly.Field} */ (node.getLocation());
     if (type == Blockly.ASTNode.types.FIELD &&
         location && location.isTabNavigable() && location.isClickable()) {
       isValid = true;

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.TabNavigateCursor');
+goog.module('Blockly.TabNavigateCursor');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.ASTNode');
 goog.require('Blockly.BasicCursor');
@@ -25,10 +26,10 @@ goog.requireType('Blockly.Field');
  * @constructor
  * @extends {Blockly.BasicCursor}
  */
-Blockly.TabNavigateCursor = function() {
-  Blockly.TabNavigateCursor.superClass_.constructor.call(this);
+const TabNavigateCursor = function() {
+  TabNavigateCursor.superClass_.constructor.call(this);
 };
-Blockly.utils.object.inherits(Blockly.TabNavigateCursor, Blockly.BasicCursor);
+Blockly.utils.object.inherits(TabNavigateCursor, Blockly.BasicCursor);
 
 /**
  * Skip all nodes except for tab navigable fields.
@@ -36,7 +37,7 @@ Blockly.utils.object.inherits(Blockly.TabNavigateCursor, Blockly.BasicCursor);
  * @return {boolean} True if the node should be visited, false otherwise.
  * @override
  */
-Blockly.TabNavigateCursor.prototype.validNode_ = function(node) {
+TabNavigateCursor.prototype.validNode_ = function(node) {
   let isValid = false;
   const type = node && node.getType();
   if (node) {
@@ -48,3 +49,5 @@ Blockly.TabNavigateCursor.prototype.validNode_ = function(node) {
   }
   return isValid;
 };
+
+exports = TabNavigateCursor;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -103,7 +103,7 @@ goog.addDependency('../../core/keyboard_nav/ast_node.js', ['Blockly.ASTNode'], [
 goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCursor'], ['Blockly.ASTNode', 'Blockly.Cursor', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
-goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object']);
+goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style']);
 goog.addDependency('../../core/menuitem.js', ['Blockly.MenuItem'], ['Blockly.utils.IdGenerator', 'Blockly.utils.aria', 'Blockly.utils.dom']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/keyboard_nav/tab_navigate_cursor.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/keyboard_nav/tab_navigate_cursor.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
