### PR TITLE
Remove usage of potentialVariableMap

### DIFF
--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -322,11 +322,6 @@ Flyout.prototype.init = function(targetWorkspace) {
   this.workspace_.getGesture =
       this.targetWorkspace.getGesture.bind(this.targetWorkspace);
 
-  // Get variables from the main workspace rather than the target workspace.
-  this.workspace_.setVariableMap(this.targetWorkspace.getVariableMap());
-
-  this.workspace_.createPotentialVariableMap();
-
   targetWorkspace.getComponentManager().addComponent({
     component: this,
     weight: 1,
@@ -800,9 +795,6 @@ Flyout.prototype.clearOldBlocks_ = function() {
     button.dispose();
   }
   this.buttons_.length = 0;
-
-  // Clear potential variables from the previous showing.
-  this.workspace_.getPotentialVariableMap().clear();
 };
 
 /**

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -358,9 +358,6 @@ VariableMap.prototype.getVariablesOfType = function(type) {
 VariableMap.prototype.getVariableTypes = function(ws) {
   const variableMap = {};
   object.mixin(variableMap, this.variableMap_);
-  if (ws && ws.getPotentialVariableMap()) {
-    object.mixin(variableMap, ws.getPotentialVariableMap().variableMap_);
-  }
   const types = Object.keys(variableMap);
   let hasEmpty = false;
   for (let i = 0; i < types.length; i++) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -472,15 +472,11 @@ exports.getOrCreateVariablePackage = getOrCreateVariablePackage;
  * @alias Blockly.Variables.getVariable
  */
 const getVariable = function(workspace, id, opt_name, opt_type) {
-  const potentialVariableMap = workspace.getPotentialVariableMap();
   let variable = null;
   // Try to just get the variable, by ID if possible.
   if (id) {
-    // Look in the real variable map before checking the potential variable map.
+    // Look in the variable map
     variable = workspace.getVariableById(id);
-    if (!variable && potentialVariableMap) {
-      variable = potentialVariableMap.getVariableById(id);
-    }
     if (variable) {
       return variable;
     }
@@ -493,9 +489,6 @@ const getVariable = function(workspace, id, opt_name, opt_type) {
     }
     // Otherwise look up by name and type.
     variable = workspace.getVariable(opt_name, opt_type);
-    if (!variable && potentialVariableMap) {
-      variable = potentialVariableMap.getVariable(opt_name, opt_type);
-    }
   }
   return variable;
 };
@@ -512,18 +505,17 @@ exports.getVariable = getVariable;
  *     or name + type combination.
  */
 const createVariable = function(workspace, id, opt_name, opt_type) {
-  const potentialVariableMap = workspace.getPotentialVariableMap();
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {
     const ws = workspace.isFlyout ? workspace.targetWorkspace : workspace;
     opt_name = exports.generateUniqueName(ws);
   }
 
-  // Create a potential variable if in the flyout.
+  // Create a variable directly in the variable map if in the flyout.
   let variable = null;
-  if (potentialVariableMap) {
-    variable = potentialVariableMap.createVariable(opt_name, opt_type, id);
-  } else {  // In the main workspace, create a real variable.
+  if (workspace.isFlyout) {
+    variable = workspace.getVariableMap().createVariable(opt_name, opt_type, id);
+  } else {  // In the main workspace, create a variable to trigger a refresh.
     variable = workspace.createVariable(opt_name, opt_type, id);
   }
   return variable;

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -129,18 +129,6 @@ const Workspace = function(opt_options) {
    * @private
    */
   this.variableMap_ = new VariableMap(this);
-
-  /**
-   * Blocks in the flyout can refer to variables that don't exist in the main
-   * workspace.  For instance, the "get item in list" block refers to an "item"
-   * variable regardless of whether the variable has been created yet.
-   * A FieldVariable must always refer to a VariableModel.  We reconcile
-   * these by tracking "potential" variables in the flyout.  These variables
-   * become real when references to them are dragged into the main workspace.
-   * @type {?VariableMap}
-   * @private
-   */
-  this.potentialVariableMap_ = null;
 };
 
 /**
@@ -397,9 +385,6 @@ Workspace.prototype.clear = function() {
       eventUtils.setGroup(false);
     }
     this.variableMap_.clear();
-    if (this.potentialVariableMap_) {
-      this.potentialVariableMap_.clear();
-    }
   } finally {
     this.isClearing = false;
   }
@@ -754,24 +739,6 @@ Workspace.prototype.allInputsFilled = function(opt_shadowBlocksAreFilled) {
     }
   }
   return true;
-};
-
-/**
- * Return the variable map that contains "potential" variables.
- * These exist in the flyout but not in the workspace.
- * @return {?VariableMap} The potential variable map.
- * @package
- */
-Workspace.prototype.getPotentialVariableMap = function() {
-  return this.potentialVariableMap_;
-};
-
-/**
- * Create and store the potential variable map for this workspace.
- * @package
- */
-Workspace.prototype.createPotentialVariableMap = function() {
-  this.potentialVariableMap_ = new VariableMap(this);
 };
 
 /**


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #5273.

### Proposed Changes

To avoid triggering a refresh, we will not create a variable like main workspaces do. Instead, we create a variable by accessing the variable map directly.

#### Behavior Before Change

Before, when creating a new variable, the flyout workspace would use potentialVariableMap to keep track of such variables that are not being used.

#### Behavior After Change

Now, flyout workspace is using its own variableMap, removing the unnecessary references to potentialVariableMap.

### Reason for Changes

Simplify the definition of what a workspace is (potentialVariableMap was a property used in the special case of a flyout workspace).

### Test Coverage

I tested on the following browsers:

* Desktop Firefox

The way I tested is by creating and deleting variables and making sure that it behaved the same way as before the changes.

### Documentation

I believe some sparse documentation needs to be updated, since the potentialVariableMap was heavily involved on the usage of flyout workspaces. I tried to reword some comments that I could find.

### Additional Information

No additional information has to be added.