### PR TITLE
JSDoc improvments for accessors, etc.

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -202,12 +202,9 @@ Object.defineProperties(exports, {
    * Wrapper to window.alert() that app developers may override to
    * provide alternatives to the modal browser window.
    * @name Blockly.alert
-   * @function
-   * @param {string} message The message to display to the user.
-   * @param {function()=} opt_callback The callback when the alert is
-   *     dismissed.
-   * @deprecated (September 2021): Use Blockly.dialog.alert /
-   *     .setAlert() instead.
+   * @type {!function(string, function()=)}
+   * @deprecated Use Blockly.dialog.alert / .setAlert() instead.
+   *     (September 2021)
    * @suppress {checkTypes}
    */
   alert: {
@@ -226,12 +223,9 @@ Object.defineProperties(exports, {
    * Wrapper to window.confirm() that app developers may override to
    * provide alternatives to the modal browser window.
    * @name Blockly.confirm
-   * @function
-   * @param {string} message The message to display to the user.
-   * @param {!function(boolean)} callback The callback for handling
-   *     user response.
-   * @deprecated (September 2021): Use Blockly.dialog.confirm /
-   *     .setConfirm() instead.
+   * @type {!function(string, function()=)}
+   * @deprecated Use Blockly.dialog.confirm / .setConfirm() instead.
+   *     (September 2021)
    * @suppress {checkTypes}
    */
   confirm: {
@@ -251,8 +245,8 @@ Object.defineProperties(exports, {
    * Set by Blockly.WorkspaceSvg.prototype.markFocused
    * @name Blockly.mainWorkspace
    * @type {Workspace}
-   * @deprecated (September 2021): Use Blockly.common.getMainWorkspace() /
-   *     .setMainWorkspace instead.
+   * @deprecated Use Blockly.common.getMainWorkspace() /
+   *     .setMainWorkspace instead.  (September 2021)
    * @suppress {checkTypes}
    */
   mainWorkspace: {
@@ -275,13 +269,9 @@ Object.defineProperties(exports, {
    * on mobile device. We strongly recommend testing mobile when
    * overriding this.
    * @name Blockly.prompt
-   * @function
-   * @param {string} message The message to display to the user.
-   * @param {string} defaultValue The value to initialize the prompt with.
-   * @param {!function(?string)} callback The callback for handling
-   *     user response.
-   * @deprecated (September 2021): Use Blockly.dialog.prompt /
-   *     .setPrompt() instead.
+   * @type {!function(string, string, function()=)}
+   * @deprecated Use Blockly.dialog.prompt / .setPrompt() instead.
+   *     (September 2021)
    * @suppress {checkTypes}
    */
   prompt: {
@@ -300,8 +290,8 @@ Object.defineProperties(exports, {
    * Currently selected block.
    * @name Blockly.selected
    * @type {?ICopyable}
-   * @deprecated (September 2021): Use Blockly.common.getSelected() /
-   *     .setSelected instead.
+   * @deprecated Use Blockly.common.getSelected() / .setSelected
+   *     instead.  (September 2021)
    * @suppress {checkTypes}
    */
   selected: {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -208,6 +208,7 @@ Object.defineProperties(exports, {
    *     dismissed.
    * @deprecated (September 2021): Use Blockly.dialog.alert /
    *     .setAlert() instead.
+   * @suppress {checkTypes}
    */
   alert: {
     set: function(newAlert) {
@@ -231,6 +232,7 @@ Object.defineProperties(exports, {
    *     user response.
    * @deprecated (September 2021): Use Blockly.dialog.confirm /
    *     .setConfirm() instead.
+   * @suppress {checkTypes}
    */
   confirm: {
     set: function(newConfirm) {
@@ -248,9 +250,10 @@ Object.defineProperties(exports, {
    * The main workspace most recently used.
    * Set by Blockly.WorkspaceSvg.prototype.markFocused
    * @name Blockly.mainWorkspace
-   * @type {Blockly.Workspace}
-   * @deprecated (September 2021): Use Blockly.common.getMainWorkspace() / 
+   * @type {Workspace}
+   * @deprecated (September 2021): Use Blockly.common.getMainWorkspace() /
    *     .setMainWorkspace instead.
+   * @suppress {checkTypes}
    */
   mainWorkspace: {
     set: function(x) {
@@ -279,6 +282,7 @@ Object.defineProperties(exports, {
    *     user response.
    * @deprecated (September 2021): Use Blockly.dialog.prompt /
    *     .setPrompt() instead.
+   * @suppress {checkTypes}
    */
   prompt: {
     set: function(newPrompt) {
@@ -295,9 +299,10 @@ Object.defineProperties(exports, {
   /**
    * Currently selected block.
    * @name Blockly.selected
-   * @type {?Blockly.ICopyable}
+   * @type {?ICopyable}
    * @deprecated (September 2021): Use Blockly.common.getSelected() /
    *     .setSelected instead.
+   * @suppress {checkTypes}
    */
   selected: {
     get: function() {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -198,6 +198,17 @@ exports.VERSION = 'uncompiled';
 // Blockly.mainWorkspace, Blockly.prompt and Blockly.selected for backwards
 // compatibility.
 Object.defineProperties(exports, {
+  /**
+   * Wrapper to window.alert() that app developers may override to
+   * provide alternatives to the modal browser window.
+   * @name Blockly.alert
+   * @function
+   * @param {string} message The message to display to the user.
+   * @param {function()=} opt_callback The callback when the alert is
+   *     dismissed.
+   * @deprecated (September 2021): Use Blockly.dialog.alert /
+   *     .setAlert() instead.
+   */
   alert: {
     set: function(newAlert) {
       deprecation.warn('Blockly.alert', 'September 2021', 'September 2022');
@@ -210,6 +221,17 @@ Object.defineProperties(exports, {
       return dialog.alert;
     }
   },
+  /**
+   * Wrapper to window.confirm() that app developers may override to
+   * provide alternatives to the modal browser window.
+   * @name Blockly.confirm
+   * @function
+   * @param {string} message The message to display to the user.
+   * @param {!function(boolean)} callback The callback for handling
+   *     user response.
+   * @deprecated (September 2021): Use Blockly.dialog.confirm /
+   *     .setConfirm() instead.
+   */
   confirm: {
     set: function(newConfirm) {
       deprecation.warn('Blockly.confirm', 'September 2021', 'September 2022');
@@ -222,6 +244,14 @@ Object.defineProperties(exports, {
       return dialog.confirm;
     }
   },
+  /**
+   * The main workspace most recently used.
+   * Set by Blockly.WorkspaceSvg.prototype.markFocused
+   * @name Blockly.mainWorkspace
+   * @type {Blockly.Workspace}
+   * @deprecated (September 2021): Use Blockly.common.getMainWorkspace() / 
+   *     .setMainWorkspace instead.
+   */
   mainWorkspace: {
     set: function(x) {
       deprecation.warn(
@@ -235,6 +265,21 @@ Object.defineProperties(exports, {
       return common.getMainWorkspace();
     }
   },
+  /**
+   * Wrapper to window.prompt() that app developers may override to
+   * provide alternatives to the modal browser window. Built-in
+   * browser prompts are often used for better text input experience
+   * on mobile device. We strongly recommend testing mobile when
+   * overriding this.
+   * @name Blockly.prompt
+   * @function
+   * @param {string} message The message to display to the user.
+   * @param {string} defaultValue The value to initialize the prompt with.
+   * @param {!function(?string)} callback The callback for handling
+   *     user response.
+   * @deprecated (September 2021): Use Blockly.dialog.prompt /
+   *     .setPrompt() instead.
+   */
   prompt: {
     set: function(newPrompt) {
       deprecation.warn('Blockly.prompt', 'September 2021', 'September 2022');
@@ -247,6 +292,13 @@ Object.defineProperties(exports, {
       return dialog.prompt;
     }
   },
+  /**
+   * Currently selected block.
+   * @name Blockly.selected
+   * @type {?Blockly.ICopyable}
+   * @deprecated (September 2021): Use Blockly.common.getSelected() /
+   *     .setSelected instead.
+   */
   selected: {
     get: function() {
       deprecation.warn(

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -68,7 +68,14 @@ const setCurrentBlock = function(block) {
 };
 exports.setCurrentBlock = setCurrentBlock;
 
-// Ad JS accessors for backwards compatibility.
+// Add JS accessors for backwards compatibility.
+/**
+ * Which block is the context menu attached to?
+ * @name Blockly.ContextMenu.currentBlock
+ * @type {Blockly.Block}
+ * @deprecated (September 2021): Use Blockly.Tooltip.getCurrentBlock() /
+ *     .setCurrentBlock() instead.
+ */
 Object.defineProperties(exports, {
   currentBlock: {
     get: function() {

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -69,14 +69,16 @@ const setCurrentBlock = function(block) {
 exports.setCurrentBlock = setCurrentBlock;
 
 // Add JS accessors for backwards compatibility.
-/**
- * Which block is the context menu attached to?
- * @name Blockly.ContextMenu.currentBlock
- * @type {Blockly.Block}
- * @deprecated (September 2021): Use Blockly.Tooltip.getCurrentBlock() /
- *     .setCurrentBlock() instead.
- */
 Object.defineProperties(exports, {
+  /**
+   * Which block is the context menu attached to?
+   * @name Blockly.ContextMenu.currentBlock
+   * @type {Block}
+   * @deprecated (September 2021): Use
+   *     Blockly.Tooltip.getCurrentBlock() / .setCurrentBlock()
+   *     instead.
+   * @suppress {checkTypes}
+   */
   currentBlock: {
     get: function() {
       deprecation.warn(

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -337,7 +337,6 @@ exports.commentDuplicateOption = commentDuplicateOption;
  * @suppress {strictModuleDepCheck,checkTypes} Suppress checks while workspace
  *     comments are not bundled in.
  * @alias Blockly.ContextMenu.workspaceCommentOption
- * @package
  */
 const workspaceCommentOption = function(ws, e) {
   const WorkspaceCommentSvg = goog.module.get('Blockly.WorkspaceCommentSvg');

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -74,9 +74,8 @@ Object.defineProperties(exports, {
    * Which block is the context menu attached to?
    * @name Blockly.ContextMenu.currentBlock
    * @type {Block}
-   * @deprecated (September 2021): Use
-   *     Blockly.Tooltip.getCurrentBlock() / .setCurrentBlock()
-   *     instead.
+   * @deprecated Use Blockly.Tooltip.getCurrentBlock() /
+   *     .setCurrentBlock() instead.  (September 2021)
    * @suppress {checkTypes}
    */
   currentBlock: {

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -124,11 +124,11 @@ exports.disableOrphans = eventUtils.disableOrphans;
 
 /**
  * Sets whether the next event should be added to the undo stack.
+ * @name Blockly.Evenents.recordUndo
  * @type {boolean}
  * @deprecated (September 2021): Use Blockly.Events.getRecordUndo()
  *     and .setRecordUndo().
  */
-exports.recordUndo;
 Object.defineProperties(exports, {
   recordUndo: {
     get: function() {

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -122,14 +122,15 @@ exports.setGroup = eventUtils.setGroup;
 exports.setRecordUndo = eventUtils.setRecordUndo;
 exports.disableOrphans = eventUtils.disableOrphans;
 
-/**
- * Sets whether the next event should be added to the undo stack.
- * @name Blockly.Evenents.recordUndo
- * @type {boolean}
- * @deprecated (September 2021): Use Blockly.Events.getRecordUndo()
- *     and .setRecordUndo().
- */
 Object.defineProperties(exports, {
+  /**
+   * Sets whether the next event should be added to the undo stack.
+   * @name Blockly.Evenents.recordUndo
+   * @type {boolean}
+   * @deprecated (September 2021): Use Blockly.Events.getRecordUndo()
+   *     and .setRecordUndo().
+   * @suppress {checkTypes}
+   */
   recordUndo: {
     get: function() {
       deprecation.warn(

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -122,6 +122,13 @@ exports.setGroup = eventUtils.setGroup;
 exports.setRecordUndo = eventUtils.setRecordUndo;
 exports.disableOrphans = eventUtils.disableOrphans;
 
+/**
+ * Sets whether the next event should be added to the undo stack.
+ * @type {boolean}
+ * @deprecated (September 2021): Use Blockly.Events.getRecordUndo()
+ *     and .setRecordUndo().
+ */
+exports.recordUndo;
 Object.defineProperties(exports, {
   recordUndo: {
     get: function() {

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -127,8 +127,8 @@ Object.defineProperties(exports, {
    * Sets whether the next event should be added to the undo stack.
    * @name Blockly.Evenents.recordUndo
    * @type {boolean}
-   * @deprecated (September 2021): Use Blockly.Events.getRecordUndo()
-   *     and .setRecordUndo().
+   * @deprecated Use Blockly.Events.getRecordUndo() and
+   *     .setRecordUndo().  (September 2021)
    * @suppress {checkTypes}
    */
   recordUndo: {

--- a/core/events/utils.js
+++ b/core/events/utils.js
@@ -31,6 +31,7 @@ const CommentMove = goog.requireType('Blockly.Events.CommentMove');
 const Workspace = goog.requireType('Blockly.Workspace');
 const idGenerator = goog.require('Blockly.utils.idGenerator');
 const registry = goog.require('Blockly.registry');
+/* eslint-disable-next-line no-unused-vars */
 const {Block} = goog.requireType('Blockly.Block');
 
 

--- a/core/generator.js
+++ b/core/generator.js
@@ -416,24 +416,19 @@ Generator.prototype.functionNames_;
  */
 Generator.prototype.nameDB_;
 
+/**
+ * A database of variable names.
+ * @name Blockly.Generator.prototype.variableDB_
+ * @type {!Names|undefined}
+ * @protected
+ * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
+ */
 Object.defineProperties(Generator.prototype, {
   variableDB_: {
-    /**
-     * Getter.
-     * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
-     * @this {Generator}
-     * @return {!Names|undefined} Name database.
-     */
     get: function() {
       deprecation.warn('variableDB_', 'May 2021', 'May 2026', 'nameDB_');
       return this.nameDB_;
     },
-    /**
-     * Setter.
-     * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
-     * @this {Generator}
-     * @param {!Names|undefined} nameDb New name database.
-     */
     set: function(nameDb) {
       deprecation.warn('variableDB_', 'May 2021', 'May 2026', 'nameDB_');
       this.nameDB_ = nameDb;

--- a/core/generator.js
+++ b/core/generator.js
@@ -416,19 +416,28 @@ Generator.prototype.functionNames_;
  */
 Generator.prototype.nameDB_;
 
-/**
- * A database of variable names.
- * @name Blockly.Generator.prototype.variableDB_
- * @type {!Names|undefined}
- * @protected
- * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
- */
 Object.defineProperties(Generator.prototype, {
+  /**
+   * A database of variable names.
+   * @name Blockly.Generator.prototype.variableDB_
+   * @type {!Names|undefined}
+   * @protected
+   * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
+   * @suppress {checkTypes}
+   */
   variableDB_: {
+    /**
+     * @this {Generator}
+     * @return {!Names|undefined} Name database.
+     */
     get: function() {
       deprecation.warn('variableDB_', 'May 2021', 'May 2026', 'nameDB_');
       return this.nameDB_;
     },
+    /**
+     * @this {Generator}
+     * @param {!Names|undefined} nameDb New name database.
+     */
     set: function(nameDb) {
       deprecation.warn('variableDB_', 'May 2021', 'May 2026', 'nameDB_');
       this.nameDB_ = nameDb;

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -92,7 +92,6 @@ exports.unregister = unregister;
  * Turn on the blocks debugger.
  * @package
  * @alias Blockly.blockRendering.startDebugger
- * @package
  */
 const startDebugger = function() {
   deprecation.warn(
@@ -106,7 +105,6 @@ exports.startDebugger = startDebugger;
  * Turn off the blocks debugger.
  * @package
  * @alias Blockly.blockRendering.stopDebugger
- * @package
  */
 const stopDebugger = function() {
   deprecation.warn(
@@ -125,7 +123,6 @@ exports.stopDebugger = stopDebugger;
  *     Already initialized.
  * @package
  * @alias Blockly.blockRendering.init
- * @package
  */
 const init = function(name, theme, opt_rendererOverrides) {
   const rendererClass = registry.getClass(registry.Type.RENDERER, name);

--- a/core/renderers/common/debug.js
+++ b/core/renderers/common/debug.js
@@ -36,7 +36,6 @@ exports.isDebuggerEnabled = isDebuggerEnabled;
  * Turn on the blocks debugger.
  * @package
  * @alias Blockly.blockRendering.debug.startDebugger
- * @package
  */
 const startDebugger = function() {
   useDebugger = true;
@@ -47,7 +46,6 @@ exports.startDebugger = startDebugger;
  * Turn off the blocks debugger.
  * @package
  * @alias Blockly.blockRendering.debug.stopDebugger
- * @package
  */
 const stopDebugger = function() {
   useDebugger = false;

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -64,8 +64,8 @@ Object.defineProperties(exports, {
    * Is a tooltip currently showing?
    * @name Blockly.Tooltip.visible
    * @type {boolean}
-   * @deprecated (September 2021): use Blockly.Tooltip.isVisible()
-   *     instead.
+   * @deprecated Use Blockly.Tooltip.isVisible() instead.  (September
+   *     2021)
    * @suppress {checkTypes}
    */
   visible: {
@@ -180,8 +180,8 @@ Object.defineProperties(exports, {
    * The HTML container.  Set once by createDom.
    * @name Blockly.Tooltip.DIV
    * @type {Element}
-   * @deprecated (September 2021): use Blockly.Tooltip.getDiv() and
-   *     .setDiv().
+   * @deprecated Use Blockly.Tooltip.getDiv() and .setDiv().
+   *     (September 2021)
    * @suppress {checkTypes}
    */
   DIV: {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -59,13 +59,15 @@ const isVisible = function() {
 };
 exports.isVisible = isVisible;
 
-/**
- * Is a tooltip currently showing?
- * @name Blockly.Tooltip.visible
- * @type {boolean}
- * @deprecated (September 2021): use Blockly.Tooltip.isVisible() instead.
- */
 Object.defineProperties(exports, {
+  /**
+   * Is a tooltip currently showing?
+   * @name Blockly.Tooltip.visible
+   * @type {boolean}
+   * @deprecated (September 2021): use Blockly.Tooltip.isVisible()
+   *     instead.
+   * @suppress {checkTypes}
+   */
   visible: {
     get: function() {
       deprecation.warn(
@@ -173,13 +175,15 @@ const getDiv = function() {
 };
 exports.getDiv = getDiv;
 
-/**
- * The HTML container.  Set once by createDom.
- * @name Blockly.Tooltip.DIV
- * @type {Element}
- * @deprecated (September 2021): use Blockly.Tooltip.getDiv() and .setDiv().
- */
 Object.defineProperties(exports, {
+  /**
+   * The HTML container.  Set once by createDom.
+   * @name Blockly.Tooltip.DIV
+   * @type {Element}
+   * @deprecated (September 2021): use Blockly.Tooltip.getDiv() and
+   *     .setDiv().
+   * @suppress {checkTypes}
+   */
   DIV: {
     get: function() {
       deprecation.warn(

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -46,7 +46,6 @@ exports.TipInfo = TipInfo;
 /**
  * Is a tooltip currently showing?
  * @type {boolean}
- * @alias Blockly.Tooltip.visible
  */
 let visible = false;
 
@@ -60,6 +59,13 @@ const isVisible = function() {
 };
 exports.isVisible = isVisible;
 
+/**
+ * Is a tooltip currently showing?
+ * @type {boolean}
+ * @alias Blockly.Tooltip.visible
+ * @deprecated (September 2021): use Blockly.Tooltip.isVisible() instead.
+ */
+exports.visible;
 Object.defineProperties(exports, {
   visible: {
     get: function() {
@@ -155,7 +161,6 @@ exports.MARGINS = MARGINS;
 /**
  * The HTML container.  Set once by createDom.
  * @type {Element}
- * @alias Blockly.Tooltip.DIV
  */
 let DIV = null;
 
@@ -169,6 +174,13 @@ const getDiv = function() {
 };
 exports.getDiv = getDiv;
 
+/**
+ * The HTML container.  Set once by createDom.
+ * @type {Element}
+ * @alias Blockly.Tooltip.DIV
+ * @deprecated (September 2021): use Blockly.Tooltip.getDiv() and .setDiv().
+ */
+exports.DIV;
 Object.defineProperties(exports, {
   DIV: {
     get: function() {

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -61,11 +61,10 @@ exports.isVisible = isVisible;
 
 /**
  * Is a tooltip currently showing?
+ * @name Blockly.Tooltip.visible
  * @type {boolean}
- * @alias Blockly.Tooltip.visible
  * @deprecated (September 2021): use Blockly.Tooltip.isVisible() instead.
  */
-exports.visible;
 Object.defineProperties(exports, {
   visible: {
     get: function() {
@@ -176,11 +175,10 @@ exports.getDiv = getDiv;
 
 /**
  * The HTML container.  Set once by createDom.
+ * @name Blockly.Tooltip.DIV
  * @type {Element}
- * @alias Blockly.Tooltip.DIV
  * @deprecated (September 2021): use Blockly.Tooltip.getDiv() and .setDiv().
  */
-exports.DIV;
 Object.defineProperties(exports, {
   DIV: {
     get: function() {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -87,8 +87,8 @@ Object.defineProperties(exports, {
    * The HTML container for popup overlays (e.g. editor widgets).
    * @name Blockly.WidgetDiv.DIV
    * @type {?Element}
-   * @deprecated (September 2021): use Blockly.WidgetDiv.getDiv() and
-   *     .setDiv().
+   * @deprecated Use Blockly.WidgetDiv.getDiv() and .setDiv().
+   *     (September 2021)
    * @suppress {checkTypes}
    */
   DIV: {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -58,7 +58,6 @@ let themeClassName = '';
 /**
  * The HTML container for popup overlays (e.g. editor widgets).
  * @type {?Element}
- * @alias Blockly.WidgetDiv.DIV
  */
 let DIV;
 
@@ -83,6 +82,13 @@ const testOnly_setDiv = function(newDiv) {
 };
 exports.testOnly_setDiv = testOnly_setDiv;
 
+/**
+ * The HTML container for popup overlays (e.g. editor widgets).
+ * @type {?Element}
+ * @alias Blockly.WidgetDiv.DIV
+ * @deprecated (September 2021): use Blockly.WidgetDiv.getDiv() and .setDiv().
+ */
+exports.DIV;
 Object.defineProperties(exports, {
   DIV: {
     get: function() {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -84,11 +84,10 @@ exports.testOnly_setDiv = testOnly_setDiv;
 
 /**
  * The HTML container for popup overlays (e.g. editor widgets).
+ * @name Blockly.WidgetDiv.DIV
  * @type {?Element}
- * @alias Blockly.WidgetDiv.DIV
  * @deprecated (September 2021): use Blockly.WidgetDiv.getDiv() and .setDiv().
  */
-exports.DIV;
 Object.defineProperties(exports, {
   DIV: {
     get: function() {

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -82,13 +82,15 @@ const testOnly_setDiv = function(newDiv) {
 };
 exports.testOnly_setDiv = testOnly_setDiv;
 
-/**
- * The HTML container for popup overlays (e.g. editor widgets).
- * @name Blockly.WidgetDiv.DIV
- * @type {?Element}
- * @deprecated (September 2021): use Blockly.WidgetDiv.getDiv() and .setDiv().
- */
 Object.defineProperties(exports, {
+  /**
+   * The HTML container for popup overlays (e.g. editor widgets).
+   * @name Blockly.WidgetDiv.DIV
+   * @type {?Element}
+   * @deprecated (September 2021): use Blockly.WidgetDiv.getDiv() and
+   *     .setDiv().
+   * @suppress {checkTypes}
+   */
   DIV: {
     get: function() {
       deprecation.warn(


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

* Revert removal of documentation for get/set accessors in #5549 (but still work around the compiler bug that caused #5538!)
* Use @name to attach JSDocs to get/set accessors.
* Restore documentation for deprecated properties that was lost when they were converted to accessors.
* Remove duplicate @Package declarations

### Reason for Changes

* Improve generated JSDocs.
* Provide model for how to document accessor properties in future.

### Test Coverage

* Passes `npm test`.
* Cursory manual checking of locally-generated `jsdoc` output.
