### PR TITLE
Make several exported private fields/methods TEST_ONLY

### DIFF
--- a/core/events/events.js
+++ b/core/events/events.js
@@ -90,17 +90,6 @@ Object.defineProperties(exports, {
  * @type {number}
  */
 let disabled = 0;
-/** @private */
-exports.disabled_ = disabled;
-
-
-Object.defineProperties(exports, {
-  disabled_: {
-    set: function(newValue) {
-      disabled = newValue;
-    },
-  },
-});
 
 /**
  * Name of event that creates a block. Will be deprecated for BLOCK_CREATE.
@@ -310,8 +299,6 @@ exports.BUMP_EVENTS = BUMP_EVENTS;
  * List of events queued for firing.
  */
 const FIRE_QUEUE = [];
-/** @private */
-exports.FIRE_QUEUE_ = FIRE_QUEUE;
 
 /**
  * Create a custom event and fire it.
@@ -346,8 +333,6 @@ const fireNow = function() {
     }
   }
 };
-/** @private */
-exports.fireNow_ = fireNow;
 
 /**
  * Filter the queued events and merge duplicates.
@@ -571,3 +556,5 @@ const disableOrphans = function(event) {
   }
 };
 exports.disableOrphans = disableOrphans;
+
+exports.TEST_ONLY = {FIRE_QUEUE, fireNow};

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -31,7 +31,7 @@ goog.requireType('Blockly.Mutator');
  * @private
  */
 const allExtensions = Object.create(null);
-exports.ALL_ = allExtensions;
+exports.TEST_ONLY = {allExtensions};
 
 /**
  * Registers a new extension function. Extensions are functions that help

--- a/core/registry.js
+++ b/core/registry.js
@@ -50,8 +50,7 @@ const ISerializer = goog.requireType('Blockly.serialization.ISerializer');
  * @type {!Object<string, !Object<string, (function(new:?)|!Object)>>}
  */
 const typeMap = Object.create(null);
-/** @private */
-exports.typeMap_ = typeMap;
+exports.TEST_ONLY = {typeMap};
 
 /**
  * A map of maps. With the keys being the type and caseless name of the class we

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1830,7 +1830,7 @@ suite('Blocks', function() {
       teardown(function() {
         workspaceTeardown.call(this, this.workspace);
         // Clear all registered themes.
-        Blockly.registry.typeMap_['theme'] = {};
+        Blockly.registry.TEST_ONLY.typeMap['theme'] = {};
       });
       test('Set colour hue', function() {
         this.block.setColour('20');

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -19,7 +19,7 @@ suite('Extensions', function() {
     sharedTestTeardown.call(this);
     for (let i = 0; i < this.extensionsCleanup_.length; i++) {
       var extension = this.extensionsCleanup_[i];
-      delete Blockly.Extensions.ALL_[extension];
+      delete Blockly.Extensions.TEST_ONLY.allExtensions[extension];
     }
   });
 
@@ -27,7 +27,8 @@ suite('Extensions', function() {
     this.extensionsCleanup_.push('extensions_test_before');
     this.extensionsCleanup_.push('extensions_test_after');
 
-    chai.assert.isUndefined(Blockly.Extensions.ALL_['extensions_test_before']);
+    chai.assert.isUndefined(
+        Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_before']);
     var beforeCallback = sinon.spy();
     // Extension defined before the block type is defined.
     Blockly.Extensions.register('extensions_test_before', beforeCallback);
@@ -38,13 +39,18 @@ suite('Extensions', function() {
       "extensions": ["extensions_test_before", "extensions_test_after"]
     }]);
 
-    chai.assert.isUndefined(Blockly.Extensions.ALL_['extensions_test_after']);
+    chai.assert.isUndefined(
+        Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_after']);
     var afterCallback = sinon.spy();
     // Extension defined after the block type (but before instantiation).
     Blockly.Extensions.register('extensions_test_after', afterCallback);
 
-    chai.assert.typeOf(Blockly.Extensions.ALL_['extensions_test_before'], 'function');
-    chai.assert.typeOf(Blockly.Extensions.ALL_['extensions_test_after'], 'function');
+    chai.assert.typeOf(
+        Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_before'],
+        'function');
+    chai.assert.typeOf(
+        Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_after'],
+        'function');
     sinon.assert.notCalled(beforeCallback);
     sinon.assert.notCalled(afterCallback);
 
@@ -118,11 +124,13 @@ suite('Extensions', function() {
         }
       };
 
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['mixin_test']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_test']);
       // Extension defined before the block type is defined.
       Blockly.Extensions.registerMixin('mixin_test', testMixin);
 
-      chai.assert.typeOf(Blockly.Extensions.ALL_['mixin_test'], 'function');
+      chai.assert.typeOf(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_test'], 'function');
 
 
       Blockly.defineBlocksWithJsonArray([{
@@ -187,7 +195,8 @@ suite('Extensions', function() {
         // Events code calls mutationToDom and expects it to give back a
         // meaningful value.
         Blockly.Events.disable();
-        chai.assert.isUndefined(Blockly.Extensions.ALL_['extensions_test']);
+        chai.assert.isUndefined(
+            Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test']);
         var helperFunctionSpy = sinon.spy();
         Blockly.Extensions.registerMutator('extensions_test',
             {
@@ -218,7 +227,8 @@ suite('Extensions', function() {
         // Events code calls mutationToDom and expects it to give back a
         // meaningful value.
         Blockly.Events.disable();
-        chai.assert.isUndefined(Blockly.Extensions.ALL_['mutator_test']);
+        chai.assert.isUndefined(
+            Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
         Blockly.Extensions.registerMutator('mutator_test',
             {
               domToMutation: function() {
@@ -248,7 +258,8 @@ suite('Extensions', function() {
         "extensions": ["missing_extension"]
       }]);
 
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['missing_extension']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['missing_extension']);
       var workspace = this.workspace;
       chai.assert.throws(function() {
         var _ = new Blockly.Block(workspace, 'missing_extension_block');
@@ -262,10 +273,14 @@ suite('Extensions', function() {
         inputList: 'bad inputList'  // Defined in constructor
       };
 
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['mixin_bad_inputList']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_inputList']);
       // Extension defined before the block type is defined.
-      Blockly.Extensions.registerMixin('mixin_bad_inputList', TEST_MIXIN_BAD_INPUTLIST);
-      chai.assert.typeOf(Blockly.Extensions.ALL_['mixin_bad_inputList'], 'function');
+      Blockly.Extensions.registerMixin(
+          'mixin_bad_inputList', TEST_MIXIN_BAD_INPUTLIST);
+      chai.assert.typeOf(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_inputList'],
+          'function');
 
       Blockly.defineBlocksWithJsonArray([{
         "type": "test_block_bad_inputList",
@@ -286,10 +301,14 @@ suite('Extensions', function() {
         colour_: 'bad colour_' // Defined on prototype
       };
 
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['mixin_bad_colour_']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_colour_']);
       // Extension defined before the block type is defined.
-      Blockly.Extensions.registerMixin('mixin_bad_colour_', TEST_MIXIN_BAD_COLOUR);
-      chai.assert.typeOf(Blockly.Extensions.ALL_['mixin_bad_colour_'], 'function');
+      Blockly.Extensions.registerMixin(
+          'mixin_bad_colour_', TEST_MIXIN_BAD_COLOUR);
+      chai.assert.typeOf(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_colour_'],
+          'function');
 
       Blockly.defineBlocksWithJsonArray([{
         "type": "test_block_bad_colour",
@@ -315,7 +334,8 @@ suite('Extensions', function() {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['mutator_test']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
       Blockly.Extensions.registerMutator('mutator_test',
           {
             domToMutation: function() {
@@ -331,7 +351,8 @@ suite('Extensions', function() {
         var _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(Blockly.Extensions.ALL_['mutator_test']);
+      chai.assert.isNotNull(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
     });
 
     test('Use mutator mixin as extension', function() {
@@ -346,7 +367,8 @@ suite('Extensions', function() {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['mutator_test']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
       Blockly.Extensions.registerMixin('mutator_test',
           {
             domToMutation: function() {
@@ -362,7 +384,8 @@ suite('Extensions', function() {
         var _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(Blockly.Extensions.ALL_['mutator_test']);
+      chai.assert.isNotNull(
+          Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
     });
 
     test('Use extension as mutator', function() {
@@ -377,7 +400,8 @@ suite('Extensions', function() {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(Blockly.Extensions.ALL_['extensions_test']);
+      chai.assert.isUndefined(
+          Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test']);
       Blockly.Extensions.register('extensions_test', function() {
         return 'extensions_test_fn';
       });
@@ -387,13 +411,15 @@ suite('Extensions', function() {
         var _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(Blockly.Extensions.ALL_['extensions_test']);
+      chai.assert.isNotNull(
+          Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test']);
     });
 
     suite('register', function() {
       test('Just a string', function() {
         this.extensionsCleanup_.push('extension_just_a_string');
-        chai.assert.isUndefined(Blockly.Extensions.ALL_['extension_just_a_string']);
+        chai.assert.isUndefined(Blockly.Extensions.TEST_ONLY
+                                    .allExtensions['extension_just_a_string']);
         chai.assert.throws(function() {
           Blockly.Extensions.register('extension_just_a_string', null);
         });
@@ -401,7 +427,8 @@ suite('Extensions', function() {
 
       test('Null', function() {
         this.extensionsCleanup_.push('extension_is_null');
-        chai.assert.isUndefined(Blockly.Extensions.ALL_['extension_is_null']);
+        chai.assert.isUndefined(
+            Blockly.Extensions.TEST_ONLY.allExtensions['extension_is_null']);
         chai.assert.throws(function() {
           Blockly.Extensions.register('extension_is_null', null);
         });
@@ -409,7 +436,8 @@ suite('Extensions', function() {
 
       test('Undefined', function() {
         this.extensionsCleanup_.push('extension_is_undefined');
-        chai.assert.isUndefined(Blockly.Extensions.ALL_['extension_is_undefined']);
+        chai.assert.isUndefined(Blockly.Extensions.TEST_ONLY
+                                    .allExtensions['extension_is_undefined']);
         chai.assert.throws(function() {
           Blockly.Extensions.register('extension_is_undefined', null);
         });

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -23,8 +23,8 @@ suite('Field Registry', function() {
   });
   teardown(function() {
     sharedTestTeardown.call(this);
-    if (Blockly.registry.typeMap_['field']['field_custom_test']) {
-      delete Blockly.registry.typeMap_['field']['field_custom_test'];
+    if (Blockly.registry.TEST_ONLY.typeMap['field']['field_custom_test']) {
+      delete Blockly.registry.TEST_ONLY.typeMap['field']['field_custom_test'];
     }
   });
 

--- a/tests/mocha/logic_ternary_test.js
+++ b/tests/mocha/logic_ternary_test.js
@@ -78,7 +78,7 @@ suite('Logic ternary', function() {
     function connectParentAndCheckConnections(
         block, parent, parentInputName, opt_thenInput, opt_elseInput) {
       parent.getInput(parentInputName).connection.connect(block.outputConnection);
-      Blockly.Events.fireNow_();  // Force synchronous onchange() call.
+      Blockly.Events.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
       chai.assert.equal(block.getParent(), parent,
           'Successful connection to parent');
       if (opt_thenInput) {
@@ -93,7 +93,7 @@ suite('Logic ternary', function() {
     function connectThenInputAndCheckConnections(
         block, thenInput, opt_elseInput, opt_parent) {
       block.getInput('THEN').connection.connect(thenInput.outputConnection);
-      Blockly.Events.fireNow_();  // Force synchronous onchange() call.
+      Blockly.Events.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
       chai.assert.equal(thenInput.getParent(), block, 'THEN is connected');
       if (opt_parent) {
         chai.assert.equal(block.getParent(), opt_parent,
@@ -107,7 +107,7 @@ suite('Logic ternary', function() {
     function connectElseInputAndCheckConnections(
         block, elseInput, opt_thenInput, opt_parent) {
       block.getInput('ELSE').connection.connect(elseInput.outputConnection);
-      Blockly.Events.fireNow_();  // Force synchronous onchange() call.
+      Blockly.Events.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
       chai.assert.equal(elseInput.getParent(), block, 'ELSE is connected');
       if (opt_parent) {
         chai.assert.equal(block.getParent(), opt_parent,

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -232,16 +232,18 @@ function sharedTestTeardown() {
   } finally {
     // Clear Blockly.Event state.
     Blockly.Events.setGroup(false);
-    Blockly.Events.disabled_ = 0;
+    while (!Blockly.Events.isEnabled()) {
+      Blockly.Events.enable();
+    }
     Blockly.Events.setRecordUndo(true);
-    if (Blockly.Events.FIRE_QUEUE_.length) {
+    if (Blockly.Events.TEST_ONLY.FIRE_QUEUE.length) {
       // If this happens, it may mean that some previous test is missing cleanup
       // (i.e. a previous test added an event to the queue on a timeout that
       // did not use a stubbed clock).
-      Blockly.Events.FIRE_QUEUE_.length = 0;
+      Blockly.Events.TEST_ONLY.FIRE_QUEUE.length = 0;
       console.warn(testRef.fullTitle() +
-          '" needed cleanup of Blockly.Events.FIRE_QUEUE_. This may indicate ' +
-          'leakage from an earlier test');
+          '" needed cleanup of Blockly.Events.TEST_ONLY.FIRE_QUEUE. This may ' +
+          'indicate leakage from an earlier test');
     }
 
     // Restore all stubbed methods.

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -16,7 +16,7 @@ suite('Theme', function() {
   teardown(function() {
     sharedTestTeardown.call(this);
     // Clear all registered themes.
-    Blockly.registry.typeMap_['theme'] = {};
+    Blockly.registry.TEST_ONLY.typeMap['theme'] = {};
   });
 
   function defineThemeTestBlocks() {


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] My code is presented in the form suggested in the [module
      conversion guide](https://github.com/google/blockly/issues/5026)
- [x] I have run `npm test`.

## The details
### Resolves

#5135

### Proposed Changes
This PR addresses exported private fields and methods in Blockly. They have been resolved as follows:

* `Blockly.Events.disabled_` -> Removed, and tests rewritten to use public API to accomplish the same thing
* `Blockly.Events.FIRE_QUEUE_`, `Blockly.Events.fireNow()` -> Moved into TEST_ONLY export and tests updated accordingly
* `Blockly.Extensions.ALL_` -> Moved into TEST_ONLY export (as allExtensions) and tests updated accordingly
* `Blockly.registry.typeMap_` -> Moved into TEST_ONLY export and tests updated accordingly

Because all these private exports were used exclusively in tests, I did not include deprecation wrappers; if we have reason to think external developers were using them I'm happy to add those.

The only other "private" export I found was `Blockly.utils.getInjectionDivXY_()`, but despite ending in an underscore, this was not marked @private pre-conversion, is not used internally in utils or in tests, and is used in workspace and scrollbar. Beka has dealt with it in #5470, so I'm ignoring it here.