### PR TITLE
Migrate core/utils/global.js to goog.module syntax

### DIFF
--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -10,20 +10,17 @@
  */
 'use strict';
 
-/**
- * @name Blockly.utils.global
- * @namespace
- */
-goog.provide('Blockly.utils.global');
+goog.module('Blockly.utils.global');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * Reference to the global object.
  *
  * More info on this implementation here:
- * https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI/edit
+ * https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI
  */
-Blockly.utils.global = function() {
+const utilsGlobal = function() {
   if (typeof self === 'object') {
     return self;
   }
@@ -35,3 +32,5 @@ Blockly.utils.global = function() {
   }
   return this;
 }();
+
+exports = utilsGlobal;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -209,7 +209,7 @@ goog.addDependency('../../core/utils/colour.js', ['Blockly.utils.colour'], [], {
 goog.addDependency('../../core/utils/coordinate.js', ['Blockly.utils.Coordinate'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], []);
+goog.addDependency('../../core/utils/global.js', ['Blockly.utils.global'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/idgenerator.js', ['Blockly.utils.IdGenerator'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/keycodes.js', ['Blockly.utils.KeyCodes'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/math.js', ['Blockly.utils.math'], [], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/utils/global.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm run test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/global.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
