### PR TITLE
Migrate core/menu.js to goog.module syntax

### DIFF
--- a/core/menu.js
+++ b/core/menu.js
@@ -118,8 +118,8 @@ Menu.prototype.addChild = function(menuItem) {
  * @param {!Element} container Element upon which to append this menu.
  */
 Menu.prototype.render = function(container) {
-  const element = /** @type {!HTMLDivElement} */ (document.createElement(
-      'div'));
+  const element =
+      /** @type {!HTMLDivElement} */ (document.createElement('div'));
   // goog-menu is deprecated, use blocklyMenu.  May 2020.
   element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
@@ -134,16 +134,16 @@ Menu.prototype.render = function(container) {
   }
 
   // Add event handlers.
-  this.mouseOverHandler_ = conditionalBind(
-      element, 'mouseover', this, this.handleMouseOver_, true);
-  this.clickHandler_ = conditionalBind(
-      element, 'click', this, this.handleClick_, true);
+  this.mouseOverHandler_ =
+      conditionalBind(element, 'mouseover', this, this.handleMouseOver_, true);
+  this.clickHandler_ =
+      conditionalBind(element, 'click', this, this.handleClick_, true);
   this.mouseEnterHandler_ = conditionalBind(
       element, 'mouseenter', this, this.handleMouseEnter_, true);
   this.mouseLeaveHandler_ = conditionalBind(
       element, 'mouseleave', this, this.handleMouseLeave_, true);
-  this.onKeyDownHandler_ = conditionalBind(
-      element, 'keydown', this, this.handleKeyEvent_);
+  this.onKeyDownHandler_ =
+      conditionalBind(element, 'keydown', this, this.handleKeyEvent_);
 
   container.appendChild(element);
 };
@@ -164,7 +164,7 @@ Menu.prototype.getElement = function() {
 Menu.prototype.focus = function() {
   const el = this.getElement();
   if (el) {
-    el.focus({preventScroll:true});
+    el.focus({preventScroll: true});
     addClass(el, 'blocklyFocused');
   }
 };
@@ -274,8 +274,7 @@ Menu.prototype.setHighlighted = function(item) {
     scrollIntoContainerView(
         /** @type {!Element} */ (item.getElement()), el);
 
-    setState(el, State.ACTIVEDESCENDANT,
-        item.getId());
+    setState(el, State.ACTIVEDESCENDANT, item.getId());
   }
 };
 
@@ -464,7 +463,7 @@ Menu.prototype.handleKeyEvent_ = function(e) {
 Menu.prototype.getSize = function() {
   const menuDom = this.getElement();
   const menuSize = getSize(/** @type {!Element} */
-      (menuDom));
+                           (menuDom));
   // Recalculate height for the total content, not only box height.
   menuSize.height = menuDom.scrollHeight;
   return menuSize;

--- a/core/menu.js
+++ b/core/menu.js
@@ -17,6 +17,7 @@ const Coordinate = goog.require('Blockly.utils.Coordinate');
 /* eslint-disable-next-line no-unused-vars */
 const MenuItem = goog.requireType('Blockly.MenuItem');
 const KeyCodes = goog.require('Blockly.utils.KeyCodes');
+/* eslint-disable-next-line no-unused-vars */
 const Size = goog.requireType('Blockly.utils.Size');
 const aria = goog.require('Blockly.utils.aria');
 const browserEvents = goog.require('Blockly.browserEvents');

--- a/core/menu.js
+++ b/core/menu.js
@@ -18,7 +18,7 @@ const MenuItem = goog.requireType('Blockly.MenuItem');
 const Size = goog.requireType('Blockly.utils.Size');
 const {addClass, hasClass, removeClass} = goog.require('Blockly.utils.dom');
 const {Data, conditionalBind, unbind} = goog.require('Blockly.browserEvents');
-const {DOWN, END, ENTER, HOME, PAGE_DOWN, PAGE_UP, SPACE, UP} = goog.require('Blockly.utils.KeyCodes');
+const KeyCodes = goog.require('Blockly.utils.KeyCodes');
 const {getSize, scrollIntoContainerView} = goog.require('Blockly.utils.style');
 const {Role, State, setRole, setState} = goog.require('Blockly.utils.aria');
 
@@ -421,28 +421,28 @@ Menu.prototype.handleKeyEvent_ = function(e) {
 
   const highlighted = this.highlightedItem_;
   switch (e.keyCode) {
-    case ENTER:
-    case SPACE:
+    case KeyCodes.ENTER:
+    case KeyCodes.SPACE:
       if (highlighted) {
         highlighted.performAction();
       }
       break;
 
-    case UP:
+    case KeyCodes.UP:
       this.highlightPrevious();
       break;
 
-    case DOWN:
+    case KeyCodes.DOWN:
       this.highlightNext();
       break;
 
-    case PAGE_UP:
-    case HOME:
+    case KeyCodes.PAGE_UP:
+    case KeyCodes.HOME:
       this.highlightFirst_();
       break;
 
-    case PAGE_DOWN:
-    case END:
+    case KeyCodes.PAGE_DOWN:
+    case KeyCodes.END:
       this.highlightLast_();
       break;
 

--- a/core/menu.js
+++ b/core/menu.js
@@ -10,7 +10,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Menu');
+goog.module('Blockly.Menu');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.browserEvents');
 goog.require('Blockly.utils.aria');
@@ -27,7 +28,7 @@ goog.requireType('Blockly.utils.Size');
  * A basic menu class.
  * @constructor
  */
-Blockly.Menu = function() {
+const Menu = function() {
   /**
    * Array of menu items.
    * (Nulls are never in the array, but typing the array as nullable prevents
@@ -109,7 +110,7 @@ Blockly.Menu = function() {
  * Add a new menu item to the bottom of this menu.
  * @param {!Blockly.MenuItem} menuItem Menu item to append.
  */
-Blockly.Menu.prototype.addChild = function(menuItem) {
+Menu.prototype.addChild = function(menuItem) {
   this.menuItems_.push(menuItem);
 };
 
@@ -117,7 +118,7 @@ Blockly.Menu.prototype.addChild = function(menuItem) {
  * Creates the menu DOM.
  * @param {!Element} container Element upon which to append this menu.
  */
-Blockly.Menu.prototype.render = function(container) {
+Menu.prototype.render = function(container) {
   const element = /** @type {!HTMLDivElement} */ (document.createElement(
       'div'));
   // goog-menu is deprecated, use blocklyMenu.  May 2020.
@@ -153,7 +154,7 @@ Blockly.Menu.prototype.render = function(container) {
  * @return {?Element} The DOM element.
  * @package
  */
-Blockly.Menu.prototype.getElement = function() {
+Menu.prototype.getElement = function() {
   return this.element_;
 };
 
@@ -161,7 +162,7 @@ Blockly.Menu.prototype.getElement = function() {
  * Focus the menu element.
  * @package
  */
-Blockly.Menu.prototype.focus = function() {
+Menu.prototype.focus = function() {
   const el = this.getElement();
   if (el) {
     el.focus({preventScroll:true});
@@ -173,7 +174,7 @@ Blockly.Menu.prototype.focus = function() {
  * Blur the menu element.
  * @private
  */
-Blockly.Menu.prototype.blur_ = function() {
+Menu.prototype.blur_ = function() {
   const el = this.getElement();
   if (el) {
     el.blur();
@@ -186,14 +187,14 @@ Blockly.Menu.prototype.blur_ = function() {
  * @param {!Blockly.utils.aria.Role} roleName role name.
  * @package
  */
-Blockly.Menu.prototype.setRole = function(roleName) {
+Menu.prototype.setRole = function(roleName) {
   this.roleName_ = roleName;
 };
 
 /**
  * Dispose of this menu.
  */
-Blockly.Menu.prototype.dispose = function() {
+Menu.prototype.dispose = function() {
   // Remove event handlers.
   if (this.mouseOverHandler_) {
     Blockly.browserEvents.unbind(this.mouseOverHandler_);
@@ -232,7 +233,7 @@ Blockly.Menu.prototype.dispose = function() {
  * @return {?Blockly.MenuItem} Menu item for which the DOM element belongs to.
  * @private
  */
-Blockly.Menu.prototype.getMenuItem_ = function(elem) {
+Menu.prototype.getMenuItem_ = function(elem) {
   const menuElem = this.getElement();
   // Node might be the menu border (resulting in no associated menu item), or
   // a menu item's div, or some element within the menu item.
@@ -259,7 +260,7 @@ Blockly.Menu.prototype.getMenuItem_ = function(elem) {
  * @param {?Blockly.MenuItem} item Item to highlight, or null.
  * @package
  */
-Blockly.Menu.prototype.setHighlighted = function(item) {
+Menu.prototype.setHighlighted = function(item) {
   const currentHighlighted = this.highlightedItem_;
   if (currentHighlighted) {
     currentHighlighted.setHighlighted(false);
@@ -284,7 +285,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
  * highlighted).
  * @package
  */
-Blockly.Menu.prototype.highlightNext = function() {
+Menu.prototype.highlightNext = function() {
   const index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index, 1);
 };
@@ -294,7 +295,7 @@ Blockly.Menu.prototype.highlightNext = function() {
  * currently highlighted).
  * @package
  */
-Blockly.Menu.prototype.highlightPrevious = function() {
+Menu.prototype.highlightPrevious = function() {
   const index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index < 0 ? this.menuItems_.length : index, -1);
 };
@@ -303,7 +304,7 @@ Blockly.Menu.prototype.highlightPrevious = function() {
  * Highlights the first highlightable item.
  * @private
  */
-Blockly.Menu.prototype.highlightFirst_ = function() {
+Menu.prototype.highlightFirst_ = function() {
   this.highlightHelper_(-1, 1);
 };
 
@@ -311,7 +312,7 @@ Blockly.Menu.prototype.highlightFirst_ = function() {
  * Highlights the last highlightable item.
  * @private
  */
-Blockly.Menu.prototype.highlightLast_ = function() {
+Menu.prototype.highlightLast_ = function() {
   this.highlightHelper_(this.menuItems_.length, -1);
 };
 
@@ -322,7 +323,7 @@ Blockly.Menu.prototype.highlightLast_ = function() {
  * @param {number} delta Step direction: 1 to go down, -1 to go up.
  * @private
  */
-Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
+Menu.prototype.highlightHelper_ = function(startIndex, delta) {
   let index = startIndex + delta;
   let menuItem;
   while ((menuItem = this.menuItems_[index])) {
@@ -341,7 +342,7 @@ Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
  * @param {!Event} e Mouse event to handle.
  * @private
  */
-Blockly.Menu.prototype.handleMouseOver_ = function(e) {
+Menu.prototype.handleMouseOver_ = function(e) {
   const menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
 
   if (menuItem) {
@@ -360,7 +361,7 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
  * @param {!Event} e Click event to handle.
  * @private
  */
-Blockly.Menu.prototype.handleClick_ = function(e) {
+Menu.prototype.handleClick_ = function(e) {
   const oldCoords = this.openingCoords;
   // Clear out the saved opening coords immediately so they're not used twice.
   this.openingCoords = null;
@@ -386,7 +387,7 @@ Blockly.Menu.prototype.handleClick_ = function(e) {
  * @param {!Event} _e Mouse event to handle.
  * @private
  */
-Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
+Menu.prototype.handleMouseEnter_ = function(_e) {
   this.focus();
 };
 
@@ -395,7 +396,7 @@ Blockly.Menu.prototype.handleMouseEnter_ = function(_e) {
  * @param {!Event} _e Mouse event to handle.
  * @private
  */
-Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
+Menu.prototype.handleMouseLeave_ = function(_e) {
   if (this.getElement()) {
     this.blur_();
     this.setHighlighted(null);
@@ -410,7 +411,7 @@ Blockly.Menu.prototype.handleMouseLeave_ = function(_e) {
  * @param {!Event} e Key event to handle.
  * @private
  */
-Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
+Menu.prototype.handleKeyEvent_ = function(e) {
   if (!this.menuItems_.length) {
     // Empty menu.
     return;
@@ -461,7 +462,7 @@ Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
  * @return {!Blockly.utils.Size} Object with width and height properties.
  * @package
  */
-Blockly.Menu.prototype.getSize = function() {
+Menu.prototype.getSize = function() {
   const menuDom = this.getElement();
   const menuSize = Blockly.utils.style.getSize(/** @type {!Element} */
       (menuDom));
@@ -469,3 +470,5 @@ Blockly.Menu.prototype.getSize = function() {
   menuSize.height = menuDom.scrollHeight;
   return menuSize;
 };
+
+exports = Menu;

--- a/core/menu.js
+++ b/core/menu.js
@@ -15,12 +15,12 @@ goog.module.declareLegacyNamespace();
 
 const Coordinate = goog.require('Blockly.utils.Coordinate');
 const MenuItem = goog.requireType('Blockly.MenuItem');
-const Size = goog.requireType('Blockly.utils.Size');
-const {addClass, hasClass, removeClass} = goog.require('Blockly.utils.dom');
-const {Data, conditionalBind, unbind} = goog.require('Blockly.browserEvents');
 const KeyCodes = goog.require('Blockly.utils.KeyCodes');
-const {getSize, scrollIntoContainerView} = goog.require('Blockly.utils.style');
-const {Role, State, setRole, setState} = goog.require('Blockly.utils.aria');
+const Size = goog.requireType('Blockly.utils.Size');
+const aria = goog.require('Blockly.utils.aria');
+const browserEvents = goog.require('Blockly.browserEvents');
+const dom = goog.require('Blockly.utils.dom');
+const style = goog.require('Blockly.utils.style');
 
 
 /**
@@ -56,35 +56,35 @@ const Menu = function() {
 
   /**
    * Mouse over event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.mouseOverHandler_ = null;
 
   /**
    * Click event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.clickHandler_ = null;
 
   /**
    * Mouse enter event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.mouseEnterHandler_ = null;
 
   /**
    * Mouse leave event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.mouseLeaveHandler_ = null;
 
   /**
    * Key down event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onKeyDownHandler_ = null;
@@ -98,7 +98,7 @@ const Menu = function() {
 
   /**
    * ARIA name for this menu.
-   * @type {?Role}
+   * @type {?aria.Role}
    * @private
    */
   this.roleName_ = null;
@@ -124,7 +124,7 @@ Menu.prototype.render = function(container) {
   element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
   if (this.roleName_) {
-    setRole(element, this.roleName_);
+    aria.setRole(element, this.roleName_);
   }
   this.element_ = element;
 
@@ -135,15 +135,15 @@ Menu.prototype.render = function(container) {
 
   // Add event handlers.
   this.mouseOverHandler_ =
-      conditionalBind(element, 'mouseover', this, this.handleMouseOver_, true);
+      browserEvents.conditionalBind(element, 'mouseover', this, this.handleMouseOver_, true);
   this.clickHandler_ =
-      conditionalBind(element, 'click', this, this.handleClick_, true);
-  this.mouseEnterHandler_ = conditionalBind(
+      browserEvents.conditionalBind(element, 'click', this, this.handleClick_, true);
+  this.mouseEnterHandler_ = browserEvents.conditionalBind(
       element, 'mouseenter', this, this.handleMouseEnter_, true);
-  this.mouseLeaveHandler_ = conditionalBind(
+  this.mouseLeaveHandler_ = browserEvents.conditionalBind(
       element, 'mouseleave', this, this.handleMouseLeave_, true);
   this.onKeyDownHandler_ =
-      conditionalBind(element, 'keydown', this, this.handleKeyEvent_);
+      browserEvents.conditionalBind(element, 'keydown', this, this.handleKeyEvent_);
 
   container.appendChild(element);
 };
@@ -165,7 +165,7 @@ Menu.prototype.focus = function() {
   const el = this.getElement();
   if (el) {
     el.focus({preventScroll: true});
-    addClass(el, 'blocklyFocused');
+    dom.addClass(el, 'blocklyFocused');
   }
 };
 
@@ -177,13 +177,13 @@ Menu.prototype.blur_ = function() {
   const el = this.getElement();
   if (el) {
     el.blur();
-    removeClass(el, 'blocklyFocused');
+    dom.removeClass(el, 'blocklyFocused');
   }
 };
 
 /**
  * Set the menu accessibility role.
- * @param {!Role} roleName role name.
+ * @param {!aria.Role} roleName role name.
  * @package
  */
 Menu.prototype.setRole = function(roleName) {
@@ -196,23 +196,23 @@ Menu.prototype.setRole = function(roleName) {
 Menu.prototype.dispose = function() {
   // Remove event handlers.
   if (this.mouseOverHandler_) {
-    unbind(this.mouseOverHandler_);
+    browserEvents.unbind(this.mouseOverHandler_);
     this.mouseOverHandler_ = null;
   }
   if (this.clickHandler_) {
-    unbind(this.clickHandler_);
+    browserEvents.unbind(this.clickHandler_);
     this.clickHandler_ = null;
   }
   if (this.mouseEnterHandler_) {
-    unbind(this.mouseEnterHandler_);
+    browserEvents.unbind(this.mouseEnterHandler_);
     this.mouseEnterHandler_ = null;
   }
   if (this.mouseLeaveHandler_) {
-    unbind(this.mouseLeaveHandler_);
+    browserEvents.unbind(this.mouseLeaveHandler_);
     this.mouseLeaveHandler_ = null;
   }
   if (this.onKeyDownHandler_) {
-    unbind(this.onKeyDownHandler_);
+    browserEvents.unbind(this.onKeyDownHandler_);
     this.onKeyDownHandler_ = null;
   }
 
@@ -239,7 +239,7 @@ Menu.prototype.getMenuItem_ = function(elem) {
   // Walk up parents until one meets either the menu's root element, or
   // a menu item's div.
   while (elem && elem != menuElem) {
-    if (hasClass(elem, 'blocklyMenuItem')) {
+    if (dom.hasClass(elem, 'blocklyMenuItem')) {
       // Having found a menu item's div, locate that menu item in this menu.
       for (let i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
         if (menuItem.getElement() == elem) {
@@ -271,10 +271,10 @@ Menu.prototype.setHighlighted = function(item) {
     // Bring the highlighted item into view. This has no effect if the menu is
     // not scrollable.
     const el = /** @type {!Element} */ (this.getElement());
-    scrollIntoContainerView(
+    style.scrollIntoContainerView(
         /** @type {!Element} */ (item.getElement()), el);
 
-    setState(el, State.ACTIVEDESCENDANT, item.getId());
+    aria.setState(el, aria.State.ACTIVEDESCENDANT, item.getId());
   }
 };
 
@@ -462,7 +462,7 @@ Menu.prototype.handleKeyEvent_ = function(e) {
  */
 Menu.prototype.getSize = function() {
   const menuDom = this.getElement();
-  const menuSize = getSize(/** @type {!Element} */
+  const menuSize = style.getSize(/** @type {!Element} */
                            (menuDom));
   // Recalculate height for the total content, not only box height.
   menuSize.height = menuDom.scrollHeight;

--- a/core/menu.js
+++ b/core/menu.js
@@ -14,6 +14,7 @@ goog.module('Blockly.Menu');
 goog.module.declareLegacyNamespace();
 
 const Coordinate = goog.require('Blockly.utils.Coordinate');
+/* eslint-disable-next-line no-unused-vars */
 const MenuItem = goog.requireType('Blockly.MenuItem');
 const KeyCodes = goog.require('Blockly.utils.KeyCodes');
 const Size = goog.requireType('Blockly.utils.Size');

--- a/core/menu.js
+++ b/core/menu.js
@@ -118,7 +118,8 @@ Blockly.Menu.prototype.addChild = function(menuItem) {
  * @param {!Element} container Element upon which to append this menu.
  */
 Blockly.Menu.prototype.render = function(container) {
-  var element = /** @type {!HTMLDivElement} */ (document.createElement('div'));
+  const element = /** @type {!HTMLDivElement} */ (document.createElement(
+      'div'));
   // goog-menu is deprecated, use blocklyMenu.  May 2020.
   element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
   element.tabIndex = 0;
@@ -128,7 +129,7 @@ Blockly.Menu.prototype.render = function(container) {
   this.element_ = element;
 
   // Add menu items.
-  for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
+  for (let i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
     element.appendChild(menuItem.createDom());
   }
 
@@ -161,7 +162,7 @@ Blockly.Menu.prototype.getElement = function() {
  * @package
  */
 Blockly.Menu.prototype.focus = function() {
-  var el = this.getElement();
+  const el = this.getElement();
   if (el) {
     el.focus({preventScroll:true});
     Blockly.utils.dom.addClass(el, 'blocklyFocused');
@@ -173,7 +174,7 @@ Blockly.Menu.prototype.focus = function() {
  * @private
  */
 Blockly.Menu.prototype.blur_ = function() {
-  var el = this.getElement();
+  const el = this.getElement();
   if (el) {
     el.blur();
     Blockly.utils.dom.removeClass(el, 'blocklyFocused');
@@ -216,7 +217,7 @@ Blockly.Menu.prototype.dispose = function() {
   }
 
   // Remove menu items.
-  for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
+  for (let i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
     menuItem.dispose();
   }
   this.element_ = null;
@@ -232,7 +233,7 @@ Blockly.Menu.prototype.dispose = function() {
  * @private
  */
 Blockly.Menu.prototype.getMenuItem_ = function(elem) {
-  var menuElem = this.getElement();
+  const menuElem = this.getElement();
   // Node might be the menu border (resulting in no associated menu item), or
   // a menu item's div, or some element within the menu item.
   // Walk up parents until one meets either the menu's root element, or
@@ -240,7 +241,7 @@ Blockly.Menu.prototype.getMenuItem_ = function(elem) {
   while (elem && elem != menuElem) {
     if (Blockly.utils.dom.hasClass(elem, 'blocklyMenuItem')) {
       // Having found a menu item's div, locate that menu item in this menu.
-      for (var i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
+      for (let i = 0, menuItem; (menuItem = this.menuItems_[i]); i++) {
         if (menuItem.getElement() == elem) {
           return menuItem;
         }
@@ -259,7 +260,7 @@ Blockly.Menu.prototype.getMenuItem_ = function(elem) {
  * @package
  */
 Blockly.Menu.prototype.setHighlighted = function(item) {
-  var currentHighlighted = this.highlightedItem_;
+  const currentHighlighted = this.highlightedItem_;
   if (currentHighlighted) {
     currentHighlighted.setHighlighted(false);
     this.highlightedItem_ = null;
@@ -269,7 +270,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
     this.highlightedItem_ = item;
     // Bring the highlighted item into view. This has no effect if the menu is
     // not scrollable.
-    var el = /** @type {!Element} */ (this.getElement());
+    const el = /** @type {!Element} */ (this.getElement());
     Blockly.utils.style.scrollIntoContainerView(
         /** @type {!Element} */ (item.getElement()), el);
 
@@ -284,7 +285,7 @@ Blockly.Menu.prototype.setHighlighted = function(item) {
  * @package
  */
 Blockly.Menu.prototype.highlightNext = function() {
-  var index = this.menuItems_.indexOf(this.highlightedItem_);
+  const index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index, 1);
 };
 
@@ -294,7 +295,7 @@ Blockly.Menu.prototype.highlightNext = function() {
  * @package
  */
 Blockly.Menu.prototype.highlightPrevious = function() {
-  var index = this.menuItems_.indexOf(this.highlightedItem_);
+  const index = this.menuItems_.indexOf(this.highlightedItem_);
   this.highlightHelper_(index < 0 ? this.menuItems_.length : index, -1);
 };
 
@@ -322,8 +323,8 @@ Blockly.Menu.prototype.highlightLast_ = function() {
  * @private
  */
 Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
-  var index = startIndex + delta;
-  var menuItem;
+  let index = startIndex + delta;
+  let menuItem;
   while ((menuItem = this.menuItems_[index])) {
     if (menuItem.isEnabled()) {
       this.setHighlighted(menuItem);
@@ -341,7 +342,7 @@ Blockly.Menu.prototype.highlightHelper_ = function(startIndex, delta) {
  * @private
  */
 Blockly.Menu.prototype.handleMouseOver_ = function(e) {
-  var menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
+  const menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
 
   if (menuItem) {
     if (menuItem.isEnabled()) {
@@ -360,11 +361,11 @@ Blockly.Menu.prototype.handleMouseOver_ = function(e) {
  * @private
  */
 Blockly.Menu.prototype.handleClick_ = function(e) {
-  var oldCoords = this.openingCoords;
+  const oldCoords = this.openingCoords;
   // Clear out the saved opening coords immediately so they're not used twice.
   this.openingCoords = null;
   if (oldCoords && typeof e.clientX == 'number') {
-    var newCoords = new Blockly.utils.Coordinate(e.clientX, e.clientY);
+    const newCoords = new Blockly.utils.Coordinate(e.clientX, e.clientY);
     if (Blockly.utils.Coordinate.distance(oldCoords, newCoords) < 1) {
       // This menu was opened by a mousedown and we're handling the consequent
       // click event. The coords haven't changed, meaning this was the same
@@ -374,7 +375,7 @@ Blockly.Menu.prototype.handleClick_ = function(e) {
     }
   }
 
-  var menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
+  const menuItem = this.getMenuItem_(/** @type {Element} */ (e.target));
   if (menuItem) {
     menuItem.performAction();
   }
@@ -419,7 +420,7 @@ Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
     return;
   }
 
-  var highlighted = this.highlightedItem_;
+  const highlighted = this.highlightedItem_;
   switch (e.keyCode) {
     case Blockly.utils.KeyCodes.ENTER:
     case Blockly.utils.KeyCodes.SPACE:
@@ -461,8 +462,9 @@ Blockly.Menu.prototype.handleKeyEvent_ = function(e) {
  * @package
  */
 Blockly.Menu.prototype.getSize = function() {
-  var menuDom = this.getElement();
-  var menuSize = Blockly.utils.style.getSize(/** @type {!Element} */ (menuDom));
+  const menuDom = this.getElement();
+  const menuSize = Blockly.utils.style.getSize(/** @type {!Element} */
+      (menuDom));
   // Recalculate height for the total content, not only box height.
   menuSize.height = menuDom.scrollHeight;
   return menuSize;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -108,7 +108,7 @@ goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Bl
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);
-goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style']);
+goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/menuitem.js', ['Blockly.MenuItem'], ['Blockly.utils.IdGenerator', 'Blockly.utils.aria', 'Blockly.utils.dom']);
 goog.addDependency('../../core/metrics_manager.js', ['Blockly.FlyoutMetricsManager', 'Blockly.MetricsManager'], ['Blockly.IMetricsManager', 'Blockly.registry', 'Blockly.utils.Size', 'Blockly.utils.toolbox'], {'lang': 'es5'});
 goog.addDependency('../../core/msg.js', ['Blockly.Msg'], ['Blockly.utils.global']);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/menu.js` to `goog.module` syntax.