### PR TITLE
fix: Fix Block Factory preview workspace

### DIFF
--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -179,14 +179,15 @@ BlockFactory.updatePreview = function() {
     return;
   }
 
-  // Backup Blockly.Blocks object so that main workspace and preview don't
-  // collide if user creates a 'factory_base' block, for instance.
-  var backupBlocks = Blockly.Blocks;
+  // Backup Blockly.Blocks definitions so we can delete them all
+  // before instantiating user-defined block.  This avoids a collision
+  // between the main workspace and preview if the user creates a
+  // 'factory_base' block, for instance.
+  var originalBlocks = Object.assign(Object.create(null), Blockly.Blocks);
   try {
-    // Make a shallow copy.
-    Blockly.Blocks = Object.create(null);
-    for (var prop in backupBlocks) {
-      Blockly.Blocks[prop] = backupBlocks[prop];
+    // Delete existing blocks.
+    for (var key in Blockly.Blocks) {
+      delete Blockly.Blocks[key];
     }
 
     if (format == 'JSON') {
@@ -206,18 +207,14 @@ BlockFactory.updatePreview = function() {
       }
     }
 
-    // Look for a block on Blockly.Blocks that does not match the backup.
-    var blockType = null;
-    for (var type in Blockly.Blocks) {
-      if (typeof Blockly.Blocks[type].init == 'function' &&
-          Blockly.Blocks[type] != backupBlocks[type]) {
-        blockType = type;
-        break;
-      }
-    }
-    if (!blockType) {
+    // Look for newly-created block(s) (ideally just one).
+    var createdTypes = Object.getOwnPropertyNames(Blockly.Blocks);
+    if (createdTypes.length < 1) {
       return;
+    } else if (createdTypes.length > 1) {
+      console.log('Unexpectedly found more than one block definition');
     }
+    var blockType = createdTypes[0];
 
     // Create the preview block.
     var previewBlock = BlockFactory.previewWorkspace.newBlock(blockType);
@@ -251,7 +248,12 @@ BlockFactory.updatePreview = function() {
     BlockFactory.updateBlocksFlag = false
     BlockFactory.updateBlocksFlagDelayed = false
   } finally {
-    Blockly.Blocks = backupBlocks;
+    // Remove all newly-created block(s).
+    for (var key in Blockly.Blocks) {
+      delete Blockly.Blocks[key];
+    }
+    // Restore original blocks.
+    Object.assign(Blockly.Blocks, originalBlocks);
   }
 };
 


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #5556

### Proposed Changes

Rewrite code that previews user-created blocks to modify the contents of, rather than entirely replace the `Blockly.Blocks` object—which no longer works.

#### Behavior Before Change

The following error appeared in the console:
```
TypeError: Unknown block type: block_type
    at BlockSvg.Block (block.js:213)
    at new BlockSvg (block_svg.js:149)
    at module$exports$Blockly$WorkspaceSvg.newBlock (workspace_svg.js:1045)
    at Object.BlockFactory.updatePreview (factory.js:223)
    at BlockFactory.updateLanguage (factory.js:143)
    at module$exports$Blockly$WorkspaceSvg.module$exports$Blockly$Workspace.fireChangeListener (workspace.js:694)
    at module$contents$Blockly$Events$utils_fireNow (utils.js:337)
```
and the preview workspace remained blank.

#### Behavior After Change

Error shown above does not appear; block preview does.

### Reason for Changes

Fix bug caused by #5026

### Test Coverage

Tested on:
* Desktop Chrome

### Additional Information

It's OK to modify the contents of Blockly.Blocks, but it's not OK to try to replace this export with a completely different object: aside from violating the style guide by modifying an export, it simply doesn't work because the Blockly library continues internally to use the original object.
