### PR TITLE
chore: create release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,10 +9,18 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - api_change
+        - breaking change
+    - title: New Features
+      labels:
+        - "PR: feature"
+    - title: Bug fixes
+      labels:
+        - "PR: fix"
     - title: Cleanup ♻️
       labels:
-        - type: cleanup
+        - "PR: chore"
+        - "PR: docs"
+        - "PR: refactor"
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## The basics

Branched from **master** for immediate effect.

## The details
### Resolves

Possibly part of #4973, since the github [blog post](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/) says that this includes ways to recognize first-time contributors.

Also progress toward larger q4 goal of improving release workflows.

### Proposed Changes

Adds a `release.yml` file to take advantage of github's new automated release note generator.  See [documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration).

#### Behavior Before Change

No template for use in automated release note generation.

#### Behavior After Change

Basic remplate for use in automated release note generation.

### Reason for Changes

Improve release process!

### Documentation

Internal documentation on how to generate release notes needs to be updated.
