### PR TITLE
chore: auto-fix violations of comma-dangle rule

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -37,14 +37,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_colour",
         "name": "COLOUR",
-        "colour": "#ff0000"
-      }
+        "colour": "#ff0000",
+      },
     ],
     "output": "Colour",
     "helpUrl": "%{BKY_COLOUR_PICKER_HELPURL}",
     "style": "colour_blocks",
     "tooltip": "%{BKY_COLOUR_PICKER_TOOLTIP}",
-    "extensions": ["parent_tooltip_when_inline"]
+    "extensions": ["parent_tooltip_when_inline"],
   },
 
   // Block for random colour.
@@ -54,7 +54,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "output": "Colour",
     "helpUrl": "%{BKY_COLOUR_RANDOM_HELPURL}",
     "style": "colour_blocks",
-    "tooltip": "%{BKY_COLOUR_RANDOM_TOOLTIP}"
+    "tooltip": "%{BKY_COLOUR_RANDOM_TOOLTIP}",
   },
 
   // Block for composing a colour from RGB components.
@@ -66,25 +66,25 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "type": "input_value",
         "name": "RED",
         "check": "Number",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "GREEN",
         "check": "Number",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "BLUE",
         "check": "Number",
-        "align": "RIGHT"
-      }
+        "align": "RIGHT",
+      },
     ],
     "output": "Colour",
     "helpUrl": "%{BKY_COLOUR_RGB_HELPURL}",
     "style": "colour_blocks",
-    "tooltip": "%{BKY_COLOUR_RGB_TOOLTIP}"
+    "tooltip": "%{BKY_COLOUR_RGB_TOOLTIP}",
   },
 
   // Block for blending two colours together.
@@ -97,24 +97,24 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "type": "input_value",
         "name": "COLOUR1",
         "check": "Colour",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "COLOUR2",
         "check": "Colour",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "RATIO",
         "check": "Number",
-        "align": "RIGHT"
-      }
+        "align": "RIGHT",
+      },
     ],
     "output": "Colour",
     "helpUrl": "%{BKY_COLOUR_BLEND_HELPURL}",
     "style": "colour_blocks",
-    "tooltip": "%{BKY_COLOUR_BLEND_TOOLTIP}"
-  }
+    "tooltip": "%{BKY_COLOUR_BLEND_TOOLTIP}",
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -40,7 +40,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "output": "Array",
     "style": "list_blocks",
     "tooltip": "%{BKY_LISTS_CREATE_EMPTY_TOOLTIP}",
-    "helpUrl": "%{BKY_LISTS_CREATE_EMPTY_HELPURL}"
+    "helpUrl": "%{BKY_LISTS_CREATE_EMPTY_HELPURL}",
   },
   // Block for creating a list with one element repeated.
   {
@@ -49,18 +49,18 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [
       {
         "type": "input_value",
-        "name": "ITEM"
+        "name": "ITEM",
       },
       {
         "type": "input_value",
         "name": "NUM",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "output": "Array",
     "style": "list_blocks",
     "tooltip": "%{BKY_LISTS_REPEAT_TOOLTIP}",
-    "helpUrl": "%{BKY_LISTS_REPEAT_HELPURL}"
+    "helpUrl": "%{BKY_LISTS_REPEAT_HELPURL}",
   },
   // Block for reversing a list.
   {
@@ -70,14 +70,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "LIST",
-        "check": "Array"
-      }
+        "check": "Array",
+      },
     ],
     "output": "Array",
     "inputsInline": true,
     "style": "list_blocks",
     "tooltip": "%{BKY_LISTS_REVERSE_TOOLTIP}",
-    "helpUrl": "%{BKY_LISTS_REVERSE_HELPURL}"
+    "helpUrl": "%{BKY_LISTS_REVERSE_HELPURL}",
   },
   // Block for checking if a list is empty
   {
@@ -87,13 +87,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": ["String", "Array"]
-      }
+        "check": ["String", "Array"],
+      },
     ],
     "output": "Boolean",
     "style": "list_blocks",
     "tooltip": "%{BKY_LISTS_ISEMPTY_TOOLTIP}",
-    "helpUrl": "%{BKY_LISTS_ISEMPTY_HELPURL}"
+    "helpUrl": "%{BKY_LISTS_ISEMPTY_HELPURL}",
   },
   // Block for getting the list length
   {
@@ -103,14 +103,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": ["String", "Array"]
-      }
+        "check": ["String", "Array"],
+      },
     ],
     "output": "Number",
     "style": "list_blocks",
     "tooltip": "%{BKY_LISTS_LENGTH_TOOLTIP}",
-    "helpUrl": "%{BKY_LISTS_LENGTH_HELPURL}"
-  }
+    "helpUrl": "%{BKY_LISTS_LENGTH_HELPURL}",
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 Blockly.Blocks['lists_create_with'] = {
@@ -254,7 +254,7 @@ Blockly.Blocks['lists_create_with'] = {
       this.removeInput('ADD' + i);
       i++;
     }
-  }
+  },
 };
 
 Blockly.Blocks['lists_create_with_container'] = {
@@ -269,7 +269,7 @@ Blockly.Blocks['lists_create_with_container'] = {
     this.appendStatementInput('STACK');
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_CONTAINER_TOOLTIP']);
     this.contextMenu = false;
-  }
+  },
 };
 
 Blockly.Blocks['lists_create_with_item'] = {
@@ -285,7 +285,7 @@ Blockly.Blocks['lists_create_with_item'] = {
     this.setNextStatement(true);
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_ITEM_TOOLTIP']);
     this.contextMenu = false;
-  }
+  },
 };
 
 Blockly.Blocks['lists_indexOf'] = {
@@ -297,7 +297,7 @@ Blockly.Blocks['lists_indexOf'] = {
     var OPERATORS =
         [
           [Blockly.Msg['LISTS_INDEX_OF_FIRST'], 'FIRST'],
-          [Blockly.Msg['LISTS_INDEX_OF_LAST'], 'LAST']
+          [Blockly.Msg['LISTS_INDEX_OF_LAST'], 'LAST'],
         ];
     this.setHelpUrl(Blockly.Msg['LISTS_INDEX_OF_HELPURL']);
     this.setStyle('list_blocks');
@@ -314,7 +314,7 @@ Blockly.Blocks['lists_indexOf'] = {
       return Blockly.Msg['LISTS_INDEX_OF_TOOLTIP'].replace('%1',
           thisBlock.workspace.options.oneBasedIndex ? '0' : '-1');
     });
-  }
+  },
 };
 
 Blockly.Blocks['lists_getIndex'] = {
@@ -327,7 +327,7 @@ Blockly.Blocks['lists_getIndex'] = {
         [
           [Blockly.Msg['LISTS_GET_INDEX_GET'], 'GET'],
           [Blockly.Msg['LISTS_GET_INDEX_GET_REMOVE'], 'GET_REMOVE'],
-          [Blockly.Msg['LISTS_GET_INDEX_REMOVE'], 'REMOVE']
+          [Blockly.Msg['LISTS_GET_INDEX_REMOVE'], 'REMOVE'],
         ];
     this.WHERE_OPTIONS =
         [
@@ -335,7 +335,7 @@ Blockly.Blocks['lists_getIndex'] = {
           [Blockly.Msg['LISTS_GET_INDEX_FROM_END'], 'FROM_END'],
           [Blockly.Msg['LISTS_GET_INDEX_FIRST'], 'FIRST'],
           [Blockly.Msg['LISTS_GET_INDEX_LAST'], 'LAST'],
-          [Blockly.Msg['LISTS_GET_INDEX_RANDOM'], 'RANDOM']
+          [Blockly.Msg['LISTS_GET_INDEX_RANDOM'], 'RANDOM'],
         ];
     this.setHelpUrl(Blockly.Msg['LISTS_GET_INDEX_HELPURL']);
     this.setStyle('list_blocks');
@@ -505,7 +505,7 @@ Blockly.Blocks['lists_getIndex'] = {
     if (Blockly.Msg['LISTS_GET_INDEX_TAIL']) {
       this.moveInputBefore('TAIL', null);
     }
-  }
+  },
 };
 
 Blockly.Blocks['lists_setIndex'] = {
@@ -517,7 +517,7 @@ Blockly.Blocks['lists_setIndex'] = {
     var MODE =
         [
           [Blockly.Msg['LISTS_SET_INDEX_SET'], 'SET'],
-          [Blockly.Msg['LISTS_SET_INDEX_INSERT'], 'INSERT']
+          [Blockly.Msg['LISTS_SET_INDEX_INSERT'], 'INSERT'],
         ];
     this.WHERE_OPTIONS =
         [
@@ -525,7 +525,7 @@ Blockly.Blocks['lists_setIndex'] = {
           [Blockly.Msg['LISTS_GET_INDEX_FROM_END'], 'FROM_END'],
           [Blockly.Msg['LISTS_GET_INDEX_FIRST'], 'FIRST'],
           [Blockly.Msg['LISTS_GET_INDEX_LAST'], 'LAST'],
-          [Blockly.Msg['LISTS_GET_INDEX_RANDOM'], 'RANDOM']
+          [Blockly.Msg['LISTS_GET_INDEX_RANDOM'], 'RANDOM'],
         ];
     this.setHelpUrl(Blockly.Msg['LISTS_SET_INDEX_HELPURL']);
     this.setStyle('list_blocks');
@@ -651,7 +651,7 @@ Blockly.Blocks['lists_setIndex'] = {
     }
 
     this.getInput('AT').appendField(menu, 'WHERE');
-  }
+  },
 };
 
 Blockly.Blocks['lists_getSublist'] = {
@@ -664,13 +664,13 @@ Blockly.Blocks['lists_getSublist'] = {
         [
           [Blockly.Msg['LISTS_GET_SUBLIST_START_FROM_START'], 'FROM_START'],
           [Blockly.Msg['LISTS_GET_SUBLIST_START_FROM_END'], 'FROM_END'],
-          [Blockly.Msg['LISTS_GET_SUBLIST_START_FIRST'], 'FIRST']
+          [Blockly.Msg['LISTS_GET_SUBLIST_START_FIRST'], 'FIRST'],
         ];
     this['WHERE_OPTIONS_2'] =
         [
           [Blockly.Msg['LISTS_GET_SUBLIST_END_FROM_START'], 'FROM_START'],
           [Blockly.Msg['LISTS_GET_SUBLIST_END_FROM_END'], 'FROM_END'],
-          [Blockly.Msg['LISTS_GET_SUBLIST_END_LAST'], 'LAST']
+          [Blockly.Msg['LISTS_GET_SUBLIST_END_LAST'], 'LAST'],
         ];
     this.setHelpUrl(Blockly.Msg['LISTS_GET_SUBLIST_HELPURL']);
     this.setStyle('list_blocks');
@@ -767,7 +767,7 @@ Blockly.Blocks['lists_getSublist'] = {
     if (Blockly.Msg['LISTS_GET_SUBLIST_TAIL']) {
       this.moveInputBefore('TAIL', null);
     }
-  }
+  },
 };
 
 Blockly.Blocks['lists_sort'] = {
@@ -785,29 +785,29 @@ Blockly.Blocks['lists_sort'] = {
           "options": [
             [Blockly.Msg['LISTS_SORT_TYPE_NUMERIC'], "NUMERIC"],
             [Blockly.Msg['LISTS_SORT_TYPE_TEXT'], "TEXT"],
-            [Blockly.Msg['LISTS_SORT_TYPE_IGNORECASE'], "IGNORE_CASE"]
-          ]
+            [Blockly.Msg['LISTS_SORT_TYPE_IGNORECASE'], "IGNORE_CASE"],
+          ],
         },
         {
           "type": "field_dropdown",
           "name": "DIRECTION",
           "options": [
             [Blockly.Msg['LISTS_SORT_ORDER_ASCENDING'], "1"],
-            [Blockly.Msg['LISTS_SORT_ORDER_DESCENDING'], "-1"]
-          ]
+            [Blockly.Msg['LISTS_SORT_ORDER_DESCENDING'], "-1"],
+          ],
         },
         {
           "type": "input_value",
           "name": "LIST",
-          "check": "Array"
-        }
+          "check": "Array",
+        },
       ],
       "output": "Array",
       "style": "list_blocks",
       "tooltip": Blockly.Msg['LISTS_SORT_TOOLTIP'],
-      "helpUrl": Blockly.Msg['LISTS_SORT_HELPURL']
+      "helpUrl": Blockly.Msg['LISTS_SORT_HELPURL'],
     });
-  }
+  },
 };
 
 Blockly.Blocks['lists_split'] = {
@@ -821,7 +821,7 @@ Blockly.Blocks['lists_split'] = {
     var dropdown = new Blockly.FieldDropdown(
         [
           [Blockly.Msg['LISTS_SPLIT_LIST_FROM_TEXT'], 'SPLIT'],
-          [Blockly.Msg['LISTS_SPLIT_TEXT_FROM_LIST'], 'JOIN']
+          [Blockly.Msg['LISTS_SPLIT_TEXT_FROM_LIST'], 'JOIN'],
         ],
         function(newMode) {
           thisBlock.updateType_(newMode);

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -40,14 +40,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "name": "BOOL",
         "options": [
           ["%{BKY_LOGIC_BOOLEAN_TRUE}", "TRUE"],
-          ["%{BKY_LOGIC_BOOLEAN_FALSE}", "FALSE"]
-        ]
-      }
+          ["%{BKY_LOGIC_BOOLEAN_FALSE}", "FALSE"],
+        ],
+      },
     ],
     "output": "Boolean",
     "style": "logic_blocks",
     "tooltip": "%{BKY_LOGIC_BOOLEAN_TOOLTIP}",
-    "helpUrl": "%{BKY_LOGIC_BOOLEAN_HELPURL}"
+    "helpUrl": "%{BKY_LOGIC_BOOLEAN_HELPURL}",
   },
   // Block for if/elseif/else condition.
   {
@@ -57,15 +57,15 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "IF0",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "message1": "%{BKY_CONTROLS_IF_MSG_THEN} %1",
     "args1": [
       {
         "type": "input_statement",
-        "name": "DO0"
-      }
+        "name": "DO0",
+      },
     ],
     "previousStatement": null,
     "nextStatement": null,
@@ -73,7 +73,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_CONTROLS_IF_HELPURL}",
     "suppressPrefixSuffix": true,
     "mutator": "controls_if_mutator",
-    "extensions": ["controls_if_tooltip"]
+    "extensions": ["controls_if_tooltip"],
   },
   // If/else block that does not use a mutator.
   {
@@ -83,22 +83,22 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "IF0",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "message1": "%{BKY_CONTROLS_IF_MSG_THEN} %1",
     "args1": [
       {
         "type": "input_statement",
-        "name": "DO0"
-      }
+        "name": "DO0",
+      },
     ],
     "message2": "%{BKY_CONTROLS_IF_MSG_ELSE} %1",
     "args2": [
       {
         "type": "input_statement",
-        "name": "ELSE"
-      }
+        "name": "ELSE",
+      },
     ],
     "previousStatement": null,
     "nextStatement": null,
@@ -106,7 +106,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "%{BKYCONTROLS_IF_TOOLTIP_2}",
     "helpUrl": "%{BKY_CONTROLS_IF_HELPURL}",
     "suppressPrefixSuffix": true,
