### PR TITLE
fix: copy paste w/ JSO hooks

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -963,18 +963,28 @@ Blockly.BlockSvg.prototype.toCopyData = function() {
   if (this.isInsertionMarker_) {
     return null;
   }
-  var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(this, true));
-  // Copy only the selected block and internal blocks.
-  Blockly.Xml.deleteNext(xml);
-  // Encode start position in XML.
-  var xy = this.getRelativeToSurfaceXY();
-  xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
-  xml.setAttribute('y', xy.y);
-  return {
-    xml: xml,
-    source: this.workspace,
-    typeCounts: Blockly.utils.getBlockTypeCounts(this, true)
-  };
+  if (this.mutationToDom && !this.saveExtraState) {
+    var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(this, true));
+    // Copy only the selected block and internal blocks.
+    Blockly.Xml.deleteNext(xml);
+    // Encode start position in XML.
+    var xy = this.getRelativeToSurfaceXY();
+    xml.setAttribute('x', this.RTL ? -xy.x : xy.x);
+    xml.setAttribute('y', xy.y);
+    return {
+      saveInfo: xml,
+      source: this.workspace,
+      typeCounts: Blockly.utils.getBlockTypeCounts(this, true)
+    };
+  } else {
+    return {
+      saveInfo: /** @type {!Blockly.serialization.blocks.State} */
+          (Blockly.serialization.blocks.save(
+              this, {addCoordinates: true, addNextBlocks: false})),
+      source: this.workspace,
+      typeCounts: Blockly.utils.getBlockTypeCounts(this, true)
+    };
+  }
 };
 
 /**

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -92,24 +92,9 @@ Blockly.draggingConnections = [];
 
 /**
  * Contents of the local clipboard.
- * @type {Element}
- * @private
+ * @type {?Blockly.ICopyable.CopyData}
  */
-Blockly.clipboardXml_ = null;
-
-/**
- * Source of the local clipboard.
- * @type {Blockly.WorkspaceSvg}
- * @private
- */
-Blockly.clipboardSource_ = null;
-
-/**
- * Map of types to type counts for the clipboard object and descendants.
- * @type {Object}
- * @private
- */
-Blockly.clipboardTypeCounts_ = null;
+Blockly.clipboardData_ = null;
 
 /**
  * Cached value for whether 3D is supported.
@@ -234,12 +219,7 @@ Blockly.deleteBlock = function(selected) {
  * @package
  */
 Blockly.copy = function(toCopy) {
-  var data = toCopy.toCopyData();
-  if (data) {
-    Blockly.clipboardXml_ = data.xml;
-    Blockly.clipboardSource_ = data.source;
-    Blockly.clipboardTypeCounts_ = data.typeCounts;
-  }
+  Blockly.clipboardData_ = toCopy.toCopyData();
 };
 
 /**
@@ -248,19 +228,19 @@ Blockly.copy = function(toCopy) {
  * @package
  */
 Blockly.paste = function() {
-  if (!Blockly.clipboardXml_) {
+  if (!Blockly.clipboardData_) {
     return false;
   }
   // Pasting always pastes to the main workspace, even if the copy
   // started in a flyout workspace.
-  var workspace = Blockly.clipboardSource_;
+  var workspace = Blockly.clipboardData_.source;
   if (workspace.isFlyout) {
     workspace = workspace.targetWorkspace;
   }
-  if (Blockly.clipboardTypeCounts_ &&
-      workspace.isCapacityAvailable(Blockly.clipboardTypeCounts_)) {
+  if (Blockly.clipboardData_.typeCounts &&
+      workspace.isCapacityAvailable(Blockly.clipboardData_.typeCounts)) {
     Blockly.Events.setGroup(true);
-    workspace.paste(Blockly.clipboardXml_);
+    workspace.paste(Blockly.clipboardData_.saveInfo);
     Blockly.Events.setGroup(false);
     return true;
   }
@@ -274,17 +254,10 @@ Blockly.paste = function() {
  * @package
  */
 Blockly.duplicate = function(toDuplicate) {
-  // Save the clipboard.
-  var clipboardXml = Blockly.clipboardXml_;
-  var clipboardSource = Blockly.clipboardSource_;
-
-  // Create a duplicate via a copy/paste operation.
+  var data = Blockly.clipboardData_;
   Blockly.copy(toDuplicate);
-  toDuplicate.workspace.paste(Blockly.clipboardXml_);
-
-  // Restore the clipboard.
-  Blockly.clipboardXml_ = clipboardXml;
-  Blockly.clipboardSource_ = clipboardSource;
+  toDuplicate.workspace.paste(Blockly.clipboardData_.saveInfo);
+  Blockly.clipboardData_ = data;
 };
 
 /**

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -26,15 +26,17 @@ Blockly.ICopyable = function() {};
 /**
  * Encode for copying.
  * @return {?Blockly.ICopyable.CopyData} Copy metadata.
+ * @package
  */
 Blockly.ICopyable.prototype.toCopyData;
 
 /**
  * Copy Metadata.
  * @typedef {{
- *            xml:!Element,
+ *            saveInfo:(!Object|!Element),
  *            source:Blockly.WorkspaceSvg,
  *            typeCounts:?Object
  *          }}
+ * @package
  */
 Blockly.ICopyable.CopyData;


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on project cereal

### Proposed Changes
Fixes copying and pasting blocks that only contain JSO serialization hooks.

### Reason for Changes
Copy paste should work for both systems.

### Test Coverage
Manually tested off of the #5392 branch.
  * Copying and pasting a block with only new hooks.
  * Copying and pasting a block with only old hooks.
  * Copying and pasting a block with both sets of hooks.