### PR TITLE
Migrate core/theme_manager.js to goog.module syntax

### DIFF
--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -32,7 +32,6 @@ const dom = goog.require('Blockly.utils.dom');
  * @package
  */
 const ThemeManager = function(workspace, theme) {
-
   /**
    * The main workspace.
    * @type {!WorkspaceSvg}
@@ -65,10 +64,10 @@ const ThemeManager = function(workspace, theme) {
 /**
  * A Blockly UI component type.
  * @typedef {{
-  *            element:!Element,
-  *            propertyName:string
-  *          }}
-  */
+ *            element:!Element,
+ *            propertyName:string
+ *          }}
+ */
 ThemeManager.Component;
 
 /**
@@ -104,8 +103,8 @@ ThemeManager.prototype.setTheme = function(theme) {
   }
 
   // Refresh all registered Blockly UI components.
-  for (let i = 0, keys = Object.keys(this.componentDB_),
-    key; (key = keys[i]); i++) {
+  for (let i = 0, keys = Object.keys(this.componentDB_), key; (key = keys[i]);
+       i++) {
     for (let j = 0, component; (component = this.componentDB_[key][j]); j++) {
       const element = component.element;
       const propertyName = component.propertyName;
@@ -149,17 +148,15 @@ ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {
  * @param {string} propertyName The inline style property name to update.
  * @package
  */
