### PR TITLE
fix: RTL copy-paste and duplicate

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1553,18 +1553,19 @@ WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock, jsonBlock) {
     if (xmlBlock) {
       block = Xml.domToBlock(xmlBlock, this);
       blockX = parseInt(xmlBlock.getAttribute('x'), 10);
+      if (this.RTL) {
+        blockX = -blockX;
+      }
       blockY = parseInt(xmlBlock.getAttribute('y'), 10);
     } else if (jsonBlock) {
       block = blocks.append(jsonBlock, this);
       blockX = jsonBlock['x'] || 10;
+      blockX = this.getWidth() - blockX;
       blockY = jsonBlock['y'] || 10;
     }
 
     // Move the duplicate to original position.
     if (!isNaN(blockX) && !isNaN(blockY)) {
-      if (this.RTL) {
-        blockX = -blockX;
-      }
       // Offset block until not clobbering another block and not in connection
       // distance with neighbouring blocks.
       let collide;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1548,8 +1548,8 @@ WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock, jsonBlock) {
   eventUtils.disable();
   let block;
   try {
-    let blockX;
-    let blockY;
+    let blockX = 0;
+    let blockY = 0;
     if (xmlBlock) {
       block = Xml.domToBlock(xmlBlock, this);
       blockX = parseInt(xmlBlock.getAttribute('x'), 10);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#5553 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes copy-paste and duplicate not positioning the block correctly in RTL mode.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The copy paste code is really wacky and needs to be cleaned. But since it's public changing the behavior would require breaking changes, so I've just put a fix in for now.

In the past the block would convert itself to XML inside [toCopyData](https://github.com/google/blockly/blob/0ac360f163ae4ea35af8f997edd92310b6c602cb/core/block_svg.js#L958), but instead of using domToBlockWithXY it would use domToBlock and add the XY itself. Confusingly, it would make it's [X coordinate negative in RTL](https://github.com/google/blockly/blob/0ac360f163ae4ea35af8f997edd92310b6c602cb/core/block_svg.js#L967) (even though that's not the proper way to handle RTL0 only for it to be [converted back to positive](https://github.com/google/blockly/blob/0ac360f163ae4ea35af8f997edd92310b6c602cb/core/workspace_svg.js#L1501) in the workspace paste function.

I've moved the logic for the positive conversion into the XML section of the workspace paste function, and added a new conversion for JSON to make the coordinates equivalent. This should be backwards compatible, and fix the issue.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome 

