### PR TITLE
Migrate core/theme/classic.js to goog.module syntax

### DIFF
--- a/core/theme/classic.js
+++ b/core/theme/classic.js
@@ -10,15 +10,16 @@
  */
 'use strict';
 
-goog.provide('Blockly.Themes.Classic');
+goog.module('Blockly.Themes.Classic');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Theme');
 
 
 // Temporary holding object.
-Blockly.Themes.Classic = {};
+let Classic = {};
 
-Blockly.Themes.Classic.defaultBlockStyles = {
+Classic.defaultBlockStyles = {
   "colour_blocks": {
     "colourPrimary": "20"
   },
@@ -52,7 +53,7 @@ Blockly.Themes.Classic.defaultBlockStyles = {
   }
 };
 
-Blockly.Themes.Classic.categoryStyles = {
+Classic.categoryStyles = {
   "colour_category": {
     "colour": "20"
   },
@@ -82,6 +83,8 @@ Blockly.Themes.Classic.categoryStyles = {
   }
 };
 
-Blockly.Themes.Classic =
-    new Blockly.Theme('classic', Blockly.Themes.Classic.defaultBlockStyles,
-        Blockly.Themes.Classic.categoryStyles);
+Classic =
+    new Blockly.Theme('classic', Classic.defaultBlockStyles,
+        Classic.categoryStyles);
+
+exports = Classic;

--- a/core/theme/classic.js
+++ b/core/theme/classic.js
@@ -13,7 +13,7 @@
 goog.module('Blockly.Themes.Classic');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Theme');
+const Theme = goog.require('Blockly.Theme');
 
 
 // Temporary holding object.
@@ -84,7 +84,7 @@ Classic.categoryStyles = {
 };
 
 Classic =
-    new Blockly.Theme('classic', Classic.defaultBlockStyles,
+    new Theme('classic', Classic.defaultBlockStyles,
         Classic.categoryStyles);
 
 exports = Classic;

--- a/core/theme/classic.js
+++ b/core/theme/classic.js
@@ -20,71 +20,31 @@ const Theme = goog.require('Blockly.Theme');
 let Classic = {};
 
 Classic.defaultBlockStyles = {
-  "colour_blocks": {
-    "colourPrimary": "20"
-  },
-  "list_blocks": {
-    "colourPrimary": "260"
-  },
-  "logic_blocks": {
-    "colourPrimary": "210"
-  },
-  "loop_blocks": {
-    "colourPrimary": "120"
-  },
-  "math_blocks": {
-    "colourPrimary": "230"
-  },
-  "procedure_blocks": {
-    "colourPrimary": "290"
-  },
-  "text_blocks": {
-    "colourPrimary": "160"
-  },
-  "variable_blocks": {
-    "colourPrimary": "330"
-  },
-  "variable_dynamic_blocks": {
-    "colourPrimary": "310"
-  },
-  "hat_blocks": {
-    "colourPrimary": "330",
-    "hat": "cap"
-  }
+  'colour_blocks': {'colourPrimary': '20'},
+  'list_blocks': {'colourPrimary': '260'},
+  'logic_blocks': {'colourPrimary': '210'},
+  'loop_blocks': {'colourPrimary': '120'},
+  'math_blocks': {'colourPrimary': '230'},
+  'procedure_blocks': {'colourPrimary': '290'},
+  'text_blocks': {'colourPrimary': '160'},
+  'variable_blocks': {'colourPrimary': '330'},
+  'variable_dynamic_blocks': {'colourPrimary': '310'},
+  'hat_blocks': {'colourPrimary': '330', 'hat': 'cap'}
 };
 
 Classic.categoryStyles = {
-  "colour_category": {
-    "colour": "20"
-  },
-  "list_category": {
-    "colour": "260"
-  },
-  "logic_category": {
-    "colour": "210"
-  },
-  "loop_category": {
-    "colour": "120"
-  },
-  "math_category": {
-    "colour": "230"
-  },
-  "procedure_category": {
-    "colour": "290"
-  },
-  "text_category": {
-    "colour": "160"
-  },
-  "variable_category": {
-    "colour": "330"
-  },
-  "variable_dynamic_category": {
-    "colour": "310"
-  }
+  'colour_category': {'colour': '20'},
+  'list_category': {'colour': '260'},
+  'logic_category': {'colour': '210'},
+  'loop_category': {'colour': '120'},
+  'math_category': {'colour': '230'},
+  'procedure_category': {'colour': '290'},
+  'text_category': {'colour': '160'},
+  'variable_category': {'colour': '330'},
+  'variable_dynamic_category': {'colour': '310'}
 };
 
 Classic =
-    new Theme('classic', Classic.defaultBlockStyles,
-        Classic.categoryStyles);
+    new Theme('classic', Classic.defaultBlockStyles, Classic.categoryStyles);
 
 exports = Classic;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -191,7 +191,7 @@ goog.addDependency('../../core/scrollbar_pair.js', ['Blockly.ScrollbarPair'], ['
 goog.addDependency('../../core/shortcut_items.js', ['Blockly.ShortcutItems'], ['Blockly', 'Blockly.Gesture', 'Blockly.ShortcutRegistry', 'Blockly.clipboard', 'Blockly.utils.KeyCodes'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/shortcut_registry.js', ['Blockly.ShortcutRegistry'], ['Blockly.utils.KeyCodes', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme.js', ['Blockly.Theme'], ['Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/theme/classic.js', ['Blockly.Themes.Classic'], ['Blockly.Theme']);
+goog.addDependency('../../core/theme/classic.js', ['Blockly.Themes.Classic'], ['Blockly.Theme'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme/zelos.js', ['Blockly.Themes.Zelos'], ['Blockly.Theme'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.utils.dom'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/toolbox/category.js', ['Blockly.ToolboxCategory'], ['Blockly', 'Blockly.Css', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/theme/classic.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm run test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/theme/classic.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
