### PR TITLE
Fix blocks with no next connections overlapping statement input in Zelos

### DIFF
--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -276,6 +276,10 @@ Blockly.zelos.RenderInfo.prototype.addInput_ = function(input, activeRow) {
     activeRow.elements.push(
         new Blockly.zelos.StatementInput(this.constants_, input));
     activeRow.hasStatement = true;
+
+    if (activeRow.align == null) {
+      activeRow.align = input.align;
+    }
     return;
   }
   Blockly.zelos.RenderInfo.superClass_.addInput_.call(this, input, activeRow);

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -28,6 +28,7 @@ goog.require('Blockly.utils.object');
 goog.require('Blockly.zelos.BottomRow');
 goog.require('Blockly.zelos.RightConnectionShape');
 goog.require('Blockly.zelos.TopRow');
+goog.require('Blockly.zelos.StatementInput');
 
 goog.requireType('Blockly.BlockSvg');
 goog.requireType('Blockly.zelos.ConstantProvider');
@@ -270,6 +271,12 @@ Blockly.zelos.RenderInfo.prototype.addInput_ = function(input, activeRow) {
       activeRow.align == Blockly.constants.ALIGN.LEFT &&
       input.align == Blockly.constants.ALIGN.RIGHT) {
     activeRow.rightAlignedDummyInput = input;
+  } else if (input.type == Blockly.inputTypes.STATEMENT) {
+    // Handle statements without next connections correctly.
+    activeRow.elements.push(
+        new Blockly.zelos.StatementInput(this.constants_, input));
+    activeRow.hasStatement = true;
+    return;
   }
   Blockly.zelos.RenderInfo.superClass_.addInput_.call(this, input, activeRow);
 };


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #5170

### Proposed Changes

Use the zelos.StatementInput function to handle statements in addInput_ instead of the blockRendering.StatementInput function used by the superclass' addInput_.

#### Behavior Before Change

![Screenshot from 2021-08-12 23-17-46](https://user-images.githubusercontent.com/57055412/129300172-57c611cb-0ce3-43fa-8450-99199a760a95.png)

#### Behavior After Change

![Screenshot from 2021-08-12 22-29-40](https://user-images.githubusercontent.com/57055412/129300190-8e5f21c9-8a13-4eb6-b1d2-96a91f5f5736.png)

### Reason for Changes

Blockly.zelos.StatementInput was unused and is required to correctly render using Zelos.

### Test Coverage

Chromium and Firefox on Ubuntu 21.04