### PR TITLE
feat: add throwing errors for bad shadows

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -781,12 +781,23 @@ Blockly.Connection.prototype.createShadowBlock_ = function(attemptToConnect) {
   if (shadowDom) {
     blockShadow = Blockly.Xml.domToBlock(shadowDom, parentBlock.workspace);
     if (attemptToConnect) {
-      if (blockShadow.outputConnection) {
-        this.connect(blockShadow.outputConnection);
-      } else if (blockShadow.previousConnection) {
-        this.connect(blockShadow.previousConnection);
+      if (this.type == Blockly.connectionTypes.INPUT_VALUE) {
+        if (!blockShadow.outputConnection) {
+          throw new Error('Shadow block is missing an output connection');
+        }
+        if (!this.connect(blockShadow.outputConnection)) {
+          throw new Error('Could not connect shadow block to connection');
+        }
+      } else if (this.type == Blockly.connectionTypes.NEXT_STATEMENT) {
+        if (!blockShadow.previousConnection) {
+          throw new Error('Shadow block is missing previous connection');
+        }
+        if (!this.connect(blockShadow.previousConnection)) {
+          throw new Error('Could not connect shadow block to connection');
+        }
       } else {
-        throw Error('Shadow block does not have output or previous statement.');
+        throw new Error(
+            'Cannot connect a shadow block to a previous/output connection');
       }
     }
     return blockShadow;

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -2512,6 +2512,53 @@ suite('Connection', function() {
               assertNextNotHasBlock(parent);
             });
           });
+
+          suite('Invalid', function() {
+            test('Attach to output', function() {
+              const block = this.workspace.newBlock('row_block');
+              chai.assert.throws(() =>
+                block.outputConnection.setShadowState({'type': 'row_block'}));
+            });
+
+            test('Attach to previous', function() {
+              const block = this.workspace.newBlock('stack_block');
+              chai.assert.throws(() =>
+                block.previousConnection.setShadowState(
+                    {'type': 'stack_block'}));
+            });
+
+            test('Missing output', function() {
+              const block = this.workspace.newBlock('row_block');
+              chai.assert.throws(() =>
+                block.outputConnection.setShadowState({'type': 'stack_block'}));
+            });
+
+            test('Missing previous', function() {
+              const block = this.workspace.newBlock('stack_block');
+              chai.assert.throws(() =>
+                block.previousConnection.setShadowState({'type': 'row_block'}));
+            });
+
+            test('Invalid connection checks, output', function() {
+              const block = this.workspace.newBlock('logic_operation');
+              chai.assert.throws(() =>
+                block.getInput('A').connection.setShadowState(
+                    {'type': 'math_number'}));
+            });
+
+            test('Invalid connection checks, previous', function() {
+              Blockly.defineBlocksWithJsonArray([{
+                "type": "stack_checks_block",
+                "message0": "",
+                "previousStatement": "check 1",
+                "nextStatement": "check 2"
+              }]);
+              const block = this.workspace.newBlock('stack_checks_block');
+              chai.assert.throws(() =>
+                block.nextConnection.setShadowState(
+                    {'type': 'stack_checks_block'}));
+            });
+          });
         });
       });
     });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -1292,6 +1292,56 @@ suite('Connection', function() {
               assertNextNotHasBlock(parent);
             });
           });
+
+          suite('Invalid', function() {
+            test('Attach to output', function() {
+              const block = this.workspace.newBlock('row_block');
+              chai.assert.throws(() =>
+                block.outputConnection.setShadowDom(Blockly.Xml.textToDom(
+                    '<block type="row_block">')));
+            });
+
+            test('Attach to previous', function() {
+              const block = this.workspace.newBlock('stack_block');
+              chai.assert.throws(() =>
+                block.previousConnection.setShadowDom(Blockly.Xml.textToDom(
+                    '<block type="stack_block">')));
+            });
+
+            test('Missing output', function() {
+              const block = this.workspace.newBlock('row_block');
+              chai.assert.throws(() =>
+                block.outputConnection.setShadowDom(Blockly.Xml.textToDom(
+                    '<block type="stack_block">')));
+            });
+
+            test('Missing previous', function() {
+              const block = this.workspace.newBlock('stack_block');
+              chai.assert.throws(() =>
+                block.previousConnection.setShadowDom(Blockly.Xml.textToDom(
+                    '<block type="row_block">')));
+            });
+
+            test('Invalid connection checks, output', function() {
+              const block = this.workspace.newBlock('logic_operation');
+              chai.assert.throws(() =>
+                block.getInput('A').connection.setShadowDom(
+                    Blockly.Xml.textToDom('<block type="stack_block">')));
+            });
+
+            test('Invalid connection checks, previous', function() {
+              Blockly.defineBlocksWithJsonArray([{
+                "type": "stack_checks_block",
+                "message0": "",
+                "previousStatement": "check 1",
+                "nextStatement": "check 2"
+              }]);
+              const block = this.workspace.newBlock('stack_checks_block');
+              chai.assert.throws(() =>
+                block.nextConnection.setShadowDom(Blockly.Xml.textToDom(
+                    '<block type="stack_checks_block">')));
+            });
+          });
         });
 
         suite('setShadowState', function() {


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Work on #4847 
Dependent on #5313 

### Proposed Changes
Adds errors which are thrown when a connection attempts to connect to a shadow which it cannot connect to. This can occur programmatically, or because of loading serialized state.

### Reason for Changes
Inform devs when something goes wrong, and signal that the workspace is in an invalid state.

### Test Coverage
Tests for all of the different error situations.