### PR TITLE
Migrate core/utils/useragent.js to goog.module syntax

### DIFF
--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -71,56 +71,47 @@ let MOBILE;
 exports.MOBILE = MOBILE;
 
 (function(raw) {
-  raw = raw;
-  const rawUpper = raw.toUpperCase();
+raw = raw;
+const rawUpper = raw.toUpperCase();
 
-  /**
-   * Case-insensitive test of whether name is in the useragent string.
-   * @param {string} name Name to test.
-   * @return {boolean} True if name is present.
-   */
-  function has(name) {
-    return rawUpper.indexOf(name.toUpperCase()) != -1;
-  }
+/**
+ * Case-insensitive test of whether name is in the useragent string.
+ * @param {string} name Name to test.
+ * @return {boolean} True if name is present.
+ */
+function has(name) {
+  return rawUpper.indexOf(name.toUpperCase()) != -1;
+}
 
-  // Browsers.  Logic from:
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/browser.js
-  IE = has('Trident') || has('MSIE');
-  EDGE = has('Edge');
-  // Useragent for JavaFX:
-  // Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44
-  //     (KHTML, like Gecko) JavaFX/8.0 Safari/537.44
-  JAVA_FX = has('JavaFX');
-  CHROME = (has('Chrome') || has('CriOS')) &&
-        !EDGE;
+// Browsers.  Logic from:
+// https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/browser.js
+IE = has('Trident') || has('MSIE');
+EDGE = has('Edge');
+// Useragent for JavaFX:
+// Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44
+//     (KHTML, like Gecko) JavaFX/8.0 Safari/537.44
+JAVA_FX = has('JavaFX');
+CHROME = (has('Chrome') || has('CriOS')) && !EDGE;
 
-  // Engines.  Logic from:
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/engine.js
-  WEBKIT = has('WebKit') &&
-      !EDGE;
-  GECKO = has('Gecko') &&
-      !WEBKIT &&
-      !IE &&
-      !EDGE;
+// Engines.  Logic from:
+// https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/engine.js
+WEBKIT = has('WebKit') && !EDGE;
+GECKO = has('Gecko') && !WEBKIT && !IE && !EDGE;
 
-  // Platforms.  Logic from:
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
-  ANDROID = has('Android');
-  const maxTouchPoints = globalUtils['navigator'] &&
-      globalUtils['navigator']['maxTouchPoints'];
-  IPAD = has('iPad') ||
-      has('Macintosh') && maxTouchPoints > 0;
-  IPOD = has('iPod');
-  IPHONE = has('iPhone') &&
-      !IPAD && !IPOD;
-  MAC = has('Macintosh');
+// Platforms.  Logic from:
+// https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js
+// and
+// https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
+ANDROID = has('Android');
+const maxTouchPoints =
+    globalUtils['navigator'] && globalUtils['navigator']['maxTouchPoints'];
+IPAD = has('iPad') || has('Macintosh') && maxTouchPoints > 0;
+IPOD = has('iPod');
+IPHONE = has('iPhone') && !IPAD && !IPOD;
+MAC = has('Macintosh');
 
-  // Devices.  Logic from:
-  // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/device.js
-  TABLET = IPAD ||
-      (ANDROID && !has('Mobile')) || has('Silk');
-  MOBILE = !TABLET &&
-      (IPOD || IPHONE ||
-       ANDROID || has('IEMobile'));
+// Devices.  Logic from:
+// https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/device.js
+TABLET = IPAD || (ANDROID && !has('Mobile')) || has('Silk');
+MOBILE = !TABLET && (IPOD || IPHONE || ANDROID || has('IEMobile'));
 })((globalUtils['navigator'] && globalUtils['navigator']['userAgent']) || '');

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -16,53 +16,67 @@
  * @name Blockly.utils.userAgent
  * @namespace
  */
