### PR TITLE
Migrate core/variables_dynamic.js to goog.module syntax

### DIFF
--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -24,20 +24,20 @@ const xml = goog.require('Blockly.utils.xml');
 
 
 const onCreateVariableButtonClick_String = function(button) {
-  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
-      undefined, 'String');
+  Variables.createVariableButtonHandler(
+      button.getTargetWorkspace(), undefined, 'String');
 };
 exports.onCreateVariableButtonClick_String = onCreateVariableButtonClick_String;
 
 const onCreateVariableButtonClick_Number = function(button) {
-  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
-      undefined, 'Number');
+  Variables.createVariableButtonHandler(
+      button.getTargetWorkspace(), undefined, 'Number');
 };
 exports.onCreateVariableButtonClick_Number = onCreateVariableButtonClick_Number;
 
 const onCreateVariableButtonClick_Colour = function(button) {
-  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
-      undefined, 'Colour');
+  Variables.createVariableButtonHandler(
+      button.getTargetWorkspace(), undefined, 'Colour');
 };
 exports.onCreateVariableButtonClick_Colour = onCreateVariableButtonClick_Colour;
 
@@ -62,12 +62,12 @@ const flyoutCategory = function(workspace) {
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_COLOUR');
   xmlList.push(button);
 
-  workspace.registerButtonCallback('CREATE_VARIABLE_STRING',
-      onCreateVariableButtonClick_String);
-  workspace.registerButtonCallback('CREATE_VARIABLE_NUMBER',
-      onCreateVariableButtonClick_Number);
-  workspace.registerButtonCallback('CREATE_VARIABLE_COLOUR',
-      onCreateVariableButtonClick_Colour);
+  workspace.registerButtonCallback(
+      'CREATE_VARIABLE_STRING', onCreateVariableButtonClick_String);
+  workspace.registerButtonCallback(
+      'CREATE_VARIABLE_NUMBER', onCreateVariableButtonClick_Number);
+  workspace.registerButtonCallback(
+      'CREATE_VARIABLE_COLOUR', onCreateVariableButtonClick_Colour);
 
 
   const blockList = flyoutCategoryBlocks(workspace);
@@ -91,8 +91,7 @@ const flyoutCategoryBlocks = function(workspace) {
       const block = xml.createElement('block');
       block.setAttribute('type', 'variables_set_dynamic');
       block.setAttribute('gap', 24);
-      block.appendChild(
-          Variables.generateVariableFieldDom(firstVariable));
+      block.appendChild(Variables.generateVariableFieldDom(firstVariable));
       xmlList.push(block);
     }
     if (Blocks['variables_get_dynamic']) {

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -14,29 +14,29 @@
 goog.module('Blockly.VariablesDynamic');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Blocks');
-goog.require('Blockly.Msg');
-goog.require('Blockly.utils.xml');
-goog.require('Blockly.VariableModel');
-goog.require('Blockly.Variables');
-
-goog.requireType('Blockly.Workspace');
+const Blocks = goog.require('Blockly.Blocks');
+const Msg = goog.require('Blockly.Msg');
+const VariableModel = goog.require('Blockly.VariableModel');
+const Variables = goog.require('Blockly.Variables');
+/* eslint-disable-next-line no-unused-vars */
+const Workspace = goog.requireType('Blockly.Workspace');
+const xml = goog.require('Blockly.utils.xml');
 
 
 const onCreateVariableButtonClick_String = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'String');
 };
 exports.onCreateVariableButtonClick_String = onCreateVariableButtonClick_String;
 
 const onCreateVariableButtonClick_Number = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'Number');
 };
 exports.onCreateVariableButtonClick_Number = onCreateVariableButtonClick_Number;
 
 const onCreateVariableButtonClick_Colour = function(button) {
-  Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
+  Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'Colour');
 };
 exports.onCreateVariableButtonClick_Colour = onCreateVariableButtonClick_Colour;
