### PR TITLE
docs: Remove @author tags

### DIFF
--- a/appengine/storage.js
+++ b/appengine/storage.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Loading and saving blocks with localStorage and cloud storage.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Bootstrap code to load Blockly in uncompiled mode.
- * @author cpcallen@google.com (Christopher Allen)
  */
 'use strict';
 

--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Procedure blocks for Blockly.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Text blocks for Blockly.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -11,7 +11,6 @@
  * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
  * only, no outside references, no functions, no trailing commas, etc. The one
  * exception is end-of-line comments, which the scraper will remove.
- * @author duzc2dtw@gmail.com (Du Tian Wei)
  */
 'use strict';
 

--- a/core/block.js
+++ b/core/block.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The class representing one block.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods animating a block on connection and disconnection.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -11,7 +11,6 @@
  * blocks are put back in into the SVG they came from. This helps
  * performance by avoiding repainting the entire SVG on every mouse move
  * while dragging blocks.
- * @author picklesrus
  */
 
 'use strict';

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for dragging a block visually.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a block as SVG.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The top level namespace used to access the Blockly library.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/blockly_options.js
+++ b/core/blockly_options.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object that defines user-specified options for the workspace.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/blocks.js
+++ b/core/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview A mapping of block type names to block prototype objects.
- * @author spertus@google.com (Ellen Spertus)
  */
 'use strict';
 

--- a/core/browser_events.js
+++ b/core/browser_events.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Browser event handling.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a UI bubble.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for dragging a bubble visually.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/bump_objects.js
+++ b/core/bump_objects.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utilities for bumping objects back into worksapce bounds.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/clipboard.js
+++ b/core/clipboard.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blockly's internal clipboard for managing copy-paste.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/comment.js
+++ b/core/comment.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a code comment.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/common.js
+++ b/core/common.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Common functions used both internally and externally, but which
  * must not be at the top level to avoid circular dependencies.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/component_manager.js
+++ b/core/component_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Manager for all items registered with the workspace.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/connection.js
+++ b/core/connection.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Components for creating connections between blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview An object that encapsulates logic for checking whether a
  * potential connection is safe and valid.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -8,7 +8,6 @@
  * @fileoverview A database of all the rendered connections that could
  *    possibly be connected to (i.e. not collapsed, etc).
  *    Sorted by y coordinate.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/connection_type.js
+++ b/core/connection_type.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An enum for the possible types of connections.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/constants.js
+++ b/core/constants.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blockly constants.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Functionality for the right-click context menus.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/contextmenu_items.js
+++ b/core/contextmenu_items.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Registers default context menu items.
- * @author maribethb@google.com (Maribeth Bottorff)
  */
 'use strict';
 

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Registry for context menu option items.
- * @author maribethb@google.com (Maribeth Bottorff)
  */
 'use strict';
 

--- a/core/css.js
+++ b/core/css.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Inject Blockly's CSS synchronously.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/delete_area.js
+++ b/core/delete_area.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The abstract class for a component that can delete a block or
  * bubble that is dropped on top of it.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The abstract class for a component with custom behaviour when a
  * block or bubble is dragged over or dropped on top of it.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -8,7 +8,6 @@
 /**
  * @fileoverview A div that floats on top of the workspace, for drop-down menus.
  * The drop-down can be kept inside the workspace, animate in/out, etc.
- * @author tmickel@mit.edu (Tim Mickel)
  */
 
 'use strict';

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of actions in Blockly's editor.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Abstract class for events fired as a result of actions in
  * Blockly's editor.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/events/events_block_base.js
+++ b/core/events/events_block_base.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Base class for all types of block events.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_block_change.js
+++ b/core/events/events_block_change.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a block change event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_block_create.js
+++ b/core/events/events_block_create.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a block creation event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_block_delete.js
+++ b/core/events/events_block_delete.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a block delete event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_block_drag.js
+++ b/core/events/events_block_drag.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a block drag.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_block_move.js
+++ b/core/events/events_block_move.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a block move event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_bubble_open.js
+++ b/core/events/events_bubble_open.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of bubble open.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_click.js
+++ b/core/events/events_click.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of UI click in Blockly's editor.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_comment_base.js
+++ b/core/events/events_comment_base.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Base class for comment events.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_comment_change.js
+++ b/core/events/events_comment_change.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for comment change event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_comment_create.js
+++ b/core/events/events_comment_create.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for comment creation event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_comment_delete.js
+++ b/core/events/events_comment_delete.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for comment deletion event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_comment_move.js
+++ b/core/events/events_comment_move.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for comment move event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of a marker move.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_selected.js
+++ b/core/events/events_selected.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of element select action.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_theme_change.js
+++ b/core/events/events_theme_change.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of a theme update.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_toolbox_item_select.js
+++ b/core/events/events_toolbox_item_select.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of selecting an item on the toolbox.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_trashcan_open.js
+++ b/core/events/events_trashcan_open.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of trashcan flyout open and close.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/events_ui.js
+++ b/core/events/events_ui.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview (Deprecated) Events fired as a result of UI actions in
  * Blockly's editor.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/events/events_ui_base.js
