### PR TITLE
Migrate core/drag_target.js to goog.module syntax

### DIFF
--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -12,7 +12,8 @@
 
 'use strict';
 
-goog.provide('Blockly.DragTarget');
+goog.module('Blockly.DragTarget');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.IDragTarget');
 
@@ -26,7 +27,7 @@ goog.requireType('Blockly.utils.Rect');
  * @implements {Blockly.IDragTarget}
  * @constructor
  */
-Blockly.DragTarget = function() {};
+const DragTarget = function() {};
 
 /**
  * Returns the bounding rectangle of the drag target area in pixel units
@@ -34,14 +35,14 @@ Blockly.DragTarget = function() {};
  * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
  *   target area should be ignored.
  */
-Blockly.DragTarget.prototype.getClientRect;
+DragTarget.prototype.getClientRect;
 
 /**
  * Handles when a cursor with a block or bubble enters this drag target.
  * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.DragTarget.prototype.onDragEnter = function(_dragElement) {
+DragTarget.prototype.onDragEnter = function(_dragElement) {
   // no-op
 };
 
@@ -51,7 +52,7 @@ Blockly.DragTarget.prototype.onDragEnter = function(_dragElement) {
  * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.DragTarget.prototype.onDragOver = function(_dragElement) {
+DragTarget.prototype.onDragOver = function(_dragElement) {
   // no-op
 };
 
@@ -60,7 +61,7 @@ Blockly.DragTarget.prototype.onDragOver = function(_dragElement) {
  * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.DragTarget.prototype.onDragExit = function(_dragElement) {
+DragTarget.prototype.onDragExit = function(_dragElement) {
   // no-op
 };
 
@@ -70,7 +71,7 @@ Blockly.DragTarget.prototype.onDragExit = function(_dragElement) {
  * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
-Blockly.DragTarget.prototype.onDrop = function(_dragElement) {
+DragTarget.prototype.onDrop = function(_dragElement) {
   // no-op
 };
 
@@ -83,6 +84,8 @@ Blockly.DragTarget.prototype.onDrop = function(_dragElement) {
  * @return {boolean} Whether the block or bubble provided should be returned to
  *     drag start.
  */
-Blockly.DragTarget.prototype.shouldPreventMove = function(_dragElement) {
+DragTarget.prototype.shouldPreventMove = function(_dragElement) {
   return false;
 };
+
+exports = DragTarget;

--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -15,16 +15,18 @@
 goog.module('Blockly.DragTarget');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.IDragTarget');
-
-goog.requireType('Blockly.IDraggable');
-goog.requireType('Blockly.utils.Rect');
+/* eslint-disable-next-line no-unused-vars */
+const IDragTarget = goog.require('Blockly.IDragTarget');
+/* eslint-disable-next-line no-unused-vars */
+const IDraggable = goog.requireType('Blockly.IDraggable');
+/* eslint-disable-next-line no-unused-vars */
+const Rect = goog.requireType('Blockly.utils.Rect');
 
 
 /**
  * Abstract class for a component with custom behaviour when a block or bubble
  * is dragged over or dropped on top of it.
- * @implements {Blockly.IDragTarget}
+ * @implements {IDragTarget}
  * @constructor
  */
 const DragTarget = function() {};
@@ -32,14 +34,14 @@ const DragTarget = function() {};
 /**
  * Returns the bounding rectangle of the drag target area in pixel units
  * relative to the Blockly injection div.
- * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
+ * @return {?Rect} The component's bounding box. Null if drag
  *   target area should be ignored.
  */
 DragTarget.prototype.getClientRect;
 
 /**
  * Handles when a cursor with a block or bubble enters this drag target.
- * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
+ * @param {!IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
 DragTarget.prototype.onDragEnter = function(_dragElement) {
@@ -49,7 +51,7 @@ DragTarget.prototype.onDragEnter = function(_dragElement) {
 /**
  * Handles when a cursor with a block or bubble is dragged over this drag
  * target.
- * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
+ * @param {!IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
 DragTarget.prototype.onDragOver = function(_dragElement) {
@@ -58,7 +60,7 @@ DragTarget.prototype.onDragOver = function(_dragElement) {
 
 /**
  * Handles when a cursor with a block or bubble exits this drag target.
- * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
+ * @param {!IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
 DragTarget.prototype.onDragExit = function(_dragElement) {
@@ -68,7 +70,7 @@ DragTarget.prototype.onDragExit = function(_dragElement) {
 /**
  * Handles when a block or bubble is dropped on this component.
  * Should not handle delete here.
- * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
+ * @param {!IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  */
 DragTarget.prototype.onDrop = function(_dragElement) {
@@ -79,7 +81,7 @@ DragTarget.prototype.onDrop = function(_dragElement) {
  * Returns whether the provided block or bubble should not be moved after being
  * dropped on this component. If true, the element will return to where it was
  * when the drag started.
- * @param {!Blockly.IDraggable} _dragElement The block or bubble currently being
+ * @param {!IDraggable} _dragElement The block or bubble currently being
  *   dragged.
  * @return {boolean} Whether the block or bubble provided should be returned to
  *     drag start.

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -29,7 +29,7 @@ goog.addDependency('../../core/contextmenu_items.js', ['Blockly.ContextMenuItems
 goog.addDependency('../../core/contextmenu_registry.js', ['Blockly.ContextMenuRegistry'], [], {'lang': 'es5'});
 goog.addDependency('../../core/css.js', ['Blockly.Css'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/delete_area.js', ['Blockly.DeleteArea'], ['Blockly.BlockSvg', 'Blockly.DragTarget', 'Blockly.IDeleteArea']);
-goog.addDependency('../../core/drag_target.js', ['Blockly.DragTarget'], ['Blockly.IDragTarget']);
+goog.addDependency('../../core/drag_target.js', ['Blockly.DragTarget'], ['Blockly.IDragTarget'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/dropdowndiv.js', ['Blockly.DropDownDiv'], ['Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.math', 'Blockly.utils.style']);
 goog.addDependency('../../core/events/block_events.js', ['Blockly.Events.BlockBase', 'Blockly.Events.BlockChange', 'Blockly.Events.BlockCreate', 'Blockly.Events.BlockDelete', 'Blockly.Events.BlockMove', 'Blockly.Events.Change', 'Blockly.Events.Create', 'Blockly.Events.Delete', 'Blockly.Events.Move'], ['Blockly.Events', 'Blockly.Events.Abstract', 'Blockly.Xml', 'Blockly.connectionTypes', 'Blockly.registry', 'Blockly.utils.Coordinate', 'Blockly.utils.object', 'Blockly.utils.xml']);
 goog.addDependency('../../core/events/events.js', ['Blockly.Events'], ['Blockly.registry', 'Blockly.utils']);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/drag_target.js` to `goog.module` with ES6 `const`/`let`.