### PR TITLE
fix: Cleanup warnings logged by mocha tests

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -35,7 +35,6 @@ const bumpObjects = goog.require('Blockly.bumpObjects');
 const common = goog.require('Blockly.common');
 const dom = goog.require('Blockly.utils.dom');
 const userAgent = goog.require('Blockly.utils.userAgent');
-const utils = goog.require('Blockly.utils');
 const {BlockDragSurfaceSvg} = goog.require('Blockly.BlockDragSurfaceSvg');
 
 
@@ -277,7 +276,7 @@ const onKeyDown = function(e) {
     return;
   }
 
-  if (utils.isTargetInput(e) ||
+  if (browserEvents.isTargetInput(e) ||
       (mainWorkspace.rendered && !mainWorkspace.isVisible())) {
     // When focused on an HTML text input widget, don't trap any keys.
     // Ignore keypresses on rendered workspaces that have been explicitly

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1176,10 +1176,7 @@ suite('Blocks', function() {
           // Restored up by call to sinon.restore() in sharedTestTeardown()
           sinon.stub(this.block, 'isEditable').returns(false);
           var icon = this.block.getCommentIcon();
-          // TODO(#4186): Remove stubbing of deprecation warning after fixing.
-          var deprecationWarnStub = createDeprecationWarningStub();
           icon.setVisible(true);
-          deprecationWarnStub.restore();
 
           this.block.setCommentText('test2');
           chai.assert.equal(this.block.getCommentText(), 'test2');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -60,10 +60,7 @@ suite('Comments', function() {
     test('Not Editable', function() {
       sinon.stub(this.block, 'isEditable').returns(false);
 
-      // TODO(#4186): Remove stubbing of deprecation warning after fixing.
-      var deprecationWarnStub = createDeprecationWarningStub();
       this.comment.setVisible(true);
-      deprecationWarnStub.restore();
 
       chai.assert.isTrue(this.comment.isVisible());
       assertNotEditable(this.comment);
@@ -76,10 +73,7 @@ suite('Comments', function() {
       this.comment.setVisible(true);
       sinon.stub(this.block, 'isEditable').returns(false);
 
-      // TODO(#4186): Remove stubbing of deprecation warning after fixing.
-      var deprecationWarnStub = createDeprecationWarningStub();
       this.comment.updateEditable();
-      deprecationWarnStub.restore();
 
       chai.assert.isTrue(this.comment.isVisible());
       assertNotEditable(this.comment);
@@ -91,10 +85,7 @@ suite('Comments', function() {
     test('Not Editable -> Editable', function() {
       var editableStub = sinon.stub(this.block, 'isEditable').returns(false);
 
-      // TODO(#4186): Remove stubbing of deprecation warning after fixing.
-      var deprecationWarnStub = createDeprecationWarningStub();
       this.comment.setVisible(true);
-      deprecationWarnStub.restore();
 
       editableStub.returns(true);
 

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -63,10 +63,7 @@ suite('Field Registry', function() {
         value: 'ok'
       };
 
-      // TODO(#4197): Remove stubbing of deprecation warning after fixing.
-      var deprecationWarnStub = createDeprecationWarningStub();
       var field = Blockly.fieldRegistry.fromJson(json);
-      deprecationWarnStub.restore();
 
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');
@@ -91,10 +88,7 @@ suite('Field Registry', function() {
         value: 'ok'
       };
 
-      // TODO(#4197): Remove stubbing of deprecation warning after fixing.
-      var deprecationWarnStub = createDeprecationWarningStub();
       var field = Blockly.fieldRegistry.fromJson(json);
-      deprecationWarnStub.restore();
       
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -12,10 +12,6 @@ const {addBlockTypeToCleanup, addMessageToCleanup, createDeprecationWarningStub,
 suite('Abstract Fields', function() {
   setup(function() {
     sharedTestSetup.call(this);
-    // TODO(#4197): Remove stubbing of deprecation warning after fixing.
-    // field.setValue calls trigger a deprecation warning, capture to prevent
-    // console logs.
-    createDeprecationWarningStub();
   });
 
   teardown(function() {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -94,6 +94,7 @@ suite('Generator', function() {
         var generator = testCase[0];
         var name = testCase[1];
         test(name, function() {
+          generator.init(this.workspace);
           this.blockToCodeTest(generator, false, true, 'row_block');
           this.blockToCodeTest(
               generator, false, false, 'row_blockstack_block', 'thisOnly=false');

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -6,8 +6,7 @@
 
 goog.module('Blockly.test.registry');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers');
-
+const {assertWarnings, sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers');
 
 
 suite('Registry', function() {
@@ -99,11 +98,15 @@ suite('Registry', function() {
 
     suite('Does not have', function() {
       test('Type', function() {
-        chai.assert.isNull(Blockly.registry.getClass('bad_type', 'test_name'));
+        assertWarnings(() => {
+          chai.assert.isNull(Blockly.registry.getClass('bad_type', 'test_name'));
+        }, /Unable to find/);
       });
 
       test('Name', function() {
-        chai.assert.isNull(Blockly.registry.getClass('test', 'bad_name'));
+        assertWarnings(() => {
+          chai.assert.isNull(Blockly.registry.getClass('test', 'bad_name'));
+        }, /Unable to find/);
       });
 
       test('Throw if missing', function() {
@@ -135,11 +138,16 @@ suite('Registry', function() {
 
     suite('Does not have', function() {
       test('Type', function() {
-        chai.assert.isNull(Blockly.registry.getObject('bad_type', 'test_name'));
+        assertWarnings(() => {
+          chai.assert.isNull(Blockly.registry.getObject('bad_type', 'test_name'));
+        }, /Unable to find/);
       });
 
       test('Name', function() {
-        chai.assert.isNull(Blockly.registry.getObject('test', 'bad_name'));
+
+        assertWarnings(() => {
+          chai.assert.isNull(Blockly.registry.getObject('test', 'bad_name'));
+        }, /Unable to find/);
       });
 
       test('Throw if missing', function() {
@@ -175,7 +183,9 @@ suite('Registry', function() {
     });
 
     test('Does not have', function() {
-      chai.assert.isNull(Blockly.registry.getAllItems('bad_type'));
+      assertWarnings(() => {
+        chai.assert.isNull(Blockly.registry.getAllItems('bad_type'));
+      }, /Unable to find/);
     });
 
     test('Throw if missing', function() {

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -257,12 +257,10 @@ suite('Registry', function() {
     test('Incorrect Plugin Name', function() {
       this.options['plugins']['test'] = 'random';
       var testClass;
-      var warnings = testHelpers.captureWarnings(() => {
+      assertWarnings(() => {
         testClass = Blockly.registry.getClassFromOptions('test', this.options);
-      });
+      }, /Unable to find/);
       chai.assert.isNull(testClass);
-      chai.assert.equal(warnings.length, 1,
-          'Expecting 1 warning about no name "random" found.');
     });
   });
 });

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -204,7 +204,7 @@ suite("Trashcan", function() {
           '</block>'
       );
       fireDeleteEvent(this.workspace,
-          '<block type="test_field_block">' +
+          '<block type="statement_block2">' +
           '  <statement name="NAME">' +
           '    <block type="statement_block2"/>' +
           '  </statement>' +

--- a/tests/mocha/workspace_helpers.js
+++ b/tests/mocha/workspace_helpers.js
@@ -6,7 +6,7 @@
 
 goog.module('Blockly.test.workspaceHelpers');
 
-const {assertVariableValues, workspaceTeardown} = goog.require('Blockly.test.helpers');
+const {assertVariableValues, assertWarnings, workspaceTeardown} = goog.require('Blockly.test.helpers');
 
 
 function testAWorkspace() {
@@ -1294,11 +1294,9 @@ function testAWorkspace() {
           this.workspace.createVariable('name1', 'type1', 'id1');
           this.workspace.deleteVariableById('id1');
           var workspace = this.workspace;
-          var warnings = testHelpers.captureWarnings(function() {
+          assertWarnings(() => {
             workspace.deleteVariableById('id1');
-          });
-          chai.assert.equal(warnings.length, 1,
-              'Expected 1 warning for second deleteVariableById call.');
+          }, /Can't delete/);
 
           // Check the undoStack only recorded one delete event.
           var undoStack = this.workspace.undoStack_;
@@ -1323,11 +1321,9 @@ function testAWorkspace() {
           createVarBlocksNoEvents(this.workspace, ['id1']);
           this.workspace.deleteVariableById('id1');
           var workspace = this.workspace;
-          var warnings = testHelpers.captureWarnings(function() {
+          assertWarnings(() => {
             workspace.deleteVariableById('id1');
-          });
-          chai.assert.equal(warnings.length, 1,
-              'Expected 1 warning for second deleteVariableById call.');
+          }, /Can't delete/);
 
           // Check the undoStack only recorded one delete event.
           var undoStack = this.workspace.undoStack_;

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -451,30 +451,6 @@ suite('XML', function() {
   suite('domToBlock', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
-      Blockly.defineBlocksWithJsonArray([{
-        "type": "variables_get",
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "field_variable",
-            "name": "VAR"
-          }
-        ]
-      },
-      {
-        "type": "variables_set",
-        "message0": "%1 %2",
-        "args0": [
-          {
-            "type": "field_variable",
-            "name": "VAR"
-          },
-          {
-            "type": "input_value",
-            "name": "VALUE"
-          }
-        ]
-      }]);
     });
     teardown(function() {
       workspaceTeardown.call(this, this.workspace);


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I have run `npm test`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/5029
Part of https://github.com/google/blockly/issues/4194

### Proposed Changes

- Updates `inject.js` to use non-deprecated method
- Various updates to tests to prevent warnings from being logged
- Removes unnecessary stubs due to https://github.com/google/blockly/issues/4186 and https://github.com/google/blockly/issues/4197 being fixed