+++ b/core/events/events_ui_base.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Base class for events fired as a result of UI actions in
  * Blockly's editor.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/events/events_var_base.js
+++ b/core/events/events_var_base.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Abstract class for a variable event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_var_create.js
+++ b/core/events/events_var_create.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a variable creation event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_var_delete.js
+++ b/core/events/events_var_delete.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Classes for all types of variable events.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_var_rename.js
+++ b/core/events/events_var_rename.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a variable rename event.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/events/events_viewport.js
+++ b/core/events/events_viewport.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Events fired as a result of a viewport change.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/events/workspace_events.js
+++ b/core/events/workspace_events.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a finished loading workspace event.
- * @author BeksOmega
  */
 'use strict';
 

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -9,7 +9,6 @@
  *      adding dynamic behavior such as onchange handlers and mutators. These
  *      are applied using Block.applyExtension(), or the JSON "extensions"
  *      array attribute.
- * @author Anm@anm.me (Andrew n marshall)
  */
 'use strict';
 

--- a/core/field.js
+++ b/core/field.js
@@ -8,7 +8,6 @@
  * @fileoverview Field.  Used for editable titles, variables, etc.
  * This is an abstract class that defines the UI on the block.  Actual
  * instances would be FieldTextInput, FieldDropdown, etc.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Angle input field.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Checkbox field.  Checked or not checked.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Colour input field.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -8,7 +8,6 @@
  * @fileoverview Dropdown input field.  Used for editable titles and variables.
  * In the interests of a consistent UI, the toolbox shares some functions and
  * properties with the context menu.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Image field.  Used for pictures, icons, etc.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Non-editable, non-serializable text field.  Used for titles,
  *    labels, etc.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -6,9 +6,6 @@
 
 /**
  * @fileoverview Text Area field.
- * @author fraser@google.com (Neil Fraser)
- * @author Andrew Mee
- * @author acbart@udel.edu (Austin Cory Bart)
  */
 'use strict';
 

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Number input field
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -8,7 +8,6 @@
  * @fileoverview Fields can be created based on a JSON definition. This file
  *    contains methods for registering those JSON definitions, and building the
  *    fields based on JSON.
- * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';
 

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Text input field.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Variable input field.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Flyout tray containing blocks which may be created.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class for a button in the flyout.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Horizontal flyout tray containing blocks which may be created.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/flyout_metrics_manager.js
+++ b/core/flyout_metrics_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Calculates and reports flyout workspace metrics.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Layout code for a vertical variant of the flyout.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/generator.js
+++ b/core/generator.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Utility functions for generating executable code from
  * Blockly code.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class representing an in-progress gesture, usually a drag
  * or a tap.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/grid.js
+++ b/core/grid.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Object for configuring and updating a workspace grid in
  * Blockly.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/icon.js
+++ b/core/icon.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing an icon on a block.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/inject.js
+++ b/core/inject.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Functions for injecting Blockly into a web page.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/input.js
+++ b/core/input.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing an input (value, statement, or dummy).
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/input_types.js
+++ b/core/input_types.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An enum for the possible types of inputs.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class that controls updates to connections during drags.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/interfaces/i_ast_node_location.js
+++ b/core/interfaces/i_ast_node_location.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an AST node location.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_ast_node_location_svg.js
+++ b/core/interfaces/i_ast_node_location_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an AST node location SVG.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_ast_node_location_with_block.js
+++ b/core/interfaces/i_ast_node_location_with_block.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for an AST node location that has an associated
  * block.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_autohideable.js
+++ b/core/interfaces/i_autohideable.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for a component that is automatically hidden
  * when WorkspaceSvg.hideChaff is called.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_block_dragger.js
