### PR TITLE
Migrate core/marker_manager.js to goog.module syntax

### DIFF
--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -27,7 +27,7 @@ const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
  * @constructor
  * @package
  */
-const MarkerManager = function(workspace){
+const MarkerManager = function(workspace) {
   /**
    * The cursor.
    * @type {?Cursor}
@@ -73,8 +73,8 @@ MarkerManager.prototype.registerMarker = function(id, marker) {
   if (this.markers_[id]) {
     this.unregisterMarker(id);
   }
-  marker.setDrawer(this.workspace_.getRenderer()
-      .makeMarkerDrawer(this.workspace_, marker));
+  marker.setDrawer(
+      this.workspace_.getRenderer().makeMarkerDrawer(this.workspace_, marker));
   this.setMarkerSvg(marker.getDrawer().createDom());
   this.markers_[id] = marker;
 };
@@ -89,7 +89,8 @@ MarkerManager.prototype.unregisterMarker = function(id) {
     marker.dispose();
     delete this.markers_[id];
   } else {
-    throw Error('Marker with ID ' + id + ' does not exist. ' +
+    throw Error(
+        'Marker with ID ' + id + ' does not exist. ' +
         'Can only unregister markers that exist.');
   }
 };
@@ -122,8 +123,8 @@ MarkerManager.prototype.setCursor = function(cursor) {
   }
   this.cursor_ = cursor;
   if (this.cursor_) {
-    const drawer = this.workspace_.getRenderer()
-        .makeMarkerDrawer(this.workspace_, this.cursor_);
+    const drawer = this.workspace_.getRenderer().makeMarkerDrawer(
+        this.workspace_, this.cursor_);
     this.cursor_.setDrawer(drawer);
     this.setCursorSvg(this.cursor_.getDrawer().createDom());
   }

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -10,7 +10,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.MarkerManager');
+goog.module('Blockly.MarkerManager');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Cursor');
 goog.require('Blockly.Marker');
@@ -24,7 +25,7 @@ goog.requireType('Blockly.WorkspaceSvg');
  * @constructor
  * @package
  */
-Blockly.MarkerManager = function(workspace){
+const MarkerManager = function(workspace){
   /**
    * The cursor.
    * @type {?Blockly.Cursor}
@@ -59,14 +60,14 @@ Blockly.MarkerManager = function(workspace){
  * @type {string}
  * @const
  */
-Blockly.MarkerManager.LOCAL_MARKER = 'local_marker_1';
+MarkerManager.LOCAL_MARKER = 'local_marker_1';
 
 /**
  * Register the marker by adding it to the map of markers.
  * @param {string} id A unique identifier for the marker.
  * @param {!Blockly.Marker} marker The marker to register.
  */
-Blockly.MarkerManager.prototype.registerMarker = function(id, marker) {
+MarkerManager.prototype.registerMarker = function(id, marker) {
   if (this.markers_[id]) {
     this.unregisterMarker(id);
   }
@@ -80,7 +81,7 @@ Blockly.MarkerManager.prototype.registerMarker = function(id, marker) {
  * Unregister the marker by removing it from the map of markers.
  * @param {string} id The ID of the marker to unregister.
  */
-Blockly.MarkerManager.prototype.unregisterMarker = function(id) {
+MarkerManager.prototype.unregisterMarker = function(id) {
   const marker = this.markers_[id];
   if (marker) {
     marker.dispose();
@@ -95,7 +96,7 @@ Blockly.MarkerManager.prototype.unregisterMarker = function(id) {
  * Get the cursor for the workspace.
  * @return {?Blockly.Cursor} The cursor for this workspace.
  */
-Blockly.MarkerManager.prototype.getCursor = function() {
+MarkerManager.prototype.getCursor = function() {
   return this.cursor_;
 };
 
@@ -105,7 +106,7 @@ Blockly.MarkerManager.prototype.getCursor = function() {
  * @return {?Blockly.Marker} The marker that corresponds to the given ID,
  *     or null if none exists.
  */
-Blockly.MarkerManager.prototype.getMarker = function(id) {
+MarkerManager.prototype.getMarker = function(id) {
   return this.markers_[id] || null;
 };
 
@@ -113,7 +114,7 @@ Blockly.MarkerManager.prototype.getMarker = function(id) {
  * Sets the cursor and initializes the drawer for use with keyboard navigation.
  * @param {Blockly.Cursor} cursor The cursor used to move around this workspace.
  */
-Blockly.MarkerManager.prototype.setCursor = function(cursor) {
+MarkerManager.prototype.setCursor = function(cursor) {
   if (this.cursor_ && this.cursor_.getDrawer()) {
     this.cursor_.getDrawer().dispose();
   }
@@ -132,7 +133,7 @@ Blockly.MarkerManager.prototype.setCursor = function(cursor) {
  *     workspace SVG group.
  * @package
  */
-Blockly.MarkerManager.prototype.setCursorSvg = function(cursorSvg) {
+MarkerManager.prototype.setCursorSvg = function(cursorSvg) {
   if (!cursorSvg) {
     this.cursorSvg_ = null;
     return;
@@ -148,7 +149,7 @@ Blockly.MarkerManager.prototype.setCursorSvg = function(cursorSvg) {
  *     workspace SVG group.
  * @package
  */
-Blockly.MarkerManager.prototype.setMarkerSvg = function(markerSvg) {
+MarkerManager.prototype.setMarkerSvg = function(markerSvg) {
   if (!markerSvg) {
     this.markerSvg_ = null;
     return;
@@ -167,7 +168,7 @@ Blockly.MarkerManager.prototype.setMarkerSvg = function(markerSvg) {
  * Redraw the attached cursor SVG if needed.
  * @package
  */
-Blockly.MarkerManager.prototype.updateMarkers = function() {
+MarkerManager.prototype.updateMarkers = function() {
   if (this.workspace_.keyboardAccessibilityMode && this.cursorSvg_) {
     this.workspace_.getCursor().draw();
   }
@@ -179,7 +180,7 @@ Blockly.MarkerManager.prototype.updateMarkers = function() {
  * @suppress {checkTypes}
  * @package
  */
-Blockly.MarkerManager.prototype.dispose = function() {
+MarkerManager.prototype.dispose = function() {
   const markerIds = Object.keys(this.markers_);
   for (let i = 0, markerId; (markerId = markerIds[i]); i++) {
     this.unregisterMarker(markerId);
@@ -190,3 +191,5 @@ Blockly.MarkerManager.prototype.dispose = function() {
     this.cursor_ = null;
   }
 };
+
+exports = MarkerManager;

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -13,22 +13,24 @@
 goog.module('Blockly.MarkerManager');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Cursor');
-goog.require('Blockly.Marker');
-
-goog.requireType('Blockly.WorkspaceSvg');
+/* eslint-disable-next-line no-unused-vars */
+const Cursor = goog.requireType('Blockly.Cursor');
+/* eslint-disable-next-line no-unused-vars */
+const Marker = goog.requireType('Blockly.Marker');
+/* eslint-disable-next-line no-unused-vars */
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 
 
 /**
  * Class to manage the multiple markers and the cursor on a workspace.
- * @param {!Blockly.WorkspaceSvg} workspace The workspace for the marker manager.
+ * @param {!WorkspaceSvg} workspace The workspace for the marker manager.
  * @constructor
  * @package
  */
 const MarkerManager = function(workspace){
   /**
    * The cursor.
-   * @type {?Blockly.Cursor}
+   * @type {?Cursor}
    * @private
    */
   this.cursor_ = null;
@@ -42,14 +44,14 @@ const MarkerManager = function(workspace){
 
   /**
    * The map of markers for the workspace.
-   * @type {!Object<string, !Blockly.Marker>}
+   * @type {!Object<string, !Marker>}
    * @private
    */
   this.markers_ = Object.create(null);
 
   /**
    * The workspace this marker manager is associated with.
-   * @type {!Blockly.WorkspaceSvg}
+   * @type {!WorkspaceSvg}
    * @private
    */
   this.workspace_ = workspace;
@@ -65,7 +67,7 @@ MarkerManager.LOCAL_MARKER = 'local_marker_1';
 /**
  * Register the marker by adding it to the map of markers.
  * @param {string} id A unique identifier for the marker.
- * @param {!Blockly.Marker} marker The marker to register.
+ * @param {!Marker} marker The marker to register.
  */
 MarkerManager.prototype.registerMarker = function(id, marker) {
   if (this.markers_[id]) {
@@ -94,7 +96,7 @@ MarkerManager.prototype.unregisterMarker = function(id) {
 
 /**
  * Get the cursor for the workspace.
- * @return {?Blockly.Cursor} The cursor for this workspace.
+ * @return {?Cursor} The cursor for this workspace.
  */
 MarkerManager.prototype.getCursor = function() {
   return this.cursor_;
@@ -103,7 +105,7 @@ MarkerManager.prototype.getCursor = function() {
 /**
  * Get a single marker that corresponds to the given ID.
  * @param {string} id A unique identifier for the marker.
- * @return {?Blockly.Marker} The marker that corresponds to the given ID,
+ * @return {?Marker} The marker that corresponds to the given ID,
  *     or null if none exists.
  */
 MarkerManager.prototype.getMarker = function(id) {
@@ -112,7 +114,7 @@ MarkerManager.prototype.getMarker = function(id) {
 
 /**
  * Sets the cursor and initializes the drawer for use with keyboard navigation.
- * @param {Blockly.Cursor} cursor The cursor used to move around this workspace.
+ * @param {Cursor} cursor The cursor used to move around this workspace.
  */
 MarkerManager.prototype.setCursor = function(cursor) {
   if (this.cursor_ && this.cursor_.getDrawer()) {

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -25,7 +25,6 @@ const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
  * Class to manage the multiple markers and the cursor on a workspace.
  * @param {!WorkspaceSvg} workspace The workspace for the marker manager.
  * @constructor
- * @package
  */
 const MarkerManager = function(workspace) {
   /**
@@ -195,4 +194,5 @@ MarkerManager.prototype.dispose = function() {
   }
 };
 
+/** @package */
 exports = MarkerManager;

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -81,7 +81,7 @@ Blockly.MarkerManager.prototype.registerMarker = function(id, marker) {
  * @param {string} id The ID of the marker to unregister.
  */
 Blockly.MarkerManager.prototype.unregisterMarker = function(id) {
-  var marker = this.markers_[id];
+  const marker = this.markers_[id];
   if (marker) {
     marker.dispose();
     delete this.markers_[id];
@@ -119,7 +119,7 @@ Blockly.MarkerManager.prototype.setCursor = function(cursor) {
   }
   this.cursor_ = cursor;
   if (this.cursor_) {
-    var drawer = this.workspace_.getRenderer()
+    const drawer = this.workspace_.getRenderer()
         .makeMarkerDrawer(this.workspace_, this.cursor_);
     this.cursor_.setDrawer(drawer);
     this.setCursorSvg(this.cursor_.getDrawer().createDom());
@@ -180,8 +180,8 @@ Blockly.MarkerManager.prototype.updateMarkers = function() {
  * @package
  */
 Blockly.MarkerManager.prototype.dispose = function() {
-  var markerIds = Object.keys(this.markers_);
-  for (var i = 0, markerId; (markerId = markerIds[i]); i++) {
+  const markerIds = Object.keys(this.markers_);
+  for (let i = 0, markerId; (markerId = markerIds[i]); i++) {
     this.unregisterMarker(markerId);
   }
   this.markers_ = null;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -107,7 +107,7 @@ goog.addDependency('../../core/keyboard_nav/basic_cursor.js', ['Blockly.BasicCur
 goog.addDependency('../../core/keyboard_nav/cursor.js', ['Blockly.Cursor'], ['Blockly.ASTNode', 'Blockly.Marker', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/keyboard_nav/marker.js', ['Blockly.Marker'], ['Blockly.ASTNode']);
 goog.addDependency('../../core/keyboard_nav/tab_navigate_cursor.js', ['Blockly.TabNavigateCursor'], ['Blockly.ASTNode', 'Blockly.BasicCursor', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], ['Blockly.Cursor', 'Blockly.Marker']);
+goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/menuitem.js', ['Blockly.MenuItem'], ['Blockly.utils.IdGenerator', 'Blockly.utils.aria', 'Blockly.utils.dom']);
 goog.addDependency('../../core/metrics_manager.js', ['Blockly.FlyoutMetricsManager', 'Blockly.MetricsManager'], ['Blockly.IMetricsManager', 'Blockly.registry', 'Blockly.utils.Size', 'Blockly.utils.toolbox'], {'lang': 'es5'});


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/marker_manager.js` to `goog.module` with ES6 `const`/`let`.