### PR TITLE
Migrate Blockly.hueToHex to Blockly.utils.colour.hueToHex

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -354,16 +354,15 @@ Blockly.isNumber = function(str) {
   return /^\s*-?\d+(\.\d+)?\s*$/.test(str);
 };
 
-/**
- * Convert a hue (HSV model) into an RGB hex triplet.
- * @param {number} hue Hue on a colour wheel (0-360).
- * @return {string} RGB code, e.g. '#5ba65b'.
- */
-Blockly.hueToHex = function(hue) {
-  return Blockly.utils.colour.hsvToHex(
-      hue, Blockly.internalConstants.HSV_SATURATION,
-      Blockly.internalConstants.HSV_VALUE * 255);
-};
+// Add a getter for Blockly.hueToHex, for legacy reasons.
+Object.defineProperty(Blockly, 'hueToHex', {
+  get: function() {
+    Blockly.utils.deprecation.warn(
+        'Blockly.hueToHex()', 'September 2021', 'September 2022',
+        'Blockly.utils.colour.hueToHex()');
+    return Blockly.utils.colour.hueToHex;
+  }
+});
 
 /**
  * Set the parent container.  This is the container element that the WidgetDiv,

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -428,7 +428,7 @@ ToolboxCategory.prototype.parseColour_ = function(colourValue) {
   } else {
     const hue = Number(colour);
     if (!isNaN(hue)) {
-      return Blockly.hueToHex(hue);
+      return colourUtils.hueToHex(hue);
     } else {
       const hex = colourUtils.parse(colour);
       if (hex) {

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -19,6 +19,8 @@
 goog.module('Blockly.utils.colour');
 goog.module.declareLegacyNamespace();
 
+const internalConstants = goog.require('Blockly.internalConstants');
+
 
 /**
  * Parses a colour from a string.
@@ -212,3 +214,14 @@ const names = {
   'yellow': '#ffff00'
 };
 exports.names = names;
+
+/**
+ * Convert a hue (HSV model) into an RGB hex triplet.
+ * @param {number} hue Hue on a colour wheel (0-360).
+ * @return {string} RGB code, e.g. '#5ba65b'.
+ */
+const hueToHex = function(hue) {
+  return hsvToHex(
+      hue, internalConstants.HSV_SATURATION, internalConstants.HSV_VALUE * 255);
+};
+exports.hueToHex = hueToHex;

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -590,7 +590,8 @@ WorkspaceFactoryController.prototype.loadCategoryByName = function(name) {
   }
   if (!standardCategory.colour && standardCategory.hue !== undefined) {
     // Calculate the hex colour based on the hue.
-    standardCategory.colour = Blockly.hueToHex(standardCategory.hue);
+    standardCategory.colour = Blockly.utils.colour.hueToHex(
+      standardCategory.hue);
   }
   // Transfers current flyout blocks to a category if it's the first category
   // created.

--- a/demos/blockfactory/workspacefactory/wfactory_init.js
+++ b/demos/blockfactory/workspacefactory/wfactory_init.js
@@ -52,7 +52,7 @@ WorkspaceFactoryInit.initColourPicker_ = function(controller) {
   // Convert hue numbers to RRGGBB strings.
   for (var i = 0; i < colours.length; i++) {
     if (colours[i] !== '') {
-      colours[i] = Blockly.hueToHex(colours[i]).substring(1);
+      colours[i] = Blockly.utils.colour.hueToHex(colours[i]).substring(1);
     }
   }
   // Convert to 2D array.

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -212,7 +212,7 @@ goog.addDependency('../../core/touch_gesture.js', ['Blockly.TouchGesture'], ['Bl
 goog.addDependency('../../core/trashcan.js', ['Blockly.Trashcan'], ['Blockly.ComponentManager', 'Blockly.DeleteArea', 'Blockly.Events', 'Blockly.Events.TrashcanOpen', 'Blockly.Options', 'Blockly.Xml', 'Blockly.browserEvents', 'Blockly.internalConstants', 'Blockly.registry', 'Blockly.uiPosition', 'Blockly.utils.Rect', 'Blockly.utils.Size', 'Blockly.utils.Svg', 'Blockly.utils.dom', 'Blockly.utils.object', 'Blockly.utils.toolbox'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils.js', ['Blockly.utils'], ['Blockly.Msg', 'Blockly.internalConstants', 'Blockly.utils.Coordinate', 'Blockly.utils.Rect', 'Blockly.utils.colour', 'Blockly.utils.deprecation', 'Blockly.utils.global', 'Blockly.utils.idGenerator', 'Blockly.utils.string', 'Blockly.utils.style', 'Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/aria.js', ['Blockly.utils.aria'], [], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../core/utils/colour.js', ['Blockly.utils.colour'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../core/utils/colour.js', ['Blockly.utils.colour'], ['Blockly.internalConstants'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/coordinate.js', ['Blockly.utils.Coordinate'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/deprecation.js', ['Blockly.utils.deprecation'], [], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../core/utils/dom.js', ['Blockly.utils.dom'], ['Blockly.utils.userAgent'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5208

### Proposed Changes

This PR migrates Blockly.hueToHex to Blockly.utils.colour.hueToHex and updates core and demos to use the new function.