### PR TITLE
Migrate core/variable_model.js to goog.module syntax

### DIFF
--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -67,8 +67,7 @@ const VariableModel = function(workspace, name, opt_type, opt_id) {
    */
   this.id_ = opt_id || utils.genUid();
 
-  Events.fire(new (Events.get(Events.VAR_CREATE))(
-      this));
+  Events.fire(new (Events.get(Events.VAR_CREATE))(this));
 };
 
 /**

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -13,18 +13,18 @@
 goog.module('Blockly.VariableModel');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Events');
+const Events = goog.require('Blockly.Events');
+/* eslint-disable-next-line no-unused-vars */
+const Workspace = goog.requireType('Blockly.Workspace');
+const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.VarCreate');
-goog.require('Blockly.utils');
-
-goog.requireType('Blockly.Workspace');
 
 
 /**
  * Class for a variable model.
  * Holds information for the variable including name, ID, and type.
- * @param {!Blockly.Workspace} workspace The variable's workspace.
+ * @param {!Workspace} workspace The variable's workspace.
  * @param {string} name The name of the variable.  This is the user-visible name
  *     (e.g. 'my var' or '私の変数'), not the generated name.
  * @param {string=} opt_type The type of the variable like 'int' or 'string'.
@@ -38,7 +38,7 @@ goog.requireType('Blockly.Workspace');
 const VariableModel = function(workspace, name, opt_type, opt_id) {
   /**
    * The workspace the variable is in.
-   * @type {!Blockly.Workspace}
+   * @type {!Workspace}
    */
   this.workspace = workspace;
 
@@ -65,9 +65,9 @@ const VariableModel = function(workspace, name, opt_type, opt_id) {
    * @type {string}
    * @private
    */
-  this.id_ = opt_id || Blockly.utils.genUid();
+  this.id_ = opt_id || utils.genUid();
 
-  Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(
+  Events.fire(new (Events.get(Events.VAR_CREATE))(
       this));
 };
 

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -10,7 +10,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.VariableModel');
+goog.module('Blockly.VariableModel');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Events');
 /** @suppress {extraRequire} */
@@ -34,7 +35,7 @@ goog.requireType('Blockly.Workspace');
  * @see {Blockly.FieldVariable}
  * @constructor
  */
-Blockly.VariableModel = function(workspace, name, opt_type, opt_id) {
+const VariableModel = function(workspace, name, opt_type, opt_id) {
   /**
    * The workspace the variable is in.
    * @type {!Blockly.Workspace}
@@ -73,18 +74,20 @@ Blockly.VariableModel = function(workspace, name, opt_type, opt_id) {
 /**
  * @return {string} The ID for the variable.
  */
-Blockly.VariableModel.prototype.getId = function() {
+VariableModel.prototype.getId = function() {
   return this.id_;
 };
 
 /**
  * A custom compare function for the VariableModel objects.
- * @param {Blockly.VariableModel} var1 First variable to compare.
- * @param {Blockly.VariableModel} var2 Second variable to compare.
+ * @param {VariableModel} var1 First variable to compare.
+ * @param {VariableModel} var2 Second variable to compare.
  * @return {number} -1 if name of var1 is less than name of var2, 0 if equal,
  *     and 1 if greater.
  * @package
  */
-Blockly.VariableModel.compareByName = function(var1, var2) {
+VariableModel.compareByName = function(var1, var2) {
   return var1.name.localeCompare(var2.name, undefined, {sensitivity: 'base'});
 };
+
+exports = VariableModel;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -196,7 +196,7 @@ goog.addDependency('../../core/utils/toolbox.js', ['Blockly.utils.toolbox'], ['B
 goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global']);
 goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.utils', 'Blockly.utils.object']);
-goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils']);
+goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.xml']);
 goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml']);
 goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/variable_model.js` to `goog.module` with ES6 `const`/`let`.