-    "extensions": ["controls_if_tooltip"]
+    "extensions": ["controls_if_tooltip"],
   },
   // Block for comparison operator.
   {
@@ -115,7 +115,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [
       {
         "type": "input_value",
-        "name": "A"
+        "name": "A",
       },
       {
         "type": "field_dropdown",
@@ -126,19 +126,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["\u200F<", "LT"],
           ["\u200F\u2264", "LTE"],
           ["\u200F>", "GT"],
-          ["\u200F\u2265", "GTE"]
-        ]
+          ["\u200F\u2265", "GTE"],
+        ],
       },
       {
         "type": "input_value",
-        "name": "B"
-      }
+        "name": "B",
+      },
     ],
     "inputsInline": true,
     "output": "Boolean",
     "style": "logic_blocks",
     "helpUrl": "%{BKY_LOGIC_COMPARE_HELPURL}",
-    "extensions": ["logic_compare", "logic_op_tooltip"]
+    "extensions": ["logic_compare", "logic_op_tooltip"],
   },
   // Block for logical operations: 'and', 'or'.
   {
@@ -148,27 +148,27 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "A",
-        "check": "Boolean"
+        "check": "Boolean",
       },
       {
         "type": "field_dropdown",
         "name": "OP",
         "options": [
           ["%{BKY_LOGIC_OPERATION_AND}", "AND"],
-          ["%{BKY_LOGIC_OPERATION_OR}", "OR"]
-        ]
+          ["%{BKY_LOGIC_OPERATION_OR}", "OR"],
+        ],
       },
       {
         "type": "input_value",
         "name": "B",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "inputsInline": true,
     "output": "Boolean",
     "style": "logic_blocks",
     "helpUrl": "%{BKY_LOGIC_OPERATION_HELPURL}",
-    "extensions": ["logic_op_tooltip"]
+    "extensions": ["logic_op_tooltip"],
   },
   // Block for negation.
   {
@@ -178,13 +178,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "BOOL",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "output": "Boolean",
     "style": "logic_blocks",
     "tooltip": "%{BKY_LOGIC_NEGATE_TOOLTIP}",
-    "helpUrl": "%{BKY_LOGIC_NEGATE_HELPURL}"
+    "helpUrl": "%{BKY_LOGIC_NEGATE_HELPURL}",
   },
   // Block for null data type.
   {
@@ -193,7 +193,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "output": null,
     "style": "logic_blocks",
     "tooltip": "%{BKY_LOGIC_NULL_TOOLTIP}",
-    "helpUrl": "%{BKY_LOGIC_NULL_HELPURL}"
+    "helpUrl": "%{BKY_LOGIC_NULL_HELPURL}",
   },
   // Block for ternary operator.
   {
@@ -203,29 +203,29 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "IF",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "message1": "%{BKY_LOGIC_TERNARY_IF_TRUE} %1",
     "args1": [
       {
         "type": "input_value",
-        "name": "THEN"
-      }
+        "name": "THEN",
+      },
     ],
     "message2": "%{BKY_LOGIC_TERNARY_IF_FALSE} %1",
     "args2": [
       {
         "type": "input_value",
-        "name": "ELSE"
-      }
+        "name": "ELSE",
+      },
     ],
     "output": null,
     "style": "logic_blocks",
     "tooltip": "%{BKY_LOGIC_TERNARY_TOOLTIP}",
     "helpUrl": "%{BKY_LOGIC_TERNARY_HELPURL}",
