### PR TITLE
Migrate core/theme/zelos.js to goog.module syntax

### DIFF
--- a/core/theme/zelos.js
+++ b/core/theme/zelos.js
@@ -12,7 +12,7 @@
 goog.module('Blockly.Themes.Zelos');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.Theme');
+const Theme = goog.require('Blockly.Theme');
 
 
 // Temporary holding object.
@@ -103,7 +103,7 @@ Zelos.categoryStyles = {
 };
 
 Zelos =
-    new Blockly.Theme('zelos', Zelos.defaultBlockStyles,
+    new Theme('zelos', Zelos.defaultBlockStyles,
         Zelos.categoryStyles);
 
 exports = Zelos;

--- a/core/theme/zelos.js
+++ b/core/theme/zelos.js
@@ -19,91 +19,71 @@ const Theme = goog.require('Blockly.Theme');
 let Zelos = {};
 
 Zelos.defaultBlockStyles = {
-  "colour_blocks": {
-    "colourPrimary": "#CF63CF",
-    "colourSecondary": "#C94FC9",
-    "colourTertiary": "#BD42BD"
+  'colour_blocks': {
+    'colourPrimary': '#CF63CF',
+    'colourSecondary': '#C94FC9',
+    'colourTertiary': '#BD42BD'
   },
-  "list_blocks": {
-    "colourPrimary": "#9966FF",
-    "colourSecondary": "#855CD6",
-    "colourTertiary": "#774DCB"
+  'list_blocks': {
+    'colourPrimary': '#9966FF',
+    'colourSecondary': '#855CD6',
+    'colourTertiary': '#774DCB'
   },
-  "logic_blocks": {
-    "colourPrimary": "#4C97FF",
-    "colourSecondary": "#4280D7",
-    "colourTertiary": "#3373CC"
+  'logic_blocks': {
+    'colourPrimary': '#4C97FF',
+    'colourSecondary': '#4280D7',
+    'colourTertiary': '#3373CC'
   },
-  "loop_blocks": {
-    "colourPrimary": "#0fBD8C",
-    "colourSecondary": "#0DA57A",
-    "colourTertiary": "#0B8E69"
+  'loop_blocks': {
+    'colourPrimary': '#0fBD8C',
+    'colourSecondary': '#0DA57A',
+    'colourTertiary': '#0B8E69'
   },
-  "math_blocks": {
-    "colourPrimary": "#59C059",
-    "colourSecondary": "#46B946",
-    "colourTertiary": "#389438"
+  'math_blocks': {
+    'colourPrimary': '#59C059',
+    'colourSecondary': '#46B946',
+    'colourTertiary': '#389438'
   },
-  "procedure_blocks": {
-    "colourPrimary": "#FF6680",
-    "colourSecondary": "#FF4D6A",
-    "colourTertiary": "#FF3355"
+  'procedure_blocks': {
+    'colourPrimary': '#FF6680',
+    'colourSecondary': '#FF4D6A',
+    'colourTertiary': '#FF3355'
   },
-  "text_blocks": {
-    "colourPrimary": "#FFBF00",
-    "colourSecondary": "#E6AC00",
-    "colourTertiary": "#CC9900"
+  'text_blocks': {
+    'colourPrimary': '#FFBF00',
+    'colourSecondary': '#E6AC00',
+    'colourTertiary': '#CC9900'
   },
-  "variable_blocks": {
-    "colourPrimary": "#FF8C1A",
-    "colourSecondary": "#FF8000",
-    "colourTertiary": "#DB6E00"
+  'variable_blocks': {
+    'colourPrimary': '#FF8C1A',
+    'colourSecondary': '#FF8000',
+    'colourTertiary': '#DB6E00'
   },
-  "variable_dynamic_blocks": {
-    "colourPrimary": "#FF8C1A",
-    "colourSecondary": "#FF8000",
-    "colourTertiary": "#DB6E00"
+  'variable_dynamic_blocks': {
+    'colourPrimary': '#FF8C1A',
+    'colourSecondary': '#FF8000',
+    'colourTertiary': '#DB6E00'
   },
-  "hat_blocks": {
-    "colourPrimary": "#4C97FF",
-    "colourSecondary": "#4280D7",
-    "colourTertiary": "#3373CC",
-    "hat": "cap"
+  'hat_blocks': {
+    'colourPrimary': '#4C97FF',
+    'colourSecondary': '#4280D7',
+    'colourTertiary': '#3373CC',
+    'hat': 'cap'
   }
 };
 
 Zelos.categoryStyles = {
-  "colour_category": {
-    "colour": "#CF63CF"
-  },
-  "list_category": {
-    "colour": "#9966FF"
-  },
-  "logic_category": {
-    "colour": "#4C97FF"
-  },
-  "loop_category": {
-    "colour": "#0fBD8C"
-  },
-  "math_category": {
-    "colour": "#59C059"
-  },
-  "procedure_category": {
-    "colour": "#FF6680"
-  },
-  "text_category": {
-    "colour": "#FFBF00"
-  },
-  "variable_category": {
-    "colour": "#FF8C1A"
-  },
-  "variable_dynamic_category": {
-    "colour": "#FF8C1A"
-  }
+  'colour_category': {'colour': '#CF63CF'},
+  'list_category': {'colour': '#9966FF'},
+  'logic_category': {'colour': '#4C97FF'},
+  'loop_category': {'colour': '#0fBD8C'},
+  'math_category': {'colour': '#59C059'},
+  'procedure_category': {'colour': '#FF6680'},
+  'text_category': {'colour': '#FFBF00'},
+  'variable_category': {'colour': '#FF8C1A'},
+  'variable_dynamic_category': {'colour': '#FF8C1A'}
 };
 
-Zelos =
-    new Theme('zelos', Zelos.defaultBlockStyles,
-        Zelos.categoryStyles);
+Zelos = new Theme('zelos', Zelos.defaultBlockStyles, Zelos.categoryStyles);
 
 exports = Zelos;

--- a/core/theme/zelos.js
+++ b/core/theme/zelos.js
@@ -9,15 +9,16 @@
  */
 'use strict';
 
-goog.provide('Blockly.Themes.Zelos');
+goog.module('Blockly.Themes.Zelos');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.Theme');
 
 
 // Temporary holding object.
-Blockly.Themes.Zelos = {};
+let Zelos = {};
 
-Blockly.Themes.Zelos.defaultBlockStyles = {
+Zelos.defaultBlockStyles = {
   "colour_blocks": {
     "colourPrimary": "#CF63CF",
     "colourSecondary": "#C94FC9",
@@ -71,7 +72,7 @@ Blockly.Themes.Zelos.defaultBlockStyles = {
   }
 };
 
-Blockly.Themes.Zelos.categoryStyles = {
+Zelos.categoryStyles = {
   "colour_category": {
     "colour": "#CF63CF"
   },
@@ -101,6 +102,8 @@ Blockly.Themes.Zelos.categoryStyles = {
   }
 };
 
-Blockly.Themes.Zelos =
-    new Blockly.Theme('zelos', Blockly.Themes.Zelos.defaultBlockStyles,
-        Blockly.Themes.Zelos.categoryStyles);
+Zelos =
+    new Blockly.Theme('zelos', Zelos.defaultBlockStyles,
+        Zelos.categoryStyles);
+
+exports = Zelos;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -189,7 +189,7 @@ goog.addDependency('../../core/shortcut_items.js', ['Blockly.ShortcutItems'], ['
 goog.addDependency('../../core/shortcut_registry.js', ['Blockly.ShortcutRegistry'], ['Blockly.utils.KeyCodes', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme.js', ['Blockly.Theme'], ['Blockly.registry', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme/classic.js', ['Blockly.Themes.Classic'], ['Blockly.Theme']);
-goog.addDependency('../../core/theme/zelos.js', ['Blockly.Themes.Zelos'], ['Blockly.Theme']);
+goog.addDependency('../../core/theme/zelos.js', ['Blockly.Themes.Zelos'], ['Blockly.Theme'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/theme_manager.js', ['Blockly.ThemeManager'], ['Blockly.utils.dom'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/toolbox/category.js', ['Blockly.ToolboxCategory'], ['Blockly', 'Blockly.Css', 'Blockly.ToolboxItem', 'Blockly.registry', 'Blockly.utils', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/toolbox/collapsible_category.js', ['Blockly.CollapsibleToolboxCategory'], ['Blockly.ToolboxCategory', 'Blockly.ToolboxSeparator', 'Blockly.registry', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/theme/zelos.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm run test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/theme/zelos.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
