### PR TITLE
Allow command key zoom on mac devices

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1801,7 +1801,8 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
 
   var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
 
-  // Zoom should also be enabled by the command key on Mac devices.
+  // Zoom should also be enabled by the command key on Mac devices,
+  // but not super on Unix.
   var commandKey;
   if (Blockly.utils.userAgent.MAC) {
     commandKey = e.metaKey;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1800,7 +1800,14 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
   }
 
   var scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
-  if (canWheelZoom && (e.ctrlKey || !canWheelMove)) {
+
+  // Zoom should also be enabled by the command key on Mac devices.
+  var commandKey;
+  if (Blockly.utils.userAgent.MAC) {
+    commandKey = e.metaKey;
+  }
+
+  if (canWheelZoom && (e.ctrlKey || commandKey || !canWheelMove)) {
     // Zoom.
     // The vertical scroll distance that corresponds to a click of a zoom
     // button.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #4993.

### Proposed Changes

Also check if the command key has been pressed on mac devices when deciding if the user is able to zoom. 

#### Behavior Before Change

The workspace can't be zoomed when the command key is pressed and the mouse wheel is scrolled (when move with wheel is enabled).

#### Behavior After Change

The command key can be used to zoom.

### Test Coverage

Tested on:
- OS: macOS 11.4, Ubuntu 21.04 (to check that zoom doesn't work with the super key)

Browsers:
- Google Chrome on macOS
- Safari on macOS
- Chromium on Ubuntu