### PR TITLE
Migrate core/events/events_abstract.js to goog.module syntax

### DIFF
--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -14,9 +14,8 @@
 goog.module('Blockly.Events.Abstract');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Events');
-
-goog.requireType('Blockly.Workspace');
+const Events = goog.require('Blockly.Events');
+const Workspace = goog.requireType('Blockly.Workspace');
 
 
 /**
@@ -43,13 +42,13 @@ const Abstract = function() {
    * perspective, and should be undone together.
    * @type {string}
    */
-  this.group = Blockly.Events.getGroup();
+  this.group = Events.getGroup();
 
   /**
    * Sets whether the event should be added to the undo stack.
    * @type {boolean}
    */
-  this.recordUndo = Blockly.Events.recordUndo;
+  this.recordUndo = Events.recordUndo;
 };
 
 /**
@@ -99,14 +98,14 @@ Abstract.prototype.run = function(_forward) {
 
 /**
  * Get workspace the event belongs to.
- * @return {!Blockly.Workspace} The workspace the event belongs to.
+ * @return {!Workspace} The workspace the event belongs to.
  * @throws {Error} if workspace is null.
  * @protected
  */
 Abstract.prototype.getEventWorkspace_ = function() {
   let workspace;
   if (this.workspaceId) {
-    workspace = Blockly.Workspace.getById(this.workspaceId);
+    workspace = Workspace.getById(this.workspaceId);
   }
   if (!workspace) {
     throw Error('Workspace is null. Event must have been generated from real' +

--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -23,7 +23,6 @@ const Workspace = goog.requireType('Blockly.Workspace');
  * @constructor
  */
 const Abstract = function() {
-
   /**
    * Whether or not the event is blank (to be populated by fromJson).
    * @type {?boolean}
@@ -62,9 +61,7 @@ Abstract.prototype.isUiEvent = false;
  * @return {!Object} JSON representation.
  */
 Abstract.prototype.toJson = function() {
-  const json = {
-    'type': this.type
-  };
+  const json = {'type': this.type};
   if (this.group) {
     json['group'] = this.group;
   }
@@ -108,7 +105,8 @@ Abstract.prototype.getEventWorkspace_ = function() {
     workspace = Workspace.getById(this.workspaceId);
   }
   if (!workspace) {
-    throw Error('Workspace is null. Event must have been generated from real' +
+    throw Error(
+        'Workspace is null. Event must have been generated from real' +
         ' Blockly events.');
   }
   return workspace;

--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Events.Abstract');
+goog.module('Blockly.Events.Abstract');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Events');
 
@@ -22,7 +23,7 @@ goog.requireType('Blockly.Workspace');
  * Abstract class for an event.
  * @constructor
  */
-Blockly.Events.Abstract = function() {
+const Abstract = function() {
 
   /**
    * Whether or not the event is blank (to be populated by fromJson).
@@ -55,13 +56,13 @@ Blockly.Events.Abstract = function() {
  * Whether or not the event is a UI event.
  * @type {boolean}
  */
-Blockly.Events.Abstract.prototype.isUiEvent = false;
+Abstract.prototype.isUiEvent = false;
 
 /**
  * Encode the event as JSON.
  * @return {!Object} JSON representation.
  */
-Blockly.Events.Abstract.prototype.toJson = function() {
+Abstract.prototype.toJson = function() {
   const json = {
     'type': this.type
   };
@@ -75,7 +76,7 @@ Blockly.Events.Abstract.prototype.toJson = function() {
  * Decode the JSON event.
  * @param {!Object} json JSON representation.
  */
-Blockly.Events.Abstract.prototype.fromJson = function(json) {
+Abstract.prototype.fromJson = function(json) {
   this.isBlank = false;
   this.group = json['group'];
 };
@@ -84,7 +85,7 @@ Blockly.Events.Abstract.prototype.fromJson = function(json) {
  * Does this event record any change of state?
  * @return {boolean} True if null, false if something changed.
  */
-Blockly.Events.Abstract.prototype.isNull = function() {
+Abstract.prototype.isNull = function() {
   return false;
 };
 
@@ -92,7 +93,7 @@ Blockly.Events.Abstract.prototype.isNull = function() {
  * Run an event.
  * @param {boolean} _forward True if run forward, false if run backward (undo).
  */
-Blockly.Events.Abstract.prototype.run = function(_forward) {
+Abstract.prototype.run = function(_forward) {
   // Defined by subclasses.
 };
 
@@ -102,7 +103,7 @@ Blockly.Events.Abstract.prototype.run = function(_forward) {
  * @throws {Error} if workspace is null.
  * @protected
  */
-Blockly.Events.Abstract.prototype.getEventWorkspace_ = function() {
+Abstract.prototype.getEventWorkspace_ = function() {
   let workspace;
   if (this.workspaceId) {
     workspace = Blockly.Workspace.getById(this.workspaceId);
@@ -113,3 +114,5 @@ Blockly.Events.Abstract.prototype.getEventWorkspace_ = function() {
   }
   return workspace;
 };
+
+exports = Abstract;

--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -62,7 +62,7 @@ Blockly.Events.Abstract.prototype.isUiEvent = false;
  * @return {!Object} JSON representation.
  */
 Blockly.Events.Abstract.prototype.toJson = function() {
-  var json = {
+  const json = {
     'type': this.type
   };
   if (this.group) {
@@ -103,8 +103,9 @@ Blockly.Events.Abstract.prototype.run = function(_forward) {
  * @protected
  */
 Blockly.Events.Abstract.prototype.getEventWorkspace_ = function() {
+  let workspace;
   if (this.workspaceId) {
-    var workspace = Blockly.Workspace.getById(this.workspaceId);
+    workspace = Blockly.Workspace.getById(this.workspaceId);
   }
   if (!workspace) {
     throw Error('Workspace is null. Event must have been generated from real' +

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -33,7 +33,7 @@ goog.addDependency('../../core/drag_target.js', ['Blockly.DragTarget'], ['Blockl
 goog.addDependency('../../core/dropdowndiv.js', ['Blockly.DropDownDiv'], ['Blockly.utils.Rect', 'Blockly.utils.dom', 'Blockly.utils.math', 'Blockly.utils.style']);
 goog.addDependency('../../core/events/block_events.js', ['Blockly.Events.BlockBase', 'Blockly.Events.BlockChange', 'Blockly.Events.BlockCreate', 'Blockly.Events.BlockDelete', 'Blockly.Events.BlockMove', 'Blockly.Events.Change', 'Blockly.Events.Create', 'Blockly.Events.Delete', 'Blockly.Events.Move'], ['Blockly.Events', 'Blockly.Events.Abstract', 'Blockly.Xml', 'Blockly.connectionTypes', 'Blockly.registry', 'Blockly.utils.Coordinate', 'Blockly.utils.object', 'Blockly.utils.xml']);
 goog.addDependency('../../core/events/events.js', ['Blockly.Events'], ['Blockly.registry', 'Blockly.utils']);
-goog.addDependency('../../core/events/events_abstract.js', ['Blockly.Events.Abstract'], ['Blockly.Events']);
+goog.addDependency('../../core/events/events_abstract.js', ['Blockly.Events.Abstract'], ['Blockly.Events'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/events/events_block_drag.js', ['Blockly.Events.BlockDrag'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_bubble_open.js', ['Blockly.Events.BubbleOpen'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_click.js', ['Blockly.Events.Click'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/events/events_abstract.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [ ] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/events/events_abstract.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
