### PR TITLE
Fix options list being repeated when showEditor is programmatically called repeatedly

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -297,6 +297,9 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(opt_e) {
   } else {
     this.menu_.openingCoords = null;
   }
+
+  // Remove any pre-existing elements in the dropdown.
+  Blockly.DropDownDiv.clearContent();
   // Element gets created in render.
   this.menu_.render(Blockly.DropDownDiv.getContentDiv());
   var menuElement = /** @type {!Element} */ (this.menu_.getElement());


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #4933.

### Proposed Changes

Clear the content of the dropdown div before rendering new elements to prevent the elements from being added "on top" of the pre-existing elements (in this very specific use case).

#### Behavior Before Change

https://user-images.githubusercontent.com/57055412/132082732-d1222893-7935-4bcf-9c84-826d8d688354.mp4

#### Behavior After Change

https://user-images.githubusercontent.com/57055412/132082733-f6426d52-efd8-44f0-919d-e0b48310464f.mp4

### Test Coverage
- Chromium on Ubuntu 21.04
- Firefox on Ubuntu 21.04