### PR TITLE
fix: Don't kludge accessors in compiled mode

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -743,7 +743,24 @@ exports.zelos = zelos;
 // declareLegacyNamespace only copies normal data properties, not
 // accessors.  This can be removed once all remaining calls to
 // declareLegacyNamspace have been removed.
-if (globalThis.Blockly && typeof globalThis.Blockly === 'object') {
+//
+// This is only needed in uncompiled mode (see
+// google/blockly-samples#902); in compiled mode the exports object is
+// already the value of globalThis.Blockly.  Because
+// closure/goog/base.js is not included in the compiler input, we
+// can't use goog.global['COMPILED'] to check if we are running in
+// compiled mode.  Instead, use existence of globalThis.goog itself
+// for this purpose.
+//
+// Note that this code will still attempt to redefine accessors on a
+// previously-imported copy of the Blockly library if both are
+// imported in uncompiled mode.  This will fail with TypeError as the
+// accessors are nonconfigurable (which is good, as otherwise one
+// accessors on one copy would call get/set functions on the other
+// copy!)
+if (globalThis.goog && globalThis.Blockly &&
+    typeof globalThis.Blockly === 'object' &&
+    globalThis.Blockly !== exports) {
   const descriptors = Object.getOwnPropertyDescriptors(exports);
   const accessors = {};
   for (const key in descriptors) {


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

This is part of the fix for google/blockly-samples#902 —it would prevent the error message from occurring, but it does not resolve the issue that more than one copy of the the blockly library is being required.

### Proposed Changes

Add check for compiled mode to kludge that exports accessor properties in `blockly.js`.

### Reason for Changes

In compiled mode we don't need to manually add accessor properties to the global `Blockly` object because they'll already be there—and attempting to do so causes problems when a project imports multiple separate copies of blockly (which it shouldn't, but many plugins seem to).

### Test Coverage

* Playground loads without any (new) errors (on desktop Chrome).
* `npm test` runs to completion without errors.
