### PR TITLE
Migrate core/warning.js to goog.module syntax

### DIFF
--- a/core/warning.js
+++ b/core/warning.js
@@ -13,24 +13,26 @@
 goog.module('Blockly.Warning');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Bubble');
-goog.require('Blockly.Events');
+/* eslint-disable-next-line no-unused-vars */
+const Block = goog.requireType('Blockly.Block');
+/* eslint-disable-next-line no-unused-vars */
+const BlockSvg = goog.requireType('Blockly.BlockSvg');
+const Bubble = goog.require('Blockly.Bubble');
+/* eslint-disable-next-line no-unused-vars */
+const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+const Events = goog.require('Blockly.Events');
+const Icon = goog.require('Blockly.Icon');
+const Svg = goog.require('Blockly.utils.Svg');
+const dom = goog.require('Blockly.utils.dom');
+const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BubbleOpen');
-goog.require('Blockly.Icon');
-goog.require('Blockly.utils.dom');
-goog.require('Blockly.utils.object');
-goog.require('Blockly.utils.Svg');
-
-goog.requireType('Blockly.Block');
-goog.requireType('Blockly.BlockSvg');
-goog.requireType('Blockly.utils.Coordinate');
 
 
 /**
  * Class for a warning.
- * @param {!Blockly.Block} block The block associated with this warning.
- * @extends {Blockly.Icon}
+ * @param {!Block} block The block associated with this warning.
+ * @extends {Icon}
  * @constructor
  */
 const Warning = function(block) {
@@ -39,7 +41,7 @@ const Warning = function(block) {
   // The text_ object can contain multiple warnings.
   this.text_ = Object.create(null);
 };
-Blockly.utils.object.inherits(Warning, Blockly.Icon);
+object.inherits(Warning, Icon);
 
 /**
  * Does this icon get hidden when the block is collapsed.
@@ -53,8 +55,8 @@ Warning.prototype.collapseHidden = false;
  */
 Warning.prototype.drawIcon_ = function(group) {
   // Triangle with rounded corners.
-  Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.PATH,
+  dom.createSvgElement(
+      Svg.PATH,
       {
         'class': 'blocklyIconShape',
         'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z'
@@ -63,16 +65,16 @@ Warning.prototype.drawIcon_ = function(group) {
   // Can't use a real '!' text character since different browsers and operating
   // systems render it differently.
   // Body of exclamation point.
-  Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.PATH,
+  dom.createSvgElement(
+      Svg.PATH,
       {
         'class': 'blocklyIconSymbol',
         'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z'
       },
       group);
   // Dot of exclamation point.
-  Blockly.utils.dom.createSvgElement(
-      Blockly.utils.Svg.RECT,
+  dom.createSvgElement(
+      Svg.RECT,
       {
         'class': 'blocklyIconSymbol',
         'x': '7', 'y': '11', 'height': '2', 'width': '2'
@@ -88,7 +90,7 @@ Warning.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
     return;
   }
-  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.BUBBLE_OPEN))(
+  Events.fire(new (Events.get(Events.BUBBLE_OPEN))(
       this.block_, visible, 'warning'));
   if (visible) {
     this.createBubble_();
@@ -102,10 +104,10 @@ Warning.prototype.setVisible = function(visible) {
  * @private
  */
 Warning.prototype.createBubble_ = function() {
-  this.paragraphElement_ = Blockly.Bubble.textToDom(this.getText());
-  this.bubble_ = Blockly.Bubble.createNonEditableBubble(
-      this.paragraphElement_, /** @type {!Blockly.BlockSvg} */ (this.block_),
-      /** @type {!Blockly.utils.Coordinate} */ (this.iconXY_));
+  this.paragraphElement_ = Bubble.textToDom(this.getText());
+  this.bubble_ = Bubble.createNonEditableBubble(
+      this.paragraphElement_, /** @type {!BlockSvg} */ (this.block_),
+      /** @type {!Coordinate} */ (this.iconXY_));
   this.applyColour();
 };
 
@@ -158,7 +160,7 @@ Warning.prototype.getText = function() {
  */
 Warning.prototype.dispose = function() {
   this.block_.warning = null;
-  Blockly.Icon.prototype.dispose.call(this);
+  Icon.prototype.dispose.call(this);
 };
 
 exports = Warning;

--- a/core/warning.js
+++ b/core/warning.js
@@ -145,8 +145,8 @@ Blockly.Warning.prototype.setText = function(text, id) {
  * @return {string} All texts concatenated into one string.
  */
 Blockly.Warning.prototype.getText = function() {
-  var allWarnings = [];
-  for (var id in this.text_) {
+  const allWarnings = [];
+  for (let id in this.text_) {
     allWarnings.push(this.text_[id]);
   }
   return allWarnings.join('\n');

--- a/core/warning.js
+++ b/core/warning.js
@@ -56,8 +56,7 @@ Warning.prototype.collapseHidden = false;
 Warning.prototype.drawIcon_ = function(group) {
   // Triangle with rounded corners.
   dom.createSvgElement(
-      Svg.PATH,
-      {
+      Svg.PATH, {
         'class': 'blocklyIconShape',
         'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z'
       },
@@ -66,18 +65,19 @@ Warning.prototype.drawIcon_ = function(group) {
   // systems render it differently.
   // Body of exclamation point.
   dom.createSvgElement(
-      Svg.PATH,
-      {
+      Svg.PATH, {
         'class': 'blocklyIconSymbol',
         'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z'
       },
       group);
   // Dot of exclamation point.
   dom.createSvgElement(
-      Svg.RECT,
-      {
+      Svg.RECT, {
         'class': 'blocklyIconSymbol',
-        'x': '7', 'y': '11', 'height': '2', 'width': '2'
+        'x': '7',
+        'y': '11',
+        'height': '2',
+        'width': '2'
       },
       group);
 };
@@ -90,8 +90,8 @@ Warning.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
     return;
   }
-  Events.fire(new (Events.get(Events.BUBBLE_OPEN))(
-      this.block_, visible, 'warning'));
+  Events.fire(
+      new (Events.get(Events.BUBBLE_OPEN))(this.block_, visible, 'warning'));
   if (visible) {
     this.createBubble_();
   } else {

--- a/core/warning.js
+++ b/core/warning.js
@@ -149,7 +149,7 @@ Warning.prototype.setText = function(text, id) {
  */
 Warning.prototype.getText = function() {
   const allWarnings = [];
-  for (let id in this.text_) {
+  for (const id in this.text_) {
     allWarnings.push(this.text_[id]);
   }
   return allWarnings.join('\n');

--- a/core/warning.js
+++ b/core/warning.js
@@ -10,7 +10,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Warning');
+goog.module('Blockly.Warning');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Bubble');
 goog.require('Blockly.Events');
@@ -32,25 +33,25 @@ goog.requireType('Blockly.utils.Coordinate');
  * @extends {Blockly.Icon}
  * @constructor
  */
-Blockly.Warning = function(block) {
-  Blockly.Warning.superClass_.constructor.call(this, block);
+const Warning = function(block) {
+  Warning.superClass_.constructor.call(this, block);
   this.createIcon();
   // The text_ object can contain multiple warnings.
   this.text_ = Object.create(null);
 };
-Blockly.utils.object.inherits(Blockly.Warning, Blockly.Icon);
+Blockly.utils.object.inherits(Warning, Blockly.Icon);
 
 /**
  * Does this icon get hidden when the block is collapsed.
  */
-Blockly.Warning.prototype.collapseHidden = false;
+Warning.prototype.collapseHidden = false;
 
 /**
  * Draw the warning icon.
  * @param {!Element} group The icon group.
  * @protected
  */
-Blockly.Warning.prototype.drawIcon_ = function(group) {
+Warning.prototype.drawIcon_ = function(group) {
   // Triangle with rounded corners.
   Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.PATH,
@@ -83,7 +84,7 @@ Blockly.Warning.prototype.drawIcon_ = function(group) {
  * Show or hide the warning bubble.
  * @param {boolean} visible True if the bubble should be visible.
  */
-Blockly.Warning.prototype.setVisible = function(visible) {
+Warning.prototype.setVisible = function(visible) {
   if (visible == this.isVisible()) {
     return;
   }
@@ -100,7 +101,7 @@ Blockly.Warning.prototype.setVisible = function(visible) {
  * Show the bubble.
  * @private
  */
-Blockly.Warning.prototype.createBubble_ = function() {
+Warning.prototype.createBubble_ = function() {
   this.paragraphElement_ = Blockly.Bubble.textToDom(this.getText());
   this.bubble_ = Blockly.Bubble.createNonEditableBubble(
       this.paragraphElement_, /** @type {!Blockly.BlockSvg} */ (this.block_),
@@ -112,7 +113,7 @@ Blockly.Warning.prototype.createBubble_ = function() {
  * Dispose of the bubble and references to it.
  * @private
  */
-Blockly.Warning.prototype.disposeBubble_ = function() {
+Warning.prototype.disposeBubble_ = function() {
   this.bubble_.dispose();
   this.bubble_ = null;
   this.paragraphElement_ = null;
@@ -125,7 +126,7 @@ Blockly.Warning.prototype.disposeBubble_ = function() {
  * @param {string} id An ID for this text entry to be able to maintain
  *     multiple warnings.
  */
-Blockly.Warning.prototype.setText = function(text, id) {
+Warning.prototype.setText = function(text, id) {
   if (this.text_[id] == text) {
     return;
   }
@@ -144,7 +145,7 @@ Blockly.Warning.prototype.setText = function(text, id) {
  * Get this warning's texts.
  * @return {string} All texts concatenated into one string.
  */
-Blockly.Warning.prototype.getText = function() {
+Warning.prototype.getText = function() {
   const allWarnings = [];
   for (let id in this.text_) {
     allWarnings.push(this.text_[id]);
@@ -155,7 +156,9 @@ Blockly.Warning.prototype.getText = function() {
 /**
  * Dispose of this warning.
  */
-Blockly.Warning.prototype.dispose = function() {
+Warning.prototype.dispose = function() {
   this.block_.warning = null;
   Blockly.Icon.prototype.dispose.call(this);
 };
+
+exports = Warning;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -199,7 +199,7 @@ goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Bloc
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils']);
 goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.xml']);
 goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml']);
-goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object']);
+goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/widgetdiv.js', ['Blockly.WidgetDiv'], ['Blockly.utils.dom']);
 goog.addDependency('../../core/workspace.js', ['Blockly.Workspace'], ['Blockly.ConnectionChecker', 'Blockly.Events', 'Blockly.IASTNodeLocation', 'Blockly.Options', 'Blockly.VariableMap', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.math']);
 goog.addDependency('../../core/workspace_audio.js', ['Blockly.WorkspaceAudio'], ['Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.global', 'Blockly.utils.userAgent'], {'lang': 'es5'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/warning.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/warning.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