+++ b/core/interfaces/i_block_dragger.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a block dragger.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_bounded_element.js
+++ b/core/interfaces/i_bounded_element.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a bounded element.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_bubble.js
+++ b/core/interfaces/i_bubble.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a bubble.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_collapsible_toolbox_item.js
+++ b/core/interfaces/i_collapsible_toolbox_item.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a collapsible toolbox item.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_component.js
+++ b/core/interfaces/i_component.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Interface for a workspace component that can be registered with
  * the ComponentManager.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_connection_checker.js
+++ b/core/interfaces/i_connection_checker.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for an object that encapsulates logic for
  * checking whether a potential connection is safe and valid.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/interfaces/i_contextmenu.js
+++ b/core/interfaces/i_contextmenu.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that supports a right-click.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_copyable.js
+++ b/core/interfaces/i_copyable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that is copyable.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_deletable.js
+++ b/core/interfaces/i_deletable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that is deletable.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_delete_area.js
+++ b/core/interfaces/i_delete_area.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for a component that can delete a block or bubble
  * that is dropped on top of it.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_drag_target.js
+++ b/core/interfaces/i_drag_target.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for a component that has a handler for when a
  * block is dropped on top of it.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_draggable.js
+++ b/core/interfaces/i_draggable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that is draggable.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_flyout.js
+++ b/core/interfaces/i_flyout.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a flyout.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_keyboard_accessible.js
+++ b/core/interfaces/i_keyboard_accessible.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for objects that handle keyboard shortcuts.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_metrics_manager.js
+++ b/core/interfaces/i_metrics_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a metrics manager.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_movable.js
+++ b/core/interfaces/i_movable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that is movable.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_positionable.js
+++ b/core/interfaces/i_positionable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a positionable UI element.
- * @author kozbial@google.com (Monica Kozbial)
  */
 
 'use strict';

--- a/core/interfaces/i_registrable.js
+++ b/core/interfaces/i_registrable.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for a Blockly component that can be registered.
  *    (Ex. Toolbox, Fields, Renderers)
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_registrable_field.js
+++ b/core/interfaces/i_registrable_field.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a Blockly field that can be registered.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_selectable.js
+++ b/core/interfaces/i_selectable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that is selectable.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/interfaces/i_selectable_toolbox_item.js
+++ b/core/interfaces/i_selectable_toolbox_item.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a selectable toolbox item.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_styleable.js
+++ b/core/interfaces/i_styleable.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for an object that a style can be added to.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_toolbox.js
+++ b/core/interfaces/i_toolbox.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a toolbox.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/interfaces/i_toolbox_item.js
+++ b/core/interfaces/i_toolbox_item.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview The interface for a toolbox item.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 
 'use strict';

--- a/core/internal_constants.js
+++ b/core/internal_constants.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Module that provides constants for use inside Blockly. Do not
  * use these constants outside of the core library.
- * @author fenichel@google.com (Rachel Fenichel)
  * @package
  */
 'use strict';

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class representing a basic cursor.
  * Used to demo switching between different cursors.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class representing a cursor.
  * Used primarily for keyboard navigation.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class representing a marker.
  * Used primarily for keyboard navigation to show a marked location.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class representing a cursor that is used to navigate
  * between tab navigable fields.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object in charge of managing markers and the cursor.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/menu.js
+++ b/core/menu.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blockly menu similar to Closure's goog.ui.Menu
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blockly menu item similar to Closure's goog.ui.MenuItem
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Calculates and reports workspace metrics.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/msg.js
+++ b/core/msg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Empty name space for the Message singleton.
- * @author scr@google.com (Sheridan Rawlins)
  */
 'use strict';
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Object representing a mutator dialog.  A mutator allows the
  * user to change the shape of a block using a nested blocks editor.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/names.js
+++ b/core/names.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility functions for handling variable and procedure names.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/options.js
+++ b/core/options.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object that controls settings for the workspace.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/positionable_helpers.js
+++ b/core/positionable_helpers.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility functions for positioning UI elements.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility functions for handling procedures.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/registry.js
+++ b/core/registry.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview This file is a universal registry that provides generic methods
  *    for registering and unregistering different types of classes.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Components for creating connections between blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Namespace for block rendering functionality.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object that provides constants for rendering blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for rendering debug graphics.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a block as SVG.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/i_path_object.js
+++ b/core/renderers/common/i_path_object.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The interface for an object that owns a block's rendering SVG
  * elements.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a block as SVG.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a marker as SVG.
