### PR TITLE
Fix issue that prevented Mocha and generator tests from running on certain configurations

### DIFF
--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -52,7 +52,8 @@ async function runGeneratorsInBrowser() {
     };
   } else {
     // --disable-gpu is needed to prevent Chrome from hanging on Linux with
-    // NVIDIA drivers older than v295.20.    
+    // NVIDIA drivers older than v295.20. See 
+    // https://github.com/google/blockly/issues/5345 for details.   
     options.capabilities['goog:chromeOptions'] = {
       args: ['--allow-file-access-from-files', '--disable-gpu']
     };

--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -51,8 +51,10 @@ async function runGeneratorsInBrowser() {
       args: ['--headless', '--no-sandbox', '--disable-dev-shm-usage', '--allow-file-access-from-files']
     };
   } else {
+    // --disable-gpu is needed to prevent Chrome from hanging on Linux with
+    // NVIDIA drivers older than v295.20.    
     options.capabilities['goog:chromeOptions'] = {
-      args: ['--allow-file-access-from-files']
+      args: ['--allow-file-access-from-files', '--disable-gpu']
     };
   }
 

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -36,8 +36,10 @@ async function runMochaTestsInBrowser() {
       ]
     };
   } else {
+    // --disable-gpu is needed to prevent Chrome from hanging on Linux with
+    // NVIDIA drivers older than v295.20.    
     options.capabilities['goog:chromeOptions'] = {
-      args: ['--allow-file-access-from-files']
+      args: ['--allow-file-access-from-files', '--disable-gpu']
     };
   }
 

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -37,7 +37,8 @@ async function runMochaTestsInBrowser() {
     };
   } else {
     // --disable-gpu is needed to prevent Chrome from hanging on Linux with
-    // NVIDIA drivers older than v295.20.    
+    // NVIDIA drivers older than v295.20. See 
+    // https://github.com/google/blockly/issues/5345 for details.
     options.capabilities['goog:chromeOptions'] = {
       args: ['--allow-file-access-from-files', '--disable-gpu']
     };


### PR DESCRIPTION
This PR adds the --disable-gpu flag to the run mocha/generator test scripts, which works around an issue where Chrome would hang when running the tests on Linux with older versions of the NVIDIA driver.

This fixes https://github.com/google/blockly/issues/5345.