### PR TITLE
fix: Fix mutators when compiled with renames.

### DIFF
--- a/core/extensions.js
+++ b/core/extensions.js
@@ -248,8 +248,7 @@ const checkJsonHooks = function(object, errorPrefix) {
  */
 const checkMutatorDialog = function(object, errorPrefix) {
   return checkHasFunctionPair(
-      object.compose, object.decompose,
-      errorPrefix + ' compose/decompose');
+      object.compose, object.decompose, errorPrefix + ' compose/decompose');
 };
 
 /**


### PR DESCRIPTION
Previous code not compatible with advanced compilation since 'mutationToDom' and other function names were hardcoded in strings.

@BeksOmega: FYI

Partially resolves #5602.