### PR TITLE
Remove require destructuring

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -8,8 +8,9 @@
  * @fileoverview A class that manages a surface for dragging blocks.  When a
  * block drag is started, we move the block (and children) to a separate DOM
  * element that we move around using translate3d. At the end of the drag, the
- * blocks are put back in into the SVG they came from. This helps performance by
- * avoiding repainting the entire SVG on every mouse move while dragging blocks.
+ * blocks are put back in into the SVG they came from. This helps
+ * performance by avoiding repainting the entire SVG on every mouse move
+ * while dragging blocks.
  * @author picklesrus
  */
 
@@ -19,9 +20,9 @@ goog.module('Blockly.BlockDragSurfaceSvg');
 goog.module.declareLegacyNamespace();
 
 const Coordinate = goog.require('Blockly.utils.Coordinate');
-const {G, SVG} = goog.require('Blockly.utils.Svg');
-const {createSvgElement, HTML_NS, setCssTransform, SVG_NS, XLINK_NS} = goog.require('Blockly.utils.dom');
-const {getRelativeXY} = goog.require('Blockly.utils');
+const Svg = goog.require('Blockly.utils.Svg');
+const dom = goog.require('Blockly.utils.dom');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -94,16 +95,16 @@ BlockDragSurfaceSvg.prototype.createDom = function() {
   if (this.SVG_) {
     return;  // Already created.
   }
-  this.SVG_ = createSvgElement(
-      SVG, {
-        'xmlns': SVG_NS,
-        'xmlns:html': HTML_NS,
-        'xmlns:xlink': XLINK_NS,
+  this.SVG_ = dom.createSvgElement(
+      Svg.SVG, {
+        'xmlns': dom.SVG_NS,
+        'xmlns:html': dom.HTML_NS,
+        'xmlns:xlink': dom.XLINK_NS,
         'version': '1.1',
         'class': 'blocklyBlockDragSurface'
       },
       this.container_);
-  this.dragGroup_ = createSvgElement(G, {}, this.SVG_);
+  this.dragGroup_ = dom.createSvgElement(Svg.G, {}, this.SVG_);
 };
 
 /**
@@ -157,7 +158,7 @@ BlockDragSurfaceSvg.prototype.translateSurfaceInternal_ = function() {
   y = y.toFixed(0);
   this.SVG_.style.display = 'block';
 
-  setCssTransform(this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
+  dom.setCssTransform(this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
 };
 
 /**
@@ -191,7 +192,7 @@ BlockDragSurfaceSvg.prototype.translateSurface = function(x, y) {
  * @return {!Coordinate} Current translation of the surface.
  */
 BlockDragSurfaceSvg.prototype.getSurfaceTranslation = function() {
-  const xy = getRelativeXY(/** @type {!SVGElement} */ (this.SVG_));
+  const xy = utils.getRelativeXY(/** @type {!SVGElement} */ (this.SVG_));
   return new Coordinate(xy.x / this.scale_, xy.y / this.scale_);
 };
 

--- a/core/comment.js
+++ b/core/comment.js
@@ -29,10 +29,10 @@ const Svg = goog.require('Blockly.utils.Svg');
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 const userAgent = goog.require('Blockly.utils.userAgent');
 /* eslint-disable-next-line no-unused-vars */
-const {conditionalBind, Data, unbind} = goog.require('Blockly.browserEvents');
-const {createSvgElement, HTML_NS} = goog.require('Blockly.utils.dom');
-const {inherits} = goog.require('Blockly.utils.object');
-const {register} = goog.require('Blockly.Css');
+const browserEvents = goog.require('Blockly.browserEvents');
+const dom = goog.require('Blockly.utils.dom');
+const object = goog.require('Blockly.utils.object');
+const Css = goog.require('Blockly.Css');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 /** @suppress {extraRequire} */
@@ -70,35 +70,35 @@ const Comment = function(block) {
 
   /**
    * Mouse up event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onMouseUpWrapper_ = null;
 
   /**
    * Wheel event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onWheelWrapper_ = null;
 
   /**
    * Change event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onChangeWrapper_ = null;
 
   /**
    * Input event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onInputWrapper_ = null;
 
   this.createIcon();
 };
-inherits(Comment, Icon);
+object.inherits(Comment, Icon);
 
 /**
  * Draw the comment icon.
@@ -107,13 +107,13 @@ inherits(Comment, Icon);
  */
 Comment.prototype.drawIcon_ = function(group) {
   // Circle.
-  createSvgElement(
+  dom.createSvgElement(
       Svg.CIRCLE, {'class': 'blocklyIconShape', 'r': '8', 'cx': '8', 'cy': '8'},
       group);
   // Can't use a real '?' text character since different browsers and operating
   // systems render it differently.
   // Body of question mark.
-  createSvgElement(
+  dom.createSvgElement(
       Svg.PATH, {
         'class': 'blocklyIconSymbol',
         'd': 'm6.8,10h2c0.003,-0.617 0.271,-0.962 0.633,-1.266 2.875,-2.405' +
@@ -122,7 +122,7 @@ Comment.prototype.drawIcon_ = function(group) {
       },
       group);
   // Dot of question mark.
-  createSvgElement(
+  dom.createSvgElement(
       Svg.RECT, {
         'class': 'blocklyIconSymbol',
         'x': '6.8',
@@ -151,15 +151,15 @@ Comment.prototype.createEditor_ = function() {
    * For non-editable mode see Warning.textToDom_.
    */
 
-  this.foreignObject_ = createSvgElement(
+  this.foreignObject_ = dom.createSvgElement(
       Svg.FOREIGNOBJECT, {'x': Bubble.BORDER_WIDTH, 'y': Bubble.BORDER_WIDTH},
       null);
 
-  const body = document.createElementNS(HTML_NS, 'body');
-  body.setAttribute('xmlns', HTML_NS);
+  const body = document.createElementNS(dom.HTML_NS, 'body');
+  body.setAttribute('xmlns', dom.HTML_NS);
   body.className = 'blocklyMinimalBody';
 
-  this.textarea_ = document.createElementNS(HTML_NS, 'textarea');
+  this.textarea_ = document.createElementNS(dom.HTML_NS, 'textarea');
   const textarea = this.textarea_;
   textarea.className = 'blocklyCommentTextarea';
   textarea.setAttribute('dir', this.block_.RTL ? 'RTL' : 'LTR');
@@ -172,23 +172,25 @@ Comment.prototype.createEditor_ = function() {
   // Ideally this would be hooked to the focus event for the comment.
   // However doing so in Firefox swallows the cursor for unknown reasons.
   // So this is hooked to mouseup instead.  No big deal.
-  this.onMouseUpWrapper_ =
-      conditionalBind(textarea, 'mouseup', this, this.startEdit_, true, true);
+  this.onMouseUpWrapper_ = browserEvents.conditionalBind(
+      textarea, 'mouseup', this, this.startEdit_, true, true);
   // Don't zoom with mousewheel.
-  this.onWheelWrapper_ = conditionalBind(textarea, 'wheel', this, function(e) {
-    e.stopPropagation();
-  });
+  this.onWheelWrapper_ =
+      browserEvents.conditionalBind(textarea, 'wheel', this, function(e) {
+        e.stopPropagation();
+      });
   this.onChangeWrapper_ =
-      conditionalBind(textarea, 'change', this, function(_e) {
+      browserEvents.conditionalBind(textarea, 'change', this, function(_e) {
         if (this.cachedText_ != this.model_.text) {
           Events.fire(new (Events.get(Events.BLOCK_CHANGE))(
               this.block_, 'comment', null, this.cachedText_,
               this.model_.text));
         }
       });
-  this.onInputWrapper_ = conditionalBind(textarea, 'input', this, function(_e) {
-    this.model_.text = textarea.value;
-  });
+  this.onInputWrapper_ =
+      browserEvents.conditionalBind(textarea, 'input', this, function(_e) {
+        this.model_.text = textarea.value;
+      });
 
   setTimeout(textarea.focus.bind(textarea), 0);
 
@@ -307,19 +309,19 @@ Comment.prototype.createNonEditableBubble_ = function() {
  */
 Comment.prototype.disposeBubble_ = function() {
   if (this.onMouseUpWrapper_) {
-    unbind(this.onMouseUpWrapper_);
+    browserEvents.unbind(this.onMouseUpWrapper_);
     this.onMouseUpWrapper_ = null;
   }
   if (this.onWheelWrapper_) {
-    unbind(this.onWheelWrapper_);
+    browserEvents.unbind(this.onWheelWrapper_);
     this.onWheelWrapper_ = null;
   }
   if (this.onChangeWrapper_) {
-    unbind(this.onChangeWrapper_);
+    browserEvents.unbind(this.onChangeWrapper_);
     this.onChangeWrapper_ = null;
   }
   if (this.onInputWrapper_) {
-    unbind(this.onInputWrapper_);
+    browserEvents.unbind(this.onInputWrapper_);
     this.onInputWrapper_ = null;
   }
   this.bubble_.dispose();
@@ -397,7 +399,7 @@ Comment.prototype.dispose = function() {
 /**
  * CSS for block comment.  See css.js for use.
  */
-register([
+Css.register([
   /* eslint-disable indent */
   '.blocklyCommentTextarea {', 'background-color: #fef49c;', 'border: 0;',
   'outline: 0;', 'margin: 0;', 'padding: 3px;', 'resize: none;',

--- a/core/comment.js
+++ b/core/comment.js
@@ -28,7 +28,6 @@ const Size = goog.requireType('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
-/* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
 const dom = goog.require('Blockly.utils.dom');
 const object = goog.require('Blockly.utils.object');

--- a/core/comment.js
+++ b/core/comment.js
@@ -20,6 +20,7 @@ const BlockSvg = goog.requireType('Blockly.BlockSvg');
 const Bubble = goog.require('Blockly.Bubble');
 /* eslint-disable-next-line no-unused-vars */
 const Coordinate = goog.requireType('Blockly.utils.Coordinate');
+const Css = goog.require('Blockly.Css');
 const Events = goog.require('Blockly.Events');
 const Icon = goog.require('Blockly.Icon');
 /* eslint-disable-next-line no-unused-vars */
@@ -27,12 +28,11 @@ const Size = goog.requireType('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
-const userAgent = goog.require('Blockly.utils.userAgent');
 /* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
 const dom = goog.require('Blockly.utils.dom');
 const object = goog.require('Blockly.utils.object');
-const Css = goog.require('Blockly.Css');
+const userAgent = goog.require('Blockly.utils.userAgent');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 /** @suppress {extraRequire} */

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -21,7 +21,7 @@ const IConnectionChecker = goog.require('Blockly.IConnectionChecker');
 const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
 const connectionTypes = goog.require('Blockly.connectionTypes');
 const registry = goog.require('Blockly.registry');
-const {OPPOSITE_TYPE} = goog.require('Blockly.internalConstants');
+const internalConstants = goog.require('Blockly.internalConstants');
 
 
 /**
@@ -145,7 +145,7 @@ ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
   }
   if (blockA == blockB) {
     return Connection.REASON_SELF_CONNECTION;
-  } else if (b.type != OPPOSITE_TYPE[a.type]) {
+  } else if (b.type != internalConstants.OPPOSITE_TYPE[a.type]) {
     return Connection.REASON_WRONG_TYPE;
   } else if (blockA.workspace !== blockB.workspace) {
     return Connection.REASON_DIFFERENT_WORKSPACES;

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -20,8 +20,8 @@ const IConnectionChecker = goog.require('Blockly.IConnectionChecker');
 /* eslint-disable-next-line no-unused-vars */
 const RenderedConnection = goog.requireType('Blockly.RenderedConnection');
 const connectionTypes = goog.require('Blockly.connectionTypes');
-const registry = goog.require('Blockly.registry');
 const internalConstants = goog.require('Blockly.internalConstants');
+const registry = goog.require('Blockly.registry');
 
 
 /**

--- a/core/delete_area.js
+++ b/core/delete_area.js
@@ -21,7 +21,7 @@ const DragTarget = goog.require('Blockly.DragTarget');
 const IDeleteArea = goog.require('Blockly.IDeleteArea');
 /* eslint-disable-next-line no-unused-vars */
 const IDraggable = goog.requireType('Blockly.IDraggable');
-const {inherits} = goog.require('Blockly.utils.object');
+const object = goog.require('Blockly.utils.object');
 
 /**
  * Abstract class for a component that can delete a block or bubble that is
@@ -42,7 +42,7 @@ const DeleteArea = function() {
    */
   this.wouldDelete_ = false;
 };
-inherits(DeleteArea, DragTarget);
+object.inherits(DeleteArea, DragTarget);
 
 /**
  * Returns whether the provided block or bubble would be deleted if dropped on

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -22,7 +22,7 @@ goog.module.declareLegacyNamespace();
 
 /* eslint-disable-next-line no-unused-vars */
 const Block = goog.requireType('Blockly.Block');
-const {checkMessageReferences, replaceMessageReferences, runAfterPageLoad} = goog.require('Blockly.utils');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -331,13 +331,13 @@ const buildTooltipForDropdown = function(dropdownName, lookupTable) {
 
   // Check the tooltip string messages for invalid references.
   // Wait for load, in case Blockly.Msg is not yet populated.
-  // runAfterPageLoad() does not run in a Node.js environment due to lack of
-  // document object, in which case skip the validation.
+  // utils.runAfterPageLoad() does not run in a Node.js environment due to lack
+  // of document object, in which case skip the validation.
   if (typeof document == 'object') {  // Relies on document.readyState
-    runAfterPageLoad(function() {
+    utils.runAfterPageLoad(function() {
       for (let key in lookupTable) {
         // Will print warnings if reference is missing.
-        checkMessageReferences(lookupTable[key]);
+        utils.checkMessageReferences(lookupTable[key]);
       }
     });
   }
@@ -366,7 +366,7 @@ const buildTooltipForDropdown = function(dropdownName, lookupTable) {
           console.warn(warning + '.');
         }
       } else {
-        tooltip = replaceMessageReferences(tooltip);
+        tooltip = utils.replaceMessageReferences(tooltip);
       }
       return tooltip;
     }.bind(this));
@@ -411,12 +411,12 @@ const checkDropdownOptionsInTable = function(block, dropdownName, lookupTable) {
 const buildTooltipWithFieldText = function(msgTemplate, fieldName) {
   // Check the tooltip string messages for invalid references.
   // Wait for load, in case Blockly.Msg is not yet populated.
-  // runAfterPageLoad() does not run in a Node.js environment due to lack of
-  // document object, in which case skip the validation.
+  // utils.runAfterPageLoad() does not run in a Node.js environment due to lack
+  // of document object, in which case skip the validation.
   if (typeof document == 'object') {  // Relies on document.readyState
-    runAfterPageLoad(function() {
+    utils.runAfterPageLoad(function() {
       // Will print warnings if reference is missing.
-      checkMessageReferences(msgTemplate);
+      utils.checkMessageReferences(msgTemplate);
     });
   }
 
@@ -427,7 +427,7 @@ const buildTooltipWithFieldText = function(msgTemplate, fieldName) {
   const extensionFn = function() {
     this.setTooltip(function() {
       const field = this.getField(fieldName);
-      return replaceMessageReferences(msgTemplate)
+      return utils.replaceMessageReferences(msgTemplate)
           .replace('%1', field ? field.getText() : '');
     }.bind(this));
   };

--- a/core/field.js
+++ b/core/field.js
@@ -32,9 +32,9 @@ const IASTNodeLocationWithBlock = goog.require('Blockly.IASTNodeLocationWithBloc
 /* eslint-disable-next-line no-unused-vars */
 const IKeyboardAccessible = goog.require('Blockly.IKeyboardAccessible');
 /* eslint-disable-next-line no-unused-vars */
+const Input = goog.requireType('Blockly.Input');
 const IRegistrable = goog.require('Blockly.IRegistrable');
 /* eslint-disable-next-line no-unused-vars */
-const Input = goog.requireType('Blockly.Input');
 const MarkerManager = goog.require('Blockly.MarkerManager');
 const Rect = goog.require('Blockly.utils.Rect');
 /* eslint-disable-next-line no-unused-vars */
@@ -45,11 +45,11 @@ const Tooltip = goog.require('Blockly.Tooltip');
 const WidgetDiv = goog.require('Blockly.WidgetDiv');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
-const userAgent = goog.require('Blockly.utils.userAgent');
 const dom = goog.require('Blockly.utils.dom');
 /* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
 const style = goog.require('Blockly.utils.style');
+const userAgent = goog.require('Blockly.utils.userAgent');
 const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');

--- a/core/field.js
+++ b/core/field.js
@@ -46,11 +46,11 @@ const WidgetDiv = goog.require('Blockly.WidgetDiv');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 const userAgent = goog.require('Blockly.utils.userAgent');
-const {addClass, createSvgElement, getFastTextWidth, removeClass, removeNode} = goog.require('Blockly.utils.dom');
+const dom = goog.require('Blockly.utils.dom');
 /* eslint-disable-next-line no-unused-vars */
-const {conditionalBind, unbind, Data} = goog.require('Blockly.browserEvents');
-const {getPageOffset} = goog.require('Blockly.utils.style');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const browserEvents = goog.require('Blockly.browserEvents');
+const style = goog.require('Blockly.utils.style');
+const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 /** @suppress {extraRequire} */
@@ -150,7 +150,7 @@ const Field = function(value, opt_validator, opt_config) {
 
   /**
    * Mouse down event listener data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.mouseDownWrapper_ = null;
@@ -281,7 +281,7 @@ Field.prototype.SERIALIZABLE = false;
 Field.prototype.configure_ = function(config) {
   let tooltip = config['tooltip'];
   if (typeof tooltip == 'string') {
-    tooltip = replaceMessageReferences(config['tooltip']);
+    tooltip = utils.replaceMessageReferences(config['tooltip']);
   }
   tooltip && this.setTooltip(tooltip);
 
@@ -331,7 +331,7 @@ Field.prototype.init = function() {
     // Field has already been initialized once.
     return;
   }
-  this.fieldGroup_ = createSvgElement(Svg.G, {}, null);
+  this.fieldGroup_ = dom.createSvgElement(Svg.G, {}, null);
   if (!this.isVisible()) {
     this.fieldGroup_.style.display = 'none';
   }
@@ -367,7 +367,7 @@ Field.prototype.initModel = function() {};
  * @protected
  */
 Field.prototype.createBorderRect_ = function() {
-  this.borderRect_ = createSvgElement(
+  this.borderRect_ = dom.createSvgElement(
       Svg.RECT, {
         'rx': this.getConstants().FIELD_BORDER_RECT_RADIUS,
         'ry': this.getConstants().FIELD_BORDER_RECT_RADIUS,
@@ -387,7 +387,7 @@ Field.prototype.createBorderRect_ = function() {
  * @protected
  */
 Field.prototype.createTextElement_ = function() {
-  this.textElement_ = createSvgElement(
+  this.textElement_ = dom.createSvgElement(
       Svg.TEXT, {
         'class': 'blocklyText',
       },
@@ -406,7 +406,7 @@ Field.prototype.createTextElement_ = function() {
  */
 Field.prototype.bindEvents_ = function() {
   Tooltip.bindMouseEvents(this.getClickTarget_());
-  this.mouseDownWrapper_ = conditionalBind(
+  this.mouseDownWrapper_ = browserEvents.conditionalBind(
       this.getClickTarget_(), 'mousedown', this, this.onMouseDown_);
 };
 
@@ -443,10 +443,10 @@ Field.prototype.dispose = function() {
   Tooltip.unbindMouseEvents(this.getClickTarget_());
 
   if (this.mouseDownWrapper_) {
-    unbind(this.mouseDownWrapper_);
+    browserEvents.unbind(this.mouseDownWrapper_);
   }
 
-  removeNode(this.fieldGroup_);
+  dom.removeNode(this.fieldGroup_);
 
   this.disposed = true;
 };
@@ -460,12 +460,12 @@ Field.prototype.updateEditable = function() {
     return;
   }
   if (this.enabled_ && this.sourceBlock_.isEditable()) {
-    addClass(group, 'blocklyEditableText');
-    removeClass(group, 'blocklyNonEditableText');
+    dom.addClass(group, 'blocklyEditableText');
+    dom.removeClass(group, 'blocklyNonEditableText');
     group.style.cursor = this.CURSOR;
   } else {
-    addClass(group, 'blocklyNonEditableText');
-    removeClass(group, 'blocklyEditableText');
+    dom.addClass(group, 'blocklyNonEditableText');
+    dom.removeClass(group, 'blocklyEditableText');
     group.style.cursor = '';
   }
 };
@@ -643,7 +643,7 @@ Field.prototype.updateSize_ = function(opt_margin) {
 
   let contentWidth = 0;
   if (this.textElement_) {
-    contentWidth = getFastTextWidth(
+    contentWidth = dom.getFastTextWidth(
         this.textElement_, constants.FIELD_TEXT_FONTSIZE,
         constants.FIELD_TEXT_FONTWEIGHT, constants.FIELD_TEXT_FONTFAMILY);
     totalWidth += contentWidth;
@@ -760,7 +760,7 @@ Field.prototype.getScaledBBox = function() {
     }
   } else {
     const bBox = this.borderRect_.getBoundingClientRect();
-    xy = getPageOffset(this.borderRect_);
+    xy = style.getPageOffset(this.borderRect_);
     scaledWidth = bBox.width;
     scaledHeight = bBox.height;
   }
@@ -1020,7 +1020,7 @@ Field.prototype.getClickTarget_ = function() {
  * @protected
  */
 Field.prototype.getAbsoluteXY_ = function() {
-  return getPageOffset(
+  return style.getPageOffset(
       /** @type {!SVGRectElement} */ (this.getClickTarget_()));
 };
 

--- a/core/field.js
+++ b/core/field.js
@@ -46,7 +46,6 @@ const WidgetDiv = goog.require('Blockly.WidgetDiv');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 const dom = goog.require('Blockly.utils.dom');
-/* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
 const style = goog.require('Blockly.utils.style');
 const userAgent = goog.require('Blockly.utils.userAgent');

--- a/core/field.js
+++ b/core/field.js
@@ -33,8 +33,8 @@ const IASTNodeLocationWithBlock = goog.require('Blockly.IASTNodeLocationWithBloc
 const IKeyboardAccessible = goog.require('Blockly.IKeyboardAccessible');
 /* eslint-disable-next-line no-unused-vars */
 const Input = goog.requireType('Blockly.Input');
-const IRegistrable = goog.require('Blockly.IRegistrable');
 /* eslint-disable-next-line no-unused-vars */
+const IRegistrable = goog.require('Blockly.IRegistrable');
 const MarkerManager = goog.require('Blockly.MarkerManager');
 const Rect = goog.require('Blockly.utils.Rect');
 /* eslint-disable-next-line no-unused-vars */

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -16,7 +16,7 @@ goog.module.declareLegacyNamespace();
 const Field = goog.require('Blockly.Field');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const {inherits} = goog.require('Blockly.utils.object');
+const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 
@@ -48,7 +48,7 @@ const FieldCheckbox = function(opt_value, opt_validator, opt_config) {
   FieldCheckbox.superClass_.constructor.call(
       this, opt_value, opt_validator, opt_config);
 };
-inherits(FieldCheckbox, Field);
+object.inherits(FieldCheckbox, Field);
 
 /**
  * The default value for this field.

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -20,11 +20,11 @@ const IdGenerator = goog.require('Blockly.utils.IdGenerator');
 const KeyCodes = goog.require('Blockly.utils.KeyCodes');
 const Size = goog.require('Blockly.utils.Size');
 const aria = goog.require('Blockly.utils.aria');
-const colour = goog.require('Blockly.utils.colour');
-const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const dom = goog.require('Blockly.utils.dom');
 /* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
+const colour = goog.require('Blockly.utils.colour');
+const dom = goog.require('Blockly.utils.dom');
+const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -20,7 +20,6 @@ const IdGenerator = goog.require('Blockly.utils.IdGenerator');
 const KeyCodes = goog.require('Blockly.utils.KeyCodes');
 const Size = goog.require('Blockly.utils.Size');
 const aria = goog.require('Blockly.utils.aria');
-/* eslint-disable-next-line no-unused-vars */
 const browserEvents = goog.require('Blockly.browserEvents');
 const colour = goog.require('Blockly.utils.colour');
 const dom = goog.require('Blockly.utils.dom');
@@ -608,32 +607,32 @@ FieldColour.prototype.dropdownDispose_ = function() {
 Css.register([
   /* eslint-disable indent */
   '.blocklyColourTable {',
-  'border-collapse: collapse;',
-  'display: block;',
-  'outline: none;',
-  'padding: 1px;',
+    'border-collapse: collapse;',
+    'display: block;',
+    'outline: none;',
+    'padding: 1px;',
   '}',
 
   '.blocklyColourTable>tr>td {',
-  'border: .5px solid #888;',
-  'box-sizing: border-box;',
-  'cursor: pointer;',
-  'display: inline-block;',
-  'height: 20px;',
-  'padding: 0;',
-  'width: 20px;',
+    'border: .5px solid #888;',
+    'box-sizing: border-box;',
+    'cursor: pointer;',
+    'display: inline-block;',
+    'height: 20px;',
+    'padding: 0;',
+    'width: 20px;',
   '}',
 
   '.blocklyColourTable>tr>td.blocklyColourHighlighted {',
-  'border-color: #eee;',
-  'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
-  'position: relative;',
+    'border-color: #eee;',
+    'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
+    'position: relative;',
   '}',
 
   '.blocklyColourSelected, .blocklyColourSelected:hover {',
-  'border-color: #eee !important;',
-  'outline: 1px solid #333;',
-  'position: relative;',
+    'border-color: #eee !important;',
+    'outline: 1px solid #333;',
+    'position: relative;',
   '}'
   /* eslint-enable indent */
 ]);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -22,10 +22,10 @@ const Size = goog.require('Blockly.utils.Size');
 const aria = goog.require('Blockly.utils.aria');
 const colour = goog.require('Blockly.utils.colour');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const {addClass, removeClass} = goog.require('Blockly.utils.dom');
+const dom = goog.require('Blockly.utils.dom');
 /* eslint-disable-next-line no-unused-vars */
-const {conditionalBind, unbind, Data} = goog.require('Blockly.browserEvents');
-const {inherits} = goog.require('Blockly.utils.object');
+const browserEvents = goog.require('Blockly.browserEvents');
+const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 
@@ -65,40 +65,40 @@ const FieldColour = function(opt_value, opt_validator, opt_config) {
 
   /**
    * Mouse click event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onClickWrapper_ = null;
 
   /**
    * Mouse move event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onMouseMoveWrapper_ = null;
 
   /**
    * Mouse enter event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onMouseEnterWrapper_ = null;
 
   /**
    * Mouse leave event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onMouseLeaveWrapper_ = null;
 
   /**
    * Key down event data.
-   * @type {?Data}
+   * @type {?browserEvents.Data}
    * @private
    */
   this.onKeyDownWrapper_ = null;
 };
-inherits(FieldColour, Field);
+object.inherits(FieldColour, Field);
 
 /**
  * Construct a FieldColour from a JSON arg object.
@@ -472,7 +472,7 @@ FieldColour.prototype.onMouseLeave_ = function() {
   this.picker_.blur();
   const highlighted = this.getHighlighted_();
   if (highlighted) {
-    removeClass(highlighted, 'blocklyColourHighlighted');
+    dom.removeClass(highlighted, 'blocklyColourHighlighted');
   }
 };
 
@@ -503,10 +503,10 @@ FieldColour.prototype.setHighlightedCell_ = function(cell, index) {
   // Unhighlight the current item.
   const highlighted = this.getHighlighted_();
   if (highlighted) {
-    removeClass(highlighted, 'blocklyColourHighlighted');
+    dom.removeClass(highlighted, 'blocklyColourHighlighted');
   }
   // Highlight new item.
-  addClass(cell, 'blocklyColourHighlighted');
+  dom.addClass(cell, 'blocklyColourHighlighted');
   // Set new highlighted index.
   this.highlightedIndex_ = index;
 
@@ -560,15 +560,15 @@ FieldColour.prototype.dropdownCreate_ = function() {
 
   // Configure event handler on the table to listen for any event in a cell.
   this.onClickWrapper_ =
-      conditionalBind(table, 'click', this, this.onClick_, true);
-  this.onMouseMoveWrapper_ =
-      conditionalBind(table, 'mousemove', this, this.onMouseMove_, true);
-  this.onMouseEnterWrapper_ =
-      conditionalBind(table, 'mouseenter', this, this.onMouseEnter_, true);
-  this.onMouseLeaveWrapper_ =
-      conditionalBind(table, 'mouseleave', this, this.onMouseLeave_, true);
+      browserEvents.conditionalBind(table, 'click', this, this.onClick_, true);
+  this.onMouseMoveWrapper_ = browserEvents.conditionalBind(
+      table, 'mousemove', this, this.onMouseMove_, true);
+  this.onMouseEnterWrapper_ = browserEvents.conditionalBind(
+      table, 'mouseenter', this, this.onMouseEnter_, true);
+  this.onMouseLeaveWrapper_ = browserEvents.conditionalBind(
+      table, 'mouseleave', this, this.onMouseLeave_, true);
   this.onKeyDownWrapper_ =
-      conditionalBind(table, 'keydown', this, this.onKeyDown_);
+      browserEvents.conditionalBind(table, 'keydown', this, this.onKeyDown_);
 
   this.picker_ = table;
 };
@@ -579,23 +579,23 @@ FieldColour.prototype.dropdownCreate_ = function() {
  */
 FieldColour.prototype.dropdownDispose_ = function() {
   if (this.onClickWrapper_) {
-    unbind(this.onClickWrapper_);
+    browserEvents.unbind(this.onClickWrapper_);
     this.onClickWrapper_ = null;
   }
   if (this.onMouseMoveWrapper_) {
-    unbind(this.onMouseMoveWrapper_);
+    browserEvents.unbind(this.onMouseMoveWrapper_);
     this.onMouseMoveWrapper_ = null;
   }
   if (this.onMouseEnterWrapper_) {
-    unbind(this.onMouseEnterWrapper_);
+    browserEvents.unbind(this.onMouseEnterWrapper_);
     this.onMouseEnterWrapper_ = null;
   }
   if (this.onMouseLeaveWrapper_) {
-    unbind(this.onMouseLeaveWrapper_);
+    browserEvents.unbind(this.onMouseLeaveWrapper_);
     this.onMouseLeaveWrapper_ = null;
   }
   if (this.onKeyDownWrapper_) {
-    unbind(this.onKeyDownWrapper_);
+    browserEvents.unbind(this.onKeyDownWrapper_);
     this.onKeyDownWrapper_ = null;
   }
   this.picker_ = null;
@@ -608,32 +608,32 @@ FieldColour.prototype.dropdownDispose_ = function() {
 Css.register([
   /* eslint-disable indent */
   '.blocklyColourTable {',
-    'border-collapse: collapse;',
-    'display: block;',
-    'outline: none;',
-    'padding: 1px;',
+  'border-collapse: collapse;',
+  'display: block;',
+  'outline: none;',
+  'padding: 1px;',
   '}',
 
   '.blocklyColourTable>tr>td {',
-    'border: .5px solid #888;',
-    'box-sizing: border-box;',
-    'cursor: pointer;',
-    'display: inline-block;',
-    'height: 20px;',
-    'padding: 0;',
-    'width: 20px;',
+  'border: .5px solid #888;',
+  'box-sizing: border-box;',
+  'cursor: pointer;',
+  'display: inline-block;',
+  'height: 20px;',
+  'padding: 0;',
+  'width: 20px;',
   '}',
 
   '.blocklyColourTable>tr>td.blocklyColourHighlighted {',
-    'border-color: #eee;',
-    'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
-    'position: relative;',
+  'border-color: #eee;',
+  'box-shadow: 2px 2px 7px 2px rgba(0,0,0,.3);',
+  'position: relative;',
   '}',
 
   '.blocklyColourSelected, .blocklyColourSelected:hover {',
-    'border-color: #eee !important;',
-    'outline: 1px solid #333;',
-    'position: relative;',
+  'border-color: #eee !important;',
+  'outline: 1px solid #333;',
+  'position: relative;',
   '}'
   /* eslint-enable indent */
 ]);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -22,12 +22,12 @@ const Menu = goog.require('Blockly.Menu');
 const MenuItem = goog.require('Blockly.MenuItem');
 const Svg = goog.require('Blockly.utils.Svg');
 const aria = goog.require('Blockly.utils.aria');
+const utilsString = goog.require('Blockly.utils.string');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const userAgent = goog.require('Blockly.utils.userAgent');
-const {commonWordPrefix, commonWordSuffix, shortestStringLength} = goog.require('Blockly.utils.string');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -130,7 +130,7 @@ const FieldDropdown = function(menuGenerator, opt_validator, opt_config) {
    */
   this.svgArrow_ = null;
 };
-inherits(FieldDropdown, Field);
+object.inherits(FieldDropdown, Field);
 
 /**
  * Dropdown image properties.
@@ -405,10 +405,10 @@ FieldDropdown.prototype.trimOptions_ = function() {
   for (let i = 0; i < options.length; i++) {
     const label = options[i][0];
     if (typeof label == 'string') {
-      options[i][0] = replaceMessageReferences(label);
+      options[i][0] = utils.replaceMessageReferences(label);
     } else {
       if (label.alt != null) {
-        options[i][0].alt = replaceMessageReferences(label.alt);
+        options[i][0].alt = utils.replaceMessageReferences(label.alt);
       }
       hasImages = true;
     }
@@ -420,9 +420,9 @@ FieldDropdown.prototype.trimOptions_ = function() {
   for (let i = 0; i < options.length; i++) {
     strings.push(options[i][0]);
   }
-  const shortest = shortestStringLength(strings);
-  const prefixLength = commonWordPrefix(strings, shortest);
-  const suffixLength = commonWordSuffix(strings, shortest);
+  const shortest = utilsString.shortestStringLength(strings);
+  const prefixLength = utilsString.commonWordPrefix(strings, shortest);
+  const suffixLength = utilsString.commonWordSuffix(strings, shortest);
   if (!prefixLength && !suffixLength) {
     return;
   }

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -22,12 +22,12 @@ const Menu = goog.require('Blockly.Menu');
 const MenuItem = goog.require('Blockly.MenuItem');
 const Svg = goog.require('Blockly.utils.Svg');
 const aria = goog.require('Blockly.utils.aria');
-const utilsString = goog.require('Blockly.utils.string');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const userAgent = goog.require('Blockly.utils.userAgent');
 const object = goog.require('Blockly.utils.object');
+const userAgent = goog.require('Blockly.utils.userAgent');
 const utils = goog.require('Blockly.utils');
+const utilsString = goog.require('Blockly.utils.string');
 
 
 /**

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -17,9 +17,9 @@ const Field = goog.require('Blockly.Field');
 const Size = goog.require('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const {createSvgElement, XLINK_NS} = goog.require('Blockly.utils.dom');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const dom = goog.require('Blockly.utils.dom');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -45,9 +45,9 @@ const FieldImage = function(
   if (!src) {
     throw Error('Src value of an image field is required');
   }
-  src = replaceMessageReferences(src);
-  const imageHeight = Number(replaceMessageReferences(height));
-  const imageWidth = Number(replaceMessageReferences(width));
+  src = utils.replaceMessageReferences(src);
+  const imageHeight = Number(utils.replaceMessageReferences(height));
+  const imageWidth = Number(utils.replaceMessageReferences(width));
   if (isNaN(imageHeight) || isNaN(imageWidth)) {
     throw Error(
         'Height and width values of an image field must cast to' +
@@ -78,7 +78,7 @@ const FieldImage = function(
 
   if (!opt_config) {  // If the config wasn't passed, do old configuration.
     this.flipRtl_ = !!opt_flipRtl;
-    this.altText_ = replaceMessageReferences(opt_alt) || '';
+    this.altText_ = utils.replaceMessageReferences(opt_alt) || '';
   }
 
   // Initialize other properties.
@@ -115,7 +115,7 @@ const FieldImage = function(
    */
   this.imageElement_ = null;
 };
-inherits(FieldImage, Field);
+object.inherits(FieldImage, Field);
 
 /**
  * The default value for this field.
@@ -174,7 +174,7 @@ FieldImage.prototype.isDirty_ = false;
 FieldImage.prototype.configure_ = function(config) {
   FieldImage.superClass_.configure_.call(this, config);
   this.flipRtl_ = !!config['flipRtl'];
-  this.altText_ = replaceMessageReferences(config['alt']) || '';
+  this.altText_ = utils.replaceMessageReferences(config['alt']) || '';
 };
 
 /**
@@ -182,7 +182,7 @@ FieldImage.prototype.configure_ = function(config) {
  * @package
  */
 FieldImage.prototype.initView = function() {
-  this.imageElement_ = createSvgElement(
+  this.imageElement_ = dom.createSvgElement(
       Svg.IMAGE, {
         'height': this.imageHeight_ + 'px',
         'width': this.size_.width + 'px',
@@ -190,7 +190,7 @@ FieldImage.prototype.initView = function() {
       },
       this.fieldGroup_);
   this.imageElement_.setAttributeNS(
-      XLINK_NS, 'xlink:href', /** @type {string} */ (this.value_));
+      dom.XLINK_NS, 'xlink:href', /** @type {string} */ (this.value_));
 
   if (this.clickHandler_) {
     this.imageElement_.style.cursor = 'pointer';
@@ -227,7 +227,7 @@ FieldImage.prototype.doValueUpdate_ = function(newValue) {
   this.value_ = newValue;
   if (this.imageElement_) {
     this.imageElement_.setAttributeNS(
-        XLINK_NS, 'xlink:href', String(this.value_));
+        dom.XLINK_NS, 'xlink:href', String(this.value_));
   }
 };
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 const Field = goog.require('Blockly.Field');
 const Size = goog.require('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
-const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const dom = goog.require('Blockly.utils.dom');
+const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const object = goog.require('Blockly.utils.object');
 const utils = goog.require('Blockly.utils');
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -17,8 +17,8 @@ goog.module.declareLegacyNamespace();
 const Field = goog.require('Blockly.Field');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -47,7 +47,7 @@ const FieldLabel = function(opt_value, opt_class, opt_config) {
     this.class_ = opt_class || null;
   }
 };
-inherits(FieldLabel, Field);
+object.inherits(FieldLabel, Field);
 
 /**
  * The default value for this field.
@@ -65,7 +65,7 @@ FieldLabel.prototype.DEFAULT_VALUE = '';
  * @nocollapse
  */
 FieldLabel.fromJson = function(options) {
-  const text = replaceMessageReferences(options['text']);
+  const text = utils.replaceMessageReferences(options['text']);
   // `this` might be a subclass of FieldLabel if that class doesn't override
   // the static fromJson method.
   return new this(text, undefined, options);

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 
 const FieldLabel = goog.require('Blockly.FieldLabel');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -37,7 +37,7 @@ const FieldLabelSerializable = function(opt_value, opt_class, opt_config) {
   FieldLabelSerializable.superClass_.constructor.call(
       this, opt_value, opt_class, opt_config);
 };
-inherits(FieldLabelSerializable, FieldLabel);
+object.inherits(FieldLabelSerializable, FieldLabel);
 
 /**
  * Construct a FieldLabelSerializable from a JSON arg object,
@@ -48,7 +48,7 @@ inherits(FieldLabelSerializable, FieldLabel);
  * @nocollapse
  */
 FieldLabelSerializable.fromJson = function(options) {
-  const text = replaceMessageReferences(options['text']);
+  const text = utils.replaceMessageReferences(options['text']);
   // `this` might be a subclass of FieldLabelSerializable if that class doesn't
   // override the static fromJson method.
   return new this(text, undefined, options);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -25,8 +25,8 @@ const aria = goog.require('Blockly.utils.aria');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const userAgent = goog.require('Blockly.utils.userAgent');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -70,7 +70,7 @@ const FieldMultilineInput = function(opt_value, opt_validator, opt_config) {
    */
   this.isOverflowedY_ = false;
 };
-inherits(FieldMultilineInput, FieldTextInput);
+object.inherits(FieldMultilineInput, FieldTextInput);
 
 /**
  * @override
@@ -89,7 +89,7 @@ FieldMultilineInput.prototype.configure_ = function(config) {
  * @nocollapse
  */
 FieldMultilineInput.fromJson = function(options) {
-  const text = replaceMessageReferences(options['text']);
+  const text = utils.replaceMessageReferences(options['text']);
   // `this` might be a subclass of FieldMultilineInput if that class doesn't
   // override the static fromJson method.
   return new this(text, undefined, options);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -24,8 +24,8 @@ const WidgetDiv = goog.require('Blockly.WidgetDiv');
 const aria = goog.require('Blockly.utils.aria');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const userAgent = goog.require('Blockly.utils.userAgent');
 const object = goog.require('Blockly.utils.object');
+const userAgent = goog.require('Blockly.utils.userAgent');
 const utils = goog.require('Blockly.utils');
 
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -15,8 +15,8 @@ goog.module.declareLegacyNamespace();
 
 const FieldTextInput = goog.require('Blockly.FieldTextInput');
 const aria = goog.require('Blockly.utils.aria');
-const {inherits} = goog.require('Blockly.utils.object');
-const {register} = goog.require('Blockly.fieldRegistry');
+const object = goog.require('Blockly.utils.object');
+const fieldRegistry = goog.require('Blockly.fieldRegistry');
 
 
 /**
@@ -74,7 +74,7 @@ const FieldNumber = function(
     this.setConstraints(opt_min, opt_max, opt_precision);
   }
 };
-inherits(FieldNumber, FieldTextInput);
+object.inherits(FieldNumber, FieldTextInput);
 
 /**
  * The default value for this field.
@@ -313,6 +313,6 @@ FieldNumber.prototype.widgetCreate_ = function() {
   return htmlInput;
 };
 
-register('field_number', FieldNumber);
+fieldRegistry.register('field_number', FieldNumber);
 
 exports = FieldNumber;

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -15,8 +15,8 @@ goog.module.declareLegacyNamespace();
 
 const FieldTextInput = goog.require('Blockly.FieldTextInput');
 const aria = goog.require('Blockly.utils.aria');
-const object = goog.require('Blockly.utils.object');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
+const object = goog.require('Blockly.utils.object');
 
 
 /**

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -29,9 +29,9 @@ const browserEvents = goog.require('Blockly.browserEvents');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const userAgent = goog.require('Blockly.utils.userAgent');
-const {inherits} = goog.require('Blockly.utils.object');
+const object = goog.require('Blockly.utils.object');
 const {prompt: blocklyPrompt} = goog.require('Blockly');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 
@@ -95,7 +95,7 @@ const FieldTextInput = function(opt_value, opt_validator, opt_config) {
    */
   this.workspace_ = null;
 };
-inherits(FieldTextInput, Field);
+object.inherits(FieldTextInput, Field);
 
 /**
  * The default value for this field.
@@ -113,7 +113,7 @@ FieldTextInput.prototype.DEFAULT_VALUE = '';
  * @nocollapse
  */
 FieldTextInput.fromJson = function(options) {
-  const text = replaceMessageReferences(options['text']);
+  const text = utils.replaceMessageReferences(options['text']);
   // `this` might be a subclass of FieldTextInput if that class doesn't override
   // the static fromJson method.
   return new this(text, undefined, options);

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -13,6 +13,7 @@
 goog.module('Blockly.FieldTextInput');
 goog.module.declareLegacyNamespace();
 
+const Blockly = goog.require('Blockly');
 /* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
 const Coordinate = goog.require('Blockly.utils.Coordinate');
@@ -30,7 +31,6 @@ const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const userAgent = goog.require('Blockly.utils.userAgent');
 const object = goog.require('Blockly.utils.object');
-const {prompt: blocklyPrompt} = goog.require('Blockly');
 const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
@@ -312,7 +312,7 @@ FieldTextInput.prototype.showEditor_ = function(_opt_e, opt_quietInput) {
  * @private
  */
 FieldTextInput.prototype.showPromptEditor_ = function() {
-  blocklyPrompt(Msg['CHANGE_VALUE_TITLE'], this.getText(), function(text) {
+  Blockly.prompt(Msg['CHANGE_VALUE_TITLE'], this.getText(), function(text) {
     this.setValue(this.getValueFromEditorText_(text));
   }.bind(this));
 };

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -29,8 +29,8 @@ const aria = goog.require('Blockly.utils.aria');
 const browserEvents = goog.require('Blockly.browserEvents');
 const dom = goog.require('Blockly.utils.dom');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
-const userAgent = goog.require('Blockly.utils.userAgent');
 const object = goog.require('Blockly.utils.object');
+const userAgent = goog.require('Blockly.utils.userAgent');
 const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -27,8 +27,8 @@ const Variables = goog.require('Blockly.Variables');
 const Xml = goog.require('Blockly.Xml');
 const fieldRegistry = goog.require('Blockly.fieldRegistry');
 const internalConstants = goog.require('Blockly.internalConstants');
-const {inherits} = goog.require('Blockly.utils.object');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
+const utils = goog.require('Blockly.utils');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockChange');
 
@@ -89,7 +89,7 @@ const FieldVariable = function(
     this.setTypes_(opt_variableTypes, opt_defaultType);
   }
 };
-inherits(FieldVariable, FieldDropdown);
+object.inherits(FieldVariable, FieldDropdown);
 
 /**
  * Construct a FieldVariable from a JSON arg object,
@@ -101,7 +101,7 @@ inherits(FieldVariable, FieldDropdown);
  * @nocollapse
  */
 FieldVariable.fromJson = function(options) {
-  const varName = replaceMessageReferences(options['variable']);
+  const varName = utils.replaceMessageReferences(options['variable']);
   // `this` might be a subclass of FieldVariable if that class doesn't override
   // the static fromJson method.
   return new this(varName, undefined, undefined, undefined, options);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -38,7 +38,7 @@ const dom = goog.require('Blockly.utils.dom');
 const toolbox = goog.require('Blockly.utils.toolbox');
 const utils = goog.require('Blockly.utils');
 const utilsXml = goog.require('Blockly.utils.xml');
-const {hideChaff} = goog.require('Blockly');
+const Blockly = goog.require('Blockly');
 /** @suppress {extraRequire} */
 goog.require('Blockly.blockRendering');
 /** @suppress {extraRequire} */
@@ -854,7 +854,7 @@ Flyout.prototype.createBlock = function(originalBlock) {
   }
 
   // Close the flyout.
-  hideChaff();
+  Blockly.hideChaff();
 
   const newVariables = Variables.getAddedVariables(
       this.targetWorkspace, variablesBeforeCreation);

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -15,6 +15,7 @@ goog.module.declareLegacyNamespace();
 
 /* eslint-disable-next-line no-unused-vars */
 const Block = goog.require('Blockly.Block');
+const Blockly = goog.require('Blockly');
 /* eslint-disable-next-line no-unused-vars */
 const BlockSvg = goog.requireType('Blockly.BlockSvg');
 const ComponentManager = goog.require('Blockly.ComponentManager');
@@ -38,7 +39,6 @@ const dom = goog.require('Blockly.utils.dom');
 const toolbox = goog.require('Blockly.utils.toolbox');
 const utils = goog.require('Blockly.utils');
 const utilsXml = goog.require('Blockly.utils.xml');
-const Blockly = goog.require('Blockly');
 /** @suppress {extraRequire} */
 goog.require('Blockly.blockRendering');
 /** @suppress {extraRequire} */

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -23,7 +23,7 @@ const dom = goog.require('Blockly.utils.dom');
 const style = goog.require('Blockly.utils.style');
 /* eslint-disable-next-line no-unused-vars */
 const toolbox = goog.requireType('Blockly.utils.toolbox');
-const {replaceMessageReferences} = goog.require('Blockly.utils');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -167,7 +167,7 @@ FlyoutButton.prototype.createDom = function() {
         'text-anchor': 'middle'
       },
       this.svgGroup_);
-  let text = replaceMessageReferences(this.text_);
+  let text = utils.replaceMessageReferences(this.text_);
   if (this.workspace_.RTL) {
     // Force text to be RTL by adding an RLM.
     text += '\u200F';
@@ -312,22 +312,13 @@ FlyoutButton.prototype.onMouseUp_ = function(e) {
  */
 Css.register([
   /* eslint-disable indent */
-  '.blocklyFlyoutButton {',
-    'fill: #888;',
-    'cursor: default;',
-  '}',
+  '.blocklyFlyoutButton {', 'fill: #888;', 'cursor: default;', '}',
 
-  '.blocklyFlyoutButtonShadow {',
-    'fill: #666;',
-  '}',
+  '.blocklyFlyoutButtonShadow {', 'fill: #666;', '}',
 
-  '.blocklyFlyoutButton:hover {',
-    'fill: #aaa;',
-  '}',
+  '.blocklyFlyoutButton:hover {', 'fill: #aaa;', '}',
 
-  '.blocklyFlyoutLabel {',
-    'cursor: default;',
-  '}',
+  '.blocklyFlyoutLabel {', 'cursor: default;', '}',
 
   '.blocklyFlyoutLabelBackground {', 'opacity: 0;', '}',
   /* eslint-enable indent */

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -312,15 +312,26 @@ FlyoutButton.prototype.onMouseUp_ = function(e) {
  */
 Css.register([
   /* eslint-disable indent */
-  '.blocklyFlyoutButton {', 'fill: #888;', 'cursor: default;', '}',
+  '.blocklyFlyoutButton {',
+    'fill: #888;',
+    'cursor: default;',
+  '}',
 
-  '.blocklyFlyoutButtonShadow {', 'fill: #666;', '}',
+  '.blocklyFlyoutButtonShadow {',
+    'fill: #666;',
+  '}',
 
-  '.blocklyFlyoutButton:hover {', 'fill: #aaa;', '}',
+  '.blocklyFlyoutButton:hover {',
+    'fill: #aaa;',
+  '}',
 
-  '.blocklyFlyoutLabel {', 'cursor: default;', '}',
+  '.blocklyFlyoutLabel {',
+    'cursor: default;',
+  '}',
 
-  '.blocklyFlyoutLabelBackground {', 'opacity: 0;', '}',
+  '.blocklyFlyoutLabelBackground {',
+    'opacity: 0;',
+  '}',
   /* eslint-enable indent */
 ]);
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -22,10 +22,10 @@ const Options = goog.requireType('Blockly.Options');
 const Rect = goog.require('Blockly.utils.Rect');
 const Scrollbar = goog.require('Blockly.Scrollbar');
 const WidgetDiv = goog.require('Blockly.WidgetDiv');
+const object = goog.require('Blockly.utils.object');
 const registry = goog.require('Blockly.registry');
 const toolbox = goog.require('Blockly.utils.toolbox');
 const utils = goog.require('Blockly.utils');
-const object = goog.require('Blockly.utils.object');
 
 
 /**

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -23,9 +23,9 @@ const Rect = goog.require('Blockly.utils.Rect');
 const Scrollbar = goog.require('Blockly.Scrollbar');
 const WidgetDiv = goog.require('Blockly.WidgetDiv');
 const registry = goog.require('Blockly.registry');
-const {Position} = goog.require('Blockly.utils.toolbox');
-const {getScrollDeltaPixels} = goog.require('Blockly.utils');
-const {inherits} = goog.require('Blockly.utils.object');
+const toolbox = goog.require('Blockly.utils.toolbox');
+const utils = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
 
 
 /**
@@ -39,7 +39,7 @@ const HorizontalFlyout = function(workspaceOptions) {
   HorizontalFlyout.superClass_.constructor.call(this, workspaceOptions);
   this.horizontalLayout = true;
 };
-inherits(HorizontalFlyout, Flyout);
+object.inherits(HorizontalFlyout, Flyout);
 
 /**
  * Sets the translation of the flyout to match the scrollbars.
@@ -92,7 +92,7 @@ HorizontalFlyout.prototype.getY = function() {
   const toolboxMetrics = metricsManager.getToolboxMetrics();
 
   let y = 0;
-  const atTop = this.toolboxPosition_ == Position.TOP;
+  const atTop = this.toolboxPosition_ == toolbox.Position.TOP;
   // If this flyout is not the trashcan flyout (e.g. toolbox or mutator).
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
@@ -159,7 +159,7 @@ HorizontalFlyout.prototype.position = function() {
  * @private
  */
 HorizontalFlyout.prototype.setBackgroundPath_ = function(width, height) {
-  const atTop = this.toolboxPosition_ == Position.TOP;
+  const atTop = this.toolboxPosition_ == toolbox.Position.TOP;
   // Start at top left.
   const path = ['M 0,' + (atTop ? 0 : this.CORNER_RADIUS)];
 
@@ -210,7 +210,7 @@ HorizontalFlyout.prototype.scrollToStart = function() {
  * @protected
  */
 HorizontalFlyout.prototype.wheel_ = function(e) {
-  const scrollDelta = getScrollDeltaPixels(e);
+  const scrollDelta = utils.getScrollDeltaPixels(e);
   const delta = scrollDelta.x || scrollDelta.y;
 
   if (delta) {
@@ -326,7 +326,7 @@ HorizontalFlyout.prototype.getClientRect = function() {
   const BIG_NUM = 1000000000;
   const top = flyoutRect.top;
 
-  if (this.toolboxPosition_ == Position.TOP) {
+  if (this.toolboxPosition_ == toolbox.Position.TOP) {
     const height = flyoutRect.height;
     return new Rect(-BIG_NUM, top + height, -BIG_NUM, BIG_NUM);
   } else {  // Bottom.
@@ -335,7 +335,7 @@ HorizontalFlyout.prototype.getClientRect = function() {
 };
 
 /**
- * Compute height of flyout.  Position mat under each block.
+ * Compute height of flyout.  toolbox.Position mat under each block.
  * For RTL: Lay out the blocks right-aligned.
  * @protected
  */
@@ -362,7 +362,7 @@ HorizontalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Position.TOP &&
+        this.toolboxPosition_ == toolbox.Position.TOP &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -22,10 +22,10 @@ const Options = goog.requireType('Blockly.Options');
 const Rect = goog.require('Blockly.utils.Rect');
 const Scrollbar = goog.require('Blockly.Scrollbar');
 const WidgetDiv = goog.require('Blockly.WidgetDiv');
+const object = goog.require('Blockly.utils.object');
 const registry = goog.require('Blockly.registry');
 const toolbox = goog.require('Blockly.utils.toolbox');
 const utils = goog.require('Blockly.utils');
-const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Block');
 /** @suppress {extraRequire} */

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -23,9 +23,9 @@ const Rect = goog.require('Blockly.utils.Rect');
 const Scrollbar = goog.require('Blockly.Scrollbar');
 const WidgetDiv = goog.require('Blockly.WidgetDiv');
 const registry = goog.require('Blockly.registry');
-const {Position} = goog.require('Blockly.utils.toolbox');
-const {getScrollDeltaPixels} = goog.require('Blockly.utils');
-const {inherits} = goog.require('Blockly.utils.object');
+const toolbox = goog.require('Blockly.utils.toolbox');
+const utils = goog.require('Blockly.utils');
+const object = goog.require('Blockly.utils.object');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Block');
 /** @suppress {extraRequire} */
@@ -42,7 +42,7 @@ goog.require('Blockly.constants');
 const VerticalFlyout = function(workspaceOptions) {
   VerticalFlyout.superClass_.constructor.call(this, workspaceOptions);
 };
-inherits(VerticalFlyout, Flyout);
+object.inherits(VerticalFlyout, Flyout);
 
 /**
  * The name of the vertical flyout in the registry.
@@ -94,14 +94,14 @@ VerticalFlyout.prototype.getX = function() {
   if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_) {
     // If there is a category toolbox.
     if (this.targetWorkspace.getToolbox()) {
-      if (this.toolboxPosition_ == Position.LEFT) {
+      if (this.toolboxPosition_ == toolbox.Position.LEFT) {
         x = toolboxMetrics.width;
       } else {
         x = viewMetrics.width - this.width_;
       }
       // Simple (flyout-only) toolbox.
     } else {
-      if (this.toolboxPosition_ == Position.LEFT) {
+      if (this.toolboxPosition_ == toolbox.Position.LEFT) {
         x = 0;
       } else {
         // The simple flyout does not cover the workspace.
@@ -110,7 +110,7 @@ VerticalFlyout.prototype.getX = function() {
     }
     // Trashcan flyout is opposite the main flyout.
   } else {
-    if (this.toolboxPosition_ == Position.LEFT) {
+    if (this.toolboxPosition_ == toolbox.Position.LEFT) {
       x = 0;
     } else {
       // Because the anchor point of the flyout is on the left, but we want
@@ -165,7 +165,7 @@ VerticalFlyout.prototype.position = function() {
  * @private
  */
 VerticalFlyout.prototype.setBackgroundPath_ = function(width, height) {
-  const atRight = this.toolboxPosition_ == Position.RIGHT;
+  const atRight = this.toolboxPosition_ == toolbox.Position.RIGHT;
   const totalWidth = width + this.CORNER_RADIUS;
 
   // Decide whether to start on the left or right.
@@ -201,7 +201,7 @@ VerticalFlyout.prototype.scrollToStart = function() {
  * @protected
  */
 VerticalFlyout.prototype.wheel_ = function(e) {
-  const scrollDelta = getScrollDeltaPixels(e);
+  const scrollDelta = utils.getScrollDeltaPixels(e);
 
   if (scrollDelta.y) {
     const metricsManager = this.workspace_.getMetricsManager();
@@ -306,7 +306,7 @@ VerticalFlyout.prototype.getClientRect = function() {
   const BIG_NUM = 1000000000;
   const left = flyoutRect.left;
 
-  if (this.toolboxPosition_ == Position.LEFT) {
+  if (this.toolboxPosition_ == toolbox.Position.LEFT) {
     const width = flyoutRect.width;
     return new Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, left + width);
   } else {  // Right
@@ -315,7 +315,7 @@ VerticalFlyout.prototype.getClientRect = function() {
 };
 
 /**
- * Compute width of flyout.  Position mat under each block.
+ * Compute width of flyout.  toolbox.Position mat under each block.
  * For RTL: Lay out the blocks and buttons to be right-aligned.
  * @protected
  */
@@ -363,7 +363,7 @@ VerticalFlyout.prototype.reflowInternal_ = function() {
     }
 
     if (this.targetWorkspace.toolboxPosition == this.toolboxPosition_ &&
-        this.toolboxPosition_ == Position.LEFT &&
+        this.toolboxPosition_ == toolbox.Position.LEFT &&
         !this.targetWorkspace.getToolbox()) {
       // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
       // is in the correct position relative to the new absolute edge (ie

--- a/core/icon.js
+++ b/core/icon.js
@@ -22,7 +22,7 @@ const Size = goog.require('Blockly.utils.Size');
 const Svg = goog.require('Blockly.utils.Svg');
 const browserEvents = goog.require('Blockly.browserEvents');
 const dom = goog.require('Blockly.utils.dom');
-const {getRelativeXY, isRightButton} = goog.require('Blockly.utils');
+const utils = goog.require('Blockly.utils');
 
 
 /**
@@ -135,7 +135,7 @@ Icon.prototype.iconClick_ = function(e) {
     // Drag operation is concluding.  Don't open the editor.
     return;
   }
-  if (!this.block_.isInFlyout && !isRightButton(e)) {
+  if (!this.block_.isInFlyout && !utils.isRightButton(e)) {
     this.setVisible(!this.isVisible());
   }
 };
@@ -167,7 +167,7 @@ Icon.prototype.setIconLocation = function(xy) {
 Icon.prototype.computeIconLocation = function() {
   // Find coordinates for the centre of the icon and update the arrow.
   const blockXY = this.block_.getRelativeToSurfaceXY();
-  const iconXY = getRelativeXY(
+  const iconXY = utils.getRelativeXY(
       /** @type {!SVGElement} */ (this.iconGroup_));
   const newXY = new Coordinate(
       blockXY.x + iconXY.x + this.SIZE / 2,

--- a/core/interfaces/i_flyout.js
+++ b/core/interfaces/i_flyout.js
@@ -25,7 +25,7 @@ const Svg = goog.requireType('Blockly.utils.Svg');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 /* eslint-disable-next-line no-unused-vars */
-const {FlyoutDefinition} = goog.requireType('Blockly.utils.toolbox');
+const toolbox = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
@@ -142,7 +142,7 @@ IFlyout.prototype.hide;
 
 /**
  * Show and populate the flyout.
- * @param {!FlyoutDefinition|string} flyoutDef Contents to
+ * @param {!toolbox.FlyoutDefinition|string} flyoutDef Contents to
  *     display in the flyout. This is either an array of Nodes, a NodeList, a
  *     toolbox definition, or a string with the name of the dynamic category.
  */

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -19,7 +19,7 @@ const Metrics = goog.requireType('Blockly.utils.Metrics');
 /* eslint-disable-next-line no-unused-vars */
 const Size = goog.requireType('Blockly.utils.Size');
 /* eslint-disable-next-line no-unused-vars */
-const {AbsoluteMetrics, ContainerRegion, ToolboxMetrics} = goog.requireType('Blockly.MetricsManager');
+const MetricsManager = goog.requireType('Blockly.MetricsManager');
 
 
 /**
@@ -39,13 +39,13 @@ IMetricsManager.prototype.hasFixedEdges;
  * Returns the metrics for the scroll area of the workspace.
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the scroll metrics
  *     in workspace coordinates, false to get them in pixel coordinates.
- * @param {!ContainerRegion=} opt_viewMetrics The view
+ * @param {!MetricsManager.ContainerRegion=} opt_viewMetrics The view
  *     metrics if they have been previously computed. Passing in null may cause
  *     the view metrics to be computed again, if it is needed.
- * @param {!ContainerRegion=} opt_contentMetrics The
+ * @param {!MetricsManager.ContainerRegion=} opt_contentMetrics The
  *     content metrics if they have been previously computed. Passing in null
  *     may cause the content metrics to be computed again, if it is needed.
- * @return {!ContainerRegion} The metrics for the scroll
+ * @return {!MetricsManager.ContainerRegion} The metrics for the scroll
  *    container
  */
 IMetricsManager.prototype.getScrollMetrics;
@@ -55,7 +55,7 @@ IMetricsManager.prototype.getScrollMetrics;
  * coordinates. Returns 0 for the width and height if the workspace has a
  * category toolbox instead of a simple toolbox.
  * @param {boolean=} opt_own Whether to only return the workspace's own flyout.
- * @return {!ToolboxMetrics} The width and height of the
+ * @return {!MetricsManager.ToolboxMetrics} The width and height of the
  *     flyout.
  * @public
  */
@@ -66,7 +66,7 @@ IMetricsManager.prototype.getFlyoutMetrics;
  * coordinates. Returns 0 for the width and height if the workspace has a simple
  * toolbox instead of a category toolbox. To get the width and height of a
  * simple toolbox @see {@link getFlyoutMetrics}.
- * @return {!ToolboxMetrics} The object with the width,
+ * @return {!MetricsManager.ToolboxMetrics} The object with the width,
  *     height and position of the toolbox.
  * @public
  */
@@ -84,7 +84,7 @@ IMetricsManager.prototype.getSvgMetrics;
 /**
  * Gets the absolute left and absolute top in pixel coordinates.
  * This is where the visible workspace starts in relation to the SVG container.
- * @return {!AbsoluteMetrics} The absolute metrics for
+ * @return {!MetricsManager.AbsoluteMetrics} The absolute metrics for
  *     the workspace.
  * @public
  */
@@ -95,7 +95,7 @@ IMetricsManager.prototype.getAbsoluteMetrics;
  * coordinates. The visible workspace does not include the toolbox or flyout.
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the view metrics in
  *     workspace coordinates, false to get them in pixel coordinates.
- * @return {!ContainerRegion} The width, height, top and
+ * @return {!MetricsManager.ContainerRegion} The width, height, top and
  *     left of the viewport in either workspace coordinates or pixel
  *     coordinates.
  * @public
@@ -108,7 +108,7 @@ IMetricsManager.prototype.getViewMetrics;
  * workspace (workspace comments and blocks).
  * @param {boolean=} opt_getWorkspaceCoordinates True to get the content metrics
  *     in workspace coordinates, false to get them in pixel coordinates.
- * @return {!ContainerRegion} The
+ * @return {!MetricsManager.ContainerRegion} The
  *     metrics for the content container.
  * @public
  */

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -17,9 +17,9 @@ goog.module.declareLegacyNamespace();
 /* eslint-disable-next-line no-unused-vars */
 const Metrics = goog.requireType('Blockly.utils.Metrics');
 /* eslint-disable-next-line no-unused-vars */
-const Size = goog.requireType('Blockly.utils.Size');
-/* eslint-disable-next-line no-unused-vars */
 const MetricsManager = goog.requireType('Blockly.MetricsManager');
+/* eslint-disable-next-line no-unused-vars */
+const Size = goog.requireType('Blockly.utils.Size');
 
 
 /**

--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -19,7 +19,7 @@ const IComponent = goog.require('Blockly.IComponent');
 /* eslint-disable-next-line no-unused-vars */
 const Rect = goog.requireType('Blockly.utils.Rect');
 /* eslint-disable-next-line no-unused-vars */
-const {UiMetrics} = goog.requireType('Blockly.MetricsManager');
+const MetricsManager = goog.requireType('Blockly.MetricsManager');
 
 
 /**
@@ -31,7 +31,7 @@ const IPositionable = function() {};
 
 /**
  * Positions the element. Called when the window is resized.
- * @param {!UiMetrics} metrics The workspace metrics.
+ * @param {!MetricsManager.UiMetrics} metrics The workspace metrics.
  * @param {!Array<!Rect>} savedPositions List of rectangles that
  *     are already on the workspace.
  */

--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -17,9 +17,9 @@ goog.module.declareLegacyNamespace();
 /* eslint-disable-next-line no-unused-vars */
 const IComponent = goog.require('Blockly.IComponent');
 /* eslint-disable-next-line no-unused-vars */
-const Rect = goog.requireType('Blockly.utils.Rect');
-/* eslint-disable-next-line no-unused-vars */
 const MetricsManager = goog.requireType('Blockly.MetricsManager');
+/* eslint-disable-next-line no-unused-vars */
+const Rect = goog.requireType('Blockly.utils.Rect');
 
 
 /**

--- a/core/interfaces/i_selectable_toolbox_item.js
+++ b/core/interfaces/i_selectable_toolbox_item.js
@@ -17,7 +17,7 @@ goog.module.declareLegacyNamespace();
 /* eslint-disable-next-line no-unused-vars */
 const IToolboxItem = goog.require('Blockly.IToolboxItem');
 /* eslint-disable-next-line no-unused-vars */
-const {FlyoutItemInfoArray} = goog.requireType('Blockly.utils.toolbox');
+const toolbox = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
@@ -37,7 +37,7 @@ ISelectableToolboxItem.prototype.getName;
 /**
  * Gets the contents of the toolbox item. These are items that are meant to be
  * displayed in the flyout.
- * @return {!FlyoutItemInfoArray|string} The definition
+ * @return {!toolbox.FlyoutItemInfoArray|string} The definition
  *     of items to be displayed in the flyout.
  * @public
  */

--- a/core/interfaces/i_toolbox.js
+++ b/core/interfaces/i_toolbox.js
@@ -23,7 +23,7 @@ const IToolboxItem = goog.requireType('Blockly.IToolboxItem');
 /* eslint-disable-next-line no-unused-vars */
 const WorkspaceSvg = goog.requireType('Blockly.WorkspaceSvg');
 /* eslint-disable-next-line no-unused-vars */
-const {ToolboxInfo} = goog.requireType('Blockly.utils.toolbox');
+const toolbox = goog.requireType('Blockly.utils.toolbox');
 
 
 /**
@@ -41,7 +41,7 @@ IToolbox.prototype.init;
 
 /**
  * Fills the toolbox with new toolbox items and removes any old contents.
- * @param {!ToolboxInfo} toolboxDef Object holding information
+ * @param {!toolbox.ToolboxInfo} toolboxDef Object holding information
  *     for creating a toolbox.
  */
 IToolbox.prototype.render;

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 
 const ASTNode = goog.require('Blockly.ASTNode');
 const Cursor = goog.require('Blockly.Cursor');
-const {register, Type} = goog.require('Blockly.registry');
-const {inherits} = goog.require('Blockly.utils.object');
+const registry = goog.require('Blockly.registry');
+const object = goog.require('Blockly.utils.object');
 
 
 /**
@@ -30,7 +30,7 @@ const {inherits} = goog.require('Blockly.utils.object');
 const BasicCursor = function() {
   BasicCursor.superClass_.constructor.call(this);
 };
-inherits(BasicCursor, Cursor);
+object.inherits(BasicCursor, Cursor);
 
 /**
  * Name used for registering a basic cursor.
@@ -214,6 +214,7 @@ BasicCursor.prototype.getRightMostChild_ = function(node) {
   return this.getRightMostChild_(newNode);
 };
 
-register(Type.CURSOR, BasicCursor.registrationName, BasicCursor);
+registry.register(
+    registry.Type.CURSOR, BasicCursor.registrationName, BasicCursor);
 
 exports = BasicCursor;

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 
 const ASTNode = goog.require('Blockly.ASTNode');
 const Cursor = goog.require('Blockly.Cursor');
-const registry = goog.require('Blockly.registry');
 const object = goog.require('Blockly.utils.object');
+const registry = goog.require('Blockly.registry');
 
 
 /**

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 
 const ASTNode = goog.require('Blockly.ASTNode');
 const Marker = goog.require('Blockly.Marker');
-const {DEFAULT, register, Type} = goog.require('Blockly.registry');
-const {inherits} = goog.require('Blockly.utils.object');
+const registry = goog.require('Blockly.registry');
+const object = goog.require('Blockly.utils.object');
 
 
 /**
@@ -34,7 +34,7 @@ const Cursor = function() {
    */
   this.type = 'cursor';
 };
-inherits(Cursor, Marker);
+object.inherits(Cursor, Marker);
 
 /**
  * Find the next connection, field, or block.
@@ -134,6 +134,6 @@ Cursor.prototype.out = function() {
   return newNode;
 };
 
-register(Type.CURSOR, DEFAULT, Cursor);
+registry.register(registry.Type.CURSOR, registry.DEFAULT, Cursor);
 
 exports = Cursor;

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -16,8 +16,8 @@ goog.module.declareLegacyNamespace();
 
 const ASTNode = goog.require('Blockly.ASTNode');
 const Marker = goog.require('Blockly.Marker');
-const registry = goog.require('Blockly.registry');
 const object = goog.require('Blockly.utils.object');
+const registry = goog.require('Blockly.registry');
 
 
 /**

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -18,7 +18,7 @@ const ASTNode = goog.require('Blockly.ASTNode');
 const BasicCursor = goog.require('Blockly.BasicCursor');
 /* eslint-disable-next-line no-unused-vars */
 const Field = goog.requireType('Blockly.Field');
-const {inherits} = goog.require('Blockly.utils.object');
+const object = goog.require('Blockly.utils.object');
 
 
 /**
@@ -29,7 +29,7 @@ const {inherits} = goog.require('Blockly.utils.object');
 const TabNavigateCursor = function() {
   TabNavigateCursor.superClass_.constructor.call(this);
 };
-inherits(TabNavigateCursor, BasicCursor);
+object.inherits(TabNavigateCursor, BasicCursor);
 
 /**
  * Skip all nodes except for tab navigable fields.

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -46,8 +46,8 @@ const SquareCorner = goog.require('Blockly.blockRendering.SquareCorner');
 const StatementInput = goog.require('Blockly.blockRendering.StatementInput');
 const TopRow = goog.require('Blockly.blockRendering.TopRow');
 const Types = goog.require('Blockly.blockRendering.Types');
-const {ALIGN} = goog.require('Blockly.constants');
-const {DUMMY, STATEMENT, VALUE} = goog.require('Blockly.inputTypes');
+const constants = goog.require('Blockly.constants');
+const inputTypes = goog.require('Blockly.inputTypes');
 
 
 
@@ -290,7 +290,7 @@ RenderInfo.prototype.populateTopRow_ = function() {
   }
 
   const precedesStatement = this.block_.inputList.length &&
-      this.block_.inputList[0].type == STATEMENT;
+      this.block_.inputList[0].type == inputTypes.STATEMENT;
 
   // This is the minimum height for the row. If one of its elements has a
   // greater height it will be overwritten in the compute pass.
@@ -314,7 +314,8 @@ RenderInfo.prototype.populateBottomRow_ = function() {
   this.bottomRow.hasNextConnection = !!this.block_.nextConnection;
 
   const followsStatement = this.block_.inputList.length &&
-      this.block_.inputList[this.block_.inputList.length - 1].type == STATEMENT;
+      this.block_.inputList[this.block_.inputList.length - 1].type ==
+          inputTypes.STATEMENT;
 
   // This is the minimum height for the row. If one of its elements has a
   // greater height it will be overwritten in the compute pass.
@@ -359,16 +360,16 @@ RenderInfo.prototype.populateBottomRow_ = function() {
  */
 RenderInfo.prototype.addInput_ = function(input, activeRow) {
   // Non-dummy inputs have visual representations onscreen.
-  if (this.isInline && input.type == VALUE) {
+  if (this.isInline && input.type == inputTypes.VALUE) {
     activeRow.elements.push(new InlineInput(this.constants_, input));
     activeRow.hasInlineInput = true;
-  } else if (input.type == STATEMENT) {
+  } else if (input.type == inputTypes.STATEMENT) {
     activeRow.elements.push(new StatementInput(this.constants_, input));
     activeRow.hasStatement = true;
-  } else if (input.type == VALUE) {
+  } else if (input.type == inputTypes.VALUE) {
     activeRow.elements.push(new ExternalValueInput(this.constants_, input));
     activeRow.hasExternalInput = true;
-  } else if (input.type == DUMMY) {
+  } else if (input.type == inputTypes.DUMMY) {
     // Dummy inputs have no visual representation, but the information is still
     // important.
     activeRow.minHeight = Math.max(
@@ -397,11 +398,12 @@ RenderInfo.prototype.shouldStartNewRow_ = function(input, lastInput) {
     return false;
   }
   // A statement input or an input following one always gets a new row.
-  if (input.type == STATEMENT || lastInput.type == STATEMENT) {
+  if (input.type == inputTypes.STATEMENT ||
+      lastInput.type == inputTypes.STATEMENT) {
     return true;
   }
   // Value and dummy inputs get new row if inputs are not inlined.
-  if (input.type == VALUE || input.type == DUMMY) {
+  if (input.type == inputTypes.VALUE || input.type == inputTypes.DUMMY) {
     return !this.isInline;
   }
   return false;
@@ -575,14 +577,14 @@ RenderInfo.prototype.addAlignmentPadding_ = function(row, missingSpace) {
   }
 
   // Decide where the extra padding goes.
-  if (row.align == ALIGN.LEFT) {
+  if (row.align == constants.ALIGN.LEFT) {
     // Add padding to the end of the row.
     lastSpacer.width += missingSpace;
-  } else if (row.align == ALIGN.CENTRE) {
+  } else if (row.align == constants.ALIGN.CENTRE) {
     // Split the padding between the beginning and end of the row.
     firstSpacer.width += missingSpace / 2;
     lastSpacer.width += missingSpace / 2;
-  } else if (row.align == ALIGN.RIGHT) {
+  } else if (row.align == constants.ALIGN.RIGHT) {
     // Add padding at the beginning of the row.
     firstSpacer.width += missingSpace;
   } else {

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -17,12 +17,12 @@
 goog.module('Blockly.utils.toolbox');
 goog.module.declareLegacyNamespace();
 
-const userAgent = goog.require('Blockly.utils.userAgent');
 /* eslint-disable-next-line no-unused-vars */
-const {CssConfig: CategoryCssConfig} = goog.requireType('Blockly.ToolboxCategory');
+const ToolboxCategory = goog.requireType('Blockly.ToolboxCategory');
 /* eslint-disable-next-line no-unused-vars */
-const {CssConfig: SeparatorCssConfig} = goog.requireType('Blockly.ToolboxSeparator');
+const ToolboxSeparator = goog.requireType('Blockly.ToolboxSeparator');
 const Xml = goog.require('Blockly.Xml');
+const userAgent = goog.require('Blockly.utils.userAgent');
 
 /**
  * The information needed to create a block in the toolbox.
@@ -43,7 +43,7 @@ exports.BlockInfo = BlockInfo;
  *            kind:string,
  *            id:(string|undefined),
  *            gap:(number|undefined),
- *            cssconfig:(!SeparatorCssConfig|undefined)
+ *            cssconfig:(!ToolboxSeparator.CssConfig|undefined)
  *          }}
  */
 let SeparatorInfo;
@@ -88,7 +88,7 @@ exports.ButtonOrLabelInfo = ButtonOrLabelInfo;
  *            id:(string|undefined),
  *            categorystyle:(string|undefined),
  *            colour:(string|undefined),
- *            cssconfig:(!CategoryCssConfig|undefined),
+ *            cssconfig:(!ToolboxCategory.CssConfig|undefined),
  *            hidden:(string|undefined)
  *          }}
  */
@@ -103,7 +103,7 @@ exports.StaticCategoryInfo = StaticCategoryInfo;
  *            id:(string|undefined),
  *            categorystyle:(string|undefined),
  *            colour:(string|undefined),
- *            cssconfig:(!CategoryCssConfig|undefined),
+ *            cssconfig:(!ToolboxCategory.CssConfig|undefined),
  *            hidden:(string|undefined)
  *          }}
  */

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -22,7 +22,7 @@ const userAgent = goog.require('Blockly.utils.userAgent');
 const {CssConfig: CategoryCssConfig} = goog.requireType('Blockly.ToolboxCategory');
 /* eslint-disable-next-line no-unused-vars */
 const {CssConfig: SeparatorCssConfig} = goog.requireType('Blockly.ToolboxSeparator');
-const {textToDom} = goog.require('Blockly.Xml');
+const Xml = goog.require('Blockly.Xml');
 
 /**
  * The information needed to create a block in the toolbox.
@@ -413,7 +413,7 @@ const parseToolboxTree = function(toolboxDef) {
       }
     }
     if (typeof toolboxDef == 'string') {
-      toolboxDef = textToDom(toolboxDef);
+      toolboxDef = Xml.textToDom(toolboxDef);
       if (toolboxDef.nodeName.toLowerCase() != 'xml') {
         throw TypeError('Toolbox should be an <xml> document.');
       }


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Removes destructuring requires from already converted modules.

### Additional Information

- Ran `npm run build:debug` on each commit
- First commit automatically converted files using bash script through regex that also ran clang-format again on any files touched.
  - Reverted changes in jsdoc that unintentionally changed `SVG` to `Svg.SVG`
  - Renamed require for `Blockly.utils.string` to use `const utilsString = goog.require('Blockly.utils.string');` to avoid collision with string type
- Second commit updates requires that used destructuring to assign new variable names
   (Ex: `const {a: blocklyA} = goog.require('Blockly.utils.string')`)
- There is a separate bug tracking fixing the formatting of `Css.register` https://github.com/google/blockly/issues/5205