-    "extensions": ["logic_ternary"]
-  }
+    "extensions": ["logic_ternary"],
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 Blockly.defineBlocksWithJsonArray([ // Mutator blocks. Do not extract.
@@ -236,7 +236,7 @@ Blockly.defineBlocksWithJsonArray([ // Mutator blocks. Do not extract.
     "nextStatement": null,
     "enableContextMenu": false,
     "style": "logic_blocks",
-    "tooltip": "%{BKY_CONTROLS_IF_IF_TOOLTIP}"
+    "tooltip": "%{BKY_CONTROLS_IF_IF_TOOLTIP}",
   },
   // Block representing the else-if statement in the controls_if mutator.
   {
@@ -246,7 +246,7 @@ Blockly.defineBlocksWithJsonArray([ // Mutator blocks. Do not extract.
     "nextStatement": null,
     "enableContextMenu": false,
     "style": "logic_blocks",
-    "tooltip": "%{BKY_CONTROLS_IF_ELSEIF_TOOLTIP}"
+    "tooltip": "%{BKY_CONTROLS_IF_ELSEIF_TOOLTIP}",
   },
   // Block representing the else statement in the controls_if mutator.
   {
@@ -255,8 +255,8 @@ Blockly.defineBlocksWithJsonArray([ // Mutator blocks. Do not extract.
     "previousStatement": null,
     "enableContextMenu": false,
     "style": "logic_blocks",
-    "tooltip": "%{BKY_CONTROLS_IF_ELSE_TOOLTIP}"
-  }
+    "tooltip": "%{BKY_CONTROLS_IF_ELSE_TOOLTIP}",
+  },
 ]);
 
 /**
@@ -277,7 +277,7 @@ Blockly.Constants.Logic.TOOLTIPS_BY_OP = {
 
   // logic_operation
   'AND': '%{BKY_LOGIC_OPERATION_TOOLTIP_AND}',
-  'OR': '%{BKY_LOGIC_OPERATION_TOOLTIP_OR}'
+  'OR': '%{BKY_LOGIC_OPERATION_TOOLTIP_OR}',
 };
 
 Blockly.Extensions.register('logic_op_tooltip',
@@ -512,7 +512,7 @@ Blockly.Constants.Logic.CONTROLS_IF_MUTATOR_MIXIN = {
       Blockly.Mutator.reconnect(statementConnections[i], this, 'DO' + i);
     }
     Blockly.Mutator.reconnect(elseStatementConnection, this, 'ELSE');
-  }
+  },
 };
 
 Blockly.Extensions.registerMutator('controls_if_mutator',
@@ -593,7 +593,7 @@ Blockly.Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN = {
     }
     this.prevBlocks_[0] = this.getInputTargetBlock('A');
     this.prevBlocks_[1] = this.getInputTargetBlock('B');
-  }
+  },
 };
 
 /**
@@ -652,7 +652,7 @@ Blockly.Constants.Logic.LOGIC_TERNARY_ONCHANGE_MIXIN = {
       }
     }
     this.prevParentConnection_ = parentConnection;
-  }
+  },
 };
 
 Blockly.Extensions.registerMixin('logic_ternary',

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -39,18 +39,18 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [{
       "type": "input_value",
       "name": "TIMES",
-      "check": "Number"
+      "check": "Number",
     }],
     "message1": "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",
     "args1": [{
       "type": "input_statement",
-      "name": "DO"
+      "name": "DO",
     }],
     "previousStatement": null,
     "nextStatement": null,
     "style": "loop_blocks",
     "tooltip": "%{BKY_CONTROLS_REPEAT_TOOLTIP}",
-    "helpUrl": "%{BKY_CONTROLS_REPEAT_HELPURL}"
+    "helpUrl": "%{BKY_CONTROLS_REPEAT_HELPURL}",
   },
   // Block for repeat n times (internal number).
   // The 'controls_repeat_ext' block is preferred as it is more flexible.
@@ -62,18 +62,18 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       "name": "TIMES",
       "value": 10,
       "min": 0,
-      "precision": 1
+      "precision": 1,
     }],
     "message1": "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",
     "args1": [{
       "type": "input_statement",
-      "name": "DO"
+      "name": "DO",
     }],
     "previousStatement": null,
     "nextStatement": null,
     "style": "loop_blocks",
     "tooltip": "%{BKY_CONTROLS_REPEAT_TOOLTIP}",
-    "helpUrl": "%{BKY_CONTROLS_REPEAT_HELPURL}"
+    "helpUrl": "%{BKY_CONTROLS_REPEAT_HELPURL}",
   },
   // Block for 'do while/until' loop.
   {
@@ -85,25 +85,25 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "name": "MODE",
         "options": [
           ["%{BKY_CONTROLS_WHILEUNTIL_OPERATOR_WHILE}", "WHILE"],
-          ["%{BKY_CONTROLS_WHILEUNTIL_OPERATOR_UNTIL}", "UNTIL"]
-        ]
+          ["%{BKY_CONTROLS_WHILEUNTIL_OPERATOR_UNTIL}", "UNTIL"],
+        ],
       },
       {
         "type": "input_value",
         "name": "BOOL",
-        "check": "Boolean"
-      }
+        "check": "Boolean",
+      },
     ],
     "message1": "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",
     "args1": [{
       "type": "input_statement",
-      "name": "DO"
+      "name": "DO",
     }],
     "previousStatement": null,
     "nextStatement": null,
     "style": "loop_blocks",
     "helpUrl": "%{BKY_CONTROLS_WHILEUNTIL_HELPURL}",
-    "extensions": ["controls_whileUntil_tooltip"]
+    "extensions": ["controls_whileUntil_tooltip"],
   },
   // Block for 'for' loop.
   {
@@ -113,31 +113,31 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_variable",
         "name": "VAR",
-        "variable": null
+        "variable": null,
       },
       {
         "type": "input_value",
         "name": "FROM",
         "check": "Number",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "TO",
         "check": "Number",
-        "align": "RIGHT"
+        "align": "RIGHT",
       },
       {
         "type": "input_value",
         "name": "BY",
         "check": "Number",
-        "align": "RIGHT"
-      }
+        "align": "RIGHT",
+      },
     ],
     "message1": "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",
     "args1": [{
       "type": "input_statement",
-      "name": "DO"
+      "name": "DO",
     }],
     "inputsInline": true,
     "previousStatement": null,
@@ -146,8 +146,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_CONTROLS_FOR_HELPURL}",
     "extensions": [
       "contextMenu_newGetVariableBlock",
-      "controls_for_tooltip"
-    ]
+      "controls_for_tooltip",
+    ],
   },
   // Block for 'for each' loop.
   {
@@ -157,18 +157,18 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_variable",
         "name": "VAR",
-        "variable": null
+        "variable": null,
       },
       {
         "type": "input_value",
         "name": "LIST",
-        "check": "Array"
-      }
+        "check": "Array",
+      },
     ],
     "message1": "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",
     "args1": [{
       "type": "input_statement",
-      "name": "DO"
+      "name": "DO",
     }],
     "previousStatement": null,
     "nextStatement": null,
@@ -176,8 +176,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_CONTROLS_FOREACH_HELPURL}",
     "extensions": [
       "contextMenu_newGetVariableBlock",
-      "controls_forEach_tooltip"
-    ]
+      "controls_forEach_tooltip",
+    ],
   },
   // Block for flow statements: continue, break.
   {
@@ -188,8 +188,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       "name": "FLOW",
       "options": [
         ["%{BKY_CONTROLS_FLOW_STATEMENTS_OPERATOR_BREAK}", "BREAK"],
-        ["%{BKY_CONTROLS_FLOW_STATEMENTS_OPERATOR_CONTINUE}", "CONTINUE"]
-      ]
+        ["%{BKY_CONTROLS_FLOW_STATEMENTS_OPERATOR_CONTINUE}", "CONTINUE"],
+      ],
     }],
     "previousStatement": null,
     "style": "loop_blocks",
@@ -197,9 +197,9 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "suppressPrefixSuffix": true,
     "extensions": [
       "controls_flow_tooltip",
-      "controls_flow_in_loop_check"
-    ]
-  }
+      "controls_flow_in_loop_check",
+    ],
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 /**
@@ -210,7 +210,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
  */
 Blockly.Constants.Loops.WHILE_UNTIL_TOOLTIPS = {
   'WHILE': '%{BKY_CONTROLS_WHILEUNTIL_TOOLTIP_WHILE}',
-  'UNTIL': '%{BKY_CONTROLS_WHILEUNTIL_TOOLTIP_UNTIL}'
+  'UNTIL': '%{BKY_CONTROLS_WHILEUNTIL_TOOLTIP_UNTIL}',
 };
 
 Blockly.Extensions.register('controls_whileUntil_tooltip',
@@ -225,7 +225,7 @@ Blockly.Extensions.register('controls_whileUntil_tooltip',
  */
 Blockly.Constants.Loops.BREAK_CONTINUE_TOOLTIPS = {
   'BREAK': '%{BKY_CONTROLS_FLOW_STATEMENTS_TOOLTIP_BREAK}',
-  'CONTINUE': '%{BKY_CONTROLS_FLOW_STATEMENTS_TOOLTIP_CONTINUE}'
+  'CONTINUE': '%{BKY_CONTROLS_FLOW_STATEMENTS_TOOLTIP_CONTINUE}',
 };
 
 Blockly.Extensions.register('controls_flow_tooltip',
@@ -264,7 +264,7 @@ Blockly.Constants.Loops.CUSTOM_CONTEXT_MENU_CREATE_VARIABLES_GET_MIXIN = {
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);
     }
-  }
+  },
 };
 
 Blockly.Extensions.registerMixin('contextMenu_newGetVariableBlock',
@@ -297,7 +297,7 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
     'controls_repeat_ext',
     'controls_forEach',
     'controls_for',
-    'controls_whileUntil'
+    'controls_whileUntil',
   ],
 
   /**
@@ -342,7 +342,7 @@ Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
       this.setEnabled(enabled);
       Blockly.Events.setGroup(group);
     }
-  }
+  },
 };
 
 Blockly.Extensions.registerMixin('controls_flow_in_loop_check',

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -38,13 +38,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [{
       "type": "field_number",
       "name": "NUM",
-      "value": 0
+      "value": 0,
     }],
     "output": "Number",
     "helpUrl": "%{BKY_MATH_NUMBER_HELPURL}",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_NUMBER_TOOLTIP}",
-    "extensions": ["parent_tooltip_when_inline"]
+    "extensions": ["parent_tooltip_when_inline"],
   },
 
   // Block for basic arithmetic operator.
@@ -55,7 +55,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "A",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "field_dropdown",
@@ -65,20 +65,20 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["%{BKY_MATH_SUBTRACTION_SYMBOL}", "MINUS"],
           ["%{BKY_MATH_MULTIPLICATION_SYMBOL}", "MULTIPLY"],
           ["%{BKY_MATH_DIVISION_SYMBOL}", "DIVIDE"],
-          ["%{BKY_MATH_POWER_SYMBOL}", "POWER"]
-        ]
+          ["%{BKY_MATH_POWER_SYMBOL}", "POWER"],
+        ],
       },
       {
         "type": "input_value",
         "name": "B",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "inputsInline": true,
     "output": "Number",
     "style": "math_blocks",
     "helpUrl": "%{BKY_MATH_ARITHMETIC_HELPURL}",
-    "extensions": ["math_op_tooltip"]
+    "extensions": ["math_op_tooltip"],
   },
 
   // Block for advanced math operators with single operand.
@@ -96,19 +96,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ['ln', 'LN'],
           ['log10', 'LOG10'],
           ['e^', 'EXP'],
-          ['10^', 'POW10']
-        ]
+          ['10^', 'POW10'],
+        ],
       },
       {
         "type": "input_value",
         "name": "NUM",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "output": "Number",
     "style": "math_blocks",
     "helpUrl": "%{BKY_MATH_SINGLE_HELPURL}",
-    "extensions": ["math_op_tooltip"]
+    "extensions": ["math_op_tooltip"],
   },
 
   // Block for trigonometry operators.
@@ -125,19 +125,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["%{BKY_MATH_TRIG_TAN}", "TAN"],
           ["%{BKY_MATH_TRIG_ASIN}", "ASIN"],
           ["%{BKY_MATH_TRIG_ACOS}", "ACOS"],
-          ["%{BKY_MATH_TRIG_ATAN}", "ATAN"]
-        ]
+          ["%{BKY_MATH_TRIG_ATAN}", "ATAN"],
+        ],
       },
       {
         "type": "input_value",
         "name": "NUM",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "output": "Number",
     "style": "math_blocks",
     "helpUrl": "%{BKY_MATH_TRIG_HELPURL}",
-    "extensions": ["math_op_tooltip"]
+    "extensions": ["math_op_tooltip"],
   },
 
   // Block for constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
@@ -154,14 +154,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["\u03c6", "GOLDEN_RATIO"],
           ["sqrt(2)", "SQRT2"],
           ["sqrt(\u00bd)", "SQRT1_2"],
-          ["\u221e", "INFINITY"]
-        ]
-      }
+          ["\u221e", "INFINITY"],
+        ],
+      },
     ],
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_CONSTANT_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_CONSTANT_HELPURL}"
+    "helpUrl": "%{BKY_MATH_CONSTANT_HELPURL}",
   },
 
   // Block for checking if a number is even, odd, prime, whole, positive,
@@ -173,7 +173,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "NUMBER_TO_CHECK",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "field_dropdown",
@@ -185,15 +185,15 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["%{BKY_MATH_IS_WHOLE}", "WHOLE"],
           ["%{BKY_MATH_IS_POSITIVE}", "POSITIVE"],
           ["%{BKY_MATH_IS_NEGATIVE}", "NEGATIVE"],
-          ["%{BKY_MATH_IS_DIVISIBLE_BY}", "DIVISIBLE_BY"]
-        ]
-      }
+          ["%{BKY_MATH_IS_DIVISIBLE_BY}", "DIVISIBLE_BY"],
+        ],
+      },
     ],
     "inputsInline": true,
     "output": "Boolean",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_IS_TOOLTIP}",
-    "mutator": "math_is_divisibleby_mutator"
+    "mutator": "math_is_divisibleby_mutator",
   },
 
   // Block for adding to a variable in place.
@@ -204,19 +204,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_variable",
         "name": "VAR",
-        "variable": "%{BKY_MATH_CHANGE_TITLE_ITEM}"
+        "variable": "%{BKY_MATH_CHANGE_TITLE_ITEM}",
       },
       {
         "type": "input_value",
         "name": "DELTA",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "previousStatement": null,
     "nextStatement": null,
     "style": "variable_blocks",
     "helpUrl": "%{BKY_MATH_CHANGE_HELPURL}",
-    "extensions": ["math_change_tooltip"]
+    "extensions": ["math_change_tooltip"],
   },
 
   // Block for rounding functions.
@@ -230,19 +230,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "options": [
           ["%{BKY_MATH_ROUND_OPERATOR_ROUND}", "ROUND"],
           ["%{BKY_MATH_ROUND_OPERATOR_ROUNDUP}", "ROUNDUP"],
-          ["%{BKY_MATH_ROUND_OPERATOR_ROUNDDOWN}", "ROUNDDOWN"]
-        ]
+          ["%{BKY_MATH_ROUND_OPERATOR_ROUNDDOWN}", "ROUNDDOWN"],
+        ],
       },
       {
         "type": "input_value",
         "name": "NUM",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "output": "Number",
     "style": "math_blocks",
     "helpUrl": "%{BKY_MATH_ROUND_HELPURL}",
-    "tooltip": "%{BKY_MATH_ROUND_TOOLTIP}"
+    "tooltip": "%{BKY_MATH_ROUND_TOOLTIP}",
   },
 
   // Block for evaluating a list of numbers to return sum, average, min, max,
@@ -262,20 +262,20 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["%{BKY_MATH_ONLIST_OPERATOR_MEDIAN}", "MEDIAN"],
           ["%{BKY_MATH_ONLIST_OPERATOR_MODE}", "MODE"],
           ["%{BKY_MATH_ONLIST_OPERATOR_STD_DEV}", "STD_DEV"],
-          ["%{BKY_MATH_ONLIST_OPERATOR_RANDOM}", "RANDOM"]
-        ]
+          ["%{BKY_MATH_ONLIST_OPERATOR_RANDOM}", "RANDOM"],
+        ],
       },
       {
         "type": "input_value",
         "name": "LIST",
-        "check": "Array"
-      }
+        "check": "Array",
+      },
     ],
     "output": "Number",
     "style": "math_blocks",
     "helpUrl": "%{BKY_MATH_ONLIST_HELPURL}",
     "mutator": "math_modes_of_list_mutator",
-    "extensions": ["math_op_tooltip"]
+    "extensions": ["math_op_tooltip"],
   },
 
   // Block for remainder of a division.
@@ -286,19 +286,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "DIVIDEND",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "input_value",
         "name": "DIVISOR",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "inputsInline": true,
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_MODULO_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_MODULO_HELPURL}"
+    "helpUrl": "%{BKY_MATH_MODULO_HELPURL}",
   },
 
   // Block for constraining a number between two limits.
@@ -309,24 +309,24 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "input_value",
         "name": "LOW",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "input_value",
         "name": "HIGH",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "inputsInline": true,
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_CONSTRAIN_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_CONSTRAIN_HELPURL}"
+    "helpUrl": "%{BKY_MATH_CONSTRAIN_HELPURL}",
   },
 
   // Block for random integer between [X] and [Y].
@@ -337,19 +337,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "FROM",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "input_value",
         "name": "TO",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "inputsInline": true,
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_RANDOM_INT_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_RANDOM_INT_HELPURL}"
+    "helpUrl": "%{BKY_MATH_RANDOM_INT_HELPURL}",
   },
 
   // Block for random integer between [X] and [Y].
@@ -359,7 +359,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_RANDOM_FLOAT_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_RANDOM_FLOAT_HELPURL}"
+    "helpUrl": "%{BKY_MATH_RANDOM_FLOAT_HELPURL}",
   },
 
   // Block for calculating atan2 of [X] and [Y].
@@ -370,20 +370,20 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "X",
-        "check": "Number"
+        "check": "Number",
       },
       {
         "type": "input_value",
         "name": "Y",
-        "check": "Number"
-      }
+        "check": "Number",
+      },
     ],
     "inputsInline": true,
     "output": "Number",
     "style": "math_blocks",
     "tooltip": "%{BKY_MATH_ATAN2_TOOLTIP}",
-    "helpUrl": "%{BKY_MATH_ATAN2_HELPURL}"
-  }
+    "helpUrl": "%{BKY_MATH_ATAN2_HELPURL}",
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 /**
@@ -426,7 +426,7 @@ Blockly.Constants.Math.TOOLTIPS_BY_OP = {
   'MEDIAN': '%{BKY_MATH_ONLIST_TOOLTIP_MEDIAN}',
   'MODE': '%{BKY_MATH_ONLIST_TOOLTIP_MODE}',
   'STD_DEV': '%{BKY_MATH_ONLIST_TOOLTIP_STD_DEV}',
-  'RANDOM': '%{BKY_MATH_ONLIST_TOOLTIP_RANDOM}'
+  'RANDOM': '%{BKY_MATH_ONLIST_TOOLTIP_RANDOM}',
 };
 
 Blockly.Extensions.register('math_op_tooltip',
@@ -487,7 +487,7 @@ Blockly.Constants.Math.IS_DIVISIBLEBY_MUTATOR_MIXIN = {
     } else if (inputExists) {
       this.removeInput('DIVISOR');
     }
-  }
+  },
 };
 
 /**

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -168,7 +168,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
           // We don't need to serialize the name, but just in case we decide
           // to separate params from variables.
           'name': this.argumentVarModels_[i].name,
-          'id': this.argumentVarModels_[i].getId()
+          'id': this.argumentVarModels_[i].getId(),
         });
       }
     }
@@ -445,7 +445,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       }
     }
   },
-  callType_: 'procedures_callnoreturn'
+  callType_: 'procedures_callnoreturn',
 };
 
 Blockly.Blocks['procedures_defreturn'] = {
@@ -505,7 +505,7 @@ Blockly.Blocks['procedures_defreturn'] = {
   updateVarName: Blockly.Blocks['procedures_defnoreturn'].updateVarName,
   displayRenamedVar_: Blockly.Blocks['procedures_defnoreturn'].displayRenamedVar_,
   customContextMenu: Blockly.Blocks['procedures_defnoreturn'].customContextMenu,
-  callType_: 'procedures_callreturn'
+  callType_: 'procedures_callreturn',
 };
 
 Blockly.Blocks['procedures_mutatorcontainer'] = {
@@ -634,7 +634,7 @@ Blockly.Blocks['procedures_mutatorarg'] = {
         outerWs.deleteVariableById(model.getId());
       }
     }
-  }
+  },
 };
 
 Blockly.Blocks['procedures_callnoreturn'] = {
@@ -1026,7 +1026,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
     };
     options.push(option);
   },
-  defType_: 'procedures_defnoreturn'
+  defType_: 'procedures_defnoreturn',
 };
 
 Blockly.Blocks['procedures_callreturn'] = {
@@ -1062,7 +1062,7 @@ Blockly.Blocks['procedures_callreturn'] = {
   onchange: Blockly.Blocks['procedures_callnoreturn'].onchange,
   customContextMenu:
       Blockly.Blocks['procedures_callnoreturn'].customContextMenu,
-  defType_: 'procedures_defreturn'
+  defType_: 'procedures_defreturn',
 };
 
 Blockly.Blocks['procedures_ifreturn'] = {
@@ -1164,5 +1164,5 @@ Blockly.Blocks['procedures_ifreturn'] = {
    * To add a new function type add this to your code:
    * Blockly.Blocks['procedures_ifreturn'].FUNCTION_TYPES.push('custom_func');
    */
-  FUNCTION_TYPES: ['procedures_defnoreturn', 'procedures_defreturn']
+  FUNCTION_TYPES: ['procedures_defnoreturn', 'procedures_defreturn'],
 };

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -35,7 +35,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [{
       "type": "field_input",
       "name": "TEXT",
-      "text": ""
+      "text": "",
     }],
     "output": "String",
     "style": "text_blocks",
@@ -43,8 +43,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "%{BKY_TEXT_TEXT_TOOLTIP}",
     "extensions": [
       "text_quotes",
-      "parent_tooltip_when_inline"
-    ]
+      "parent_tooltip_when_inline",
+    ],
   },
   {
     "type": "text_multiline",
@@ -62,19 +62,19 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
              'wA5X2Z9AYnQrEAAAAASUVORK5CYII=',
       "width": 12,
       "height": 17,
-      "alt": '\u00B6'
+      "alt": '\u00B6',
     },{
       "type": "field_multilinetext",
       "name": "TEXT",
-      "text": ""
+      "text": "",
     }],
     "output": "String",
     "style": "text_blocks",
     "helpUrl": "%{BKY_TEXT_TEXT_HELPURL}",
     "tooltip": "%{BKY_TEXT_TEXT_TOOLTIP}",
     "extensions": [
-      "parent_tooltip_when_inline"
-    ]
+      "parent_tooltip_when_inline",
+    ],
   },
   {
     "type": "text_join",
@@ -83,22 +83,22 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "style": "text_blocks",
     "helpUrl": "%{BKY_TEXT_JOIN_HELPURL}",
     "tooltip": "%{BKY_TEXT_JOIN_TOOLTIP}",
-    "mutator": "text_join_mutator"
+    "mutator": "text_join_mutator",
 
   },
   {
     "type": "text_create_join_container",
     "message0": "%{BKY_TEXT_CREATE_JOIN_TITLE_JOIN} %1 %2",
     "args0": [{
-      "type": "input_dummy"
+      "type": "input_dummy",
     },
     {
       "type": "input_statement",
-      "name": "STACK"
+      "name": "STACK",
     }],
     "style": "text_blocks",
     "tooltip": "%{BKY_TEXT_CREATE_JOIN_TOOLTIP}",
-    "enableContextMenu": false
+    "enableContextMenu": false,
   },
   {
     "type": "text_create_join_item",
@@ -107,7 +107,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "nextStatement": null,
     "style": "text_blocks",
     "tooltip": "%{BKY_TEXT_CREATE_JOIN_ITEM_TOOLTIP}",
-    "enableContextMenu": false
+    "enableContextMenu": false,
   },
   {
     "type": "text_append",
@@ -115,18 +115,18 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "args0": [{
       "type": "field_variable",
       "name": "VAR",
-      "variable": "%{BKY_TEXT_APPEND_VARIABLE}"
+      "variable": "%{BKY_TEXT_APPEND_VARIABLE}",
     },
     {
       "type": "input_value",
-      "name": "TEXT"
+      "name": "TEXT",
     }],
     "previousStatement": null,
     "nextStatement": null,
     "style": "text_blocks",
     "extensions": [
-      "text_append_tooltip"
-    ]
+      "text_append_tooltip",
+    ],
   },
   {
     "type": "text_length",
@@ -135,13 +135,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": ['String', 'Array']
-      }
+        "check": ['String', 'Array'],
+      },
     ],
     "output": 'Number',
     "style": "text_blocks",
     "tooltip": "%{BKY_TEXT_LENGTH_TOOLTIP}",
-    "helpUrl": "%{BKY_TEXT_LENGTH_HELPURL}"
+    "helpUrl": "%{BKY_TEXT_LENGTH_HELPURL}",
   },
   {
     "type": "text_isEmpty",
@@ -150,13 +150,13 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": ['String', 'Array']
-      }
+        "check": ['String', 'Array'],
+      },
     ],
     "output": 'Boolean',
     "style": "text_blocks",
     "tooltip": "%{BKY_TEXT_ISEMPTY_TOOLTIP}",
-    "helpUrl": "%{BKY_TEXT_ISEMPTY_HELPURL}"
+    "helpUrl": "%{BKY_TEXT_ISEMPTY_HELPURL}",
   },
   {
     "type": "text_indexOf",
@@ -165,7 +165,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "input_value",
         "name": "VALUE",
-        "check": "String"
+        "check": "String",
       },
       {
         "type": "field_dropdown",
@@ -173,27 +173,27 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
         "options": [
           [
             "%{BKY_TEXT_INDEXOF_OPERATOR_FIRST}",
-            "FIRST"
+            "FIRST",
           ],
           [
             "%{BKY_TEXT_INDEXOF_OPERATOR_LAST}",
-            "LAST"
-          ]
-        ]
+            "LAST",
+          ],
+        ],
       },
       {
         "type": "input_value",
         "name": "FIND",
-        "check": "String"
-      }
+        "check": "String",
+      },
     ],
     "output": "Number",
     "style": "text_blocks",
     "helpUrl": "%{BKY_TEXT_INDEXOF_HELPURL}",
     "inputsInline": true,
     "extensions": [
-      "text_indexOf_tooltip"
-    ]
+      "text_indexOf_tooltip",
+    ],
   },
   {
     "type": "text_charAt",
@@ -202,7 +202,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type":"input_value",
         "name": "VALUE",
-        "check": "String"
+        "check": "String",
       },
       {
         "type": "field_dropdown",
@@ -212,16 +212,16 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
           ["%{BKY_TEXT_CHARAT_FROM_END}", "FROM_END"],
           ["%{BKY_TEXT_CHARAT_FIRST}", "FIRST"],
           ["%{BKY_TEXT_CHARAT_LAST}", "LAST"],
-          ["%{BKY_TEXT_CHARAT_RANDOM}", "RANDOM"]
-        ]
-      }
+          ["%{BKY_TEXT_CHARAT_RANDOM}", "RANDOM"],
+        ],
+      },
     ],
     "output": "String",
     "style": "text_blocks",
     "helpUrl": "%{BKY_TEXT_CHARAT_HELPURL}",
     "inputsInline": true,