- * @author samelh@microsoft.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object that owns a block's rendering SVG elements.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Base renderer.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview An object that provides constants for rendering blocks in Geras
  * mode.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Renderer that preserves the look and feel of Blockly pre-2019.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/geras/highlight_constants.js
+++ b/core/renderers/geras/highlight_constants.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Objects for rendering highlights on blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Methods for adding highlights on block, for rendering in
  * compatibility mode.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Old (compatibility) renderer.
  * Geras: spirit of old age.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/geras/measurables/inline_input.js
+++ b/core/renderers/geras/measurables/inline_input.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing inline inputs with connections on a
  * rendered block.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/renderers/geras/measurables/statement_input.js
+++ b/core/renderers/geras/measurables/statement_input.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing statement inputs with connections on a
  * rendered block.
- * @author kozbial@google.com (Monica Kozbial)
  */
 'use strict';
 

--- a/core/renderers/geras/path_object.js
+++ b/core/renderers/geras/path_object.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object that owns a block's rendering SVG elements.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/renderers/geras/renderer.js
+++ b/core/renderers/geras/renderer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Geras renderer.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/measurables/base.js
+++ b/core/renderers/measurables/base.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a block as SVG.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 'use strict';

--- a/core/renderers/measurables/bottom_row.js
+++ b/core/renderers/measurables/bottom_row.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Object representing a bottom row on a rendered block.
  * of its subcomponents.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/connection.js
+++ b/core/renderers/measurables/connection.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Base class representing the space a connection takes up during
  * rendering.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/external_value_input.js
+++ b/core/renderers/measurables/external_value_input.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Class representing external value inputs with connections on a
  * rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/field.js
+++ b/core/renderers/measurables/field.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a field in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/hat.js
+++ b/core/renderers/measurables/hat.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a hat in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/icon.js
+++ b/core/renderers/measurables/icon.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing an icon in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/in_row_spacer.js
+++ b/core/renderers/measurables/in_row_spacer.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a spacer in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/inline_input.js
+++ b/core/renderers/measurables/inline_input.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Class representing inline inputs with connections on a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/input_connection.js
+++ b/core/renderers/measurables/input_connection.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Class representing inputs with connections on a rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/input_row.js
+++ b/core/renderers/measurables/input_row.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Object representing a row that holds one or more inputs on a
  * rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/jagged_edge.js
+++ b/core/renderers/measurables/jagged_edge.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a jagged edge in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/next_connection.js
+++ b/core/renderers/measurables/next_connection.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Class representing the space a next connection takes up during
  * rendering.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/output_connection.js
