### PR TITLE
Fix double execution in Code demo

### DIFF
--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -188,7 +188,12 @@ Code.bindClick = function(el, func) {
     el = document.getElementById(el);
   }
   el.addEventListener('click', func, true);
-  el.addEventListener('touchend', func, true);
+  function touchFunc(e) {
+    // Prevent code from being executed twice on touchscreens.
+    e.preventDefault();
+    func();
+  }
+  el.addEventListener('touchend', touchFunc, true);
 };
 
 /**
@@ -549,14 +554,8 @@ Code.initLanguage = function() {
 /**
  * Execute the user's code.
  * Just a quick and dirty eval.  Catch infinite loops.
- * @param {Event} event Event created from listener bound to the function.
  */
-Code.runJS = function(event) {
-  // Prevent code from being executed twice on touchscreens.
-  if (event.type == 'touchend') {
-    event.preventDefault();
-  }
-
+Code.runJS = function() {
   Blockly.JavaScript.INFINITE_LOOP_TRAP = 'checkTimeout();\n';
   var timeouts = 0;
   var checkTimeout = function() {

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -191,7 +191,7 @@ Code.bindClick = function(el, func) {
   function touchFunc(e) {
     // Prevent code from being executed twice on touchscreens.
     e.preventDefault();
-    func();
+    func(e);
   }
   el.addEventListener('touchend', touchFunc, true);
 };


### PR DESCRIPTION
PR #5037 fixed double execution of the run button on mobile.  But the link button and other events still suffer from double execution.  This PR moves the fix from the run button to the central bind function so that it applies universally.
