### PR TITLE
Note Blockly.alert/confirm/prompt/hueToHex/hideChaff migrations in renamings.js

### DIFF
--- a/scripts/migration/renamings.js
+++ b/scripts/migration/renamings.js
@@ -64,7 +64,26 @@ const renamings = {
         },
         setParentContainer: {module: 'Blockly.common'},
         draggingConnections: {module: 'Blockly.common'},
-
+        // Dialogs.  See PR #5457.
+        alert: {
+          module: 'Blockly.dialog',
+          export: 'alert',
+          set: 'setAlert',
+        },
+        confirm: {
+          module: 'Blockly.dialog',
+          export: 'confirm',
+          set: 'setConfirm',
+        },
+        prompt: {
+          module: 'Blockly.dialog',
+          export: 'prompt',
+          set: 'setPrompt',
+        },
+        // hueToHex.  See PR #5462.
+        hueToHex: {module: 'Blockly.utils.colour'},
+        // Blockly.hideChaff() became
+        // Blockly.common.getMainWorkspace().hideChaff().  See PR #5460.
       },
     },
     'Blockly.utils': {


### PR DESCRIPTION
<!-- Suggested PR title: Migrate PATH/TO/FILE.js to goog.module syntax -->

## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

Part of #5208

### Proposed Changes
Adds records of renaming Blockly.alert, Blockly.confirm, Blockly.prompt and Blockly.hueToHex to renamings.js. Also adds a comment about hideChaff, but since that's not strictly a rename (minor change in semantics and moving onto the WorkspaceSvg class) I did not include an actual rename record.