### PR TITLE
Create `scripts/migration/renamings.js` to collect information about renamed API entries

### DIFF
--- a/scripts/migration/renamings.js
+++ b/scripts/migration/renamings.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Collected information about modules and module
+ * exports that have been renamed between versions.
+ *
+ * For now this is a node module, not a goog.module.
+ */
+'use strict';
+
+/**
+ * Map from Blockly core version number to table of renamings made
+ * *since* that version was released (since we don't know for sure
+ * what the version number of the release that will incorporate those
+ * renamings will be yet).
+ * @type {Object<string, ?>}
+ */
+const renamings = {
+  '4.20201217.0': {
+    Blockly: {
+      exports: {
+        // bind/unbind events functions.  See PR #4642
+        EventData: {module: 'Blockly.eventHandling', export: 'Data'},
+        bindEvent_: {module: 'Blockly.browserEvents', export: 'bind'},
+        unbindEvent_: {module: 'Blockly.browserEvents', export: 'unbind'},
+        bindEventWithChecks_: {
+          module: 'Blockly.browserEvents',
+          export: 'conditionalBind',
+        },
+      },
+    }
+  },
+  '6.20210701.0': {
+    Blockly: {
+      exports: {
+        // Clipboard.  See PR #5237.
+        clipboardXml_: {module: 'Blockly.clipboard', export: 'xml'},
+        clipboardSource_: {module: 'Blockly.clipboard', export: 'source'},
+        clipboardTypeCounts_: {
+          module: 'Blockly.clipboard',
+          export: 'typeCounts',
+        },
+        copy: {module: 'Blockly.clipboard'},
+        paste: {module: 'Blockly.clipboard'},
+        duplicate: {module: 'Blockly.clipboard'},
+
+        // mainWorkspace.  See PR #5244.
+        mainWorkspace: {
+          module: 'Blockly.common',
+          get: 'getMainWorkspace',
+          set: 'setMainWorkspace',
+        },
+        getMainWorkspace: {module: 'Blockly.common'},
+
+        // parentContainer, draggingConnections.  See PR #5262.
+        parentContainer: {
+          module: 'Blockly.common',
+          get: 'getParentContainer',
+          set: 'setParentContainer',
+        },
+        setParentContainer: {module: 'Blockly.common'},
+        draggingConnections: {module: 'Blockly.common'},
+
+      },
+    },
+  },
+};
+
+exports.renamings = renamings;


### PR DESCRIPTION
## The basics

- [X] I branched from `goog_module`
- [X] My pull request is against `goog_module`
- [ ] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5026.

### Proposed Changes

Create a file `scripts/migration/renamings.js` to collect information about renamed API entries.  Start by filling it with the renamings already done to blockly.js.

### Additional Information

This will be consumed by a script to be written in the blockly-samples repo that will assist users in automatically updating references to parts of the Blockly API that we have renamed.

The exact file format is not fully finalised (nor documented), but the entries added so far should be reasonably self-explanatory.  Details not fully decided yet include:

* Is having the old version number as the main key the best way to organise the file?
* How should this file indicat that the default export has been given a name (in that module or another)?
  * Or vice versa, in the unlikely event that we introduce new default exports?
* Will the script try to rewrite gets/sets of mutable exports now available only via getter/setters functions?
