### PR TITLE
chore: More spelunking in GitHub Action data

### DIFF
--- a/.github/workflows/report_clang_format.yml
+++ b/.github/workflows/report_clang_format.yml
@@ -25,5 +25,6 @@ jobs:
       with:
         script: |
           // Not sure yet how to find out which PR triggered the run, so
-          // dump the whole context object to try to find useful information.
-          console.log('%o', context);
+          // dump the whole github.event object to try to find useful
+          // information.
+          console.log('%o', github.event);


### PR DESCRIPTION
## The basics

- [X] I branched from ~develop~ **master**
- [X] My pull request is against ~develop~ **master**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

In aid of #5669.

### Proposed Changes

`console.log` the `github.event` object, in search of information about PR that triggered original `check_clang_format` run that triggered this workflow.
