### PR TITLE
Update goog.module-migrated files to fix style issues

### DIFF
--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -13,9 +13,10 @@
 goog.module('Blockly.blockAnimations');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
-const dom = goog.require('Blockly.utils.dom');
 const Svg = goog.require('Blockly.utils.Svg');
+const dom = goog.require('Blockly.utils.dom');
 
 
 /**
@@ -34,7 +35,7 @@ let disconnectGroup = null;
  * Play some UI effects (sound, animation) when disposing of a block.
  * @param {!BlockSvg} block The block being disposed of.
  */
-function disposeUiEffect(block) {
+const disposeUiEffect = function(block) {
   const workspace = block.workspace;
   const svgGroup = block.getSvgRoot();
   workspace.getAudioManager().play('delete');
@@ -49,7 +50,7 @@ function disposeUiEffect(block) {
   clone.bBox_ = clone.getBBox();
   // Start the animation.
   disposeUiStep(clone, workspace.RTL, new Date, workspace.scale);
-}
+};
 /** @package */
 exports.disposeUiEffect = disposeUiEffect;
 
@@ -62,7 +63,7 @@ exports.disposeUiEffect = disposeUiEffect;
  * @param {!Date} start Date of animation's start.
  * @param {number} workspaceScale Scale of workspace.
  */
-function disposeUiStep(clone, rtl, start, workspaceScale) {
+const disposeUiStep = function(clone, rtl, start, workspaceScale) {
   const ms = new Date - start;
   const percent = ms / 150;
   if (percent > 1) {
@@ -78,13 +79,13 @@ function disposeUiStep(clone, rtl, start, workspaceScale) {
             ' scale(' + scale + ')');
     setTimeout(disposeUiStep, 10, clone, rtl, start, workspaceScale);
   }
-}
+};
 
 /**
  * Play some UI effects (sound, ripple) after a connection has been established.
  * @param {!BlockSvg} block The block being connected.
  */
-function connectionUiEffect(block) {
+const connectionUiEffect = function(block) {
   const workspace = block.workspace;
   const scale = workspace.scale;
   workspace.getAudioManager().play('click');
@@ -113,7 +114,7 @@ function connectionUiEffect(block) {
       workspace.getParentSvg());
   // Start the animation.
   connectionUiStep(ripple, new Date, scale);
-}
+};
 /** @package */
 exports.connectionUiEffect = connectionUiEffect;
 
@@ -123,7 +124,7 @@ exports.connectionUiEffect = connectionUiEffect;
  * @param {!Date} start Date of animation's start.
  * @param {number} scale Scale of workspace.
  */
-function connectionUiStep(ripple, start, scale) {
+const connectionUiStep = function(ripple, start, scale) {
   const ms = new Date - start;
   const percent = ms / 150;
   if (percent > 1) {
@@ -133,13 +134,13 @@ function connectionUiStep(ripple, start, scale) {
     ripple.style.opacity = 1 - percent;
     disconnectPid = setTimeout(connectionUiStep, 10, ripple, start, scale);
   }
-}
+};
 
 /**
  * Play some UI effects (sound, animation) when disconnecting a block.
  * @param {!BlockSvg} block The block being disconnected.
  */
-function disconnectUiEffect(block) {
+const disconnectUiEffect = function(block) {
   block.workspace.getAudioManager().play('disconnect');
   if (block.workspace.scale < 1) {
     return;  // Too small to care about visual effects.
@@ -154,7 +155,7 @@ function disconnectUiEffect(block) {
   }
   // Start the animation.
   disconnectUiStep(block.getSvgRoot(), magnitude, new Date);
-}
+};
 /** @package */
 exports.disconnectUiEffect = disconnectUiEffect;
 
@@ -164,7 +165,7 @@ exports.disconnectUiEffect = disconnectUiEffect;
  * @param {number} magnitude Maximum degrees skew (reversed for RTL).
  * @param {!Date} start Date of animation's start.
  */
-function disconnectUiStep(group, magnitude, start) {
+const disconnectUiStep = function(group, magnitude, start) {
   const DURATION = 200;  // Milliseconds.
   const WIGGLES = 3;     // Half oscillations.
 
@@ -181,12 +182,12 @@ function disconnectUiStep(group, magnitude, start) {
     disconnectPid = setTimeout(disconnectUiStep, 10, group, magnitude, start);
   }
   group.setAttribute('transform', group.translate_ + group.skew_);
-}
+};
 
 /**
  * Stop the disconnect UI animation immediately.
  */
-function disconnectUiStop() {
+const disconnectUiStop = function() {
   if (disconnectGroup) {
     clearTimeout(disconnectPid);
     const group = disconnectGroup;
@@ -194,6 +195,6 @@ function disconnectUiStop() {
     group.setAttribute('transform', group.translate_);
     disconnectGroup = null;
   }
-}
+};
 /** @package */
 exports.disconnectUiStop = disconnectUiStop;

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -20,8 +20,8 @@ goog.module.declareLegacyNamespace();
 
 const Coordinate = goog.require('Blockly.utils.Coordinate');
 const {G, SVG} = goog.require('Blockly.utils.Svg');
-const {getRelativeXY} = goog.require('Blockly.utils');
 const {createSvgElement, HTML_NS, setCssTransform, SVG_NS, XLINK_NS} = goog.require('Blockly.utils.dom');
+const {getRelativeXY} = goog.require('Blockly.utils');
 
 
 /**

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -13,21 +13,26 @@
 goog.module('Blockly.BubbleDragger');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockDragSurfaceSvg = goog.requireType('Blockly.BlockDragSurfaceSvg');
 const ComponentManager = goog.require('Blockly.ComponentManager');
 const Coordinate = goog.require('Blockly.utils.Coordinate');
 const Events = goog.require('Blockly.Events');
+/* eslint-disable-next-line no-unused-vars */
 const IBubble = goog.requireType('Blockly.IBubble');
+/* eslint-disable-next-line no-unused-vars */
 const IDeleteArea = goog.requireType('Blockly.IDeleteArea');
+/* eslint-disable-next-line no-unused-vars */
 const IDragTarget = goog.requireType('Blockly.IDragTarget');
-const utils = goog.require('Blockly.utils');
+/* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Bubble');
 /** @suppress {extraRequire} */
-goog.require('Blockly.constants');
-/** @suppress {extraRequire} */
 goog.require('Blockly.Events.CommentMove');
+/** @suppress {extraRequire} */
+goog.require('Blockly.constants');
 
 
 /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -13,16 +13,22 @@
 goog.module('Blockly.Comment');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Block = goog.requireType('Blockly.Block');
+/* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
 const Bubble = goog.require('Blockly.Bubble');
+/* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
 const Events = goog.require('Blockly.Events');
 const Icon = goog.require('Blockly.Icon');
+/* eslint-disable-next-line no-unused-vars */
 const Size = goog.requireType('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
+/* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 const userAgent = goog.require('Blockly.utils.userAgent');
+/* eslint-disable-next-line no-unused-vars */
 const {conditionalBind, Data, unbind} = goog.require('Blockly.browserEvents');
 const {createSvgElement, HTML_NS} = goog.require('Blockly.utils.dom');
 const {inherits} = goog.require('Blockly.utils.object');

--- a/core/component_manager.js
+++ b/core/component_manager.js
@@ -14,10 +14,15 @@
 goog.module('Blockly.ComponentManager');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IAutoHideable = goog.requireType('Blockly.IAutoHideable');
+/* eslint-disable-next-line no-unused-vars */
 const IComponent = goog.requireType('Blockly.IComponent');
+/* eslint-disable-next-line no-unused-vars */
 const IDeleteArea = goog.requireType('Blockly.IDeleteArea');
+/* eslint-disable-next-line no-unused-vars */
 const IDragTarget = goog.requireType('Blockly.IDragTarget');
+/* eslint-disable-next-line no-unused-vars */
 const IPositionable = goog.requireType('Blockly.IPositionable');
 
 

--- a/core/connection.js
+++ b/core/connection.js
@@ -13,14 +13,18 @@
 goog.module('Blockly.Connection');
 goog.module.declareLegacyNamespace();
 
-const connectionTypes = goog.require('Blockly.connectionTypes');
+/* eslint-disable-next-line no-unused-vars */
 const Block = goog.requireType('Blockly.Block');
-const deprecation = goog.require('Blockly.utils.deprecation');
 const Events = goog.require('Blockly.Events');
+/* eslint-disable-next-line no-unused-vars */
 const IASTNodeLocationWithBlock = goog.require('Blockly.IASTNodeLocationWithBlock');
+/* eslint-disable-next-line no-unused-vars */
 const IConnectionChecker = goog.requireType('Blockly.IConnectionChecker');
+/* eslint-disable-next-line no-unused-vars */
 const Input = goog.requireType('Blockly.Input');
 const Xml = goog.require('Blockly.Xml');
+const connectionTypes = goog.require('Blockly.connectionTypes');
+const deprecation = goog.require('Blockly.utils.deprecation');
 /** @suppress {extraRequire} */
 goog.require('Blockly.constants');
 /** @suppress {extraRequire} */

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -15,7 +15,9 @@ goog.module('Blockly.ConnectionChecker');
 goog.module.declareLegacyNamespace();
 
 const Connection = goog.require('Blockly.Connection');
+/* eslint-disable-next-line no-unused-vars */
 const IConnectionChecker = goog.require('Blockly.IConnectionChecker');
+/* eslint-disable-next-line no-unused-vars */
 const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
 const connectionTypes = goog.require('Blockly.connectionTypes');
 const registry = goog.require('Blockly.registry');

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -15,8 +15,11 @@
 goog.module('Blockly.ConnectionDB');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+/* eslint-disable-next-line no-unused-vars */
 const IConnectionChecker = goog.requireType('Blockly.IConnectionChecker');
+/* eslint-disable-next-line no-unused-vars */
 const RenderedConnection = goog.require('Blockly.RenderedConnection');
 const connectionTypes = goog.require('Blockly.connectionTypes');
 /** @suppress {extraRequire} */

--- a/core/css.js
+++ b/core/css.js
@@ -39,6 +39,7 @@ const register = function(cssArray) {
   Array.prototype.push.apply(CONTENT, cssArray);
   cssArray.length = 0;  // Garbage collect provided CSS content.
 };
+exports.register = register;
 
 /**
  * Inject the CSS into the DOM.  This is preferable over using a regular CSS
@@ -72,6 +73,7 @@ const inject = function(hasCss, pathToMedia) {
   cssNode.appendChild(cssTextNode);
   document.head.insertBefore(cssNode, document.head.firstChild);
 };
+exports.inject = inject;
 
 /**
  * Array making up the CSS content for Blockly.
@@ -553,9 +555,4 @@ const CONTENT = [
   margin-right: -24px;
 }`,
 ];
-
-exports = {
-  register,
-  inject,
-  CONTENT
-};
+exports.CONTENT = CONTENT;

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -20,6 +20,7 @@
 goog.module('Blockly.Extensions');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Block = goog.requireType('Blockly.Block');
 const {checkMessageReferences, replaceMessageReferences, runAfterPageLoad} = goog.require('Blockly.utils');
 
@@ -29,6 +30,7 @@ const {checkMessageReferences, replaceMessageReferences, runAfterPageLoad} = goo
  * @private
  */
 const allExtensions = Object.create(null);
+exports.ALL_ = allExtensions;
 
 /**
  * Registers a new extension function. Extensions are functions that help
@@ -52,6 +54,7 @@ const register = function(name, initFn) {
   }
   allExtensions[name] = initFn;
 };
+exports.register = register;
 
 /**
  * Registers a new extension function that adds all key/value of mixinObj.
@@ -68,6 +71,7 @@ const registerMixin = function(name, mixinObj) {
     this.mixin(mixinObj);
   });
 };
+exports.registerMixin = registerMixin;
 
 /**
  * Registers a new extension function that adds a mutator to the block.
@@ -111,6 +115,7 @@ const registerMutator = function(name, mixinObj, opt_helperFn, opt_blockList) {
     }
   });
 };
+exports.registerMutator = registerMutator;
 
 /**
  * Unregisters the extension registered with the given name.
@@ -124,6 +129,7 @@ const unregister = function(name) {
         'No extension mapping for name "' + name + '" found to unregister');
   }
 };
+exports.unregister = unregister;
 
 /**
  * Applies an extension method to a block. This should only be called during
@@ -161,6 +167,7 @@ const apply = function(name, block, isMutator) {
     }
   }
 };
+exports.apply = apply;
 
 /**
  * Check that the given value is a function.
@@ -366,6 +373,7 @@ const buildTooltipForDropdown = function(dropdownName, lookupTable) {
   };
   return extensionFn;
 };
+exports.buildTooltipForDropdown = buildTooltipForDropdown;
 
 /**
  * Checks all options keys are present in the provided string lookup table.
@@ -425,6 +433,7 @@ const buildTooltipWithFieldText = function(msgTemplate, fieldName) {
   };
   return extensionFn;
 };
+exports.buildTooltipWithFieldText = buildTooltipWithFieldText;
 
 /**
  * Configures the tooltip to mimic the parent block when connected. Otherwise,
@@ -443,14 +452,3 @@ const extensionParentTooltip = function() {
   }.bind(this));
 };
 register('parent_tooltip_when_inline', extensionParentTooltip);
-
-exports = {
-  ALL_: allExtensions,
-  register,
-  registerMixin,
-  registerMutator,
-  unregister,
-  apply,
-  buildTooltipForDropdown,
-  buildTooltipWithFieldText
-};

--- a/core/interfaces/i_ast_node_location_svg.js
+++ b/core/interfaces/i_ast_node_location_svg.js
@@ -14,6 +14,7 @@
 goog.module('Blockly.IASTNodeLocationSvg');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IASTNodeLocation = goog.require('Blockly.IASTNodeLocation');
 
 

--- a/core/interfaces/i_ast_node_location_with_block.js
+++ b/core/interfaces/i_ast_node_location_with_block.js
@@ -15,7 +15,9 @@
 goog.module('Blockly.IASTNodeLocationWithBlock');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Block = goog.requireType('Blockly.Block');
+/* eslint-disable-next-line no-unused-vars */
 const IASTNodeLocation = goog.require('Blockly.IASTNodeLocation');
 
 

--- a/core/interfaces/i_autohideable.js
+++ b/core/interfaces/i_autohideable.js
@@ -15,6 +15,7 @@
 goog.module('Blockly.IAutoHideable');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IComponent = goog.require('Blockly.IComponent');
 
 

--- a/core/interfaces/i_block_dragger.js
+++ b/core/interfaces/i_block_dragger.js
@@ -14,7 +14,9 @@
 goog.module('Blockly.IBlockDragger');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
+/* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
 
 

--- a/core/interfaces/i_bounded_element.js
+++ b/core/interfaces/i_bounded_element.js
@@ -14,6 +14,7 @@
 goog.module('Blockly.IBoundedElement');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Rect = goog.requireType('Blockly.utils.Rect');
 
 

--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -14,9 +14,13 @@
 goog.module('Blockly.IBubble');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockDragSurfaceSvg = goog.requireType('Blockly.BlockDragSurfaceSvg');
+/* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+/* eslint-disable-next-line no-unused-vars */
 const IContextMenu = goog.require('Blockly.IContextMenu');
+/* eslint-disable-next-line no-unused-vars */
 const IDraggable = goog.require('Blockly.IDraggable');
 
 

--- a/core/interfaces/i_connection_checker.js
+++ b/core/interfaces/i_connection_checker.js
@@ -14,7 +14,9 @@
 goog.module('Blockly.IConnectionChecker');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Connection = goog.requireType('Blockly.Connection');
+/* eslint-disable-next-line no-unused-vars */
 const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
 
 

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -14,7 +14,9 @@
 goog.module('Blockly.ICopyable');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const ISelectable = goog.requireType('Blockly.ISelectable');
+/* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 
 

--- a/core/interfaces/i_delete_area.js
+++ b/core/interfaces/i_delete_area.js
@@ -15,7 +15,9 @@
 goog.module('Blockly.IDeleteArea');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IDraggable = goog.requireType('Blockly.IDraggable');
+/* eslint-disable-next-line no-unused-vars */
 const IDragTarget = goog.require('Blockly.IDragTarget');
 
 

--- a/core/interfaces/i_drag_target.js
+++ b/core/interfaces/i_drag_target.js
@@ -15,8 +15,11 @@
 goog.module('Blockly.IDragTarget');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IComponent = goog.require('Blockly.IComponent');
+/* eslint-disable-next-line no-unused-vars */
 const IDraggable = goog.requireType('Blockly.IDraggable');
+/* eslint-disable-next-line no-unused-vars */
 const Rect = goog.requireType('Blockly.utils.Rect');
 
 

--- a/core/interfaces/i_draggable.js
+++ b/core/interfaces/i_draggable.js
@@ -14,6 +14,7 @@
 goog.module('Blockly.IDraggable');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IDeletable = goog.require('Blockly.IDeletable');
 
 

--- a/core/interfaces/i_flyout.js
+++ b/core/interfaces/i_flyout.js
@@ -14,11 +14,17 @@
 goog.module('Blockly.IFlyout');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
+/* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+/* eslint-disable-next-line no-unused-vars */
 const IRegistrable = goog.require('Blockly.IRegistrable');
+/* eslint-disable-next-line no-unused-vars */
 const Svg = goog.requireType('Blockly.utils.Svg');
+/* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+/* eslint-disable-next-line no-unused-vars */
 const {FlyoutDefinition} = goog.requireType('Blockly.utils.toolbox');
 
 

--- a/core/interfaces/i_keyboard_accessible.js
+++ b/core/interfaces/i_keyboard_accessible.js
@@ -14,6 +14,7 @@
 goog.module('Blockly.IKeyboardAccessible');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const {KeyboardShortcut} = goog.requireType('Blockly.ShortcutRegistry');
 
 

--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -14,8 +14,11 @@
 goog.module('Blockly.IPositionable');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IComponent = goog.require('Blockly.IComponent');
+/* eslint-disable-next-line no-unused-vars */
 const Rect = goog.requireType('Blockly.utils.Rect');
+/* eslint-disable-next-line no-unused-vars */
 const {UiMetrics} = goog.requireType('Blockly.MetricsManager');
 
 

--- a/core/interfaces/i_toolbox.js
+++ b/core/interfaces/i_toolbox.js
@@ -14,10 +14,15 @@
 goog.module('Blockly.IToolbox');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const IFlyout = goog.requireType('Blockly.IFlyout');
+/* eslint-disable-next-line no-unused-vars */
 const IRegistrable = goog.require('Blockly.IRegistrable');
+/* eslint-disable-next-line no-unused-vars */
 const IToolboxItem = goog.requireType('Blockly.IToolboxItem');
+/* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+/* eslint-disable-next-line no-unused-vars */
 const {ToolboxInfo} = goog.requireType('Blockly.utils.toolbox');
 
 

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -13,15 +13,22 @@
 goog.module('Blockly.blockRendering.Drawer');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
+/* eslint-disable-next-line no-unused-vars */
 const ConstantProvider = goog.requireType('Blockly.blockRendering.ConstantProvider');
+/* eslint-disable-next-line no-unused-vars */
 const Field = goog.requireType('Blockly.blockRendering.Field');
+/* eslint-disable-next-line no-unused-vars */
 const Icon = goog.requireType('Blockly.blockRendering.Icon');
+/* eslint-disable-next-line no-unused-vars */
 const InlineInput = goog.requireType('Blockly.blockRendering.InlineInput');
+/* eslint-disable-next-line no-unused-vars */
 const RenderInfo = goog.requireType('Blockly.blockRendering.RenderInfo');
+/* eslint-disable-next-line no-unused-vars */
 const Row = goog.require('Blockly.blockRendering.Row');
-const svgPaths = goog.require('Blockly.utils.svgPaths');
 const Types = goog.require('Blockly.blockRendering.Types');
+const svgPaths = goog.require('Blockly.utils.svgPaths');
 
 
 /**

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -60,6 +60,7 @@ const parse = function(str) {
   }
   return null;
 };
+exports.parse = parse;
 
 /**
  * Converts a colour from RGB to hex representation.
@@ -75,6 +76,7 @@ const rgbToHex = function(r, g, b) {
   }
   return '#' + rgb.toString(16);
 };
+exports.rgbToHex = rgbToHex;
 
 /**
  * Converts a colour to RGB.
@@ -95,6 +97,7 @@ const hexToRgb = function(colour) {
 
   return [r, g, b];
 };
+exports.hexToRgb = hexToRgb;
 
 /**
  * Converts an HSV triplet to hex representation.
@@ -153,6 +156,7 @@ const hsvToHex = function(h, s, v) {
   }
   return rgbToHex(Math.floor(red), Math.floor(green), Math.floor(blue));
 };
+exports.hsvToHex = hsvToHex;
 
 /**
  * Blend two colours together, using the specified factor to indicate the
@@ -179,6 +183,7 @@ const blend = function(colour1, colour2, factor) {
   const b = Math.round(rgb2[2] + factor * (rgb1[2] - rgb2[2]));
   return rgbToHex(r, g, b);
 };
+exports.blend = blend;
 
 /**
  * A map that contains the 16 basic colour keywords as defined by W3C:
@@ -206,12 +211,4 @@ const names = {
   'white': '#ffffff',
   'yellow': '#ffff00'
 };
-
-exports = {
-  parse,
-  rgbToHex,
-  hexToRgb,
-  hsvToHex,
-  blend,
-  names
-};
+exports.names = names;

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -28,7 +28,6 @@ goog.module.declareLegacyNamespace();
  *     deprecation date.
  * @param {string=} opt_use The name of a function or property to use instead,
  *     if any.
- * @package
  */
 const warn = function(name, deprecationDate, deletionDate, opt_use) {
   let msg = name + ' was deprecated on ' + deprecationDate +
@@ -38,5 +37,5 @@ const warn = function(name, deprecationDate, deletionDate, opt_use) {
   }
   console.warn(msg);
 };
-
-exports = {warn};
+/** @package */
+exports.warn = warn;

--- a/core/utils/idgenerator.js
+++ b/core/utils/idgenerator.js
@@ -23,7 +23,6 @@ goog.module.declareLegacyNamespace();
 /**
  * Next unique ID to use.
  * @type {number}
- * @private
  */
 let nextId = 0;
 
@@ -36,5 +35,4 @@ let nextId = 0;
 const getNextUniqueId = function() {
   return 'blockly-' + (nextId++).toString(36);
 };
-
-exports = {getNextUniqueId};
+exports.getNextUniqueId = getNextUniqueId;

--- a/core/utils/math.js
+++ b/core/utils/math.js
@@ -29,6 +29,7 @@ goog.module.declareLegacyNamespace();
 const toRadians = function(angleDegrees) {
   return angleDegrees * Math.PI / 180;
 };
+exports.toRadians = toRadians;
 
 /**
  * Converts radians to degrees.
@@ -39,6 +40,7 @@ const toRadians = function(angleDegrees) {
 const toDegrees = function(angleRadians) {
   return angleRadians * 180 / Math.PI;
 };
+exports.toDegrees = toDegrees;
 
 /**
  * Clamp the provided number between the lower bound and the upper bound.
@@ -55,9 +57,4 @@ const clamp = function(lowerBound, number, upperBound) {
   }
   return Math.max(lowerBound, Math.min(number, upperBound));
 };
-
-exports = {
-  toRadians,
-  toDegrees,
-  clamp
-};
+exports.clamp = clamp;

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -40,6 +40,7 @@ const inherits = function(childCtor, parentCtor) {
   // Alternatively, one could use this instead:
   // Object.setPrototypeOf(childCtor.prototype, parentCtor.prototype);
 };
+exports.inherits = inherits;
 
 /**
  * Copies all the members of a source object to a target object.
@@ -51,6 +52,7 @@ const mixin = function(target, source) {
     target[x] = source[x];
   }
 };
+exports.mixin = mixin;
 
 /**
  * Complete a deep merge of all members of a source object with a target object.
@@ -68,6 +70,7 @@ const deepMerge = function(target, source) {
   }
   return target;
 };
+exports.deepMerge = deepMerge;
 
 /**
  * Returns an array of a given object's own enumerable property values.
@@ -83,10 +86,4 @@ const values = function(obj) {
     return obj[e];
   });
 };
-
-exports = {
-  inherits,
-  mixin,
-  deepMerge,
-  values,
-};
+exports.values = values;

--- a/core/utils/style.js
+++ b/core/utils/style.js
@@ -29,7 +29,7 @@ const Size = goog.require('Blockly.utils.Size');
  * @param {!Element} element Element to get size of.
  * @return {!Size} Object with width/height properties.
  */
-function getSize(element) {
+const getSize = function(element) {
   if (getStyle(element, 'display') != 'none') {
     return getSizeWithDisplay(element);
   }
@@ -52,7 +52,7 @@ function getSize(element) {
   style.visibility = originalVisibility;
 
   return new Size(offsetWidth, offsetHeight);
-}
+};
 exports.getSize = getSize;
 
 /**
@@ -60,11 +60,11 @@ exports.getSize = getSize;
  * @param {!Element} element Element to get size of.
  * @return {!Size} Object with width/height properties.
  */
-function getSizeWithDisplay(element) {
+const getSizeWithDisplay = function(element) {
   const offsetWidth = /** @type {!HTMLElement} */ (element).offsetWidth;
   const offsetHeight = /** @type {!HTMLElement} */ (element).offsetHeight;
   return new Size(offsetWidth, offsetHeight);
-}
+};
 
 /**
  * Cross-browser pseudo get computed style. It returns the computed style where
@@ -79,10 +79,10 @@ function getSizeWithDisplay(element) {
  * @param {string} style Property to get (must be camelCase, not CSS-style).
  * @return {string} Style value.
  */
-function getStyle(element, style) {
+const getStyle = function(element, style) {
   return getComputedStyle(element, style) || getCascadedStyle(element, style) ||
       (element.style && element.style[style]);
-}
+};
 
 /**
  * Retrieves a computed style value of a node. It returns empty string if the
@@ -96,7 +96,7 @@ function getStyle(element, style) {
  * @param {string} property Property to get (camel-case).
  * @return {string} Style value.
  */
-function getComputedStyle(element, property) {
+const getComputedStyle = function(element, property) {
   if (document.defaultView && document.defaultView.getComputedStyle) {
     const styles = document.defaultView.getComputedStyle(element, null);
     if (styles) {
@@ -107,7 +107,7 @@ function getComputedStyle(element, property) {
   }
 
   return '';
-}
+};
 exports.getComputedStyle = getComputedStyle;
 
 /**
@@ -120,10 +120,10 @@ exports.getComputedStyle = getComputedStyle;
  * @param {string} style Property to get (camel-case).
  * @return {string} Style value.
  */
-function getCascadedStyle(element, style) {
+const getCascadedStyle = function(element, style) {
   return /** @type {string} */ (
       element.currentStyle ? element.currentStyle[style] : null);
-}
+};
 exports.getCascadedStyle = getCascadedStyle;
 
 /**
@@ -132,7 +132,7 @@ exports.getCascadedStyle = getCascadedStyle;
  * @param {!Element} el Element to get the page offset for.
  * @return {!Coordinate} The page offset.
  */
-function getPageOffset(el) {
+const getPageOffset = function(el) {
   const pos = new Coordinate(0, 0);
   const box = el.getBoundingClientRect();
   const documentElement = document.documentElement;
@@ -146,7 +146,7 @@ function getPageOffset(el) {
   pos.y = box.top + scrollCoord.y;
 
   return pos;
-}
+};
 exports.getPageOffset = getPageOffset;
 
 /**
@@ -154,13 +154,13 @@ exports.getPageOffset = getPageOffset;
  * Similar to Closure's goog.style.getViewportPageOffset
  * @return {!Coordinate} The page offset of the viewport.
  */
-function getViewportPageOffset() {
+const getViewportPageOffset = function() {
   const body = document.body;
   const documentElement = document.documentElement;
   const scrollLeft = body.scrollLeft || documentElement.scrollLeft;
   const scrollTop = body.scrollTop || documentElement.scrollTop;
   return new Coordinate(scrollLeft, scrollTop);
-}
+};
 exports.getViewportPageOffset = getViewportPageOffset;
 
 /**
@@ -175,9 +175,9 @@ exports.getViewportPageOffset = getViewportPageOffset;
  * @param {*} isShown True to render the element in its default style,
  *     false to disable rendering the element.
  */
-function setElementShown(el, isShown) {
+const setElementShown = function(el, isShown) {
   el.style.display = isShown ? '' : 'none';
-}
+};
 exports.setElementShown = setElementShown;
 
 /**
@@ -187,9 +187,9 @@ exports.setElementShown = setElementShown;
  * @param {!Element} el The element to test.
  * @return {boolean} True for right to left, false for left to right.
  */
-function isRightToLeft(el) {
+const isRightToLeft = function(el) {
   return 'rtl' == getStyle(el, 'direction');
-}
+};
 exports.isRightToLeft = isRightToLeft;
 
 /**
@@ -198,7 +198,7 @@ exports.isRightToLeft = isRightToLeft;
  * @param {!Element} element  The element to get the border widths for.
  * @return {!Object} The computed border widths.
  */
-function getBorderBox(element) {
+const getBorderBox = function(element) {
   const left = getComputedStyle(element, 'borderLeftWidth');
   const right = getComputedStyle(element, 'borderRightWidth');
   const top = getComputedStyle(element, 'borderTopWidth');
@@ -210,7 +210,7 @@ function getBorderBox(element) {
     bottom: parseFloat(bottom),
     left: parseFloat(left)
   };
-}
+};
 exports.getBorderBox = getBorderBox;
 
 /**
@@ -226,11 +226,11 @@ exports.getBorderBox = getBorderBox;
  * @param {boolean=} opt_center Whether to center the element in the container.
  *     Defaults to false.
  */
-function scrollIntoContainerView(element, container, opt_center) {
+const scrollIntoContainerView = function(element, container, opt_center) {
   const offset = getContainerOffsetToScrollInto(element, container, opt_center);
   container.scrollLeft = offset.x;
   container.scrollTop = offset.y;
-}
+};
 exports.scrollIntoContainerView = scrollIntoContainerView;
 
 /**
@@ -248,7 +248,7 @@ exports.scrollIntoContainerView = scrollIntoContainerView;
  * @return {!Coordinate} The new scroll position of the container,
  *     in form of goog.math.Coordinate(scrollLeft, scrollTop).
  */
-function getContainerOffsetToScrollInto(element, container, opt_center) {
+const getContainerOffsetToScrollInto = function(element, container, opt_center) {
   // Absolute position of the element's border's top left corner.
   const elementPos = getPageOffset(element);
   // Absolute position of the container's border's top left corner.
@@ -281,5 +281,5 @@ function getContainerOffsetToScrollInto(element, container, opt_center) {
     scrollTop += Math.min(relY, Math.max(relY - spaceY, 0));
   }
   return new Coordinate(scrollLeft, scrollTop);
-}
+};
 exports.getContainerOffsetToScrollInto = getContainerOffsetToScrollInto;

--- a/core/utils/svg_paths.js
+++ b/core/utils/svg_paths.js
@@ -27,11 +27,11 @@ goog.module.declareLegacyNamespace();
  * @param {number} x The x coordinate.
  * @param {number} y The y coordinate.
  * @return {string} A string of the format ' x,y '
- * @public
  */
 const point = function(x, y) {
   return ' ' + x + ',' + y + ' ';
 };
+exports.point = point;
 
 /**
  * Draw a cubic or quadratic curve.  See
@@ -44,11 +44,11 @@ const point = function(x, y) {
  *     the format ' x, y '.
  * @return {string} A string defining one or more Bezier curves.  See the MDN
  *     documentation for exact format.
- * @public
  */
 const curve = function(command, points) {
   return ' ' + command + points.join('');
 };
+exports.curve = curve;
 
 /**
  * Move the cursor to the given position without drawing a line.
@@ -58,11 +58,11 @@ const curve = function(command, points) {
  * @param {number} x The absolute x coordinate.
  * @param {number} y The absolute y coordinate.
  * @return {string} A string of the format ' M x,y '
- * @public
  */
 const moveTo = function(x, y) {
   return ' M ' + x + ',' + y + ' ';
 };
+exports.moveTo = moveTo;
 
 /**
  * Move the cursor to the given position without drawing a line.
@@ -72,11 +72,11 @@ const moveTo = function(x, y) {
  * @param {number} dx The relative x coordinate.
  * @param {number} dy The relative y coordinate.
  * @return {string} A string of the format ' m dx,dy '
- * @public
  */
 const moveBy = function(dx, dy) {
   return ' m ' + dx + ',' + dy + ' ';
 };
+exports.moveBy = moveBy;
 
 /**
  * Draw a line from the current point to the end point, which is the current
@@ -86,11 +86,11 @@ const moveBy = function(dx, dy) {
  * @param {number} dx The relative x coordinate.
  * @param {number} dy The relative y coordinate.
  * @return {string} A string of the format ' l dx,dy '
- * @public
  */
 const lineTo = function(dx, dy) {
   return ' l ' + dx + ',' + dy + ' ';
 };
+exports.lineTo = lineTo;
 
 /**
  * Draw multiple lines connecting all of the given points in order.  This is
@@ -101,11 +101,11 @@ const lineTo = function(dx, dy) {
  *     draw lines to, in order.  The points are represented as strings of the
  *     format ' dx,dy '.
  * @return {string} A string of the format ' l (dx,dy)+ '
- * @public
  */
 const line = function(points) {
   return ' l' + points.join('');
 };
+exports.line = line;
 
 /**
  * Draw a horizontal or vertical line.
@@ -118,11 +118,11 @@ const line = function(points) {
  * @param {number} val The coordinate to pass to the command.  It may be
  *     absolute or relative.
  * @return {string} A string of the format ' command val '
- * @public
  */
 const lineOnAxis = function(command, val) {
   return ' ' + command + ' ' + val + ' ';
 };
+exports.lineOnAxis = lineOnAxis;
 
 /**
  * Draw an elliptical arc curve.
@@ -136,19 +136,8 @@ const lineOnAxis = function(command, val) {
  *     specified either in absolute or relative coordinates depending on the
  *     command.
  * @return {string} A string of the format 'command radius radius flags point'
- * @public
  */
 const arc = function(command, flags, radius, point) {
   return command + ' ' + radius + ' ' + radius + ' ' + flags + point;
 };
-
-exports = {
-  point,
-  curve,
-  moveTo,
-  moveBy,
-  lineTo,
-  line,
-  lineOnAxis,
-  arc,
-};
+exports.arc = arc;

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -18,11 +18,11 @@ goog.module('Blockly.utils.toolbox');
 goog.module.declareLegacyNamespace();
 
 const userAgent = goog.require('Blockly.utils.userAgent');
-const {textToDom} = goog.require('Blockly.Xml');
-
+/* eslint-disable-next-line no-unused-vars */
 const {CssConfig: CategoryCssConfig} = goog.requireType('Blockly.ToolboxCategory');
+/* eslint-disable-next-line no-unused-vars */
 const {CssConfig: SeparatorCssConfig} = goog.requireType('Blockly.ToolboxSeparator');
-
+const {textToDom} = goog.require('Blockly.Xml');
 
 /**
  * The information needed to create a block in the toolbox.
@@ -35,6 +35,7 @@ const {CssConfig: SeparatorCssConfig} = goog.requireType('Blockly.ToolboxSeparat
  *          }}
  */
 let BlockInfo;
+exports.BlockInfo = BlockInfo;
 
 /**
  * The information needed to create a separator in the toolbox.
@@ -46,6 +47,7 @@ let BlockInfo;
  *          }}
  */
 let SeparatorInfo;
+exports.SeparatorInfo = SeparatorInfo;
 
 /**
  * The information needed to create a button in the toolbox.
@@ -56,6 +58,7 @@ let SeparatorInfo;
  *          }}
  */
 let ButtonInfo;
+exports.ButtonInfo = ButtonInfo;
 
 /**
  * The information needed to create a label in the toolbox.
@@ -66,6 +69,7 @@ let ButtonInfo;
  *          }}
  */
 let LabelInfo;
+exports.LabelInfo = LabelInfo;
 
 /**
  * The information needed to create either a button or a label in the flyout.
@@ -73,6 +77,7 @@ let LabelInfo;
  *           LabelInfo}
  */
 let ButtonOrLabelInfo;
+exports.ButtonOrLabelInfo = ButtonOrLabelInfo;
 
 /**
  * The information needed to create a category in the toolbox.
@@ -88,6 +93,7 @@ let ButtonOrLabelInfo;
  *          }}
  */
 let StaticCategoryInfo;
+exports.StaticCategoryInfo = StaticCategoryInfo;
 
 /**
  * The information needed to create a custom category.
@@ -102,6 +108,7 @@ let StaticCategoryInfo;
  *          }}
  */
 let DynamicCategoryInfo;
+exports.DynamicCategoryInfo = DynamicCategoryInfo;
 
 /**
  * The information needed to create either a dynamic or static category.
@@ -109,6 +116,7 @@ let DynamicCategoryInfo;
  *           DynamicCategoryInfo}
  */
 let CategoryInfo;
+exports.CategoryInfo = CategoryInfo;
 
 /**
  * Any information that can be used to create an item in the toolbox.
@@ -116,6 +124,7 @@ let CategoryInfo;
  *           StaticCategoryInfo}
  */
 let ToolboxItemInfo;
+exports.ToolboxItemInfo = ToolboxItemInfo;
 
 /**
  * All the different types that can be displayed in a flyout.
@@ -126,6 +135,7 @@ let ToolboxItemInfo;
  *           DynamicCategoryInfo}
  */
 let FlyoutItemInfo;
+exports.FlyoutItemInfo = FlyoutItemInfo;
 
 /**
  * The JSON definition of a toolbox.
@@ -135,6 +145,7 @@ let FlyoutItemInfo;
  *          }}
  */
 let ToolboxInfo;
+exports.ToolboxInfo = ToolboxInfo;
 
 /**
  * An array holding flyout items.
@@ -143,6 +154,7 @@ let ToolboxInfo;
  *          }
  */
 let FlyoutItemInfoArray;
+exports.FlyoutItemInfoArray = FlyoutItemInfoArray;
 
 /**
  * All of the different types that can create a toolbox.
@@ -151,6 +163,7 @@ let FlyoutItemInfoArray;
  *           string}
  */
 let ToolboxDefinition;
+exports.ToolboxDefinition = ToolboxDefinition;
 
 /**
  * All of the different types that can be used to show items in a flyout.
@@ -160,6 +173,7 @@ let ToolboxDefinition;
  *           Array<!Node>}
  */
 let FlyoutDefinition;
+exports.FlyoutDefinition = FlyoutDefinition;
 
 /**
  * The name used to identify a toolbox that has category like items.
@@ -187,6 +201,7 @@ const Position = {
   LEFT: 2,
   RIGHT: 3
 };
+exports.Position = Position;
 
 /**
  * Converts the toolbox definition into toolbox JSON.
@@ -194,7 +209,6 @@ const Position = {
  *     of the toolbox in one of its many forms.
  * @return {?ToolboxInfo} Object holding information
  *     for creating a toolbox.
- * @package
  */
 const convertToolboxDefToJson = function(toolboxDef) {
   if (!toolboxDef) {
@@ -210,13 +224,14 @@ const convertToolboxDefToJson = function(toolboxDef) {
   validateToolbox(toolboxJson);
   return toolboxJson;
 };
+/** @package */
+exports.convertToolboxDefToJson = convertToolboxDefToJson;
 
 /**
  * Validates the toolbox JSON fields have been set correctly.
  * @param {!ToolboxInfo} toolboxJson Object holding
  *     information for creating a toolbox.
  * @throws {Error} if the toolbox is not the correct format.
- * @private
  */
 const validateToolbox = function(toolboxJson) {
   const toolboxKind = toolboxJson['kind'];
@@ -241,7 +256,6 @@ const validateToolbox = function(toolboxJson) {
  * @param {?FlyoutDefinition} flyoutDef The definition of
  *    the flyout in one of its many forms.
  * @return {!FlyoutItemInfoArray} A list of flyout items.
- * @package
  */
 const convertFlyoutDefToJsonArray = function(flyoutDef) {
   if (!flyoutDef) {
@@ -260,13 +274,14 @@ const convertFlyoutDefToJsonArray = function(flyoutDef) {
 
   return xmlToJsonArray(/** @type {!Array<Node>|!NodeList} */ (flyoutDef));
 };
+/** @package */
+exports.convertFlyoutDefToJsonArray = convertFlyoutDefToJsonArray;
 
 /**
  * Whether or not the toolbox definition has categories.
  * @param {?ToolboxInfo} toolboxJson Object holding
  *     information for creating a toolbox.
  * @return {boolean} True if the toolbox has categories.
- * @package
  */
 const hasCategories = function(toolboxJson) {
   if (!toolboxJson) {
@@ -283,13 +298,14 @@ const hasCategories = function(toolboxJson) {
   });
   return !!categories.length;
 };
+/** @package */
+exports.hasCategories = hasCategories;
 
 /**
  * Whether or not the category is collapsible.
  * @param {!CategoryInfo} categoryInfo Object holing
  *    information for creating a category.
  * @return {boolean} True if the category has subcategories.
- * @package
  */
 const isCategoryCollapsible = function(categoryInfo) {
   if (!categoryInfo || !categoryInfo['contents']) {
@@ -301,6 +317,8 @@ const isCategoryCollapsible = function(categoryInfo) {
   });
   return !!categories.length;
 };
+/** @package */
+exports.isCategoryCollapsible = isCategoryCollapsible;
 
 /**
  * Parses the provided toolbox definition into a consistent format.
@@ -308,7 +326,6 @@ const isCategoryCollapsible = function(categoryInfo) {
  *     forms.
  * @return {!ToolboxInfo} Object holding information
  *     for creating a toolbox.
- * @private
  */
 const convertToToolboxJson = function(toolboxDef) {
   const contents = xmlToJsonArray(
@@ -327,7 +344,6 @@ const convertToToolboxJson = function(toolboxDef) {
  * @return {!FlyoutItemInfoArray|
  *          !Array<ToolboxItemInfo>} A list of objects in
  *          the toolbox.
- * @private
  */
 const xmlToJsonArray = function(toolboxDef) {
   const arr = [];
@@ -364,7 +380,6 @@ const xmlToJsonArray = function(toolboxDef) {
  * Adds the attributes on the node to the given object.
  * @param {!Node} node The node to copy the attributes from.
  * @param {!Object} obj The object to copy the attributes to.
- * @private
  */
 const addAttributes = function(node, obj) {
   for (let j = 0; j < node.attributes.length; j++) {
@@ -408,26 +423,4 @@ const parseToolboxTree = function(toolboxDef) {
   }
   return toolboxDef;
 };
-
-exports = {
-  BlockInfo,
-  SeparatorInfo,
-  ButtonInfo,
-  LabelInfo,
-  ButtonOrLabelInfo,
-  StaticCategoryInfo,
-  DynamicCategoryInfo,
-  CategoryInfo,
-  ToolboxItemInfo,
-  FlyoutItemInfo,
-  ToolboxInfo,
-  FlyoutItemInfoArray,
-  ToolboxDefinition,
-  FlyoutDefinition,
-  Position,
-  convertToolboxDefToJson,
-  convertFlyoutDefToJsonArray,
-  hasCategories,
-  isCategoryCollapsible,
-  parseToolboxTree
-};
+exports.parseToolboxTree = parseToolboxTree;


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes
* This moves from one exports = {} statement at the end to exporting each individual function. 
* Imports have been sorted alphabetically by Capital, lowercase, {Capital}, {lowercase}, extraRequires. 
* @public/@private annotations on top-level functions have been removed, and @package annotations have been moved to the export. 
* Files have been migrated to the const foo = function(){...}; exports.foo = foo; syntax.
* Requires used only in JSDoc have had the linter disabled.