### PR TITLE
Add missing requireType

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -22,6 +22,7 @@ const ComponentManager = goog.require('Blockly.ComponentManager');
 const Css = goog.require('Blockly.Css');
 const DeleteArea = goog.require('Blockly.DeleteArea');
 const Events = goog.require('Blockly.Events');
+/* eslint-disable-next-line no-unused-vars */
 const IAutoHideable = goog.require('Blockly.IAutoHideable');
 /* eslint-disable-next-line no-unused-vars */
 const ICollapsibleToolboxItem = goog.requireType('Blockly.ICollapsibleToolboxItem');
@@ -29,10 +30,13 @@ const ICollapsibleToolboxItem = goog.requireType('Blockly.ICollapsibleToolboxIte
 const IDraggable = goog.requireType('Blockly.IDraggable');
 /* eslint-disable-next-line no-unused-vars */
 const IFlyout = goog.requireType('Blockly.IFlyout');
+/* eslint-disable-next-line no-unused-vars */
 const IKeyboardAccessible = goog.require('Blockly.IKeyboardAccessible');
 /* eslint-disable-next-line no-unused-vars */
 const ISelectableToolboxItem = goog.requireType('Blockly.ISelectableToolboxItem');
+/* eslint-disable-next-line no-unused-vars */
 const IStyleable = goog.require('Blockly.IStyleable');
+/* eslint-disable-next-line no-unused-vars */
 const IToolbox = goog.require('Blockly.IToolbox');
 /* eslint-disable-next-line no-unused-vars */
 const IToolboxItem = goog.requireType('Blockly.IToolboxItem');


### PR DESCRIPTION
<!-- Suggested PR title: Migrate FILEPATH to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)

## The details
### Resolves

Part of #5026

### Proposed Changes

Add missing eslint disable.