### PR TITLE
chore: Add feedback on expiry page.

### DIFF
--- a/appengine/expiration.py
+++ b/appengine/expiration.py
@@ -39,13 +39,14 @@ def delete_expired():
     results = query.fetch(limit=QUERY_LIMIT, keys_only=True)
     for x in results:
       x.delete()
+  return len(results)
 
 
 def app(environ, start_response):
-  out = ""
   headers = [
     ("Content-Type", "text/plain")
   ]
   start_response("200 OK", headers)
-  delete_expired()
+  n = delete_expired()
+  out = "%d records deleted." % n
   return [out.encode("utf-8")]


### PR DESCRIPTION
Blank pages are bad for confirming anything happened.

Can be temporarily tested at:
https://fraserexpire-dot-blockly-demo.appspot.com/expiration
This shows that the production version is actually working fine, so there's no bug (just a lot of data).

For reference, our current DB size is 1.88 GB, and every execution kills 1000 records.
I've increased the hit from once a week to every two minutes, and will let that run until the above URL stops saying 1000.