### PR TITLE
fix: Make update_metadata.sh work on macOS

### DIFF
--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -10,25 +10,29 @@ blockly_size=$(wc -c < "build/blockly_compressed.js")
 blocks_size=$(wc -c < "build/blocks_compressed.js")
 blockly_gz_size=$(wc -c < "build/blockly_compressed.js.gz")
 blocks_gz_size=$(wc -c < "build/blocks_compressed.js.gz")
-quarter=$(date "+Q%q %Y")
+quarters=(1 1 1 2 2 2 3 3 3 4 4 4)
+month=$(date +%-m)
+quarter=$(echo Q${quarters[$month - 1]} $(date +%Y))
 version=$(npx -c 'echo "$npm_package_version"')
 
 replacement="# ${quarter}\t${version}\t${blockly_size}\n"
 replacement+="readonly BLOCKLY_SIZE_EXPECTED=${blockly_size}"
-sed -ri "s/readonly BLOCKLY_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+sed -ri.bak "s/readonly BLOCKLY_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
   tests/scripts/check_metadata.sh
 
 replacement="# ${quarter}\t${version}\t${blocks_size}\n"
 replacement+="readonly BLOCKS_SIZE_EXPECTED=${blocks_size}"
-sed -ri "s/readonly BLOCKS_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+sed -ri.bak "s/readonly BLOCKS_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
   tests/scripts/check_metadata.sh
 
 replacement="# ${quarter}\t${version}\t${blockly_gz_size}\n"
 replacement+="readonly BLOCKLY_GZ_SIZE_EXPECTED=${blockly_gz_size}"
-sed -ri "s/readonly BLOCKLY_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+sed -ri.bak "s/readonly BLOCKLY_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
   tests/scripts/check_metadata.sh
 
 replacement="# ${quarter}\t${version}\t${blocks_gz_size}\n"
 replacement+="readonly BLOCKS_GZ_SIZE_EXPECTED=${blocks_gz_size}"
-sed -ri "s/readonly BLOCKS_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
+sed -ri.bak "s/readonly BLOCKS_GZ_SIZE_EXPECTED=[0-9]+/${replacement}/g" \
   tests/scripts/check_metadata.sh
+
+rm tests/scripts/check_metadata.sh.bak


### PR DESCRIPTION
## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
#5463

### Proposed Changes
Works around incompatibility between macOS and Linux `sed` (https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940) and macOS's `date` command's lack of support for the %Q year-quarter date format specifier.

#### Behavior Before Change
`update_metadata.sh` fails on macOS

#### Behavior After Change
`update_metadata.sh` works on macOS
