### PR TITLE
Add regex lookarounds to check for require overlaps

### DIFF
--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -151,7 +151,7 @@ getPropertiesAccessed() {
   # Detect if there was any overlap.
   if [[ -n "${requires_overlap}" ]]; then
     while read -r requires_overlap_prop; do
-      # Replace any instances of $requires_overlap_prop. Includes regex
+      # Removes any instances of $requires_overlap_prop. Includes regex
       # lookarounds so that it does not simply match string contains.
       # Ex: if $requires_overlap is "Svg", then it would update the list
       # "isTargetInput mouseToSvg noEvent Svg" to

--- a/scripts/goog_module/convert-file.sh
+++ b/scripts/goog_module/convert-file.sh
@@ -151,7 +151,12 @@ getPropertiesAccessed() {
   # Detect if there was any overlap.
   if [[ -n "${requires_overlap}" ]]; then
     while read -r requires_overlap_prop; do
-      properties_accessed=$(echo "${properties_accessed}" | perl -pe 's/'"${requires_overlap_prop}"'//g')
+      # Replace any instances of $requires_overlap_prop. Includes regex
+      # lookarounds so that it does not simply match string contains.
+      # Ex: if $requires_overlap is "Svg", then it would update the list
+      # "isTargetInput mouseToSvg noEvent Svg" to
+      # "isTargetInput mouseToSvg noEvent " (note that mouseToSvg is unchanged).
+      properties_accessed=$(echo "${properties_accessed}" | perl -pe 's/(?<!\w)'"${requires_overlap_prop}"'(?!\w)//g')
     done <<<"${requires_overlap}"
   fi
 


### PR DESCRIPTION
Updates logic in the method in covert-script used for getting the list of properties accessed on a module reference.

Additional Context:
- `(?<!)` is a negative lookbehind and `(?!\w)` is a negative lookahead used to ensure that there isn't a word character (`\w`) before or after the matched string to replace.