+++ b/core/renderers/measurables/output_connection.js
@@ -8,7 +8,6 @@
 /**
  * @fileoverview Class representing the space a output connection takes up
  * during rendering.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/previous_connection.js
+++ b/core/renderers/measurables/previous_connection.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Class representing the space a previous connection takes up
  * during rendering.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/round_corner.js
+++ b/core/renderers/measurables/round_corner.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a round corner in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/row.js
+++ b/core/renderers/measurables/row.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a single row on a rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/spacer_row.js
+++ b/core/renderers/measurables/spacer_row.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a spacer between two rows.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/square_corner.js
+++ b/core/renderers/measurables/square_corner.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Objects representing a square corner in a row of a rendered
  * block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/statement_input.js
+++ b/core/renderers/measurables/statement_input.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Class representing statement inputs with connections on a
  * rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/top_row.js
+++ b/core/renderers/measurables/top_row.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a top row on a rendered block.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 
 /**

--- a/core/renderers/measurables/types.js
+++ b/core/renderers/measurables/types.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Measurable types.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview New (evolving) renderer.
  * Thrasos: spirit of boldness.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/thrasos/renderer.js
+++ b/core/renderers/thrasos/renderer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Thrasos renderer.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview An object that provides constants for rendering blocks in Zelos
  * mode.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Zelos renderer.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Makecode/scratch-style renderer.
  * Zelos: spirit of eager rivalry, emulation, envy, jealousy, and zeal.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for graphically rendering a marker as SVG.
- * @author samelh@microsoft.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/renderers/zelos/measurables/bottom_row.js
+++ b/core/renderers/zelos/measurables/bottom_row.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object representing the bottom row of a rendered block.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/renderers/zelos/measurables/inputs.js
+++ b/core/renderers/zelos/measurables/inputs.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Zelos specific objects representing inputs with connections on
  * a rendered block.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 /**

--- a/core/renderers/zelos/measurables/row_elements.js
+++ b/core/renderers/zelos/measurables/row_elements.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Zelos specific objects representing elements in a row of a
  * rendered block.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 /**

--- a/core/renderers/zelos/measurables/top_row.js
+++ b/core/renderers/zelos/measurables/top_row.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object representing the top row of a rendered block.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An object that owns a block's rendering SVG elements.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 'use strict';

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Zelos renderer.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/requires.js
+++ b/core/requires.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Default Blockly entry point. Use this to pick and choose which
  * fields and renderers to include in your Blockly bundle.
- * @author samelh@google.com (Sam El-Husseini)
  * @suppress {extraRequire}
  */
 'use strict';

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a scrollbar.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/scrollbar_pair.js
+++ b/core/scrollbar_pair.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a pair of scrollbars.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/shortcut_items.js
+++ b/core/shortcut_items.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Registers default keyboard shortcuts.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The namespace used to keep track of keyboard shortcuts and the
  * key codes used to execute those shortcuts.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -7,8 +7,6 @@
 /**
  * @fileoverview Object in charge of storing and updating a workspace theme
  *     and UI components.
- * @author aschmiedt@google.com (Abby Schmiedt)
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview A toolbox category used to organize blocks in the toolbox.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/toolbox/collapsible_category.js
+++ b/core/toolbox/collapsible_category.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview A toolbox category used to organize blocks in the toolbox.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/toolbox/separator.js
+++ b/core/toolbox/separator.js
@@ -6,8 +6,6 @@
 
 /**
  * @fileoverview A separator used for separating toolbox categories.
- * @author aschmiedt@google.com (Abby Schmiedt)
- * @author maribethb@google.com (Maribeth Bottorff)
  */
 'use strict';
 

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Toolbox from whence to create blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/toolbox/toolbox_item.js
+++ b/core/toolbox/toolbox_item.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview An item in the toolbox.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -11,7 +11,6 @@
  * If the tooltip is a string, then that message will be displayed.
  * If the tooltip is an SVG element, then that object's tooltip will be used.
  * Third, call bindMouseEvents(e) passing the SVG element.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/touch.js
+++ b/core/touch.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Touch handling for Blockly.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview The class extends Gesture to support pinch to zoom
  * for both pointer and touch events.
- * @author samelh@microsoft.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a trash can icon.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/aria.js
+++ b/core/utils/aria.js
@@ -8,7 +8,6 @@
  * @fileoverview ARIA-related constants and utilities.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for colour manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/coordinate.js
+++ b/core/utils/coordinate.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for coordinate manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/deprecation.js
+++ b/core/utils/deprecation.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Helper function for warning developers about deprecations.
  * This method is not specific to Blockly.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for DOM manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Provides a reference to the global object.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/idgenerator.js
+++ b/core/utils/idgenerator.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generators for unique IDs.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/keycodes.js
+++ b/core/utils/keycodes.js
@@ -8,7 +8,6 @@
  * @fileoverview Constant declarations for common key codes.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/math.js
+++ b/core/utils/math.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for math.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/metrics.js
+++ b/core/utils/metrics.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Workspace metrics definitions.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/object.js
+++ b/core/utils/object.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility methods for objects.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/rect.js
+++ b/core/utils/rect.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for rectangle manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/size.js
+++ b/core/utils/size.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for size calculation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/string.js
+++ b/core/utils/string.js
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for string manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/style.js
+++ b/core/utils/style.js
@@ -8,7 +8,6 @@
  * @fileoverview Utilities for element styles.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/svg.js
+++ b/core/utils/svg.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Defines the Svg class. Its constants enumerate
  * all SVG tag names used by Blockly.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/core/utils/svg_paths.js
+++ b/core/utils/svg_paths.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Methods for creating parts of SVG path strings.  See
  * developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility functions for the toolbox and flyout.
- * @author aschmiedt@google.com (Abby Schmiedt)
  */
 'use strict';
 

--- a/core/utils/useragent.js
+++ b/core/utils/useragent.js
@@ -8,7 +8,6 @@
  * @fileoverview Useragent detection.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -8,7 +8,6 @@
  * @fileoverview XML element manipulation.
  * These methods are not specific to Blockly, and could be factored out into
  * a JavaScript framework such as Closure.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a map of variables and their types.
- * @author marisaleung@google.com (Marisa Leung)
  */
 'use strict';
 

--- a/core/variable_model.js
+++ b/core/variable_model.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Components for the variable model.
- * @author marisaleung@google.com (Marisa Leung)
  */
 'use strict';
 

