### PR TITLE
Fix issue where the trashcan flyout would remain an active delete region even when closed with the continuous toolbox plugin

### DIFF
--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -440,6 +440,7 @@ Blockly.Trashcan.prototype.closeFlyout = function() {
   }
   this.flyout.hide();
   this.fireUiEvent_(false);
+  this.workspace_.recordDragTargets();
 };
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Issue reported in https://groups.google.com/g/blockly/c/Wv38l8bwX5Q

### Proposed Changes
This PR recalculates the drag targets of the main workspace when the trashcan flyout is closed.

#### Behavior Before Change
With the continuous toolbox plugin, the region occupied by the trashcan flyout would remain an active delete region even once the flyout had closed.

#### Behavior After Change
The region previously occupied by the trashcan flyout is not a delete region once the flyout is closed.

### Reason for Changes
The old behavior could cause the inadvertent deletion of blocks.

### Test Coverage
Verified that all tests continue to pass.