### PR TITLE
fix: Add hack to copy accessors to global Blockly namespace object

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -158,6 +158,7 @@ const {BlockSvg} = goog.require('Blockly.BlockSvg');
 const {Blocks} = goog.require('Blockly.blocks');
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
 const {Cursor} = goog.require('Blockly.Cursor');
+const {globalThis} = goog.require('Blockly.utils.global');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Events.BlockCreate');
 /** @suppress {extraRequire} */
@@ -671,3 +672,20 @@ exports.thrasos = thrasos;
 exports.uiPosition = uiPosition;
 exports.utils = utils;
 exports.zelos = zelos;
+
+// Temporary hack to copy accessor properties from exports to the
+// global Blockly object as the routine to copy exports in
+// goog.exportPath_ (see closure/goog/base.js) invoked by
+// declareLegacyNamespace only copies normal data properties, not
+// accessors.  This can be removed once all remaining calls to
+// declareLegacyNamspace have been removed.
+if (globalThis.Blockly && typeof globalThis.Blockly === 'object') {
+  const descriptors = Object.getOwnPropertyDescriptors(exports);
+  const accessors = {};
+  for (const key in descriptors) {
+    if (descriptors[key].get || descriptors[key].set) {
+      accessors[key] = descriptors[key];
+    }
+  }
+  Object.defineProperties(globalThis.Blockly, accessors);
+}


### PR DESCRIPTION
## The basics

- [x] I branched from `goog_module`
- [x] My pull request is against `goog_module`
- [x] My code follows the [style guide](
      https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I have run `npm test`.

## The details
### Resolves

Issue with accessor properties (e.g. `Blockly.selected`) not being copied from the `exports` object of the`Blockly` module to the `Blockly` namespace object in the global scope.

### Proposed Changes

Copy them explicitly.

### Additional Information

See implementation of `goog.exportPath_` in `closure/goog/base.js` for why this is necessary (and note that `globalThis.Blockly` will have been pre-created by any dependency of `blockly.js` with a `declareLegacyNamespace` call, or failing that, by the hack in `core/msg.js`.

Once the `declareLegacyNamespace call has been removed from `core/blockly.js`—which entails all users of the `Blockly` module require it via something equivalent to `const Blockly = goog.require('Blockly');`—then `goog.exportPath_` will never be invoked for the `Blockly` module and this hack can be removed.

In case that does not happen before this release, this hack will ensure that at least `Blockly.selected` and friends will continue to work, preserving backwards compatibility.