### PR TITLE
Migrate core/utils/size.js to goog.module syntax

### DIFF
--- a/core/utils/size.js
+++ b/core/utils/size.js
@@ -13,10 +13,11 @@
 'use strict';
 
 /**
- * @name Blockly.utils.Size
+ * @name Size
  * @namespace
  */
-goog.provide('Blockly.utils.Size');
+goog.module('Blockly.utils.Size');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -26,7 +27,7 @@ goog.provide('Blockly.utils.Size');
  * @struct
  * @constructor
  */
-Blockly.utils.Size = function(width, height) {
+const Size = function(width, height) {
   /**
    * Width
    * @type {number}
@@ -42,12 +43,12 @@ Blockly.utils.Size = function(width, height) {
 
 /**
  * Compares sizes for equality.
- * @param {?Blockly.utils.Size} a A Size.
- * @param {?Blockly.utils.Size} b A Size.
+ * @param {?Size} a A Size.
+ * @param {?Size} b A Size.
  * @return {boolean} True iff the sizes have equal widths and equal
  *     heights, or if both are null.
  */
-Blockly.utils.Size.equals = function(a, b) {
+Size.equals = function(a, b) {
   if (a == b) {
     return true;
   }
@@ -56,3 +57,5 @@ Blockly.utils.Size.equals = function(a, b) {
   }
   return a.width == b.width && a.height == b.height;
 };
+
+exports = Size;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -187,7 +187,7 @@ goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], [], {'lan
 goog.addDependency('../../core/utils/metrics.js', ['Blockly.utils.Metrics'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/object.js', ['Blockly.utils.object'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], []);
+goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], []);
 goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Blockly.utils.Coordinate', 'Blockly.utils.Size'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], []);


### PR DESCRIPTION
## The basics

- [X] I branched from `goog_module`
- [X] My pull request is against `goog_module`
- [X] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [X] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/size.js` to `goog.module` with ES6 `const`/`let`.

### Additional Information

<!-- Anything else we should know? -->
