### PR TITLE
chore: Remove spurious extra `on` clause in report_clang_format.yml

### DIFF
--- a/.github/workflows/report_clang_format.yml
+++ b/.github/workflows/report_clang_format.yml
@@ -16,8 +16,6 @@ on:
     types:
       - completed
 
-on: [pull_request]
-
 jobs:
   on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The basics

- [X] I branched from ~develop~ **master**
- [X] My pull request is against ~develop~ **master**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Removes an unwanted `on` clause that was overlooked in #5670 by author and reviewer.
