### PR TITLE
fix: loading blocks in RTL

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -399,8 +399,12 @@ const loadPrivate = function(
  * @param {!State} state The state object to reference.
  */
 const loadCoords = function(block, state) {
-  const x = state['x'] === undefined ? 0 : state['x'];
+  let x = state['x'] === undefined ? 0 : state['x'];
   const y = state['y'] === undefined ? 0 : state['y'];
+
+  const workspace = block.workspace;
+  x = workspace.RTL ? workspace.getWidth() - x : x;
+
   block.moveBy(x, y);
 };
 


### PR DESCRIPTION
## The basics

- [X] I branched from **project-cereal**
- [X] My pull request is against **project-cereal**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Work on project cereal

### Description

* Fixes block positions for RTL

### Testing
* Tested saving in RTL and then loading into RTL. Position is now the same.
* Tested saving in LTR and then loading into RTL. Position is now the same relative to the toolbox.