### PR TITLE
[DONT MERGE] Project cereal upgrader script

### DIFF
--- a/core/serialization/test_defs.js
+++ b/core/serialization/test_defs.js
@@ -5,8 +5,14 @@ Blockly.Blocks['test1'] = {
   mutationToDom: function() {
 
   },
+  saveExtraState: function() {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  },
   domToMutation: function(mutation) {
 
+  },
+  loadExtraState: function(state) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   },
 }
 
@@ -15,8 +21,14 @@ Blockly.Blocks['test3'] = {
   'mutationToDom': function() {
 
   },
+  'saveExtraState': function() {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  },
   'domToMutation': function(mutation) {
 
+  },
+  'loadExtraState': function(state) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   },
 };
 
@@ -25,8 +37,14 @@ Blockly.Blocks['test3'] = {
        'mutationToDom': function() {
 
        },
+       'saveExtraState': function() {
+         return Blockly.Xml.domToText(this.mutationToDom());
+       },
        'domToMutation': function(mutation) {
 
+       },
+       'loadExtraState': function(state) {
+         return this.domToMutation(Blockly.Xml.textToDom(state));
        },
      };
 
@@ -35,8 +53,14 @@ const mutator = {
   mutationToDom: function() {
 
   },
+  saveExtraState: function() {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  },
   domToMutation: function(mutation) {
 
+  },
+  loadExtraState: function(state) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   },
 };
 
@@ -45,8 +69,14 @@ const mutator2 = {
   'mutationToDom': function() {
 
   },
+  'saveExtraState': function() {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  },
   'domToMutation': function(mutation) {
 
+  },
+  'loadExtraState': function(state) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   },
 };
 
@@ -57,9 +87,15 @@ class Es6Class {
   mutationToDom() {
 
   }
+  saveExtraState() {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  }
 
   domToMutation(mutation) {
 
+  }
+  loadExtraState(state) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   }
 }
 
@@ -68,9 +104,15 @@ class TypeScriptClass {
   mutationToDom(): Element {
 
   }
+  saveExtraState(): string {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  }
 
   domToMutation(el: Element) {
 
+  }
+  loadExtraState(state: string) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   }
 }
 
@@ -79,8 +121,14 @@ Blockly.Blocks['typescript_obj_literal']: Whatever = {
   mutationToDom: function(this: Whatever): Element {
 
   },
+  saveExtraState: function(this: Whatever): string {
+    return Blockly.Xml.domToText(this.mutationToDom());
+  },
   domToMutation: function(this: Whatever, el: Element): {
 
+  }
+  loadExtraState: function(this: Whatever, state: string) {
+    return this.domToMutation(Blockly.Xml.textToDom(state));
   }
 }
 
