### PR TITLE
chore: replace var with const and let in python block generators

### DIFF
--- a/generators/python/colour.js
+++ b/generators/python/colour.js
@@ -16,39 +16,39 @@ goog.require('Blockly.Python');
 
 Blockly.Python['colour_picker'] = function(block) {
   // Colour picker.
-  var code = Blockly.Python.quote_(block.getFieldValue('COLOUR'));
+  const code = Blockly.Python.quote_(block.getFieldValue('COLOUR'));
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Python['colour_random'] = function(block) {
   // Generate a random colour.
   Blockly.Python.definitions_['import_random'] = 'import random';
-  var code = '\'#%06x\' % random.randint(0, 2**24 - 1)';
+  const code = '\'#%06x\' % random.randint(0, 2**24 - 1)';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
-  var functionName = Blockly.Python.provideFunction_(
+  const functionName = Blockly.Python.provideFunction_(
       'colour_rgb',
       ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(r, g, b):',
        '  r = round(min(100, max(0, r)) * 2.55)',
        '  g = round(min(100, max(0, g)) * 2.55)',
        '  b = round(min(100, max(0, b)) * 2.55)',
        '  return \'#%02x%02x%02x\' % (r, g, b)']);
-  var r = Blockly.Python.valueToCode(block, 'RED',
+  const r = Blockly.Python.valueToCode(block, 'RED',
                                      Blockly.Python.ORDER_NONE) || 0;
-  var g = Blockly.Python.valueToCode(block, 'GREEN',
+  const g = Blockly.Python.valueToCode(block, 'GREEN',
                                      Blockly.Python.ORDER_NONE) || 0;
-  var b = Blockly.Python.valueToCode(block, 'BLUE',
+  const b = Blockly.Python.valueToCode(block, 'BLUE',
                                      Blockly.Python.ORDER_NONE) || 0;
-  var code = functionName + '(' + r + ', ' + g + ', ' + b + ')';
+  const code = functionName + '(' + r + ', ' + g + ', ' + b + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['colour_blend'] = function(block) {
   // Blend two colours together.
-  var functionName = Blockly.Python.provideFunction_(
+  const functionName = Blockly.Python.provideFunction_(
       'colour_blend',
       ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ +
           '(colour1, colour2, ratio):',
@@ -60,12 +60,12 @@ Blockly.Python['colour_blend'] = function(block) {
        '  g = round(g1 * (1 - ratio) + g2 * ratio)',
        '  b = round(b1 * (1 - ratio) + b2 * ratio)',
        '  return \'#%02x%02x%02x\' % (r, g, b)']);
-  var colour1 = Blockly.Python.valueToCode(block, 'COLOUR1',
+  const colour1 = Blockly.Python.valueToCode(block, 'COLOUR1',
       Blockly.Python.ORDER_NONE) || '\'#000000\'';
-  var colour2 = Blockly.Python.valueToCode(block, 'COLOUR2',
+  const colour2 = Blockly.Python.valueToCode(block, 'COLOUR2',
       Blockly.Python.ORDER_NONE) || '\'#000000\'';
-  var ratio = Blockly.Python.valueToCode(block, 'RATIO',
+  const ratio = Blockly.Python.valueToCode(block, 'RATIO',
       Blockly.Python.ORDER_NONE) || 0;
-  var code = functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };

--- a/generators/python/lists.js
+++ b/generators/python/lists.js
@@ -21,145 +21,150 @@ Blockly.Python['lists_create_empty'] = function(block) {
 
 Blockly.Python['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
-  var elements = new Array(block.itemCount_);
-  for (var i = 0; i < block.itemCount_; i++) {
+  const elements = new Array(block.itemCount_);
+  for (let i = 0; i < block.itemCount_; i++) {
     elements[i] = Blockly.Python.valueToCode(block, 'ADD' + i,
         Blockly.Python.ORDER_NONE) || 'None';
   }
-  var code = '[' + elements.join(', ') + ']';
+  const code = '[' + elements.join(', ') + ']';
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Python['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
-  var item = Blockly.Python.valueToCode(block, 'ITEM',
+  const item = Blockly.Python.valueToCode(block, 'ITEM',
       Blockly.Python.ORDER_NONE) || 'None';
-  var times = Blockly.Python.valueToCode(block, 'NUM',
+  const times = Blockly.Python.valueToCode(block, 'NUM',
       Blockly.Python.ORDER_MULTIPLICATIVE) || '0';
-  var code = '[' + item + '] * ' + times;
+  const code = '[' + item + '] * ' + times;
   return [code, Blockly.Python.ORDER_MULTIPLICATIVE];
 };
 
 Blockly.Python['lists_length'] = function(block) {
   // String or array length.
-  var list = Blockly.Python.valueToCode(block, 'VALUE',
+  const list = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '[]';
   return ['len(' + list + ')', Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  var list = Blockly.Python.valueToCode(block, 'VALUE',
+  const list = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '[]';
-  var code = 'not len(' + list + ')';
+  const code = 'not len(' + list + ')';
   return [code, Blockly.Python.ORDER_LOGICAL_NOT];
 };
 
 Blockly.Python['lists_indexOf'] = function(block) {
   // Find an item in the list.
-  var item = Blockly.Python.valueToCode(block, 'FIND',
+  const item = Blockly.Python.valueToCode(block, 'FIND',
       Blockly.Python.ORDER_NONE) || '[]';
-  var list = Blockly.Python.valueToCode(block, 'VALUE',
+  const list = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '\'\'';
+  let errorIndex = ' -1';
+  let firstIndexAdjustment = '';
+  let lastIndexAdjustment = ' - 1';
+
   if (block.workspace.options.oneBasedIndex) {
-    var errorIndex = ' 0';
-    var firstIndexAdjustment = ' + 1';
-    var lastIndexAdjustment = '';
-  } else {
-    var errorIndex = ' -1';
-    var firstIndexAdjustment = '';
-    var lastIndexAdjustment = ' - 1';
+    errorIndex = ' 0';
+    firstIndexAdjustment = ' + 1';
+    lastIndexAdjustment = '';
   }
+
   if (block.getFieldValue('END') === 'FIRST') {
-    var functionName = Blockly.Python.provideFunction_(
+    const functionName = Blockly.Python.provideFunction_(
         'first_index',
         ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ +
             '(my_list, elem):',
          '  try: index = my_list.index(elem)' + firstIndexAdjustment,
          '  except: index =' + errorIndex,
          '  return index']);
-    var code = functionName + '(' + list + ', ' + item + ')';
+    const code = functionName + '(' + list + ', ' + item + ')';
     return [code, Blockly.Python.ORDER_FUNCTION_CALL];
   }
-  var functionName = Blockly.Python.provideFunction_(
+  const functionName = Blockly.Python.provideFunction_(
       'last_index',
       ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(my_list, elem):',
        '  try: index = len(my_list) - my_list[::-1].index(elem)' +
          lastIndexAdjustment,
        '  except: index =' + errorIndex,
        '  return index']);
-  var code = functionName + '(' + list + ', ' + item + ')';
+  const code = functionName + '(' + list + ', ' + item + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
-  var mode = block.getFieldValue('MODE') || 'GET';
-  var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var listOrder = (where === 'RANDOM') ? Blockly.Python.ORDER_NONE :
+  const mode = block.getFieldValue('MODE') || 'GET';
+  const where = block.getFieldValue('WHERE') || 'FROM_START';
+  const listOrder = (where === 'RANDOM') ? Blockly.Python.ORDER_NONE :
       Blockly.Python.ORDER_MEMBER;
-  var list = Blockly.Python.valueToCode(block, 'VALUE', listOrder) || '[]';
+  const list = Blockly.Python.valueToCode(block, 'VALUE', listOrder) || '[]';
 
   switch (where) {
-    case 'FIRST':
+    case 'FIRST': {
       if (mode === 'GET') {
-        var code = list + '[0]';
+        const code = list + '[0]';
         return [code, Blockly.Python.ORDER_MEMBER];
       } else if (mode === 'GET_REMOVE') {
-        var code = list + '.pop(0)';
+        const code = list + '.pop(0)';
         return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       } else if (mode === 'REMOVE') {
         return list + '.pop(0)\n';
       }
       break;
-    case 'LAST':
+    }
+    case 'LAST': {
       if (mode === 'GET') {
-        var code = list + '[-1]';
+        const code = list + '[-1]';
         return [code, Blockly.Python.ORDER_MEMBER];
       } else if (mode === 'GET_REMOVE') {
-        var code = list + '.pop()';
+        const code = list + '.pop()';
         return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       } else if (mode === 'REMOVE') {
         return list + '.pop()\n';
       }
       break;
-    case 'FROM_START':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT');
+    }
+    case 'FROM_START': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT');
       if (mode === 'GET') {
-        var code = list + '[' + at + ']';
+        const code = list + '[' + at + ']';
         return [code, Blockly.Python.ORDER_MEMBER];
       } else if (mode === 'GET_REMOVE') {
-        var code = list + '.pop(' + at + ')';
+        const code = list + '.pop(' + at + ')';
         return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       } else if (mode === 'REMOVE') {
         return list + '.pop(' + at + ')\n';
       }
       break;
-    case'FROM_END':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
+    }
+    case'FROM_END': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
       if (mode === 'GET') {
-        var code = list + '[' + at + ']';
+        const code = list + '[' + at + ']';
         return [code, Blockly.Python.ORDER_MEMBER];
       } else if (mode === 'GET_REMOVE') {
-        var code = list + '.pop(' + at + ')';
+        const code = list + '.pop(' + at + ')';
         return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       } else if (mode === 'REMOVE') {
         return list + '.pop(' + at + ')\n';
       }
       break;
-    case 'RANDOM':
+    }
+    case 'RANDOM': {
       Blockly.Python.definitions_['import_random'] = 'import random';
       if (mode === 'GET') {
-        code = 'random.choice(' + list + ')';
+        const code = 'random.choice(' + list + ')';
         return [code, Blockly.Python.ORDER_FUNCTION_CALL];
       } else {
-        var functionName = Blockly.Python.provideFunction_(
+        const functionName = Blockly.Python.provideFunction_(
             'lists_remove_random_item',
             ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(myList):',
               '  x = int(random.random() * len(myList))',
               '  return myList.pop(x)']);
-        code = functionName + '(' + list + ')';
+        const code = functionName + '(' + list + ')';
         if (mode === 'GET_REMOVE') {
           return [code, Blockly.Python.ORDER_FUNCTION_CALL];
         } else if (mode === 'REMOVE') {
@@ -167,6 +172,7 @@ Blockly.Python['lists_getIndex'] = function(block) {
         }
       }
       break;
+    }
   }
   throw Error('Unhandled combination (lists_getIndex).');
 };
@@ -174,11 +180,11 @@ Blockly.Python['lists_getIndex'] = function(block) {
 Blockly.Python['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
-  var list = Blockly.Python.valueToCode(block, 'LIST',
+  let list = Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_MEMBER) || '[]';
-  var mode = block.getFieldValue('MODE') || 'GET';
-  var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var value = Blockly.Python.valueToCode(block, 'TO',
+  const mode = block.getFieldValue('MODE') || 'GET';
+  const where = block.getFieldValue('WHERE') || 'FROM_START';
+  const value = Blockly.Python.valueToCode(block, 'TO',
       Blockly.Python.ORDER_NONE) || 'None';
   // Cache non-trivial values to variables to prevent repeated look-ups.
   // Closure, which accesses and modifies 'list'.
@@ -186,48 +192,52 @@ Blockly.Python['lists_setIndex'] = function(block) {
     if (list.match(/^\w+$/)) {
       return '';
     }
-    var listVar = Blockly.Python.nameDB_.getDistinctName(
+    const listVar = Blockly.Python.nameDB_.getDistinctName(
         'tmp_list', Blockly.VARIABLE_CATEGORY_NAME);
-    var code = listVar + ' = ' + list + '\n';
+    const code = listVar + ' = ' + list + '\n';
     list = listVar;
     return code;
   }
 
   switch (where) {
-    case 'FIRST':
+    case 'FIRST': {
       if (mode === 'SET') {
         return list + '[0] = ' + value + '\n';
       } else if (mode === 'INSERT') {
         return list + '.insert(0, ' + value + ')\n';
       }
       break;
-    case 'LAST':
+    }
+    case 'LAST': {
         if (mode === 'SET') {
           return list + '[-1] = ' + value + '\n';
         } else if (mode === 'INSERT') {
           return list + '.append(' + value + ')\n';
         }
       break;
-    case 'FROM_START':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT');
+    }
+    case 'FROM_START': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT');
         if (mode === 'SET') {
           return list + '[' + at + '] = ' + value + '\n';
         } else if (mode === 'INSERT') {
           return list + '.insert(' + at + ', ' + value + ')\n';
         }
       break;
-    case 'FROM_END':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
+    }
+    case 'FROM_END': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
         if (mode === 'SET') {
           return list + '[' + at + '] = ' + value + '\n';
         } else if (mode === 'INSERT') {
           return list + '.insert(' + at + ', ' + value + ')\n';
         }
       break;
-    case 'RANDOM':
+    }
+    case 'RANDOM': {
         Blockly.Python.definitions_['import_random'] = 'import random';
-        var code = cacheList();
-        var xVar = Blockly.Python.nameDB_.getDistinctName(
+        let code = cacheList();
+        const xVar = Blockly.Python.nameDB_.getDistinctName(
             'tmp_x', Blockly.VARIABLE_CATEGORY_NAME);
         code += xVar + ' = int(random.random() * len(' + list + '))\n';
         if (mode === 'SET') {
@@ -238,38 +248,46 @@ Blockly.Python['lists_setIndex'] = function(block) {
           return code;
         }
       break;
+    }
   }
   throw Error('Unhandled combination (lists_setIndex).');
 };
 
 Blockly.Python['lists_getSublist'] = function(block) {
   // Get sublist.
-  var list = Blockly.Python.valueToCode(block, 'LIST',
+  const list = Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_MEMBER) || '[]';
-  var where1 = block.getFieldValue('WHERE1');
-  var where2 = block.getFieldValue('WHERE2');
+  const where1 = block.getFieldValue('WHERE1');
+  const where2 = block.getFieldValue('WHERE2');
+  let at1;
   switch (where1) {
-    case 'FROM_START':
-      var at1 = Blockly.Python.getAdjustedInt(block, 'AT1');
+    case 'FROM_START': {
+      at1 = Blockly.Python.getAdjustedInt(block, 'AT1');
       if (at1 === 0) {
         at1 = '';
       }
       break;
-    case 'FROM_END':
-      var at1 = Blockly.Python.getAdjustedInt(block, 'AT1', 1, true);
+    }
+    case 'FROM_END': {
+      at1 = Blockly.Python.getAdjustedInt(block, 'AT1', 1, true);
       break;
-    case 'FIRST':
-      var at1 = '';
+    }
+    case 'FIRST': {
+      at1 = '';
       break;
+    }
     default:
       throw Error('Unhandled option (lists_getSublist)');
   }
+
+  let at2;
   switch (where2) {
-    case 'FROM_START':
-      var at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 1);
+    case 'FROM_START': {
+      at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 1);
       break;
-    case 'FROM_END':
-      var at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 0, true);
+    }
+    case 'FROM_END': {
+      at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 0, true);
       // Ensure that if the result calculated is 0 that sub-sequence will
       // include all elements as expected.
       if (!Blockly.isNumber(String(at2))) {
@@ -279,23 +297,25 @@ Blockly.Python['lists_getSublist'] = function(block) {
         at2 = '';
       }
       break;
-    case 'LAST':
-      var at2 = '';
+    }
+    case 'LAST': {
+      at2 = '';
       break;
+    }
     default:
       throw Error('Unhandled option (lists_getSublist)');
   }
-  var code = list + '[' + at1 + ' : ' + at2 + ']';
+  const code = list + '[' + at1 + ' : ' + at2 + ']';
   return [code, Blockly.Python.ORDER_MEMBER];
 };
 
 Blockly.Python['lists_sort'] = function(block) {
   // Block for sorting a list.
-  var list = (Blockly.Python.valueToCode(block, 'LIST',
+  const list = (Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_NONE) || '[]');
-  var type = block.getFieldValue('TYPE');
-  var reverse = block.getFieldValue('DIRECTION') === '1' ? 'False' : 'True';
-  var sortFunctionName = Blockly.Python.provideFunction_('lists_sort',
+  const type = block.getFieldValue('TYPE');
+  const reverse = block.getFieldValue('DIRECTION') === '1' ? 'False' : 'True';
+  const sortFunctionName = Blockly.Python.provideFunction_('lists_sort',
   ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ +
       '(my_list, type, reverse):',
     '  def try_float(s):',
@@ -313,26 +333,29 @@ Blockly.Python['lists_sort'] = function(block) {
     '  return sorted(list_cpy, key=key_func, reverse=reverse)'
   ]);
 
-  var code = sortFunctionName +
+  const code = sortFunctionName +
       '(' + list + ', "' + type + '", ' + reverse + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
-  var mode = block.getFieldValue('MODE');
+  const mode = block.getFieldValue('MODE');
+  let code;
   if (mode === 'SPLIT') {
-    var value_input = Blockly.Python.valueToCode(block, 'INPUT',
+    const value_input = Blockly.Python.valueToCode(block, 'INPUT',
         Blockly.Python.ORDER_MEMBER) || '\'\'';
-    var value_delim = Blockly.Python.valueToCode(block, 'DELIM',
-        Blockly.Python.ORDER_NONE);
-    var code = value_input + '.split(' + value_delim + ')';
+    const value_delim =
+        Blockly.Python.valueToCode(block, 'DELIM', Blockly.Python.ORDER_NONE);
+    code = value_input + '.split(' + value_delim + ')';
   } else if (mode === 'JOIN') {
-    var value_input = Blockly.Python.valueToCode(block, 'INPUT',
-        Blockly.Python.ORDER_NONE) || '[]';
-    var value_delim = Blockly.Python.valueToCode(block, 'DELIM',
-        Blockly.Python.ORDER_MEMBER) || '\'\'';
-    var code = value_delim + '.join(' + value_input + ')';
+    const value_input =
+        Blockly.Python.valueToCode(block, 'INPUT', Blockly.Python.ORDER_NONE) ||
+        '[]';
+    const value_delim = Blockly.Python.valueToCode(
+                            block, 'DELIM', Blockly.Python.ORDER_MEMBER) ||
+        '\'\'';
+    code = value_delim + '.join(' + value_input + ')';
   } else {
     throw Error('Unknown mode: ' + mode);
   }
@@ -341,8 +364,8 @@ Blockly.Python['lists_split'] = function(block) {
 
 Blockly.Python['lists_reverse'] = function(block) {
   // Block for reversing a list.
-  var list = Blockly.Python.valueToCode(block, 'LIST',
+  const list = Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_NONE) || '[]';
-  var code = 'list(reversed(' + list + '))';
+  const code = 'list(reversed(' + list + '))';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };

--- a/generators/python/lists.js
+++ b/generators/python/lists.js
@@ -103,7 +103,7 @@ Blockly.Python['lists_getIndex'] = function(block) {
   const list = Blockly.Python.valueToCode(block, 'VALUE', listOrder) || '[]';
 
   switch (where) {
-    case 'FIRST': {
+    case 'FIRST':
       if (mode === 'GET') {
         const code = list + '[0]';
         return [code, Blockly.Python.ORDER_MEMBER];
@@ -114,8 +114,7 @@ Blockly.Python['lists_getIndex'] = function(block) {
         return list + '.pop(0)\n';
       }
       break;
-    }
-    case 'LAST': {
+    case 'LAST':
       if (mode === 'GET') {
         const code = list + '[-1]';
         return [code, Blockly.Python.ORDER_MEMBER];
@@ -126,7 +125,6 @@ Blockly.Python['lists_getIndex'] = function(block) {
         return list + '.pop()\n';
       }
       break;
-    }
     case 'FROM_START': {
       const at = Blockly.Python.getAdjustedInt(block, 'AT');
       if (mode === 'GET') {
@@ -153,7 +151,7 @@ Blockly.Python['lists_getIndex'] = function(block) {
       }
       break;
     }
-    case 'RANDOM': {
+    case 'RANDOM':
       Blockly.Python.definitions_['import_random'] = 'import random';
       if (mode === 'GET') {
         const code = 'random.choice(' + list + ')';
@@ -172,7 +170,6 @@ Blockly.Python['lists_getIndex'] = function(block) {
         }
       }
       break;
-    }
   }
   throw Error('Unhandled combination (lists_getIndex).');
 };
@@ -200,22 +197,20 @@ Blockly.Python['lists_setIndex'] = function(block) {
   }
 
   switch (where) {
-    case 'FIRST': {
+    case 'FIRST':
       if (mode === 'SET') {
         return list + '[0] = ' + value + '\n';
       } else if (mode === 'INSERT') {
         return list + '.insert(0, ' + value + ')\n';
       }
       break;
-    }
-    case 'LAST': {
+    case 'LAST':
         if (mode === 'SET') {
           return list + '[-1] = ' + value + '\n';
         } else if (mode === 'INSERT') {
           return list + '.append(' + value + ')\n';
         }
       break;
-    }
     case 'FROM_START': {
       const at = Blockly.Python.getAdjustedInt(block, 'AT');
         if (mode === 'SET') {
@@ -261,32 +256,28 @@ Blockly.Python['lists_getSublist'] = function(block) {
   const where2 = block.getFieldValue('WHERE2');
   let at1;
   switch (where1) {
-    case 'FROM_START': {
+    case 'FROM_START':
       at1 = Blockly.Python.getAdjustedInt(block, 'AT1');
       if (at1 === 0) {
         at1 = '';
       }
       break;
-    }
-    case 'FROM_END': {
+    case 'FROM_END':
       at1 = Blockly.Python.getAdjustedInt(block, 'AT1', 1, true);
       break;
-    }
-    case 'FIRST': {
+    case 'FIRST':
       at1 = '';
       break;
-    }
     default:
       throw Error('Unhandled option (lists_getSublist)');
   }
 
   let at2;
   switch (where2) {
-    case 'FROM_START': {
+    case 'FROM_START':
       at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 1);
       break;
-    }
-    case 'FROM_END': {
+    case 'FROM_END':
       at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 0, true);
       // Ensure that if the result calculated is 0 that sub-sequence will
       // include all elements as expected.
@@ -297,11 +288,9 @@ Blockly.Python['lists_getSublist'] = function(block) {
         at2 = '';
       }
       break;
-    }
-    case 'LAST': {
+    case 'LAST':
       at2 = '';
       break;
-    }
     default:
       throw Error('Unhandled option (lists_getSublist)');
   }

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -16,8 +16,8 @@ goog.require('Blockly.Python');
 
 Blockly.Python['controls_if'] = function(block) {
   // If/elseif/else condition.
-  var n = 0;
-  var code = '', branchCode, conditionCode;
+  let n = 0;
+  let code = '', branchCode, conditionCode;
   if (Blockly.Python.STATEMENT_PREFIX) {
     // Automatic prefix insertion is switched off for this block.  Add manually.
     code += Blockly.Python.injectId(Blockly.Python.STATEMENT_PREFIX, block);
@@ -53,7 +53,7 @@ Blockly.Python['controls_ifelse'] = Blockly.Python['controls_if'];
 
 Blockly.Python['logic_compare'] = function(block) {
   // Comparison operator.
-  var OPERATORS = {
+  const OPERATORS = {
     'EQ': '==',
     'NEQ': '!=',
     'LT': '<',
@@ -61,28 +61,28 @@ Blockly.Python['logic_compare'] = function(block) {
     'GT': '>',
     'GTE': '>='
   };
-  var operator = OPERATORS[block.getFieldValue('OP')];
-  var order = Blockly.Python.ORDER_RELATIONAL;
-  var argument0 = Blockly.Python.valueToCode(block, 'A', order) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'B', order) || '0';
-  var code = argument0 + ' ' + operator + ' ' + argument1;
+  const operator = OPERATORS[block.getFieldValue('OP')];
+  const order = Blockly.Python.ORDER_RELATIONAL;
+  const argument0 = Blockly.Python.valueToCode(block, 'A', order) || '0';
+  const argument1 = Blockly.Python.valueToCode(block, 'B', order) || '0';
+  const code = argument0 + ' ' + operator + ' ' + argument1;
   return [code, order];
 };
 
 Blockly.Python['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
-  var operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
-  var order = (operator === 'and') ? Blockly.Python.ORDER_LOGICAL_AND :
+  const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
+  const order = (operator === 'and') ? Blockly.Python.ORDER_LOGICAL_AND :
       Blockly.Python.ORDER_LOGICAL_OR;
-  var argument0 = Blockly.Python.valueToCode(block, 'A', order);
-  var argument1 = Blockly.Python.valueToCode(block, 'B', order);
+  let argument0 = Blockly.Python.valueToCode(block, 'A', order);
+  let argument1 = Blockly.Python.valueToCode(block, 'B', order);
   if (!argument0 && !argument1) {
     // If there are no arguments, then the return value is false.
     argument0 = 'False';
     argument1 = 'False';
   } else {
     // Single missing arguments have no effect on the return value.
-    var defaultArgument = (operator === 'and') ? 'True' : 'False';
+    const defaultArgument = (operator === 'and') ? 'True' : 'False';
     if (!argument0) {
       argument0 = defaultArgument;
     }
@@ -90,21 +90,21 @@ Blockly.Python['logic_operation'] = function(block) {
       argument1 = defaultArgument;
     }
   }
-  var code = argument0 + ' ' + operator + ' ' + argument1;
+  const code = argument0 + ' ' + operator + ' ' + argument1;
   return [code, order];
 };
 
 Blockly.Python['logic_negate'] = function(block) {
   // Negation.
-  var argument0 = Blockly.Python.valueToCode(block, 'BOOL',
+  const argument0 = Blockly.Python.valueToCode(block, 'BOOL',
       Blockly.Python.ORDER_LOGICAL_NOT) || 'True';
-  var code = 'not ' + argument0;
+  const code = 'not ' + argument0;
   return [code, Blockly.Python.ORDER_LOGICAL_NOT];
 };
 
 Blockly.Python['logic_boolean'] = function(block) {
   // Boolean values true and false.
-  var code = (block.getFieldValue('BOOL') === 'TRUE') ? 'True' : 'False';
+  const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'True' : 'False';
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
@@ -115,12 +115,12 @@ Blockly.Python['logic_null'] = function(block) {
 
 Blockly.Python['logic_ternary'] = function(block) {
   // Ternary operator.
-  var value_if = Blockly.Python.valueToCode(block, 'IF',
+  const value_if = Blockly.Python.valueToCode(block, 'IF',
       Blockly.Python.ORDER_CONDITIONAL) || 'False';
-  var value_then = Blockly.Python.valueToCode(block, 'THEN',
+  const value_then = Blockly.Python.valueToCode(block, 'THEN',
       Blockly.Python.ORDER_CONDITIONAL) || 'None';
-  var value_else = Blockly.Python.valueToCode(block, 'ELSE',
+  const value_else = Blockly.Python.valueToCode(block, 'ELSE',
       Blockly.Python.ORDER_CONDITIONAL) || 'None';
-  var code = value_then + ' if ' + value_if + ' else ' + value_else;
+  const code = value_then + ' if ' + value_if + ' else ' + value_else;
   return [code, Blockly.Python.ORDER_CONDITIONAL];
 };

--- a/generators/python/loops.js
+++ b/generators/python/loops.js
@@ -16,12 +16,13 @@ goog.require('Blockly.Python');
 
 Blockly.Python['controls_repeat_ext'] = function(block) {
   // Repeat n times.
+  let repeats;
   if (block.getField('TIMES')) {
     // Internal number.
-    var repeats = String(parseInt(block.getFieldValue('TIMES'), 10));
+    repeats = String(parseInt(block.getFieldValue('TIMES'), 10));
   } else {
     // External number.
-    var repeats = Blockly.Python.valueToCode(block, 'TIMES',
+    repeats = Blockly.Python.valueToCode(block, 'TIMES',
         Blockly.Python.ORDER_NONE) || '0';
   }
   if (Blockly.isNumber(repeats)) {
@@ -29,11 +30,11 @@ Blockly.Python['controls_repeat_ext'] = function(block) {
   } else {
     repeats = 'int(' + repeats + ')';
   }
-  var branch = Blockly.Python.statementToCode(block, 'DO');
+  let branch = Blockly.Python.statementToCode(block, 'DO');
   branch = Blockly.Python.addLoopTrap(branch, block) || Blockly.Python.PASS;
-  var loopVar = Blockly.Python.nameDB_.getDistinctName(
+  const loopVar = Blockly.Python.nameDB_.getDistinctName(
       'count', Blockly.VARIABLE_CATEGORY_NAME);
-  var code = 'for ' + loopVar + ' in range(' + repeats + '):\n' + branch;
+  const code = 'for ' + loopVar + ' in range(' + repeats + '):\n' + branch;
   return code;
 };
 
@@ -41,11 +42,11 @@ Blockly.Python['controls_repeat'] = Blockly.Python['controls_repeat_ext'];
 
 Blockly.Python['controls_whileUntil'] = function(block) {
   // Do while/until loop.
-  var until = block.getFieldValue('MODE') === 'UNTIL';
-  var argument0 = Blockly.Python.valueToCode(block, 'BOOL',
+  const until = block.getFieldValue('MODE') === 'UNTIL';
+  let argument0 = Blockly.Python.valueToCode(block, 'BOOL',
       until ? Blockly.Python.ORDER_LOGICAL_NOT :
       Blockly.Python.ORDER_NONE) || 'False';
-  var branch = Blockly.Python.statementToCode(block, 'DO');
+  let branch = Blockly.Python.statementToCode(block, 'DO');
   branch = Blockly.Python.addLoopTrap(branch, block) || Blockly.Python.PASS;
   if (until) {
     argument0 = 'not ' + argument0;
@@ -55,22 +56,22 @@ Blockly.Python['controls_whileUntil'] = function(block) {
 
 Blockly.Python['controls_for'] = function(block) {
   // For loop.
-  var variable0 = Blockly.Python.nameDB_.getName(
+  const variable0 = Blockly.Python.nameDB_.getName(
       block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  var argument0 = Blockly.Python.valueToCode(block, 'FROM',
+  let argument0 = Blockly.Python.valueToCode(block, 'FROM',
       Blockly.Python.ORDER_NONE) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'TO',
+  let argument1 = Blockly.Python.valueToCode(block, 'TO',
       Blockly.Python.ORDER_NONE) || '0';
-  var increment = Blockly.Python.valueToCode(block, 'BY',
+  let increment = Blockly.Python.valueToCode(block, 'BY',
       Blockly.Python.ORDER_NONE) || '1';
-  var branch = Blockly.Python.statementToCode(block, 'DO');
+  let branch = Blockly.Python.statementToCode(block, 'DO');
   branch = Blockly.Python.addLoopTrap(branch, block) || Blockly.Python.PASS;
 
-  var code = '';
-  var range;
+  let code = '';
+  let range;
 
   // Helper functions.
-  var defineUpRange = function() {
+  const defineUpRange = function() {
     return Blockly.Python.provideFunction_(
         'upRange',
         ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ +
@@ -79,7 +80,7 @@ Blockly.Python['controls_for'] = function(block) {
          '    yield start',
          '    start += abs(step)']);
   };
-  var defineDownRange = function() {
+  const defineDownRange = function() {
     return Blockly.Python.provideFunction_(
         'downRange',
         ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ +
@@ -89,7 +90,7 @@ Blockly.Python['controls_for'] = function(block) {
          '    start -= abs(step)']);
   };
   // Arguments are legal Python code (numbers or strings returned by scrub()).
-  var generateUpDownRange = function(start, end, inc) {
+  const generateUpDownRange = function(start, end, inc) {
     return '(' + start + ' <= ' + end + ') and ' +
         defineUpRange() + '(' + start + ', ' + end + ', ' + inc + ') or ' +
         defineDownRange() + '(' + start + ', ' + end + ', ' + inc + ')';
@@ -133,7 +134,7 @@ Blockly.Python['controls_for'] = function(block) {
     }
   } else {
     // Cache non-trivial values to variables to prevent repeated look-ups.
-    var scrub = function(arg, suffix) {
+    const scrub = function(arg, suffix) {
       if (Blockly.isNumber(arg)) {
         // Simple number.
         arg = Number(arg);
@@ -142,16 +143,16 @@ Blockly.Python['controls_for'] = function(block) {
         arg = 'float(' + arg + ')';
       } else {
         // It's complicated.
-        var varName = Blockly.Python.nameDB_.getDistinctName(
+        const varName = Blockly.Python.nameDB_.getDistinctName(
             variable0 + suffix, Blockly.VARIABLE_CATEGORY_NAME);
         code += varName + ' = float(' + arg + ')\n';
         arg = varName;
       }
       return arg;
     };
-    var startVar = scrub(argument0, '_start');
-    var endVar = scrub(argument1, '_end');
-    var incVar = scrub(increment, '_inc');
+    const startVar = scrub(argument0, '_start');
+    const endVar = scrub(argument1, '_end');
+    const incVar = scrub(increment, '_inc');
 
     if (typeof startVar === 'number' && typeof endVar === 'number') {
       if (startVar < endVar) {
@@ -171,19 +172,19 @@ Blockly.Python['controls_for'] = function(block) {
 
 Blockly.Python['controls_forEach'] = function(block) {
   // For each loop.
-  var variable0 = Blockly.Python.nameDB_.getName(
+  const variable0 = Blockly.Python.nameDB_.getName(
       block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  var argument0 = Blockly.Python.valueToCode(block, 'LIST',
+  const argument0 = Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_RELATIONAL) || '[]';
-  var branch = Blockly.Python.statementToCode(block, 'DO');
+  let branch = Blockly.Python.statementToCode(block, 'DO');
   branch = Blockly.Python.addLoopTrap(branch, block) || Blockly.Python.PASS;
-  var code = 'for ' + variable0 + ' in ' + argument0 + ':\n' + branch;
+  const code = 'for ' + variable0 + ' in ' + argument0 + ':\n' + branch;
   return code;
 };
 
 Blockly.Python['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
-  var xfix = '';
+  let xfix = '';
   if (Blockly.Python.STATEMENT_PREFIX) {
     // Automatic prefix insertion is switched off for this block.  Add manually.
     xfix += Blockly.Python.injectId(Blockly.Python.STATEMENT_PREFIX, block);
@@ -194,7 +195,7 @@ Blockly.Python['controls_flow_statements'] = function(block) {
     xfix += Blockly.Python.injectId(Blockly.Python.STATEMENT_SUFFIX, block);
   }
   if (Blockly.Python.STATEMENT_PREFIX) {
-    var loop = Blockly.Constants.Loops
+    const loop = Blockly.Constants.Loops
         .CONTROL_FLOW_IN_LOOP_CHECK_MIXIN.getSurroundLoop(block);
     if (loop && !loop.suppressPrefixSuffix) {
       // Inject loop's statement prefix here since the regular one at the end

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -19,8 +19,8 @@ Blockly.Python.addReservedWords('math,random,Number');
 
 Blockly.Python['math_number'] = function(block) {
   // Numeric value.
-  var code = Number(block.getFieldValue('NUM'));
-  var order;
+  let code = Number(block.getFieldValue('NUM'));
+  let order;
   if (code === Infinity) {
     code = 'float("inf")';
     order = Blockly.Python.ORDER_FUNCTION_CALL;
@@ -36,19 +36,19 @@ Blockly.Python['math_number'] = function(block) {
 
 Blockly.Python['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
-  var OPERATORS = {
+  const OPERATORS = {
     'ADD': [' + ', Blockly.Python.ORDER_ADDITIVE],
     'MINUS': [' - ', Blockly.Python.ORDER_ADDITIVE],
     'MULTIPLY': [' * ', Blockly.Python.ORDER_MULTIPLICATIVE],
     'DIVIDE': [' / ', Blockly.Python.ORDER_MULTIPLICATIVE],
     'POWER': [' ** ', Blockly.Python.ORDER_EXPONENTIATION]
   };
-  var tuple = OPERATORS[block.getFieldValue('OP')];
-  var operator = tuple[0];
-  var order = tuple[1];
-  var argument0 = Blockly.Python.valueToCode(block, 'A', order) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'B', order) || '0';
-  var code = argument0 + operator + argument1;
+  const tuple = OPERATORS[block.getFieldValue('OP')];
+  const operator = tuple[0];
+  const order = tuple[1];
+  const argument0 = Blockly.Python.valueToCode(block, 'A', order) || '0';
+  const argument1 = Blockly.Python.valueToCode(block, 'B', order) || '0';
+  const code = argument0 + operator + argument1;
   return [code, order];
   // In case of 'DIVIDE', division between integers returns different results
   // in Python 2 and 3. However, is not an issue since Blockly does not
@@ -59,9 +59,9 @@ Blockly.Python['math_arithmetic'] = function(block) {
 
 Blockly.Python['math_single'] = function(block) {
   // Math operators with single operand.
-  var operator = block.getFieldValue('OP');
-  var code;
-  var arg;
+  const operator = block.getFieldValue('OP');
+  let code;
+  let arg;
   if (operator === 'NEG') {
     // Negation is a special case given its different operator precedence.
     code = Blockly.Python.valueToCode(block, 'NUM',
@@ -139,7 +139,7 @@ Blockly.Python['math_single'] = function(block) {
 
 Blockly.Python['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
-  var CONSTANTS = {
+  const CONSTANTS = {
     'PI': ['math.pi', Blockly.Python.ORDER_MEMBER],
     'E': ['math.e', Blockly.Python.ORDER_MEMBER],
     'GOLDEN_RATIO': ['(1 + math.sqrt(5)) / 2',
@@ -148,7 +148,7 @@ Blockly.Python['math_constant'] = function(block) {
     'SQRT1_2': ['math.sqrt(1.0 / 2)', Blockly.Python.ORDER_MEMBER],
     'INFINITY': ['float(\'inf\')', Blockly.Python.ORDER_ATOMIC]
   };
-  var constant = block.getFieldValue('CONSTANT');
+  const constant = block.getFieldValue('CONSTANT');
   if (constant !== 'INFINITY') {
     Blockly.Python.definitions_['import_math'] = 'import math';
   }
@@ -158,15 +158,15 @@ Blockly.Python['math_constant'] = function(block) {
 Blockly.Python['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  var number_to_check = Blockly.Python.valueToCode(block, 'NUMBER_TO_CHECK',
+  const number_to_check = Blockly.Python.valueToCode(block, 'NUMBER_TO_CHECK',
       Blockly.Python.ORDER_MULTIPLICATIVE) || '0';
-  var dropdown_property = block.getFieldValue('PROPERTY');
-  var code;
+  const dropdown_property = block.getFieldValue('PROPERTY');
+  let code;
   if (dropdown_property === 'PRIME') {
     Blockly.Python.definitions_['import_math'] = 'import math';
     Blockly.Python.definitions_['from_numbers_import_Number'] =
         'from numbers import Number';
-    var functionName = Blockly.Python.provideFunction_(
+    const functionName = Blockly.Python.provideFunction_(
         'math_isPrime',
         ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(n):',
          '  # https://en.wikipedia.org/wiki/Primality_test#Naive_methods',
@@ -206,8 +206,8 @@ Blockly.Python['math_number_property'] = function(block) {
     case 'NEGATIVE':
       code = number_to_check + ' < 0';
       break;
-    case 'DIVISIBLE_BY':
-      var divisor = Blockly.Python.valueToCode(block, 'DIVISOR',
+    case 'DIVISIBLE_BY': {
+      const divisor = Blockly.Python.valueToCode(block, 'DIVISOR',
           Blockly.Python.ORDER_MULTIPLICATIVE);
       // If 'divisor' is some code that evals to 0, Python will raise an error.
       if (!divisor || divisor === '0') {
@@ -215,6 +215,7 @@ Blockly.Python['math_number_property'] = function(block) {
       }
       code = number_to_check + ' % ' + divisor + ' == 0';
       break;
+    }
   }
   return [code, Blockly.Python.ORDER_RELATIONAL];
 };
@@ -223,9 +224,9 @@ Blockly.Python['math_change'] = function(block) {
   // Add to a variable in place.
   Blockly.Python.definitions_['from_numbers_import_Number'] =
       'from numbers import Number';
-  var argument0 = Blockly.Python.valueToCode(block, 'DELTA',
+  const argument0 = Blockly.Python.valueToCode(block, 'DELTA',
       Blockly.Python.ORDER_ADDITIVE) || '0';
-  var varName = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
+  const varName = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
       Blockly.VARIABLE_CATEGORY_NAME);
   return varName + ' = (' + varName + ' if isinstance(' + varName +
       ', Number) else 0) + ' + argument0 + '\n';
@@ -238,10 +239,10 @@ Blockly.Python['math_trig'] = Blockly.Python['math_single'];
 
 Blockly.Python['math_on_list'] = function(block) {
   // Math functions for lists.
-  var func = block.getFieldValue('OP');
-  var list = Blockly.Python.valueToCode(block, 'LIST',
+  const func = block.getFieldValue('OP');
+  const list = Blockly.Python.valueToCode(block, 'LIST',
       Blockly.Python.ORDER_NONE) || '[]';
-  var code;
+  let code;
   switch (func) {
     case 'SUM':
       code = 'sum(' + list + ')';
@@ -252,10 +253,10 @@ Blockly.Python['math_on_list'] = function(block) {
     case 'MAX':
       code = 'max(' + list + ')';
       break;
-    case 'AVERAGE':
+    case 'AVERAGE': {
       Blockly.Python.definitions_['from_numbers_import_Number'] =
           'from numbers import Number';
-      var functionName = Blockly.Python.provideFunction_(
+      const functionName = Blockly.Python.provideFunction_(
           'math_mean',
           // This operation excludes null and values that aren't int or float:
           // math_mean([null, null, "aString", 1, 9]) -> 5.0
@@ -265,10 +266,11 @@ Blockly.Python['math_on_list'] = function(block) {
            '  return float(sum(localList)) / len(localList)']);
       code = functionName + '(' + list + ')';
       break;
-    case 'MEDIAN':
+    }
+    case 'MEDIAN': {
       Blockly.Python.definitions_['from_numbers_import_Number'] =
           'from numbers import Number';
-      var functionName = Blockly.Python.provideFunction_(
+      const functionName = Blockly.Python.provideFunction_(
           'math_median',
           // This operation excludes null values:
           // math_median([null, null, 1, 3]) -> 2.0
@@ -282,8 +284,9 @@ Blockly.Python['math_on_list'] = function(block) {
            '    return localList[(len(localList) - 1) // 2]']);
       code = functionName + '(' + list + ')';
       break;
-    case 'MODE':
-      var functionName = Blockly.Python.provideFunction_(
+    }
+    case 'MODE': {
+      const functionName = Blockly.Python.provideFunction_(
           'math_modes',
           // As a list of numbers can contain more than one mode,
           // the returned result is provided as an array.
@@ -310,9 +313,10 @@ Blockly.Python['math_on_list'] = function(block) {
            '  return modes']);
       code = functionName + '(' + list + ')';
       break;
-    case 'STD_DEV':
+    }
+    case 'STD_DEV': {
       Blockly.Python.definitions_['import_math'] = 'import math';
-      var functionName = Blockly.Python.provideFunction_(
+      const functionName = Blockly.Python.provideFunction_(
           'math_standard_deviation',
           ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(numbers):',
            '  n = len(numbers)',
@@ -322,10 +326,12 @@ Blockly.Python['math_on_list'] = function(block) {
            '  return math.sqrt(variance)']);
       code = functionName + '(' + list + ')';
       break;
-    case 'RANDOM':
+    }
+    case 'RANDOM':{
       Blockly.Python.definitions_['import_random'] = 'import random';
       code = 'random.choice(' + list + ')';
       break;
+    }
     default:
       throw Error('Unknown operator: ' + func);
   }
@@ -334,23 +340,23 @@ Blockly.Python['math_on_list'] = function(block) {
 
 Blockly.Python['math_modulo'] = function(block) {
   // Remainder computation.
-  var argument0 = Blockly.Python.valueToCode(block, 'DIVIDEND',
+  const argument0 = Blockly.Python.valueToCode(block, 'DIVIDEND',
       Blockly.Python.ORDER_MULTIPLICATIVE) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'DIVISOR',
+  const argument1 = Blockly.Python.valueToCode(block, 'DIVISOR',
       Blockly.Python.ORDER_MULTIPLICATIVE) || '0';
-  var code = argument0 + ' % ' + argument1;
+  const code = argument0 + ' % ' + argument1;
   return [code, Blockly.Python.ORDER_MULTIPLICATIVE];
 };
 
 Blockly.Python['math_constrain'] = function(block) {
   // Constrain a number between two limits.
-  var argument0 = Blockly.Python.valueToCode(block, 'VALUE',
+  const argument0 = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'LOW',
+  const argument1 = Blockly.Python.valueToCode(block, 'LOW',
       Blockly.Python.ORDER_NONE) || '0';
-  var argument2 = Blockly.Python.valueToCode(block, 'HIGH',
+  const argument2 = Blockly.Python.valueToCode(block, 'HIGH',
       Blockly.Python.ORDER_NONE) || 'float(\'inf\')';
-  var code = 'min(max(' + argument0 + ', ' + argument1 + '), ' +
+  const code = 'min(max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
@@ -358,11 +364,11 @@ Blockly.Python['math_constrain'] = function(block) {
 Blockly.Python['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   Blockly.Python.definitions_['import_random'] = 'import random';
-  var argument0 = Blockly.Python.valueToCode(block, 'FROM',
+  const argument0 = Blockly.Python.valueToCode(block, 'FROM',
       Blockly.Python.ORDER_NONE) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'TO',
+  const argument1 = Blockly.Python.valueToCode(block, 'TO',
       Blockly.Python.ORDER_NONE) || '0';
-  var code = 'random.randint(' + argument0 + ', ' + argument1 + ')';
+  const code = 'random.randint(' + argument0 + ', ' + argument1 + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
@@ -375,9 +381,9 @@ Blockly.Python['math_random_float'] = function(block) {
 Blockly.Python['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   Blockly.Python.definitions_['import_math'] = 'import math';
-  var argument0 = Blockly.Python.valueToCode(block, 'X',
+  const argument0 = Blockly.Python.valueToCode(block, 'X',
       Blockly.Python.ORDER_NONE) || '0';
-  var argument1 = Blockly.Python.valueToCode(block, 'Y',
+  const argument1 = Blockly.Python.valueToCode(block, 'Y',
       Blockly.Python.ORDER_NONE) || '0';
   return ['math.atan2(' + argument1 + ', ' + argument0 + ') / math.pi * 180',
       Blockly.Python.ORDER_MULTIPLICATIVE];

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -327,11 +327,10 @@ Blockly.Python['math_on_list'] = function(block) {
       code = functionName + '(' + list + ')';
       break;
     }
-    case 'RANDOM':{
+    case 'RANDOM':
       Blockly.Python.definitions_['import_random'] = 'import random';
       code = 'random.choice(' + list + ')';
       break;
-    }
     default:
       throw Error('Unknown operator: ' + func);
   }

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -18,28 +18,28 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   // First, add a 'global' statement for every variable that is not shadowed by
   // a local parameter.
-  var globals = [];
-  var workspace = block.workspace;
-  var variables = Blockly.Variables.allUsedVarModels(workspace) || [];
-  for (var i = 0, variable; (variable = variables[i]); i++) {
-    var varName = variable.name;
+  const globals = [];
+  const workspace = block.workspace;
+  const usedVariables = Blockly.Variables.allUsedVarModels(workspace) || [];
+  for (let i = 0, variable; (variable = usedVariables[i]); i++) {
+    const varName = variable.name;
     if (block.getVars().indexOf(varName) === -1) {
       globals.push(Blockly.Python.nameDB_.getName(varName,
           Blockly.VARIABLE_CATEGORY_NAME));
     }
   }
   // Add developer variables.
-  var devVarList = Blockly.Variables.allDeveloperVariables(workspace);
-  for (var i = 0; i < devVarList.length; i++) {
+  const devVarList = Blockly.Variables.allDeveloperVariables(workspace);
+  for (let i = 0; i < devVarList.length; i++) {
     globals.push(Blockly.Python.nameDB_.getName(devVarList[i],
         Blockly.Names.DEVELOPER_VARIABLE_TYPE));
   }
 
-  globals = globals.length ?
+  const globalString = globals.length ?
       Blockly.Python.INDENT + 'global ' + globals.join(', ') + '\n' : '';
-  var funcName = Blockly.Python.nameDB_.getName(
+  const funcName = Blockly.Python.nameDB_.getName(
       block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
-  var xfix1 = '';
+  let xfix1 = '';
   if (Blockly.Python.STATEMENT_PREFIX) {
     xfix1 += Blockly.Python.injectId(Blockly.Python.STATEMENT_PREFIX, block);
   }
@@ -49,16 +49,16 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   if (xfix1) {
     xfix1 = Blockly.Python.prefixLines(xfix1, Blockly.Python.INDENT);
   }
-  var loopTrap = '';
+  let loopTrap = '';
   if (Blockly.Python.INFINITE_LOOP_TRAP) {
     loopTrap = Blockly.Python.prefixLines(
         Blockly.Python.injectId(Blockly.Python.INFINITE_LOOP_TRAP, block),
         Blockly.Python.INDENT);
   }
-  var branch = Blockly.Python.statementToCode(block, 'STACK');
-  var returnValue = Blockly.Python.valueToCode(block, 'RETURN',
+  let branch = Blockly.Python.statementToCode(block, 'STACK');
+  let returnValue = Blockly.Python.valueToCode(block, 'RETURN',
       Blockly.Python.ORDER_NONE) || '';
-  var xfix2 = '';
+  let xfix2 = '';
   if (branch && returnValue) {
     // After executing the function body, revisit this block for the return.
     xfix2 = xfix1;
@@ -68,14 +68,14 @@ Blockly.Python['procedures_defreturn'] = function(block) {
   } else if (!branch) {
     branch = Blockly.Python.PASS;
   }
-  var args = [];
-  var variables = block.getVars();
-  for (var i = 0; i < variables.length; i++) {
+  const args = [];
+  const variables = block.getVars();
+  for (let i = 0; i < variables.length; i++) {
     args[i] = Blockly.Python.nameDB_.getName(variables[i],
         Blockly.VARIABLE_CATEGORY_NAME);
   }
-  var code = 'def ' + funcName + '(' + args.join(', ') + '):\n' +
-      globals + xfix1 + loopTrap + branch + xfix2 + returnValue;
+  let code = 'def ' + funcName + '(' + args.join(', ') + '):\n' + globalString +
+      xfix1 + loopTrap + branch + xfix2 + returnValue;
   code = Blockly.Python.scrub_(block, code);
   // Add % so as not to collide with helper functions in definitions list.
   Blockly.Python.definitions_['%' + funcName] = code;
@@ -89,15 +89,15 @@ Blockly.Python['procedures_defnoreturn'] =
 
 Blockly.Python['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
-  var funcName = Blockly.Python.nameDB_.getName(block.getFieldValue('NAME'),
+  const funcName = Blockly.Python.nameDB_.getName(block.getFieldValue('NAME'),
       Blockly.PROCEDURE_CATEGORY_NAME);
-  var args = [];
-  var variables = block.getVars();
-  for (var i = 0; i < variables.length; i++) {
+  const args = [];
+  const variables = block.getVars();
+  for (let i = 0; i < variables.length; i++) {
     args[i] = Blockly.Python.valueToCode(block, 'ARG' + i,
         Blockly.Python.ORDER_NONE) || 'None';
   }
-  var code = funcName + '(' + args.join(', ') + ')';
+  const code = funcName + '(' + args.join(', ') + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
@@ -105,15 +105,15 @@ Blockly.Python['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  var tuple = Blockly.Python['procedures_callreturn'](block);
+  const tuple = Blockly.Python['procedures_callreturn'](block);
   return tuple[0] + '\n';
 };
 
 Blockly.Python['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
-  var condition = Blockly.Python.valueToCode(block, 'CONDITION',
+  const condition = Blockly.Python.valueToCode(block, 'CONDITION',
       Blockly.Python.ORDER_NONE) || 'False';
-  var code = 'if ' + condition + ':\n';
+  let code = 'if ' + condition + ':\n';
   if (Blockly.Python.STATEMENT_SUFFIX) {
     // Inject any statement suffix here since the regular one at the end
     // will not get executed if the return is triggered.
@@ -122,7 +122,7 @@ Blockly.Python['procedures_ifreturn'] = function(block) {
         Blockly.Python.INDENT);
   }
   if (block.hasReturnValue_) {
-    var value = Blockly.Python.valueToCode(block, 'VALUE',
+    const value = Blockly.Python.valueToCode(block, 'VALUE',
         Blockly.Python.ORDER_NONE) || 'None';
     code += Blockly.Python.INDENT + 'return ' + value + '\n';
   } else {

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -16,14 +16,14 @@ goog.require('Blockly.Python');
 
 Blockly.Python['text'] = function(block) {
   // Text value.
-  var code = Blockly.Python.quote_(block.getFieldValue('TEXT'));
+  const code = Blockly.Python.quote_(block.getFieldValue('TEXT'));
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Python['text_multiline'] = function(block) {
   // Text value.
-  var code = Blockly.Python.multiline_quote_(block.getFieldValue('TEXT'));
-  var order = code.indexOf('+') !== -1 ? Blockly.Python.ORDER_ADDITIVE :
+  const code = Blockly.Python.multiline_quote_(block.getFieldValue('TEXT'));
+  const order = code.indexOf('+') !== -1 ? Blockly.Python.ORDER_ADDITIVE :
       Blockly.Python.ORDER_ATOMIC;
   return [code, order];
 };
@@ -52,43 +52,46 @@ Blockly.Python['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   //Should we allow joining by '-' or ',' or any other characters?
   switch (block.itemCount_) {
-    case 0:
+    case 0: {
       return ['\'\'', Blockly.Python.ORDER_ATOMIC];
-      break;
-    case 1:
-      var element = Blockly.Python.valueToCode(block, 'ADD0',
+    }
+    case 1: {
+      const element = Blockly.Python.valueToCode(block, 'ADD0',
               Blockly.Python.ORDER_NONE) || '\'\'';
-      var codeAndOrder = Blockly.Python.text.forceString_(element);
+      const codeAndOrder = Blockly.Python.text.forceString_(element);
       return codeAndOrder;
-      break;
-    case 2:
-      var element0 = Blockly.Python.valueToCode(block, 'ADD0',
-          Blockly.Python.ORDER_NONE) || '\'\'';
-      var element1 = Blockly.Python.valueToCode(block, 'ADD1',
-          Blockly.Python.ORDER_NONE) || '\'\'';
-      var code = Blockly.Python.text.forceString_(element0)[0] + ' + ' +
+    }
+    case 2: {
+      const element0 = Blockly.Python.valueToCode(
+                           block, 'ADD0', Blockly.Python.ORDER_NONE) ||
+          '\'\'';
+      const element1 = Blockly.Python.valueToCode(
+                           block, 'ADD1', Blockly.Python.ORDER_NONE) ||
+          '\'\'';
+      const code = Blockly.Python.text.forceString_(element0)[0] + ' + ' +
           Blockly.Python.text.forceString_(element1)[0];
       return [code, Blockly.Python.ORDER_ADDITIVE];
-      break;
-    default:
-      var elements = [];
-      for (var i = 0; i < block.itemCount_; i++) {
+    }
+    default: {
+      const elements = [];
+      for (let i = 0; i < block.itemCount_; i++) {
         elements[i] = Blockly.Python.valueToCode(block, 'ADD' + i,
                 Blockly.Python.ORDER_NONE) || '\'\'';
       }
-      var tempVar = Blockly.Python.nameDB_.getDistinctName('x',
-          Blockly.VARIABLE_CATEGORY_NAME);
-      var code = '\'\'.join([str(' + tempVar + ') for ' + tempVar + ' in [' +
+      const tempVar = Blockly.Python.nameDB_.getDistinctName(
+          'x', Blockly.VARIABLE_CATEGORY_NAME);
+      const code = '\'\'.join([str(' + tempVar + ') for ' + tempVar + ' in [' +
           elements.join(', ') + ']])';
       return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+    }
   }
 };
 
 Blockly.Python['text_append'] = function(block) {
   // Append to a variable in place.
-  var varName = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
+  const varName = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
       Blockly.VARIABLE_CATEGORY_NAME);
-  var value = Blockly.Python.valueToCode(block, 'TEXT',
+  const value = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_NONE) || '\'\'';
   return varName + ' = str(' + varName + ') + ' +
       Blockly.Python.text.forceString_(value)[0] + '\n';
@@ -96,28 +99,28 @@ Blockly.Python['text_append'] = function(block) {
 
 Blockly.Python['text_length'] = function(block) {
   // Is the string null or array empty?
-  var text = Blockly.Python.valueToCode(block, 'VALUE',
+  const text = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '\'\'';
   return ['len(' + text + ')', Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  var text = Blockly.Python.valueToCode(block, 'VALUE',
+  const text = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  var code = 'not len(' + text + ')';
+  const code = 'not len(' + text + ')';
   return [code, Blockly.Python.ORDER_LOGICAL_NOT];
 };
 
 Blockly.Python['text_indexOf'] = function(block) {
   // Search the text for a substring.
   // Should we allow for non-case sensitive???
-  var operator = block.getFieldValue('END') === 'FIRST' ? 'find' : 'rfind';
-  var substring = Blockly.Python.valueToCode(block, 'FIND',
+  const operator = block.getFieldValue('END') === 'FIRST' ? 'find' : 'rfind';
+  const substring = Blockly.Python.valueToCode(block, 'FIND',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  var text = Blockly.Python.valueToCode(block, 'VALUE',
+  const text = Blockly.Python.valueToCode(block, 'VALUE',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var code = text + '.' + operator + '(' + substring + ')';
+  const code = text + '.' + operator + '(' + substring + ')';
   if (block.workspace.options.oneBasedIndex) {
     return [code + ' + 1', Blockly.Python.ORDER_ADDITIVE];
   }
@@ -127,66 +130,74 @@ Blockly.Python['text_indexOf'] = function(block) {
 Blockly.Python['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
-  var where = block.getFieldValue('WHERE') || 'FROM_START';
-  var textOrder = (where === 'RANDOM') ? Blockly.Python.ORDER_NONE :
+  const where = block.getFieldValue('WHERE') || 'FROM_START';
+  const textOrder = (where === 'RANDOM') ? Blockly.Python.ORDER_NONE :
       Blockly.Python.ORDER_MEMBER;
-  var text = Blockly.Python.valueToCode(block, 'VALUE', textOrder) || '\'\'';
+  const text = Blockly.Python.valueToCode(block, 'VALUE', textOrder) || '\'\'';
   switch (where) {
-    case 'FIRST':
-      var code = text + '[0]';
+    case 'FIRST': {
+      const code = text + '[0]';
       return [code, Blockly.Python.ORDER_MEMBER];
-    case 'LAST':
-      var code = text + '[-1]';
+    }
+    case 'LAST': {
+      const code = text + '[-1]';
       return [code, Blockly.Python.ORDER_MEMBER];
-    case 'FROM_START':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT');
-      var code = text + '[' + at + ']';
+    }
+    case 'FROM_START': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT');
+      const code = text + '[' + at + ']';
       return [code, Blockly.Python.ORDER_MEMBER];
-    case 'FROM_END':
-      var at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
-      var code = text + '[' + at + ']';
+    }
+    case 'FROM_END': {
+      const at = Blockly.Python.getAdjustedInt(block, 'AT', 1, true);
+      const code = text + '[' + at + ']';
       return [code, Blockly.Python.ORDER_MEMBER];
-    case 'RANDOM':
+    }
+    case 'RANDOM': {
       Blockly.Python.definitions_['import_random'] = 'import random';
-      var functionName = Blockly.Python.provideFunction_(
-          'text_random_letter',
-          ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(text):',
-           '  x = int(random.random() * len(text))',
-           '  return text[x];']);
-      code = functionName + '(' + text + ')';
+      const functionName =
+          Blockly.Python.provideFunction_('text_random_letter', [
+            'def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(text):',
+            '  x = int(random.random() * len(text))', '  return text[x];'
+          ]);
+      const code = functionName + '(' + text + ')';
       return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+    }
   }
   throw Error('Unhandled option (text_charAt).');
 };
 
 Blockly.Python['text_getSubstring'] = function(block) {
   // Get substring.
-  var where1 = block.getFieldValue('WHERE1');
-  var where2 = block.getFieldValue('WHERE2');
-  var text = Blockly.Python.valueToCode(block, 'STRING',
+  const where1 = block.getFieldValue('WHERE1');
+  const where2 = block.getFieldValue('WHERE2');
+  const text = Blockly.Python.valueToCode(block, 'STRING',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
+  let at1;
   switch (where1) {
     case 'FROM_START':
-      var at1 = Blockly.Python.getAdjustedInt(block, 'AT1');
+      at1 = Blockly.Python.getAdjustedInt(block, 'AT1');
       if (at1 === 0) {
         at1 = '';
       }
       break;
     case 'FROM_END':
-      var at1 = Blockly.Python.getAdjustedInt(block, 'AT1', 1, true);
+      at1 = Blockly.Python.getAdjustedInt(block, 'AT1', 1, true);
       break;
     case 'FIRST':
-      var at1 = '';
+      at1 = '';
       break;
     default:
       throw Error('Unhandled option (text_getSubstring)');
   }
+
+  let at2;
   switch (where2) {
     case 'FROM_START':
-      var at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 1);
+      at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 1);
       break;
     case 'FROM_END':
-      var at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 0, true);
+      at2 = Blockly.Python.getAdjustedInt(block, 'AT2', 0, true);
       // Ensure that if the result calculated is 0 that sub-sequence will
       // include all elements as expected.
       if (!Blockly.isNumber(String(at2))) {
@@ -197,69 +208,70 @@ Blockly.Python['text_getSubstring'] = function(block) {
       }
       break;
     case 'LAST':
-      var at2 = '';
+      at2 = '';
       break;
     default:
       throw Error('Unhandled option (text_getSubstring)');
   }
-  var code = text + '[' + at1 + ' : ' + at2 + ']';
+  const code = text + '[' + at1 + ' : ' + at2 + ']';
   return [code, Blockly.Python.ORDER_MEMBER];
 };
 
 Blockly.Python['text_changeCase'] = function(block) {
   // Change capitalization.
-  var OPERATORS = {
+  const OPERATORS = {
     'UPPERCASE': '.upper()',
     'LOWERCASE': '.lower()',
     'TITLECASE': '.title()'
   };
-  var operator = OPERATORS[block.getFieldValue('CASE')];
-  var text = Blockly.Python.valueToCode(block, 'TEXT',
+  const operator = OPERATORS[block.getFieldValue('CASE')];
+  const text = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var code = text + operator;
+  const code = text + operator;
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['text_trim'] = function(block) {
   // Trim spaces.
-  var OPERATORS = {
+  const OPERATORS = {
     'LEFT': '.lstrip()',
     'RIGHT': '.rstrip()',
     'BOTH': '.strip()'
   };
-  var operator = OPERATORS[block.getFieldValue('MODE')];
-  var text = Blockly.Python.valueToCode(block, 'TEXT',
+  const operator = OPERATORS[block.getFieldValue('MODE')];
+  const text = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var code = text + operator;
+  const code = text + operator;
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['text_print'] = function(block) {
   // Print statement.
-  var msg = Blockly.Python.valueToCode(block, 'TEXT',
+  const msg = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_NONE) || '\'\'';
   return 'print(' + msg + ')\n';
 };
 
 Blockly.Python['text_prompt_ext'] = function(block) {
   // Prompt function.
-  var functionName = Blockly.Python.provideFunction_(
+  const functionName = Blockly.Python.provideFunction_(
       'text_prompt',
       ['def ' + Blockly.Python.FUNCTION_NAME_PLACEHOLDER_ + '(msg):',
        '  try:',
        '    return raw_input(msg)',
        '  except NameError:',
        '    return input(msg)']);
+  let msg;
   if (block.getField('TEXT')) {
     // Internal message.
-    var msg = Blockly.Python.quote_(block.getFieldValue('TEXT'));
+    msg = Blockly.Python.quote_(block.getFieldValue('TEXT'));
   } else {
     // External message.
-    var msg = Blockly.Python.valueToCode(block, 'TEXT',
+    msg = Blockly.Python.valueToCode(block, 'TEXT',
         Blockly.Python.ORDER_NONE) || '\'\'';
   }
-  var code = functionName + '(' + msg + ')';
-  var toNumber = block.getFieldValue('TYPE') === 'NUMBER';
+  let code = functionName + '(' + msg + ')';
+  const toNumber = block.getFieldValue('TYPE') === 'NUMBER';
   if (toNumber) {
     code = 'float(' + code + ')';
   }
@@ -269,28 +281,28 @@ Blockly.Python['text_prompt_ext'] = function(block) {
 Blockly.Python['text_prompt'] = Blockly.Python['text_prompt_ext'];
 
 Blockly.Python['text_count'] = function(block) {
-  var text = Blockly.Python.valueToCode(block, 'TEXT',
+  const text = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var sub = Blockly.Python.valueToCode(block, 'SUB',
+  const sub = Blockly.Python.valueToCode(block, 'SUB',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  var code = text + '.count(' + sub + ')';
+  const code = text + '.count(' + sub + ')';
   return [code, Blockly.Python.ORDER_FUNCTION_CALL];
 };
 
 Blockly.Python['text_replace'] = function(block) {
-  var text = Blockly.Python.valueToCode(block, 'TEXT',
+  const text = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var from = Blockly.Python.valueToCode(block, 'FROM',
+  const from = Blockly.Python.valueToCode(block, 'FROM',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  var to = Blockly.Python.valueToCode(block, 'TO',
+  const to = Blockly.Python.valueToCode(block, 'TO',
       Blockly.Python.ORDER_NONE) || '\'\'';
-  var code = text + '.replace(' + from + ', ' + to + ')';
+  const code = text + '.replace(' + from + ', ' + to + ')';
   return [code, Blockly.Python.ORDER_MEMBER];
 };
 
 Blockly.Python['text_reverse'] = function(block) {
-  var text = Blockly.Python.valueToCode(block, 'TEXT',
+  const text = Blockly.Python.valueToCode(block, 'TEXT',
       Blockly.Python.ORDER_MEMBER) || '\'\'';
-  var code = text + '[::-1]';
+  const code = text + '[::-1]';
   return [code, Blockly.Python.ORDER_MEMBER];
 };

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -52,9 +52,8 @@ Blockly.Python['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   //Should we allow joining by '-' or ',' or any other characters?
   switch (block.itemCount_) {
-    case 0: {
+    case 0:
       return ['\'\'', Blockly.Python.ORDER_ATOMIC];
-    }
     case 1: {
       const element = Blockly.Python.valueToCode(block, 'ADD0',
               Blockly.Python.ORDER_NONE) || '\'\'';

--- a/generators/python/variables.js
+++ b/generators/python/variables.js
@@ -16,16 +16,17 @@ goog.require('Blockly.Python');
 
 Blockly.Python['variables_get'] = function(block) {
   // Variable getter.
-  var code = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
+  const code = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
       Blockly.VARIABLE_CATEGORY_NAME);
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Python['variables_set'] = function(block) {
   // Variable setter.
-  var argument0 = Blockly.Python.valueToCode(block, 'VALUE',
-      Blockly.Python.ORDER_NONE) || '0';
-  var varName = Blockly.Python.nameDB_.getName(block.getFieldValue('VAR'),
-      Blockly.VARIABLE_CATEGORY_NAME);
+  const argument0 =
+      Blockly.Python.valueToCode(block, 'VALUE', Blockly.Python.ORDER_NONE) ||
+      '0';
+  const varName = Blockly.Python.nameDB_.getName(
+      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
   return varName + ' = ' + argument0 + '\n';
 };

--- a/tests/deps.mocha.js
+++ b/tests/deps.mocha.js
@@ -302,11 +302,11 @@ goog.addDependency('../../generators/php/text.js', ['Blockly.PHP.texts'], ['Bloc
 goog.addDependency('../../generators/php/variables.js', ['Blockly.PHP.variables'], ['Blockly.PHP']);
 goog.addDependency('../../generators/php/variables_dynamic.js', ['Blockly.PHP.variablesDynamic'], ['Blockly.PHP', 'Blockly.PHP.variables']);
 goog.addDependency('../../generators/python.js', ['Blockly.Python'], ['Blockly.Generator', 'Blockly.inputTypes', 'Blockly.utils.string']);
-goog.addDependency('../../generators/python/colour.js', ['Blockly.Python.colour'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/lists.js', ['Blockly.Python.lists'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/logic.js', ['Blockly.Python.logic'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/loops.js', ['Blockly.Python.loops'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/math.js', ['Blockly.Python.math'], ['Blockly.Python']);
+goog.addDependency('../../generators/python/colour.js', ['Blockly.Python.colour'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/lists.js', ['Blockly.Python.lists'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/logic.js', ['Blockly.Python.logic'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/loops.js', ['Blockly.Python.loops'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/math.js', ['Blockly.Python.math'], ['Blockly.Python'], {'lang': 'es6'});
 goog.addDependency('../../generators/python/procedures.js', ['Blockly.Python.procedures'], ['Blockly.Python']);
 goog.addDependency('../../generators/python/text.js', ['Blockly.Python.texts'], ['Blockly.Python']);
 goog.addDependency('../../generators/python/variables.js', ['Blockly.Python.variables'], ['Blockly.Python']);

--- a/tests/deps.mocha.js
+++ b/tests/deps.mocha.js
@@ -307,9 +307,9 @@ goog.addDependency('../../generators/python/lists.js', ['Blockly.Python.lists'],
 goog.addDependency('../../generators/python/logic.js', ['Blockly.Python.logic'], ['Blockly.Python'], {'lang': 'es6'});
 goog.addDependency('../../generators/python/loops.js', ['Blockly.Python.loops'], ['Blockly.Python'], {'lang': 'es6'});
 goog.addDependency('../../generators/python/math.js', ['Blockly.Python.math'], ['Blockly.Python'], {'lang': 'es6'});
-goog.addDependency('../../generators/python/procedures.js', ['Blockly.Python.procedures'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/text.js', ['Blockly.Python.texts'], ['Blockly.Python']);
-goog.addDependency('../../generators/python/variables.js', ['Blockly.Python.variables'], ['Blockly.Python']);
+goog.addDependency('../../generators/python/procedures.js', ['Blockly.Python.procedures'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/text.js', ['Blockly.Python.texts'], ['Blockly.Python'], {'lang': 'es6'});
+goog.addDependency('../../generators/python/variables.js', ['Blockly.Python.variables'], ['Blockly.Python'], {'lang': 'es6'});
 goog.addDependency('../../generators/python/variables_dynamic.js', ['Blockly.Python.variablesDynamic'], ['Blockly.Python', 'Blockly.Python.variables']);
 goog.addDependency('../../tests/mocha/.mocharc.js', [], []);
 goog.addDependency('../../tests/mocha/astnode_test.js', ['Blockly.test.astNode'], ['Blockly.ASTNode', 'Blockly.test.helpers'], {'lang': 'es6', 'module': 'goog'});


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Updates python block generators to `const` and `let` in preparation for modularization. (Part of https://github.com/google/blockly/issues/5598)

### Proposed Changes

Replace `var` with `const` and `let`. Where needed, restructure code that was relying on hoisting and multiple declarations of a variable.

#### Behavior Before Change
No change.

### Test Coverage

Tested by generator tests.
