### PR TITLE
chore: update dev tools dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "blockly",
       "version": "6.20210701.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -13,7 +12,7 @@
       },
       "devDependencies": {
         "@blockly/block-test": "^1.0.0",
-        "@blockly/dev-tools": "^2.6.1-beta.0",
+        "@blockly/dev-tools": "^2.6.1",
         "@blockly/theme-modern": "^2.1.1",
         "@wdio/selenium-standalone-service": "^6.11.0",
         "babel-eslint": "^10.1.0",
@@ -279,9 +278,9 @@
       }
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "2.6.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.6.1-beta.0.tgz",
-      "integrity": "sha512-GKnOT+EkvhRtwG6ZRseWEFB96xMyzzY6CPCkPHbCHGNnOB4Z4j3jmU2zIMkWG8lR8pQF0CCWKZinDrMtXSeLjQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.6.1.tgz",
+      "integrity": "sha512-mv7u3x/Z2qA2PCSPomz0S4ofQn+m/UHC/AoNu1FZuwNAwuE5SCy7HCTDracpKWqoK8iuXwi4PWUdu669CDbp5A==",
       "dev": true,
       "dependencies": {
         "@blockly/block-test": "^1.1.5",
@@ -12735,9 +12734,9 @@
       "requires": {}
     },
     "@blockly/dev-tools": {
-      "version": "2.6.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.6.1-beta.0.tgz",
-      "integrity": "sha512-GKnOT+EkvhRtwG6ZRseWEFB96xMyzzY6CPCkPHbCHGNnOB4Z4j3jmU2zIMkWG8lR8pQF0CCWKZinDrMtXSeLjQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.6.1.tgz",
+      "integrity": "sha512-mv7u3x/Z2qA2PCSPomz0S4ofQn+m/UHC/AoNu1FZuwNAwuE5SCy7HCTDracpKWqoK8iuXwi4PWUdu669CDbp5A==",
       "dev": true,
       "requires": {
         "@blockly/block-test": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@blockly/block-test": "^1.0.0",
-    "@blockly/dev-tools": "^2.6.1-beta.0",
+    "@blockly/dev-tools": "^2.6.1",
     "@blockly/theme-modern": "^2.1.1",
     "@wdio/selenium-standalone-service": "^6.11.0",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
Updates the dev tools dependency to 2.6.1. We were previously using the beta version as a stand in until the 2.6.1 version was updated.