### PR TITLE
fix: blocks dragged from RTL flyout being incorrectly positioned

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -1117,7 +1117,7 @@ Flyout.prototype.positionNewBlock_ = function(oldBlock, block) {
   // The position of the old block in main workspace coordinates.
   finalOffset.scale(1 / targetWorkspace.scale);
 
-  block.moveBy(finalOffset.x, finalOffset.y);
+  block.moveTo(new Coordinate(finalOffset.x, finalOffset.y));
 };
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #5545 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Uses `moveTo` instead of `moveBy` when positioning blocks dragged from the flyout.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
In the XML system `domToBlock` positions blocks at (0, 0) regardless of whether the workspace is RTL or LTR, while `workspaceToDom` positions blocks correctly, by mirroring the X coordinate in RTL mode.

The JSON system always places blocks correctly (from `blocks.append` and `workspaces.load`), which causes an issue when flyouts assume that blocks will be initially positioned at (0, 0).

Changing the code to use `moveTo` instead of `moveBy` removes this assumption, making the flyout code work properly once again.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome

