### PR TITLE
fix: serializing edited shadows

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -257,7 +257,7 @@ const saveNextBlocks = function(block, state) {
  *     shadow block, or any connected real block.
  */
 const saveConnection = function(connection) {
-  const shadow = connection.getShadowState();
+  const shadow = connection.getShadowState(true);
   const child = connection.targetBlock();
   if (!shadow && !child) {
     return null;

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -426,6 +426,62 @@ suite('JSO Serialization', function() {
         };
       });
 
+      suite('Editing shadow value', function() {
+        test('Not overwritten', function() {
+          const block = this.workspace.newBlock('text_print');
+          block.getInput('TEXT').connection.setShadowState({
+            'type': 'text',
+            'id': 'id'
+          });
+          block.getInputTargetBlock('TEXT').setFieldValue('new value', 'TEXT');
+          const jso = Blockly.serialization.blocks.save(block);
+          this.assertInput(
+              jso,
+              'TEXT',
+              {
+                'shadow': {
+                  'type': 'text',
+                  'id': 'id',
+                  'fields': {
+                    'TEXT': 'new value'
+                  }
+                }
+              });
+        });
+
+        test('Overwritten', function() {
+          const block = this.workspace.newBlock('text_print');
+          block.getInput('TEXT').connection.setShadowState({
+            'type': 'text',
+            'id': 'id'
+          });
+          block.getInputTargetBlock('TEXT').setFieldValue('new value', 'TEXT');
+          const childBlock = this.workspace.newBlock('text');
+          block.getInput('TEXT').connection.connect(
+              childBlock.outputConnection);
+          const jso = Blockly.serialization.blocks.save(block);
+          this.assertInput(
+              jso,
+              'TEXT',
+              {
+                'shadow': {
+                  'type': 'text',
+                  'id': 'id',
+                  'fields': {
+                    'TEXT': 'new value'
+                  }
+                },
+                'block': {
+                  'type': 'text',
+                  'id': 'id3',
+                  'fields': {
+                    'TEXT': ''
+                  }
+                },
+              });
+        });
+      });
+
       suite('Value', function() {
         suite('With serialization', function() {
           test('Child', function() {


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on project cereal

### Description

Fixes serializing shadows that have been edited and not overwritten.

### Testing
Added tests for serializing shadows that have been edited.