### PR TITLE
fix: Don't crash when unable to post comment to PR

### DIFF
--- a/.github/workflows/check_clang_format.yml
+++ b/.github/workflows/check_clang_format.yml
@@ -1,5 +1,7 @@
 name: Check clang format
 
+# N.B.: Runs with a read-only repo token.  Safe(ish) to check out the
+# submitted branch.
 on: [pull_request]
 
 jobs:
@@ -15,14 +17,7 @@ jobs:
         clangFormatVersion: 12
         style: Google
 
-    - uses: actions/github-script@v5
-      if: failure()
-      with:
-        script: |
-          console.log(context.issue.number)
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'It looks like some of your files have not been formatted properly. Please run `npm run format`.'
-          })
+    # The Report clang format workflow (report_clang_format.yml) will
+    # run (if required) after this one to post a comment to the PR.
+    # (Note that the version of that workflow run will be the one on
+    # the master (default) branch, not the PR target branch.)


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5659.

### Proposed Changes

Do not attempt to post comments from this workflow.

#### Behaviour Before Change

A PR with clang-format issues would fail the check, but the failure would manifest itself as an `Resource not accessible by integration` error caused by insufficient permissions to post a comment on the PR.

#### Behaviour After Change

A PR with a clang-format issue should fail this check but no other errors should occur (and no comment should be posted).

### Reason for Changes

The check-clang-format workflow needs to be split into two parts: one that checks out the submitted code, and a separate one which has permission to post a comment.  See #5659 for more information.

### Test Coverage

I created draft PR #5667 to test this, but that PR appears to be 404, most probably due to @cpcallen-test being flagged.  

Then @alschmiedt created PR 5668 which verified that this change worked as intended.

### Additional Information

There will be a separate PR for the other workflow that does post comments, because it needs to be in the master branch.