--- a/core/variables.js
+++ b/core/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Utility functions for handling variables.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Utility functions for handling typed variables.
  *
- * @author duzc2dtw@gmail.com (Du Tian Wei)
  */
 'use strict';
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a warning.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -8,7 +8,6 @@
  * @fileoverview A div that floats on top of Blockly.  This singleton contains
  *     temporary HTML UI widgets that the user is currently interacting with.
  *     E.g. text input areas, colour pickers, context menus.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a workspace.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/workspace_audio.js
+++ b/core/workspace_audio.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview Object in charge of loading, storing, and playing audio for a
  *     workspace.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a code comment on the workspace.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a code comment on a rendered workspace.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -9,7 +9,6 @@
  * Blocks are moved into this SVG during a drag, improving performance.
  * The entire SVG is translated using CSS translation instead of SVG so the
  * blocks are never repainted during drag improving performance.
- * @author katelyn@google.com (Katelyn Mann)
  */
 
 'use strict';

--- a/core/workspace_dragger.js
+++ b/core/workspace_dragger.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Methods for dragging a workspace visually.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a workspace rendered as SVG.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview XML reader and writer.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Object representing a zoom icons.
- * @author carloslfu@gmail.com (Carlos Galarza)
  */
 'use strict';
 

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -9,7 +9,6 @@
  * Factory, Block Library, and Block Exporter functionality into a single web
  * app.
  *
- * @author quachtina96 (Tina Quach)
  */
 
 /**

--- a/demos/blockfactory/block_definition_extractor.js
+++ b/demos/blockfactory/block_definition_extractor.js
@@ -18,7 +18,6 @@
  * The <code>exampleBlocklyBlock</code> is usually the block loaded into the
  * preview workspace after manually entering the block definition.
  *
- * @author JC-Orozco (Juan Carlos Orozco), AnmAtAnm (Andrew n marshall)
  */
 'use strict';
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -10,7 +10,6 @@
  * easily using a visual interface. Depends on Block Exporter View and Block
  * Exporter Tools classes. Interacts with Export Settings in the index.html.
  *
- * @author quachtina96 (Tina Quach)
  */
 
 'use strict';

--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -10,7 +10,6 @@
  * toolbox XML for the exporter's workspace.  Depends on the FactoryUtils for
  * its code generation functions.
  *
- * @author quachtina96 (Tina Quach)
  */
 'use strict';
 

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -8,7 +8,6 @@
  * @fileoverview Javascript for the Block Exporter View class. Reads from and
  * manages a block selector through which users select blocks to export.
  *
- * @author quachtina96 (Tina Quach)
  */
 
 'use strict';

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -14,7 +14,6 @@
  *  - clear their block library
  * Depends on BlockFactory functions defined in factory.js.
  *
- * @author quachtina96 (Tina Quach)
  */
 'use strict';
 

--- a/demos/blockfactory/block_library_storage.js
+++ b/demos/blockfactory/block_library_storage.js
@@ -8,7 +8,6 @@
  * @fileoverview Javascript for Block Library's Storage Class.
  * Depends on Block Library for its namespace.
  *
- * @author quachtina96 (Tina Quach)
  */
 
 'use strict';

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -8,7 +8,6 @@
  * @fileoverview Javascript for BlockLibraryView class. It manages the display
  * of the Block Library dropdown, save, and delete buttons.
  *
- * @author quachtina96 (Tina Quach)
  */
 
 'use strict';

--- a/demos/blockfactory/block_option.js
+++ b/demos/blockfactory/block_option.js
@@ -10,7 +10,6 @@
  * option has a checkbox, a label, and a preview workspace through which to
  * view the block.
  *
- * @author quachtina96 (Tina Quach)
  */
 'use strict';
 

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blocks for Blockly's Block Factory application.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -11,7 +11,6 @@
  * generator stub. Uses the Block Factory namespace. Depends on the FactoryUtils
  * for its code generation functions.
  *
- * @author fraser@google.com (Neil Fraser), quachtina96 (Tina Quach)
  */
 'use strict';
 

--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -10,7 +10,6 @@
  * Exporter applications within Blockly Factory. Holds functions to generate
  * block definitions and generator stubs and to create and download files.
  *
- * @author fraser@google.com (Neil Fraser), quachtina96 (Tina Quach), JC-Orozco
  * (Juan Carlos Orozco)
  */
 'use strict';

