### PR TITLE
chore: update dependabot messages and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
         # We should test that this does not cause issue 
         # google/blockly-samples#665 when version 17 is released.
         versions: "16.x"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "chore"
+      - "dependencies"


### PR DESCRIPTION
The same as #5618, but against master because dependabot ignores changes on develop.
See https://github.com/google/blockly/pull/5618