### PR TITLE
Remove need for require instead of requireType for Block in ASTNode

### DIFF
--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -420,7 +420,7 @@ Blockly.ASTNode.prototype.findPrevForField_ = function() {
  */
 Blockly.ASTNode.prototype.navigateBetweenStacks_ = function(forward) {
   var curLocation = this.getLocation();
-  if (!(curLocation instanceof Blockly.Block)) {
+  if (curLocation.getSourceBlock) {
     curLocation = /** @type {!Blockly.IASTNodeLocationWithBlock} */ (
       curLocation).getSourceBlock();
   }


### PR DESCRIPTION
Replacing check `instance of Blockly.Block` in order to fix circular dependency between `Blockly.Block` and `Blockly.ASTNode`.