### PR TITLE
feat: add initialization of blocks and event firing

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -262,10 +262,31 @@ const saveConnection = function(connection) {
  * Loads the block represented by the given state into the given workspace.
  * @param {!State} state The state of a block to deserialize into the workspace.
  * @param {!Workspace} workspace The workspace to add the block to.
+ * @return {!Block} The block that was just loaded.
  */
 const load = function(state, workspace) {
-  loadInternal(state, workspace);
+  // We only want to fire an event for the top block.
+  Blockly.Events.disable();
+
+  const block = loadInternal(state, workspace);
+
+  Blockly.Events.enable();
+  Blockly.Events.fire(
+      new (Blockly.Events.get(Blockly.Events.BLOCK_CREATE))(block));
+  
+  // Adding connections to the connection db is expensive. This defers that
+  // operation to decrease load time.
+  if (block instanceof Blockly.BlockSvg) {
+    setTimeout(() => {
+      if (!block.disposed) {
+        block.setConnectionTracking(true);
+      }
+    }, 1);
+  }
+
+  return block;
 };
+exports.load = load;
 
 /**
  * Loads the block represented by the given state into the given workspace.
@@ -275,6 +296,7 @@ const load = function(state, workspace) {
  * @param {!Workspace} workspace The workspace to add the block to.
  * @param {!Connection} parentConnection The optional parent connection to
  *     attach the block to.
+ * @return {!Block} The block that was just loaded.
  */
 const loadInternal = function(state, workspace, parentConnection = undefined) {
   const block = workspace.newBlock(state['type'], state['id']);
@@ -291,6 +313,8 @@ const loadInternal = function(state, workspace, parentConnection = undefined) {
   loadFields(block, state);
   loadInputBlocks(block, state);
   loadNextBlocks(block, state);
+  initBlock(block);
+  return block;
 };
 
 /**
@@ -424,4 +448,22 @@ const loadConnection = function(connection, connectionState) {
         connection);
   }
 };
-exports.load = load;
+
+// TODO (#5146): Remove this from the serialization system.
+/**
+ * Initializes the give block, eg init the model, inits the svg, renders, etc.
+ * @param {!Block} block The block to initialize.
+ */
+const initBlock = function(block) {
+  if (block instanceof Blockly.BlockSvg) {
+    // Adding connections to the connection db is expensive. This defers that
+    // operation to decrease load time.
+    block.setConnectionTracking(false);
+
+    block.initSvg();
+    block.render(false);
+    block.updateDisabled();
+  } else {
+    block.initModel();
+  }
+};

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -294,7 +294,7 @@ exports.load = load;
  * clutter our external API.
  * @param {!State} state The state of a block to deserialize into the workspace.
  * @param {!Workspace} workspace The workspace to add the block to.
- * @param {!Connection} parentConnection The optional parent connection to
+ * @param {!Connection=} parentConnection The optional parent connection to
  *     attach the block to.
  * @return {!Block} The block that was just loaded.
  */
@@ -449,7 +449,7 @@ const loadConnection = function(connection, connectionState) {
   }
 };
 
-// TODO (#5146): Remove this from the serialization system.
+// TODO(#5146): Remove this from the serialization system.
 /**
  * Initializes the give block, eg init the model, inits the svg, renders, etc.
  * @param {!Block} block The block to initialize.

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -84,6 +84,7 @@
     <script src="input_test.js"></script>
     <script src="insertion_marker_test.js"></script>
     <script src="json_test.js"></script>
+    <script src="jso_deserialization_test.js"></script>
     <script src="jso_serialization_test.js"></script>
     <script src="shortcut_registry_test.js"></script>
     <script src="keydown_test.js"></script>

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -16,7 +16,7 @@ suite('JSO Deserialization', function() {
   });
 
   suite('Events', function() {
-    test('Finished loading', function() {
+    test.skip('Finished loading', function() {
       const state = {
         'blocks': {
           'blocks': [

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -55,7 +55,7 @@ suite('JSO Deserialization', function() {
             this.workspace.id);
       });
 
-      test('Var with block', function() {
+      test('Only fire one event with var and var on block', function() {
         const state = {
           'variables': [
             {
@@ -95,7 +95,7 @@ suite('JSO Deserialization', function() {
     });
 
     suite('Block create', function() {
-      test('No children', function() {
+      test('Simple', function() {
         const state = {
           'blocks': {
             'blocks': [
@@ -117,7 +117,7 @@ suite('JSO Deserialization', function() {
             'testId');
       });
 
-      test('with children', function() {
+      test('Only fire event for top block', function() {
         const state = {
           'blocks': {
             'blocks': [

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+suite('JSO Deserialization', function() {
+  setup(function() {
+    sharedTestSetup.call(this);
+    this.workspace = new Blockly.Workspace();
+  });
+
+  teardown(function() {
+    workspaceTeardown.call(this, this.workspace);
+    sharedTestTeardown.call(this);
+  });
+
+  suite('Events', function() {
+    test('Finished loading', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'controls_if',
+              'id': 'testId',
+              'x': 42,
+              'y': 42
+            },
+          ]
+        }
+      };
+      Blockly.serialization.workspaces.load(state, this.workspace);
+      assertEventFired(
+          this.eventsFireStub,
+          Blockly.Events.FinishedLoading,
+          {},
+          this.workspace.id);
+    });
+
+    suite('Var create', function() {
+      test('Just var', function() {
+        const state = {
+          'variables': [
+            {
+              'name': 'test',
+              'id': 'testId',
+            }
+          ]
+        };
+        Blockly.serialization.workspaces.load(state, this.workspace);
+        assertEventFired(
+            this.eventsFireStub,
+            Blockly.Events.VarCreate,
+            {'varName': 'test', 'varId': 'testId', 'varType': ''},
+            this.workspace.id);
+      });
+
+      test('Var with block', function() {
+        const state = {
+          'variables': [
+            {
+              'name': 'test',
+              'id': 'testId',
+            }
+          ],
+          'blocks': {
+            'blocks': [
+              {
+                'type': 'variables_get',
+                'id': 'blockId',
+                'x': 42,
+                'y': 42,
+                'fields': {
+                  'VAR': 'testId'
+                }
+              },
+            ]
+          }
+        };
+        Blockly.serialization.workspaces.load(state, this.workspace);
+        const calls = this.eventsFireStub.getCalls();
+        const count = calls.reduce((acc, call) => {
+          if (call.args[0] instanceof Blockly.Events.VarCreate) {
+            return acc + 1;
+          }
+          return acc;
+        }, 0);
+        chai.assert.equal(count, 1);
+        assertEventFired(
+            this.eventsFireStub,
+            Blockly.Events.VarCreate,
+            {'varName': 'test', 'varId': 'testId', 'varType': ''},
+            this.workspace.id);
+      });
+    });
+
+    suite('Block create', function() {
+      test('No children', function() {
+        const state = {
+          'blocks': {
+            'blocks': [
+              {
+                'type': 'controls_if',
+                'id': 'testId',
+                'x': 42,
+                'y': 42
+              },
+            ]
+          }
+        };
+        Blockly.serialization.workspaces.load(state, this.workspace);
+        assertEventFired(
+            this.eventsFireStub,
+            Blockly.Events.BlockCreate,
+            {},
+            this.workspace.id,
+            'testId');
+      });
+
+      test('with children', function() {
+        const state = {
+          'blocks': {
+            'blocks': [
+              {
+                'type': 'controls_if',
+                'id': 'id1',
+                'x': 42,
+                'y': 42,
+                'inputs': {
+                  'DO0': {
+                    'block': {
+                      'type': 'controls_if',
+                      'id': 'id2'
+                    }
+                  }
+                },
+                'next': {
+                  'block': {
+                    'type': 'controls_if',
+                    'id': 'id3'
+                  }
+                }
+              },
+            ]
+          }
+        };
+        Blockly.serialization.workspaces.load(state, this.workspace);
+        assertEventFired(
+            this.eventsFireStub,
+            Blockly.Events.BlockCreate,
+            {},
+            this.workspace.id,
+            'id1');
+      });
+    });
+  });
+});

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-suite('JSO', function() {
+suite('JSO Serialization', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -204,9 +204,18 @@ function initToolbox(workspace) {
   }
 }
 
-function save() {
+function saveXml() {
   var output = document.getElementById('importExport');
-  var state = Blockly.serialization.save(workspace);
+  var xml = Blockly.Xml.workspaceToDom(workspace);
+  output.value = Blockly.Xml.domToPrettyText(xml);
+  output.focus();
+  output.select();
+  taChange();
+}
+
+function saveJson() {
+  var output = document.getElementById('importExport');
+  var state = Blockly.serialization.workspaces.save(workspace);
   output.value = JSON.stringify(state, null, 2);
   output.focus();
   output.select();
@@ -218,8 +227,14 @@ function load() {
   if (!input.value) {
     return;
   }
-  var state = JSON.parse(input.value);
-  Blockly.serialization.load(state, workspace);
+  var valid = saveIsValid(input.value);
+  if (valid.json) {
+    var state = JSON.parse(input.value);
+    Blockly.serialization.workspaces.load(state, workspace);
+  } else if (valid.xml) {
+    var xml = Blockly.Xml.textToDom(input.value);
+    Blockly.Xml.domToWorkspace(xml, workspace);
+  }
   taChange();
 }
 
@@ -236,13 +251,27 @@ function taChange() {
   if (sessionStorage) {
     sessionStorage.setItem('textarea', textarea.value);
   }
-  var valid = true;
+  var valid = saveIsValid(textarea.value);
+  document.getElementById('import').disabled = !valid.json && !valid.xml;
+}
+
+function saveIsValid(save) {
+  var validJson = true;
   try {
-    JSON.parse(textarea.value);
+    JSON.parse(save);
   } catch (e) {
-    valid = false;
+    validJson = false;
   }
-  document.getElementById('import').disabled = !valid;
+  var validXml = true
+  try {
+    Blockly.Xml.textToDom(save);
+  } catch (e) {
+    validXml = false;
+  }
+  return {
+    json: validJson,
+    xml: validXml
+  }
 }
 
 function logEvents(state) {
@@ -423,18 +452,14 @@ var spaghettiXml = [
     </select>
   </form>
   <p>
-    <input type="button" value="Save" onclick="save()">
-    &nbsp;
+    <input type="button" value="Save JSON" onclick="saveJson()">
+    <input type="button" value="Save XML" onclick="saveXml()">
     <input type="button" value="Load" onclick="load()" id="import">
     <br>
     <input type="button" value="To JavaScript" onclick="toCode('JavaScript')">
-    &nbsp;
     <input type="button" value="To Python" onclick="toCode('Python')">
-    &nbsp;
     <input type="button" value="To PHP" onclick="toCode('PHP')">
-    &nbsp;
     <input type="button" value="To Lua" onclick="toCode('Lua')">
-    &nbsp;
     <input type="button" value="To Dart" onclick="toCode('Dart')">
     <br>
     <textarea id="importExport" style="width: 26%; height: 12em"

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -146,7 +146,7 @@ function start() {
   }
   taChange();
   if (autoimport) {
-    fromXml();
+    load();
   }
 }
 
@@ -204,22 +204,22 @@ function initToolbox(workspace) {
   }
 }
 
-function toXml() {
+function save() {
   var output = document.getElementById('importExport');
-  var xml = Blockly.Xml.workspaceToDom(workspace);
-  output.value = Blockly.Xml.domToPrettyText(xml);
+  var state = Blockly.serialization.save(workspace);
+  output.value = JSON.stringify(state, null, 2);
   output.focus();
   output.select();
   taChange();
 }
 
-function fromXml() {
+function load() {
   var input = document.getElementById('importExport');
   if (!input.value) {
     return;
   }
-  var xml = Blockly.Xml.textToDom(input.value);
-  Blockly.Xml.domToWorkspace(xml, workspace);
+  var state = JSON.parse(input.value);
+  Blockly.serialization.load(state, workspace);
   taChange();
 }
 
@@ -229,7 +229,7 @@ function toCode(lang) {
   taChange();
 }
 
-// Disable the "Import from XML" button if the XML is invalid.
+// Disable the "Load" button if the save state is invalid.
 // Preserve text between page reloads.
 function taChange() {
   var textarea = document.getElementById('importExport');
@@ -238,7 +238,7 @@ function taChange() {
   }
   var valid = true;
   try {
-    Blockly.Xml.textToDom(textarea.value);
+    JSON.parse(textarea.value);
   } catch (e) {
     valid = false;
   }
@@ -423,9 +423,9 @@ var spaghettiXml = [
     </select>
   </form>
   <p>
-    <input type="button" value="Export to XML" onclick="toXml()">
+    <input type="button" value="Save" onclick="save()">
     &nbsp;
-    <input type="button" value="Import from XML" onclick="fromXml()" id="import">
+    <input type="button" value="Load" onclick="load()" id="import">
     <br>
     <input type="button" value="To JavaScript" onclick="toCode('JavaScript')">
     &nbsp;


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on project cereal
Dependent on #5137 

### Proposed Changes

Adds (hopefully) properly initializing blocks for rendered workspaces, and firing block create events. Note that variable events are already [fired by the variable model](https://github.com/google/blockly/blob/64188ae27297b1ca23a3244cc987dfbfc6e98f34/core/variable_model.js#L69).

This also modifies the playground (not the advanced playground) to use JSO serialization for testing.

### Reason for Changes

Properly rendering blocks is important. Also being consistent with our events system.

### Test Coverage

Added tests for properly firing events. If you have recommendations for testing the other parts of initialization I'd love to do that as well!

### Additional Information

NOTE FOR REVIEWERS: Please look over the logic in [domToBlock](https://github.com/google/blockly/blob/d4196c1105d3d7719e967edb0cecd0d7f76508c0/core/xml.js#L543) and check if you think the logic added to the JSO serializer covers it. This uses a different (hopefully nicer) organization, but it should be equivalent.