@@ -88,9 +136,17 @@ Blockly.Blocks['typescript_obj_literal']: Whatever = {
 Blockly.CustomField.prototype.toXml = function(fieldElement) {
 
 };
+Blockly.CustomField.prototype.saveState = function() {
+  var elem = Blockly.utils.xml.createElement("field");
+  elem.setAttribute("name", this.name || '');
+  return Blockly.Xml.domToText(this.toXml(elem));
+};
 
 Blockly.CustomField.prototype.fromXml = function(fieldElement) {
 
+};
+Blockly.CustomField.prototype.loadState = function(state) {
+  this.fromXml(Blockly.Xml.textToDom(state));
 };
 
 // Class based field def
@@ -100,9 +156,17 @@ class CustomField extends Field {
   toXml(fieldElement) {
 
   }
+  saveState() {
+    var elem = Blockly.utils.xml.createElement("field");
+    elem.setAttribute("name", this.name || '');
+    return Blockly.Xml.domToText(this.toXml(elem));
+  }
 
   fromXml(fieldElement) {
 
+  }
+  loadState(state) {
+    this.fromXml(Blockly.Xml.textToDom(state));
   }
 }
 
@@ -113,9 +177,17 @@ class CustomField extends Field {
   toXml(fieldElement: Element): Element {
 
   }
+  saveState(): string {
+    var elem = Blockly.utils.xml.createElement("field");
+    elem.setAttribute("name", this.name || '');
+    return Blockly.Xml.domToText(this.toXml(elem));
+  }
 
   fromXml(fieldElement: Element) {
 
+  }
+  loadState(state: string) {
+    this.fromXml(Blockly.Xml.textToDom(state));
   }
 }
 

--- a/core/serialization/test_defs.js
+++ b/core/serialization/test_defs.js
@@ -1,0 +1,135 @@
+/* eslint-disable */
+
+// JS block def.
+Blockly.Blocks['test1'] = {
+  mutationToDom: function() {
+
+  },
+  domToMutation: function(mutation) {
+
+  },
+}
+
+// JS block def with string keys.
+Blockly.Blocks['test3'] = {
+  'mutationToDom': function() {
+
+  },
+  'domToMutation': function(mutation) {
+
+  },
+};
+
+      // Weird indentation.
+     Blockly.Blocks['test4'] = {
+       'mutationToDom': function() {
+
+       },
+       'domToMutation': function(mutation) {
+
+       },
+     };
+
+// JS mutator def.
+const mutator = {
+  mutationToDom: function() {
+
+  },
+  domToMutation: function(mutation) {
+
+  },
+};
+
+// JS mutator def with string keys.
+const mutator2 = {
+  'mutationToDom': function() {
+
+  },
+  'domToMutation': function(mutation) {
+
+  },
+};
+
+// JS block-class def.
+class Es6Class {
+  constructor() {}
+
+  mutationToDom() {
+
+  }
+
+  domToMutation(mutation) {
+
+  }
+}
+
+// Typescript block-class def.
+class TypeScriptClass {
+  mutationToDom(): Element {
+
+  }
+
+  domToMutation(el: Element) {
+
+  }
+}
+
+// Typescript object literal def.
+Blockly.Blocks['typescript_obj_literal']: Whatever = {
+  mutationToDom: function(this: Whatever): Element {
+
+  },
+  domToMutation: function(this: Whatever, el: Element): {
+
+  }
+}
+
+// Prototype based field def
+Blockly.CustomField.prototype.toXml = function(fieldElement) {
+
+};
+
+Blockly.CustomField.prototype.fromXml = function(fieldElement) {
+
+};
+
+// Class based field def
+class CustomField extends Field {
+  constructor() {}
+
+  toXml(fieldElement) {
+
+  }
+
+  fromXml(fieldElement) {
+
+  }
+}
+
+// Typescript field def
+class CustomField extends Field {
+  constructor() {}
+
+  toXml(fieldElement: Element): Element {
+
+  }
+
+  fromXml(fieldElement: Element) {
+
+  }
+}
+
+
+/**** Missed Cases ****/
+
+// JS Block def that points to other def.
+Blockly.Bocks['test2'] = {
+  mutationToDom: Blockly.Blocks['text_prompt_ext'].mutationToDom,
+  domToMutation: Blockly.Blocks['text_prompt_ext'].domToMutation
+}
+
+// Typescript interface definition.
+interface Whatever {
+  mutationToDom(this: Whatever): () => Element,
+  domtoMutation(this: Whatever): (Element) => void,
+}

--- a/core/serialization/upgrader.py
+++ b/core/serialization/upgrader.py
@@ -1,0 +1,361 @@
+# Copyright 2021 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Available under the same license as the core Blockly library:
+# https://github.com/google/blockly/blob/master/LICENSE
+
+
+"""Upgrades blocks and fields to be compatible with JSO serialization.
+
+This is a command line script that walks over all of the files in a given
+directory, and adds default implementations of JSO serialization hooks if it
+detects existing XML hooks.
+
+  Typical usage examples:
+
+  python upgrader.py         : Walks over the files in the pwd
+  python upgrader.py ./dir   : Walks over all of the files in the dir directory
+"""
+
+import regex
+import sys
+from os import walk
+
+Match = regex.Match
+
+
+mutation_to_dom_pattern = regex.compile(
+  r'(?P<pre>'            # Start a capture group named pre.
+    '(?P<indent>'        # Start a capture group named indent.
+      '[^\'"\n]*'        # Match against anything that is not a
+                         #   quote or newline 0-many times.
+    ')'                  # End indent group.
+    '[\'"]?'             # Match against a quote 0-1 times.
+  ')'                    # End pre group.
+  'mutationToDom'        # Match against the string mutationToDom
+  '(?P<suf>.*)'          # Match against any character besides newline 0-many times.
+  '(?P<scope>'           # Start a capture group named scope.
+    '{'                  # Match against a left brace.
+    '([^{}]|(?&scope))*' # Match against any non-brace character,
+                         #   or the scope group recursively 0-many times.
+    '}'                  # Match against a right brace.
+  ')'                    # End scope group.
+  '(?P<comma>,)?'        # Match against an optional comma.
+)
+
+
+# Match against any character besides newline 0-many times.
+# Then match a right brace, and a colon.
+return_type_pattern = regex.compile('.*\):')
+
+
+dom_to_mutation_pattern = regex.compile(
+  r'(?P<pre>'            # Start a capture group named pre.
+    '(?P<indent>'        # Start a capture group named indent.
+      '[^\'"\n]*'        # Match against anything that is not a
+                         #   quote or newline 0-many times.
+    ')'                  # End indent group.
+    '[\'"]?'             # Match against a quote 0-1 times.
+  ')'                    # End pre group.
+  'domToMutation'        # Match against the string domToMutation.
+  '(?P<suf>.*)'          # Match against any character besides newline 0-many times.
+  '(?P<scope>'           # Start a capture group named scope.
+    '{'                  # Match against a left brace.
+    '([^{}]|(?&scope))*' # Match against any non-brace character,
+                         #   or the scope group recursively 0-many times.
+    '}'                  # Match against a right brace.
+  ')'                    # End scope group.
+  '(?P<comma>,)?'        # Match against an optional comma.
+)
+
+
+# Match against any character besides a quote followed by a colon.
+param_type_pattern = regex.compile(r'[^\'"]:')
+
+
+# Match against any character besides \n 0-many times
+# followed by the string (this:
+# Then match against the *least* number of any character (ie non-greedy)
+# followed by a comma.
+this_pattern = regex.compile(r'.*\(this:.*?,')
+
+
+# Match against any character besides \n 0-many times, followed by (
+pre_parens_pattern = regex.compile(r'(.*)\(')
+
+
+to_xml_patten = regex.compile(
+  r'(?P<pre>'            # Start a capture group named pre.
+    '(?P<indent>'        # Start a capture group named indent.
+      ' *'               # Match against a space character 0-many times.
+    ')'                  # End indent group.
+    '.*'                 # Match against any character besides \n 0-many times.
+  ')'                    # End pre group.
+  'toXml'                # Match against the string toXml
+  '(?P<suf>.*)'          # Match against any character besides \n 0-many times.
+  '(?P<scope>'           # Start a capture group named scope.
+    '{'                  # Match against a left brace.
+    '([^{}]|(?&scope))*' # Match against any non-brace character,
+                         #   or the scope group recursively 0-many times.
+    '}'                  # Match against a right brace.
+  ')'                    # End scope group.
+  '(?P<semi>;)?'         # Match against an optional semicolon
+)
+
+
+from_xml_pattern = regex.compile(
+  r'(?P<pre>'            # Start a capture group named pre.
+    '(?P<indent>'        # Start a capture group named indent.
+      ' *'               # Match against a space character 0-many times.
+    ')'                  # End indent group.
+    '.*'                 # Match against any character besides \n 0-many times.
+  ')'                    # End pre group.
+  'fromXml'              # Match against the string fromXml
+  '(?P<suf>.*)'          # Match against any character besides \n 0-many times.
+  '(?P<scope>'           # Start a capture group named scope.
+    '{'                  # Match against a left brace.
+    '([^{}]|(?&scope))*' # Match against any non-brace character,
+                         #   o the scope group recursively 0-many times.
+    '}'                  # Match against a right brace.
+  ')'                    # End scope group.
+  '(?P<semi>;)?'         # Match against an optional semicolon
+)
+
+
+def insert_block_save(contents: str, match: Match) -> str:
+  """Inserts a default implementation of saveExtraState after the match.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    match:
+      The regex match object for the mutationToDom function.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  index = match.end('comma') if match.end('comma') != -1 else match.end('scope')
+  pre = match.group('pre')
+  indent = match.group('indent')
+
+  return_type_match = return_type_pattern.match(match.group('suf'))
+  suf = (f'{return_type_match.group(0)} string ' if return_type_match != None
+      else match.group('suf'))
+
+  comma = match.group('comma') if match.group('comma') != None else ''
+
+  return (
+    f'{contents[0:index]}'
+    f'\n{pre}saveExtraState{suf}{{' +
+    f'\n{indent}  return Blockly.Xml.domToText(this.mutationToDom());' +
+    f'\n{indent}}}{comma}' +
+    f'{contents[index:len(contents)]}')
+
+
+def add_block_saves(contents:str) -> str:
+  """Inserts default implementations of saveExtraState.
+
+  Inserts a default implementation of the saveExtraState hook after every
+  instance of the mutationToDom hook.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  matches = list(regex.finditer(mutation_to_dom_pattern, contents))
+  matches.reverse()
+  for match in matches:
+      contents = insert_block_save(contents, match)
+  return contents
+
+
+def insert_block_load(contents: str, match: Match) -> str:
+  """Inserts a default implementation of loadExtraState after the match.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    match:
+      The regex match object for the domToMutation function.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  index = match.end('comma') if match.end('comma') != -1 else match.end('scope')
+  pre = match.group('pre')
+  indent = match.group('indent')
+
+  suf = match.group('suf')
+  has_param_types = param_type_pattern.search(suf) != None
+  this_match = this_pattern.match(suf)
+  pre_parens_match = pre_parens_pattern.match(suf)
+  pre_parens = pre_parens_match.group(1) if pre_parens_match != None else ''
+  if has_param_types:
+    if this_match != None:
+      suf = f'{this_match.group(0)} state: string) '
+    else:
+      suf = f'{pre_parens}(state: string) '
+  else:
+    suf = f'{pre_parens}(state) '
+
+  comma = match.group('comma') if match.group('comma') != None else ''
+
+  return (
+    f'{contents[0:index]}'
+    f'\n{pre}loadExtraState{suf}{{'
+    f'\n{indent}  return this.domToMutation(Blockly.Xml.textToDom(state));'
+    f'\n{indent}}}{comma}'
+    f'{contents[index:len(contents)]}')
+
+
+def add_block_loads(contents:str) -> str:
+  """Inserts default implementations of loadExtraState.
+
+  Inserts a default implementation of the loadExtraState hook after every
+  instance of the domToMutation hook.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  matches = list(regex.finditer(dom_to_mutation_pattern, contents))
+  matches.reverse()
+  for match in matches:
+    contents = insert_block_load(contents, match)
+  return contents
+
+
+def insert_field_save(contents:str, match: Match) -> str:
+  """Inserts a default implementation of saveState after the match.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    match:
+      The regex match object for the toXml function.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  index = match.end('semi') if match.end('semi') != -1 else match.end('scope')
+  pre = match.group('pre')
+  indent = match.group('indent')
+
+  suf = match.group('suf')
+  return_type_match = return_type_pattern.match(suf)
+  pre_parens_match = pre_parens_pattern.match(suf)
+  pre_parens = pre_parens_match.group(1) if pre_parens_match != None else ''
+  suf = (f'{pre_parens}(): string ' if return_type_match != None
+      else f'{pre_parens}() ')
+
+  comma = match.group('semi') if match.group('semi') != None else ''
+
+  return (
+    f'{contents[0:index]}'
+    f'\n{pre}saveState{suf}{{'
+    f'\n{indent}  var elem = Blockly.utils.xml.createElement("field");'
+    f'\n{indent}  elem.setAttribute("name", this.name || \'\');'
+    f'\n{indent}  return Blockly.Xml.domToText(this.toXml(elem));'
+    f'\n{indent}}}{comma}'
+    f'{contents[index:len(contents)]}')
+
+
+def add_field_saves(contents:str) -> str:
+  """Inserts default implementations of saveState.
+
+  Inserts a default implementation of the state hook after every instance of
+  the toXml hook.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  matches = list(regex.finditer(to_xml_patten, contents))
+  matches.reverse()
+  for match in matches:
+      contents = insert_field_save(contents, match)
+  return contents
+
+
+def insert_field_load(contents: str, match: Match) -> str:
+  """Inserts a default implementation of loadState after the match.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    match:
+      The regex match object for the fromXml function.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  index = match.end('semi') if match.end('semi') != -1 else match.end('scope')
+  pre = match.group('pre')
+  indent = match.group('indent')
+
+  suf = match.group('suf')
+  has_param_types = param_type_pattern.search(suf) != None
+  pre_parens_match = pre_parens_pattern.match(suf)
+  pre_parens = pre_parens_match.group(1) if pre_parens_match != None else ''
+  suf = (f'{pre_parens}(state: string) ' if has_param_types
+      else f'{pre_parens}(state) ')
+
+  comma = match.group('semi') if match.group('semi') != None else ''
+
+  return (
+    f'{contents[0:index]}'
+    f'\n{pre}loadState{suf}{{'
+    f'\n{indent}  this.fromXml(Blockly.Xml.textToDom(state));'
+    f'\n{indent}}}{comma}'
+    f'{contents[index:len(contents)]}')
+
+
+def add_field_loads(contents: str) -> str:
+  """Inserts default implementations of loadState.
+
+  Inserts a default implementation of the state hook after every instance of
+  the fromXml hook.
+
+  Args:
+    contents:
+      A string containing the contents of the file being modified.
+    
+  Returns:
+    A string containing the modified contents of the file.
+  """
+  matches = list(regex.finditer(from_xml_pattern, contents))
+  matches.reverse()
+  for match in matches:
+    contents = insert_field_load(contents, match)
+  return contents
+
+
+path = sys.argv[1] if len(sys.argv) > 1 else './'
+
+files = []
+for (dir_path, dir_names, file_names) in walk(path):
+  files.extend(file_names)
+
+for file_name in files:
+  with open(file_name, 'r+') as f:
+    originalContents = f.read()
+    contents = originalContents
+    contents = add_block_saves(contents)
+    contents = add_block_loads(contents)
+    contents = add_field_saves(contents)
+    contents = add_field_loads(contents)
+    if contents != originalContents:
+      print(f'Upgrading {file_name}')
+      f.seek(0, 0)
+      f.write(contents)
+
+print('Done upgrading files.')

--- a/core/serialization/upgrader.py
+++ b/core/serialization/upgrader.py
@@ -6,13 +6,10 @@
 
 
 """Upgrades blocks and fields to be compatible with JSO serialization.
-
 This is a command line script that walks over all of the files in a given
 directory, and adds default implementations of JSO serialization hooks if it
 detects existing XML hooks.
-
   Typical usage examples:
-
   python upgrader.py         : Walks over the files in the pwd
   python upgrader.py ./dir   : Walks over all of the files in the dir directory
 """
@@ -124,7 +121,6 @@ from_xml_pattern = regex.compile(
 
 def insert_block_save(contents: str, match: Match) -> str:
   """Inserts a default implementation of saveExtraState after the match.
-
   Args:
     contents:
       A string containing the contents of the file being modified.
@@ -161,7 +157,7 @@ def add_block_saves(contents:str) -> str:
   Args:
     contents:
       A string containing the contents of the file being modified.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -180,7 +176,7 @@ def insert_block_load(contents: str, match: Match) -> str:
       A string containing the contents of the file being modified.
     match:
       The regex match object for the domToMutation function.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -206,7 +202,7 @@ def insert_block_load(contents: str, match: Match) -> str:
   return (
     f'{contents[0:index]}'
     f'\n{pre}loadExtraState{suf}{{'
-    f'\n{indent}  return this.domToMutation(Blockly.Xml.textToDom(state));'
+    f'\n{indent}  this.domToMutation(Blockly.Xml.textToDom(state));'
     f'\n{indent}}}{comma}'
     f'{contents[index:len(contents)]}')
 
@@ -220,7 +216,7 @@ def add_block_loads(contents:str) -> str:
   Args:
     contents:
       A string containing the contents of the file being modified.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -239,7 +235,7 @@ def insert_field_save(contents:str, match: Match) -> str:
       A string containing the contents of the file being modified.
     match:
       The regex match object for the toXml function.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -275,7 +271,7 @@ def add_field_saves(contents:str) -> str:
   Args:
     contents:
       A string containing the contents of the file being modified.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -294,7 +290,7 @@ def insert_field_load(contents: str, match: Match) -> str:
       A string containing the contents of the file being modified.
     match:
       The regex match object for the fromXml function.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -328,7 +324,7 @@ def add_field_loads(contents: str) -> str:
   Args:
     contents:
       A string containing the contents of the file being modified.
-    
+
   Returns:
     A string containing the modified contents of the file.
   """
@@ -343,7 +339,7 @@ path = sys.argv[1] if len(sys.argv) > 1 else './'
 
 files = []
 for (dir_path, dir_names, file_names) in walk(path):
-  files.extend(file_names)
+  files.extend([f'{dir_path}/{name}' for name in file_names])
 
 for file_name in files:
   with open(file_name, 'r+') as f:


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the python styleguide (I think)

## The details
### Resolves
Work on project cereal.

### Proposed Changes
Adds a python script which walks over all of the files in a director and adds default implementations of the new JSO serialization hooks where it finds old XML hooks.

### Reason for Changes
Our previous idea for backwards compatibility was to build it into core itself, but that ran into two problems:
1) For fields, the plan was to add default backwards-compatibles implementations of the new hooks to the base Field class. These implementations would just call the corresponding xml hooks, and stringify the result.
    The problem with this method is that if you subclassed a field besides Field (eg FieldDropdown, FieldNumber, or FieldTextInput) you would hit *that* field's implementation of `saveState`/`loadState` rather than the base backwards-compatible implementation.
2) For blocks, the plan was to add special handling inside the block serialization system to stringify the values returned by XML hooks if necessary.
    The problem with this method is that it ties the new system to the old system, making the old system harder to remove in the future. It also makes the new system messy.

### Testing
I created a test_defs.js file which includes different methods for specifying blocks and fields. This includes js definitions and typescript definitions.

The upgrader included in the PR handles *almost* all of the cases. The cases it misses are:
```typescript
// JS Block def that points to other def.
Blockly.Bocks['test2'] = {
  mutationToDom: Blockly.Blocks['text_prompt_ext'].mutationToDom,
  domToMutation: Blockly.Blocks['text_prompt_ext'].domToMutation
}

// Typescript interface definition.
interface Whatever {
  mutationToDom(this: Whatever): () => Element,
  domtoMutation(this: Whatever): (Element) => void,
} 
```

### Additional Info
If anyone has other suggestions for how to handle backwards compatibility, I'm totally open to investigating them as well!

This code should not be merged into core. Instead the script should be included with the release notes when the new serializer is published.

### Reading this PR
The first commit contains the test_defs.js file with its initial definitions.
The second commit contains the upgrader script.
The third commit contains the modifications the upgrader script made to the test_defs.js file.