### PR TITLE
Migrate core/variables.js to goog.module syntax

### DIFF
--- a/core/variables.js
+++ b/core/variables.js
@@ -83,12 +83,11 @@ const allDeveloperVariables = function(workspace) {
       // August 2018: getDeveloperVars() was deprecated and renamed
       // getDeveloperVariables().
       getDeveloperVariables = block.getDeveloperVars;
-      if (!ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[
-          block.type]) {
-        console.warn('Function getDeveloperVars() deprecated. Use ' +
+      if (!ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[block.type]) {
+        console.warn(
+            'Function getDeveloperVars() deprecated. Use ' +
             'getDeveloperVariables() (block type \'' + block.type + '\')');
-        ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[
-            block.type] = true;
+        ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[block.type] = true;
       }
     }
     if (getDeveloperVariables) {
@@ -144,16 +143,14 @@ const flyoutCategoryBlocks = function(workspace) {
       const block = utilsXml.createElement('block');
       block.setAttribute('type', 'variables_set');
       block.setAttribute('gap', Blocks['math_change'] ? 8 : 24);
-      block.appendChild(
-          generateVariableFieldDom(mostRecentVariable));
+      block.appendChild(generateVariableFieldDom(mostRecentVariable));
       xmlList.push(block);
     }
     if (Blocks['math_change']) {
       const block = utilsXml.createElement('block');
       block.setAttribute('type', 'math_change');
       block.setAttribute('gap', Blocks['variables_get'] ? 20 : 8);
-      block.appendChild(
-          generateVariableFieldDom(mostRecentVariable));
+      block.appendChild(generateVariableFieldDom(mostRecentVariable));
       const value = Xml.textToDom(
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
@@ -192,9 +189,7 @@ exports.VAR_LETTER_OPTIONS = VAR_LETTER_OPTIONS;
  */
 const generateUniqueName = function(workspace) {
   return generateUniqueNameFromOptions(
-      VAR_LETTER_OPTIONS.charAt(0),
-      workspace.getAllVariableNames()
-  );
+      VAR_LETTER_OPTIONS.charAt(0), workspace.getAllVariableNames());
 };
 exports.generateUniqueName = generateUniqueName;
 
@@ -262,39 +257,34 @@ const createVariableButtonHandler = function(
   const type = opt_type || '';
   // This function needs to be named so it can be called recursively.
   const promptAndCheckWithAlert = function(defaultName) {
-    promptName(Msg['NEW_VARIABLE_TITLE'], defaultName,
-        function(text) {
-          if (text) {
-            const existing =
-                nameUsedWithAnyType(text, workspace);
-            if (existing) {
-              let msg;
-              if (existing.type == type) {
-                msg = Msg['VARIABLE_ALREADY_EXISTS'].replace(
-                    '%1', existing.name);
-              } else {
-                msg =
-                    Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE'];
-                msg = msg.replace('%1', existing.name).replace('%2', existing.type);
-              }
-              Blockly.alert(msg,
-                  function() {
-                    promptAndCheckWithAlert(text);  // Recurse
-                  });
-            } else {
-              // No conflict
-              workspace.createVariable(text, type);
-              if (opt_callback) {
-                opt_callback(text);
-              }
-            }
+    promptName(Msg['NEW_VARIABLE_TITLE'], defaultName, function(text) {
+      if (text) {
+        const existing = nameUsedWithAnyType(text, workspace);
+        if (existing) {
+          let msg;
+          if (existing.type == type) {
+            msg = Msg['VARIABLE_ALREADY_EXISTS'].replace('%1', existing.name);
           } else {
-            // User canceled prompt.
-            if (opt_callback) {
-              opt_callback(null);
-            }
+            msg = Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE'];
+            msg = msg.replace('%1', existing.name).replace('%2', existing.type);
           }
-        });
+          Blockly.alert(msg, function() {
+            promptAndCheckWithAlert(text);  // Recurse
+          });
+        } else {
+          // No conflict
+          workspace.createVariable(text, type);
+          if (opt_callback) {
+            opt_callback(text);
+          }
+        }
+      } else {
+        // User canceled prompt.
+        if (opt_callback) {
+          opt_callback(null);
+        }
+      }
+    });
   };
   promptAndCheckWithAlert('');
 };
@@ -316,32 +306,30 @@ const renameVariable = function(workspace, variable, opt_callback) {
   const promptAndCheckWithAlert = function(defaultName) {
     const promptText =
         Msg['RENAME_VARIABLE_TITLE'].replace('%1', variable.name);
-    promptName(promptText, defaultName,
-        function(newName) {
-          if (newName) {
-            const existing = nameUsedWithOtherType(newName,
-                variable.type, workspace);
-            if (existing) {
-              const msg = Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
-                  .replace('%1', existing.name)
-                  .replace('%2', existing.type);
-              Blockly.alert(msg,
-                  function() {
-                    promptAndCheckWithAlert(newName);  // Recurse
-                  });
-            } else {
-              workspace.renameVariableById(variable.getId(), newName);
-              if (opt_callback) {
-                opt_callback(newName);
-              }
-            }
-          } else {
-            // User canceled prompt.
-            if (opt_callback) {
-              opt_callback(null);
-            }
+    promptName(promptText, defaultName, function(newName) {
+      if (newName) {
+        const existing =
+            nameUsedWithOtherType(newName, variable.type, workspace);
+        if (existing) {
+          const msg = Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
+                          .replace('%1', existing.name)
+                          .replace('%2', existing.type);
+          Blockly.alert(msg, function() {
+            promptAndCheckWithAlert(newName);  // Recurse
+          });
+        } else {
+          workspace.renameVariableById(variable.getId(), newName);
+          if (opt_callback) {
+            opt_callback(newName);
           }
-        });
+        }
+      } else {
+        // User canceled prompt.
+        if (opt_callback) {
+          opt_callback(null);
+        }
+      }
+    });
   };
   promptAndCheckWithAlert('');
 };
@@ -360,8 +348,7 @@ const promptName = function(promptText, defaultText, callback) {
     // Beyond this, all names are legal.
     if (newVar) {
       newVar = newVar.replace(/[\s\xa0]+/g, ' ').trim();
-      if (newVar == Msg['RENAME_VARIABLE'] ||
-          newVar == Msg['NEW_VARIABLE']) {
+      if (newVar == Msg['RENAME_VARIABLE'] || newVar == Msg['NEW_VARIABLE']) {
         // Ok, not ALL names are legal...
         newVar = null;
       }
@@ -446,13 +433,10 @@ exports.generateVariableFieldDom = generateVariableFieldDom;
  * @return {!VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
  */
-const getOrCreateVariablePackage = function(workspace, id, opt_name,
-    opt_type) {
-  let variable = getVariable(workspace, id, opt_name,
-      opt_type);
+const getOrCreateVariablePackage = function(workspace, id, opt_name, opt_type) {
+  let variable = getVariable(workspace, id, opt_name, opt_type);
   if (!variable) {
-    variable = createVariable(workspace, id, opt_name,
-        opt_type);
+    variable = createVariable(workspace, id, opt_name, opt_type);
   }
   return variable;
 };
@@ -512,8 +496,7 @@ exports.getVariable = getVariable;
  * @return {!VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
  */
-const createVariable = function(workspace, id, opt_name,
-    opt_type) {
+const createVariable = function(workspace, id, opt_name, opt_type) {
   const potentialVariableMap = workspace.getPotentialVariableMap();
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -545,7 +545,12 @@ exports.getAddedVariables = getAddedVariables;
 
 const testDeps = {generateUniqueName};
 
+/**
+ * Exports functions to allow them to be mocked by unit tests.
+ * @return {!Array<!Function>} An array of functions to be mocked.
+ */
 const getTestDeps = function() {
+  goog.setTestOnly();
   return testDeps;
 };
 exports.getTestDeps = getTestDeps;

--- a/core/variables.js
+++ b/core/variables.js
@@ -14,10 +14,10 @@
  * @name Blockly.Variables
  * @namespace
  */
-goog.provide('Blockly.Variables');
+goog.module('Blockly.Variables');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Blocks');
-goog.require('Blockly.internalConstants');
 goog.require('Blockly.Msg');
 goog.require('Blockly.utils');
 goog.require('Blockly.utils.xml');
@@ -28,13 +28,6 @@ goog.requireType('Blockly.Workspace');
 
 
 /**
- * Constant to separate variable names from procedures and generated functions
- * when running generators.
- * @deprecated Use Blockly.internalConstants.VARIABLE_CATEGORY_NAME
- */
-Blockly.Variables.NAME_TYPE = Blockly.internalConstants.VARIABLE_CATEGORY_NAME;
-
-/**
  * Find all user-created variables that are in use in the workspace.
  * For use by generators.
  * To get a list of all variables on a workspace, including unused variables,
@@ -42,7 +35,7 @@ Blockly.Variables.NAME_TYPE = Blockly.internalConstants.VARIABLE_CATEGORY_NAME;
  * @param {!Blockly.Workspace} ws The workspace to search for variables.
  * @return {!Array<!Blockly.VariableModel>} Array of variable models.
  */
-Blockly.Variables.allUsedVarModels = function(ws) {
+const allUsedVarModels = function(ws) {
   const blocks = ws.getAllBlocks(false);
   const variableHash = Object.create(null);
   // Iterate through every block and add each variable to the hash.
@@ -65,12 +58,12 @@ Blockly.Variables.allUsedVarModels = function(ws) {
   }
   return variableList;
 };
+exports.allUsedVarModels = allUsedVarModels;
 
 /**
- * @private
  * @type {Object<string,boolean>}
  */
-Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
+const ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE = {};
 
 /**
  * Find all developer variables used by blocks in the workspace.
@@ -82,7 +75,7 @@ Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
  * @param {!Blockly.Workspace} workspace The workspace to search.
  * @return {!Array<string>} A list of non-duplicated variable names.
  */
-Blockly.Variables.allDeveloperVariables = function(workspace) {
+const allDeveloperVariables = function(workspace) {
   const blocks = workspace.getAllBlocks(false);
   const variableHash = Object.create(null);
   for (let i = 0, block; (block = blocks[i]); i++) {
@@ -91,11 +84,11 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
       // August 2018: getDeveloperVars() was deprecated and renamed
       // getDeveloperVariables().
       getDeveloperVariables = block.getDeveloperVars;
-      if (!Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_[
+      if (!ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[
           block.type]) {
         console.warn('Function getDeveloperVars() deprecated. Use ' +
             'getDeveloperVariables() (block type \'' + block.type + '\')');
-        Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_[
+        ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[
             block.type] = true;
       }
     }
@@ -110,6 +103,7 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
   // Flatten the hash into a list.
   return Object.keys(variableHash);
 };
+exports.allDeveloperVariables = allDeveloperVariables;
 
 /**
  * Construct the elements (blocks and button) required by the flyout for the
@@ -117,29 +111,30 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
  * @param {!Blockly.Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML elements.
  */
-Blockly.Variables.flyoutCategory = function(workspace) {
+const flyoutCategory = function(workspace) {
   let xmlList = [];
   const button = document.createElement('button');
   button.setAttribute('text', '%{BKY_NEW_VARIABLE}');
   button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
   workspace.registerButtonCallback('CREATE_VARIABLE', function(button) {
-    Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());
+    createVariableButtonHandler(button.getTargetWorkspace());
   });
 
   xmlList.push(button);
 
-  const blockList = Blockly.Variables.flyoutCategoryBlocks(workspace);
+  const blockList = flyoutCategoryBlocks(workspace);
   xmlList = xmlList.concat(blockList);
   return xmlList;
 };
+exports.flyoutCategory = flyoutCategory;
 
 /**
  * Construct the blocks required by the flyout for the variable category.
  * @param {!Blockly.Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML block elements.
  */
-Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
+const flyoutCategoryBlocks = function(workspace) {
   const variableModelList = workspace.getVariablesOfType('');
 
   const xmlList = [];
@@ -151,7 +146,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       block.setAttribute('type', 'variables_set');
       block.setAttribute('gap', Blockly.Blocks['math_change'] ? 8 : 24);
       block.appendChild(
-          Blockly.Variables.generateVariableFieldDom(mostRecentVariable));
+          generateVariableFieldDom(mostRecentVariable));
       xmlList.push(block);
     }
     if (Blockly.Blocks['math_change']) {
@@ -159,7 +154,7 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       block.setAttribute('type', 'math_change');
       block.setAttribute('gap', Blockly.Blocks['variables_get'] ? 20 : 8);
       block.appendChild(
-          Blockly.Variables.generateVariableFieldDom(mostRecentVariable));
+          generateVariableFieldDom(mostRecentVariable));
       const value = Blockly.Xml.textToDom(
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
@@ -176,15 +171,17 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
         const block = Blockly.utils.xml.createElement('block');
         block.setAttribute('type', 'variables_get');
         block.setAttribute('gap', 8);
-        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+        block.appendChild(generateVariableFieldDom(variable));
         xmlList.push(block);
       }
     }
   }
   return xmlList;
 };
+exports.flyoutCategoryBlocks = flyoutCategoryBlocks;
 
-Blockly.Variables.VAR_LETTER_OPTIONS = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
+const VAR_LETTER_OPTIONS = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
+exports.VAR_LETTER_OPTIONS = VAR_LETTER_OPTIONS;
 
 /**
  * Return a new variable name that is not yet being used. This will try to
@@ -194,12 +191,13 @@ Blockly.Variables.VAR_LETTER_OPTIONS = 'ijkmnopqrstuvwxyzabcdefgh';  // No 'l'.
  * @param {!Blockly.Workspace} workspace The workspace to be unique in.
  * @return {string} New variable name.
  */
-Blockly.Variables.generateUniqueName = function(workspace) {
-  return Blockly.Variables.generateUniqueNameFromOptions(
-      Blockly.Variables.VAR_LETTER_OPTIONS.charAt(0),
+const generateUniqueName = function(workspace) {
+  return generateUniqueNameFromOptions(
+      VAR_LETTER_OPTIONS.charAt(0),
       workspace.getAllVariableNames()
   );
 };
+exports.generateUniqueName = generateUniqueName;
 
 /**
  * Returns a unique name that is not present in the usedNames array. This
@@ -209,12 +207,12 @@ Blockly.Variables.generateUniqueName = function(workspace) {
  * @param {!Array<string>} usedNames A list of all of the used names.
  * @return {string} A unique name that is not present in the usedNames array.
  */
-Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames) {
+const generateUniqueNameFromOptions = function(startChar, usedNames) {
   if (!usedNames.length) {
     return startChar;
   }
 
-  const letters = Blockly.Variables.VAR_LETTER_OPTIONS;
+  const letters = VAR_LETTER_OPTIONS;
   let suffix = '';
   let letterIndex = letters.indexOf(startChar);
   let potName = startChar;
@@ -241,6 +239,7 @@ Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames)
     potName = letters.charAt(letterIndex) + suffix;
   }
 };
+exports.generateUniqueNameFromOptions = generateUniqueNameFromOptions;
 
 /**
  * Handles "Create Variable" button in the default variables toolbox category.
@@ -259,16 +258,16 @@ Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames)
  * @param {string=} opt_type The type of the variable like 'int', 'string', or
  *     ''. This will default to '', which is a specific type.
  */
-Blockly.Variables.createVariableButtonHandler = function(
+const createVariableButtonHandler = function(
     workspace, opt_callback, opt_type) {
   const type = opt_type || '';
   // This function needs to be named so it can be called recursively.
   const promptAndCheckWithAlert = function(defaultName) {
-    Blockly.Variables.promptName(Blockly.Msg['NEW_VARIABLE_TITLE'], defaultName,
+    promptName(Blockly.Msg['NEW_VARIABLE_TITLE'], defaultName,
         function(text) {
           if (text) {
             const existing =
-                Blockly.Variables.nameUsedWithAnyType(text, workspace);
+                nameUsedWithAnyType(text, workspace);
             if (existing) {
               let msg;
               if (existing.type == type) {
@@ -300,21 +299,7 @@ Blockly.Variables.createVariableButtonHandler = function(
   };
   promptAndCheckWithAlert('');
 };
-
-/**
- * Original name of Blockly.Variables.createVariableButtonHandler(..).
- * @deprecated Use Blockly.Variables.createVariableButtonHandler(..).
- *
- * @param {!Blockly.Workspace} workspace The workspace on which to create the
- *     variable.
- * @param {function(?string=)=} opt_callback A callback. It will be passed an
- *     acceptable new variable name, or null if change is to be aborted (cancel
- *     button), or undefined if an existing variable was chosen.
- * @param {string=} opt_type The type of the variable like 'int', 'string', or
- *     ''. This will default to '', which is a specific type.
- */
-Blockly.Variables.createVariable =
-    Blockly.Variables.createVariableButtonHandler;
+exports.createVariableButtonHandler = createVariableButtonHandler;
 
 /**
  * Opens a prompt that allows the user to enter a new name for a variable.
@@ -327,15 +312,15 @@ Blockly.Variables.createVariable =
  *     be passed an acceptable new variable name, or null if change is to be
  *     aborted (cancel button), or undefined if an existing variable was chosen.
  */
-Blockly.Variables.renameVariable = function(workspace, variable, opt_callback) {
+const renameVariable = function(workspace, variable, opt_callback) {
   // This function needs to be named so it can be called recursively.
   const promptAndCheckWithAlert = function(defaultName) {
     const promptText =
         Blockly.Msg['RENAME_VARIABLE_TITLE'].replace('%1', variable.name);
-    Blockly.Variables.promptName(promptText, defaultName,
+    promptName(promptText, defaultName,
         function(newName) {
           if (newName) {
-            const existing = Blockly.Variables.nameUsedWithOtherType_(newName,
+            const existing = nameUsedWithOtherType(newName,
                 variable.type, workspace);
             if (existing) {
               const msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
@@ -361,6 +346,7 @@ Blockly.Variables.renameVariable = function(workspace, variable, opt_callback) {
   };
   promptAndCheckWithAlert('');
 };
+exports.renameVariable = renameVariable;
 
 /**
  * Prompt the user for a new variable name.
@@ -369,7 +355,7 @@ Blockly.Variables.renameVariable = function(workspace, variable, opt_callback) {
  * @param {function(?string)} callback A callback. It will return the new
  *     variable name, or null if the user picked something illegal.
  */
-Blockly.Variables.promptName = function(promptText, defaultText, callback) {
+const promptName = function(promptText, defaultText, callback) {
   Blockly.prompt(promptText, defaultText, function(newVar) {
     // Merge runs of whitespace.  Strip leading and trailing whitespace.
     // Beyond this, all names are legal.
@@ -384,6 +370,7 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
     callback(newVar);
   });
 };
+exports.promptName = promptName;
 
 /**
  * Check whether there exists a variable with the given name but a different
@@ -394,9 +381,8 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
  *     variable.
  * @return {?Blockly.VariableModel} The variable with the given name and a
  *     different type, or null if none was found.
- * @private
  */
-Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
+const nameUsedWithOtherType = function(name, type, workspace) {
   const allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
@@ -416,7 +402,7 @@ Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
  * @return {?Blockly.VariableModel} The variable with the given name,
  *     or null if none was found.
  */
-Blockly.Variables.nameUsedWithAnyType = function(name, workspace) {
+const nameUsedWithAnyType = function(name, workspace) {
   const allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
@@ -427,15 +413,15 @@ Blockly.Variables.nameUsedWithAnyType = function(name, workspace) {
   }
   return null;
 };
+exports.nameUsedWithAnyType = nameUsedWithAnyType;
 
 /**
  * Generate DOM objects representing a variable field.
  * @param {!Blockly.VariableModel} variableModel The variable model to
  *     represent.
  * @return {?Element} The generated DOM.
- * @public
  */
-Blockly.Variables.generateVariableFieldDom = function(variableModel) {
+const generateVariableFieldDom = function(variableModel) {
   /* Generates the following XML:
    * <field name="VAR" id="goKTKmYJ8DhVHpruv" variabletype="int">foo</field>
    */
@@ -447,6 +433,7 @@ Blockly.Variables.generateVariableFieldDom = function(variableModel) {
   field.appendChild(name);
   return field;
 };
+exports.generateVariableFieldDom = generateVariableFieldDom;
 
 /**
  * Helper function to look up or create a variable on the given workspace.
@@ -460,16 +447,17 @@ Blockly.Variables.generateVariableFieldDom = function(variableModel) {
  * @return {!Blockly.VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
  */
-Blockly.Variables.getOrCreateVariablePackage = function(workspace, id, opt_name,
+const getOrCreateVariablePackage = function(workspace, id, opt_name,
     opt_type) {
-  let variable = Blockly.Variables.getVariable(workspace, id, opt_name,
+  let variable = getVariable(workspace, id, opt_name,
       opt_type);
   if (!variable) {
-    variable = Blockly.Variables.createVariable_(workspace, id, opt_name,
+    variable = createVariable(workspace, id, opt_name,
         opt_type);
   }
   return variable;
 };
+exports.getOrCreateVariablePackage = getOrCreateVariablePackage;
 
 /**
  * Look up  a variable on the given workspace.
@@ -484,9 +472,8 @@ Blockly.Variables.getOrCreateVariablePackage = function(workspace, id, opt_name,
  *     Only used if lookup by ID fails.
  * @return {?Blockly.VariableModel} The variable corresponding to the given ID
  *     or name + type combination, or null if not found.
- * @public
  */
-Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
+const getVariable = function(workspace, id, opt_name, opt_type) {
   const potentialVariableMap = workspace.getPotentialVariableMap();
   let variable = null;
   // Try to just get the variable, by ID if possible.
@@ -514,6 +501,7 @@ Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
   }
   return variable;
 };
+exports.getVariable = getVariable;
 
 /**
  * Helper function to create a variable on the given workspace.
@@ -524,15 +512,14 @@ Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
  * @param {string=} opt_type The type to use to create the variable.
  * @return {!Blockly.VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
- * @private
  */
-Blockly.Variables.createVariable_ = function(workspace, id, opt_name,
+const createVariable = function(workspace, id, opt_name,
     opt_type) {
   const potentialVariableMap = workspace.getPotentialVariableMap();
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {
     const ws = workspace.isFlyout ? workspace.targetWorkspace : workspace;
-    opt_name = Blockly.Variables.generateUniqueName(ws);
+    opt_name = testDeps.generateUniqueName(ws);
   }
 
   // Create a potential variable if in the flyout.
@@ -555,9 +542,8 @@ Blockly.Variables.createVariable_ = function(workspace, id, opt_name,
  * @return {!Array<!Blockly.VariableModel>} The new array of variables that
  *     were freshly added to the workspace after creating the new block,
  *     or [] if no new variables were added to the workspace.
- * @package
  */
-Blockly.Variables.getAddedVariables = function(workspace, originalVariables) {
+const getAddedVariables = function(workspace, originalVariables) {
   const allCurrentVariables = workspace.getAllVariables();
   const addedVariables = [];
   if (originalVariables.length != allCurrentVariables.length) {
@@ -572,3 +558,12 @@ Blockly.Variables.getAddedVariables = function(workspace, originalVariables) {
   }
   return addedVariables;
 };
+/** @package */
+exports.getAddedVariables = getAddedVariables;
+
+const testDeps = {generateUniqueName};
+
+const getTestDeps = function() {
+  return testDeps;
+};
+exports.getTestDeps = getTestDeps;

--- a/core/variables.js
+++ b/core/variables.js
@@ -187,11 +187,10 @@ exports.VAR_LETTER_OPTIONS = VAR_LETTER_OPTIONS;
  * @param {!Workspace} workspace The workspace to be unique in.
  * @return {string} New variable name.
  */
-const generateUniqueName = function(workspace) {
+exports.generateUniqueName = function(workspace) {
   return generateUniqueNameFromOptions(
       VAR_LETTER_OPTIONS.charAt(0), workspace.getAllVariableNames());
 };
-exports.generateUniqueName = generateUniqueName;
 
 /**
  * Returns a unique name that is not present in the usedNames array. This
@@ -501,7 +500,7 @@ const createVariable = function(workspace, id, opt_name, opt_type) {
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {
     const ws = workspace.isFlyout ? workspace.targetWorkspace : workspace;
-    opt_name = testDeps.generateUniqueName(ws);
+    opt_name = exports.generateUniqueName(ws);
   }
 
   // Create a potential variable if in the flyout.
@@ -542,15 +541,3 @@ const getAddedVariables = function(workspace, originalVariables) {
 };
 /** @package */
 exports.getAddedVariables = getAddedVariables;
-
-const testDeps = {generateUniqueName};
-
-/**
- * Exports functions to allow them to be mocked by unit tests.
- * @return {!Object<!string,!Function>} An array of functions to be mocked.
- */
-const getTestDeps = function() {
-  goog.setTestOnly();
-  return testDeps;
-};
-exports.getTestDeps = getTestDeps;

--- a/core/variables.js
+++ b/core/variables.js
@@ -17,14 +17,13 @@
 goog.module('Blockly.Variables');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Blocks');
-goog.require('Blockly.Msg');
-goog.require('Blockly.utils');
-goog.require('Blockly.utils.xml');
-goog.require('Blockly.VariableModel');
-goog.require('Blockly.Xml');
-
-goog.requireType('Blockly.Workspace');
+const Blocks = goog.require('Blockly.Blocks');
+const Msg = goog.require('Blockly.Msg');
+const VariableModel = goog.require('Blockly.VariableModel');
+/* eslint-disable-next-line no-unused-vars */
+const Workspace = goog.requireType('Blockly.Workspace');
+const Xml = goog.require('Blockly.Xml');
+const utilsXml = goog.require('Blockly.utils.xml');
 
 
 /**
@@ -32,8 +31,8 @@ goog.requireType('Blockly.Workspace');
  * For use by generators.
  * To get a list of all variables on a workspace, including unused variables,
  * call Workspace.getAllVariables.
- * @param {!Blockly.Workspace} ws The workspace to search for variables.
- * @return {!Array<!Blockly.VariableModel>} Array of variable models.
+ * @param {!Workspace} ws The workspace to search for variables.
+ * @return {!Array<!VariableModel>} Array of variable models.
  */
 const allUsedVarModels = function(ws) {
   const blocks = ws.getAllBlocks(false);
@@ -72,7 +71,7 @@ const ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE = {};
  * To declare developer variables, define the getDeveloperVariables function on
  * your block and return a list of variable names.
  * For use by generators.
- * @param {!Blockly.Workspace} workspace The workspace to search.
+ * @param {!Workspace} workspace The workspace to search.
  * @return {!Array<string>} A list of non-duplicated variable names.
  */
 const allDeveloperVariables = function(workspace) {
@@ -108,7 +107,7 @@ exports.allDeveloperVariables = allDeveloperVariables;
 /**
  * Construct the elements (blocks and button) required by the flyout for the
  * variable category.
- * @param {!Blockly.Workspace} workspace The workspace containing variables.
+ * @param {!Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML elements.
  */
 const flyoutCategory = function(workspace) {
@@ -131,7 +130,7 @@ exports.flyoutCategory = flyoutCategory;
 
 /**
  * Construct the blocks required by the flyout for the variable category.
- * @param {!Blockly.Workspace} workspace The workspace containing variables.
+ * @param {!Workspace} workspace The workspace containing variables.
  * @return {!Array<!Element>} Array of XML block elements.
  */
 const flyoutCategoryBlocks = function(workspace) {
@@ -141,21 +140,21 @@ const flyoutCategoryBlocks = function(workspace) {
   if (variableModelList.length > 0) {
     // New variables are added to the end of the variableModelList.
     const mostRecentVariable = variableModelList[variableModelList.length - 1];
-    if (Blockly.Blocks['variables_set']) {
-      const block = Blockly.utils.xml.createElement('block');
+    if (Blocks['variables_set']) {
+      const block = utilsXml.createElement('block');
       block.setAttribute('type', 'variables_set');
-      block.setAttribute('gap', Blockly.Blocks['math_change'] ? 8 : 24);
+      block.setAttribute('gap', Blocks['math_change'] ? 8 : 24);
       block.appendChild(
           generateVariableFieldDom(mostRecentVariable));
       xmlList.push(block);
     }
-    if (Blockly.Blocks['math_change']) {
-      const block = Blockly.utils.xml.createElement('block');
+    if (Blocks['math_change']) {
+      const block = utilsXml.createElement('block');
       block.setAttribute('type', 'math_change');
-      block.setAttribute('gap', Blockly.Blocks['variables_get'] ? 20 : 8);
+      block.setAttribute('gap', Blocks['variables_get'] ? 20 : 8);
       block.appendChild(
           generateVariableFieldDom(mostRecentVariable));
-      const value = Blockly.Xml.textToDom(
+      const value = Xml.textToDom(
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +
@@ -165,10 +164,10 @@ const flyoutCategoryBlocks = function(workspace) {
       xmlList.push(block);
     }
 
-    if (Blockly.Blocks['variables_get']) {
-      variableModelList.sort(Blockly.VariableModel.compareByName);
+    if (Blocks['variables_get']) {
+      variableModelList.sort(VariableModel.compareByName);
       for (let i = 0, variable; (variable = variableModelList[i]); i++) {
-        const block = Blockly.utils.xml.createElement('block');
+        const block = utilsXml.createElement('block');
         block.setAttribute('type', 'variables_get');
         block.setAttribute('gap', 8);
         block.appendChild(generateVariableFieldDom(variable));
@@ -188,7 +187,7 @@ exports.VAR_LETTER_OPTIONS = VAR_LETTER_OPTIONS;
  * generate single letter variable names in the range 'i' to 'z' to start with.
  * If no unique name is located it will try 'i' to 'z', 'a' to 'h',
  * then 'i2' to 'z2' etc.  Skip 'l'.
- * @param {!Blockly.Workspace} workspace The workspace to be unique in.
+ * @param {!Workspace} workspace The workspace to be unique in.
  * @return {string} New variable name.
  */
 const generateUniqueName = function(workspace) {
@@ -250,7 +249,7 @@ exports.generateUniqueNameFromOptions = generateUniqueNameFromOptions;
  * types and after-creation processing. More complex customization (e.g.,
  * prompting for variable type) is beyond the scope of this function.
  *
- * @param {!Blockly.Workspace} workspace The workspace on which to create the
+ * @param {!Workspace} workspace The workspace on which to create the
  *     variable.
  * @param {function(?string=)=} opt_callback A callback. It will be passed an
  *     acceptable new variable name, or null if change is to be aborted (cancel
@@ -263,7 +262,7 @@ const createVariableButtonHandler = function(
   const type = opt_type || '';
   // This function needs to be named so it can be called recursively.
   const promptAndCheckWithAlert = function(defaultName) {
-    promptName(Blockly.Msg['NEW_VARIABLE_TITLE'], defaultName,
+    promptName(Msg['NEW_VARIABLE_TITLE'], defaultName,
         function(text) {
           if (text) {
             const existing =
@@ -271,11 +270,11 @@ const createVariableButtonHandler = function(
             if (existing) {
               let msg;
               if (existing.type == type) {
-                msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS'].replace(
+                msg = Msg['VARIABLE_ALREADY_EXISTS'].replace(
                     '%1', existing.name);
               } else {
                 msg =
-                    Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE'];
+                    Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE'];
                 msg = msg.replace('%1', existing.name).replace('%2', existing.type);
               }
               Blockly.alert(msg,
@@ -305,9 +304,9 @@ exports.createVariableButtonHandler = createVariableButtonHandler;
  * Opens a prompt that allows the user to enter a new name for a variable.
  * Triggers a rename if the new name is valid. Or re-prompts if there is a
  * collision.
- * @param {!Blockly.Workspace} workspace The workspace on which to rename the
+ * @param {!Workspace} workspace The workspace on which to rename the
  *     variable.
- * @param {!Blockly.VariableModel} variable Variable to rename.
+ * @param {!VariableModel} variable Variable to rename.
  * @param {function(?string=)=} opt_callback A callback. It will
  *     be passed an acceptable new variable name, or null if change is to be
  *     aborted (cancel button), or undefined if an existing variable was chosen.
@@ -316,14 +315,14 @@ const renameVariable = function(workspace, variable, opt_callback) {
   // This function needs to be named so it can be called recursively.
   const promptAndCheckWithAlert = function(defaultName) {
     const promptText =
-        Blockly.Msg['RENAME_VARIABLE_TITLE'].replace('%1', variable.name);
+        Msg['RENAME_VARIABLE_TITLE'].replace('%1', variable.name);
     promptName(promptText, defaultName,
         function(newName) {
           if (newName) {
             const existing = nameUsedWithOtherType(newName,
                 variable.type, workspace);
             if (existing) {
-              const msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
+              const msg = Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
                   .replace('%1', existing.name)
                   .replace('%2', existing.type);
               Blockly.alert(msg,
@@ -361,8 +360,8 @@ const promptName = function(promptText, defaultText, callback) {
     // Beyond this, all names are legal.
     if (newVar) {
       newVar = newVar.replace(/[\s\xa0]+/g, ' ').trim();
-      if (newVar == Blockly.Msg['RENAME_VARIABLE'] ||
-          newVar == Blockly.Msg['NEW_VARIABLE']) {
+      if (newVar == Msg['RENAME_VARIABLE'] ||
+          newVar == Msg['NEW_VARIABLE']) {
         // Ok, not ALL names are legal...
         newVar = null;
       }
@@ -377,9 +376,9 @@ exports.promptName = promptName;
  * type.
  * @param {string} name The name to search for.
  * @param {string} type The type to exclude from the search.
- * @param {!Blockly.Workspace} workspace The workspace to search for the
+ * @param {!Workspace} workspace The workspace to search for the
  *     variable.
- * @return {?Blockly.VariableModel} The variable with the given name and a
+ * @return {?VariableModel} The variable with the given name and a
  *     different type, or null if none was found.
  */
 const nameUsedWithOtherType = function(name, type, workspace) {
@@ -397,9 +396,9 @@ const nameUsedWithOtherType = function(name, type, workspace) {
 /**
  * Check whether there exists a variable with the given name of any type.
  * @param {string} name The name to search for.
- * @param {!Blockly.Workspace} workspace The workspace to search for the
+ * @param {!Workspace} workspace The workspace to search for the
  *     variable.
- * @return {?Blockly.VariableModel} The variable with the given name,
+ * @return {?VariableModel} The variable with the given name,
  *     or null if none was found.
  */
 const nameUsedWithAnyType = function(name, workspace) {
@@ -417,7 +416,7 @@ exports.nameUsedWithAnyType = nameUsedWithAnyType;
 
 /**
  * Generate DOM objects representing a variable field.
- * @param {!Blockly.VariableModel} variableModel The variable model to
+ * @param {!VariableModel} variableModel The variable model to
  *     represent.
  * @return {?Element} The generated DOM.
  */
@@ -425,11 +424,11 @@ const generateVariableFieldDom = function(variableModel) {
   /* Generates the following XML:
    * <field name="VAR" id="goKTKmYJ8DhVHpruv" variabletype="int">foo</field>
    */
-  const field = Blockly.utils.xml.createElement('field');
+  const field = utilsXml.createElement('field');
   field.setAttribute('name', 'VAR');
   field.setAttribute('id', variableModel.getId());
   field.setAttribute('variabletype', variableModel.type);
-  const name = Blockly.utils.xml.createTextNode(variableModel.name);
+  const name = utilsXml.createTextNode(variableModel.name);
   field.appendChild(name);
   return field;
 };
@@ -438,13 +437,13 @@ exports.generateVariableFieldDom = generateVariableFieldDom;
 /**
  * Helper function to look up or create a variable on the given workspace.
  * If no variable exists, creates and returns it.
- * @param {!Blockly.Workspace} workspace The workspace to search for the
+ * @param {!Workspace} workspace The workspace to search for the
  *     variable.  It may be a flyout workspace or main workspace.
  * @param {?string} id The ID to use to look up or create the variable, or null.
  * @param {string=} opt_name The string to use to look up or create the
  *     variable.
  * @param {string=} opt_type The type to use to look up or create the variable.
- * @return {!Blockly.VariableModel} The variable corresponding to the given ID
+ * @return {!VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
  */
 const getOrCreateVariablePackage = function(workspace, id, opt_name,
@@ -463,14 +462,14 @@ exports.getOrCreateVariablePackage = getOrCreateVariablePackage;
  * Look up  a variable on the given workspace.
  * Always looks in the main workspace before looking in the flyout workspace.
  * Always prefers lookup by ID to lookup by name + type.
- * @param {!Blockly.Workspace} workspace The workspace to search for the
+ * @param {!Workspace} workspace The workspace to search for the
  *     variable.  It may be a flyout workspace or main workspace.
  * @param {?string} id The ID to use to look up the variable, or null.
  * @param {string=} opt_name The string to use to look up the variable.
  *     Only used if lookup by ID fails.
  * @param {string=} opt_type The type to use to look up the variable.
  *     Only used if lookup by ID fails.
- * @return {?Blockly.VariableModel} The variable corresponding to the given ID
+ * @return {?VariableModel} The variable corresponding to the given ID
  *     or name + type combination, or null if not found.
  */
 const getVariable = function(workspace, id, opt_name, opt_type) {
@@ -505,12 +504,12 @@ exports.getVariable = getVariable;
 
 /**
  * Helper function to create a variable on the given workspace.
- * @param {!Blockly.Workspace} workspace The workspace in which to create the
+ * @param {!Workspace} workspace The workspace in which to create the
  * variable.  It may be a flyout workspace or main workspace.
  * @param {?string} id The ID to use to create the variable, or null.
  * @param {string=} opt_name The string to use to create the variable.
  * @param {string=} opt_type The type to use to create the variable.
- * @return {!Blockly.VariableModel} The variable corresponding to the given ID
+ * @return {!VariableModel} The variable corresponding to the given ID
  *     or name + type combination.
  */
 const createVariable = function(workspace, id, opt_name,
@@ -536,10 +535,10 @@ const createVariable = function(workspace, id, opt_name,
  * Helper function to get the list of variables that have been added to the
  * workspace after adding a new block, using the given list of variables that
  * were in the workspace before the new block was added.
- * @param {!Blockly.Workspace} workspace The workspace to inspect.
- * @param {!Array<!Blockly.VariableModel>} originalVariables The array of
+ * @param {!Workspace} workspace The workspace to inspect.
+ * @param {!Array<!VariableModel>} originalVariables The array of
  *     variables that existed in the workspace before adding the new block.
- * @return {!Array<!Blockly.VariableModel>} The new array of variables that
+ * @return {!Array<!VariableModel>} The new array of variables that
  *     were freshly added to the workspace after creating the new block,
  *     or [] if no new variables were added to the workspace.
  */

--- a/core/variables.js
+++ b/core/variables.js
@@ -43,15 +43,15 @@ Blockly.Variables.NAME_TYPE = Blockly.internalConstants.VARIABLE_CATEGORY_NAME;
  * @return {!Array<!Blockly.VariableModel>} Array of variable models.
  */
 Blockly.Variables.allUsedVarModels = function(ws) {
-  var blocks = ws.getAllBlocks(false);
-  var variableHash = Object.create(null);
+  const blocks = ws.getAllBlocks(false);
+  const variableHash = Object.create(null);
   // Iterate through every block and add each variable to the hash.
-  for (var i = 0; i < blocks.length; i++) {
-    var blockVariables = blocks[i].getVarModels();
+  for (let i = 0; i < blocks.length; i++) {
+    const blockVariables = blocks[i].getVarModels();
     if (blockVariables) {
-      for (var j = 0; j < blockVariables.length; j++) {
-        var variable = blockVariables[j];
-        var id = variable.getId();
+      for (let j = 0; j < blockVariables.length; j++) {
+        const variable = blockVariables[j];
+        const id = variable.getId();
         if (id) {
           variableHash[id] = variable;
         }
@@ -59,8 +59,8 @@ Blockly.Variables.allUsedVarModels = function(ws) {
     }
   }
   // Flatten the hash into a list.
-  var variableList = [];
-  for (var id in variableHash) {
+  const variableList = [];
+  for (const id in variableHash) {
     variableList.push(variableHash[id]);
   }
   return variableList;
@@ -83,10 +83,10 @@ Blockly.Variables.ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE_ = {};
  * @return {!Array<string>} A list of non-duplicated variable names.
  */
 Blockly.Variables.allDeveloperVariables = function(workspace) {
-  var blocks = workspace.getAllBlocks(false);
-  var variableHash = Object.create(null);
-  for (var i = 0, block; (block = blocks[i]); i++) {
-    var getDeveloperVariables = block.getDeveloperVariables;
+  const blocks = workspace.getAllBlocks(false);
+  const variableHash = Object.create(null);
+  for (let i = 0, block; (block = blocks[i]); i++) {
+    let getDeveloperVariables = block.getDeveloperVariables;
     if (!getDeveloperVariables && block.getDeveloperVars) {
       // August 2018: getDeveloperVars() was deprecated and renamed
       // getDeveloperVariables().
@@ -100,8 +100,8 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
       }
     }
     if (getDeveloperVariables) {
-      var devVars = getDeveloperVariables();
-      for (var j = 0; j < devVars.length; j++) {
+      const devVars = getDeveloperVariables();
+      for (let j = 0; j < devVars.length; j++) {
         variableHash[devVars[j]] = true;
       }
     }
@@ -118,8 +118,8 @@ Blockly.Variables.allDeveloperVariables = function(workspace) {
  * @return {!Array<!Element>} Array of XML elements.
  */
 Blockly.Variables.flyoutCategory = function(workspace) {
-  var xmlList = [];
-  var button = document.createElement('button');
+  let xmlList = [];
+  const button = document.createElement('button');
   button.setAttribute('text', '%{BKY_NEW_VARIABLE}');
   button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
@@ -129,7 +129,7 @@ Blockly.Variables.flyoutCategory = function(workspace) {
 
   xmlList.push(button);
 
-  var blockList = Blockly.Variables.flyoutCategoryBlocks(workspace);
+  const blockList = Blockly.Variables.flyoutCategoryBlocks(workspace);
   xmlList = xmlList.concat(blockList);
   return xmlList;
 };
@@ -140,14 +140,14 @@ Blockly.Variables.flyoutCategory = function(workspace) {
  * @return {!Array<!Element>} Array of XML block elements.
  */
 Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
-  var variableModelList = workspace.getVariablesOfType('');
+  const variableModelList = workspace.getVariablesOfType('');
 
-  var xmlList = [];
+  const xmlList = [];
   if (variableModelList.length > 0) {
     // New variables are added to the end of the variableModelList.
-    var mostRecentVariable = variableModelList[variableModelList.length - 1];
+    const mostRecentVariable = variableModelList[variableModelList.length - 1];
     if (Blockly.Blocks['variables_set']) {
-      var block = Blockly.utils.xml.createElement('block');
+      const block = Blockly.utils.xml.createElement('block');
       block.setAttribute('type', 'variables_set');
       block.setAttribute('gap', Blockly.Blocks['math_change'] ? 8 : 24);
       block.appendChild(
@@ -155,12 +155,12 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
       xmlList.push(block);
     }
     if (Blockly.Blocks['math_change']) {
-      var block = Blockly.utils.xml.createElement('block');
+      const block = Blockly.utils.xml.createElement('block');
       block.setAttribute('type', 'math_change');
       block.setAttribute('gap', Blockly.Blocks['variables_get'] ? 20 : 8);
       block.appendChild(
           Blockly.Variables.generateVariableFieldDom(mostRecentVariable));
-      var value = Blockly.Xml.textToDom(
+      const value = Blockly.Xml.textToDom(
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +
@@ -172,8 +172,8 @@ Blockly.Variables.flyoutCategoryBlocks = function(workspace) {
 
     if (Blockly.Blocks['variables_get']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
-      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
-        var block = Blockly.utils.xml.createElement('block');
+      for (let i = 0, variable; (variable = variableModelList[i]); i++) {
+        const block = Blockly.utils.xml.createElement('block');
         block.setAttribute('type', 'variables_get');
         block.setAttribute('gap', 8);
         block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
@@ -214,15 +214,15 @@ Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames)
     return startChar;
   }
 
-  var letters = Blockly.Variables.VAR_LETTER_OPTIONS;
-  var suffix = '';
-  var letterIndex = letters.indexOf(startChar);
-  var potName = startChar;
+  const letters = Blockly.Variables.VAR_LETTER_OPTIONS;
+  let suffix = '';
+  let letterIndex = letters.indexOf(startChar);
+  let potName = startChar;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    var inUse = false;
-    for (var i = 0; i < usedNames.length; i++) {
+    let inUse = false;
+    for (let i = 0; i < usedNames.length; i++) {
       if (usedNames[i].toLowerCase() == potName) {
         inUse = true;
         break;
@@ -261,20 +261,21 @@ Blockly.Variables.generateUniqueNameFromOptions = function(startChar, usedNames)
  */
 Blockly.Variables.createVariableButtonHandler = function(
     workspace, opt_callback, opt_type) {
-  var type = opt_type || '';
+  const type = opt_type || '';
   // This function needs to be named so it can be called recursively.
-  var promptAndCheckWithAlert = function(defaultName) {
+  const promptAndCheckWithAlert = function(defaultName) {
     Blockly.Variables.promptName(Blockly.Msg['NEW_VARIABLE_TITLE'], defaultName,
         function(text) {
           if (text) {
-            var existing =
+            const existing =
                 Blockly.Variables.nameUsedWithAnyType(text, workspace);
             if (existing) {
+              let msg;
               if (existing.type == type) {
-                var msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS'].replace(
+                msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS'].replace(
                     '%1', existing.name);
               } else {
-                var msg =
+                msg =
                     Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE'];
                 msg = msg.replace('%1', existing.name).replace('%2', existing.type);
               }
@@ -328,16 +329,16 @@ Blockly.Variables.createVariable =
  */
 Blockly.Variables.renameVariable = function(workspace, variable, opt_callback) {
   // This function needs to be named so it can be called recursively.
-  var promptAndCheckWithAlert = function(defaultName) {
-    var promptText =
+  const promptAndCheckWithAlert = function(defaultName) {
+    const promptText =
         Blockly.Msg['RENAME_VARIABLE_TITLE'].replace('%1', variable.name);
     Blockly.Variables.promptName(promptText, defaultName,
         function(newName) {
           if (newName) {
-            var existing = Blockly.Variables.nameUsedWithOtherType_(newName,
+            const existing = Blockly.Variables.nameUsedWithOtherType_(newName,
                 variable.type, workspace);
             if (existing) {
-              var msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
+              const msg = Blockly.Msg['VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE']
                   .replace('%1', existing.name)
                   .replace('%2', existing.type);
               Blockly.alert(msg,
@@ -396,10 +397,10 @@ Blockly.Variables.promptName = function(promptText, defaultText, callback) {
  * @private
  */
 Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
-  var allVariables = workspace.getVariableMap().getAllVariables();
+  const allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
-  for (var i = 0, variable; (variable = allVariables[i]); i++) {
+  for (let i = 0, variable; (variable = allVariables[i]); i++) {
     if (variable.name.toLowerCase() == name && variable.type != type) {
       return variable;
     }
@@ -416,10 +417,10 @@ Blockly.Variables.nameUsedWithOtherType_ = function(name, type, workspace) {
  *     or null if none was found.
  */
 Blockly.Variables.nameUsedWithAnyType = function(name, workspace) {
-  var allVariables = workspace.getVariableMap().getAllVariables();
+  const allVariables = workspace.getVariableMap().getAllVariables();
 
   name = name.toLowerCase();
-  for (var i = 0, variable; (variable = allVariables[i]); i++) {
+  for (let i = 0, variable; (variable = allVariables[i]); i++) {
     if (variable.name.toLowerCase() == name) {
       return variable;
     }
@@ -438,11 +439,11 @@ Blockly.Variables.generateVariableFieldDom = function(variableModel) {
   /* Generates the following XML:
    * <field name="VAR" id="goKTKmYJ8DhVHpruv" variabletype="int">foo</field>
    */
-  var field = Blockly.utils.xml.createElement('field');
+  const field = Blockly.utils.xml.createElement('field');
   field.setAttribute('name', 'VAR');
   field.setAttribute('id', variableModel.getId());
   field.setAttribute('variabletype', variableModel.type);
-  var name = Blockly.utils.xml.createTextNode(variableModel.name);
+  const name = Blockly.utils.xml.createTextNode(variableModel.name);
   field.appendChild(name);
   return field;
 };
@@ -461,7 +462,7 @@ Blockly.Variables.generateVariableFieldDom = function(variableModel) {
  */
 Blockly.Variables.getOrCreateVariablePackage = function(workspace, id, opt_name,
     opt_type) {
-  var variable = Blockly.Variables.getVariable(workspace, id, opt_name,
+  let variable = Blockly.Variables.getVariable(workspace, id, opt_name,
       opt_type);
   if (!variable) {
     variable = Blockly.Variables.createVariable_(workspace, id, opt_name,
@@ -486,8 +487,8 @@ Blockly.Variables.getOrCreateVariablePackage = function(workspace, id, opt_name,
  * @public
  */
 Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
-  var potentialVariableMap = workspace.getPotentialVariableMap();
-  var variable = null;
+  const potentialVariableMap = workspace.getPotentialVariableMap();
+  let variable = null;
   // Try to just get the variable, by ID if possible.
   if (id) {
     // Look in the real variable map before checking the potential variable map.
@@ -527,15 +528,15 @@ Blockly.Variables.getVariable = function(workspace, id, opt_name, opt_type) {
  */
 Blockly.Variables.createVariable_ = function(workspace, id, opt_name,
     opt_type) {
-  var potentialVariableMap = workspace.getPotentialVariableMap();
+  const potentialVariableMap = workspace.getPotentialVariableMap();
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {
-    var ws = workspace.isFlyout ? workspace.targetWorkspace : workspace;
+    const ws = workspace.isFlyout ? workspace.targetWorkspace : workspace;
     opt_name = Blockly.Variables.generateUniqueName(ws);
   }
 
   // Create a potential variable if in the flyout.
-  var variable = null;
+  let variable = null;
   if (potentialVariableMap) {
     variable = potentialVariableMap.createVariable(opt_name, opt_type, id);
   } else {  // In the main workspace, create a real variable.
@@ -557,11 +558,11 @@ Blockly.Variables.createVariable_ = function(workspace, id, opt_name,
  * @package
  */
 Blockly.Variables.getAddedVariables = function(workspace, originalVariables) {
-  var allCurrentVariables = workspace.getAllVariables();
-  var addedVariables = [];
+  const allCurrentVariables = workspace.getAllVariables();
+  const addedVariables = [];
   if (originalVariables.length != allCurrentVariables.length) {
-    for (var i = 0; i < allCurrentVariables.length; i++) {
-      var variable = allCurrentVariables[i];
+    for (let i = 0; i < allCurrentVariables.length; i++) {
+      const variable = allCurrentVariables[i];
       // For any variable that is present in allCurrentVariables but not
       // present in originalVariables, add the variable to addedVariables.
       if (originalVariables.indexOf(variable) == -1) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -547,7 +547,7 @@ const testDeps = {generateUniqueName};
 
 /**
  * Exports functions to allow them to be mocked by unit tests.
- * @return {!Array<!Function>} An array of functions to be mocked.
+ * @return {!Object<!string,!Function>} An array of functions to be mocked.
  */
 const getTestDeps = function() {
   goog.setTestOnly();

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -213,7 +213,7 @@ goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'],
 goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.Names', 'Blockly.VariableModel', 'Blockly.utils', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.utils', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/widgetdiv.js', ['Blockly.WidgetDiv'], ['Blockly.common', 'Blockly.utils.dom']);

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -213,7 +213,7 @@ goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'],
 goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.Names', 'Blockly.VariableModel', 'Blockly.utils', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils', 'Blockly.utils.xml']);
+goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.utils', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variables_dynamic.js', ['Blockly.VariablesDynamic'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Variables', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/widgetdiv.js', ['Blockly.WidgetDiv'], ['Blockly.common', 'Blockly.utils.dom']);

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -11,8 +11,8 @@ suite('Variable Fields', function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
     // Stub for default variable name.
-    sinon.stub(Blockly.Variables, 'generateUniqueName')
-        .returns(FAKE_VARIABLE_NAME);
+    const testDeps = Blockly.Variables.getTestDeps();
+    sinon.stub(testDeps, 'generateUniqueName').returns(FAKE_VARIABLE_NAME);
   });
   teardown(function() {
     sharedTestTeardown.call(this);

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -11,8 +11,8 @@ suite('Variable Fields', function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
     // Stub for default variable name.
-    const testDeps = Blockly.Variables.getTestDeps();
-    sinon.stub(testDeps, 'generateUniqueName').returns(FAKE_VARIABLE_NAME);
+    sinon.stub(Blockly.Variables, 'generateUniqueName').returns(
+      FAKE_VARIABLE_NAME);
   });
   teardown(function() {
     sharedTestTeardown.call(this);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/variables.js` to `goog.module` with ES6 `const`/`let`.

### Additional Information
This uses the approach outlined in https://github.com/google/blockly/issues/5199 to export a function in order to make it mockable by the unit tests.