### PR TITLE
chore: sets polyfill flag to true

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -119,7 +119,7 @@ function compile(compilerOptions, opt_verbose, opt_warnings_as_error,
   options.warning_level = opt_verbose ? 'VERBOSE' : 'DEFAULT';
   options.language_in = 'ECMASCRIPT6_STRICT',
   options.language_out = 'ECMASCRIPT5_STRICT';
-  options.rewrite_polyfills = false;
+  options.rewrite_polyfills = true;
   options.hide_warnings_for = 'node_modules';
   if (opt_warnings_as_error || opt_strict_typechecker) {
     options.jscomp_error = JSCOMP_ERROR;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->


## The details
### Resolves
#5039
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Additional Details

Updating this flag caused the following changes in the compressed files:

**Old**
blockly_compressed: **795798**
blockly_compressed.js.gz: **151736**

**New**
blockly_compressed: **800683**
blockly_compressed.js.gz: **153167**

**Deltas** 
blockly_compressed: **4885** (~5kb)
blockly_compressed.js.gz: **1431**(~1.5kb)

**Note**: this is for about 6 polyfills(as far as I could tell). As we increase the number of methods that need polyfills, the size will increase. 

**How I tested?** 
- Changed the flag in the `build_tasks.js` file
- `npm run build`
- `./tests/scripts/check_metadata.sh` to get the new size.