### PR TITLE
Remove deconstructing properties and update logic

### DIFF
--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -163,6 +163,11 @@ step3() {
       continue
     fi
 
+    local require_name=$(echo "${require}" | perl -pe 's/(\w+\.)+(\w+)/\2/g')
+    inf "Updating require declaration for ${require}..."
+    perl -pi -e 's/^(goog\.(require|requireType)\('\'"${require}"\''\);)/const '"${require_name}"' = \1/' "${filepath}"
+
+    # Parse property access of module
     local direct_access_count=$(perl -nle'print $& while m{'"${require}"'[^\.'\'']}g' "${filepath}" | wc -l)
     local properties_accessed=$(perl -nle'print $& while m{(?<='"${require}"'\.)(?!prototype)\w+}g' "${filepath}" | tr ' ' '\n' | sort -u)
     # Detect requires overlap
@@ -181,42 +186,18 @@ step3() {
     fi
     properties_accessed=$(echo "${properties_accessed}" | perl -pe 's/\s+/ /g' | xargs)
 
-    if [[ "${direct_access_count}" -eq "0" && -n "${properties_accessed}" ]]; then
-      local deconstructed_comma=$(echo "${properties_accessed}" | perl -pe 's/\s+/, /g' | perl -pe 's/, $//')
-      local confirm=''
-      while true; do
-        read -p "Would you like to deconstruct ${require} into \"{${deconstructed_comma}}\"? (y/n): " yn </dev/tty
-        case $yn in
-          [Yy]* )
-            confirm='true'
-            break
-            ;;
-          [Nn]* )
-            confirm='false'
-            break
-            ;;
-          * ) reenter_instructions "Please type y or n \"${yn}\"";;
-        esac
+    if [[ -n "${properties_accessed}" ]]; then
+      local comma_properties=$(echo "${properties_accessed}" | perl -pe 's/\s+/, /g' | perl -pe 's/, $//')
+      inf "Detected references of ${require}: ${comma_properties}"
+
+      for require_prop in echo "${properties_accessed}"; do
+        inf "Updating references of ${require}.${require_prop} to ${require_name}.${require_prop}..."
+        perl -pi -e 's/'"${require}"'\.'"${require_prop}"'([^'\''\w])/'"${require_name}"'\.'"${require_prop}"'\1/g' "${filepath}"
       done
-
-      if [[ "${confirm}" == 'true' ]]; then
-        inf "Deconstructing ${require} into \"{${deconstructed_comma}}\"..."
-        perl -pi -e 's/^(goog\.(require|requireType)\('\'"${require}"\''\);)/const \{'"${deconstructed_comma}"'\} = \1/' "${filepath}"
-
-        for require_prop in $(echo "${properties_accessed}"); do
-          inf "Updating references of ${require}.${require_prop} to ${require_prop}..."
-          perl -pi -e 's/'"${require}"'\.'"${require_prop}"'([^'\''\w])/'"${require_prop}"'\1/g' "${filepath}"
-        done
-        continue
-      fi
     fi
 
-    local require_name=$(echo "${require}" | perl -pe 's/(\w+\.)+(\w+)/\2/g')
-    inf "Updating require declaration for ${require}..."
-    perl -pi -e 's/^(goog\.(require|requireType)\('\'"${require}"\''\);)/const '"${require_name}"' = \1/' "${filepath}"
-
     inf "Updating references of ${require} to ${require_name}..."
-    perl -pi -e 's/'"${require}"'([^'\''\w])/'"${require_name}"'\1/g' "${filepath}"
+    perl -pi -e 's/'"${require}"'([^'\''\w]\.)/'"${require_name}"'\1/g' "${filepath}"
   done
 
   local missing_requires=$(perl -nle'print $& while m{(?<!'\'')Blockly(\.\w+)+}g' "${filepath}")

--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -196,7 +196,7 @@ step3() {
       done
     fi
 
-    inf "Updating references of ${require} to ${require_name}..."
+    inf "Updating direct references of ${require} to ${require_name}..."
     perl -pi -e 's/'"${require}"'([^'\''\w]\.)/'"${require_name}"'\1/g' "${filepath}"
   done
 


### PR DESCRIPTION
Remove logic for deconstructing require and update logic so that it correctly handles instances like:
`Blockly.utils` and `Blockly.utils.dom` both being required (previously this only worked correctly if both were deconstructed)