--- a/demos/blockfactory/standard_categories.js
+++ b/demos/blockfactory/standard_categories.js
@@ -11,7 +11,6 @@
  * that particular category. Also has a list of core block types provided
  * by Blockly.
  *
- * @author Emma Dauterman (evd2014)
  */
  'use strict';
 

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -17,7 +17,6 @@
  * - changing a category name
  * - moving the position of a category.
  *
- * @author Emma Dauterman (evd2014)
  */
 
 /**

--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -11,7 +11,6 @@
  * Depends on a hidden workspace created in the generator to load saved XML in
  * order to generate toolbox XML.
  *
- * @author Emma Dauterman (evd2014)
  */
 
 

--- a/demos/blockfactory/workspacefactory/wfactory_init.js
+++ b/demos/blockfactory/workspacefactory/wfactory_init.js
@@ -10,7 +10,6 @@
  * keydown events and Blockly events, and configures the initial setup of
  * the page.
  *
- * @author Emma Dauterman (evd2014)
  */
 
 /**

--- a/demos/blockfactory/workspacefactory/wfactory_model.js
+++ b/demos/blockfactory/workspacefactory/wfactory_model.js
@@ -13,7 +13,6 @@
  * element. Also keeps track of all the user-created shadow blocks and
  * manipulates them as necessary.
  *
- * @author Emma Dauterman (evd2014)
  */
 
 /**

--- a/demos/blockfactory/workspacefactory/wfactory_view.js
+++ b/demos/blockfactory/workspacefactory/wfactory_view.js
@@ -11,7 +11,6 @@
  * each category are stored in tab map, which associates a unique ID for a
  * category with a particular tab.
  *
- * @author Emma Dauterman (edauterman)
  */
 
 

