### PR TITLE
Note behavior of centerOnBlock when block is part of a stack in the JSDoc

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -2168,7 +2168,8 @@ Blockly.WorkspaceSvg.prototype.scrollCenter = function() {
 };
 
 /**
- * Scroll the workspace to center on the given block.
+ * Scroll the workspace to center on the given block. If the block has other
+ * blocks stacked below it, the workspace will be centered on the stack.
  * @param {?string} id ID of block center on.
  * @public
  */


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
Clarifies the JSDoc for centerOnBlock to document the behavior noted in #5432.