### PR TITLE
chore: Update dependabot labelling config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,4 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     labels:
-      - "chore"
-      - "dependencies"
+      - "PR: dependencies"


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

[Error comments from dependabot](https://github.com/google/blockly/pull/5658#issuecomment-956413784): "The following labels could not be found: `chore`, `dependencies`."

### Proposed Changes

Label all dependabot PRs as "PR: dependencies", following
@rachel-fenichel's recent rationalisation of issue/PR labels.

### Test Coverage

Kind of hard to test in advance, really…  Please proofread my change carefully.
