### PR TITLE
Migrate core/utils/xml.js to goog.module syntax

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -63,7 +63,7 @@ Blockly.utils.xml.createTextNode = function(text) {
  * @public
  */
 Blockly.utils.xml.textToDomDocument = function(text) {
-  var oParser = new DOMParser();
+  const oParser = new DOMParser();
   return oParser.parseFromString(text, 'text/xml');
 };
 
@@ -75,6 +75,6 @@ Blockly.utils.xml.textToDomDocument = function(text) {
  * @public
  */
 Blockly.utils.xml.domToText = function(dom) {
-  var oSerializer = new XMLSerializer();
+  const oSerializer = new XMLSerializer();
   return oSerializer.serializeToString(dom);
 };

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -30,7 +30,7 @@ exports.NAME_SPACE = NAME_SPACE;
  * Get the document object.  This method is overridden in the Node.js build of
  * Blockly. See gulpfile.js, package-blockly-node task.
  *
- * Note that this function is named myDocument so as to not shadow the
+ * Note that this function is named getDocument so as to not shadow the
  * global of the same name, but (for now) exported as .document to not
  * break existing importers.
  *
@@ -47,7 +47,7 @@ exports.document = getDocument;
  * @return {!Element} New DOM element.
  */
 const createElement = function(tagName) {
-  return getDocument().createElementNS(NAME_SPACE, tagName);
+  return exports.document().createElementNS(NAME_SPACE, tagName);
 };
 exports.createElement = createElement;
 
@@ -57,7 +57,7 @@ exports.createElement = createElement;
  * @return {!Text} New DOM text node.
  */
 const createTextNode = function(text) {
-  return getDocument().createTextNode(text);
+  return exports.document().createTextNode(text);
 };
 exports.createTextNode = createTextNode;
 

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -16,65 +16,72 @@
  * @name Blockly.utils.xml
  * @namespace
  */
-goog.provide('Blockly.utils.xml');
+goog.module('Blockly.utils.xml');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * Namespace for Blockly's XML.
  */
-Blockly.utils.xml.NAME_SPACE = 'https://developers.google.com/blockly/xml';
+const NAME_SPACE = 'https://developers.google.com/blockly/xml';
+exports.NAME_SPACE = NAME_SPACE;
 
 /**
  * Get the document object.  This method is overridden in the Node.js build of
  * Blockly. See gulpfile.js, package-blockly-node task.
+ *
+ * Note that this function is named myDocument so as to not shadow the
+ * global of the same name, but (for now) exported as .document to not
+ * break existing importers.
+ *
  * @return {!Document} The document object.
- * @public
  */
-Blockly.utils.xml.document = function() {
+const getDocument = function() {
   return document;
 };
+exports.document = getDocument;
 
 /**
  * Create DOM element for XML.
  * @param {string} tagName Name of DOM element.
  * @return {!Element} New DOM element.
- * @public
  */
-Blockly.utils.xml.createElement = function(tagName) {
-  return Blockly.utils.xml.document().createElementNS(
-      Blockly.utils.xml.NAME_SPACE, tagName);
+const createElement = function(tagName) {
+  return getDocument().createElementNS(
+      NAME_SPACE, tagName);
 };
+exports.createElement = createElement;
 
 /**
  * Create text element for XML.
  * @param {string} text Text content.
  * @return {!Text} New DOM text node.
- * @public
  */
-Blockly.utils.xml.createTextNode = function(text) {
-  return Blockly.utils.xml.document().createTextNode(text);
+const createTextNode = function(text) {
+  return getDocument().createTextNode(text);
 };
+exports.createTextNode = createTextNode;
 
 /**
  * Converts an XML string into a DOM tree.
  * @param {string} text XML string.
  * @return {Document} The DOM document.
  * @throws if XML doesn't parse.
- * @public
  */
-Blockly.utils.xml.textToDomDocument = function(text) {
+const textToDomDocument = function(text) {
   const oParser = new DOMParser();
   return oParser.parseFromString(text, 'text/xml');
 };
+exports.textToDomDocument = textToDomDocument;
 
 /**
  * Converts a DOM structure into plain text.
  * Currently the text format is fairly ugly: all one line with no whitespace.
  * @param {!Node} dom A tree of XML nodes.
  * @return {string} Text representation.
- * @public
  */
-Blockly.utils.xml.domToText = function(dom) {
+const domToText = function(dom) {
   const oSerializer = new XMLSerializer();
   return oSerializer.serializeToString(dom);
 };
+exports.domToText = domToText;

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -47,8 +47,7 @@ exports.document = getDocument;
  * @return {!Element} New DOM element.
  */
 const createElement = function(tagName) {
-  return getDocument().createElementNS(
-      NAME_SPACE, tagName);
+  return getDocument().createElementNS(NAME_SPACE, tagName);
 };
 exports.createElement = createElement;
 

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -229,7 +229,7 @@ goog.addDependency('../../core/utils/svg.js', ['Blockly.utils.Svg'], [], {'lang'
 goog.addDependency('../../core/utils/svg_paths.js', ['Blockly.utils.svgPaths'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/toolbox.js', ['Blockly.utils.toolbox'], ['Blockly.Xml', 'Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/useragent.js', ['Blockly.utils.userAgent'], ['Blockly.utils.global'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], []);
+goog.addDependency('../../core/utils/xml.js', ['Blockly.utils.xml'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variable_map.js', ['Blockly.VariableMap'], ['Blockly.Events', 'Blockly.Events.VarDelete', 'Blockly.Events.VarRename', 'Blockly.Msg', 'Blockly.Names', 'Blockly.VariableModel', 'Blockly.utils.idGenerator', 'Blockly.utils.object'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variable_model.js', ['Blockly.VariableModel'], ['Blockly.Events', 'Blockly.Events.VarCreate', 'Blockly.utils.idGenerator'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/variables.js', ['Blockly.Variables'], ['Blockly.Blocks', 'Blockly.Msg', 'Blockly.VariableModel', 'Blockly.Xml', 'Blockly.utils.xml'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
## The basics

- [X] I branched from `goog_module`
- [X] My pull request is against `goog_module`
- [X] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5026

### Proposed Changes

Converts `core/utils/xml.js` to `goog.module` with ES6 `const`/`let`.

### Additional Information

The `.documents` export is monkey-patched in `scripts/package/node/core.js`; removing this monkey-patching will be addressed in a separate PR.