### PR TITLE
Add missing eslint disable to core/renderers/common/i_path_object.js

### DIFF
--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -19,6 +19,7 @@ goog.module.declareLegacyNamespace();
 const Block = goog.requireType('Blockly.Block');
 /* eslint-disable-next-line no-unused-vars */
 const ConstantProvider = goog.requireType('Blockly.blockRendering.ConstantProvider');
+/* eslint-disable-next-line no-unused-vars */
 const Theme = goog.requireType('Blockly.Theme');
 
 


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/toolbox/toolbox_item.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5026

### Proposed Changes

Adds missing eslint disable.

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * →
