### PR TITLE
Migrate core/utils/svg.js to goog.module syntax

### DIFF
--- a/core/utils/svg.js
+++ b/core/utils/svg.js
@@ -5,17 +5,18 @@
  */
 
 /**
- * @fileoverview Defines the Blockly.utils.Svg class. Its constants enumerate
+ * @fileoverview Defines the Svg class. Its constants enumerate
  * all SVG tag names used by Blockly.
  * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 
 /**
- * @name Blockly.utils.Svg
+ * @name Svg
  * @namespace
  */
-goog.provide('Blockly.utils.Svg');
+goog.module('Blockly.utils.Svg');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -25,7 +26,7 @@ goog.provide('Blockly.utils.Svg');
  * @template T
  * @private
  */
-Blockly.utils.Svg = function(tagName) {
+const Svg = function(tagName) {
   /**
    * @type {string}
    * @private
@@ -38,144 +39,146 @@ Blockly.utils.Svg = function(tagName) {
  * @return {string} The name.
  * @override
  */
-Blockly.utils.Svg.prototype.toString = function() {
+Svg.prototype.toString = function() {
   return this.tagName_;
 };
 
-/** @type {!Blockly.utils.Svg<!SVGAnimateElement>}
+/** @type {!Svg<!SVGAnimateElement>}
  * @package
  */
-Blockly.utils.Svg.ANIMATE =
-    new Blockly.utils.Svg('animate');
+Svg.ANIMATE =
+    new Svg('animate');
 
-/** @type {!Blockly.utils.Svg<!SVGCircleElement>}
+/** @type {!Svg<!SVGCircleElement>}
 * @package
  */
-Blockly.utils.Svg.CIRCLE =
-    new Blockly.utils.Svg('circle');
+Svg.CIRCLE =
+    new Svg('circle');
 
-/** @type {!Blockly.utils.Svg<!SVGClipPathElement>}
+/** @type {!Svg<!SVGClipPathElement>}
  * @package
  */
-Blockly.utils.Svg.CLIPPATH =
-    new Blockly.utils.Svg('clipPath');
+Svg.CLIPPATH =
+    new Svg('clipPath');
 
-/** @type {!Blockly.utils.Svg<!SVGDefsElement>}
+/** @type {!Svg<!SVGDefsElement>}
  * @package
  */
-Blockly.utils.Svg.DEFS =
-    new Blockly.utils.Svg('defs');
+Svg.DEFS =
+    new Svg('defs');
 
-/** @type {!Blockly.utils.Svg<!SVGFECompositeElement>}
+/** @type {!Svg<!SVGFECompositeElement>}
  * @package
  */
-Blockly.utils.Svg.FECOMPOSITE =
-    new Blockly.utils.Svg('feComposite');
+Svg.FECOMPOSITE =
+    new Svg('feComposite');
 
-/** @type {!Blockly.utils.Svg<!SVGFEComponentTransferElement>}
+/** @type {!Svg<!SVGFEComponentTransferElement>}
  * @package
  */
-Blockly.utils.Svg.FECOMPONENTTRANSFER =
-    new Blockly.utils.Svg('feComponentTransfer');
+Svg.FECOMPONENTTRANSFER =
+    new Svg('feComponentTransfer');
 
-/** @type {!Blockly.utils.Svg<!SVGFEFloodElement>}
+/** @type {!Svg<!SVGFEFloodElement>}
  * @package
  */
-Blockly.utils.Svg.FEFLOOD =
-    new Blockly.utils.Svg('feFlood');
+Svg.FEFLOOD =
+    new Svg('feFlood');
 
-/** @type {!Blockly.utils.Svg<!SVGFEFuncAElement>}
+/** @type {!Svg<!SVGFEFuncAElement>}
  * @package
  */
-Blockly.utils.Svg.FEFUNCA =
-    new Blockly.utils.Svg('feFuncA');
+Svg.FEFUNCA =
+    new Svg('feFuncA');
 
-/** @type {!Blockly.utils.Svg<!SVGFEGaussianBlurElement>}
+/** @type {!Svg<!SVGFEGaussianBlurElement>}
  * @package
  */
-Blockly.utils.Svg.FEGAUSSIANBLUR =
-    new Blockly.utils.Svg('feGaussianBlur');
+Svg.FEGAUSSIANBLUR =
+    new Svg('feGaussianBlur');
 
-/** @type {!Blockly.utils.Svg<!SVGFEPointLightElement>}
+/** @type {!Svg<!SVGFEPointLightElement>}
  * @package
  */
-Blockly.utils.Svg.FEPOINTLIGHT =
-    new Blockly.utils.Svg('fePointLight');
+Svg.FEPOINTLIGHT =
+    new Svg('fePointLight');
 
-/** @type {!Blockly.utils.Svg<!SVGFESpecularLightingElement>}
+/** @type {!Svg<!SVGFESpecularLightingElement>}
  * @package
  */
-Blockly.utils.Svg.FESPECULARLIGHTING =
-    new Blockly.utils.Svg('feSpecularLighting');
+Svg.FESPECULARLIGHTING =
+    new Svg('feSpecularLighting');
 
-/** @type {!Blockly.utils.Svg<!SVGFilterElement>}
+/** @type {!Svg<!SVGFilterElement>}
  * @package
  */
-Blockly.utils.Svg.FILTER =
-    new Blockly.utils.Svg('filter');
+Svg.FILTER =
+    new Svg('filter');
 
-/** @type {!Blockly.utils.Svg<!SVGForeignObjectElement>}
+/** @type {!Svg<!SVGForeignObjectElement>}
  * @package
  */
-Blockly.utils.Svg.FOREIGNOBJECT =
-    new Blockly.utils.Svg('foreignObject');
+Svg.FOREIGNOBJECT =
+    new Svg('foreignObject');
 
-/** @type {!Blockly.utils.Svg<!SVGGElement>}
+/** @type {!Svg<!SVGGElement>}
  * @package
  */
-Blockly.utils.Svg.G =
-    new Blockly.utils.Svg('g');
+Svg.G =
+    new Svg('g');
 
-/** @type {!Blockly.utils.Svg<!SVGImageElement>}
+/** @type {!Svg<!SVGImageElement>}
  * @package
  */
-Blockly.utils.Svg.IMAGE =
-    new Blockly.utils.Svg('image');
+Svg.IMAGE =
+    new Svg('image');
 
-/** @type {!Blockly.utils.Svg<!SVGLineElement>}
+/** @type {!Svg<!SVGLineElement>}
  * @package
  */
-Blockly.utils.Svg.LINE =
-    new Blockly.utils.Svg('line');
+Svg.LINE =
+    new Svg('line');
 
-/** @type {!Blockly.utils.Svg<!SVGPathElement>}
+/** @type {!Svg<!SVGPathElement>}
  * @package
  */
-Blockly.utils.Svg.PATH =
-    new Blockly.utils.Svg('path');
+Svg.PATH =
+    new Svg('path');
 
-/** @type {!Blockly.utils.Svg<!SVGPatternElement>}
+/** @type {!Svg<!SVGPatternElement>}
  * @package
  */
-Blockly.utils.Svg.PATTERN =
-    new Blockly.utils.Svg('pattern');
+Svg.PATTERN =
+    new Svg('pattern');
 
-/** @type {!Blockly.utils.Svg<!SVGPolygonElement>}
+/** @type {!Svg<!SVGPolygonElement>}
  * @package
  */
-Blockly.utils.Svg.POLYGON =
-    new Blockly.utils.Svg('polygon');
+Svg.POLYGON =
+    new Svg('polygon');
 
-/** @type {!Blockly.utils.Svg<!SVGRectElement>}
+/** @type {!Svg<!SVGRectElement>}
  * @package
  */
-Blockly.utils.Svg.RECT =
-    new Blockly.utils.Svg('rect');
+Svg.RECT =
+    new Svg('rect');
 
-/** @type {!Blockly.utils.Svg<!SVGSVGElement>}
+/** @type {!Svg<!SVGSVGElement>}
  * @package
  */
-Blockly.utils.Svg.SVG =
-    new Blockly.utils.Svg('svg');
+Svg.SVG =
+    new Svg('svg');
 
-/** @type {!Blockly.utils.Svg<!SVGTextElement>}
+/** @type {!Svg<!SVGTextElement>}
  * @package
  */
-Blockly.utils.Svg.TEXT =
-    new Blockly.utils.Svg('text');
+Svg.TEXT =
+    new Svg('text');
 
-/** @type {!Blockly.utils.Svg<!SVGTSpanElement>}
+/** @type {!Svg<!SVGTSpanElement>}
  * @package
  */
-Blockly.utils.Svg.TSPAN =
-    new Blockly.utils.Svg('tspan');
+Svg.TSPAN =
+    new Svg('tspan');
+
+exports = Svg;

--- a/core/utils/svg.js
+++ b/core/utils/svg.js
@@ -43,142 +43,142 @@ Svg.prototype.toString = function() {
   return this.tagName_;
 };
 
-/** @type {!Svg<!SVGAnimateElement>}
+/**
+ * @type {!Svg<!SVGAnimateElement>}
  * @package
  */
-Svg.ANIMATE =
-    new Svg('animate');
+Svg.ANIMATE = new Svg('animate');
 
-/** @type {!Svg<!SVGCircleElement>}
-* @package
- */
-Svg.CIRCLE =
-    new Svg('circle');
-
-/** @type {!Svg<!SVGClipPathElement>}
+/**
+ * @type {!Svg<!SVGCircleElement>}
  * @package
  */
-Svg.CLIPPATH =
-    new Svg('clipPath');
+Svg.CIRCLE = new Svg('circle');
 
-/** @type {!Svg<!SVGDefsElement>}
+/**
+ * @type {!Svg<!SVGClipPathElement>}
  * @package
  */
-Svg.DEFS =
-    new Svg('defs');
+Svg.CLIPPATH = new Svg('clipPath');
 
-/** @type {!Svg<!SVGFECompositeElement>}
+/**
+ * @type {!Svg<!SVGDefsElement>}
  * @package
  */
-Svg.FECOMPOSITE =
-    new Svg('feComposite');
+Svg.DEFS = new Svg('defs');
 
-/** @type {!Svg<!SVGFEComponentTransferElement>}
+/**
+ * @type {!Svg<!SVGFECompositeElement>}
  * @package
  */
-Svg.FECOMPONENTTRANSFER =
-    new Svg('feComponentTransfer');
+Svg.FECOMPOSITE = new Svg('feComposite');
 
-/** @type {!Svg<!SVGFEFloodElement>}
+/**
+ * @type {!Svg<!SVGFEComponentTransferElement>}
  * @package
  */
-Svg.FEFLOOD =
-    new Svg('feFlood');
+Svg.FECOMPONENTTRANSFER = new Svg('feComponentTransfer');
 
-/** @type {!Svg<!SVGFEFuncAElement>}
+/**
+ * @type {!Svg<!SVGFEFloodElement>}
  * @package
  */
-Svg.FEFUNCA =
-    new Svg('feFuncA');
+Svg.FEFLOOD = new Svg('feFlood');
 
-/** @type {!Svg<!SVGFEGaussianBlurElement>}
+/**
+ * @type {!Svg<!SVGFEFuncAElement>}
  * @package
  */
-Svg.FEGAUSSIANBLUR =
-    new Svg('feGaussianBlur');
+Svg.FEFUNCA = new Svg('feFuncA');
 
-/** @type {!Svg<!SVGFEPointLightElement>}
+/**
+ * @type {!Svg<!SVGFEGaussianBlurElement>}
  * @package
  */
-Svg.FEPOINTLIGHT =
-    new Svg('fePointLight');
+Svg.FEGAUSSIANBLUR = new Svg('feGaussianBlur');
 
-/** @type {!Svg<!SVGFESpecularLightingElement>}
+/**
+ * @type {!Svg<!SVGFEPointLightElement>}
  * @package
  */
-Svg.FESPECULARLIGHTING =
-    new Svg('feSpecularLighting');
+Svg.FEPOINTLIGHT = new Svg('fePointLight');
 
-/** @type {!Svg<!SVGFilterElement>}
+/**
+ * @type {!Svg<!SVGFESpecularLightingElement>}
  * @package
  */
-Svg.FILTER =
-    new Svg('filter');
+Svg.FESPECULARLIGHTING = new Svg('feSpecularLighting');
 
-/** @type {!Svg<!SVGForeignObjectElement>}
+/**
+ * @type {!Svg<!SVGFilterElement>}
  * @package
  */
-Svg.FOREIGNOBJECT =
-    new Svg('foreignObject');
+Svg.FILTER = new Svg('filter');
 
-/** @type {!Svg<!SVGGElement>}
+/**
+ * @type {!Svg<!SVGForeignObjectElement>}
  * @package
  */
-Svg.G =
-    new Svg('g');
+Svg.FOREIGNOBJECT = new Svg('foreignObject');
 
-/** @type {!Svg<!SVGImageElement>}
+/**
+ * @type {!Svg<!SVGGElement>}
  * @package
  */
-Svg.IMAGE =
-    new Svg('image');
+Svg.G = new Svg('g');
 
-/** @type {!Svg<!SVGLineElement>}
+/**
+ * @type {!Svg<!SVGImageElement>}
  * @package
  */
-Svg.LINE =
-    new Svg('line');
+Svg.IMAGE = new Svg('image');
 
-/** @type {!Svg<!SVGPathElement>}
+/**
+ * @type {!Svg<!SVGLineElement>}
  * @package
  */
-Svg.PATH =
-    new Svg('path');
+Svg.LINE = new Svg('line');
 
-/** @type {!Svg<!SVGPatternElement>}
+/**
+ * @type {!Svg<!SVGPathElement>}
  * @package
  */
-Svg.PATTERN =
-    new Svg('pattern');
+Svg.PATH = new Svg('path');
 
-/** @type {!Svg<!SVGPolygonElement>}
+/**
+ * @type {!Svg<!SVGPatternElement>}
  * @package
  */
-Svg.POLYGON =
-    new Svg('polygon');
+Svg.PATTERN = new Svg('pattern');
 
-/** @type {!Svg<!SVGRectElement>}
+/**
+ * @type {!Svg<!SVGPolygonElement>}
  * @package
  */
-Svg.RECT =
-    new Svg('rect');
+Svg.POLYGON = new Svg('polygon');
 
-/** @type {!Svg<!SVGSVGElement>}
+/**
+ * @type {!Svg<!SVGRectElement>}
  * @package
  */
-Svg.SVG =
-    new Svg('svg');
+Svg.RECT = new Svg('rect');
 
-/** @type {!Svg<!SVGTextElement>}
+/**
+ * @type {!Svg<!SVGSVGElement>}
  * @package
  */
-Svg.TEXT =
-    new Svg('text');
+Svg.SVG = new Svg('svg');
 
-/** @type {!Svg<!SVGTSpanElement>}
+/**
+ * @type {!Svg<!SVGTextElement>}
  * @package
  */
-Svg.TSPAN =
-    new Svg('tspan');
+Svg.TEXT = new Svg('text');
+
+/**
+ * @type {!Svg<!SVGTSpanElement>}
+ * @package
+ */
+Svg.TSPAN = new Svg('tspan');
 
 exports = Svg;

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -219,7 +219,7 @@ goog.addDependency('../../core/utils/rect.js', ['Blockly.utils.Rect'], [], {'lan
 goog.addDependency('../../core/utils/size.js', ['Blockly.utils.Size'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/string.js', ['Blockly.utils.string'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Blockly.utils.Coordinate', 'Blockly.utils.Size'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], []);
+goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/toolbox.js', ['Blockly.utils.toolbox'], ['Blockly.Xml', 'Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global']);


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/utils/svg.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm run test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/svg.js` to `goog.module` syntax. 


### Additional Information

Considered exporting properties directory instead of as static properties on the `Blockly.utils.Svg` class (and not export the class), but found that the class `Blockly.utils.Svg` is used outside of this module, as a type, and must be exported.