### PR TITLE
Add serializing shadows as JSOs for the JSO system

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -744,7 +744,7 @@ Blockly.Connection.prototype.setShadowStateInternal_ =
           this.serializeShadow_(this.targetBlock());
         }
       } else {
-        var shadow = this.createShadowBlock_();
+        var shadow = this.createShadowBlock_(false);
         this.serializeShadow_(shadow);
         if (shadow) {
           shadow.dispose(false);
@@ -791,6 +791,7 @@ Blockly.Connection.prototype.createShadowBlock_ = function(attemptToConnect) {
     }
     return blockShadow;
   }
+  return null;
 };
 
 /**

--- a/core/connection.js
+++ b/core/connection.js
@@ -603,8 +603,8 @@ Blockly.Connection.prototype.getShadowDom = function(returnCurrent) {
 
 /**
  * Changes the connection's shadow block.
- * @param {?blocks.State} shadowState An state represetation of the block or
- *     null.
+ * @param {?Blockly.serialization.blocks.State} shadowState An state
+ *     represetation of the block or null.
  */
 Blockly.Connection.prototype.setShadowState = function(shadowState) {
   this.setShadowStateInternal_({shadowState: shadowState});
@@ -617,13 +617,14 @@ Blockly.Connection.prototype.setShadowState = function(shadowState) {
  *     attached to this connection, this serializes the state of that block
  *     and returns it (so that field values are correct). Otherwise the saved
  *     state is just returned.
- * @return {?blocks.State} Serialized object representation of the block, or
- *     null.
+ * @return {?Blockly.serialization.blocks.State} Serialized object
+ *     representation of the block, or null.
  */
 Blockly.Connection.prototype.getShadowState = function(returnCurrent) {
   if (returnCurrent && this.targetBlock() && this.targetBlock().isShadow()) {
-    return Blockly.serialization.blocks
-        .save(this.targetBlock(), {addNextBlocks: true});
+    return Blockly.serialization.blocks.save(
+        /** @type {!Blockly.Block} */ (this.targetBlock()),
+        {addNextBlocks: true});
   }
   return this.shadowState_;
 };
@@ -700,7 +701,8 @@ Blockly.Connection.prototype.toString = function() {
 /**
  * Returns the state of the shadowDom_ and shadowState_ properties, then
  * temporarily sets those properties to null so no shadow respawns.
- * @return {{shadowDom: ?Element, shadowState: ?Object}} The state of both the
+ * @return {{shadowDom: ?Element,
+ *     shadowState: ?Blockly.serialization.blocks.State}} The state of both the
  *     shadowDom_ and shadowState_ properties.
  * @private
  */
@@ -715,9 +717,9 @@ Blockly.Connection.prototype.stashShadowState_ = function() {
 
 /**
  * Reapplies the stashed state of the shadowDom_ and shadowState_ properties.
- * @param {{shadowDom: (?Element|undefined), shadowState:
- *     (?Object|undefined)}=} param0 The state to reapply to the shadowDom_ and
- *     shadowState_ properties.
+ * @param {{shadowDom: ?Element,
+ *     shadowState: ?Blockly.serialization.blocks.State}} param0 The state to
+ *     reapply to the shadowDom_ and shadowState_ properties.
  * @private
  */
 Blockly.Connection.prototype.applyShadowState_ =
@@ -728,9 +730,9 @@ Blockly.Connection.prototype.applyShadowState_ =
 
 /**
  * Sets the state of the shadow of this connection.
- * @param {{shadowDom: (?Element|undefined), shadowState:
- *     (?Object|undefined)}=} param0 The state to set the shadow of this
- *     connection to.
+ * @param {{shadowDom: (?Element|undefined),
+ *     shadowState: (?Blockly.serialization.blocks.State|undefined)}=} param0
+ *     The state to set the shadow of this connection to.
  * @private
  */
 Blockly.Connection.prototype.setShadowStateInternal_ =
@@ -756,7 +758,7 @@ Blockly.Connection.prototype.setShadowStateInternal_ =
         var shadow = this.createShadowBlock_();
         this.serializeShadow_(shadow);
         if (shadow) {
-          shadow.dispose();
+          shadow.dispose(false);
         }
       }
     };
@@ -797,7 +799,7 @@ Blockly.Connection.prototype.serializeShadow_ = function(shadow) {
   if (!shadow) {
     return;
   }
-  this.shadowDom_ = Blockly.Xml.blockToDom(shadow);
+  this.shadowDom_ = /** @type {!Element} */ (Blockly.Xml.blockToDom(shadow));
   this.shadowState_ = Blockly.serialization.blocks
       .save(shadow, {addNextBlocks: true});
 };

--- a/core/connection.js
+++ b/core/connection.js
@@ -702,6 +702,7 @@ Blockly.Connection.prototype.toString = function() {
  * temporarily sets those properties to null so no shadow respawns.
  * @return {{shadowDom: ?Element, shadowState: ?Object}} The state of both the
  *     shadowDom_ and shadowState_ properties.
+ * @private
  */
 Blockly.Connection.prototype.stashShadowState_ = function() {
   const shadowDom = this.getShadowDom(true);
@@ -717,6 +718,7 @@ Blockly.Connection.prototype.stashShadowState_ = function() {
  * @param {{shadowDom: (?Element|undefined), shadowState:
  *     (?Object|undefined)}=} param0 The state to reapply to the shadowDom_ and
  *     shadowState_ properties.
+ * @private
  */
 Blockly.Connection.prototype.applyShadowState_ =
     function({shadowDom, shadowState}) {
@@ -729,6 +731,7 @@ Blockly.Connection.prototype.applyShadowState_ =
  * @param {{shadowDom: (?Element|undefined), shadowState:
  *     (?Object|undefined)}=} param0 The state to set the shadow of this
  *     connection to.
+ * @private
  */
 Blockly.Connection.prototype.setShadowStateInternal_ =
     function({shadowDom = null, shadowState = null} = {}) {
@@ -763,6 +766,7 @@ Blockly.Connection.prototype.setShadowStateInternal_ =
  * shadowState_ gets priority.
  * @return {?Blockly.Block} The shadow block that was created, or null if both
  *     the shadowState_ and shadowDom_ are null.
+ * @private
  */
 Blockly.Connection.prototype.createShadowBlock_ = function() {
   var parentBlock = this.getSourceBlock();
@@ -787,6 +791,7 @@ Blockly.Connection.prototype.createShadowBlock_ = function() {
  * Saves the given shadow block to both the shadowDom_ and shadowState_
  * properties, in their respective serialized forms.
  * @param {?Blockly.Block} shadow The shadow to serialize, or null.
+ * @private
  */
 Blockly.Connection.prototype.serializeShadow_ = function(shadow) {
   if (!shadow) {

--- a/core/connection.js
+++ b/core/connection.js
@@ -623,8 +623,7 @@ Blockly.Connection.prototype.setShadowState = function(shadowState) {
 Blockly.Connection.prototype.getShadowState = function(returnCurrent) {
   if (returnCurrent && this.targetBlock() && this.targetBlock().isShadow()) {
     return Blockly.serialization.blocks.save(
-        /** @type {!Blockly.Block} */ (this.targetBlock()),
-        {addNextBlocks: true});
+        /** @type {!Blockly.Block} */ (this.targetBlock()));
   }
   return this.shadowState_;
 };
@@ -800,6 +799,5 @@ Blockly.Connection.prototype.serializeShadow_ = function(shadow) {
     return;
   }
   this.shadowDom_ = /** @type {!Element} */ (Blockly.Xml.blockToDom(shadow));
-  this.shadowState_ = Blockly.serialization.blocks
-      .save(shadow, {addNextBlocks: true});
+  this.shadowState_ = Blockly.serialization.blocks.save(shadow);
 };

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -504,7 +504,6 @@ Blockly.RenderedConnection.prototype.respawnShadow_ = function() {
   Blockly.RenderedConnection.superClass_.respawnShadow_.call(this);
   var blockShadow = this.targetBlock();
   if (!blockShadow) {
-    // This connection must not have a shadowDom_.
     return;
   }
   blockShadow.initSvg();

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -23,7 +23,6 @@ const {MissingBlockType, MissingConnection, BadConnectionCheck} =
 const Size = goog.require('Blockly.utils.Size');
 // eslint-disable-next-line no-unused-vars
 const Workspace = goog.requireType('Blockly.Workspace');
-const Xml = goog.require('Blockly.Xml');
 const inputTypes = goog.require('Blockly.inputTypes');
 
 
@@ -266,15 +265,14 @@ const saveNextBlocks = function(block, state) {
  *     shadow block, or any connected real block.
  */
 const saveConnection = function(connection) {
-  const shadow = connection.getShadowDom();
+  const shadow = connection.getShadowState();
   const child = connection.targetBlock();
   if (!shadow && !child) {
     return null;
   }
   var state = Object.create(null);
   if (shadow) {
-    state['shadow'] = Xml.domToText(shadow)
-        .replace('xmlns="https://developers.google.com/blockly/xml"', '');
+    state['shadow'] = shadow;
   }
   if (child && !child.isShadow()) {
     state['block'] = save(child);
@@ -542,7 +540,7 @@ const loadNextBlocks = function(block, state) {
  */
 const loadConnection = function(connection, connectionState) {
   if (connectionState['shadow']) {
-    connection.setShadowDom(Blockly.Xml.textToDom(connectionState['shadow']));
+    connection.setShadowState(connectionState['shadow']);
   }
   if (connectionState['block']) {
     loadInternal(

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -5,7 +5,7 @@
  */
 
 
-suite.only('Connection', function() {
+suite('Connection', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = sinon.createStubInstance(Blockly.Workspace);

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -111,12 +111,12 @@ suite('Connection', function() {
     }
 
     var testSuites = [
-      // {
-      //   title: 'Rendered',
-      //   createWorkspace: () => {
-      //     return Blockly.inject('blocklyDiv');
-      //   },
-      // },
+      {
+        title: 'Rendered',
+        createWorkspace: () => {
+          return Blockly.inject('blocklyDiv');
+        },
+      },
       {
         title: 'Headless',
         createWorkspace: () => {

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const { textChangeRangeIsUnchanged } = require("typescript");
 
-suite('Connection', function() {
+suite.only('Connection', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = sinon.createStubInstance(Blockly.Workspace);
@@ -27,8 +26,8 @@ suite('Connection', function() {
 
   test('Deprecated - canConnectWithReason passes', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
-    var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
-    var conn2 = this.createConnection(Blockly.NEXT_STATEMENT);
+    var conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    var conn2 = this.createConnection(Blockly.NEXT_NAME);
     chai.assert.equal(conn1.canConnectWithReason(conn2),
         Blockly.Connection.CAN_CONNECT);
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
@@ -37,7 +36,7 @@ suite('Connection', function() {
 
   test('Deprecated - canConnectWithReason fails', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
-    var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
+    var conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
     var conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
     chai.assert.equal(conn1.canConnectWithReason(conn2),
         Blockly.Connection.REASON_WRONG_TYPE);
@@ -47,8 +46,8 @@ suite('Connection', function() {
 
   test('Deprecated - checkConnection passes', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
-    var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
-    var conn2 = this.createConnection(Blockly.NEXT_STATEMENT);
+    var conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    var conn2 = this.createConnection(Blockly.NEXT_NAME);
     chai.assert.doesNotThrow(function() {
       conn1.checkConnection(conn2);
     });
@@ -58,7 +57,7 @@ suite('Connection', function() {
 
   test('Deprecated - checkConnection fails', function() {
     var deprecateWarnSpy = createDeprecationWarningStub();
-    var conn1 = this.createConnection(Blockly.PREVIOUS_STATEMENT);
+    var conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
     var conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
     chai.assert.throws(function() {
       conn1.checkConnection(conn2);
@@ -186,23 +185,23 @@ suite('Connection', function() {
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block"/>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true);
             });
   
             test('Multiple Statement', function() {
               var parent = createStatementBlock(this.workspace);
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '  </statement>' +
                   '</shadow>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
             });
   
             test('Next', function() {
@@ -245,7 +244,7 @@ suite('Connection', function() {
             function createStatementBlocks(workspace) {
               var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <block type="statement_block"/>' +
                   '  </statement>' +
                   '</block>'
@@ -298,29 +297,29 @@ suite('Connection', function() {
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block"/>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', false);
-              parent.getInput('STATEMENT').connection.disconnect();
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
             });
   
             test('Multiple Statement', function() {
               var parent = createStatementBlocks(this.workspace);
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '  </statement>' +
                   '</shadow>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', false);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', false);
               assertInputNotHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT');
-              parent.getInput('STATEMENT').connection.disconnect();
-              assertInputHasBlock(parent, 'STATEMENT', true);
+                  parent.getInputTargetBlock('NAME'), 'NAME');
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
             });
   
             test('Next', function() {
@@ -420,39 +419,39 @@ suite('Connection', function() {
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="1"/>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true, '1');
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true, '1');
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="2"/>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true, '2');
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true, '2');
             });
   
             test('Multiple Statement', function() {
               var parent = createStatementBlock(this.workspace);
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="1">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="a"/>' +
                   '  </statement>' +
                   '</shadow>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true, '1');
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true, '1');
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true, 'a');
+                  parent.getInputTargetBlock('NAME'), 'NAME', true, 'a');
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="2">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="b"/>' +
                   '  </statement>' +
                   '</shadow>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true, '2');
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true, '2');
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true, 'b');
+                  parent.getInputTargetBlock('NAME'), 'NAME', true, 'b');
             });
   
             test('Next', function() {
@@ -510,7 +509,7 @@ suite('Connection', function() {
             function createStatementBlock(workspace) {
               var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '  </statement>' +
                   '</block>'
@@ -537,8 +536,8 @@ suite('Connection', function() {
   
             test('Statement', function() {
               var parent = createStatementBlock(this.workspace);
-              parent.getInput('STATEMENT').connection.setShadowDom(null);
-              assertInputNotHasBlock(parent, 'STATMENT');
+              parent.getInput('NAME').connection.setShadowDom(null);
+              assertInputNotHasBlock(parent, 'STATEMENT');
             });
   
             test('Next', function() {
@@ -565,7 +564,7 @@ suite('Connection', function() {
             function createStatementBlock(workspace) {
               var block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '    <block type="statement_block"/>' +
                   '  </statement>' +
@@ -596,10 +595,10 @@ suite('Connection', function() {
   
             test('Statement', function() {
               var parent = createStatementBlock(this.workspace);
-              parent.getInput('STATEMENT').connection.setShadowDom(null);
-              assertInputHasBlock(parent, 'STATEMENT', false);
-              parent.getInput('STATEMENT').connection.disconnect();
-              assertInputNotHasBlock(parent, 'STATEMENT');
+              parent.getInput('NAME').connection.setShadowDom(null);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputNotHasBlock(parent, 'NAME');
             });
   
             test('Next', function() {
@@ -679,41 +678,41 @@ suite('Connection', function() {
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block"/>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true);
               var child = createStatementBlock(this.workspace);
-              parent.getInput('STATEMENT').connection
+              parent.getInput('NAME').connection
                   .connect(child.previousConnection);
-              assertInputHasBlock(parent, 'STATEMENT', false);
-              parent.getInput('STATEMENT').connection.disconnect();
-              assertInputHasBlock(parent, 'STATEMENT', true);
-              parent.getInput('STATEMENT').connection.setShadowDom(null);
-              assertInputNotHasBlock(parent, 'STATEMENT');
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
+              parent.getInput('NAME').connection.setShadowDom(null);
+              assertInputNotHasBlock(parent, 'NAME');
             });
   
             test('Multiple Statement', function() {
               var parent = createStatementBlock(this.workspace);
               var xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block">' +
-                  '  <statement name="STATEMENT">' +
+                  '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '  </statement>' +
                   '</shadow>'
               );
-              parent.getInput('STATEMENT').connection.setShadowDom(xml);
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              parent.getInput('NAME').connection.setShadowDom(xml);
+              assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
               var child = createStatementBlock(this.workspace);
-              parent.getInput('STATEMENT').connection
+              parent.getInput('NAME').connection
                   .connect(child.previousConnection);
-              assertInputHasBlock(parent, 'STATEMENT', false);
-              parent.getInput('STATEMENT').connection.disconnect();
-              assertInputHasBlock(parent, 'STATEMENT', true);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
-                  parent.getInputTargetBlock('STATEMENT'), 'STATEMENT', true);
-              parent.getInput('STATEMENT').connection.setShadowDom(null);
-              assertInputNotHasBlock(parent, 'STATEMENT');
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
+              parent.getInput('NAME').connection.setShadowDom(null);
+              assertInputNotHasBlock(parent, 'NAME');
             });
   
             test('Next', function() {
@@ -735,9 +734,9 @@ suite('Connection', function() {
             test('Multiple Next', function() {
               var parent = createStackBlock(this.workspace);
               var xml = Blockly.Xml.textToDom(
-                  '<shadow type="stack_block">' +
+                  '<shadow type="stack_block" id="parent">' +
                   '  <next>' +
-                  '    <shadow type="stack_block"/>' +
+                  '    <shadow type="stack_block" id="child"/>' +
                   '  </next>' +
                   '</shadow>'
               );
@@ -757,7 +756,660 @@ suite('Connection', function() {
         });
 
         suite('setShadowState', function() {
+          suite('Add - No Block Connected', function() {
+            // These are defined separately in each suite.
+            function createRowBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'row_block'}, workspace);
+            }
+  
+            function createStatementBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'statement_block'}, workspace);
+            }
+  
+            function createStackBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'stack_block'}, workspace);
+            }
 
+            test('Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection
+                  .setShadowState({'type': 'row_block'});
+              assertInputHasBlock(parent, 'INPUT', true);
+            });
+
+            test('Multiple Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState({
+                'type': 'row_block',
+                'inputs': {
+                  'INPUT': {
+                    'shadow': {
+                      'type': 'row_block',
+                    }
+                  }
+                }
+              });
+              assertInputHasBlock(parent, 'INPUT', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+            });
+
+            test('Statement', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection
+                  .setShadowState({'type': 'statement_block'});
+              assertInputHasBlock(parent, 'NAME', true);
+            });
+
+            test('Multiple Statment', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection.setShadowState({
+                'type': 'statement_block',
+                'inputs': {
+                  'NAME': {
+                    'shadow': {
+                      'type': 'statement_block',
+                    }
+                  }
+                }
+              });
+              assertInputHasBlock(parent, 'NAME', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
+            });
+
+            test('Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection.setShadowState({'type': 'stack_block'});
+              assertNextHasBlock(parent, true);
+            });
+
+            test('Muitple Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection.setShadowState({
+                'type': 'stack_block',
+                'next': {
+                  'shadow': {
+                    'type': 'stack_block'
+                  }
+                }
+              });
+              assertNextHasBlock(parent, true);
+              assertNextHasBlock(parent.getNextBlock(), true);
+            });
+          });
+
+          suite('Add - With Block Connected', function() {
+            // These are defined separately in each suite.
+            function createRowBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'row_block',
+                    'inputs': {
+                      'INPUT': {
+                        'block': {
+                          'type': 'row_block'
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStatementBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'statement_block',
+                    'inputs': {
+                      'NAME': {
+                        'block': {
+                          'type': 'statement_block'
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStackBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'stack_block',
+                    'next': {
+                      'block': {
+                        'type': 'stack_block'
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            test('Value', function() {
+              var parent = createRowBlocks(this.workspace);
+              parent.getInput('INPUT').connection
+                  .setShadowState({'type': 'row_block'});
+              assertInputHasBlock(parent, 'INPUT', false);
+              parent.getInput('INPUT').connection.disconnect();
+              assertInputHasBlock(parent, 'INPUT', true);
+            });
+  
+            test('Multiple Value', function() {
+              var parent = createRowBlocks(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState(
+                  {
+                    'type': 'row_block',
+                    'inputs': {
+                      'INPUT': {
+                        'shadow': {
+                          'type': 'row_block'
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'INPUT', false);
+              assertInputNotHasBlock(parent.getInputTargetBlock('INPUT'), 'INPUT');
+              parent.getInput('INPUT').connection.disconnect();
+              assertInputHasBlock(parent, 'INPUT', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+            });
+  
+            test('Statement', function() {
+              var parent = createStatementBlocks(this.workspace);
+              parent.getInput('NAME').connection
+                  .setShadowState({'type': 'statement_block'});
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
+            });
+  
+            test('Multiple Statement', function() {
+              var parent = createStatementBlocks(this.workspace);
+              parent.getInput('NAME').connection.setShadowState(
+                  {
+                    'type': 'statement_block',
+                    'inputs': {
+                      'NAME': {
+                        'shadow': {
+                          'type': 'statement_block'
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'NAME', false);
+              assertInputNotHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME');
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
+            });
+  
+            test('Next', function() {
+              var parent = createStackBlocks(this.workspace);
+              parent.nextConnection.setShadowState({'type': 'stack_block'});
+              assertNextHasBlock(parent, false);
+              parent.nextConnection.disconnect();
+              assertNextHasBlock(parent, true);
+            });
+  
+            test('Multiple Next', function() {
+              var parent = createStackBlocks(this.workspace);
+              parent.nextConnection.setShadowState(
+                  {
+                    'type': 'stack_block',
+                    'next': {
+                      'shadow': {
+                        'type': 'stack_block'
+                      }
+                    }
+                  }
+              );
+              assertNextHasBlock(parent, false);
+              assertNextNotHasBlock(parent.getNextBlock());
+              parent.nextConnection.disconnect();
+              assertNextHasBlock(parent, true);
+              assertNextHasBlock(parent.getNextBlock(), true);
+            });
+          });
+  
+          suite('Add - With Shadow Connected', function() {
+            // These are defined separately in each suite.
+            function createRowBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'row_block'}, workspace);
+            }
+  
+            function createStatementBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'statement_block'}, workspace);
+            }
+  
+            function createStackBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'stack_block'}, workspace);
+            }
+  
+            test('Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection
+                  .setShadowState({'type': 'row_block', 'id': '1'});
+              assertInputHasBlock(parent, 'INPUT', true, '1');
+              parent.getInput('INPUT').connection
+                  .setShadowState({'type': 'row_block', 'id': '2'});
+              assertInputHasBlock(parent, 'INPUT', true, '2');
+            });
+  
+            test('Multiple Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState(
+                  {
+                    'type': 'row_block',
+                    'id': '1',
+                    'inputs': {
+                      'INPUT': {
+                        'shadow': {
+                          'type': 'row_block',
+                          'id': 'a',
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'INPUT', true, '1');
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'a');
+              parent.getInput('INPUT').connection.setShadowState(
+                  {
+                    'type': 'row_block',
+                    'id': '2',
+                    'inputs': {
+                      'INPUT': {
+                        'shadow': {
+                          'type': 'row_block',
+                          'id': 'b',
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'INPUT', true, '2');
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'b');
+            });
+  
+            test('Statement', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection
+                  .setShadowState({'type': 'statement_block', 'id': '1'});
+              assertInputHasBlock(parent, 'NAME', true, '1');
+              parent.getInput('NAME').connection
+                  .setShadowState({'type': 'statement_block', 'id': '2'});
+              assertInputHasBlock(parent, 'NAME', true, '2');
+            });
+  
+            test('Multiple Statement', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection.setShadowState(
+                  {
+                    'type': 'statement_block',
+                    'id': '1',
+                    'inputs': {
+                      'NAME': {
+                        'shadow': {
+                          'type': 'statement_block',
+                          'id': 'a',
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'NAME', true, '1');
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true, 'a');
+              parent.getInput('NAME').connection.setShadowState(
+                  {
+                    'type': 'statement_block',
+                    'id': '2',
+                    'inputs': {
+                      'NAME': {
+                        'shadow': {
+                          'type': 'statement_block',
+                          'id': 'b',
+                        }
+                      }
+                    }
+                  }
+              );
+              assertInputHasBlock(parent, 'NAME', true, '2');
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true, 'b');
+            });
+  
+            test('Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection
+                  .setShadowState({'type': 'stack_block', 'id': '1'});
+              assertNextHasBlock(parent, true, '1');
+              parent.nextConnection
+                  .setShadowState({'type': 'stack_block', 'id': '2'});
+              assertNextHasBlock(parent, true, '2');
+            });
+  
+            test('Multiple Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection.setShadowState(
+                  {
+                    'type': 'stack_block',
+                    'id': '1',
+                    'next': {
+                      'shadow': {
+                        'type': 'stack_block',
+                        'id': 'a',
+                      }
+                    }
+                  }
+              );
+              assertNextHasBlock(parent, true, '1');
+              assertNextHasBlock(parent.getNextBlock(), true, 'a');
+              parent.nextConnection.setShadowState(
+                  {
+                    'type': 'stack_block',
+                    'id': '2',
+                    'next': {
+                      'shadow': {
+                        'type': 'stack_block',
+                        'id': 'b',
+                      }
+                    }
+                  }
+              );
+              assertNextHasBlock(parent, true, '2');
+              assertNextHasBlock(parent.getNextBlock(), true, 'b');
+            });
+          });
+  
+          suite('Remove - No Block Connected', function() {
+            // These are defined separately in each suite.
+            function createRowBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'row_block',
+                    'inputs': {
+                      'INPUT': {
+                        'shadow': {
+                          'type': 'row_block'
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStatementBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'statement_block',
+                    'inputs': {
+                      'NAME': {
+                        'shadow': {
+                          'type': 'statement_block'
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStackBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'stack_block',
+                    'next': {
+                      'shadow': {
+                        'type': 'stack_block'
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            test('Value', function() {
+              var parent = createRowBlocks(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'INPUT');
+            });
+  
+            test('Statement', function() {
+              var parent = createStatementBlocks(this.workspace);
+              parent.getInput('NAME').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'NAME');
+            });
+  
+            test('Next', function() {
+              var parent = createStackBlocks(this.workspace);
+              parent.nextConnection.setShadowState(null);
+              assertNextNotHasBlock(parent);
+            });
+          });
+  
+          suite('Remove - Block Connected', function() {
+            // These are defined separately in each suite.
+            function createRowBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'row_block',
+                    'inputs': {
+                      'INPUT': {
+                        'shadow': {
+                          'type': 'row_block'
+                        },
+                        'block': {
+                          'type': 'row_block',
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStatementBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'statement_block',
+                    'inputs': {
+                      'NAME': {
+                        'shadow': {
+                          'type': 'statement_block'
+                        },
+                        'block': {
+                          'type': 'statement_block'
+                        }
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            function createStackBlocks(workspace) {
+              return Blockly.serialization.blocks.load(
+                  {
+                    'type': 'stack_block',
+                    'next': {
+                      'shadow': {
+                        'type': 'stack_block'
+                      },
+                      'block': {
+                        'type': 'stack_block'
+                      }
+                    }
+                  },
+                  workspace);
+            }
+  
+            test('Value', function() {
+              var parent = createRowBlocks(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState(null);
+              assertInputHasBlock(parent, 'INPUT', false);
+              parent.getInput('INPUT').connection.disconnect();
+              assertInputNotHasBlock(parent, 'INPUT');
+            });
+  
+            test('Statement', function() {
+              var parent = createStatementBlocks(this.workspace);
+              parent.getInput('NAME').connection.setShadowState(null);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputNotHasBlock(parent, 'NAME');
+            });
+  
+            test('Next', function() {
+              var parent = createStackBlocks(this.workspace);
+              parent.nextConnection.setShadowState(null);
+              assertNextHasBlock(parent, false);
+              parent.nextConnection.disconnect();
+              assertNextNotHasBlock(parent);
+            });
+          });
+  
+          suite('Add - Connect & Disconnect - Remove', function() {
+            // These are defined separately in each suite.
+            function createRowBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'row_block'}, workspace);
+            }
+  
+            function createStatementBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'statement_block'}, workspace);
+            }
+  
+            function createStackBlock(workspace) {
+              return Blockly.serialization.blocks
+                  .load({'type': 'stack_block'}, workspace);
+            }
+  
+            test('Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection
+                  .setShadowState({'type': 'row_block'});
+              assertInputHasBlock(parent, 'INPUT', true);
+              var child = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              assertInputHasBlock(parent, 'INPUT', false);
+              parent.getInput('INPUT').connection.disconnect();
+              assertInputHasBlock(parent, 'INPUT', true);
+              parent.getInput('INPUT').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'INPUT');
+            });
+  
+            test('Multiple Value', function() {
+              var parent = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection.setShadowState({
+                'type': 'row_block',
+                'inputs': {
+                  'INPUT': {
+                    'shadow': {
+                      'type': 'row_block',
+                    }
+                  }
+                }
+              });
+              assertInputHasBlock(parent, 'INPUT', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+              var child = createRowBlock(this.workspace);
+              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              assertInputHasBlock(parent, 'INPUT', false);
+              parent.getInput('INPUT').connection.disconnect();
+              assertInputHasBlock(parent, 'INPUT', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT', true);
+              parent.getInput('INPUT').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'INPUT');
+            });
+  
+            test('Statement', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection
+                  .setShadowState({'type': 'statement_block'});
+              assertInputHasBlock(parent, 'NAME', true);
+              var child = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection
+                  .connect(child.previousConnection);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
+              parent.getInput('NAME').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'NAME');
+            });
+  
+            test('Multiple Statement', function() {
+              var parent = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection.setShadowState({
+                'type': 'statement_block',
+                'inputs': {
+                  'NAME': {
+                    'shadow': {
+                      'type': 'statement_block',
+                    }
+                  }
+                }
+              });
+              assertInputHasBlock(parent, 'NAME', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
+              var child = createStatementBlock(this.workspace);
+              parent.getInput('NAME').connection
+                  .connect(child.previousConnection);
+              assertInputHasBlock(parent, 'NAME', false);
+              parent.getInput('NAME').connection.disconnect();
+              assertInputHasBlock(parent, 'NAME', true);
+              assertInputHasBlock(
+                  parent.getInputTargetBlock('NAME'), 'NAME', true);
+              parent.getInput('NAME').connection.setShadowState(null);
+              assertInputNotHasBlock(parent, 'NAME');
+            });
+  
+            test('Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection.setShadowState({'type': 'stack_block'});
+              var child = createStatementBlock(this.workspace);
+              parent.nextConnection.connect(child.previousConnection);
+              assertNextHasBlock(parent, false);
+              parent.nextConnection.disconnect();
+              assertNextHasBlock(parent, true);
+              parent.nextConnection.setShadowState(null);
+              assertNextNotHasBlock(parent);
+            });
+  
+            test('Multiple Next', function() {
+              var parent = createStackBlock(this.workspace);
+              parent.nextConnection.setShadowState({
+                'type': 'stack_block',
+                'next': {
+                  'shadow': {
+                    'type': 'stack_block'
+                  }
+                }
+              });
+              assertNextHasBlock(parent, true);
+              assertNextHasBlock(parent.getNextBlock(), true);
+              var child = createStatementBlock(this.workspace);
+              parent.nextConnection.connect(child.previousConnection);
+              assertNextHasBlock(parent, false);
+              parent.nextConnection.disconnect();
+              assertNextHasBlock(parent, true);
+              assertNextHasBlock(parent.getNextBlock(), true);
+              parent.nextConnection.setShadowState(null);
+              assertNextNotHasBlock(parent);
+            });
+          });
         });
       });
     });
@@ -888,7 +1540,7 @@ suite('Connection', function() {
             },
             {
               "type": "input_statement",
-              "name": "STATEMENT",
+              "name": "NAME",
               "check": 'check1'
             }
           ],
@@ -901,7 +1553,7 @@ suite('Connection', function() {
           "args0": [
             {
               "type": "input_statement",
-              "name": "STATEMENT",
+              "name": "NAME",
               "check": 'check1'
             }
           ],
@@ -914,7 +1566,7 @@ suite('Connection', function() {
           "args0": [
             {
               "type": "input_statement",
-              "name": "STATEMENT",
+              "name": "NAME",
               "check": 'check2'
             }
           ],
@@ -927,7 +1579,7 @@ suite('Connection', function() {
           "args0": [
             {
               "type": "input_statement",
-              "name": "STATEMENT",
+              "name": "NAME",
               "check": 'check1'
             }
           ],
@@ -960,13 +1612,13 @@ suite('Connection', function() {
         var newParent = this.workspace.newBlock('statement_block');
         var child = this.workspace.newBlock('stack_block');
 
-        oldParent.getInput('STATEMENT').connection
+        oldParent.getInput('NAME').connection
             .connect(child.previousConnection);
-        newParent.getInput('STATEMENT').connection
+        newParent.getInput('NAME').connection
             .connect(child.previousConnection);
 
         chai.assert.isFalse(
-            oldParent.getInput('STATEMENT').connection.isConnected());
+            oldParent.getInput('NAME').connection.isConnected());
         this.assertBlockCount(3);
       });
 
@@ -1005,15 +1657,15 @@ suite('Connection', function() {
         var xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
-        newParent.getInput('STATEMENT').connection.setShadowDom(xml);
+        newParent.getInput('NAME').connection.setShadowDom(xml);
         chai.assert.isTrue(
-            newParent.getInputTargetBlock('STATEMENT').isShadow());
+            newParent.getInputTargetBlock('NAME').isShadow());
 
-        newParent.getInput('STATEMENT').connection
+        newParent.getInput('NAME').connection
             .connect(child.previousConnection);
 
         chai.assert.isFalse(
-            newParent.getInputTargetBlock('STATEMENT').isShadow());
+            newParent.getInputTargetBlock('NAME').isShadow());
         this.assertBlockCount(2);
       });
 
@@ -1058,15 +1710,15 @@ suite('Connection', function() {
         var xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
-        newParent.getInput('STATEMENT').connection.setShadowDom(xml);
-        newParent.getInputTargetBlock('STATEMENT')
+        newParent.getInput('NAME').connection.setShadowDom(xml);
+        newParent.getInputTargetBlock('NAME')
             .setFieldValue('new', 'FIELD');
 
-        newParent.getInput('STATEMENT').connection
+        newParent.getInput('NAME').connection
             .connect(child.previousConnection);
-        newParent.getInput('STATEMENT').connection.disconnect();
+        newParent.getInput('NAME').connection.disconnect();
 
-        const target = newParent.getInputTargetBlock('STATEMENT');
+        const target = newParent.getInputTargetBlock('NAME');
         chai.assert.isTrue(target.isShadow());
         chai.assert.equal(target.getFieldValue('FIELD'), 'new');
         this.assertBlockCount(3);
@@ -1384,16 +2036,16 @@ suite('Connection', function() {
             var parent = this.workspace.newBlock('statement_block');
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild = this.workspace.newBlock('stack_block');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild);
+                parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
@@ -1404,17 +2056,17 @@ suite('Connection', function() {
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild1 = this.workspace.newBlock('stack_block_1to2');
             var newChild2 = this.workspace.newBlock('stack_block_2to1');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild1.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild1);
+                parent.getInputTargetBlock('NAME'), newChild1);
             chai.assert.isTrue(newChild2.nextConnection.isConnected());
             chai.assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
@@ -1424,17 +2076,17 @@ suite('Connection', function() {
             var parent = this.workspace.newBlock('statement_block');
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild = this.workspace.newBlock('stack_block_1to2');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             var spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild);
+                parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isFalse(newChild.nextConnection.isConnected());
             chai.assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
@@ -1444,17 +2096,17 @@ suite('Connection', function() {
             var parent = this.workspace.newBlock('statement_block');
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild = this.workspace.newBlock('stack_block_noend');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             var spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild);
+                parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
@@ -1465,20 +2117,20 @@ suite('Connection', function() {
             var parent = this.workspace.newBlock('statement_block');
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild = this.workspace.newBlock('stack_block');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             var xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild);
+                parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
@@ -1489,7 +2141,7 @@ suite('Connection', function() {
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild1 = this.workspace.newBlock('stack_block_1to2');
             var newChild2 = this.workspace.newBlock('stack_block_2to1');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
             var xml = Blockly.Xml.textToDom(
@@ -1497,13 +2149,13 @@ suite('Connection', function() {
             );
             newChild2.nextConnection.setShadowDom(xml);
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild1.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild1);
+                parent.getInputTargetBlock('NAME'), newChild1);
             chai.assert.isTrue(newChild2.nextConnection.isConnected());
             chai.assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
@@ -1513,7 +2165,7 @@ suite('Connection', function() {
             var parent = this.workspace.newBlock('statement_block');
             var oldChild = this.workspace.newBlock('stack_block');
             var newChild = this.workspace.newBlock('stack_block_1to2');
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             var xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block_2to1"/>'
@@ -1521,13 +2173,13 @@ suite('Connection', function() {
             newChild.nextConnection.setShadowDom(xml);
             var spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('STATEMENT').connection
+            parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
 
             chai.assert.isTrue(
-                parent.getInput('STATEMENT').connection.isConnected());
+                parent.getInput('NAME').connection.isConnected());
             chai.assert.equal(
-                parent.getInputTargetBlock('STATEMENT'), newChild);
+                parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.isTrue(newChild.getNextBlock().isShadow());
             chai.assert.isTrue(spy.calledOnce);

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -622,7 +622,7 @@ suite('JSO Deserialization', function() {
       });
     });
 
-    suite.skip('Real child of shadow', function() {
+    suite('Real child of shadow', function() {
       test('Input', function() {
         const state = {
           'blocks': {
@@ -659,10 +659,10 @@ suite('JSO Deserialization', function() {
                 'type': 'text_print',
                 'next': {
                   'shadow': {
-                    'type': 'text_input',
+                    'type': 'text_print',
                     'next': {
                       'block': {
-                        'type': 'text_input',
+                        'type': 'text_print',
                       }
                     }
                   }

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -419,7 +419,7 @@ suite('JSO Serialization', function() {
           const block = this.workspace.newBlock(blockType);
           block.getInput(inputName).connection.setShadowDom(
               Blockly.Xml.textToDom(
-                  '<block type="' + blockType + '" id="test"></block>'));
+                  '<shadow type="' + blockType + '" id="test"></shadow>'));
           return block;
         };
 
@@ -430,7 +430,7 @@ suite('JSO Serialization', function() {
               childBlock.outputConnection || childBlock.previousConnection);
           block.getInput(inputName).connection.setShadowDom(
               Blockly.Xml.textToDom(
-                  '<block type="' + blockType + '" id="test"></block>'));
+                  '<shadow type="' + blockType + '" id="test"></shadow>'));
           return block;
         };
   
@@ -496,11 +496,11 @@ suite('JSO Serialization', function() {
             this.assertChild('row_block', 'INPUT');
           });
   
-          test.skip('Shadow', function() {
+          test('Shadow', function() {
             this.assertShadow('row_block', 'INPUT');
           });
   
-          test.skip('Overwritten shadow', function() {
+          test('Overwritten shadow', function() {
             this.assertOverwrittenShadow('row_block', 'INPUT');
           });
         });
@@ -526,11 +526,11 @@ suite('JSO Serialization', function() {
             this.assertChild('statement_block', 'NAME');
           });
   
-          test.skip('Shadow', function() {
+          test('Shadow', function() {
             this.assertShadow('statement_block', 'NAME');
           });
   
-          test.skip('Overwritten shadow', function() {
+          test('Overwritten shadow', function() {
             this.assertOverwrittenShadow('statement_block', 'NAME');
           });
 
@@ -590,7 +590,7 @@ suite('JSO Serialization', function() {
             const block = this.workspace.newBlock('stack_block');
             block.nextConnection.setShadowDom(
                 Blockly.Xml.textToDom(
-                    '<block type="stack_block" id="test"></block>'));
+                    '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };
 
@@ -600,7 +600,7 @@ suite('JSO Serialization', function() {
             block.nextConnection.connect(childBlock.previousConnection);
             block.nextConnection.setShadowDom(
                 Blockly.Xml.textToDom(
-                    '<block type="stack_block" id="test"></block>'));
+                    '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };
         });
@@ -614,14 +614,14 @@ suite('JSO Serialization', function() {
                 jso['next'], {'block': { 'type': 'stack_block', 'id': 'id2'}});
           });
   
-          test.skip('Shadow', function() {
+          test('Shadow', function() {
             const block = this.createNextWithShadow();
             const jso = Blockly.serialization.blocks.save(block);
             chai.assert.deepInclude(
                 jso['next'], {'shadow': { 'type': 'stack_block', 'id': 'test'}});
           });
   
-          test.skip('Overwritten shadow', function() {
+          test('Overwritten shadow', function() {
             const block = this.createNextWithShadowAndChild();
             const jso = Blockly.serialization.blocks.save(block);
             chai.assert.deepInclude(


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

Link for Diff: https://github.com/BeksOmega/blockly/compare/cereal/comments...BeksOmega:cereal/shadows
## The details
### Resolves

Work on project cereal
Dependent on #5216

### Proposed Changes
Makes it so that shadow blocks are encoded as JSOs rather than stringified XML when using the JSO serialization system.

### Reason for Changes
Stringified XML takes up more space than the normal JSO representation.

### Test Coverage
Added tests to make sure that the new setShadowState hook works correctly, and that the state serializes to XML and JSO properly, regardless of whether you use the setShadowDom or setShadowState hooks.

Also adds two simple tests for recycling vs not recycling blocks.