--- a/demos/blockfactory_old/blocks.js
+++ b/demos/blockfactory_old/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blocks for Blockly's Block Factory application.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/blockfactory_old/factory.js
+++ b/demos/blockfactory_old/factory.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview JavaScript for Blockly's Block Factory application.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview JavaScript for Blockly's Code demo.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/custom-fields/pitch/blocks.js
+++ b/demos/custom-fields/pitch/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Pitch field demo blocks.
- * @author samelh@gmail.com (Sam El-Husseini)
  */
 
 Blockly.Blocks['test_pitch_field'] = {

--- a/demos/custom-fields/pitch/field_pitch.js
+++ b/demos/custom-fields/pitch/field_pitch.js
@@ -7,8 +7,6 @@
 
 /**
  * @fileoverview Music pitch input field. Borrowed from Blockly Games.
- * @author fraser@google.com (Neil Fraser)
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/demos/custom-fields/turtle/blocks.js
+++ b/demos/custom-fields/turtle/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Turtle field demo blocks.
- * @author bekawestberg@gmail.com (Beka Westberg)
  */
 
 Blockly.Blocks['turtle_basic'] = {

--- a/demos/custom-fields/turtle/field_turtle.js
+++ b/demos/custom-fields/turtle/field_turtle.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview A field used to customize a turtle.
- * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';
 

--- a/demos/minimap/minimap.js
+++ b/demos/minimap/minimap.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview JavaScript for Blockly's Minimap demo.
- * @author karnpurohit@gmail.com (Karan Purohit)
  */
 'use strict';
 

--- a/demos/plane/blocks.js
+++ b/demos/plane/blocks.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Blocks for Blockly's Plane Seat Calculator application.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/plane/plane.js
+++ b/demos/plane/plane.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview JavaScript for Blockly's Plane Seat Calculator demo.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/demos/plane/slider.js
+++ b/demos/plane/slider.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview A slider control in SVG.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Helper functions for generating Dart for blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/colour.js
+++ b/generators/dart/colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for colour blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/lists.js
+++ b/generators/dart/lists.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for list blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/logic.js
+++ b/generators/dart/logic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for logic blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/dart/loops.js
+++ b/generators/dart/loops.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for loop blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/math.js
+++ b/generators/dart/math.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for math blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/dart/procedures.js
+++ b/generators/dart/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for procedure blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for text blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/variables.js
+++ b/generators/dart/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for variable blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/dart/variables_dynamic.js
+++ b/generators/dart/variables_dynamic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for dynamic variable blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Helper functions for generating JavaScript for blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/colour.js
+++ b/generators/javascript/colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for colour blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for list blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/logic.js
+++ b/generators/javascript/logic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for logic blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/javascript/loops.js
+++ b/generators/javascript/loops.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for loop blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for math blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for procedure blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for text blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/variables.js
+++ b/generators/javascript/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for variable blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/javascript/variables_dynamic.js
+++ b/generators/javascript/variables_dynamic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for dynamic variable blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Helper functions for generating Lua for blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  * Based on Ellen Spertus's blocky-lua project.
  */
 'use strict';

--- a/generators/lua/colour.js
+++ b/generators/lua/colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for colour blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for list blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for logic blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for loop blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for math blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for procedure blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for text blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/variables.js
+++ b/generators/lua/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for variable blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/generators/lua/variables_dynamic.js
+++ b/generators/lua/variables_dynamic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for dynamic variable blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/generators/php.js
+++ b/generators/php.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Helper functions for generating PHP for blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/colour.js
+++ b/generators/php/colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for colour blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/lists.js
+++ b/generators/php/lists.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for list blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 
 /**

--- a/generators/php/logic.js
+++ b/generators/php/logic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for logic blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/loops.js
+++ b/generators/php/loops.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for loop blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/math.js
+++ b/generators/php/math.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for math blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for procedure blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/text.js
+++ b/generators/php/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for text blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/variables.js
+++ b/generators/php/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for variable blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/generators/php/variables_dynamic.js
+++ b/generators/php/variables_dynamic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for dynamic variable blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/generators/python.js
+++ b/generators/python.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Helper functions for generating Python for blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/python/colour.js
+++ b/generators/python/colour.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for colour blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/python/lists.js
+++ b/generators/python/lists.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for list blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for logic blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/loops.js
+++ b/generators/python/loops.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for loop blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for math blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for procedure blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for text blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/variables.js
+++ b/generators/python/variables.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for variable blocks.
- * @author q.neutron@gmail.com (Quynh Neutron)
  */
 'use strict';
 

--- a/generators/python/variables_dynamic.js
+++ b/generators/python/variables_dynamic.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for dynamic variable blocks.
- * @author fenichel@google.com (Rachel Fenichel)
  */
 'use strict';
 

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview English strings.
- * @author fraser@google.com (Neil Fraser)
  *
  * After modifying this file, run:
  *

--- a/scripts/i18n/js_to_json.py
+++ b/scripts/i18n/js_to_json.py
@@ -35,8 +35,6 @@ The file qqq.json would get:
     "Blockly.SOME_KEY", "Here is a description of the following message.",
 
 Commas would of course be omitted for the final entry of each value.
-
-@author Ellen Spertus (ellen.spertus@gmail.com)
 """
 
 import argparse

--- a/tests/generators/unittest.js
+++ b/tests/generators/unittest.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Unit test blocks for Blockly.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/tests/generators/unittest_dart.js
+++ b/tests/generators/unittest_dart.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Dart for unit test blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating JavaScript for unit test blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/tests/generators/unittest_lua.js
+++ b/tests/generators/unittest_lua.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Lua for unit test blocks.
- * @author rodrigoq@google.com (Rodrigo Queiro)
  */
 'use strict';
 

--- a/tests/generators/unittest_php.js
+++ b/tests/generators/unittest_php.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating PHP for unit test blocks.
- * @author daarond@gmail.com (Daaron Dwyer)
  */
 'use strict';
 

--- a/tests/generators/unittest_python.js
+++ b/tests/generators/unittest_python.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Generating Python for unit test blocks.
- * @author fraser@google.com (Neil Fraser)
  */
 'use strict';
 

--- a/tests/playgrounds/screenshot.js
+++ b/tests/playgrounds/screenshot.js
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Download screenshot.
- * @author samelh@google.com (Sam El-Husseini)
  */
 'use strict';
 

--- a/typings/templates/blockly-header.template
+++ b/typings/templates/blockly-header.template
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Type definitions for Blockly.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 export = Blockly;

--- a/typings/templates/msg.template
+++ b/typings/templates/msg.template
@@ -6,7 +6,6 @@
 
 /**
  * @fileoverview Type definitions for the Blockly <%= locale %> locale.
- * @author samelh@google.com (Sam El-Husseini)
  */
 
 /// <reference path="msg.d.ts" />


### PR DESCRIPTION
Our files are up to a decade old, and have churned so much, that the initial author of the file no longer has much meaning.

Furthermore, this will encourage developers to post to the developer group, rather than emailing Googlers (usually me) directly.