### PR TITLE
Migrate core/interfaces/i_metrics_manager.js to goog.module syntax

### DIFF
--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-goog.provide('Blockly.IMetricsManager');
+goog.module('Blockly.IMetricsManager');
+goog.module.declareLegacyNamespace();
 
 goog.requireType('Blockly.MetricsManager');
 goog.requireType('Blockly.utils.Metrics');
@@ -22,14 +23,14 @@ goog.requireType('Blockly.utils.Size');
  * Interface for a metrics manager.
  * @interface
  */
-Blockly.IMetricsManager = function() {};
+const IMetricsManager = function() {};
 
 /**
  * Returns whether the scroll area has fixed edges.
  * @return {boolean} Whether the scroll area has fixed edges.
  * @package
  */
-Blockly.IMetricsManager.prototype.hasFixedEdges;
+IMetricsManager.prototype.hasFixedEdges;
 
 /**
  * Returns the metrics for the scroll area of the workspace.
@@ -44,7 +45,7 @@ Blockly.IMetricsManager.prototype.hasFixedEdges;
  * @return {!Blockly.MetricsManager.ContainerRegion} The metrics for the scroll
  *    container
  */
-Blockly.IMetricsManager.prototype.getScrollMetrics;
+IMetricsManager.prototype.getScrollMetrics;
 
 /**
  * Gets the width and the height of the flyout on the workspace in pixel
@@ -55,7 +56,7 @@ Blockly.IMetricsManager.prototype.getScrollMetrics;
  *     flyout.
  * @public
  */
-Blockly.IMetricsManager.prototype.getFlyoutMetrics;
+IMetricsManager.prototype.getFlyoutMetrics;
 
 /**
  * Gets the width, height and position of the toolbox on the workspace in pixel
@@ -66,7 +67,7 @@ Blockly.IMetricsManager.prototype.getFlyoutMetrics;
  *     height and position of the toolbox.
  * @public
  */
-Blockly.IMetricsManager.prototype.getToolboxMetrics;
+IMetricsManager.prototype.getToolboxMetrics;
 
 /**
  * Gets the width and height of the workspace's parent SVG element in pixel
@@ -75,7 +76,7 @@ Blockly.IMetricsManager.prototype.getToolboxMetrics;
  *     SVG element.
  * @public
  */
-Blockly.IMetricsManager.prototype.getSvgMetrics;
+IMetricsManager.prototype.getSvgMetrics;
 
 /**
  * Gets the absolute left and absolute top in pixel coordinates.
@@ -84,7 +85,7 @@ Blockly.IMetricsManager.prototype.getSvgMetrics;
  *     the workspace.
  * @public
  */
-Blockly.IMetricsManager.prototype.getAbsoluteMetrics;
+IMetricsManager.prototype.getAbsoluteMetrics;
 
 /**
  * Gets the metrics for the visible workspace in either pixel or workspace
@@ -96,7 +97,7 @@ Blockly.IMetricsManager.prototype.getAbsoluteMetrics;
  *     coordinates.
  * @public
  */
-Blockly.IMetricsManager.prototype.getViewMetrics;
+IMetricsManager.prototype.getViewMetrics;
 
 /**
  * Gets content metrics in either pixel or workspace coordinates.
@@ -108,7 +109,7 @@ Blockly.IMetricsManager.prototype.getViewMetrics;
  *     metrics for the content container.
  * @public
  */
-Blockly.IMetricsManager.prototype.getContentMetrics;
+IMetricsManager.prototype.getContentMetrics;
 
 /**
  * Returns an object with all the metrics required to size scrollbars for a
@@ -142,4 +143,6 @@ Blockly.IMetricsManager.prototype.getContentMetrics;
  *     level workspace.
  * @public
  */
-Blockly.IMetricsManager.prototype.getMetrics;
+IMetricsManager.prototype.getMetrics;
+
+exports = IMetricsManager;

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -14,8 +14,11 @@
 goog.module('Blockly.IMetricsManager');
 goog.module.declareLegacyNamespace();
 
+/* eslint-disable-next-line no-unused-vars */
 const Metrics = goog.requireType('Blockly.utils.Metrics');
+/* eslint-disable-next-line no-unused-vars */
 const Size = goog.requireType('Blockly.utils.Size');
+/* eslint-disable-next-line no-unused-vars */
 const {AbsoluteMetrics, ContainerRegion, ToolboxMetrics} = goog.requireType('Blockly.MetricsManager');
 
 

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -14,9 +14,9 @@
 goog.module('Blockly.IMetricsManager');
 goog.module.declareLegacyNamespace();
 
