### PR TITLE
Migrate core/events/events_marker_move.js to goog.module syntax

### DIFF
--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -13,35 +13,36 @@
 goog.module('Blockly.Events.MarkerMove');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Events');
-goog.require('Blockly.Events.UiBase');
-goog.require('Blockly.registry');
-goog.require('Blockly.utils.object');
-
-goog.requireType('Blockly.ASTNode');
-goog.requireType('Blockly.Block');
-goog.requireType('Blockly.Workspace');
+const ASTNode = goog.require('Blockly.ASTNode');
+/* eslint-disable-next-line no-unused-vars */
+const Block = goog.requireType('Blockly.Block');
+const Events = goog.require('Blockly.Events');
+const UiBase = goog.require('Blockly.Events.UiBase');
+/* eslint-disable-next-line no-unused-vars */
+const Workspace = goog.requireType('Blockly.Workspace');
+const object = goog.require('Blockly.utils.object');
+const registry = goog.require('Blockly.registry');
 
 
 /**
  * Class for a marker move event.
- * @param {?Blockly.Block=} opt_block The affected block. Null if current node
+ * @param {?Block=} opt_block The affected block. Null if current node
  *    is of type workspace. Undefined for a blank event.
  * @param {boolean=} isCursor Whether this is a cursor event. Undefined for a
  *    blank event.
- * @param {?Blockly.ASTNode=} opt_oldNode The old node the marker used to be on.
+ * @param {?ASTNode=} opt_oldNode The old node the marker used to be on.
  *    Undefined for a blank event.
- * @param {!Blockly.ASTNode=} opt_newNode The new node the marker is now on.
+ * @param {!ASTNode=} opt_newNode The new node the marker is now on.
  *    Undefined for a blank event.
- * @extends {Blockly.Events.UiBase}
+ * @extends {UiBase}
  * @constructor
  */
 const MarkerMove = function(opt_block, isCursor, opt_oldNode,
     opt_newNode) {
   let workspaceId = opt_block ? opt_block.workspace.id : undefined;
-  if (opt_newNode && opt_newNode.getType() == Blockly.ASTNode.types.WORKSPACE) {
+  if (opt_newNode && opt_newNode.getType() == ASTNode.types.WORKSPACE) {
     workspaceId =
-        (/** @type {!Blockly.Workspace} */ (opt_newNode.getLocation())).id;
+        (/** @type {!Workspace} */ (opt_newNode.getLocation())).id;
   }
   MarkerMove.superClass_.constructor.call(this, workspaceId);
 
@@ -53,13 +54,13 @@ const MarkerMove = function(opt_block, isCursor, opt_oldNode,
 
   /**
    * The old node the marker used to be on.
-   * @type {?Blockly.ASTNode|undefined}
+   * @type {?ASTNode|undefined}
    */
   this.oldNode = opt_oldNode;
 
   /**
    * The new node the  marker is now on.
-   * @type {Blockly.ASTNode|undefined}
+   * @type {ASTNode|undefined}
    */
   this.newNode = opt_newNode;
 
@@ -69,13 +70,13 @@ const MarkerMove = function(opt_block, isCursor, opt_oldNode,
    */
   this.isCursor = isCursor;
 };
-Blockly.utils.object.inherits(MarkerMove, Blockly.Events.UiBase);
+object.inherits(MarkerMove, UiBase);
 
 /**
  * Type of this event.
  * @type {string}
  */
-MarkerMove.prototype.type = Blockly.Events.MARKER_MOVE;
+MarkerMove.prototype.type = Events.MARKER_MOVE;
 
 /**
  * Encode the event as JSON.
@@ -102,7 +103,7 @@ MarkerMove.prototype.fromJson = function(json) {
   this.newNode = json['newNode'];
 };
 
-Blockly.registry.register(Blockly.registry.Type.EVENT,
-    Blockly.Events.MARKER_MOVE, MarkerMove);
+registry.register(registry.Type.EVENT,
+    Events.MARKER_MOVE, MarkerMove);
 
 exports = MarkerMove;

--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -37,12 +37,10 @@ const registry = goog.require('Blockly.registry');
  * @extends {UiBase}
  * @constructor
  */
-const MarkerMove = function(opt_block, isCursor, opt_oldNode,
-    opt_newNode) {
+const MarkerMove = function(opt_block, isCursor, opt_oldNode, opt_newNode) {
   let workspaceId = opt_block ? opt_block.workspace.id : undefined;
   if (opt_newNode && opt_newNode.getType() == ASTNode.types.WORKSPACE) {
-    workspaceId =
-        (/** @type {!Workspace} */ (opt_newNode.getLocation())).id;
+    workspaceId = (/** @type {!Workspace} */ (opt_newNode.getLocation())).id;
   }
   MarkerMove.superClass_.constructor.call(this, workspaceId);
 
@@ -103,7 +101,6 @@ MarkerMove.prototype.fromJson = function(json) {
   this.newNode = json['newNode'];
 };
 
-registry.register(registry.Type.EVENT,
-    Events.MARKER_MOVE, MarkerMove);
+registry.register(registry.Type.EVENT, Events.MARKER_MOVE, MarkerMove);
 
 exports = MarkerMove;

--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -37,7 +37,7 @@ goog.requireType('Blockly.Workspace');
  */
 Blockly.Events.MarkerMove = function(opt_block, isCursor, opt_oldNode,
     opt_newNode) {
-  var workspaceId = opt_block ? opt_block.workspace.id : undefined;
+  let workspaceId = opt_block ? opt_block.workspace.id : undefined;
   if (opt_newNode && opt_newNode.getType() == Blockly.ASTNode.types.WORKSPACE) {
     workspaceId =
         (/** @type {!Blockly.Workspace} */ (opt_newNode.getLocation())).id;
@@ -81,7 +81,7 @@ Blockly.Events.MarkerMove.prototype.type = Blockly.Events.MARKER_MOVE;
  * @return {!Object} JSON representation.
  */
 Blockly.Events.MarkerMove.prototype.toJson = function() {
-  var json = Blockly.Events.MarkerMove.superClass_.toJson.call(this);
+  const json = Blockly.Events.MarkerMove.superClass_.toJson.call(this);
   json['isCursor'] = this.isCursor;
   json['blockId'] = this.blockId;
   json['oldNode'] = this.oldNode;

--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -10,7 +10,8 @@
  */
 'use strict';
 
-goog.provide('Blockly.Events.MarkerMove');
+goog.module('Blockly.Events.MarkerMove');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Events');
 goog.require('Blockly.Events.UiBase');
@@ -35,14 +36,14 @@ goog.requireType('Blockly.Workspace');
  * @extends {Blockly.Events.UiBase}
  * @constructor
  */
-Blockly.Events.MarkerMove = function(opt_block, isCursor, opt_oldNode,
+const MarkerMove = function(opt_block, isCursor, opt_oldNode,
     opt_newNode) {
   let workspaceId = opt_block ? opt_block.workspace.id : undefined;
   if (opt_newNode && opt_newNode.getType() == Blockly.ASTNode.types.WORKSPACE) {
     workspaceId =
         (/** @type {!Blockly.Workspace} */ (opt_newNode.getLocation())).id;
   }
-  Blockly.Events.MarkerMove.superClass_.constructor.call(this, workspaceId);
+  MarkerMove.superClass_.constructor.call(this, workspaceId);
 
   /**
    * The workspace identifier for this event.
@@ -68,20 +69,20 @@ Blockly.Events.MarkerMove = function(opt_block, isCursor, opt_oldNode,
    */
   this.isCursor = isCursor;
 };
-Blockly.utils.object.inherits(Blockly.Events.MarkerMove, Blockly.Events.UiBase);
+Blockly.utils.object.inherits(MarkerMove, Blockly.Events.UiBase);
 
 /**
  * Type of this event.
  * @type {string}
  */
-Blockly.Events.MarkerMove.prototype.type = Blockly.Events.MARKER_MOVE;
+MarkerMove.prototype.type = Blockly.Events.MARKER_MOVE;
 
 /**
  * Encode the event as JSON.
  * @return {!Object} JSON representation.
  */
-Blockly.Events.MarkerMove.prototype.toJson = function() {
-  const json = Blockly.Events.MarkerMove.superClass_.toJson.call(this);
+MarkerMove.prototype.toJson = function() {
+  const json = MarkerMove.superClass_.toJson.call(this);
   json['isCursor'] = this.isCursor;
   json['blockId'] = this.blockId;
   json['oldNode'] = this.oldNode;
@@ -93,8 +94,8 @@ Blockly.Events.MarkerMove.prototype.toJson = function() {
  * Decode the JSON event.
  * @param {!Object} json JSON representation.
  */
-Blockly.Events.MarkerMove.prototype.fromJson = function(json) {
-  Blockly.Events.MarkerMove.superClass_.fromJson.call(this, json);
+MarkerMove.prototype.fromJson = function(json) {
+  MarkerMove.superClass_.fromJson.call(this, json);
   this.isCursor = json['isCursor'];
   this.blockId = json['blockId'];
   this.oldNode = json['oldNode'];
@@ -102,4 +103,6 @@ Blockly.Events.MarkerMove.prototype.fromJson = function(json) {
 };
 
 Blockly.registry.register(Blockly.registry.Type.EVENT,
-    Blockly.Events.MARKER_MOVE, Blockly.Events.MarkerMove);
+    Blockly.Events.MARKER_MOVE, MarkerMove);
+
+exports = MarkerMove;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -39,7 +39,7 @@ goog.addDependency('../../core/events/events_abstract.js', ['Blockly.Events.Abst
 goog.addDependency('../../core/events/events_block_drag.js', ['Blockly.Events.BlockDrag'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_bubble_open.js', ['Blockly.Events.BubbleOpen'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_click.js', ['Blockly.Events.Click'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
-goog.addDependency('../../core/events/events_marker_move.js', ['Blockly.Events.MarkerMove'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
+goog.addDependency('../../core/events/events_marker_move.js', ['Blockly.Events.MarkerMove'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/events/events_selected.js', ['Blockly.Events.Selected'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_theme_change.js', ['Blockly.Events.ThemeChange'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_toolbox_item_select.js', ['Blockly.Events.ToolboxItemSelect'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -39,7 +39,7 @@ goog.addDependency('../../core/events/events_abstract.js', ['Blockly.Events.Abst
 goog.addDependency('../../core/events/events_block_drag.js', ['Blockly.Events.BlockDrag'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_bubble_open.js', ['Blockly.Events.BubbleOpen'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_click.js', ['Blockly.Events.Click'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
-goog.addDependency('../../core/events/events_marker_move.js', ['Blockly.Events.MarkerMove'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/events/events_marker_move.js', ['Blockly.Events.MarkerMove'], ['Blockly.ASTNode', 'Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/events/events_selected.js', ['Blockly.Events.Selected'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_theme_change.js', ['Blockly.Events.ThemeChange'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);
 goog.addDependency('../../core/events/events_toolbox_item_select.js', ['Blockly.Events.ToolboxItemSelect'], ['Blockly.Events', 'Blockly.Events.UiBase', 'Blockly.registry', 'Blockly.utils.object']);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/events/events_marker_move.js` to `goog.module` with ES6 `const`/`let`.