### PR TITLE
Fix Mutator editor block positions sometimes being out of place for an instant

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -352,7 +352,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.resizeBubble_();
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
-    // Update the source block immediately after the bubble becomes visible
+    // Update the source block immediately after the bubble becomes visible.
     this.updateWorkspace_();
     this.applyColour();
   } else {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -353,7 +353,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     // Update source block immediately when bubble is visible
-    this.workspaceChanged_();
+    this.workspaceChanged_(null);
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -379,7 +379,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
  * @param {!Blockly.Events.Abstract} e Custom data for event.
  * @private
  */
-Blockly.Mutator.prototype.workspaceChanged_ = function(e = undefined) {
+Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (e && (e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -352,7 +352,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.resizeBubble_();
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
-    // Update source block immediately when bubble is visible
+    // Update the source block immediately after the bubble becomes visible
     this.updateWorkspace_();
     this.applyColour();
   } else {

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -352,6 +352,8 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     this.resizeBubble_();
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
+    // Update source block immediately when bubble is visible
+    this.workspaceChanged_();
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -378,8 +380,9 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
  * @private
  */
 Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
-  if (e.isUiEvent ||
-      (e.type == Blockly.Events.CHANGE && e.element == 'disabled')) {
+  if (e && (e.isUiEvent ||
+      (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
+      e.type == Blockly.Events.CREATE)) {
     return;
   }
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -353,7 +353,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     // Update source block immediately when bubble is visible
-    this.updateWorkspace();
+    this.updateWorkspace_();
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -381,7 +381,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (!(e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {
-    this.updateWorkspace();
+    this.updateWorkspace_();
   }
 };
 
@@ -390,7 +390,7 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
  * Bump down any block that's too high.
  * @private
  */
-Blockly.Mutator.prototype.updateWorkspace = function() {
+Blockly.Mutator.prototype.updateWorkspace_ = function() {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -353,7 +353,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     // Update source block immediately when bubble is visible
-    this.workspaceChanged_(null);
+    this.updateWorkspace();
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -373,19 +373,24 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
 };
 
 /**
- * Update the source block when the mutator's blocks are changed.
- * Bump down any block that's too high.
  * Fired whenever a change is made to the mutator's workspace.
  * @param {!Blockly.Events.Abstract} e Custom data for event.
  * @private
  */
 Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
-  if (e && (e.isUiEvent ||
+  if (!(e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {
-    return;
+    this.updateWorkspace();
   }
+};
 
+/**
+ * Update the source block when the mutator's blocks are changed.
+ * Bump down any block that's too high.
+ * @private
+ */
+Blockly.Mutator.prototype.updateWorkspace = function() {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -353,7 +353,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     // Update source block immediately when bubble is visible
-    this.updateWorkspace_();
+    this.updateWorkspace();
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -381,16 +381,15 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (!(e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {
-    this.updateWorkspace_();
+    this.updateWorkspace();
   }
 };
 
 /**
  * Update the source block when the mutator's blocks are changed.
  * Bump down any block that's too high.
- * @private
  */
-Blockly.Mutator.prototype.updateWorkspace_ = function() {
+Blockly.Mutator.prototype.updateWorkspace = function() {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -353,7 +353,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     // When the mutator's workspace changes, update the source block.
     this.workspace_.addChangeListener(this.workspaceChanged_.bind(this));
     // Update source block immediately when bubble is visible
-    this.updateWorkspace();
+    this.updateWorkspace_();
     this.applyColour();
   } else {
     // Dispose of the bubble.
@@ -381,15 +381,16 @@ Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
   if (!(e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {
-    this.updateWorkspace();
+    this.updateWorkspace_();
   }
 };
 
 /**
- * Update the source block when the mutator's blocks are changed.
+ * Updates the source block when the mutator's blocks are changed.
  * Bump down any block that's too high.
+ * @private
  */
-Blockly.Mutator.prototype.updateWorkspace = function() {
+Blockly.Mutator.prototype.updateWorkspace_ = function() {
   if (!this.workspace_.isDragging()) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -379,7 +379,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
  * @param {!Blockly.Events.Abstract} e Custom data for event.
  * @private
  */
-Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
+Blockly.Mutator.prototype.workspaceChanged_ = function(e = undefined) {
   if (e && (e.isUiEvent ||
       (e.type == Blockly.Events.CHANGE && e.element == 'disabled') ||
       e.type == Blockly.Events.CREATE)) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #5183

### Proposed Changes

Updates the mutator workspace immediately when it is visible instead of waiting for the Blockly.Events.CREATE event to fire, since there is sometimes a delay between when the mutator workspace is set to visible and when the event is fired, which causes a visible shift in block position when such a delay occurs.

Also updated the workspaceChanged_ function so it does not continue execution of if the parameter event type is a Blockly.Events.CREATE event to avoid multiple calls when the mutator is set to visible. 
(May cause some issues though if the workspaceChanged_ listener is being used to initialise the mutator workspace elsewhere; doesn't seem like it but not sure)

#### Behavior Before Change

Blocks will sometimes remain in their default position for a moment before moving to their correct positions.

#### Behavior After Change

Blocks immediately move to their correct position when the mutator editor is set to visible.

### Test Coverage

Tested on:
- Ubuntu 21.04 desktop Chromium
- Ubuntu 21.04 desktop Firefox

