### PR TITLE
fix: Prevent request of (non-existent) closure/goog/deps.js

### DIFF
--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -16,7 +16,7 @@
  * loads closure/goog/base.js and tests/deps.js, then (in any case)
  * requires Blockly.requires.
  */
-(function(_global) {
+(function(globalThis) {
   /* eslint-disable no-undef */
   var IS_NODE_JS = !!(typeof module !== 'undefined' && module.exports);
 
@@ -40,6 +40,8 @@
     if (!BLOCKLY_DIR) {
       alert('Could not detect Blockly\'s directory name.');
     }
+    // Disable loading of closure/goog/deps.js (which doesn't exist).
+    globalThis.CLOSURE_NO_DEPS = true;
     // Load Closure Library base.js (the only part of the libary we use,
     // mainly for goog.require / goog.provide / goog.module).
     document.write(


### PR DESCRIPTION
## The basics

- [X] I branched from `goog_module`
- [X] My pull request is against `goog_module`
- [X] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I have run `npm test`.

## The details
### Resolves

Fixes #5103

### Proposed Changes

Since the only part of the Closure Library we have is `closure/goog/base.js`, set the global `CLOSURE_NO_DEPS` flag to prevent it from trying to load `deps.js` from the same directory.

### Additional Information

We already load our own dependency graph from `tests/deps.js`.
