### PR TITLE
chore: update dependabot messages and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
         # We should test that this does not cause issue 
         # google/blockly-samples#665 when version 17 is released.
         versions: "16.x"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "chore"
+      - "dependencies"


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Related to conventional commit work.

### Proposed Changes

Updates our dependabot config to add the prefix "chore(deps)" to dependabot PRs, and to add the label "chore" in addition to the label "dependencies".

### Reason for Changes

Allows dependabot-generated changes to pass conventional commit linting.
Part of getting our labels sorted out so we can autogenerate informational release notes.

### Documentation
See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message

### Additional Information

I *think* this will actually add the prefix with a colon, but I'm not 100% certain and can't find it either way in the docs.