### PR TITLE
Quiet the typings script unless you tell it to be verbose.

### DIFF
--- a/scripts/gulpfiles/typings.js
+++ b/scripts/gulpfiles/typings.js
@@ -12,6 +12,7 @@
 var gulp = require('gulp');
 gulp.concat = require('gulp-concat');
 
+var argv = require('yargs').argv;
 var path = require('path');
 var fs = require('fs');
 var rimraf = require('rimraf');
@@ -83,8 +84,12 @@ function typings() {
       return;
     }
     const cmd = `closure2ts ${file} ${typescriptFileName}`;
-    console.log(`Generating typings for ${file}`);
-    execSync(cmd, { stdio: 'inherit' });
+    let outputMode = 'ignore';
+    if (argv.verbose) {
+      console.log(`Generating typings for ${file}`);
+      outputMode = 'inherit';
+    }
+    execSync(cmd, { stdio: outputMode });
   });
 
   const srcs = [


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Removes most of the output from `npm run typings` unless you call `npm run typings -- --verbose`

#### Behavior Before Change

Lots of useless output during `npm run test` (2 lines for every single file)

#### Behavior After Change

No useless output unless you actually want to see it, and pass the `--verbose` flag

### Reason for Changes

I got tired of scrolling through a lot of output I didn't care about after running `npm run test`.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

I didn't really know where to document this flag. I did pick the same flag that is used in eg `npm run build -- --verbose`. It doesn't look like our gulp commands really come with help descriptions and I don't know that much about gulp but if you have any ideas about where to document this, I can add it.

### Additional Information

<!-- Anything else we should know? -->

I don't know of a scenario where we wouldn't want to suppress this output. I added a bunch of obvious type errors:

 * @type {Blockly.Workspace}}
 * @type {?Blockly.orasentoenaf}
 * @type {!Array<<!Blockly.Connection>}
 * @type {42}
 * @type {?}

And none of these caused any useful output from the `typings` script. Some of them did cause the build to fail but the `typings` step of `npm run test` always says success no matter what I tried, so personally don't know why we would not want to make this change. But please let me know if I missed something.
