### PR TITLE
fix: dragging blocks from the flyout that only have XML hooks

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -1061,24 +1061,13 @@ Blockly.Flyout.prototype.placeNewBlock_ = function(oldBlock) {
     throw Error('oldBlock is not rendered.');
   }
 
-  if (oldBlock.mutationToDom && !oldBlock.saveExtraState) {
-    // Create the new block by cloning the block in the flyout (via XML).
-    // This cast assumes that the oldBlock can not be an insertion marker.
-    var xml = /** @type {!Element} */ (Blockly.Xml.blockToDom(oldBlock, true));
-    // The target workspace would normally resize during domToBlock, which will
-    // lead to weird jumps.  Save it for terminateDrag.
-    targetWorkspace.setResizesEnabled(false);
-    // Using domToBlock instead of domToWorkspace means that the new block will be
-    // placed at position (0, 0) in main workspace units.
-    var block = /** @type {!Blockly.BlockSvg} */
-        (Blockly.Xml.domToBlock(xml, targetWorkspace));
-  } else {
-    var json = /** @type {!Blockly.serialization.blocks.State} */
-        (Blockly.serialization.blocks.save(oldBlock));
-    targetWorkspace.setResizesEnabled(false);
-    var block = /** @type {!Blockly.BlockSvg} */
-        (Blockly.serialization.blocks.load(json, targetWorkspace));
-  }
+  // Clone the block.
+  var json = /** @type {!Blockly.serialization.blocks.State} */
+      (Blockly.serialization.blocks.save(oldBlock));
+  // Normallly this resizes leading to weird jumps. Save it for terminateDrag.
+  targetWorkspace.setResizesEnabled(false);
+  var block = /** @type {!Blockly.BlockSvg} */
+      (Blockly.serialization.blocks.load(json, targetWorkspace));
 
   // The offset in pixels between the main workspace's origin and the upper left
   // corner of the injection div.

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -399,8 +399,8 @@ const loadPrivate = function(
  * @param {!State} state The state object to reference.
  */
 const loadCoords = function(block, state) {
-  const x = state['x'] === undefined ? 10 : state['x'];
-  const y = state['y'] === undefined ? 10 : state['y'];
+  const x = state['x'] === undefined ? 0 : state['x'];
+  const y = state['y'] === undefined ? 0 : state['y'];
   block.moveBy(x, y);
 };
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -197,19 +197,6 @@ function setToolboxDropdown() {
 }
 
 function initToolbox(workspace) {
-  workspace.registerToolboxCategoryCallback('JSON', function() {
-    return [
-      {
-        'kind': 'block',
-        'type': 'lists_create_with_json'
-      },
-      {
-        'kind': 'block',
-        'type': 'lists_create_with_json',
-        'extraState': {'itemCount': 2}
-      }
-    ]
-  });
   var toolboxSuffix = getToolboxSuffix();
   if (toolboxSuffix == 'test-blocks' &&
       typeof window.toolboxTestBlocksInit !== 'undefined') {
@@ -460,130 +447,6 @@ var spaghettiXml = [
     },
     'next': { }
   });
-
-
-Blockly.Blocks['lists_create_with_json'] = {
-  /**
-   * Block for creating a list with any number of elements of any type.
-   * @this {Blockly.Block}
-   */
-  init: function() {
-    this.setHelpUrl(Blockly.Msg['LISTS_CREATE_WITH_HELPURL']);
-    this.setStyle('list_blocks');
-    this.itemCount_ = 3;
-    this.updateShape_();
-    this.setOutput(true, 'Array');
-    this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
-    this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
-  },
-  /**
-   * Returns the state of this block as a JSON serializable object.
-   * @return {{itemCount: number}} The state of this block, ie the item count.
-   */
-  saveExtraState: function() {
-    return {
-      'itemCount': this.itemCount_,
-    };
-  },
-  /**
-   * Applies the given state to this block.
-   * @param {*} state The state to apply to this block, ie the item count.
-   */
-  loadExtraState: function(state) {
-    this.itemCount_ = state['itemCount'];
-    this.updateShape_();
-  },
-  /**
-   * Populate the mutator's dialog with this block's components.
-   * @param {!Blockly.Workspace} workspace Mutator's workspace.
-   * @return {!Blockly.Block} Root block in mutator.
-   * @this {Blockly.Block}
-   */
-  decompose: function(workspace) {
-    var containerBlock = workspace.newBlock('lists_create_with_container');
-    containerBlock.initSvg();
-    var connection = containerBlock.getInput('STACK').connection;
-    for (var i = 0; i < this.itemCount_; i++) {
-      var itemBlock = workspace.newBlock('lists_create_with_item');
-      itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
-      connection = itemBlock.nextConnection;
-    }
-    return containerBlock;
-  },
-  /**
-   * Reconfigure this block based on the mutator dialog's components.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
-   */
-  compose: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    // Count number of inputs.
-    var connections = [];
-    while (itemBlock && !itemBlock.isInsertionMarker()) {
-      connections.push(itemBlock.valueConnection_);
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-    }
-    // Disconnect any children that don't belong.
-    for (var i = 0; i < this.itemCount_; i++) {
-      var connection = this.getInput('ADD' + i).connection.targetConnection;
-      if (connection && connections.indexOf(connection) == -1) {
-        connection.disconnect();
-      }
-    }
-    this.itemCount_ = connections.length;
-    this.updateShape_();
-    // Reconnect any child blocks.
-    for (var i = 0; i < this.itemCount_; i++) {
-      Blockly.Mutator.reconnect(connections[i], this, 'ADD' + i);
-    }
-  },
-  /**
-   * Store pointers to any connected child blocks.
-   * @param {!Blockly.Block} containerBlock Root block in mutator.
-   * @this {Blockly.Block}
-   */
-  saveConnections: function(containerBlock) {
-    var itemBlock = containerBlock.getInputTargetBlock('STACK');
-    var i = 0;
-    while (itemBlock) {
-      var input = this.getInput('ADD' + i);
-      itemBlock.valueConnection_ = input && input.connection.targetConnection;
-      i++;
-      itemBlock = itemBlock.nextConnection &&
-          itemBlock.nextConnection.targetBlock();
-    }
-  },
-  /**
-   * Modify this block to have the correct number of inputs.
-   * @private
-   * @this {Blockly.Block}
-   */
-  updateShape_: function() {
-    if (this.itemCount_ && this.getInput('EMPTY')) {
-      this.removeInput('EMPTY');
-    } else if (!this.itemCount_ && !this.getInput('EMPTY')) {
-      this.appendDummyInput('EMPTY')
-          .appendField(Blockly.Msg['LISTS_CREATE_EMPTY_TITLE']);
-    }
-    // Add new inputs.
-    for (var i = 0; i < this.itemCount_; i++) {
-      if (!this.getInput('ADD' + i)) {
-        var input = this.appendValueInput('ADD' + i)
-            .setAlign(Blockly.ALIGN_RIGHT);
-        if (i == 0) {
-          input.appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
-        }
-      }
-    }
-    // Remove deleted inputs.
-    while (this.getInput('ADD' + i)) {
-      this.removeInput('ADD' + i);
-      i++;
-    }
-  }
-};
 
 </script>
 
@@ -1060,8 +923,6 @@ Blockly.Blocks['lists_create_with_json'] = {
     <sep></sep>
     <category name="Variables" categorystyle="variable_category" custom="VARIABLE"></category>
     <category name="Functions" categorystyle="procedure_category" custom="PROCEDURE"></category>
-    <sep></sep>
-    <category name="JSON" categorystyle="procedure_category" custom="JSON"></category>
   </xml>
 
   <!-- toolbox-categories-typed-variables has a category menu and an


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)


## The details
### Resolves

Work on project cereal

### Description

1) Fixes a blocks not being positioned correctly in the flyout
2) Dragging blocks/fields out of the flyout that only have XML hooks

### Testing
Tested dragging blocks/fields that only have XML hooks out of the flyout using https://github.com/google/blockly-samples/pull/875