-    "mutator": "text_charAt_mutator"
-  }
+    "mutator": "text_charAt_mutator",
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 Blockly.Blocks['text_getSubstring'] = {
@@ -233,12 +233,12 @@ Blockly.Blocks['text_getSubstring'] = {
     this['WHERE_OPTIONS_1'] = [
       [Blockly.Msg['TEXT_GET_SUBSTRING_START_FROM_START'], 'FROM_START'],
       [Blockly.Msg['TEXT_GET_SUBSTRING_START_FROM_END'], 'FROM_END'],
-      [Blockly.Msg['TEXT_GET_SUBSTRING_START_FIRST'], 'FIRST']
+      [Blockly.Msg['TEXT_GET_SUBSTRING_START_FIRST'], 'FIRST'],
     ];
     this['WHERE_OPTIONS_2'] = [
       [Blockly.Msg['TEXT_GET_SUBSTRING_END_FROM_START'], 'FROM_START'],
       [Blockly.Msg['TEXT_GET_SUBSTRING_END_FROM_END'], 'FROM_END'],
-      [Blockly.Msg['TEXT_GET_SUBSTRING_END_LAST'], 'LAST']
+      [Blockly.Msg['TEXT_GET_SUBSTRING_END_LAST'], 'LAST'],
     ];
     this.setHelpUrl(Blockly.Msg['TEXT_GET_SUBSTRING_HELPURL']);
     this.setStyle('text_blocks');
@@ -342,7 +342,7 @@ Blockly.Blocks['text_getSubstring'] = {
         this.moveInputBefore('ORDINAL1', 'AT2');
       }
     }
-  }
+  },
 };
 
 Blockly.Blocks['text_changeCase'] = {
@@ -354,7 +354,7 @@ Blockly.Blocks['text_changeCase'] = {
     var OPERATORS = [
       [Blockly.Msg['TEXT_CHANGECASE_OPERATOR_UPPERCASE'], 'UPPERCASE'],
       [Blockly.Msg['TEXT_CHANGECASE_OPERATOR_LOWERCASE'], 'LOWERCASE'],
-      [Blockly.Msg['TEXT_CHANGECASE_OPERATOR_TITLECASE'], 'TITLECASE']
+      [Blockly.Msg['TEXT_CHANGECASE_OPERATOR_TITLECASE'], 'TITLECASE'],
     ];
     this.setHelpUrl(Blockly.Msg['TEXT_CHANGECASE_HELPURL']);
     this.setStyle('text_blocks');
@@ -363,7 +363,7 @@ Blockly.Blocks['text_changeCase'] = {
         .appendField(new Blockly.FieldDropdown(OPERATORS), 'CASE');
     this.setOutput(true, 'String');
     this.setTooltip(Blockly.Msg['TEXT_CHANGECASE_TOOLTIP']);
-  }
+  },
 };
 
 Blockly.Blocks['text_trim'] = {
@@ -375,7 +375,7 @@ Blockly.Blocks['text_trim'] = {
     var OPERATORS = [
       [Blockly.Msg['TEXT_TRIM_OPERATOR_BOTH'], 'BOTH'],
       [Blockly.Msg['TEXT_TRIM_OPERATOR_LEFT'], 'LEFT'],
-      [Blockly.Msg['TEXT_TRIM_OPERATOR_RIGHT'], 'RIGHT']
+      [Blockly.Msg['TEXT_TRIM_OPERATOR_RIGHT'], 'RIGHT'],
     ];
     this.setHelpUrl(Blockly.Msg['TEXT_TRIM_HELPURL']);
     this.setStyle('text_blocks');
@@ -384,7 +384,7 @@ Blockly.Blocks['text_trim'] = {
         .appendField(new Blockly.FieldDropdown(OPERATORS), 'MODE');
     this.setOutput(true, 'String');
     this.setTooltip(Blockly.Msg['TEXT_TRIM_TOOLTIP']);
-  }
+  },
 };
 
 Blockly.Blocks['text_print'] = {
@@ -398,16 +398,16 @@ Blockly.Blocks['text_print'] = {
       "args0": [
         {
           "type": "input_value",
-          "name": "TEXT"
-        }
+          "name": "TEXT",
+        },
       ],
       "previousStatement": null,
       "nextStatement": null,
       "style": "text_blocks",
       "tooltip": Blockly.Msg['TEXT_PRINT_TOOLTIP'],
-      "helpUrl": Blockly.Msg['TEXT_PRINT_HELPURL']
+      "helpUrl": Blockly.Msg['TEXT_PRINT_HELPURL'],
     });
-  }
+  },
 };
 
 Blockly.Blocks['text_prompt_ext'] = {
@@ -418,7 +418,7 @@ Blockly.Blocks['text_prompt_ext'] = {
   init: function() {
     var TYPES = [
       [Blockly.Msg['TEXT_PROMPT_TYPE_TEXT'], 'TEXT'],
-      [Blockly.Msg['TEXT_PROMPT_TYPE_NUMBER'], 'NUMBER']
+      [Blockly.Msg['TEXT_PROMPT_TYPE_NUMBER'], 'NUMBER'],
     ];
     this.setHelpUrl(Blockly.Msg['TEXT_PROMPT_HELPURL']);
     this.setStyle('text_blocks');
@@ -482,7 +482,7 @@ Blockly.Blocks['text_prompt'] = {
     this.mixin(Blockly.Constants.Text.QUOTE_IMAGE_MIXIN);
     var TYPES = [
       [Blockly.Msg['TEXT_PROMPT_TYPE_TEXT'], 'TEXT'],
-      [Blockly.Msg['TEXT_PROMPT_TYPE_NUMBER'], 'NUMBER']
+      [Blockly.Msg['TEXT_PROMPT_TYPE_NUMBER'], 'NUMBER'],
     ];
 
     // Assign 'this' to a variable for use in the closures below.
@@ -506,7 +506,7 @@ Blockly.Blocks['text_prompt'] = {
   },
   updateType_: Blockly.Blocks['text_prompt_ext'].updateType_,
   mutationToDom: Blockly.Blocks['text_prompt_ext'].mutationToDom,
-  domToMutation: Blockly.Blocks['text_prompt_ext'].domToMutation
+  domToMutation: Blockly.Blocks['text_prompt_ext'].domToMutation,
 };
 
 Blockly.Blocks['text_count'] = {
@@ -521,21 +521,21 @@ Blockly.Blocks['text_count'] = {
         {
           "type": "input_value",
           "name": "SUB",
-          "check": "String"
+          "check": "String",
         },
         {
           "type": "input_value",
           "name": "TEXT",
-          "check": "String"
-        }
+          "check": "String",
+        },
       ],
       "output": "Number",
       "inputsInline": true,
       "style": "text_blocks",
       "tooltip": Blockly.Msg['TEXT_COUNT_TOOLTIP'],
-      "helpUrl": Blockly.Msg['TEXT_COUNT_HELPURL']
+      "helpUrl": Blockly.Msg['TEXT_COUNT_HELPURL'],
     });
-  }
+  },
 };
 
 Blockly.Blocks['text_replace'] = {
@@ -550,26 +550,26 @@ Blockly.Blocks['text_replace'] = {
         {
           "type": "input_value",
           "name": "FROM",
-          "check": "String"
+          "check": "String",
         },
         {
           "type": "input_value",
           "name": "TO",
-          "check": "String"
+          "check": "String",
         },
         {
           "type": "input_value",
           "name": "TEXT",
-          "check": "String"
-        }
+          "check": "String",
+        },
       ],
       "output": "String",
       "inputsInline": true,
       "style": "text_blocks",
       "tooltip": Blockly.Msg['TEXT_REPLACE_TOOLTIP'],
-      "helpUrl": Blockly.Msg['TEXT_REPLACE_HELPURL']
+      "helpUrl": Blockly.Msg['TEXT_REPLACE_HELPURL'],
     });
-  }
+  },
 };
 
 Blockly.Blocks['text_reverse'] = {
@@ -584,16 +584,16 @@ Blockly.Blocks['text_reverse'] = {
         {
           "type": "input_value",
           "name": "TEXT",
-          "check": "String"
-        }
+          "check": "String",
+        },
       ],
       "output": "String",
       "inputsInline": true,
       "style": "text_blocks",
       "tooltip": Blockly.Msg['TEXT_REVERSE_TOOLTIP'],
-      "helpUrl": Blockly.Msg['TEXT_REVERSE_HELPURL']
+      "helpUrl": Blockly.Msg['TEXT_REVERSE_HELPURL'],
     });
-  }
+  },
 };
 
 /**
@@ -670,7 +670,7 @@ Blockly.Constants.Text.QUOTE_IMAGE_MIXIN = {
         this.QUOTE_IMAGE_WIDTH,
         this.QUOTE_IMAGE_HEIGHT,
         isLeft ? '\u201C' : '\u201D');
-  }
+  },
 };
 
 /**
@@ -817,7 +817,7 @@ Blockly.Constants.Text.TEXT_JOIN_MUTATOR_MIXIN = {
       this.removeInput('ADD' + i);
       i++;
     }
-  }
+  },
 };
 
 /**
@@ -913,7 +913,7 @@ Blockly.Constants.Text.TEXT_CHARAT_MUTATOR_MIXIN = {
     }
 
     this.isAt_ = isAt;
-  }
+  },
 };
 
 /**

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -37,14 +37,14 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_variable",
         "name": "VAR",
-        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}"
-      }
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+      },
     ],
     "output": null,
     "style": "variable_blocks",
     "helpUrl": "%{BKY_VARIABLES_GET_HELPURL}",
     "tooltip": "%{BKY_VARIABLES_GET_TOOLTIP}",
-    "extensions": ["contextMenu_variableSetterGetter"]
+    "extensions": ["contextMenu_variableSetterGetter"],
   },
   // Block for variable setter.
   {
@@ -54,20 +54,20 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       {
         "type": "field_variable",
         "name": "VAR",
-        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}"
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
       },
       {
         "type": "input_value",
-        "name": "VALUE"
-      }
+        "name": "VALUE",
+      },
     ],
     "previousStatement": null,
     "nextStatement": null,
     "style": "variable_blocks",
     "tooltip": "%{BKY_VARIABLES_SET_TOOLTIP}",
     "helpUrl": "%{BKY_VARIABLES_SET_HELPURL}",
-    "extensions": ["contextMenu_variableSetterGetter"]
-  }
+    "extensions": ["contextMenu_variableSetterGetter"],
+  },
 ]);  // END JSON EXTRACT (Do not delete this comment.)
 
 /**
@@ -113,19 +113,19 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
         var renameOption = {
           text: Blockly.Msg.RENAME_VARIABLE,
           enabled: true,
-          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
+          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this),
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
           text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
           enabled: true,
-          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
+          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this),
         };
         options.unshift(renameOption);
         options.unshift(deleteOption);
       }
     }
-  }
+  },
 };
 
 /**

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -35,13 +35,13 @@ Blockly.defineBlocksWithJsonArray([ // BEGIN JSON EXTRACT
     "args0": [{
       "type": "field_variable",
       "name": "VAR",
-      "variable": "%{BKY_VARIABLES_DEFAULT_NAME}"
+      "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
     }],
     "output": null,
     "style": "variable_dynamic_blocks",
     "helpUrl": "%{BKY_VARIABLES_GET_HELPURL}",
     "tooltip": "%{BKY_VARIABLES_GET_TOOLTIP}",
-    "extensions": ["contextMenu_variableDynamicSetterGetter"]
+    "extensions": ["contextMenu_variableDynamicSetterGetter"],
   },
   // Block for variable setter.
   {
@@ -50,20 +50,20 @@ Blockly.defineBlocksWithJsonArray([ // BEGIN JSON EXTRACT
     "args0": [{
       "type": "field_variable",
       "name": "VAR",
-      "variable": "%{BKY_VARIABLES_DEFAULT_NAME}"
+      "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
     },
     {
       "type": "input_value",
-      "name": "VALUE"
-    }
+      "name": "VALUE",
+    },
     ],
     "previousStatement": null,
     "nextStatement": null,
     "style": "variable_dynamic_blocks",
     "tooltip": "%{BKY_VARIABLES_SET_TOOLTIP}",
     "helpUrl": "%{BKY_VARIABLES_SET_HELPURL}",
-    "extensions": ["contextMenu_variableDynamicSetterGetter"]
-  }
+    "extensions": ["contextMenu_variableDynamicSetterGetter"],
+  },
 ]); // END JSON EXTRACT (Do not delete this comment.)
 
 /**
@@ -115,13 +115,13 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
         var renameOption = {
           text: Blockly.Msg.RENAME_VARIABLE,
           enabled: true,
-          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this)
+          callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this),
         };
         var name = this.getField('VAR').getText();
         var deleteOption = {
           text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
           enabled: true,
-          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this)
+          callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this),
         };
         options.unshift(renameOption);
         options.unshift(deleteOption);
@@ -142,7 +142,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
     } else {
       this.getInput('VALUE').connection.setCheck(variableModel.type);
     }
-  }
+  },
 };
 
 /**

--- a/core/block.js
+++ b/core/block.js
@@ -1833,7 +1833,7 @@ Block.prototype.inputFromJson_ = function(element, warningPrefix) {
     'LEFT': constants.ALIGN.LEFT,
     'RIGHT': constants.ALIGN.RIGHT,
     'CENTRE': constants.ALIGN.CENTRE,
-    'CENTER': constants.ALIGN.CENTRE
+    'CENTER': constants.ALIGN.CENTRE,
   };
 
   let input = null;

--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -114,7 +114,7 @@ const connectionUiEffect = function(block) {
         'r': 0,
         'fill': 'none',
         'stroke': '#888',
-        'stroke-width': 10
+        'stroke-width': 10,
       },
       workspace.getParentSvg());
   // Start the animation.

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -109,7 +109,7 @@ BlockDragSurfaceSvg.prototype.createDom = function() {
         'xmlns:html': dom.HTML_NS,
         'xmlns:xlink': dom.XLINK_NS,
         'version': '1.1',
-        'class': 'blocklyBlockDragSurface'
+        'class': 'blocklyBlockDragSurface',
       },
       this.container_);
   this.dragGroup_ = dom.createSvgElement(Svg.G, {}, this.SVG_);

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -133,7 +133,7 @@ const initIconData = function(block) {
         // coordinates).
         location: icons[j].getIconLocation(),
         // Blockly.Icon
-        icon: icons[j]
+        icon: icons[j],
       };
       dragIconData.push(data);
     }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -973,7 +973,7 @@ BlockSvg.prototype.toCopyData = function() {
     saveInfo: /** @type {!blocks.State} */ (
         blocks.save(this, {addCoordinates: true, addNextBlocks: false})),
     source: this.workspace,
