### PR TITLE
Migrate core/msg.js to goog.module syntax

### DIFF
--- a/core/msg.js
+++ b/core/msg.js
@@ -17,16 +17,16 @@
 goog.module('Blockly.Msg');
 goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.utils.global');
+const global = goog.require('Blockly.utils.global');
 
 
 /**
  * Exported so that if Blockly is compiled with ADVANCED_COMPILATION,
  * the Blockly.Msg object exists for message files included in script tags.
  */
-if (!Blockly.utils.global['Blockly']) {
-  Blockly.utils.global['Blockly'] = {};
+if (!global['Blockly']) {
+  global['Blockly'] = {};
 }
-if (!Blockly.utils.global['Blockly']['Msg']) {
-  Blockly.utils.global['Blockly']['Msg'] = exports;
+if (!global['Blockly']['Msg']) {
+  global['Blockly']['Msg'] = exports;
 }

--- a/core/msg.js
+++ b/core/msg.js
@@ -14,7 +14,8 @@
  * Name space for the Msg singleton.
  * Msg gets populated in the message files.
  */
-goog.provide('Blockly.Msg');
+goog.module('Blockly.Msg');
+goog.module.declareLegacyNamespace();
 
 goog.require('Blockly.utils.global');
 
@@ -27,5 +28,5 @@ if (!Blockly.utils.global['Blockly']) {
   Blockly.utils.global['Blockly'] = {};
 }
 if (!Blockly.utils.global['Blockly']['Msg']) {
-  Blockly.utils.global['Blockly']['Msg'] = Blockly.Msg;
+  Blockly.utils.global['Blockly']['Msg'] = exports;
 }

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -127,7 +127,7 @@ goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], []
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/menuitem.js', ['Blockly.MenuItem'], ['Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.idGenerator'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/metrics_manager.js', ['Blockly.MetricsManager'], ['Blockly.registry', 'Blockly.utils.Size', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/msg.js', ['Blockly.Msg'], ['Blockly.utils.global'], {'module': 'goog'});
+goog.addDependency('../../core/msg.js', ['Blockly.Msg'], ['Blockly.utils.global'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/mutator.js', ['Blockly.Mutator'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BlockChange', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.Options', 'Blockly.WorkspaceSvg', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/names.js', ['Blockly.Names'], ['Blockly.Msg', 'Blockly.Variables', 'Blockly.internalConstants'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/options.js', ['Blockly.Options'], ['Blockly.Theme', 'Blockly.Themes.Classic', 'Blockly.registry', 'Blockly.utils.deprecation', 'Blockly.utils.idGenerator', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -127,7 +127,7 @@ goog.addDependency('../../core/marker_manager.js', ['Blockly.MarkerManager'], []
 goog.addDependency('../../core/menu.js', ['Blockly.Menu'], ['Blockly.browserEvents', 'Blockly.utils.Coordinate', 'Blockly.utils.KeyCodes', 'Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.style'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/menuitem.js', ['Blockly.MenuItem'], ['Blockly.utils.aria', 'Blockly.utils.dom', 'Blockly.utils.idGenerator'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/metrics_manager.js', ['Blockly.MetricsManager'], ['Blockly.registry', 'Blockly.utils.Size', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/msg.js', ['Blockly.Msg'], ['Blockly.utils.global']);
+goog.addDependency('../../core/msg.js', ['Blockly.Msg'], ['Blockly.utils.global'], {'module': 'goog'});
 goog.addDependency('../../core/mutator.js', ['Blockly.Mutator'], ['Blockly.Bubble', 'Blockly.Events', 'Blockly.Events.BlockChange', 'Blockly.Events.BubbleOpen', 'Blockly.Icon', 'Blockly.Options', 'Blockly.WorkspaceSvg', 'Blockly.Xml', 'Blockly.internalConstants', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/names.js', ['Blockly.Names'], ['Blockly.Msg', 'Blockly.Variables', 'Blockly.internalConstants'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/options.js', ['Blockly.Options'], ['Blockly.Theme', 'Blockly.Themes.Classic', 'Blockly.registry', 'Blockly.utils.deprecation', 'Blockly.utils.idGenerator', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
## The basics

- [X] I branched from `goog_module`
- [X] My pull request is against `goog_module`
- [X] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [X] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/msg.js` to `goog.module` with ES6 `const`/`let`.

### Additional Information

There is some doubt about whether this PR will cause issues with localisation because:

* The `exports` object of a `goog.module` gets frozen upon being loaded.
* This will prevent any additional properties from being added to it.
* `msg.js` doesn't actually add any message properties to it at all.
* How is the playground successfully loading messages after the fact?
* Will this continue to work with advanced compilation?