@@ -44,21 +44,21 @@ exports.onCreateVariableButtonClick_Colour = onCreateVariableButtonClick_Colour;
 /**
  * Construct the elements (blocks and button) required by the flyout for the
  * variable category.
- * @param {!Blockly.Workspace} workspace The workspace containing variables.
+ * @param {!Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML elements.
  */
 const flyoutCategory = function(workspace) {
   let xmlList = [];
   let button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_STRING_VARIABLE']);
+  button.setAttribute('text', Msg['NEW_STRING_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_STRING');
   xmlList.push(button);
   button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_NUMBER_VARIABLE']);
+  button.setAttribute('text', Msg['NEW_NUMBER_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_NUMBER');
   xmlList.push(button);
   button = document.createElement('button');
-  button.setAttribute('text', Blockly.Msg['NEW_COLOUR_VARIABLE']);
+  button.setAttribute('text', Msg['NEW_COLOUR_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_COLOUR');
   xmlList.push(button);
 
@@ -78,7 +78,7 @@ exports.flyoutCategory = flyoutCategory;
 
 /**
  * Construct the blocks required by the flyout for the variable category.
- * @param {!Blockly.Workspace} workspace The workspace containing variables.
+ * @param {!Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML block elements.
  */
 const flyoutCategoryBlocks = function(workspace) {
@@ -86,22 +86,22 @@ const flyoutCategoryBlocks = function(workspace) {
 
   const xmlList = [];
   if (variableModelList.length > 0) {
-    if (Blockly.Blocks['variables_set_dynamic']) {
+    if (Blocks['variables_set_dynamic']) {
       const firstVariable = variableModelList[variableModelList.length - 1];
-      const block = Blockly.utils.xml.createElement('block');
+      const block = xml.createElement('block');
       block.setAttribute('type', 'variables_set_dynamic');
       block.setAttribute('gap', 24);
       block.appendChild(
-          Blockly.Variables.generateVariableFieldDom(firstVariable));
+          Variables.generateVariableFieldDom(firstVariable));
       xmlList.push(block);
     }
-    if (Blockly.Blocks['variables_get_dynamic']) {
-      variableModelList.sort(Blockly.VariableModel.compareByName);
+    if (Blocks['variables_get_dynamic']) {
+      variableModelList.sort(VariableModel.compareByName);
       for (let i = 0, variable; (variable = variableModelList[i]); i++) {
-        const block = Blockly.utils.xml.createElement('block');
+        const block = xml.createElement('block');
         block.setAttribute('type', 'variables_get_dynamic');
         block.setAttribute('gap', 8);
-        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+        block.appendChild(Variables.generateVariableFieldDom(variable));
         xmlList.push(block);
       }
     }

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -41,8 +41,8 @@ Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
  * @return {!Array<!Element>} Array of XML elements.
  */
 Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
-  var xmlList = [];
-  var button = document.createElement('button');
+  let xmlList = [];
+  let button = document.createElement('button');
   button.setAttribute('text', Blockly.Msg['NEW_STRING_VARIABLE']);
   button.setAttribute('callbackKey', 'CREATE_VARIABLE_STRING');
   xmlList.push(button);
@@ -63,7 +63,7 @@ Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
       Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour);
 
 
-  var blockList = Blockly.VariablesDynamic.flyoutCategoryBlocks(workspace);
+  const blockList = Blockly.VariablesDynamic.flyoutCategoryBlocks(workspace);
   xmlList = xmlList.concat(blockList);
   return xmlList;
 };
@@ -74,13 +74,13 @@ Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
  * @return {!Array<!Element>} Array of XML block elements.
  */
 Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
-  var variableModelList = workspace.getAllVariables();
+  const variableModelList = workspace.getAllVariables();
 
-  var xmlList = [];
+  const xmlList = [];
   if (variableModelList.length > 0) {
     if (Blockly.Blocks['variables_set_dynamic']) {
-      var firstVariable = variableModelList[variableModelList.length - 1];
-      var block = Blockly.utils.xml.createElement('block');
+      const firstVariable = variableModelList[variableModelList.length - 1];
+      const block = Blockly.utils.xml.createElement('block');
       block.setAttribute('type', 'variables_set_dynamic');
       block.setAttribute('gap', 24);
       block.appendChild(
@@ -89,8 +89,8 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
     }
     if (Blockly.Blocks['variables_get_dynamic']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
-      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
-        var block = Blockly.utils.xml.createElement('block');
+      for (let i = 0, variable; (variable = variableModelList[i]); i++) {
+        const block = Blockly.utils.xml.createElement('block');
         block.setAttribute('type', 'variables_get_dynamic');
         block.setAttribute('gap', 8);
         block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -11,7 +11,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.VariablesDynamic');
+goog.module('Blockly.VariablesDynamic');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Msg');
@@ -22,25 +23,31 @@ goog.require('Blockly.Variables');
 goog.requireType('Blockly.Workspace');
 
 
-Blockly.VariablesDynamic.onCreateVariableButtonClick_String = function(button) {
+const onCreateVariableButtonClick_String = function(button) {
   Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'String');
 };
-Blockly.VariablesDynamic.onCreateVariableButtonClick_Number = function(button) {
+exports.onCreateVariableButtonClick_String = onCreateVariableButtonClick_String;
+
+const onCreateVariableButtonClick_Number = function(button) {
   Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'Number');
 };
-Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour = function(button) {
+exports.onCreateVariableButtonClick_Number = onCreateVariableButtonClick_Number;
+
+const onCreateVariableButtonClick_Colour = function(button) {
   Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(),
       undefined, 'Colour');
 };
+exports.onCreateVariableButtonClick_Colour = onCreateVariableButtonClick_Colour;
+
 /**
  * Construct the elements (blocks and button) required by the flyout for the
  * variable category.
  * @param {!Blockly.Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML elements.
  */
-Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
+const flyoutCategory = function(workspace) {
   let xmlList = [];
   let button = document.createElement('button');
   button.setAttribute('text', Blockly.Msg['NEW_STRING_VARIABLE']);
@@ -56,24 +63,25 @@ Blockly.VariablesDynamic.flyoutCategory = function(workspace) {
   xmlList.push(button);
 
   workspace.registerButtonCallback('CREATE_VARIABLE_STRING',
-      Blockly.VariablesDynamic.onCreateVariableButtonClick_String);
+      onCreateVariableButtonClick_String);
   workspace.registerButtonCallback('CREATE_VARIABLE_NUMBER',
-      Blockly.VariablesDynamic.onCreateVariableButtonClick_Number);
+      onCreateVariableButtonClick_Number);
   workspace.registerButtonCallback('CREATE_VARIABLE_COLOUR',
-      Blockly.VariablesDynamic.onCreateVariableButtonClick_Colour);
+      onCreateVariableButtonClick_Colour);
 
 
-  const blockList = Blockly.VariablesDynamic.flyoutCategoryBlocks(workspace);
+  const blockList = flyoutCategoryBlocks(workspace);
   xmlList = xmlList.concat(blockList);
   return xmlList;
 };
+exports.flyoutCategory = flyoutCategory;
 
 /**
  * Construct the blocks required by the flyout for the variable category.
  * @param {!Blockly.Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML block elements.
  */
-Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
+const flyoutCategoryBlocks = function(workspace) {
   const variableModelList = workspace.getAllVariables();
 
   const xmlList = [];
@@ -100,3 +108,4 @@ Blockly.VariablesDynamic.flyoutCategoryBlocks = function(workspace) {
   }
   return xmlList;
 };
+exports.flyoutCategoryBlocks = flyoutCategoryBlocks;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -199,7 +199,7 @@ goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.utils', 'Blockly.utils.object']);
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.xml']);
-goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml']);
+goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/widgetdiv.js', ['Blockly.WidgetDiv'], ['Blockly.utils.dom']);
 goog.addDependency('../../core/workspace.js', ['Blockly.Workspace'], ['Blockly.ConnectionChecker', 'Blockly.Events', 'Blockly.IASTNodeLocation', 'Blockly.Options', 'Blockly.VariableMap', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.math']);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/variables_dynamic.js` to `goog.module` with ES6 `const`/`let`.