### PR TITLE
Fix edge cases for convert-script

### DIFF
--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -141,7 +141,6 @@ step2 () {
 
   npm run build:deps
   success "Completed automation for step 3. Please manually review and add exports for non-private top-level functions."
-
 }
 #######################################
 # Runs step 3 of the automated conversion.
@@ -285,7 +284,7 @@ function help {
   echo " 3. Rewrite goog.requires statements and add missing requires (often skipped for simple files)"
   echo " 4. Run clang-format on the whole file"
   echo ""
-  echo "Usage: $0 [-h|-c <number>|-s <number>|-f] <filepath>"
+  echo "Usage: $0 [-h|-c <number>|-s <number>] <filepath>"
   echo "  -h                      Display help"
   echo "  -c <step> <filepath>    Create a commit for the specified step [2-4]"
   echo "  -s <step> <filepath>    Run the specified step [1-4]"

--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -201,12 +201,12 @@ step3() {
   done
 
   local missing_requires=$(perl -nle'print $& while m{(?<!'\'')Blockly(\.\w+)+}g' "${filepath}")
-  local missing_require_lines=$(echo "${missing_requires}" | wc -l)
-  if [[ "${missing_require_lines}" -gt "0" ]]; then
+  if [[ ! -z "${missing_require_lines}" ]]; then
+    err $missing_require_lines
     err "Missing requires for: ${missing_requires} Please manually fix."
   fi
 
-  inf "Add missing nullability modifier..."
+  inf "Add missing nullability modifiers..."
   perl -pi -e 's/@(param|return) \{([A-Z])/@\1 \{?\2/g' "${filepath}"
 
   success "Completed automation for step 3. Please manually review and reorder requires."

--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -217,7 +217,6 @@ step3() {
 
   local missing_requires=$(perl -nle'print $& while m{(?<!'\'')Blockly(\.\w+)+}g' "${filepath}")
   if [[ ! -z "${missing_require_lines}" ]]; then
-    err $missing_require_lines
     err "Missing requires for: ${missing_requires} Please manually fix."
   fi
 

--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -219,9 +219,6 @@ step3() {
     err "Missing requires for: ${missing_requires} Please manually fix."
   fi
 
-  inf "Add missing nullability modifiers..."
-  perl -pi -e 's/@(param|return) \{([A-Z])/@\1 \{?\2/g' "${filepath}"
-
   success "Completed automation for step 3. Please manually review and reorder requires."
 }
 #######################################


### PR DESCRIPTION
Fixes bugs for the following edge cases:
* No missing requires -  corrects logic for detecting missing requires by checking for non-empty string instead of counting lines for the regex match return
* Checks for overlapping requires, such as if `Blockly.utils` and `Blockly.utils.dom` are both required
* Checks for overlap with module name and require, such as if `Blockly` is a require