-    typeCounts: utils.getBlockTypeCounts(this, true)
+    typeCounts: utils.getBlockTypeCounts(this, true),
   };
 };
 

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -206,7 +206,7 @@ Object.defineProperties(exports, {
           'Blockly.alert', 'September 2021', 'September 2022',
           'Blockly.dialog.alert()');
       return dialog.alert;
-    }
+    },
   },
   /**
    * Wrapper to window.confirm() that app developers may override to
@@ -227,7 +227,7 @@ Object.defineProperties(exports, {
           'Blockly.confirm', 'September 2021', 'September 2022',
           'Blockly.dialog.confirm()');
       return dialog.confirm;
-    }
+    },
   },
   /**
    * The main workspace most recently used.
@@ -249,7 +249,7 @@ Object.defineProperties(exports, {
           'Blockly.mainWorkspace', 'September 2021', 'September 2022',
           'Blockly.getMainWorkspace()');
       return common.getMainWorkspace();
-    }
+    },
   },
   /**
    * Wrapper to window.prompt() that app developers may override to
@@ -273,7 +273,7 @@ Object.defineProperties(exports, {
           'Blockly.prompt', 'September 2021', 'September 2022',
           'Blockly.dialog.prompt()');
       return dialog.prompt;
-    }
+    },
   },
   /**
    * Currently selected block.
@@ -295,7 +295,7 @@ Object.defineProperties(exports, {
           'Blockly.selected', 'September 2021', 'September 2022',
           'Blockly.common.setSelected()');
       common.setSelected(newSelection);
-    }
+    },
   },
 });
 

--- a/core/browser_events.js
+++ b/core/browser_events.js
@@ -255,12 +255,12 @@ const getScrollDeltaPixels = function(e) {
     case 0x01:  // Line mode.
       return {
         x: e.deltaX * internalConstants.LINE_MODE_MULTIPLIER,
-        y: e.deltaY * internalConstants.LINE_MODE_MULTIPLIER
+        y: e.deltaY * internalConstants.LINE_MODE_MULTIPLIER,
       };
     case 0x02:  // Page mode.
       return {
         x: e.deltaX * internalConstants.PAGE_MODE_MULTIPLIER,
-        y: e.deltaY * internalConstants.PAGE_MODE_MULTIPLIER
+        y: e.deltaY * internalConstants.PAGE_MODE_MULTIPLIER,
       };
   }
 };

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -253,7 +253,7 @@ Bubble.prototype.createDom_ = function(content, hasResize) {
   this.bubbleGroup_ = dom.createSvgElement(Svg.G, {}, null);
   let filter = {
     'filter': 'url(#' +
-        this.workspace_.getRenderer().getConstants().embossFilterId + ')'
+        this.workspace_.getRenderer().getConstants().embossFilterId + ')',
   };
   if (userAgent.JAVA_FX) {
     // Multiple reports that JavaFX can't handle filters.
@@ -268,7 +268,7 @@ Bubble.prototype.createDom_ = function(content, hasResize) {
         'x': 0,
         'y': 0,
         'rx': Bubble.BORDER_WIDTH,
-        'ry': Bubble.BORDER_WIDTH
+        'ry': Bubble.BORDER_WIDTH,
       },
       bubbleEmboss);
   if (hasResize) {
@@ -287,7 +287,7 @@ Bubble.prototype.createDom_ = function(content, hasResize) {
           'x1': resizeSize / 3,
           'y1': resizeSize - 1,
           'x2': resizeSize - 1,
-          'y2': resizeSize / 3
+          'y2': resizeSize / 3,
         },
         this.resizeGroup_);
     dom.createSvgElement(
@@ -296,7 +296,7 @@ Bubble.prototype.createDom_ = function(content, hasResize) {
           'x1': resizeSize * 2 / 3,
           'y1': resizeSize - 1,
           'x2': resizeSize - 1,
-          'y2': resizeSize * 2 / 3
+          'y2': resizeSize * 2 / 3,
         },
         this.resizeGroup_);
   } else {
@@ -473,7 +473,7 @@ Bubble.prototype.layoutBubble_ = function() {
   const topPosition = {
     x: optimalLeft,
     y: -this.height_ -
-        this.workspace_.getRenderer().getConstants().MIN_BLOCK_HEIGHT
+        this.workspace_.getRenderer().getConstants().MIN_BLOCK_HEIGHT,
   };
   const startPosition = {x: -this.width_ - 30, y: optimalTop};
   const endPosition = {x: bbox.width, y: optimalTop};
@@ -531,12 +531,12 @@ Bubble.prototype.getOverlap_ = function(relativeMin, viewMetrics) {
   const bubbleMin = {
     x: this.workspace_.RTL ? (this.anchorXY_.x - relativeMin.x - this.width_) :
                              (relativeMin.x + this.anchorXY_.x),
-    y: relativeMin.y + this.anchorXY_.y
+    y: relativeMin.y + this.anchorXY_.y,
   };
   // The position of the bottom-right corner of the bubble in workspace units.
   const bubbleMax = {
     x: bubbleMin.x + this.width_,
-    y: bubbleMin.y + this.height_
+    y: bubbleMin.y + this.height_,
   };
 
   // We could adjust these values to account for the scrollbars, but the
@@ -549,7 +549,7 @@ Bubble.prototype.getOverlap_ = function(relativeMin, viewMetrics) {
   // The position of the bottom-right corner of the workspace.
   const workspaceMax = {
     x: viewMetrics.left + viewMetrics.width,
-    y: viewMetrics.top + viewMetrics.height
+    y: viewMetrics.top + viewMetrics.height,
   };
 
   const overlapWidth = Math.min(bubbleMax.x, workspaceMax.x) -
@@ -896,7 +896,7 @@ Bubble.textToDom = function(text) {
   const paragraph = dom.createSvgElement(
       Svg.TEXT, {
         'class': 'blocklyText blocklyBubbleText blocklyNoPointerEvents',
-        'y': Bubble.BORDER_WIDTH
+        'y': Bubble.BORDER_WIDTH,
       },
       null);
   const lines = text.split('\n');

--- a/core/comment.js
+++ b/core/comment.js
@@ -120,7 +120,7 @@ Comment.prototype.drawIcon_ = function(group) {
         'class': 'blocklyIconSymbol',
         'd': 'm6.8,10h2c0.003,-0.617 0.271,-0.962 0.633,-1.266 2.875,-2.405' +
             '0.607,-5.534 -3.765,-3.874v1.7c3.12,-1.657 3.698,0.118 2.336,1.25' +
-            '-1.201,0.998 -1.201,1.528 -1.204,2.19z'
+            '-1.201,0.998 -1.201,1.528 -1.204,2.19z',
       },
       group);
   // Dot of question mark.
@@ -130,7 +130,7 @@ Comment.prototype.drawIcon_ = function(group) {
         'x': '6.8',
         'y': '10.78',
         'height': '2',
-        'width': '2'
+        'width': '2',
       },
       group);
 };

--- a/core/connection_type.js
+++ b/core/connection_type.js
@@ -30,7 +30,7 @@ const ConnectionType = {
   // A down-facing block stack.  E.g. 'if-do' or 'else'.
   NEXT_STATEMENT: 3,
   // An up-facing block stack.  E.g. 'break out of loop'.
-  PREVIOUS_STATEMENT: 4
+  PREVIOUS_STATEMENT: 4,
 };
 
 exports.ConnectionType = ConnectionType;

--- a/core/constants.js
+++ b/core/constants.js
@@ -24,7 +24,7 @@ goog.module('Blockly.constants');
 const ALIGN = {
   LEFT: -1,
   CENTRE: 0,
-  RIGHT: 1
+  RIGHT: 1,
 };
 exports.ALIGN = ALIGN;
 

--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -299,7 +299,7 @@ const commentDeleteOption = function(comment) {
       eventUtils.setGroup(true);
       comment.dispose();
       eventUtils.setGroup(false);
-    }
+    },
   };
   return deleteOption;
 };
@@ -319,7 +319,7 @@ const commentDuplicateOption = function(comment) {
     enabled: true,
     callback: function() {
       clipboard.duplicate(comment);
-    }
+    },
   };
   return duplicateOption;
 };
@@ -382,7 +382,7 @@ const workspaceCommentOption = function(ws, e) {
   const wsCommentOption = {
     // Foreign objects don't work in IE.  Don't let the user create comments
     // that they won't be able to edit.
-    enabled: !userAgent.IE
+    enabled: !userAgent.IE,
   };
   wsCommentOption.text = Msg['ADD_COMMENT'];
   wsCommentOption.callback = function() {

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -425,7 +425,7 @@ internal.getBoundsInfo = function() {
     top: boundPosition.y,
     bottom: boundPosition.y + boundSize.height,
     width: boundSize.width,
-    height: boundSize.height
+    height: boundSize.height,
   };
 };
 
@@ -495,7 +495,7 @@ const getPositionBelowMetrics = function(
     arrowX: xCoords.arrowX,
     arrowY: arrowY,
     arrowAtTop: true,
-    arrowVisible: true
+    arrowVisible: true,
   };
 };
 
@@ -530,7 +530,7 @@ const getPositionAboveMetrics = function(
     arrowX: xCoords.arrowX,
     arrowY: arrowY,
     arrowAtTop: false,
-    arrowVisible: true
+    arrowVisible: true,
   };
 };
 
@@ -557,7 +557,7 @@ const getPositionTopOfPageMetrics = function(sourceX, boundsInfo, divSize) {
     arrowAtTop: null,
     arrowX: null,
     arrowY: null,
-    arrowVisible: false
+    arrowVisible: false,
   };
 };
 

--- a/core/events/events.js
+++ b/core/events/events.js
@@ -143,6 +143,6 @@ Object.defineProperties(exports, {
           'Blockly.Events.setRecordUndo()');
       eventUtils.setRecordUndo(record);
     },
-  }
+  },
 });
 

--- a/core/events/utils.js
+++ b/core/events/utils.js
@@ -581,5 +581,5 @@ exports.disableOrphans = disableOrphans;
 
 exports.TEST_ONLY = {
   FIRE_QUEUE,
-  fireNow
+  fireNow,
 };

--- a/core/field.js
+++ b/core/field.js
@@ -381,7 +381,7 @@ Field.prototype.createBorderRect_ = function() {
         'y': 0,
         'height': this.size_.height,
         'width': this.size_.width,
-        'class': 'blocklyFieldRect'
+        'class': 'blocklyFieldRect',
       },
       this.fieldGroup_);
 };

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -303,7 +303,7 @@ FieldAngle.prototype.dropdownCreate_ = function() {
         'version': '1.1',
         'height': (FieldAngle.HALF * 2) + 'px',
         'width': (FieldAngle.HALF * 2) + 'px',
-        'style': 'touch-action: none'
+        'style': 'touch-action: none',
       },
       null);
   const circle = dom.createSvgElement(
@@ -311,7 +311,7 @@ FieldAngle.prototype.dropdownCreate_ = function() {
         'cx': FieldAngle.HALF,
         'cy': FieldAngle.HALF,
         'r': FieldAngle.RADIUS,
-        'class': 'blocklyAngleCircle'
+        'class': 'blocklyAngleCircle',
       },
       svg);
   this.gauge_ =
@@ -320,7 +320,7 @@ FieldAngle.prototype.dropdownCreate_ = function() {
       Svg.LINE, {
         'x1': FieldAngle.HALF,
         'y1': FieldAngle.HALF,
-        'class': 'blocklyAngleLine'
+        'class': 'blocklyAngleLine',
       },
       svg);
   // Draw markers around the edge.
@@ -334,7 +334,7 @@ FieldAngle.prototype.dropdownCreate_ = function() {
           'y2': FieldAngle.HALF,
           'class': 'blocklyAngleMarks',
           'transform': 'rotate(' + angle + ',' + FieldAngle.HALF + ',' +
-              FieldAngle.HALF + ')'
+              FieldAngle.HALF + ')',
         },
         svg);
   }

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -273,7 +273,7 @@ FieldColour.COLOURS = [
   // purples
   '#ccccff', '#9999ff', '#6666cc', '#6633ff', '#6600cc', '#333399', '#330099',
   // violets
-  '#ffccff', '#ff99ff', '#cc66cc', '#cc33cc', '#993399', '#663366', '#330033'
+  '#ffccff', '#ff99ff', '#cc66cc', '#cc33cc', '#993399', '#663366', '#330033',
 ];
 
 /**

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -293,7 +293,7 @@ FieldDropdown.prototype.createSVGArrow_ = function() {
   this.svgArrow_ = dom.createSvgElement(
       Svg.IMAGE, {
         'height': this.getConstants().FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px',
-        'width': this.getConstants().FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px'
+        'width': this.getConstants().FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px',
       },
       this.fieldGroup_);
   this.svgArrow_.setAttributeNS(

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -189,7 +189,7 @@ FieldImage.prototype.initView = function() {
       Svg.IMAGE, {
         'height': this.imageHeight_ + 'px',
         'width': this.size_.width + 'px',
-        'alt': this.altText_
+        'alt': this.altText_,
       },
       this.fieldGroup_);
   this.imageElement_.setAttributeNS(

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -238,7 +238,7 @@ FieldMultilineInput.prototype.render_ = function() {
           'class': 'blocklyText blocklyMultilineText',
           x: this.getConstants().FIELD_BORDER_RECT_X_PADDING,
           y: y + this.getConstants().FIELD_BORDER_RECT_Y_PADDING,
-          dy: this.getConstants().FIELD_TEXT_BASELINE
+          dy: this.getConstants().FIELD_TEXT_BASELINE,
         },
         this.textGroup_);
     span.appendChild(document.createTextNode(lines[i]));

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -472,7 +472,7 @@ FieldVariable.dropdownCreate = function() {
   if (Msg['DELETE_VARIABLE']) {
     options.push([
       Msg['DELETE_VARIABLE'].replace('%1', name),
-      internalConstants.DELETE_VARIABLE_ID
+      internalConstants.DELETE_VARIABLE_ID,
     ]);
   }
 

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -332,8 +332,8 @@ Flyout.prototype.init = function(targetWorkspace) {
     weight: 1,
     capabilities: [
       ComponentManager.Capability.DELETE_AREA,
-      ComponentManager.Capability.DRAG_TARGET
-    ]
+      ComponentManager.Capability.DRAG_TARGET,
+    ],
   });
 };
 
@@ -991,7 +991,7 @@ Flyout.prototype.createRect_ = function(block, x, y, blockHW, index) {
         'x': x,
         'y': y,
         'height': blockHW.height,
-        'width': blockHW.width
+        'width': blockHW.width,
       },
       null);
   rect.tooltip = block;

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -148,7 +148,7 @@ FlyoutButton.prototype.createDom = function() {
           'rx': 4,
           'ry': 4,
           'x': 1,
-          'y': 1
+          'y': 1,
         },
         this.svgGroup_);
   }
@@ -158,7 +158,7 @@ FlyoutButton.prototype.createDom = function() {
         'class': this.isLabel_ ? 'blocklyFlyoutLabelBackground' :
                                  'blocklyFlyoutButtonBackground',
         'rx': 4,
-        'ry': 4
+        'ry': 4,
       },
       this.svgGroup_);
 
@@ -167,7 +167,7 @@ FlyoutButton.prototype.createDom = function() {
         'class': this.isLabel_ ? 'blocklyFlyoutLabelText' : 'blocklyText',
         'x': 0,
         'y': 0,
-        'text-anchor': 'middle'
+        'text-anchor': 'middle',
       },
       this.svgGroup_);
   let text = utils.replaceMessageReferences(this.text_);

--- a/core/inject.js
+++ b/core/inject.js
@@ -124,7 +124,7 @@ const createDom = function(container, options) {
         'xmlns:xlink': dom.XLINK_NS,
         'version': '1.1',
         'class': 'blocklySvg',
-        'tabindex': '0'
+        'tabindex': '0',
       },
       container);
   /*
@@ -344,19 +344,19 @@ const loadSounds = function(pathToMedia, workspace) {
   audioMgr.load(
       [
         pathToMedia + 'click.mp3', pathToMedia + 'click.wav',
-        pathToMedia + 'click.ogg'
+        pathToMedia + 'click.ogg',
       ],
       'click');
   audioMgr.load(
       [
         pathToMedia + 'disconnect.wav', pathToMedia + 'disconnect.mp3',
-        pathToMedia + 'disconnect.ogg'
+        pathToMedia + 'disconnect.ogg',
       ],
       'disconnect');
   audioMgr.load(
       [
         pathToMedia + 'delete.mp3', pathToMedia + 'delete.ogg',
-        pathToMedia + 'delete.wav'
+        pathToMedia + 'delete.wav',
       ],
       'delete');
 

--- a/core/input_types.js
+++ b/core/input_types.js
@@ -30,7 +30,7 @@ const inputTypes = {
   // A down-facing block stack.  E.g. 'if-do' or 'else'.
   STATEMENT: ConnectionType.NEXT_STATEMENT,
   // A dummy input.  Used to add field(s) with no input.
-  DUMMY: 5
+  DUMMY: 5,
 };
 
 exports.inputTypes = inputTypes;

--- a/core/internal_constants.js
+++ b/core/internal_constants.js
@@ -144,7 +144,7 @@ exports.HSV_VALUE = HSV_VALUE;
 const SPRITE = {
   width: 96,
   height: 124,
-  url: 'sprites.png'
+  url: 'sprites.png',
 };
 exports.SPRITE = SPRITE;
 

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -102,7 +102,7 @@ ASTNode.types = {
   NEXT: 'next',
   PREVIOUS: 'previous',
   STACK: 'stack',
-  WORKSPACE: 'workspace'
+  WORKSPACE: 'workspace',
 };
 
 /**

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -128,7 +128,7 @@ MetricsManager.prototype.getFlyoutMetrics = function(opt_own) {
   return {
     width: flyoutDimensions.width,
     height: flyoutDimensions.height,
-    position: this.workspace_.toolboxPosition
+    position: this.workspace_.toolboxPosition,
   };
 };
 
@@ -147,7 +147,7 @@ MetricsManager.prototype.getToolboxMetrics = function() {
   return {
     width: toolboxDimensions.width,
     height: toolboxDimensions.height,
-    position: this.workspace_.toolboxPosition
+    position: this.workspace_.toolboxPosition,
   };
 };
 
@@ -395,7 +395,7 @@ MetricsManager.prototype.getUiMetrics = function() {
   return {
     viewMetrics: this.getViewMetrics(),
     absoluteMetrics: this.getAbsoluteMetrics(),
-    toolboxMetrics: this.getToolboxMetrics()
+    toolboxMetrics: this.getToolboxMetrics(),
   };
 };
 
@@ -472,7 +472,7 @@ MetricsManager.prototype.getMetrics = function() {
     toolboxPosition: toolboxMetrics.position,
 
     flyoutWidth: flyoutMetrics.width,
-    flyoutHeight: flyoutMetrics.height
+    flyoutHeight: flyoutMetrics.height,
   };
 };
 

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -111,7 +111,7 @@ Mutator.prototype.drawIcon_ = function(group) {
         'rx': '4',
         'ry': '4',
         'height': '16',
-        'width': '16'
+        'width': '16',
       },
       group);
   // Gear teeth.
@@ -124,7 +124,7 @@ Mutator.prototype.drawIcon_ = function(group) {
             '-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,' +
             '-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 ' +
             '-0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,' +
-            '0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z'
+            '0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z',
       },
       group);
   // Axle hole.
@@ -182,7 +182,7 @@ Mutator.prototype.createEditor_ = function() {
         'rtl': this.block_.RTL,
         'horizontalLayout': false,
         'renderer': this.block_.workspace.options.renderer,
-        'rendererOverrides': this.block_.workspace.options.rendererOverrides
+        'rendererOverrides': this.block_.workspace.options.rendererOverrides,
       }));
   workspaceOptions.toolboxPosition =
       this.block_.RTL ? toolbox.Position.RIGHT : toolbox.Position.LEFT;

--- a/core/positionable_helpers.js
+++ b/core/positionable_helpers.js
@@ -34,7 +34,7 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  */
 const verticalPosition = {
   TOP: 0,
-  BOTTOM: 1
+  BOTTOM: 1,
 };
 exports.verticalPosition = verticalPosition;
 