-goog.requireType('Blockly.MetricsManager');
-goog.requireType('Blockly.utils.Metrics');
-goog.requireType('Blockly.utils.Size');
+const Metrics = goog.requireType('Blockly.utils.Metrics');
+const Size = goog.requireType('Blockly.utils.Size');
+const {AbsoluteMetrics, ContainerRegion, ToolboxMetrics} = goog.requireType('Blockly.MetricsManager');
 
 
 /**
@@ -36,13 +36,13 @@ IMetricsManager.prototype.hasFixedEdges;
  * Returns the metrics for the scroll area of the workspace.
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the scroll metrics
  *     in workspace coordinates, false to get them in pixel coordinates.
- * @param {!Blockly.MetricsManager.ContainerRegion=} opt_viewMetrics The view
+ * @param {!ContainerRegion=} opt_viewMetrics The view
  *     metrics if they have been previously computed. Passing in null may cause
  *     the view metrics to be computed again, if it is needed.
- * @param {!Blockly.MetricsManager.ContainerRegion=} opt_contentMetrics The
+ * @param {!ContainerRegion=} opt_contentMetrics The
  *     content metrics if they have been previously computed. Passing in null
  *     may cause the content metrics to be computed again, if it is needed.
- * @return {!Blockly.MetricsManager.ContainerRegion} The metrics for the scroll
+ * @return {!ContainerRegion} The metrics for the scroll
  *    container
  */
 IMetricsManager.prototype.getScrollMetrics;
@@ -52,7 +52,7 @@ IMetricsManager.prototype.getScrollMetrics;
  * coordinates. Returns 0 for the width and height if the workspace has a
  * category toolbox instead of a simple toolbox.
  * @param {boolean=} opt_own Whether to only return the workspace's own flyout.
- * @return {!Blockly.MetricsManager.ToolboxMetrics} The width and height of the
+ * @return {!ToolboxMetrics} The width and height of the
  *     flyout.
  * @public
  */
@@ -63,7 +63,7 @@ IMetricsManager.prototype.getFlyoutMetrics;
  * coordinates. Returns 0 for the width and height if the workspace has a simple
  * toolbox instead of a category toolbox. To get the width and height of a
  * simple toolbox @see {@link getFlyoutMetrics}.
- * @return {!Blockly.MetricsManager.ToolboxMetrics} The object with the width,
+ * @return {!ToolboxMetrics} The object with the width,
  *     height and position of the toolbox.
  * @public
  */
@@ -72,7 +72,7 @@ IMetricsManager.prototype.getToolboxMetrics;
 /**
  * Gets the width and height of the workspace's parent SVG element in pixel
  * coordinates. This area includes the toolbox and the visible workspace area.
- * @return {!Blockly.utils.Size} The width and height of the workspace's parent
+ * @return {!Size} The width and height of the workspace's parent
  *     SVG element.
  * @public
  */
@@ -81,7 +81,7 @@ IMetricsManager.prototype.getSvgMetrics;
 /**
  * Gets the absolute left and absolute top in pixel coordinates.
  * This is where the visible workspace starts in relation to the SVG container.
- * @return {!Blockly.MetricsManager.AbsoluteMetrics} The absolute metrics for
+ * @return {!AbsoluteMetrics} The absolute metrics for
  *     the workspace.
  * @public
  */
@@ -92,7 +92,7 @@ IMetricsManager.prototype.getAbsoluteMetrics;
  * coordinates. The visible workspace does not include the toolbox or flyout.
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the view metrics in
  *     workspace coordinates, false to get them in pixel coordinates.
- * @return {!Blockly.MetricsManager.ContainerRegion} The width, height, top and
+ * @return {!ContainerRegion} The width, height, top and
  *     left of the viewport in either workspace coordinates or pixel
  *     coordinates.
  * @public
@@ -105,7 +105,7 @@ IMetricsManager.prototype.getViewMetrics;
  * workspace (workspace comments and blocks).
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the content metrics
  *     in workspace coordinates, false to get them in pixel coordinates.
- * @return {!Blockly.MetricsManager.ContainerRegion} The
+ * @return {!ContainerRegion} The
  *     metrics for the content container.
  * @public
  */
@@ -139,7 +139,7 @@ IMetricsManager.prototype.getContentMetrics;
  * .flyoutHeight: Height of the flyout if it is always open.  Otherwise zero.
  * .toolboxPosition: Top, bottom, left or right. Use TOOLBOX_AT constants to
  *     compare.
- * @return {!Blockly.utils.Metrics} Contains size and position metrics of a top
+ * @return {!Metrics} Contains size and position metrics of a top
  *     level workspace.
  * @public
  */

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -91,7 +91,7 @@ goog.addDependency('../../core/interfaces/i_drag_target.js', ['Blockly.IDragTarg
 goog.addDependency('../../core/interfaces/i_draggable.js', ['Blockly.IDraggable'], ['Blockly.IDeletable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_flyout.js', ['Blockly.IFlyout'], ['Blockly.IRegistrable'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_keyboard_accessible.js', ['Blockly.IKeyboardAccessible'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], []);
+goog.addDependency('../../core/interfaces/i_metrics_manager.js', ['Blockly.IMetricsManager'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_movable.js', ['Blockly.IMovable'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_positionable.js', ['Blockly.IPositionable'], ['Blockly.IComponent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/interfaces/i_registrable.js', ['Blockly.IRegistrable'], [], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/interfaces/i_metrics_manager.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/interfaces/i_metrics_manager.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