-goog.provide('Blockly.utils.userAgent');
+goog.module('Blockly.utils.userAgent');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.utils.global');
 
 
-/** @const {boolean} */
-Blockly.utils.userAgent.IE;
+/** @type {boolean} */
+let IE;
+exports.IE = IE;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.EDGE;
+/** @type {boolean} */
+let EDGE;
+exports.EDGE = EDGE;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.JAVA_FX;
+/** @type {boolean} */
+let JAVA_FX;
+exports.JAVA_FX = JAVA_FX;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.CHROME;
+/** @type {boolean} */
+let CHROME;
+exports.CHROME = CHROME;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.WEBKIT;
+/** @type {boolean} */
+let WEBKIT;
+exports.WEBKIT = WEBKIT;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.GECKO;
+/** @type {boolean} */
+let GECKO;
+exports.GECKO = GECKO;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.ANDROID;
+/** @type {boolean} */
+let ANDROID;
+exports.ANDROID = ANDROID;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.IPAD;
+/** @type {boolean} */
+let IPAD;
+exports.IPAD = IPAD;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.IPOD;
+/** @type {boolean} */
+let IPOD;
+exports.IPOD = IPOD;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.IPHONE;
+/** @type {boolean} */
+let IPHONE;
+exports.IPHONE = IPHONE;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.MAC;
+/** @type {boolean} */
+let MAC;
+exports.MAC = MAC;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.TABLET;
+/** @type {boolean} */
+let TABLET;
+exports.TABLET = TABLET;
 
