### PR TITLE
Add supressPrefixSuffix to if/else block

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -73,6 +73,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "nextStatement": null,
     "style": "logic_blocks",
     "helpUrl": "%{BKY_CONTROLS_IF_HELPURL}",
+    "suppressPrefixSuffix": true,
     "mutator": "controls_if_mutator",
     "extensions": ["controls_if_tooltip"]
   },
@@ -106,6 +107,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "style": "logic_blocks",
     "tooltip": "%{BKYCONTROLS_IF_TOOLTIP_2}",
     "helpUrl": "%{BKY_CONTROLS_IF_HELPURL}",
+    "suppressPrefixSuffix": true,
     "extensions": ["controls_if_tooltip"]
   },
   // Block for comparison operator.
@@ -294,12 +296,6 @@ Blockly.Extensions.register('logic_op_tooltip',
 Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
   elseifCount_: 0,
   elseCount_: 0,
-
-  /**
-   * Don't automatically add STATEMENT_PREFIX and STATEMENT_SUFFIX to generated
-   * code.  These will be handled manually in this block's generators.
-   */
-  suppressPrefixSuffix: true,
 
   /**
    * Create XML to represent the number of else-if and else inputs.

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -196,6 +196,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "previousStatement": null,
     "style": "loop_blocks",
     "helpUrl": "%{BKY_CONTROLS_FLOW_STATEMENTS_HELPURL}",
+    "suppressPrefixSuffix": true,
     "extensions": [
       "controls_flow_tooltip",
       "controls_flow_in_loop_check"
@@ -300,12 +301,6 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
     'controls_for',
     'controls_whileUntil'
   ],
-
-  /**
-   * Don't automatically add STATEMENT_PREFIX and STATEMENT_SUFFIX to generated
-   * code.  These will be handled manually in this block's generators.
-   */
-  suppressPrefixSuffix: true,
 
   /**
    * Is the given block enclosed (at any level) by a loop?

--- a/core/block.js
+++ b/core/block.js
@@ -1556,8 +1556,10 @@ Blockly.Block.prototype.jsonInit = function(json) {
     this.setTooltip(localizedText);
   }
   if (json['enableContextMenu'] !== undefined) {
-    var rawValue = json['enableContextMenu'];
-    this.contextMenu = !!rawValue;
+    this.contextMenu = !!json['enableContextMenu'];
+  }
+  if (json['suppressPrefixSuffix'] !== undefined) {
+    this.suppressPrefixSuffix = !!json['suppressPrefixSuffix'];
   }
   if (json['helpUrl'] !== undefined) {
     var rawValue = json['helpUrl'];


### PR DESCRIPTION
The no-mutator version of the if/else block (playground - simple blocks) fails to set suppressPrefixSuffix, which means there are two prefix calls and two suffix calls.  All languages.  By contrast, the if/else block with the mutator only has one prefix and suffix call.

This PR adds a new JSON option to set this boolean.  Alternatively, this could be done by using an extension, rather than JSON.  I have no preference.

Issue #5268.