@@ -46,7 +46,7 @@ exports.verticalPosition = verticalPosition;
  */
 const horizontalPosition = {
   LEFT: 0,
-  RIGHT: 1
+  RIGHT: 1,
 };
 exports.horizontalPosition = horizontalPosition;
 
@@ -70,7 +70,7 @@ exports.Position = Position;
  */
 const bumpDirection = {
   UP: 0,
-  DOWN: 1
+  DOWN: 1,
 };
 exports.bumpDirection = bumpDirection;
 

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -99,7 +99,7 @@ object.inherits(RenderedConnection, Connection);
 RenderedConnection.TrackedState = {
   WILL_TRACK: -1,
   UNTRACKED: 0,
-  TRACKED: 1
+  TRACKED: 1,
 };
 
 /**
@@ -320,7 +320,7 @@ RenderedConnection.prototype.highlight = function() {
         'class': 'blocklyHighlightedConnectionPath',
         'd': steps,
         transform: 'translate(' + x + ',' + y + ')' +
-            (this.sourceBlock_.RTL ? ' scale(-1 1)' : '')
+            (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
       },
       this.sourceBlock_.getSvgRoot());
 };

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -785,7 +785,7 @@ ConstantProvider.prototype.makeJaggedTeeth = function() {
 
   const mainPath = svgPaths.line([
     svgPaths.point(width, height / 4), svgPaths.point(-width * 2, height / 2),
-    svgPaths.point(width, height / 4)
+    svgPaths.point(width, height / 4),
   ]);
   return {height: height, width: width, path: mainPath};
 };
@@ -801,7 +801,7 @@ ConstantProvider.prototype.makeStartHat = function() {
 
   const mainPath = svgPaths.curve('c', [
     svgPaths.point(30, -height), svgPaths.point(70, -height),
-    svgPaths.point(width, 0)
+    svgPaths.point(width, 0),
   ]);
   return {height: height, width: width, path: mainPath};
 };
@@ -837,7 +837,7 @@ ConstantProvider.prototype.makePuzzleTab = function() {
                'c',
                [
                  svgPaths.point(0, forward * control1Y),
-                 svgPaths.point(-width, back * control2Y), endPoint1
+                 svgPaths.point(-width, back * control2Y), endPoint1,
                ]) +
         svgPaths.curve(
             's', [svgPaths.point(width, back * control3Y), endPoint2]);
@@ -853,7 +853,7 @@ ConstantProvider.prototype.makePuzzleTab = function() {
     width: width,
     height: height,
     pathDown: pathDown,
-    pathUp: pathUp
+    pathUp: pathUp,
   };
 };
 
@@ -871,7 +871,7 @@ ConstantProvider.prototype.makeNotch = function() {
     return svgPaths.line([
       svgPaths.point(dir * outerWidth, height),
       svgPaths.point(dir * innerWidth, 0),
-      svgPaths.point(dir * outerWidth, -height)
+      svgPaths.point(dir * outerWidth, -height),
     ]);
   }
   const pathLeft = makeMainPath(1);
@@ -882,7 +882,7 @@ ConstantProvider.prototype.makeNotch = function() {
     width: width,
     height: height,
     pathLeft: pathLeft,
-    pathRight: pathRight
+    pathRight: pathRight,
   };
 };
 
@@ -904,7 +904,7 @@ ConstantProvider.prototype.makeInsideCorners = function() {
     width: radius,
     height: radius,
     pathTop: innerTopLeftCorner,
-    pathBottom: innerBottomLeftCorner
+    pathBottom: innerBottomLeftCorner,
   };
 };
 
@@ -948,7 +948,7 @@ ConstantProvider.prototype.makeOutsideCorners = function() {
     topRight: topRight,
     bottomRight: bottomRight,
     bottomLeft: bottomLeft,
-    rightHeight: radius
+    rightHeight: radius,
   };
 };
 
@@ -1017,7 +1017,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'specularConstant': 0.5,
         'specularExponent': 10,
         'lighting-color': 'white',
-        'result': 'specOut'
+        'result': 'specOut',
       },
       embossFilter);
   dom.createSvgElement(
@@ -1028,7 +1028,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'in': 'specOut',
         'in2': 'SourceAlpha',
         'operator': 'in',
-        'result': 'specOut'
+        'result': 'specOut',
       },
       embossFilter);
   dom.createSvgElement(
@@ -1039,7 +1039,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'k1': 0,
         'k2': 1,
         'k3': 1,
-        'k4': 0
+        'k4': 0,
       },
       embossFilter);
   this.embossFilterId = embossFilter.id;
@@ -1057,7 +1057,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'id': 'blocklyDisabledPattern' + this.randomIdentifier,
         'patternUnits': 'userSpaceOnUse',
         'width': 10,
-        'height': 10
+        'height': 10,
       },
       this.defs_);
   dom.createSvgElement(
@@ -1085,7 +1085,7 @@ ConstantProvider.prototype.createDebugFilter = function() {
           'height': '160%',
           'width': '180%',
           y: '-30%',
-          x: '-40%'
+          x: '-40%',
         },
         this.defs_);
     // Set all gaussian blur pixels to 1 opacity before applying flood
@@ -1105,7 +1105,7 @@ ConstantProvider.prototype.createDebugFilter = function() {
           'in': 'outColor',
           'in2': 'outBlur',
           'operator': 'in',
-          'result': 'outGlow'
+          'result': 'outGlow',
         },
         debugFilter);
     this.debugFilterId = debugFilter.id;

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -81,7 +81,7 @@ Debug.config = {
   connections: true,
   blockBounds: true,
   connectedBlockBounds: true,
-  render: true
+  render: true,
 };
 
 /**
@@ -125,7 +125,7 @@ Debug.prototype.drawSpacerRow = function(row, cursorY, isRtl) {
         'stroke': isNegativeSpacing ? 'black' : 'blue',
         'fill': 'blue',
         'fill-opacity': '0.5',
-        'stroke-width': '1px'
+        'stroke-width': '1px',
       },
       this.svgRoot_));
 };
@@ -159,7 +159,7 @@ Debug.prototype.drawSpacerElem = function(elem, rowHeight, isRtl) {
         'stroke': 'pink',
         'fill': isNegativeSpacing ? 'black' : 'pink',
         'fill-opacity': '0.5',
-        'stroke-width': '1px'
+        'stroke-width': '1px',
       },
       this.svgRoot_));
 };
@@ -186,7 +186,7 @@ Debug.prototype.drawRenderedElem = function(elem, isRtl) {
           'height': elem.height,
           'stroke': 'black',
           'fill': 'none',
-          'stroke-width': '1px'
+          'stroke-width': '1px',
         },
         this.svgRoot_));
 
@@ -201,7 +201,7 @@ Debug.prototype.drawRenderedElem = function(elem, isRtl) {
             'height': '0.1px',
             'stroke': 'red',
             'fill': 'none',
-            'stroke-width': '0.5px'
+            'stroke-width': '0.5px',
           },
           this.svgRoot_));
     }
@@ -279,7 +279,7 @@ Debug.prototype.drawRenderedRow = function(row, cursorY, isRtl) {
         'height': row.height,
         'stroke': 'red',
         'fill': 'none',
-        'stroke-width': '1px'
+        'stroke-width': '1px',
       },
       this.svgRoot_));
 
@@ -298,7 +298,7 @@ Debug.prototype.drawRenderedRow = function(row, cursorY, isRtl) {
           'stroke': this.randomColour_,
           'fill': 'none',
           'stroke-width': '1px',
-          'stroke-dasharray': '3,3'
+          'stroke-dasharray': '3,3',
         },
         this.svgRoot_));
   }
@@ -351,7 +351,7 @@ Debug.prototype.drawBoundingBox = function(info) {
         'stroke': 'black',
         'fill': 'none',
         'stroke-width': '1px',
-        'stroke-dasharray': '5,5'
+        'stroke-dasharray': '5,5',
       },
       this.svgRoot_));
 
@@ -368,7 +368,7 @@ Debug.prototype.drawBoundingBox = function(info) {
           'stroke': '#DF57BC',
           'fill': 'none',
           'stroke-width': '1px',
-          'stroke-dasharray': '3,3'
+          'stroke-dasharray': '3,3',
         },
         this.svgRoot_));
   }

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -577,7 +577,7 @@ MarkerSvg.prototype.getBlinkProperties_ = function() {
     'attributeName': 'fill',
     'dur': '1s',
     'values': this.colour_ + ';transparent;transparent;',
-    'repeatCount': 'indefinite'
+    'repeatCount': 'indefinite',
   };
 };
 
@@ -601,7 +601,7 @@ MarkerSvg.prototype.createDomInternal_ = function() {
   this.markerSvg_ = dom.createSvgElement(
       Svg.G, {
         'width': this.constants_.CURSOR_WS_WIDTH,
-        'height': this.constants_.WS_CURSOR_HEIGHT
+        'height': this.constants_.WS_CURSOR_HEIGHT,
       },
       this.svgGroup_);
 
@@ -611,7 +611,7 @@ MarkerSvg.prototype.createDomInternal_ = function() {
       Svg.RECT, {
         'width': this.constants_.CURSOR_WS_WIDTH,
         'height': this.constants_.WS_CURSOR_HEIGHT,
-        'style': 'display: none'
+        'style': 'display: none',
       },
       this.markerSvg_);
 
@@ -621,7 +621,7 @@ MarkerSvg.prototype.createDomInternal_ = function() {
         'class': 'blocklyVerticalMarker',
         'rx': 10,
         'ry': 10,
-        'style': 'display: none'
+        'style': 'display: none',
       },
       this.markerSvg_);
 
@@ -636,7 +636,7 @@ MarkerSvg.prototype.createDomInternal_ = function() {
         'transform': '',
         'style': 'display: none',
         'fill': 'none',
-        'stroke-width': this.constants_.CURSOR_STROKE_WIDTH
+        'stroke-width': this.constants_.CURSOR_STROKE_WIDTH,
       },
       this.markerSvg_);
 

--- a/core/renderers/geras/highlight_constants.js
+++ b/core/renderers/geras/highlight_constants.js
@@ -190,7 +190,7 @@ HighlightConstantProvider.prototype.makeOutsideCorner = function() {
     },
     bottomLeft: function() {
       return bottomLeftPath;
-    }
+    },
   };
 };
 
@@ -215,7 +215,7 @@ HighlightConstantProvider.prototype.makePuzzleTab = function() {
       svgPaths.curve(
           'q',
           [
-            svgPaths.point(-width * 0.05, 10), svgPaths.point(width * 0.3, 9.5)
+            svgPaths.point(-width * 0.05, 10), svgPaths.point(width * 0.3, 9.5),
           ]) +
       svgPaths.moveBy(width * 0.67, -1.9) +
       svgPaths.lineOnAxis('v', verticalOverlap);
@@ -237,7 +237,7 @@ HighlightConstantProvider.prototype.makePuzzleTab = function() {
     },
     pathDown: function(rtl) {
       return rtl ? highlightRtlDown : highlightLtrDown;
-    }
+    },
   };
 };
 
@@ -273,17 +273,17 @@ HighlightConstantProvider.prototype.makeStartHat = function() {
   const hatHeight = this.constantProvider.START_HAT.height;
   const pathRtl = svgPaths.moveBy(25, -8.7) + svgPaths.curve('c', [
     svgPaths.point(29.7, -6.2), svgPaths.point(57.2, -0.5),
-    svgPaths.point(75, 8.7)
+    svgPaths.point(75, 8.7),
   ]);
 
   const pathLtr = svgPaths.curve('c', [
     svgPaths.point(17.8, -9.2), svgPaths.point(45.3, -14.9),
-    svgPaths.point(75, -8.7)
+    svgPaths.point(75, -8.7),
   ]) + svgPaths.moveTo(100.5, hatHeight + 0.5);
   return {
     path: function(rtl) {
       return rtl ? pathRtl : pathLtr;
-    }
+    },
   };
 };
 

--- a/core/renderers/measurables/types.js
+++ b/core/renderers/measurables/types.js
@@ -52,7 +52,7 @@ const Types = {
   ROW: 1 << 20,                  // Row.
   TOP_ROW: 1 << 21,              // Top Row.
   BOTTOM_ROW: 1 << 22,           // Bottom Row.
-  INPUT_ROW: 1 << 23             // Input Row.
+  INPUT_ROW: 1 << 23,             // Input Row.
 };
 
 /**

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -216,22 +216,22 @@ const ConstantProvider = function() {
       0: 5 * this.GRID_UNIT,  // Field in hexagon.
       1: 2 * this.GRID_UNIT,  // Hexagon in hexagon.
       2: 5 * this.GRID_UNIT,  // Round in hexagon.
-      3: 5 * this.GRID_UNIT   // Square in hexagon.
+      3: 5 * this.GRID_UNIT,   // Square in hexagon.
     },
     2: {
       // Outer shape: round.
       0: 3 * this.GRID_UNIT,  // Field in round.
       1: 3 * this.GRID_UNIT,  // Hexagon in round.
       2: 1 * this.GRID_UNIT,  // Round in round.
-      3: 2 * this.GRID_UNIT   // Square in round.
+      3: 2 * this.GRID_UNIT,   // Square in round.
     },
     3: {
       // Outer shape: square.
       0: 2 * this.GRID_UNIT,  // Field in square.
       1: 2 * this.GRID_UNIT,  // Hexagon in square.
       2: 2 * this.GRID_UNIT,  // Round in square.
-      3: 2 * this.GRID_UNIT   // Square in square.
-    }
+      3: 2 * this.GRID_UNIT,   // Square in square.
+    },
   };
 
   /**
@@ -456,7 +456,7 @@ ConstantProvider.prototype.makeStartHat = function() {
 
   const mainPath = svgPaths.curve('c', [
     svgPaths.point(25, -height), svgPaths.point(71, -height),
-    svgPaths.point(width, 0)
+    svgPaths.point(width, 0),
   ]);
   return {height: height, width: width, path: mainPath};
 };
@@ -698,7 +698,7 @@ ConstantProvider.prototype.makeNotch = function() {
             [
               svgPaths.point(dir * curveWidth / 2, 0),
               svgPaths.point(dir * curveWidth * 3 / 4, quarterHeight / 2),
-              svgPaths.point(dir * curveWidth, quarterHeight)
+              svgPaths.point(dir * curveWidth, quarterHeight),
             ]) +
         svgPaths.line([svgPaths.point(dir * curveWidth, halfHeight)]) +
         svgPaths.curve(
@@ -706,7 +706,7 @@ ConstantProvider.prototype.makeNotch = function() {
             [
               svgPaths.point(dir * curveWidth / 4, quarterHeight / 2),
               svgPaths.point(dir * curveWidth / 2, quarterHeight),
-              svgPaths.point(dir * curveWidth, quarterHeight)
+              svgPaths.point(dir * curveWidth, quarterHeight),
             ]) +
         svgPaths.lineOnAxis('h', dir * innerWidth) +
         svgPaths.curve(
@@ -714,13 +714,13 @@ ConstantProvider.prototype.makeNotch = function() {
             [
               svgPaths.point(dir * curveWidth / 2, 0),
               svgPaths.point(dir * curveWidth * 3 / 4, -(quarterHeight / 2)),
-              svgPaths.point(dir * curveWidth, -quarterHeight)
+              svgPaths.point(dir * curveWidth, -quarterHeight),
             ]) +
         svgPaths.line([svgPaths.point(dir * curveWidth, -halfHeight)]) +
         svgPaths.curve('c', [
           svgPaths.point(dir * curveWidth / 4, -(quarterHeight / 2)),
           svgPaths.point(dir * curveWidth / 2, -quarterHeight),
-          svgPaths.point(dir * curveWidth, -quarterHeight)
+          svgPaths.point(dir * curveWidth, -quarterHeight),
         ]));
   }
 
@@ -732,7 +732,7 @@ ConstantProvider.prototype.makeNotch = function() {
     width: width,
     height: height,
     pathLeft: pathLeft,
-    pathRight: pathRight
+    pathRight: pathRight,
   };
 };
 
@@ -762,7 +762,7 @@ ConstantProvider.prototype.makeInsideCorners = function() {
     rightWidth: radius,
     rightHeight: radius,
     pathTopRight: innerTopRightCorner,
-    pathBottomRight: innerBottomRightCorner
+    pathBottomRight: innerBottomRightCorner,
   };
 };
 
@@ -799,7 +799,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'height': '160%',
         'width': '180%',
         y: '-30%',
-        x: '-40%'
+        x: '-40%',
       },
       defs);
   dom.createSvgElement(
@@ -818,7 +818,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
       Svg.FEFLOOD, {
         'flood-color': this.SELECTED_GLOW_COLOUR,
         'flood-opacity': 1,
-        'result': 'outColor'
+        'result': 'outColor',
       },
       selectedGlowFilter);
   dom.createSvgElement(
@@ -826,7 +826,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'in': 'outColor',
         'in2': 'outBlur',
         'operator': 'in',
-        'result': 'outGlow'
+        'result': 'outGlow',
       },
       selectedGlowFilter);
   this.selectedGlowFilterId = selectedGlowFilter.id;
@@ -840,7 +840,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'height': '160%',
         'width': '180%',
         y: '-30%',
-        x: '-40%'
+        x: '-40%',
       },
       defs);
   dom.createSvgElement(
@@ -859,7 +859,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
       Svg.FEFLOOD, {
         'flood-color': this.REPLACEMENT_GLOW_COLOUR,
         'flood-opacity': 1,
-        'result': 'outColor'
+        'result': 'outColor',
       },
       replacementGlowFilter);
   dom.createSvgElement(
@@ -867,7 +867,7 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'in': 'outColor',
         'in2': 'outBlur',
         'operator': 'in',
-        'result': 'outGlow'
+        'result': 'outGlow',
       },
       replacementGlowFilter);
   dom.createSvgElement(

--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -134,7 +134,7 @@ MarkerSvg.prototype.createDomInternal_ = function() {
       Svg.CIRCLE, {
         'r': this.constants_.CURSOR_RADIUS,
         'style': 'display: none',
-        'stroke-width': this.constants_.CURSOR_STROKE_WIDTH
+        'stroke-width': this.constants_.CURSOR_STROKE_WIDTH,
       },
       this.markerSvg_);
 

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -223,7 +223,7 @@ PathObject.prototype.getOutlinePath_ = function(name) {
           'class': 'blocklyOutlinePath',
           // IE doesn't like paths without the data definition, set empty
           // default
-          'd': ''
+          'd': '',
         },
         this.svgRoot);
   }

--- a/core/scrollbar_pair.js
+++ b/core/scrollbar_pair.js
@@ -64,7 +64,7 @@ const ScrollbarPair = function(
         Svg.RECT, {
           'height': Scrollbar.scrollbarThickness,
           'width': Scrollbar.scrollbarThickness,
-          'class': 'blocklyScrollbarBackground'
+          'class': 'blocklyScrollbarBackground',
         },
         null);
     dom.insertAfter(this.corner_, workspace.getBubbleCanvas());

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -106,7 +106,7 @@ const save = function(
 
   const state = {
     'type': block.type,
-    'id': block.id
+    'id': block.id,
   };
 
   if (addCoordinates) {
@@ -196,7 +196,7 @@ const saveIcons = function(block, state) {
         'pinned': block.commentModel.pinned,
         'height': Math.round(block.commentModel.size.height),
         'width': Math.round(block.commentModel.size.width),
-      }
+      },
     };
   }
 };
@@ -335,7 +335,7 @@ const appendInternal = function(
     {
       parentConnection = undefined,
       isShadow = false,
-      recordUndo = false
+      recordUndo = false,
     } = {}
 ) {
   const prevRecordUndo = eventUtils.getRecordUndo();
@@ -666,7 +666,7 @@ class BlockSerializer {
     if (blockStates.length) {
       return {
         'languageVersion': 0, // Currently unused.
-        'blocks': blockStates
+        'blocks': blockStates,
       };
     }
     return null;

--- a/core/serialization/variables.js
+++ b/core/serialization/variables.js
@@ -63,7 +63,7 @@ class VariableSerializer {
     for (const variable of workspace.getAllVariables()) {
       const state = {
         'name': variable.name,
-        'id': variable.getId()
+        'id': variable.getId(),
       };
       if (variable.type) {
         state['type'] = variable.type;

--- a/core/shortcut_items.js
+++ b/core/shortcut_items.js
@@ -38,7 +38,7 @@ const names = {
   CUT: 'cut',
   PASTE: 'paste',
   UNDO: 'undo',
-  REDO: 'redo'
+  REDO: 'redo',
 };
 exports.names = names;
 
@@ -56,7 +56,7 @@ const registerEscape = function() {
     callback: function(workspace) {
       workspace.hideChaff();
       return true;
-    }
+    },
   };
   ShortcutRegistry.registry.register(escapeAction);
   ShortcutRegistry.registry.addKeyMapping(KeyCodes.ESC, escapeAction.name);
@@ -87,7 +87,7 @@ const registerDelete = function() {
       }
       (/** @type {!BlockSvg} */ (common.getSelected())).checkAndDelete();
       return true;