-/** @const {boolean} */
-Blockly.utils.userAgent.MOBILE;
+/** @type {boolean} */
+let MOBILE;
+exports.MOBILE = MOBILE;
 
 (function(raw) {
-  Blockly.utils.userAgent.raw = raw;
-  const rawUpper = Blockly.utils.userAgent.raw.toUpperCase();
+  raw = raw;
+  const rawUpper = raw.toUpperCase();
 
   /**
    * Case-insensitive test of whether name is in the useragent string.
@@ -75,42 +89,42 @@ Blockly.utils.userAgent.MOBILE;
 
   // Browsers.  Logic from:
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/browser.js
-  Blockly.utils.userAgent.IE = has('Trident') || has('MSIE');
-  Blockly.utils.userAgent.EDGE = has('Edge');
+  IE = has('Trident') || has('MSIE');
+  EDGE = has('Edge');
   // Useragent for JavaFX:
   // Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44
   //     (KHTML, like Gecko) JavaFX/8.0 Safari/537.44
-  Blockly.utils.userAgent.JAVA_FX = has('JavaFX');
-  Blockly.utils.userAgent.CHROME = (has('Chrome') || has('CriOS')) &&
-        !Blockly.utils.userAgent.EDGE;
+  JAVA_FX = has('JavaFX');
+  CHROME = (has('Chrome') || has('CriOS')) &&
+        !EDGE;
 
   // Engines.  Logic from:
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/engine.js
-  Blockly.utils.userAgent.WEBKIT = has('WebKit') &&
-      !Blockly.utils.userAgent.EDGE;
-  Blockly.utils.userAgent.GECKO = has('Gecko') &&
-      !Blockly.utils.userAgent.WEBKIT &&
-      !Blockly.utils.userAgent.IE &&
-      !Blockly.utils.userAgent.EDGE;
+  WEBKIT = has('WebKit') &&
+      !EDGE;
+  GECKO = has('Gecko') &&
+      !WEBKIT &&
+      !IE &&
+      !EDGE;
 
   // Platforms.  Logic from:
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
-  Blockly.utils.userAgent.ANDROID = has('Android');
+  ANDROID = has('Android');
   const maxTouchPoints = Blockly.utils.global['navigator'] &&
       Blockly.utils.global['navigator']['maxTouchPoints'];
-  Blockly.utils.userAgent.IPAD = has('iPad') ||
+  IPAD = has('iPad') ||
       has('Macintosh') && maxTouchPoints > 0;
-  Blockly.utils.userAgent.IPOD = has('iPod');
-  Blockly.utils.userAgent.IPHONE = has('iPhone') &&
-      !Blockly.utils.userAgent.IPAD && !Blockly.utils.userAgent.IPOD;
-  Blockly.utils.userAgent.MAC = has('Macintosh');
+  IPOD = has('iPod');
+  IPHONE = has('iPhone') &&
+      !IPAD && !IPOD;
+  MAC = has('Macintosh');
 
   // Devices.  Logic from:
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/device.js
-  Blockly.utils.userAgent.TABLET = Blockly.utils.userAgent.IPAD ||
-      (Blockly.utils.userAgent.ANDROID && !has('Mobile')) || has('Silk');
-  Blockly.utils.userAgent.MOBILE = !Blockly.utils.userAgent.TABLET &&
-      (Blockly.utils.userAgent.IPOD || Blockly.utils.userAgent.IPHONE ||
-       Blockly.utils.userAgent.ANDROID || has('IEMobile'));
+  TABLET = IPAD ||
+      (ANDROID && !has('Mobile')) || has('Silk');
+  MOBILE = !TABLET &&
+      (IPOD || IPHONE ||
+       ANDROID || has('IEMobile'));
 })((Blockly.utils.global['navigator'] && Blockly.utils.global['navigator']['userAgent']) || '');

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -62,7 +62,8 @@ Blockly.utils.userAgent.MOBILE;
 
 (function(raw) {
   Blockly.utils.userAgent.raw = raw;
-  var rawUpper = Blockly.utils.userAgent.raw.toUpperCase();
+  const rawUpper = Blockly.utils.userAgent.raw.toUpperCase();
+
   /**
    * Case-insensitive test of whether name is in the useragent string.
    * @param {string} name Name to test.
@@ -96,7 +97,7 @@ Blockly.utils.userAgent.MOBILE;
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
   Blockly.utils.userAgent.ANDROID = has('Android');
-  var maxTouchPoints = Blockly.utils.global['navigator'] &&
+  const maxTouchPoints = Blockly.utils.global['navigator'] &&
       Blockly.utils.global['navigator']['maxTouchPoints'];
   Blockly.utils.userAgent.IPAD = has('iPad') ||
       has('Macintosh') && maxTouchPoints > 0;

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -12,14 +12,10 @@
  */
 'use strict';
 
-/**
- * @name Blockly.utils.userAgent
- * @namespace
- */
 goog.module('Blockly.utils.userAgent');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.utils.global');
+const globalUtils = goog.require('Blockly.utils.global');
 
 
 /** @type {boolean} */
@@ -111,8 +107,8 @@ exports.MOBILE = MOBILE;
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js and
   // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/extra.js
   ANDROID = has('Android');
-  const maxTouchPoints = Blockly.utils.global['navigator'] &&
-      Blockly.utils.global['navigator']['maxTouchPoints'];
+  const maxTouchPoints = globalUtils['navigator'] &&
+      globalUtils['navigator']['maxTouchPoints'];
   IPAD = has('iPad') ||
       has('Macintosh') && maxTouchPoints > 0;
   IPOD = has('iPod');
@@ -127,4 +123,4 @@ exports.MOBILE = MOBILE;
   MOBILE = !TABLET &&
       (IPOD || IPHONE ||
        ANDROID || has('IEMobile'));
-})((Blockly.utils.global['navigator'] && Blockly.utils.global['navigator']['userAgent']) || '');
+})((globalUtils['navigator'] && globalUtils['navigator']['userAgent']) || '');

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -222,7 +222,7 @@ goog.addDependency('../../core/utils/style.js', ['Blockly.utils.style'], ['Block
 goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], []);
 goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/toolbox.js', ['Blockly.utils.toolbox'], ['Blockly.Xml', 'Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global']);
+goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.Names', 'Blockly.VariableModel', 'Blockly.utils', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
<!-- Suggested PR title: Migrate core/utils/useragent.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm run test` locally already.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/useragent.js` to `goog.module` syntax. 

<!-- 
 * ### Additional Information
 * Un-comment and update this section if relevant.
 * -->
