### PR TITLE
Remove extra eslint disable from core/gesture.js

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -20,7 +20,6 @@ goog.module.declareLegacyNamespace();
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
 const BubbleDragger = goog.require('Blockly.BubbleDragger');
 const Coordinate = goog.require('Blockly.utils.Coordinate');
-/* eslint-disable-next-line no-unused-vars */
 const Events = goog.require('Blockly.Events');
 /* eslint-disable-next-line no-unused-vars */
 const Field = goog.requireType('Blockly.Field');


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/toolbox/toolbox_item.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5026

### Proposed Changes

Removes extra eslint disable.

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * →
