### PR TITLE
maxInstance fix

### DIFF
--- a/core/workspace.js
+++ b/core/workspace.js
@@ -266,7 +266,12 @@ Blockly.Workspace.prototype.getBlocksByType = function(type, ordered) {
     }
     blocks.sort(this.sortObjects_);
   }
-  return blocks;
+
+  var filtered = blocks.filter(function(block) {
+    return !block.isInsertionMarker();
+  });
+
+  return filtered;
 };
 
 /**

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -267,11 +267,9 @@ Blockly.Workspace.prototype.getBlocksByType = function(type, ordered) {
     blocks.sort(this.sortObjects_);
   }
 
-  var filtered = blocks.filter(function(block) {
+  return blocks.filter(function(block) {
     return !block.isInsertionMarker();
   });
-
-  return filtered;
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Issue Fix #5374 
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
This PR fixes the issue #5374, Filtering out the insertion marker in the function [getsBlockByType](https://github.com/google/blockly/blob/f94b1db85018b5a7261fa01f7d04cd5c8367fe2c/core/workspace.js#L257) will fix the issue.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change
As @kvanthienen stated-
When the maxInstances option is set for a block (for example to 5), the corresponding block in the toolbox gets the 'blocklyDisabled' class after all the instances have been used in the workspace as expected.
The strange thing, however, is that this block already temporarily gets the 'blocklyDisabled' status while dragging around the second-last block on the workspace (for example block number 4). When the block is released, the status is flipped again.

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change
This is a short term fix where blocks which are not real ` Insertion marker ` are filtered out. Hence, on dragging the block it is not counted twice.Thus solving the issue when Maxinstance is reached when the **block haven't placed yet**.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->
https://user-images.githubusercontent.com/57873504/132156519-8a06f96c-7e8f-49dd-a840-3e1e2fd6173e.mov

### Reason for Changes
Whenever we were picking a block set with a maxInstance, [getsBlockByType](https://github.com/google/blockly/blob/f94b1db85018b5a7261fa01f7d04cd5c8367fe2c/core/workspace.js#L257) returns the value with insertion marker + number of blocks, which was causing the problem as an virtual object `(Insertion marker)` got counted as well as.
So filtering out insertion marker gives the correct count.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
 Tested on: 
 * Desktop Chrome: Yes, Worked perfectly
<!-- * Desktop Firefox -->
* Desktop Safari: Yes, Worked perfectly
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation
No changes in documentation 
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

@BeksOmega 