### PR TITLE
chore: Create separate report_clang_format workflow in master branch

### DIFF
--- a/.github/workflows/report_clang_format.yml
+++ b/.github/workflows/report_clang_format.yml
@@ -1,0 +1,31 @@
+name: Report clang format
+
+# Runs after the Check clang format workflow (check_clang_format.yml) to
+# post a helpful comment to the PR if the check failed.
+#
+# N.B.: Per https://github.community/t/workflow-runs-not-starting-after-previous-workflow-completes/128345/8
+# only the version of this workflow on the master (default) branch
+# will be run, regardless of what branch is targetted by the PR being
+# checked by check_clang_format.yml.
+#
+# N.B.: Runs with a read-write repo token.  Do not check out the
+# submitted branch!
+on:
+  workflow_run:
+    workflows: ["Check clang format"]
+    types:
+      - completed
+
+on: [pull_request]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+    - uses: actions/github-script@v5
+      with:
+        script: |
+          // Not sure yet how to find out which PR triggered the run, so
+          // dump the whole context object to try to find useful information.
+          console.log('%o', context);


### PR DESCRIPTION
## The basics

- [X] I branched from ~develop~ **master**
- [X] My pull request is against ~develop~ **master**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5659.

### Proposed Changes

The initial version of this workflow just uses `console.log` to report the context of the `context` object.  It is hoped that there will be enough information in this context to identify the PR to comment on, without the `check_clang_format` workflow having to upload a 'build artefact' of some kind - see example of what I hope to avoid [starting at `ReceivePR.yml` here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

A follow-up PR will (if possible) add the code to create comments when `check_clang_format` fails.

### Reason for Changes

The check-clang-format workflow needs to be split into two parts: one that checks out the submitted code, and a separate one which has permission to post a comment. See #5659 for more information.

### Test Coverage

This is a test.

### Additional Information

This workflow needs to be in the `master` branch because [apparently only workflows in the default branch are run in response to `workflow_run` events](https://github.community/t/workflow-runs-not-starting-after-previous-workflow-completes/128345/8).