-ThemeManager.prototype.subscribe = function(element, componentName,
-    propertyName) {
+ThemeManager.prototype.subscribe = function(
+    element, componentName, propertyName) {
   if (!this.componentDB_[componentName]) {
     this.componentDB_[componentName] = [];
   }
 
   // Add the element to our component map.
-  this.componentDB_[componentName].push({
-    element: element,
-    propertyName: propertyName
-  });
+  this.componentDB_[componentName].push(
+      {element: element, propertyName: propertyName});
 
   // Initialize the element with its corresponding theme style.
   const style = this.theme_ && this.theme_.getComponentStyle(componentName);

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -12,7 +12,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.ThemeManager');
+goog.module('Blockly.ThemeManager');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Theme');
 
@@ -27,7 +28,7 @@ goog.requireType('Blockly.WorkspaceSvg');
  * @constructor
  * @package
  */
-Blockly.ThemeManager = function(workspace, theme) {
+const ThemeManager = function(workspace, theme) {
 
   /**
    * The main workspace.
@@ -52,7 +53,7 @@ Blockly.ThemeManager = function(workspace, theme) {
 
   /**
    * A map of subscribed UI components, keyed by component name.
-   * @type {!Object<string, !Array<!Blockly.ThemeManager.Component>>}
+   * @type {!Object<string, !Array<!ThemeManager.Component>>}
    * @private
    */
   this.componentDB_ = Object.create(null);
@@ -65,14 +66,14 @@ Blockly.ThemeManager = function(workspace, theme) {
   *            propertyName:string
   *          }}
   */
-Blockly.ThemeManager.Component;
+ThemeManager.Component;
 
 /**
  * Get the workspace theme.
  * @return {!Blockly.Theme} The workspace theme.
  * @package
  */
-Blockly.ThemeManager.prototype.getTheme = function() {
+ThemeManager.prototype.getTheme = function() {
   return this.theme_;
 };
 
@@ -81,7 +82,7 @@ Blockly.ThemeManager.prototype.getTheme = function() {
  * @param {!Blockly.Theme} theme The workspace theme.
  * @package
  */
-Blockly.ThemeManager.prototype.setTheme = function(theme) {
+ThemeManager.prototype.setTheme = function(theme) {
   const prevTheme = this.theme_;
   this.theme_ = theme;
 
@@ -119,7 +120,7 @@ Blockly.ThemeManager.prototype.setTheme = function(theme) {
  * @param {!Blockly.Workspace} workspace The workspace to subscribe.
  * @package
  */
-Blockly.ThemeManager.prototype.subscribeWorkspace = function(workspace) {
+ThemeManager.prototype.subscribeWorkspace = function(workspace) {
   this.subscribedWorkspaces_.push(workspace);
 };
 
@@ -128,7 +129,7 @@ Blockly.ThemeManager.prototype.subscribeWorkspace = function(workspace) {
  * @param {!Blockly.Workspace} workspace The workspace to unsubscribe.
  * @package
  */
-Blockly.ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {
+ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {
   const index = this.subscribedWorkspaces_.indexOf(workspace);
   if (index < 0) {
     throw Error('Cannot unsubscribe a workspace that hasn\'t been subscribed.');
@@ -145,7 +146,7 @@ Blockly.ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {
  * @param {string} propertyName The inline style property name to update.
  * @package
  */
-Blockly.ThemeManager.prototype.subscribe = function(element, componentName,
+ThemeManager.prototype.subscribe = function(element, componentName,
     propertyName) {
   if (!this.componentDB_[componentName]) {
     this.componentDB_[componentName] = [];
@@ -167,7 +168,7 @@ Blockly.ThemeManager.prototype.subscribe = function(element, componentName,
  * @param {Element} element The element to unsubscribe.
  * @package
  */
-Blockly.ThemeManager.prototype.unsubscribe = function(element) {
+ThemeManager.prototype.unsubscribe = function(element) {
   if (!element) {
     return;
   }
@@ -192,9 +193,11 @@ Blockly.ThemeManager.prototype.unsubscribe = function(element) {
  * @package
  * @suppress {checkTypes}
  */
-Blockly.ThemeManager.prototype.dispose = function() {
+ThemeManager.prototype.dispose = function() {
   this.owner_ = null;
   this.theme_ = null;
   this.subscribedWorkspaces_ = null;
   this.componentDB_ = null;
 };
+
+exports = ThemeManager;

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -82,11 +82,11 @@ Blockly.ThemeManager.prototype.getTheme = function() {
  * @package
  */
 Blockly.ThemeManager.prototype.setTheme = function(theme) {
-  var prevTheme = this.theme_;
+  const prevTheme = this.theme_;
   this.theme_ = theme;
 
   // Set the theme name onto the injection div.
-  var injectionDiv = this.workspace_.getInjectionDiv();
+  const injectionDiv = this.workspace_.getInjectionDiv();
   if (injectionDiv) {
     if (prevTheme) {
       Blockly.utils.dom.removeClass(injectionDiv, prevTheme.getClassName());
@@ -95,17 +95,17 @@ Blockly.ThemeManager.prototype.setTheme = function(theme) {
   }
 
   // Refresh all subscribed workspaces.
-  for (var i = 0, workspace; (workspace = this.subscribedWorkspaces_[i]); i++) {
+  for (let i = 0, workspace; (workspace = this.subscribedWorkspaces_[i]); i++) {
     workspace.refreshTheme();
   }
 
   // Refresh all registered Blockly UI components.
-  for (var i = 0, keys = Object.keys(this.componentDB_),
+  for (let i = 0, keys = Object.keys(this.componentDB_),
     key; (key = keys[i]); i++) {
-    for (var j = 0, component; (component = this.componentDB_[key][j]); j++) {
-      var element = component.element;
-      var propertyName = component.propertyName;
-      var style = this.theme_ && this.theme_.getComponentStyle(key);
+    for (let j = 0, component; (component = this.componentDB_[key][j]); j++) {
+      const element = component.element;
+      const propertyName = component.propertyName;
+      const style = this.theme_ && this.theme_.getComponentStyle(key);
       element.style[propertyName] = style || '';
     }
   }
@@ -129,7 +129,7 @@ Blockly.ThemeManager.prototype.subscribeWorkspace = function(workspace) {
  * @package
  */
 Blockly.ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {
-  var index = this.subscribedWorkspaces_.indexOf(workspace);
+  const index = this.subscribedWorkspaces_.indexOf(workspace);
   if (index < 0) {
     throw Error('Cannot unsubscribe a workspace that hasn\'t been subscribed.');
   }
@@ -158,7 +158,7 @@ Blockly.ThemeManager.prototype.subscribe = function(element, componentName,
   });
 
   // Initialize the element with its corresponding theme style.
-  var style = this.theme_ && this.theme_.getComponentStyle(componentName);
+  const style = this.theme_ && this.theme_.getComponentStyle(componentName);
   element.style[propertyName] = style || '';
 };
 
@@ -172,10 +172,10 @@ Blockly.ThemeManager.prototype.unsubscribe = function(element) {
     return;
   }
   // Go through all component, and remove any references to this element.
-  var componentNames = Object.keys(this.componentDB_);
-  for (var c = 0, componentName; (componentName = componentNames[c]); c++) {
-    var elements = this.componentDB_[componentName];
-    for (var i = elements.length - 1; i >= 0; i--) {
+  const componentNames = Object.keys(this.componentDB_);
+  for (let c = 0, componentName; (componentName = componentNames[c]); c++) {
+    const elements = this.componentDB_[componentName];
+    for (let i = elements.length - 1; i >= 0; i--) {
       if (elements[i].element === element) {
         elements.splice(i, 1);
       }

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -15,16 +15,19 @@
 goog.module('Blockly.ThemeManager');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Theme');
-
-goog.requireType('Blockly.Workspace');
-goog.requireType('Blockly.WorkspaceSvg');
+/* eslint-disable-next-line no-unused-vars */
+const Theme = goog.requireType('Blockly.Theme');
+/* eslint-disable-next-line no-unused-vars */
+const Workspace = goog.requireType('Blockly.Workspace');
+/* eslint-disable-next-line no-unused-vars */
+const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
+const dom = goog.require('Blockly.utils.dom');
 
 
 /**
  * Class for storing and updating a workspace's theme and UI components.
- * @param {!Blockly.WorkspaceSvg} workspace The main workspace.
- * @param {!Blockly.Theme} theme The workspace theme.
+ * @param {!WorkspaceSvg} workspace The main workspace.
+ * @param {!Theme} theme The workspace theme.
  * @constructor
  * @package
  */
@@ -32,21 +35,21 @@ const ThemeManager = function(workspace, theme) {
 
   /**
    * The main workspace.
-   * @type {!Blockly.WorkspaceSvg}
+   * @type {!WorkspaceSvg}
    * @private
    */
   this.workspace_ = workspace;
 
   /**
    * The Blockly theme to use.
-   * @type {!Blockly.Theme}
+   * @type {!Theme}
    * @private
    */
   this.theme_ = theme;
 
   /**
    * A list of workspaces that are subscribed to this theme.
-   * @type {!Array<Blockly.Workspace>}
+   * @type {!Array<Workspace>}
    * @private
    */
   this.subscribedWorkspaces_ = [];
@@ -70,7 +73,7 @@ ThemeManager.Component;
 
 /**
  * Get the workspace theme.
- * @return {!Blockly.Theme} The workspace theme.
+ * @return {!Theme} The workspace theme.
  * @package
  */
 ThemeManager.prototype.getTheme = function() {
@@ -79,7 +82,7 @@ ThemeManager.prototype.getTheme = function() {
 
 /**
  * Set the workspace theme, and refresh the workspace and all components.
- * @param {!Blockly.Theme} theme The workspace theme.
+ * @param {!Theme} theme The workspace theme.
  * @package
  */
 ThemeManager.prototype.setTheme = function(theme) {
@@ -90,9 +93,9 @@ ThemeManager.prototype.setTheme = function(theme) {
   const injectionDiv = this.workspace_.getInjectionDiv();
   if (injectionDiv) {
     if (prevTheme) {
-      Blockly.utils.dom.removeClass(injectionDiv, prevTheme.getClassName());
+      dom.removeClass(injectionDiv, prevTheme.getClassName());
     }
-    Blockly.utils.dom.addClass(injectionDiv, this.theme_.getClassName());
+    dom.addClass(injectionDiv, this.theme_.getClassName());
   }
 
   // Refresh all subscribed workspaces.
@@ -117,7 +120,7 @@ ThemeManager.prototype.setTheme = function(theme) {
 /**
  * Subscribe a workspace to changes to the selected theme.  If a new theme is
  * set, the workspace is called to refresh its blocks.
- * @param {!Blockly.Workspace} workspace The workspace to subscribe.
+ * @param {!Workspace} workspace The workspace to subscribe.
  * @package
  */
 ThemeManager.prototype.subscribeWorkspace = function(workspace) {
@@ -126,7 +129,7 @@ ThemeManager.prototype.subscribeWorkspace = function(workspace) {
 
 /**
  * Unsubscribe a workspace to changes to the selected theme.
- * @param {!Blockly.Workspace} workspace The workspace to unsubscribe.
+ * @param {!Workspace} workspace The workspace to unsubscribe.
  * @package
  */
 ThemeManager.prototype.unsubscribeWorkspace = function(workspace) {

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -164,7 +164,7 @@ goog.addDependency('../../core/shortcut_registry.js', ['Blockly.ShortcutRegistry
 goog.addDependency('../../core/theme.js', ['Blockly.Theme'], ['Blockly.registry', 'Blockly.utils', 'Blockly.utils.object']);
 goog.addDependency('../../core/theme/classic.js', ['Blockly.Themes.Classic'], ['Blockly.Theme']);
 goog.addDependency('../../core/theme/zelos.js', ['Blockly.Themes.Zelos'], ['Blockly.Theme']);
-goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.Theme']);
+goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.Theme'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/toolbox/category.js', ['Blockly.ToolboxCategory'], ['Blockly.ISelectableToolboxItem', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es5'});
 goog.addDependency('../../core/toolbox/collapsible_category.js', ['Blockly.CollapsibleToolboxCategory'], ['Blockly.ICollapsibleToolboxItem', 'Blockly.ToolboxCategory', 'Blockly.ToolboxItem', 'Blockly.ToolboxSeparator', 'Blockly.registry', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox']);
 goog.addDependency('../../core/toolbox/separator.js', ['Blockly.ToolboxSeparator'], ['Blockly.IToolboxItem', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils.dom'], {'lang': 'es5'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -164,7 +164,7 @@ goog.addDependency('../../core/shortcut_registry.js', ['Blockly.ShortcutRegistry
 goog.addDependency('../../core/theme.js', ['Blockly.Theme'], ['Blockly.registry', 'Blockly.utils', 'Blockly.utils.object']);
 goog.addDependency('../../core/theme/classic.js', ['Blockly.Themes.Classic'], ['Blockly.Theme']);
 goog.addDependency('../../core/theme/zelos.js', ['Blockly.Themes.Zelos'], ['Blockly.Theme']);
-goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.Theme'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.utils.dom'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/toolbox/category.js', ['Blockly.ToolboxCategory'], ['Blockly.ISelectableToolboxItem', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es5'});
 goog.addDependency('../../core/toolbox/collapsible_category.js', ['Blockly.CollapsibleToolboxCategory'], ['Blockly.ICollapsibleToolboxItem', 'Blockly.ToolboxCategory', 'Blockly.ToolboxItem', 'Blockly.ToolboxSeparator', 'Blockly.registry', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox']);
 goog.addDependency('../../core/toolbox/separator.js', ['Blockly.ToolboxSeparator'], ['Blockly.IToolboxItem', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils.dom'], {'lang': 'es5'});


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/theme_manager.js` to `goog.module` with ES6 `const`/`let`.