### PR TITLE
fix: update tag module workflow to add labels instead of setting one label

### DIFF
--- a/.github/workflows/tag_module_cleanup.yml
+++ b/.github/workflows/tag_module_cleanup.yml
@@ -5,14 +5,14 @@ name: Tag module cleanup
 
 # Trigger on pull requests against goog_module branch only
 # Uses pull_request_target to get write permissions so that it can write labels.
-on: 
+on:
   pull_request_target:
     branches:
       - goog_module
 
 jobs:
   tag-module-cleanup:
-  
+
     # Add the type: cleanup label
     runs-on: ubuntu-latest
     steps:
@@ -23,13 +23,22 @@ jobs:
             // https://github.com/google/blockly/milestone/18
             const milestoneNumber = 18;
             // Note that pull requests are accessed through the issues API.
-            const issuesUpdateParams = { 
-              owner: context.repo.owner, 
-              repo: context.repo.repo, 
+
+            const issueGetParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            }
+
+            const issueInfo = await github.issues.get(issueGetParams)
+
+            const issuesUpdateParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               // Adds the milestone
-              milestone: milestoneNumber, 
+              milestone: milestoneNumber,
               issue_number: context.issue.number,
               // Sets the labels
-              labels: ['type: cleanup']
+              labels: [...issueInfo.labels, 'type: cleanup']
             }
             await github.issues.update(issuesUpdateParams)


### PR DESCRIPTION


## The basics

- [x] I branched from goog_module
- [x] My pull request is against goog_module
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #5298

### Proposed Changes

Instead of just using the update endpoint to set the labels to a single-item list, get the information about the issue and add the new label to the end of the existing list when updating the issue.

Note that I'm using update because I also want to set the milestone. An alternate approach would be two writes: one to set the milestone and one to add the label, using the addLabel endpoint.

#### Behavior Before Change

Conflicts with the cla-bot because the cla: yes label is being removed.

#### Behavior After Change

Existing labels are left in place and the new label is added.

### Reason for Changes

Watching bots fighting is kind of sad.