-    }
+    },
   };
   ShortcutRegistry.registry.register(deleteShortcut);
   ShortcutRegistry.registry.addKeyMapping(KeyCodes.DELETE, deleteShortcut.name);
@@ -116,7 +116,7 @@ const registerCopy = function() {
       workspace.hideChaff();
       clipboard.copy(/** @type {!ICopyable} */ (common.getSelected()));
       return true;
-    }
+    },
   };
   ShortcutRegistry.registry.register(copyShortcut);
 
@@ -157,7 +157,7 @@ const registerCut = function() {
       clipboard.copy(selected);
       (/** @type {!BlockSvg} */ (selected)).checkAndDelete();
       return true;
-    }
+    },
   };
 
   ShortcutRegistry.registry.register(cutShortcut);
@@ -189,7 +189,7 @@ const registerPaste = function() {
     },
     callback: function() {
       return clipboard.paste();
-    }
+    },
   };
 
   ShortcutRegistry.registry.register(pasteShortcut);
@@ -224,7 +224,7 @@ const registerUndo = function() {
       workspace.hideChaff();
       workspace.undo(false);
       return true;
-    }
+    },
   };
   ShortcutRegistry.registry.register(undoShortcut);
 
@@ -259,7 +259,7 @@ const registerRedo = function() {
       workspace.hideChaff();
       workspace.undo(true);
       return true;
-    }
+    },
   };
   ShortcutRegistry.registry.register(redoShortcut);
 

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -57,7 +57,7 @@ ShortcutRegistry.modifierKeys = {
   'Shift': KeyCodes.SHIFT,
   'Control': KeyCodes.CTRL,
   'Alt': KeyCodes.ALT,
-  'Meta': KeyCodes.META
+  'Meta': KeyCodes.META,
 };
 
 /**

--- a/core/theme/classic.js
+++ b/core/theme/classic.js
@@ -30,7 +30,7 @@ let defaultBlockStyles = {
   'text_blocks': {'colourPrimary': '160'},
   'variable_blocks': {'colourPrimary': '330'},
   'variable_dynamic_blocks': {'colourPrimary': '310'},
-  'hat_blocks': {'colourPrimary': '330', 'hat': 'cap'}
+  'hat_blocks': {'colourPrimary': '330', 'hat': 'cap'},
 };
 
 let categoryStyles = {
@@ -42,7 +42,7 @@ let categoryStyles = {
   'procedure_category': {'colour': '290'},
   'text_category': {'colour': '160'},
   'variable_category': {'colour': '330'},
-  'variable_dynamic_category': {'colour': '310'}
+  'variable_dynamic_category': {'colour': '310'},
 };
 
 /**

--- a/core/theme/zelos.js
+++ b/core/theme/zelos.js
@@ -22,54 +22,54 @@ let defaultBlockStyles = {
   'colour_blocks': {
     'colourPrimary': '#CF63CF',
     'colourSecondary': '#C94FC9',
-    'colourTertiary': '#BD42BD'
+    'colourTertiary': '#BD42BD',
   },
   'list_blocks': {
     'colourPrimary': '#9966FF',
     'colourSecondary': '#855CD6',
-    'colourTertiary': '#774DCB'
+    'colourTertiary': '#774DCB',
   },
   'logic_blocks': {
     'colourPrimary': '#4C97FF',
     'colourSecondary': '#4280D7',
-    'colourTertiary': '#3373CC'
+    'colourTertiary': '#3373CC',
   },
   'loop_blocks': {
     'colourPrimary': '#0fBD8C',
     'colourSecondary': '#0DA57A',
-    'colourTertiary': '#0B8E69'
+    'colourTertiary': '#0B8E69',
   },
   'math_blocks': {
     'colourPrimary': '#59C059',
     'colourSecondary': '#46B946',
-    'colourTertiary': '#389438'
+    'colourTertiary': '#389438',
   },
   'procedure_blocks': {
     'colourPrimary': '#FF6680',
     'colourSecondary': '#FF4D6A',
-    'colourTertiary': '#FF3355'
+    'colourTertiary': '#FF3355',
   },
   'text_blocks': {
     'colourPrimary': '#FFBF00',
     'colourSecondary': '#E6AC00',
-    'colourTertiary': '#CC9900'
+    'colourTertiary': '#CC9900',
   },
   'variable_blocks': {
     'colourPrimary': '#FF8C1A',
     'colourSecondary': '#FF8000',
-    'colourTertiary': '#DB6E00'
+    'colourTertiary': '#DB6E00',
   },
   'variable_dynamic_blocks': {
     'colourPrimary': '#FF8C1A',
     'colourSecondary': '#FF8000',
-    'colourTertiary': '#DB6E00'
+    'colourTertiary': '#DB6E00',
   },
   'hat_blocks': {
     'colourPrimary': '#4C97FF',
     'colourSecondary': '#4280D7',
     'colourTertiary': '#3373CC',
-    'hat': 'cap'
-  }
+    'hat': 'cap',
+  },
 };
 
 let categoryStyles = {
@@ -81,7 +81,7 @@ let categoryStyles = {
   'procedure_category': {'colour': '#FF6680'},
   'text_category': {'colour': '#FFBF00'},
   'variable_category': {'colour': '#FF8C1A'},
-  'variable_dynamic_category': {'colour': '#FF8C1A'}
+  'variable_dynamic_category': {'colour': '#FF8C1A'},
 };
 
 /**

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -232,8 +232,8 @@ Toolbox.prototype.init = function() {
     capabilities: [
       ComponentManager.Capability.AUTOHIDEABLE,
       ComponentManager.Capability.DELETE_AREA,
-      ComponentManager.Capability.DRAG_TARGET
-    ]
+      ComponentManager.Capability.DRAG_TARGET,
+    ],
   });
 };
 
@@ -397,7 +397,7 @@ Toolbox.prototype.createFlyout_ = function() {
         'rendererOverrides': workspace.options.rendererOverrides,
         'move': {
           'scrollbars': true,
-        }
+        },
       }));
   // Options takes in either 'end' or 'start'. This has already been parsed to
   // be either 0 or 1, so set it after.

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -73,8 +73,8 @@ Object.defineProperties(exports, {
           'Blockly.Tooltip.visible', 'September 2021', 'September 2022',
           'Blockly.Tooltip.isVisible()');
       return isVisible();
-    }
-  }
+    },
+  },
 });
 
 /**
@@ -189,8 +189,8 @@ Object.defineProperties(exports, {
           'Blockly.Tooltip.DIV', 'September 2021', 'September 2022',
           'Blockly.Tooltip.getDiv()');
       return getDiv();
-    }
-  }
+    },
+  },
 });
 
 /**

--- a/core/touch.js
+++ b/core/touch.js
@@ -60,13 +60,13 @@ if (globalThis['PointerEvent']) {
     'mouseover': ['pointerover'],
     'mouseup': ['pointerup', 'pointercancel'],
     'touchend': ['pointerup'],
-    'touchcancel': ['pointercancel']
+    'touchcancel': ['pointercancel'],
   };
 } else if (TOUCH_ENABLED) {
   TOUCH_MAP = {
     'mousedown': ['touchstart'],
     'mousemove': ['touchmove'],
-    'mouseup': ['touchend', 'touchcancel']
+    'mouseup': ['touchend', 'touchcancel'],
   };
 }
 exports.TOUCH_MAP = TOUCH_MAP;
@@ -269,7 +269,7 @@ const splitEventByTouches = function(e) {
         },
         preventDefault: function() {
           e.preventDefault();
-        }
+        },
       };
       events[i] = newEvent;
     }

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -105,7 +105,7 @@ const Trashcan = function(workspace) {
         'rendererOverrides': this.workspace_.options.rendererOverrides,
         'move': {
           'scrollbars': true,
-        }
+        },
       }));
   // Create vertical or horizontal flyout.
   if (this.workspace_.horizontalLayout) {
@@ -297,7 +297,7 @@ Trashcan.prototype.createDom = function() {
         'x': -SPRITE_LEFT,
         'height': internalConstants.SPRITE.height,
         'y': -SPRITE_TOP,
-        'clip-path': 'url(#blocklyTrashBodyClipPath' + rnd + ')'
+        'clip-path': 'url(#blocklyTrashBodyClipPath' + rnd + ')',
       },
       this.svgGroup_);
   body.setAttributeNS(
@@ -313,7 +313,7 @@ Trashcan.prototype.createDom = function() {
         'x': -SPRITE_LEFT,
         'height': internalConstants.SPRITE.height,
         'y': -SPRITE_TOP,
-        'clip-path': 'url(#blocklyTrashLidClipPath' + rnd + ')'
+        'clip-path': 'url(#blocklyTrashLidClipPath' + rnd + ')',
       },
       this.svgGroup_);
   this.svgLid_.setAttributeNS(
@@ -350,8 +350,8 @@ Trashcan.prototype.init = function() {
       ComponentManager.Capability.AUTOHIDEABLE,
       ComponentManager.Capability.DELETE_AREA,
       ComponentManager.Capability.DRAG_TARGET,
-      ComponentManager.Capability.POSITIONABLE
-    ]
+      ComponentManager.Capability.POSITIONABLE,
+    ],
   });
   this.initialized_ = true;
   this.setLidOpen(false);

--- a/core/utils.js
+++ b/core/utils.js
@@ -476,7 +476,7 @@ const is3dSupported = function() {
     'OTransform': '-o-transform',
     'msTransform': '-ms-transform',
     'MozTransform': '-moz-transform',
-    'transform': 'transform'
+    'transform': 'transform',
   };
 
   // Add it to the body to get the computed style.
@@ -673,7 +673,7 @@ const parseBlockColour = function(colour) {
       hue: hue,
       hex: colourUtils.hsvToHex(
           hue, internalConstants.HSV_SATURATION,
-          internalConstants.HSV_VALUE * 255)
+          internalConstants.HSV_VALUE * 255),
     };
   } else {
     const hex = colourUtils.parse(dereferenced);

--- a/core/utils/aria.js
+++ b/core/utils/aria.js
@@ -68,7 +68,7 @@ const Role = {
   TREE: 'tree',
 
   // ARIA role for a tree item that sometimes may be expanded or collapsed.
-  TREEITEM: 'treeitem'
+  TREEITEM: 'treeitem',
 };
 exports.Role = Role;
 
@@ -135,7 +135,7 @@ const State = {
   VALUEMAX: 'valuemax',
 
   // ARIA property for slider minimum value. Value: number.
-  VALUEMIN: 'valuemin'
+  VALUEMIN: 'valuemin',
 };
 exports.State = State;
 

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -217,7 +217,7 @@ const names = {
   'silver': '#c0c0c0',
   'teal': '#008080',
   'white': '#ffffff',
-  'yellow': '#ffff00'
+  'yellow': '#ffff00',
 };
 exports.names = names;
 

--- a/core/utils/dom.js
+++ b/core/utils/dom.js
@@ -58,7 +58,7 @@ const NodeType = {
   ELEMENT_NODE: 1,
   TEXT_NODE: 3,
   COMMENT_NODE: 8,
-  DOCUMENT_POSITION_CONTAINED_BY: 16
+  DOCUMENT_POSITION_CONTAINED_BY: 16,
 };
 exports.NodeType = NodeType;
 

--- a/core/utils/keycodes.js
+++ b/core/utils/keycodes.js
@@ -166,7 +166,7 @@ const KeyCodes = {
   // they're all using Dell Inspiron laptops, so we suspect that this
   // indicates a hardware/bios problem.
   // http://en.community.dell.com/support-forums/laptop/f/3518/p/19285957/19523128.aspx
-  PHANTOM: 255
+  PHANTOM: 255,
 };
 
 exports.KeyCodes = KeyCodes;

--- a/core/utils/style.js
+++ b/core/utils/style.js
@@ -216,7 +216,7 @@ const getBorderBox = function(element) {
     top: parseFloat(top),
     right: parseFloat(right),
     bottom: parseFloat(bottom),
-    left: parseFloat(left)
+    left: parseFloat(left),
   };
 };
 exports.getBorderBox = getBorderBox;

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -227,7 +227,7 @@ const Position = {
   TOP: 0,
   BOTTOM: 1,
   LEFT: 2,
-  RIGHT: 3
+  RIGHT: 3,
 };
 exports.Position = Position;
 

--- a/core/warning.js
+++ b/core/warning.js
@@ -61,7 +61,7 @@ Warning.prototype.drawIcon_ = function(group) {
   dom.createSvgElement(
       Svg.PATH, {
         'class': 'blocklyIconShape',
-        'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z'
+        'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z',
       },
       group);
   // Can't use a real '!' text character since different browsers and operating
@@ -70,7 +70,7 @@ Warning.prototype.drawIcon_ = function(group) {
   dom.createSvgElement(
       Svg.PATH, {
         'class': 'blocklyIconSymbol',
-        'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z'
+        'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z',
       },
       group);
   // Dot of exclamation point.
@@ -80,7 +80,7 @@ Warning.prototype.drawIcon_ = function(group) {
         'x': '7',
         'y': '11',
         'height': '2',
-        'width': '2'
+        'width': '2',
       },
       group);
 };

--- a/core/widgetdiv.js
+++ b/core/widgetdiv.js
@@ -96,8 +96,8 @@ Object.defineProperties(exports, {
           'Blockly.WidgetDiv.DIV', 'September 2021', 'September 2022',
           'Blockly.WidgetDiv.getDiv()');
       return getDiv();
-    }
-  }
+    },
+  },
 });
 
 /**

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -383,7 +383,7 @@ WorkspaceComment.parseAttributes = function(xml) {
     // @type {number}
     y: parseInt(xml.getAttribute('y'), 10),
     // @type {string}
-    content: xml.textContent
+    content: xml.textContent,
   };
 };
 

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -119,7 +119,7 @@ const WorkspaceCommentSvg = function(
     'x': 0,
     'y': 0,
     'rx': BORDER_RADIUS,
-    'ry': BORDER_RADIUS
+    'ry': BORDER_RADIUS,
   });
   this.svgGroup_.appendChild(this.svgRect_);
 
@@ -673,7 +673,7 @@ WorkspaceCommentSvg.prototype.toCopyData = function() {
   return {
     saveInfo: this.toXmlWithXY(),
     source: this.workspace,
-    typeCounts: null
+    typeCounts: null,
   };
 };
 
@@ -710,7 +710,7 @@ WorkspaceCommentSvg.prototype.render = function() {
     'x': 0,
     'y': 0,
     'rx': BORDER_RADIUS,
-    'ry': BORDER_RADIUS
+    'ry': BORDER_RADIUS,
   });
   this.svgGroup_.appendChild(this.svgRectTarget_);
 
@@ -762,7 +762,7 @@ WorkspaceCommentSvg.prototype.createEditor_ = function() {
       Svg.FOREIGNOBJECT, {
         'x': 0,
         'y': WorkspaceCommentSvg.TOP_OFFSET,
-        'class': 'blocklyCommentForeignObject'
+        'class': 'blocklyCommentForeignObject',
       },
       null);
   const body = document.createElementNS(dom.HTML_NS, 'body');
@@ -807,7 +807,7 @@ WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
         'x1': RESIZE_SIZE / 3,
         'y1': RESIZE_SIZE - 1,
         'x2': RESIZE_SIZE - 1,
-        'y2': RESIZE_SIZE / 3
+        'y2': RESIZE_SIZE / 3,
       },
       this.resizeGroup_);
   dom.createSvgElement(
@@ -816,7 +816,7 @@ WorkspaceCommentSvg.prototype.addResizeDom_ = function() {
         'x1': RESIZE_SIZE * 2 / 3,
         'y1': RESIZE_SIZE - 1,
         'x2': RESIZE_SIZE - 1,
-        'y2': RESIZE_SIZE * 2 / 3
+        'y2': RESIZE_SIZE * 2 / 3,
       },
       this.resizeGroup_);
 };
@@ -840,7 +840,7 @@ WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
         'x2': '10',
         'y2': '5',
         'stroke': '#fff',
-        'stroke-width': '2'
+        'stroke-width': '2',
       },
       this.deleteGroup_);
   dom.createSvgElement(
@@ -850,7 +850,7 @@ WorkspaceCommentSvg.prototype.addDeleteDom_ = function() {
         'x2': '10',
         'y2': '10',
         'stroke': '#fff',
-        'stroke-width': '2'
+        'stroke-width': '2',
       },
       this.deleteGroup_);
 };

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -78,7 +78,7 @@ WorkspaceDragSurfaceSvg.prototype.createDom = function() {
         'xmlns:html': dom.HTML_NS,
         'xmlns:xlink': dom.XLINK_NS,
         'version': '1.1',
-        'class': 'blocklyWsDragSurface blocklyOverflowVisible'
+        'class': 'blocklyWsDragSurface blocklyOverflowVisible',
       },
       null);
   this.container_.appendChild(this.SVG_);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1100,7 +1100,7 @@ WorkspaceSvg.prototype.addFlyout = function(tagName) {
         'rendererOverrides': this.options.rendererOverrides,
         'move': {
           'scrollbars': true,
-        }
+        },
       }));
   workspaceOptions.toolboxPosition = this.options.toolboxPosition;
   if (this.horizontalLayout) {

--- a/core/zoom_controls.js
+++ b/core/zoom_controls.js
@@ -206,7 +206,7 @@ ZoomControls.prototype.init = function() {
   this.workspace_.getComponentManager().addComponent({
     component: this,
     weight: 2,
-    capabilities: [ComponentManager.Capability.POSITIONABLE]
+    capabilities: [ComponentManager.Capability.POSITIONABLE],
   });
   this.initialized_ = true;
 };
@@ -340,7 +340,7 @@ ZoomControls.prototype.createZoomOutSvg_ = function(rnd) {
         'height': internalConstants.SPRITE.height,
         'x': -64,
         'y': -92,
-        'clip-path': 'url(#blocklyZoomoutClipPath' + rnd + ')'
+        'clip-path': 'url(#blocklyZoomoutClipPath' + rnd + ')',
       },
       this.zoomOutGroup_);
   zoomoutSvg.setAttributeNS(
@@ -386,7 +386,7 @@ ZoomControls.prototype.createZoomInSvg_ = function(rnd) {
         'height': internalConstants.SPRITE.height,
         'x': -32,
         'y': -92,
-        'clip-path': 'url(#blocklyZoominClipPath' + rnd + ')'
+        'clip-path': 'url(#blocklyZoominClipPath' + rnd + ')',
       },
       this.zoomInGroup_);
   zoominSvg.setAttributeNS(
@@ -444,7 +444,7 @@ ZoomControls.prototype.createZoomResetSvg_ = function(rnd) {
         'width': internalConstants.SPRITE.width,
         'height': internalConstants.SPRITE.height,
         'y': -92,
-        'clip-path': 'url(#blocklyZoomresetClipPath' + rnd + ')'
+        'clip-path': 'url(#blocklyZoomresetClipPath' + rnd + ')',
       },
       this.zoomResetGroup_);
   zoomresetSvg.setAttributeNS(


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5160 

### Proposed Changes

Apply rule [`"comma-dangle": ["error", "always-multiline"]`](https://eslint.org/docs/rules/comma-dangle).

This configuration of the comma rule comes from [eslint-config-google](https://github.com/google/eslint-config-google/blob/master/index.js#L195) and the relevant part of the [google style guide](https://google.github.io/styleguide/jsguide.html#features-objects-use-trailing-comma).

#### Behavior Before Change

No behaviour change.

#### Behavior After Change

No behaviour change.

### Reason for Changes

Get closer to google style, so that we don't have to record how our style differs. Gets us closer to using `eslint-config-google`.

### Documentation

None because we didn't document this deviation from google style.
