### PR TITLE
Migrate core/contextmenu_items.js to goog.module syntax

### DIFF
--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -28,17 +28,19 @@ goog.requireType('Blockly.BlockSvg');
 /** Option to undo previous action. */
 Blockly.ContextMenuItems.registerUndo = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var undoOption = {
-    displayText: function() {
+  const undoOption = {
+    displayText: function () {
       return Blockly.Msg['UNDO'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.workspace.getUndoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.workspace.undo(false);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -51,15 +53,19 @@ Blockly.ContextMenuItems.registerUndo = function() {
 /** Option to redo previous action. */
 Blockly.ContextMenuItems.registerRedo = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var redoOption = {
-    displayText: function() { return Blockly.Msg['REDO']; },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const redoOption = {
+    displayText: function () {
+      return Blockly.Msg['REDO'];
+    },
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.workspace.getRedoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.workspace.undo(true);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -72,11 +78,12 @@ Blockly.ContextMenuItems.registerRedo = function() {
 /** Option to clean up blocks. */
 Blockly.ContextMenuItems.registerCleanup = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var cleanOption = {
-    displayText: function() {
+  const cleanOption = {
+    displayText: function () {
       return Blockly.Msg['CLEAN_UP'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.workspace.isMovable()) {
         if (scope.workspace.getTopBlocks(false).length > 1) {
           return 'enabled';
@@ -85,7 +92,8 @@ Blockly.ContextMenuItems.registerCleanup = function() {
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.workspace.cleanUp();
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -102,10 +110,10 @@ Blockly.ContextMenuItems.registerCleanup = function() {
  * @private
  */
 Blockly.ContextMenuItems.toggleOption_ = function(shouldCollapse, topBlocks) {
-  var DELAY = 10;
-  var ms = 0;
-  for (var i = 0; i < topBlocks.length; i++) {
-    var block = topBlocks[i];
+  const DELAY = 10;
+  let ms = 0;
+  for (let i = 0; i < topBlocks.length; i++) {
+    let block = topBlocks[i];
     while (block) {
       setTimeout(block.setCollapsed.bind(block, shouldCollapse), ms);
       block = block.getNextBlock();
@@ -117,15 +125,16 @@ Blockly.ContextMenuItems.toggleOption_ = function(shouldCollapse, topBlocks) {
 /** Option to collapse all blocks. */
 Blockly.ContextMenuItems.registerCollapse = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var collapseOption = {
-    displayText:  function() {
+  const collapseOption = {
+    displayText: function () {
       return Blockly.Msg['COLLAPSE_ALL'];
     },
-    preconditionFn:  function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.workspace.options.collapse) {
-        var topBlocks = scope.workspace.getTopBlocks(false);
-        for (var i = 0; i < topBlocks.length; i++) {
-          var block = topBlocks[i];
+        const topBlocks = scope.workspace.getTopBlocks(false);
+        for (let i = 0; i < topBlocks.length; i++) {
+          let block = topBlocks[i];
           while (block) {
             if (!block.isCollapsed()) {
               return 'enabled';
@@ -137,12 +146,14 @@ Blockly.ContextMenuItems.registerCollapse = function() {
       }
       return 'hidden';
     },
-    callback:  function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      Blockly.ContextMenuItems.toggleOption_(true, scope.workspace.getTopBlocks(true));
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      Blockly.ContextMenuItems.toggleOption_(true,
+          scope.workspace.getTopBlocks(true));
     },
-    scopeType:  Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
-    id:  'collapseWorkspace',
-    weight:  4,
+    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    id: 'collapseWorkspace',
+    weight: 4,
   };
   Blockly.ContextMenuRegistry.registry.register(collapseOption);
 };
@@ -150,15 +161,16 @@ Blockly.ContextMenuItems.registerCollapse = function() {
 /** Option to expand all blocks. */
 Blockly.ContextMenuItems.registerExpand = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var expandOption = {
-    displayText: function() {
+  const expandOption = {
+    displayText: function () {
       return Blockly.Msg['EXPAND_ALL'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.workspace.options.collapse) {
-        var topBlocks = scope.workspace.getTopBlocks(false);
-        for (var i = 0; i < topBlocks.length; i++) {
-          var block = topBlocks[i];
+        const topBlocks = scope.workspace.getTopBlocks(false);
+        for (let i = 0; i < topBlocks.length; i++) {
+          let block = topBlocks[i];
           while (block) {
             if (block.isCollapsed()) {
               return 'enabled';
@@ -170,8 +182,10 @@ Blockly.ContextMenuItems.registerExpand = function() {
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      Blockly.ContextMenuItems.toggleOption_(false, scope.workspace.getTopBlocks(true));
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      Blockly.ContextMenuItems.toggleOption_(false,
+          scope.workspace.getTopBlocks(true));
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'expandWorkspace',
@@ -191,9 +205,9 @@ Blockly.ContextMenuItems.addDeletableBlocks_ = function(block, deleteList) {
   if (block.isDeletable()) {
     Array.prototype.push.apply(deleteList, block.getDescendants(false));
   } else {
-    var children =  /* eslint-disable-next-line indent */
+    const children =  /* eslint-disable-next-line indent */
         /** @type {!Array<!Blockly.BlockSvg>} */ (block.getChildren(false));
-    for (var i = 0; i < children.length; i++) {
+    for (let i = 0; i < children.length; i++) {
       Blockly.ContextMenuItems.addDeletableBlocks_(children[i], deleteList);
     }
   }
@@ -206,9 +220,9 @@ Blockly.ContextMenuItems.addDeletableBlocks_ = function(block, deleteList) {
  * @private
  */
 Blockly.ContextMenuItems.getDeletableBlocks_ = function(workspace) {
-  var deleteList = [];
-  var topBlocks = workspace.getTopBlocks(true);
-  for (var i = 0; i < topBlocks.length; i++) {
+  const deleteList = [];
+  const topBlocks = workspace.getTopBlocks(true);
+  for (let i = 0; i < topBlocks.length; i++) {
     Blockly.ContextMenuItems.addDeletableBlocks_(topBlocks[i], deleteList);
   }
   return deleteList;
@@ -220,9 +234,9 @@ Blockly.ContextMenuItems.getDeletableBlocks_ = function(workspace) {
  * @private
  */
 Blockly.ContextMenuItems.deleteNext_ = function(deleteList, eventGroup) {
-  var DELAY = 10;
+  const DELAY = 10;
   Blockly.Events.setGroup(eventGroup);
-  var block = deleteList.shift();
+  const block = deleteList.shift();
   if (block) {
     if (block.workspace) {
       block.dispose(false, true);
@@ -237,42 +251,49 @@ Blockly.ContextMenuItems.deleteNext_ = function(deleteList, eventGroup) {
 /** Option to delete all blocks. */
 Blockly.ContextMenuItems.registerDeleteAll = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var deleteOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const deleteOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (!scope.workspace) {
         return;
       }
-      var deletableBlocksLength =
+      const deletableBlocksLength =
           Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace).length;
       if (deletableBlocksLength == 1) {
         return Blockly.Msg['DELETE_BLOCK'];
       } else {
-        return Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(deletableBlocksLength));
+        return Blockly.Msg['DELETE_X_BLOCKS'].replace('%1',
+            String(deletableBlocksLength));
       }
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (!scope.workspace) {
         return;
       }
-      var deletableBlocksLength =
-         Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace).length;
+      const deletableBlocksLength =
+          Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace).length;
       return deletableBlocksLength > 0 ? 'enabled' : 'disabled';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (!scope.workspace) {
         return;
       }
       scope.workspace.cancelCurrentGesture();
-      var deletableBlocks = Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace);
-      var eventGroup = Blockly.utils.genUid();
+      const deletableBlocks = Blockly.ContextMenuItems.getDeletableBlocks_(
+          scope.workspace);
+      const eventGroup = Blockly.utils.genUid();
       if (deletableBlocks.length < 2) {
         Blockly.ContextMenuItems.deleteNext_(deletableBlocks, eventGroup);
       } else {
         Blockly.confirm(
-            Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1', deletableBlocks.length),
-            function(ok) {
+            Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1',
+                deletableBlocks.length),
+            function (ok) {
               if (ok) {
-                Blockly.ContextMenuItems.deleteNext_(deletableBlocks, eventGroup);
+                Blockly.ContextMenuItems.deleteNext_(deletableBlocks,
+                    eventGroup);
               }
             });
       }
@@ -300,12 +321,13 @@ Blockly.ContextMenuItems.registerWorkspaceOptions_ = function() {
 /** Option to duplicate a block. */
 Blockly.ContextMenuItems.registerDuplicate = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var duplicateOption = {
-    displayText: function() {
+  const duplicateOption = {
+    displayText: function () {
       return Blockly.Msg['DUPLICATE_BLOCK'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
       if (!block.isInFlyout && block.isDeletable() && block.isMovable()) {
         if (block.isDuplicatable()) {
           return 'enabled';
@@ -314,7 +336,8 @@ Blockly.ContextMenuItems.registerDuplicate = function() {
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.block) {
         Blockly.clipboard.duplicate(scope.block);
       }
@@ -329,8 +352,9 @@ Blockly.ContextMenuItems.registerDuplicate = function() {
 /** Option to add or remove block-level comment. */
 Blockly.ContextMenuItems.registerComment = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var commentOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const commentOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (scope.block.getCommentIcon()) {
         // If there's already a comment,  option is to remove.
         return Blockly.Msg['REMOVE_COMMENT'];
@@ -338,17 +362,20 @@ Blockly.ContextMenuItems.registerComment = function() {
       // If there's no comment yet, option is to add.
       return Blockly.Msg['ADD_COMMENT'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
       // IE doesn't support necessary features for comment editing.
-      if (!Blockly.utils.userAgent.IE && !block.isInFlyout && block.workspace.options.comments &&
-        !block.isCollapsed() && block.isEditable()) {
+      if (!Blockly.utils.userAgent.IE && !block.isInFlyout
+          && block.workspace.options.comments &&
+          !block.isCollapsed() && block.isEditable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
       if (block.getCommentIcon()) {
         block.setCommentText(null);
       } else {
@@ -365,15 +392,17 @@ Blockly.ContextMenuItems.registerComment = function() {
 /** Option to inline variables. */
 Blockly.ContextMenuItems.registerInline = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var inlineOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const inlineOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       return (scope.block.getInputsInline()) ?
           Blockly.Msg['EXTERNAL_INPUTS'] : Blockly.Msg['INLINE_INPUTS'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
       if (!block.isInFlyout && block.isMovable() && !block.isCollapsed()) {
-        for (var i = 1; i < block.inputList.length; i++) {
+        for (let i = 1; i < block.inputList.length; i++) {
           // Only display this option if there are two value or dummy inputs next to each other.
           if (block.inputList[i - 1].type != Blockly.inputTypes.STATEMENT &&
               block.inputList[i].type != Blockly.inputTypes.STATEMENT) {
@@ -383,7 +412,8 @@ Blockly.ContextMenuItems.registerInline = function() {
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.block.setInputsInline(!scope.block.getInputsInline());
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
@@ -396,19 +426,23 @@ Blockly.ContextMenuItems.registerInline = function() {
 /** Option to collapse or expand a block. */
 Blockly.ContextMenuItems.registerCollapseExpandBlock = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var collapseExpandOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const collapseExpandOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       return scope.block.isCollapsed() ?
           Blockly.Msg['EXPAND_BLOCK'] : Blockly.Msg['COLLAPSE_BLOCK'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
-      if (!block.isInFlyout && block.isMovable() && block.workspace.options.collapse) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
+      if (!block.isInFlyout && block.isMovable()
+          && block.workspace.options.collapse) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.block.setCollapsed(!scope.block.isCollapsed());
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
@@ -421,14 +455,17 @@ Blockly.ContextMenuItems.registerCollapseExpandBlock = function() {
 /** Option to disable or enable a block. */
 Blockly.ContextMenuItems.registerDisable = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var disableOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+  const disableOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       return (scope.block.isEnabled()) ?
           Blockly.Msg['DISABLE_BLOCK'] : Blockly.Msg['ENABLE_BLOCK'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
-      if (!block.isInFlyout && block.workspace.options.disable && block.isEditable()) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
+      if (!block.isInFlyout && block.workspace.options.disable
+          && block.isEditable()) {
         if (block.getInheritedDisabled()) {
           return 'disabled';
         }
@@ -436,9 +473,10 @@ Blockly.ContextMenuItems.registerDisable = function() {
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
-      var group = Blockly.Events.getGroup();
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
+      const group = Blockly.Events.getGroup();
       if (!group) {
         Blockly.Events.setGroup(true);
       }
@@ -457,12 +495,13 @@ Blockly.ContextMenuItems.registerDisable = function() {
 /** Option to delete a block. */
 Blockly.ContextMenuItems.registerDelete = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var deleteOption = {
-    displayText: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
+  const deleteOption = {
+    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
       // Count the number of blocks that are nested in this block.
-      var descendantCount = block.getDescendants(false).length;
-      var nextBlock = block.getNextBlock();
+      let descendantCount = block.getDescendants(false).length;
+      const nextBlock = block.getNextBlock();
       if (nextBlock) {
         // Blocks in the current stack would survive this block's deletion.
         descendantCount -= nextBlock.getDescendants(false).length;
@@ -470,13 +509,15 @@ Blockly.ContextMenuItems.registerDelete = function() {
       return (descendantCount == 1) ? Blockly.Msg['DELETE_BLOCK'] :
           Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       if (!scope.block.isInFlyout && scope.block.isDeletable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       Blockly.Events.setGroup(true);
       if (scope.block) {
         Blockly.deleteBlock(scope.block);
@@ -493,20 +534,22 @@ Blockly.ContextMenuItems.registerDelete = function() {
 /** Option to open help for a block. */
 Blockly.ContextMenuItems.registerHelp = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
-  var helpOption = {
-    displayText: function() {
+  const helpOption = {
+    displayText: function () {
       return Blockly.Msg['HELP'];
     },
-    preconditionFn: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-      var block = scope.block;
-      var url = (typeof block.helpUrl == 'function') ?
+    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
+      const block = scope.block;
+      const url = (typeof block.helpUrl == 'function') ?
           block.helpUrl() : block.helpUrl;
       if (url) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function(/** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
+    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+        scope) {
       scope.block.showHelp();
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -31,18 +31,18 @@ const utils = goog.require('Blockly.utils');
 const registerUndo = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const undoOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['UNDO'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (scope.workspace.getUndoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.workspace.undo(false);
     },
     scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -57,18 +57,18 @@ exports.registerUndo = registerUndo;
 const registerRedo = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const redoOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['REDO'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (scope.workspace.getRedoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.workspace.undo(true);
     },
     scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -83,11 +83,11 @@ exports.registerRedo = registerRedo;
 const registerCleanup = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const cleanOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['CLEAN_UP'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (scope.workspace.isMovable()) {
         if (scope.workspace.getTopBlocks(false).length > 1) {
           return 'enabled';
@@ -96,8 +96,8 @@ const registerCleanup = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.workspace.cleanUp();
     },
     scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -131,11 +131,11 @@ const toggleOption_ = function(shouldCollapse, topBlocks) {
 const registerCollapse = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const collapseOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['COLLAPSE_ALL'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (scope.workspace.options.collapse) {
         const topBlocks = scope.workspace.getTopBlocks(false);
         for (let i = 0; i < topBlocks.length; i++) {
@@ -151,10 +151,9 @@ const registerCollapse = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
-      toggleOption_(true,
-          scope.workspace.getTopBlocks(true));
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
+      toggleOption_(true, scope.workspace.getTopBlocks(true));
     },
     scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'collapseWorkspace',
@@ -168,11 +167,11 @@ exports.registerCollapse = registerCollapse;
 const registerExpand = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const expandOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['EXPAND_ALL'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (scope.workspace.options.collapse) {
         const topBlocks = scope.workspace.getTopBlocks(false);
         for (let i = 0; i < topBlocks.length; i++) {
@@ -188,10 +187,9 @@ const registerExpand = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
-      toggleOption_(false,
-          scope.workspace.getTopBlocks(true));
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
+      toggleOption_(false, scope.workspace.getTopBlocks(true));
     },
     scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'expandWorkspace',
@@ -204,7 +202,8 @@ exports.registerExpand = registerExpand;
 /**
  * Adds a block and its children to a list of deletable blocks.
  * @param {!BlockSvg} block to delete.
- * @param {!Array<!BlockSvg>} deleteList list of blocks that can be deleted. This will be
+ * @param {!Array<!BlockSvg>} deleteList list of blocks that can be deleted.
+ *     This will be
  *    modifed in place with the given block and its descendants.
  * @private
  */
@@ -212,7 +211,7 @@ const addDeletableBlocks_ = function(block, deleteList) {
   if (block.isDeletable()) {
     Array.prototype.push.apply(deleteList, block.getDescendants(false));
   } else {
-    const children =  /* eslint-disable-next-line indent */
+    const children = /* eslint-disable-next-line indent */
         /** @type {!Array<!BlockSvg>} */ (block.getChildren(false));
     for (let i = 0; i < children.length; i++) {
       addDeletableBlocks_(children[i], deleteList);
@@ -235,9 +234,11 @@ const getDeletableBlocks_ = function(workspace) {
   return deleteList;
 };
 
-/** Deletes the given blocks. Used to delete all blocks in the workspace.
+/**
+ * Deletes the given blocks. Used to delete all blocks in the workspace.
  * @param {!Array<!BlockSvg>} deleteList list of blocks to delete.
- * @param {string} eventGroup event group ID with which all delete events should be associated.
+ * @param {string} eventGroup event group ID with which all delete events should
+ *     be associated.
  * @private
  */
 const deleteNext_ = function(deleteList, eventGroup) {
@@ -259,48 +260,43 @@ const deleteNext_ = function(deleteList, eventGroup) {
 const registerDeleteAll = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
       if (!scope.workspace) {
         return;
       }
-      const deletableBlocksLength =
-          getDeletableBlocks_(scope.workspace).length;
+      const deletableBlocksLength = getDeletableBlocks_(scope.workspace).length;
       if (deletableBlocksLength == 1) {
         return Msg['DELETE_BLOCK'];
       } else {
-        return Msg['DELETE_X_BLOCKS'].replace('%1',
-            String(deletableBlocksLength));
+        return Msg['DELETE_X_BLOCKS'].replace(
+            '%1', String(deletableBlocksLength));
       }
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (!scope.workspace) {
         return;
       }
-      const deletableBlocksLength =
-          getDeletableBlocks_(scope.workspace).length;
+      const deletableBlocksLength = getDeletableBlocks_(scope.workspace).length;
       return deletableBlocksLength > 0 ? 'enabled' : 'disabled';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       if (!scope.workspace) {
         return;
       }
       scope.workspace.cancelCurrentGesture();
-      const deletableBlocks = getDeletableBlocks_(
-          scope.workspace);
+      const deletableBlocks = getDeletableBlocks_(scope.workspace);
       const eventGroup = utils.genUid();
       if (deletableBlocks.length < 2) {
         deleteNext_(deletableBlocks, eventGroup);
       } else {
         Blockly.confirm(
-            Msg['DELETE_ALL_BLOCKS'].replace('%1',
-                deletableBlocks.length),
-            function (ok) {
+            Msg['DELETE_ALL_BLOCKS'].replace('%1', deletableBlocks.length),
+            function(ok) {
               if (ok) {
-                deleteNext_(deletableBlocks,
-                    eventGroup);
+                deleteNext_(deletableBlocks, eventGroup);
               }
             });
       }
@@ -330,11 +326,11 @@ const registerWorkspaceOptions_ = function() {
 const registerDuplicate = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const duplicateOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['DUPLICATE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.isDeletable() && block.isMovable()) {
         if (block.isDuplicatable()) {
@@ -344,8 +340,8 @@ const registerDuplicate = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       if (scope.block) {
         clipboard.duplicate(scope.block);
       }
@@ -362,8 +358,8 @@ exports.registerDuplicate = registerDuplicate;
 const registerComment = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const commentOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
       if (scope.block.getCommentIcon()) {
         // If there's already a comment,  option is to remove.
         return Msg['REMOVE_COMMENT'];
@@ -371,19 +367,19 @@ const registerComment = function() {
       // If there's no comment yet, option is to add.
       return Msg['ADD_COMMENT'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
       // IE doesn't support necessary features for comment editing.
-      if (!userAgent.IE && !block.isInFlyout
-          && block.workspace.options.comments &&
-          !block.isCollapsed() && block.isEditable()) {
+      if (!userAgent.IE && !block.isInFlyout &&
+          block.workspace.options.comments && !block.isCollapsed() &&
+          block.isEditable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       const block = scope.block;
       if (block.getCommentIcon()) {
         block.setCommentText(null);
@@ -403,17 +399,18 @@ exports.registerComment = registerComment;
 const registerInline = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const inlineOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
-      return (scope.block.getInputsInline()) ?
-          Msg['EXTERNAL_INPUTS'] : Msg['INLINE_INPUTS'];
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
+      return (scope.block.getInputsInline()) ? Msg['EXTERNAL_INPUTS'] :
+                                               Msg['INLINE_INPUTS'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.isMovable() && !block.isCollapsed()) {
         for (let i = 1; i < block.inputList.length; i++) {
-          // Only display this option if there are two value or dummy inputs next to each other.
+          // Only display this option if there are two value or dummy inputs
+          // next to each other.
           if (block.inputList[i - 1].type != inputTypes.STATEMENT &&
               block.inputList[i].type != inputTypes.STATEMENT) {
             return 'enabled';
@@ -422,8 +419,8 @@ const registerInline = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.block.setInputsInline(!scope.block.getInputsInline());
     },
     scopeType: ContextMenuRegistry.ScopeType.BLOCK,
@@ -438,22 +435,22 @@ exports.registerInline = registerInline;
 const registerCollapseExpandBlock = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const collapseExpandOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
-      return scope.block.isCollapsed() ?
-          Msg['EXPAND_BLOCK'] : Msg['COLLAPSE_BLOCK'];
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
+      return scope.block.isCollapsed() ? Msg['EXPAND_BLOCK'] :
+                                         Msg['COLLAPSE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
-      if (!block.isInFlyout && block.isMovable()
-          && block.workspace.options.collapse) {
+      if (!block.isInFlyout && block.isMovable() &&
+          block.workspace.options.collapse) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.block.setCollapsed(!scope.block.isCollapsed());
     },
     scopeType: ContextMenuRegistry.ScopeType.BLOCK,
@@ -468,16 +465,16 @@ exports.registerCollapseExpandBlock = registerCollapseExpandBlock;
 const registerDisable = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const disableOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
-      return (scope.block.isEnabled()) ?
-          Msg['DISABLE_BLOCK'] : Msg['ENABLE_BLOCK'];
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
+      return (scope.block.isEnabled()) ? Msg['DISABLE_BLOCK'] :
+                                         Msg['ENABLE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
-      if (!block.isInFlyout && block.workspace.options.disable
-          && block.isEditable()) {
+      if (!block.isInFlyout && block.workspace.options.disable &&
+          block.isEditable()) {
         if (block.getInheritedDisabled()) {
           return 'disabled';
         }
@@ -485,8 +482,8 @@ const registerDisable = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       const block = scope.block;
       const group = Events.getGroup();
       if (!group) {
@@ -509,8 +506,8 @@ exports.registerDisable = registerDisable;
 const registerDelete = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
-    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    displayText: function(/** @type {!ContextMenuRegistry.Scope} */
+                          scope) {
       const block = scope.block;
       // Count the number of blocks that are nested in this block.
       let descendantCount = block.getDescendants(false).length;
@@ -519,18 +516,19 @@ const registerDelete = function() {
         // Blocks in the current stack would survive this block's deletion.
         descendantCount -= nextBlock.getDescendants(false).length;
       }
-      return (descendantCount == 1) ? Msg['DELETE_BLOCK'] :
+      return (descendantCount == 1) ?
+          Msg['DELETE_BLOCK'] :
           Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       if (!scope.block.isInFlyout && scope.block.isDeletable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       Events.setGroup(true);
       if (scope.block) {
         Blockly.deleteBlock(scope.block);
@@ -549,21 +547,21 @@ exports.registerDelete = registerDelete;
 const registerHelp = function() {
   /** @type {!ContextMenuRegistry.RegistryItem} */
   const helpOption = {
-    displayText: function () {
+    displayText: function() {
       return Msg['HELP'];
     },
-    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    preconditionFn: function(/** @type {!ContextMenuRegistry.Scope} */
+                             scope) {
       const block = scope.block;
-      const url = (typeof block.helpUrl == 'function') ?
-          block.helpUrl() : block.helpUrl;
+      const url = (typeof block.helpUrl == 'function') ? block.helpUrl() :
+                                                         block.helpUrl;
       if (url) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!ContextMenuRegistry.Scope} */
-        scope) {
+    callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                       scope) {
       scope.block.showHelp();
     },
     scopeType: ContextMenuRegistry.ScopeType.BLOCK,
@@ -589,8 +587,8 @@ const registerBlockOptions_ = function() {
 };
 
 /**
- * Registers all default context menu items. This should be called once per instance of
- * ContextMenuRegistry.
+ * Registers all default context menu items. This should be called once per
+ * instance of ContextMenuRegistry.
  * @package
  */
 const registerDefaultOptions = function() {

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -14,19 +14,23 @@
  * @name Blockly.ContextMenuItems
  * @namespace
  */
-goog.provide('Blockly.ContextMenuItems');
+goog.module('Blockly.ContextMenuItems');
+goog.module.declareLegacyNamespace();
+
+goog.require('Blockly');
 goog.require('Blockly.clipboard');
-/** @suppress {extraRequire} */
-goog.require('Blockly.constants');
 goog.require('Blockly.ContextMenuRegistry');
 goog.require('Blockly.Events');
 goog.require('Blockly.inputTypes');
-
+goog.require('Blockly.Msg');
+goog.require('Blockly.utils');
+goog.require('Blockly.utils.userAgent');
+goog.requireType('Blockly.WorkspaceSvg');
 goog.requireType('Blockly.BlockSvg');
 
 
 /** Option to undo previous action. */
-Blockly.ContextMenuItems.registerUndo = function() {
+const registerUndo = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const undoOption = {
     displayText: function () {
@@ -49,9 +53,10 @@ Blockly.ContextMenuItems.registerUndo = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(undoOption);
 };
+exports.registerUndo = registerUndo;
 
 /** Option to redo previous action. */
-Blockly.ContextMenuItems.registerRedo = function() {
+const registerRedo = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const redoOption = {
     displayText: function () {
@@ -74,9 +79,10 @@ Blockly.ContextMenuItems.registerRedo = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(redoOption);
 };
+exports.registerRedo = registerRedo;
 
 /** Option to clean up blocks. */
-Blockly.ContextMenuItems.registerCleanup = function() {
+const registerCleanup = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const cleanOption = {
     displayText: function () {
@@ -102,6 +108,7 @@ Blockly.ContextMenuItems.registerCleanup = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(cleanOption);
 };
+exports.registerCleanup = registerCleanup;
 
 /**
  * Creates a callback to collapse or expand top blocks.
@@ -109,7 +116,7 @@ Blockly.ContextMenuItems.registerCleanup = function() {
  * @param {!Array<Blockly.BlockSvg>} topBlocks Top blocks in the workspace.
  * @private
  */
-Blockly.ContextMenuItems.toggleOption_ = function(shouldCollapse, topBlocks) {
+const toggleOption_ = function(shouldCollapse, topBlocks) {
   const DELAY = 10;
   let ms = 0;
   for (let i = 0; i < topBlocks.length; i++) {
@@ -123,7 +130,7 @@ Blockly.ContextMenuItems.toggleOption_ = function(shouldCollapse, topBlocks) {
 };
 
 /** Option to collapse all blocks. */
-Blockly.ContextMenuItems.registerCollapse = function() {
+const registerCollapse = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const collapseOption = {
     displayText: function () {
@@ -148,7 +155,7 @@ Blockly.ContextMenuItems.registerCollapse = function() {
     },
     callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
         scope) {
-      Blockly.ContextMenuItems.toggleOption_(true,
+      toggleOption_(true,
           scope.workspace.getTopBlocks(true));
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -157,9 +164,10 @@ Blockly.ContextMenuItems.registerCollapse = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(collapseOption);
 };
+exports.registerCollapse = registerCollapse;
 
 /** Option to expand all blocks. */
-Blockly.ContextMenuItems.registerExpand = function() {
+const registerExpand = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const expandOption = {
     displayText: function () {
@@ -184,7 +192,7 @@ Blockly.ContextMenuItems.registerExpand = function() {
     },
     callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
         scope) {
-      Blockly.ContextMenuItems.toggleOption_(false,
+      toggleOption_(false,
           scope.workspace.getTopBlocks(true));
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -193,6 +201,7 @@ Blockly.ContextMenuItems.registerExpand = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(expandOption);
 };
+exports.registerExpand = registerExpand;
 
 /**
  * Adds a block and its children to a list of deletable blocks.
@@ -201,14 +210,14 @@ Blockly.ContextMenuItems.registerExpand = function() {
  *    modifed in place with the given block and its descendants.
  * @private
  */
-Blockly.ContextMenuItems.addDeletableBlocks_ = function(block, deleteList) {
+const addDeletableBlocks_ = function(block, deleteList) {
   if (block.isDeletable()) {
     Array.prototype.push.apply(deleteList, block.getDescendants(false));
   } else {
     const children =  /* eslint-disable-next-line indent */
         /** @type {!Array<!Blockly.BlockSvg>} */ (block.getChildren(false));
     for (let i = 0; i < children.length; i++) {
-      Blockly.ContextMenuItems.addDeletableBlocks_(children[i], deleteList);
+      addDeletableBlocks_(children[i], deleteList);
     }
   }
 };
@@ -219,11 +228,11 @@ Blockly.ContextMenuItems.addDeletableBlocks_ = function(block, deleteList) {
  * @return {!Array<!Blockly.BlockSvg>} list of blocks to delete.
  * @private
  */
-Blockly.ContextMenuItems.getDeletableBlocks_ = function(workspace) {
+const getDeletableBlocks_ = function(workspace) {
   const deleteList = [];
   const topBlocks = workspace.getTopBlocks(true);
   for (let i = 0; i < topBlocks.length; i++) {
-    Blockly.ContextMenuItems.addDeletableBlocks_(topBlocks[i], deleteList);
+    addDeletableBlocks_(topBlocks[i], deleteList);
   }
   return deleteList;
 };
@@ -233,23 +242,23 @@ Blockly.ContextMenuItems.getDeletableBlocks_ = function(workspace) {
  * @param {string} eventGroup event group ID with which all delete events should be associated.
  * @private
  */
-Blockly.ContextMenuItems.deleteNext_ = function(deleteList, eventGroup) {
+const deleteNext_ = function(deleteList, eventGroup) {
   const DELAY = 10;
   Blockly.Events.setGroup(eventGroup);
   const block = deleteList.shift();
   if (block) {
     if (block.workspace) {
       block.dispose(false, true);
-      setTimeout(Blockly.ContextMenuItems.deleteNext_, DELAY, deleteList, eventGroup);
+      setTimeout(deleteNext_, DELAY, deleteList, eventGroup);
     } else {
-      Blockly.ContextMenuItems.deleteNext_(deleteList, eventGroup);
+      deleteNext_(deleteList, eventGroup);
     }
   }
   Blockly.Events.setGroup(false);
 };
 
 /** Option to delete all blocks. */
-Blockly.ContextMenuItems.registerDeleteAll = function() {
+const registerDeleteAll = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -258,7 +267,7 @@ Blockly.ContextMenuItems.registerDeleteAll = function() {
         return;
       }
       const deletableBlocksLength =
-          Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace).length;
+          getDeletableBlocks_(scope.workspace).length;
       if (deletableBlocksLength == 1) {
         return Blockly.Msg['DELETE_BLOCK'];
       } else {
@@ -272,7 +281,7 @@ Blockly.ContextMenuItems.registerDeleteAll = function() {
         return;
       }
       const deletableBlocksLength =
-          Blockly.ContextMenuItems.getDeletableBlocks_(scope.workspace).length;
+          getDeletableBlocks_(scope.workspace).length;
       return deletableBlocksLength > 0 ? 'enabled' : 'disabled';
     },
     callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -281,18 +290,18 @@ Blockly.ContextMenuItems.registerDeleteAll = function() {
         return;
       }
       scope.workspace.cancelCurrentGesture();
-      const deletableBlocks = Blockly.ContextMenuItems.getDeletableBlocks_(
+      const deletableBlocks = getDeletableBlocks_(
           scope.workspace);
       const eventGroup = Blockly.utils.genUid();
       if (deletableBlocks.length < 2) {
-        Blockly.ContextMenuItems.deleteNext_(deletableBlocks, eventGroup);
+        deleteNext_(deletableBlocks, eventGroup);
       } else {
         Blockly.confirm(
             Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1',
                 deletableBlocks.length),
             function (ok) {
               if (ok) {
-                Blockly.ContextMenuItems.deleteNext_(deletableBlocks,
+                deleteNext_(deletableBlocks,
                     eventGroup);
               }
             });
@@ -304,22 +313,23 @@ Blockly.ContextMenuItems.registerDeleteAll = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(deleteOption);
 };
+exports.registerDeleteAll = registerDeleteAll;
 
 /**
  * Registers all workspace-scoped context menu items.
  * @private
  */
-Blockly.ContextMenuItems.registerWorkspaceOptions_ = function() {
-  Blockly.ContextMenuItems.registerUndo();
-  Blockly.ContextMenuItems.registerRedo();
-  Blockly.ContextMenuItems.registerCleanup();
-  Blockly.ContextMenuItems.registerCollapse();
-  Blockly.ContextMenuItems.registerExpand();
-  Blockly.ContextMenuItems.registerDeleteAll();
+const registerWorkspaceOptions_ = function() {
+  registerUndo();
+  registerRedo();
+  registerCleanup();
+  registerCollapse();
+  registerExpand();
+  registerDeleteAll();
 };
 
 /** Option to duplicate a block. */
-Blockly.ContextMenuItems.registerDuplicate = function() {
+const registerDuplicate = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const duplicateOption = {
     displayText: function () {
@@ -348,9 +358,10 @@ Blockly.ContextMenuItems.registerDuplicate = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(duplicateOption);
 };
+exports.registerDuplicate = registerDuplicate;
 
 /** Option to add or remove block-level comment. */
-Blockly.ContextMenuItems.registerComment = function() {
+const registerComment = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const commentOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -388,9 +399,10 @@ Blockly.ContextMenuItems.registerComment = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(commentOption);
 };
+exports.registerComment = registerComment;
 
 /** Option to inline variables. */
-Blockly.ContextMenuItems.registerInline = function() {
+const registerInline = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const inlineOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -422,9 +434,10 @@ Blockly.ContextMenuItems.registerInline = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(inlineOption);
 };
+exports.registerInline = registerInline;
 
 /** Option to collapse or expand a block. */
-Blockly.ContextMenuItems.registerCollapseExpandBlock = function() {
+const registerCollapseExpandBlock = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const collapseExpandOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -451,9 +464,10 @@ Blockly.ContextMenuItems.registerCollapseExpandBlock = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(collapseExpandOption);
 };
+exports.registerCollapseExpandBlock = registerCollapseExpandBlock;
 
 /** Option to disable or enable a block. */
-Blockly.ContextMenuItems.registerDisable = function() {
+const registerDisable = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const disableOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -491,9 +505,10 @@ Blockly.ContextMenuItems.registerDisable = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(disableOption);
 };
+exports.registerDisable = registerDisable;
 
 /** Option to delete a block. */
-Blockly.ContextMenuItems.registerDelete = function() {
+const registerDelete = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
     displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
@@ -530,9 +545,10 @@ Blockly.ContextMenuItems.registerDelete = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(deleteOption);
 };
+exports.registerDelete = registerDelete;
 
 /** Option to open help for a block. */
-Blockly.ContextMenuItems.registerHelp = function() {
+const registerHelp = function() {
   /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
   const helpOption = {
     displayText: function () {
@@ -558,19 +574,20 @@ Blockly.ContextMenuItems.registerHelp = function() {
   };
   Blockly.ContextMenuRegistry.registry.register(helpOption);
 };
+exports.registerHelp = registerHelp;
 
 /**
  * Registers all block-scoped context menu items.
  * @private
  */
-Blockly.ContextMenuItems.registerBlockOptions_ = function() {
-  Blockly.ContextMenuItems.registerDuplicate();
-  Blockly.ContextMenuItems.registerComment();
-  Blockly.ContextMenuItems.registerInline();
-  Blockly.ContextMenuItems.registerCollapseExpandBlock();
-  Blockly.ContextMenuItems.registerDisable();
-  Blockly.ContextMenuItems.registerDelete();
-  Blockly.ContextMenuItems.registerHelp();
+const registerBlockOptions_ = function() {
+  registerDuplicate();
+  registerComment();
+  registerInline();
+  registerCollapseExpandBlock();
+  registerDisable();
+  registerDelete();
+  registerHelp();
 };
 
 /**
@@ -578,9 +595,10 @@ Blockly.ContextMenuItems.registerBlockOptions_ = function() {
  * ContextMenuRegistry.
  * @package
  */
-Blockly.ContextMenuItems.registerDefaultOptions = function() {
-  Blockly.ContextMenuItems.registerWorkspaceOptions_();
-  Blockly.ContextMenuItems.registerBlockOptions_();
+const registerDefaultOptions = function() {
+  registerWorkspaceOptions_();
+  registerBlockOptions_();
 };
+exports.registerDefaultOptions = registerDefaultOptions;
 
-Blockly.ContextMenuItems.registerDefaultOptions();
+registerDefaultOptions();

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -10,85 +10,83 @@
  */
 'use strict';
 
-/**
- * @name Blockly.ContextMenuItems
- * @namespace
- */
 goog.module('Blockly.ContextMenuItems');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly');
-goog.require('Blockly.clipboard');
-goog.require('Blockly.ContextMenuRegistry');
-goog.require('Blockly.Events');
-goog.require('Blockly.inputTypes');
-goog.require('Blockly.Msg');
-goog.require('Blockly.utils');
-goog.require('Blockly.utils.userAgent');
-goog.requireType('Blockly.WorkspaceSvg');
-goog.requireType('Blockly.BlockSvg');
+const Blockly = goog.require('Blockly');
+/* eslint-disable-next-line no-unused-vars */
+const BlockSvg = goog.requireType('Blockly.BlockSvg');
+const ContextMenuRegistry = goog.require('Blockly.ContextMenuRegistry');
+const Events = goog.require('Blockly.Events');
+const Msg = goog.require('Blockly.Msg');
+/* eslint-disable-next-line no-unused-vars */
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+const clipboard = goog.require('Blockly.clipboard');
+const inputTypes = goog.require('Blockly.inputTypes');
+const userAgent = goog.require('Blockly.utils.userAgent');
+const utils = goog.require('Blockly.utils');
 
 
 /** Option to undo previous action. */
 const registerUndo = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const undoOption = {
     displayText: function () {
-      return Blockly.Msg['UNDO'];
+      return Msg['UNDO'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.workspace.getUndoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.workspace.undo(false);
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'undoWorkspace',
     weight: 1,
   };
-  Blockly.ContextMenuRegistry.registry.register(undoOption);
+  ContextMenuRegistry.registry.register(undoOption);
 };
 exports.registerUndo = registerUndo;
 
 /** Option to redo previous action. */
 const registerRedo = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const redoOption = {
     displayText: function () {
-      return Blockly.Msg['REDO'];
+      return Msg['REDO'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.workspace.getRedoStack().length > 0) {
         return 'enabled';
       }
       return 'disabled';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.workspace.undo(true);
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'redoWorkspace',
     weight: 2,
   };
-  Blockly.ContextMenuRegistry.registry.register(redoOption);
+  ContextMenuRegistry.registry.register(redoOption);
 };
 exports.registerRedo = registerRedo;
 
 /** Option to clean up blocks. */
 const registerCleanup = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const cleanOption = {
     displayText: function () {
-      return Blockly.Msg['CLEAN_UP'];
+      return Msg['CLEAN_UP'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.workspace.isMovable()) {
         if (scope.workspace.getTopBlocks(false).length > 1) {
@@ -98,22 +96,22 @@ const registerCleanup = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.workspace.cleanUp();
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'cleanWorkspace',
     weight: 3,
   };
-  Blockly.ContextMenuRegistry.registry.register(cleanOption);
+  ContextMenuRegistry.registry.register(cleanOption);
 };
 exports.registerCleanup = registerCleanup;
 
 /**
  * Creates a callback to collapse or expand top blocks.
  * @param {boolean} shouldCollapse Whether a block should collapse.
- * @param {!Array<Blockly.BlockSvg>} topBlocks Top blocks in the workspace.
+ * @param {!Array<BlockSvg>} topBlocks Top blocks in the workspace.
  * @private
  */
 const toggleOption_ = function(shouldCollapse, topBlocks) {
@@ -131,12 +129,12 @@ const toggleOption_ = function(shouldCollapse, topBlocks) {
 
 /** Option to collapse all blocks. */
 const registerCollapse = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const collapseOption = {
     displayText: function () {
-      return Blockly.Msg['COLLAPSE_ALL'];
+      return Msg['COLLAPSE_ALL'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.workspace.options.collapse) {
         const topBlocks = scope.workspace.getTopBlocks(false);
@@ -153,27 +151,27 @@ const registerCollapse = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       toggleOption_(true,
           scope.workspace.getTopBlocks(true));
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'collapseWorkspace',
     weight: 4,
   };
-  Blockly.ContextMenuRegistry.registry.register(collapseOption);
+  ContextMenuRegistry.registry.register(collapseOption);
 };
 exports.registerCollapse = registerCollapse;
 
 /** Option to expand all blocks. */
 const registerExpand = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const expandOption = {
     displayText: function () {
-      return Blockly.Msg['EXPAND_ALL'];
+      return Msg['EXPAND_ALL'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.workspace.options.collapse) {
         const topBlocks = scope.workspace.getTopBlocks(false);
@@ -190,23 +188,23 @@ const registerExpand = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       toggleOption_(false,
           scope.workspace.getTopBlocks(true));
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'expandWorkspace',
     weight: 5,
   };
-  Blockly.ContextMenuRegistry.registry.register(expandOption);
+  ContextMenuRegistry.registry.register(expandOption);
 };
 exports.registerExpand = registerExpand;
 
 /**
  * Adds a block and its children to a list of deletable blocks.
- * @param {!Blockly.BlockSvg} block to delete.
- * @param {!Array<!Blockly.BlockSvg>} deleteList list of blocks that can be deleted. This will be
+ * @param {!BlockSvg} block to delete.
+ * @param {!Array<!BlockSvg>} deleteList list of blocks that can be deleted. This will be
  *    modifed in place with the given block and its descendants.
  * @private
  */
@@ -215,7 +213,7 @@ const addDeletableBlocks_ = function(block, deleteList) {
     Array.prototype.push.apply(deleteList, block.getDescendants(false));
   } else {
     const children =  /* eslint-disable-next-line indent */
-        /** @type {!Array<!Blockly.BlockSvg>} */ (block.getChildren(false));
+        /** @type {!Array<!BlockSvg>} */ (block.getChildren(false));
     for (let i = 0; i < children.length; i++) {
       addDeletableBlocks_(children[i], deleteList);
     }
@@ -224,8 +222,8 @@ const addDeletableBlocks_ = function(block, deleteList) {
 
 /**
  * Constructs a list of blocks that can be deleted in the given workspace.
- * @param {!Blockly.WorkspaceSvg} workspace to delete all blocks from.
- * @return {!Array<!Blockly.BlockSvg>} list of blocks to delete.
+ * @param {!WorkspaceSvg} workspace to delete all blocks from.
+ * @return {!Array<!BlockSvg>} list of blocks to delete.
  * @private
  */
 const getDeletableBlocks_ = function(workspace) {
@@ -238,13 +236,13 @@ const getDeletableBlocks_ = function(workspace) {
 };
 
 /** Deletes the given blocks. Used to delete all blocks in the workspace.
- * @param {!Array<!Blockly.BlockSvg>} deleteList list of blocks to delete.
+ * @param {!Array<!BlockSvg>} deleteList list of blocks to delete.
  * @param {string} eventGroup event group ID with which all delete events should be associated.
  * @private
  */
 const deleteNext_ = function(deleteList, eventGroup) {
   const DELAY = 10;
-  Blockly.Events.setGroup(eventGroup);
+  Events.setGroup(eventGroup);
   const block = deleteList.shift();
   if (block) {
     if (block.workspace) {
@@ -254,14 +252,14 @@ const deleteNext_ = function(deleteList, eventGroup) {
       deleteNext_(deleteList, eventGroup);
     }
   }
-  Blockly.Events.setGroup(false);
+  Events.setGroup(false);
 };
 
 /** Option to delete all blocks. */
 const registerDeleteAll = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (!scope.workspace) {
         return;
@@ -269,13 +267,13 @@ const registerDeleteAll = function() {
       const deletableBlocksLength =
           getDeletableBlocks_(scope.workspace).length;
       if (deletableBlocksLength == 1) {
-        return Blockly.Msg['DELETE_BLOCK'];
+        return Msg['DELETE_BLOCK'];
       } else {
-        return Blockly.Msg['DELETE_X_BLOCKS'].replace('%1',
+        return Msg['DELETE_X_BLOCKS'].replace('%1',
             String(deletableBlocksLength));
       }
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (!scope.workspace) {
         return;
@@ -284,7 +282,7 @@ const registerDeleteAll = function() {
           getDeletableBlocks_(scope.workspace).length;
       return deletableBlocksLength > 0 ? 'enabled' : 'disabled';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (!scope.workspace) {
         return;
@@ -292,12 +290,12 @@ const registerDeleteAll = function() {
       scope.workspace.cancelCurrentGesture();
       const deletableBlocks = getDeletableBlocks_(
           scope.workspace);
-      const eventGroup = Blockly.utils.genUid();
+      const eventGroup = utils.genUid();
       if (deletableBlocks.length < 2) {
         deleteNext_(deletableBlocks, eventGroup);
       } else {
         Blockly.confirm(
-            Blockly.Msg['DELETE_ALL_BLOCKS'].replace('%1',
+            Msg['DELETE_ALL_BLOCKS'].replace('%1',
                 deletableBlocks.length),
             function (ok) {
               if (ok) {
@@ -307,11 +305,11 @@ const registerDeleteAll = function() {
             });
       }
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    scopeType: ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'workspaceDelete',
     weight: 6,
   };
-  Blockly.ContextMenuRegistry.registry.register(deleteOption);
+  ContextMenuRegistry.registry.register(deleteOption);
 };
 exports.registerDeleteAll = registerDeleteAll;
 
@@ -330,12 +328,12 @@ const registerWorkspaceOptions_ = function() {
 
 /** Option to duplicate a block. */
 const registerDuplicate = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const duplicateOption = {
     displayText: function () {
-      return Blockly.Msg['DUPLICATE_BLOCK'];
+      return Msg['DUPLICATE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.isDeletable() && block.isMovable()) {
@@ -346,45 +344,45 @@ const registerDuplicate = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.block) {
-        Blockly.clipboard.duplicate(scope.block);
+        clipboard.duplicate(scope.block);
       }
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockDuplicate',
     weight: 1,
   };
-  Blockly.ContextMenuRegistry.registry.register(duplicateOption);
+  ContextMenuRegistry.registry.register(duplicateOption);
 };
 exports.registerDuplicate = registerDuplicate;
 
 /** Option to add or remove block-level comment. */
 const registerComment = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const commentOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (scope.block.getCommentIcon()) {
         // If there's already a comment,  option is to remove.
-        return Blockly.Msg['REMOVE_COMMENT'];
+        return Msg['REMOVE_COMMENT'];
       }
       // If there's no comment yet, option is to add.
-      return Blockly.Msg['ADD_COMMENT'];
+      return Msg['ADD_COMMENT'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       // IE doesn't support necessary features for comment editing.
-      if (!Blockly.utils.userAgent.IE && !block.isInFlyout
+      if (!userAgent.IE && !block.isInFlyout
           && block.workspace.options.comments &&
           !block.isCollapsed() && block.isEditable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       if (block.getCommentIcon()) {
@@ -393,59 +391,59 @@ const registerComment = function() {
         block.setCommentText('');
       }
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockComment',
     weight: 2,
   };
-  Blockly.ContextMenuRegistry.registry.register(commentOption);
+  ContextMenuRegistry.registry.register(commentOption);
 };
 exports.registerComment = registerComment;
 
 /** Option to inline variables. */
 const registerInline = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const inlineOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       return (scope.block.getInputsInline()) ?
-          Blockly.Msg['EXTERNAL_INPUTS'] : Blockly.Msg['INLINE_INPUTS'];
+          Msg['EXTERNAL_INPUTS'] : Msg['INLINE_INPUTS'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.isMovable() && !block.isCollapsed()) {
         for (let i = 1; i < block.inputList.length; i++) {
           // Only display this option if there are two value or dummy inputs next to each other.
-          if (block.inputList[i - 1].type != Blockly.inputTypes.STATEMENT &&
-              block.inputList[i].type != Blockly.inputTypes.STATEMENT) {
+          if (block.inputList[i - 1].type != inputTypes.STATEMENT &&
+              block.inputList[i].type != inputTypes.STATEMENT) {
             return 'enabled';
           }
         }
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.block.setInputsInline(!scope.block.getInputsInline());
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockInline',
     weight: 3,
   };
-  Blockly.ContextMenuRegistry.registry.register(inlineOption);
+  ContextMenuRegistry.registry.register(inlineOption);
 };
 exports.registerInline = registerInline;
 
 /** Option to collapse or expand a block. */
 const registerCollapseExpandBlock = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const collapseExpandOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       return scope.block.isCollapsed() ?
-          Blockly.Msg['EXPAND_BLOCK'] : Blockly.Msg['COLLAPSE_BLOCK'];
+          Msg['EXPAND_BLOCK'] : Msg['COLLAPSE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.isMovable()
@@ -454,28 +452,28 @@ const registerCollapseExpandBlock = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.block.setCollapsed(!scope.block.isCollapsed());
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockCollapseExpand',
     weight: 4,
   };
-  Blockly.ContextMenuRegistry.registry.register(collapseExpandOption);
+  ContextMenuRegistry.registry.register(collapseExpandOption);
 };
 exports.registerCollapseExpandBlock = registerCollapseExpandBlock;
 
 /** Option to disable or enable a block. */
 const registerDisable = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const disableOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       return (scope.block.isEnabled()) ?
-          Blockly.Msg['DISABLE_BLOCK'] : Blockly.Msg['ENABLE_BLOCK'];
+          Msg['DISABLE_BLOCK'] : Msg['ENABLE_BLOCK'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       if (!block.isInFlyout && block.workspace.options.disable
@@ -487,31 +485,31 @@ const registerDisable = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
-      const group = Blockly.Events.getGroup();
+      const group = Events.getGroup();
       if (!group) {
-        Blockly.Events.setGroup(true);
+        Events.setGroup(true);
       }
       block.setEnabled(!block.isEnabled());
       if (!group) {
-        Blockly.Events.setGroup(false);
+        Events.setGroup(false);
       }
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockDisable',
     weight: 5,
   };
-  Blockly.ContextMenuRegistry.registry.register(disableOption);
+  ContextMenuRegistry.registry.register(disableOption);
 };
 exports.registerDisable = registerDisable;
 
 /** Option to delete a block. */
 const registerDelete = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const deleteOption = {
-    displayText: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    displayText: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       // Count the number of blocks that are nested in this block.
@@ -521,40 +519,40 @@ const registerDelete = function() {
         // Blocks in the current stack would survive this block's deletion.
         descendantCount -= nextBlock.getDescendants(false).length;
       }
-      return (descendantCount == 1) ? Blockly.Msg['DELETE_BLOCK'] :
-          Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));
+      return (descendantCount == 1) ? Msg['DELETE_BLOCK'] :
+          Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       if (!scope.block.isInFlyout && scope.block.isDeletable()) {
         return 'enabled';
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
-      Blockly.Events.setGroup(true);
+      Events.setGroup(true);
       if (scope.block) {
         Blockly.deleteBlock(scope.block);
       }
-      Blockly.Events.setGroup(false);
+      Events.setGroup(false);
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockDelete',
     weight: 6,
   };
-  Blockly.ContextMenuRegistry.registry.register(deleteOption);
+  ContextMenuRegistry.registry.register(deleteOption);
 };
 exports.registerDelete = registerDelete;
 
 /** Option to open help for a block. */
 const registerHelp = function() {
-  /** @type {!Blockly.ContextMenuRegistry.RegistryItem} */
+  /** @type {!ContextMenuRegistry.RegistryItem} */
   const helpOption = {
     displayText: function () {
-      return Blockly.Msg['HELP'];
+      return Msg['HELP'];
     },
-    preconditionFn: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    preconditionFn: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       const block = scope.block;
       const url = (typeof block.helpUrl == 'function') ?
@@ -564,15 +562,15 @@ const registerHelp = function() {
       }
       return 'hidden';
     },
-    callback: function (/** @type {!Blockly.ContextMenuRegistry.Scope} */
+    callback: function (/** @type {!ContextMenuRegistry.Scope} */
         scope) {
       scope.block.showHelp();
     },
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockHelp',
     weight: 7,
   };
-  Blockly.ContextMenuRegistry.registry.register(helpOption);
+  ContextMenuRegistry.registry.register(helpOption);
 };
 exports.registerHelp = registerHelp;
 

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -27,7 +27,7 @@ goog.addDependency('../../core/connection_db.js', ['Blockly.ConnectionDB'], ['Bl
 goog.addDependency('../../core/connection_types.js', ['Blockly.connectionTypes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/constants.js', ['Blockly.constants'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/contextmenu.js', ['Blockly.ContextMenu'], ['Blockly.Events', 'Blockly.Events.BlockCreate', 'Blockly.Menu', 'Blockly.MenuItem', 'Blockly.Msg', 'Blockly.WidgetDiv', 'Blockly.Xml', 'Blockly.browserEvents', 'Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.userAgent']);
-goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems'], ['Blockly.ContextMenuRegistry', 'Blockly.Events', 'Blockly.clipboard', 'Blockly.constants', 'Blockly.inputTypes'], {'lang': 'es5'});
+goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems'], ['Blockly', 'Blockly.ContextMenuRegistry', 'Blockly.Events', 'Blockly.Msg', 'Blockly.clipboard', 'Blockly.inputTypes', 'Blockly.utils', 'Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/contextmenu_registry.js', ['Blockly.ContextMenuRegistry'], [], {'lang': 'es5'});
 goog.addDependency('../../core/css.js', ['Blockly.Css'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/delete_area.js', ['Blockly.DeleteArea'], ['Blockly.BlockSvg', 'Blockly.DragTarget', 'Blockly.IDeleteArea', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/contextmenu_items.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/contextmenu_items.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
