### PR TITLE
chore: fix more lint

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -523,7 +523,6 @@ Blockly.Extensions.registerMutator('controls_if_mutator',
  * @package
  */
 Blockly.Constants.Logic.CONTROLS_IF_TOOLTIP_EXTENSION = function() {
-
   this.setTooltip(function() {
     if (!this.elseifCount_ && !this.elseCount_) {
       return Blockly.Msg['CONTROLS_IF_TOOLTIP_1'];

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -75,7 +75,6 @@ Blockly.Blocks['procedures_defnoreturn'] = {
    * @this {Blockly.Block}
    */
   updateParams_: function() {
-
     // Merge the arguments into a human-readable list.
     let paramString = '';
     if (this.arguments_.length) {

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -63,7 +63,8 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       "width": 12,
       "height": 17,
       "alt": '\u00B6',
-    },{
+    },
+    {
       "type": "field_multilinetext",
       "name": "TEXT",
       "text": "",
@@ -200,7 +201,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "message0": "%{BKY_TEXT_CHARAT_TITLE}", // "in text %1 %2"
     "args0": [
       {
-        "type":"input_value",
+        "type": "input_value",
         "name": "VALUE",
         "check": "String",
       },

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -87,14 +87,14 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
    */
   customContextMenu: function(options) {
     if (!this.isInFlyout) {
-      let opposite_type;
+      let oppositeType;
       let contextMenuMsg;
       // Getter blocks have the option to create a setter block, and vice versa.
       if (this.type === 'variables_get') {
-        opposite_type = 'variables_set';
+        oppositeType = 'variables_set';
         contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
       } else {
-        opposite_type = 'variables_get';
+        oppositeType = 'variables_get';
         contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
       }
 
@@ -105,7 +105,7 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
       xmlField.setAttribute('name', 'VAR');
       xmlField.appendChild(Blockly.utils.xml.createTextNode(name));
       const xmlBlock = Blockly.utils.xml.createElement('block');
-      xmlBlock.setAttribute('type', opposite_type);
+      xmlBlock.setAttribute('type', oppositeType);
       xmlBlock.appendChild(xmlField);
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -84,16 +84,16 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
   customContextMenu: function(options) {
     // Getter blocks have the option to create a setter block, and vice versa.
     if (!this.isInFlyout) {
-      let opposite_type;
+      let oppositeType;
       let contextMenuMsg;
       const id = this.getFieldValue('VAR');
       const variableModel = this.workspace.getVariableById(id);
       const varType = variableModel.type;
       if (this.type === 'variables_get_dynamic') {
-        opposite_type = 'variables_set_dynamic';
+        oppositeType = 'variables_set_dynamic';
         contextMenuMsg = Blockly.Msg['VARIABLES_GET_CREATE_SET'];
       } else {
-        opposite_type = 'variables_get_dynamic';
+        oppositeType = 'variables_get_dynamic';
         contextMenuMsg = Blockly.Msg['VARIABLES_SET_CREATE_GET'];
       }
 
@@ -105,7 +105,7 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       xmlField.setAttribute('variabletype', varType);
       xmlField.appendChild(Blockly.utils.xml.createTextNode(name));
       const xmlBlock = Blockly.utils.xml.createElement('block');
-      xmlBlock.setAttribute('type', opposite_type);
+      xmlBlock.setAttribute('type', oppositeType);
       xmlBlock.appendChild(xmlField);
       option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
       options.push(option);

--- a/core/block.js
+++ b/core/block.js
@@ -243,7 +243,6 @@ const Block = function(workspace, prototypeName, opt_id) {
     if (eventUtils.isEnabled()) {
       eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(this));
     }
-
   } finally {
     if (!existingGroup) {
       eventUtils.setGroup(false);
@@ -1669,7 +1668,7 @@ Block.prototype.mixin = function(mixinObj, opt_disableCheck) {
   }
   if (!opt_disableCheck) {
     const overwrites = [];
-    for (let key in mixinObj) {
+    for (const key in mixinObj) {
       if (this[key] !== undefined) {
         overwrites.push(key);
       }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -397,10 +397,9 @@ BlockSvg.prototype.setParent = function(newParent) {
     const newXY = this.getRelativeToSurfaceXY();
     // Move the connections to match the child's new position.
     this.moveConnections(newXY.x - oldXY.x, newXY.y - oldXY.y);
-  }
-  // If we are losing a parent, we want to move our DOM element to the
-  // root of the workspace.
-  else if (oldParent) {
+  } else if (oldParent) {
+    // If we are losing a parent, we want to move our DOM element to the
+    // root of the workspace.
     this.workspace.getCanvas().appendChild(svgRoot);
     this.translate(oldXY.x, oldXY.y);
   }

--- a/core/connection.js
+++ b/core/connection.js
@@ -414,7 +414,9 @@ Connection.prototype.disconnect = function() {
   if (otherConnection.targetConnection !== this) {
     throw Error('Target connection not connected to source connection.');
   }
-  let parentBlock, childBlock, parentConnection;
+  let parentBlock;
+  let childBlock;
+  let parentConnection;
   if (this.isSuperior()) {
     // Superior block.
     parentBlock = this.sourceBlock_;

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -140,7 +140,8 @@ ConnectionChecker.prototype.doSafetyChecks = function(a, b) {
   if (!a || !b) {
     return Connection.REASON_TARGET_NULL;
   }
-  let blockA, blockB;
+  let blockA;
+  let blockB;
   if (a.isSuperior()) {
     blockA = a.getSourceBlock();
     blockB = b.getSourceBlock();

--- a/core/css.js
+++ b/core/css.js
@@ -71,7 +71,7 @@ const inject = function(hasCss, pathToMedia) {
   }
   // Strip off any trailing slash (either Unix or Windows).
   const mediaPath = pathToMedia.replace(/[\\/]$/, '');
-  let cssContent = content.replace(/<<<PATH>>>/g, mediaPath);
+  const cssContent = content.replace(/<<<PATH>>>/g, mediaPath);
   // Cleanup the collected css content after injecting it to the DOM.
   content = '';
 

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -576,14 +576,13 @@ const getPositionTopOfPageMetrics = function(sourceX, boundsInfo, divSize) {
  */
 DropDownDiv.getPositionX = function(
     sourceX, boundsLeft, boundsRight, divWidth) {
-  let arrowX, divX;
-  arrowX = divX = sourceX;
-
+  let divX = sourceX;
   // Offset the topLeft coord so that the dropdowndiv is centered.
   divX -= divWidth / 2;
   // Fit the dropdowndiv within the bounds of the workspace.
   divX = math.clamp(boundsLeft, divX, boundsRight - divWidth);
 
+  let arrowX = sourceX;
   // Offset the arrow coord so that the arrow is centered.
   arrowX -= DropDownDiv.ARROW_SIZE / 2;
   // Convert the arrow position to be relative to the top left of the div.

--- a/core/extensions.js
+++ b/core/extensions.js
@@ -374,7 +374,7 @@ const buildTooltipForDropdown = function(dropdownName, lookupTable) {
   // of document object, in which case skip the validation.
   if (typeof document === 'object') {  // Relies on document.readyState
     utils.runAfterPageLoad(function() {
-      for (let key in lookupTable) {
+      for (const key in lookupTable) {
         // Will print warnings if reference is missing.
         utils.checkMessageReferences(lookupTable[key]);
       }

--- a/core/field.js
+++ b/core/field.js
@@ -813,7 +813,9 @@ Field.prototype.getSize = function() {
  * @package
  */
 Field.prototype.getScaledBBox = function() {
-  let scaledWidth, scaledHeight, xy;
+  let scaledWidth;
+  let scaledHeight;
+  let xy;
   if (!this.borderRect_) {
     // Browsers are inconsistent in what they return for a bounding box.
     // - Webkit / Blink: fill-box / object bounding box

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -236,9 +236,9 @@ FieldMultilineInput.prototype.render_ = function() {
     const span = dom.createSvgElement(
         Svg.TEXT, {
           'class': 'blocklyText blocklyMultilineText',
-          x: this.getConstants().FIELD_BORDER_RECT_X_PADDING,
-          y: y + this.getConstants().FIELD_BORDER_RECT_Y_PADDING,
-          dy: this.getConstants().FIELD_TEXT_BASELINE,
+          'x': this.getConstants().FIELD_BORDER_RECT_X_PADDING,
+          'y': y + this.getConstants().FIELD_BORDER_RECT_Y_PADDING,
+          'dy': this.getConstants().FIELD_TEXT_BASELINE,
         },
         this.textGroup_);
     span.appendChild(document.createTextNode(lines[i]));

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -670,10 +670,9 @@ InsertionMarkerManager.prototype.hideInsertionMarker_ = function() {
   // anything in that case.  Instead, unplug the following block.
   if (isFirstInStatementStack || isFirstInOutputStack) {
     imConn.targetBlock().unplug(false);
-  }
-  // Inside of a C-block, first statement connection.
-  else if (
+  } else if (
       imConn.type === ConnectionType.NEXT_STATEMENT && imConn !== markerNext) {
+    // Inside of a C-block, first statement connection.
     const innerConnection = imConn.targetConnection;
     innerConnection.getSourceBlock().unplug(false);
 

--- a/core/interfaces/i_registrable_field.js
+++ b/core/interfaces/i_registrable_field.js
@@ -29,7 +29,7 @@ const {Field} = goog.requireType('Blockly.Field');
  * }}
  * @alias Blockly.IRegistrableField
  */
-let IRegistrableField = {};
+const IRegistrableField = {};
 
 /**
  * @typedef {function(!Object): Field}

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -487,10 +487,9 @@ ASTNode.prototype.getOutAstNodeForBlock_ = function(block) {
   if (!block) {
     return null;
   }
-  let topBlock;
   // If the block doesn't have a previous connection then it is the top of the
   // substack.
-  topBlock = block.getTopStackBlock();
+  const topBlock = block.getTopStackBlock();
   const topConnection =
       topBlock.previousConnection || topBlock.outputConnection;
   // If the top connection has a parentInput, create an AST node pointing to

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -324,7 +324,8 @@ Mutator.prototype.setVisible = function(visible) {
     // The root block should not be draggable or deletable.
     this.rootBlock_.setMovable(false);
     this.rootBlock_.setDeletable(false);
-    let margin, x;
+    let margin;
+    let x;
     if (flyout) {
       margin = flyout.CORNER_RADIUS * 2;
       x = this.rootBlock_.RTL ? flyout.getWidth() + margin : margin;

--- a/core/procedures.js
+++ b/core/procedures.js
@@ -238,6 +238,13 @@ const flyoutCategory = function(workspace) {
     xmlList[xmlList.length - 1].setAttribute('gap', 24);
   }
 
+  /**
+   * Add items to xmlList for each listed procedure.
+   * @param {!Array<!Array>} procedureList A list of procedures, each of which
+   *     is defined by a three-element list of name, parameter list, and return
+   *     value boolean.
+   * @param {string} templateName The type of the block to generate.
+   */
   function populateProcedures(procedureList, templateName) {
     for (let i = 0; i < procedureList.length; i++) {
       const name = procedureList[i][0];

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -319,7 +319,7 @@ RenderedConnection.prototype.highlight = function() {
       Svg.PATH, {
         'class': 'blocklyHighlightedConnectionPath',
         'd': steps,
-        transform: 'translate(' + x + ',' + y + ')' +
+        'transform': 'translate(' + x + ',' + y + ')' +
             (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
       },
       this.sourceBlock_.getSvgRoot());

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -817,11 +817,16 @@ ConstantProvider.prototype.makePuzzleTab = function() {
   const width = this.TAB_WIDTH;
   const height = this.TAB_HEIGHT;
 
-  // The main path for the puzzle tab is made out of a few curves (c and s).
-  // Those curves are defined with relative positions.  The 'up' and 'down'
-  // versions of the paths are the same, but the Y sign flips.  Forward and back
-  // are the signs to use to move the cursor in the direction that the path is
-  // being drawn.
+  /**
+   * Make the main path for the puzzle tab made out of a few curves (c and s).
+   * Those curves are defined with relative positions.  The 'up' and 'down'
+   * versions of the paths are the same, but the Y sign flips.  Forward and back
+   * are the signs to use to move the cursor in the direction that the path is
+   * being drawn.
+   * @param {boolean} up True if the path should be drawn from bottom to top,
+   *     false otherwise.
+   * @return {string} A path fragment describing a puzzle tab.
+   */
   function makeMainPath(up) {
     const forward = up ? -1 : 1;
     const back = -forward;
@@ -870,6 +875,13 @@ ConstantProvider.prototype.makeNotch = function() {
   const height = this.NOTCH_HEIGHT;
   const innerWidth = 3;
   const outerWidth = (width - innerWidth) / 2;
+
+  /**
+   * Make the main path for the notch.
+   * @param {number} dir Direction multiplier to apply to horizontal offsets
+   *     along the path. Either 1 or -1.
+   * @return {string} A path fragment describing a notch.
+   */
   function makeMainPath(dir) {
     return svgPaths.line([
       svgPaths.point(dir * outerWidth, height),
@@ -1087,8 +1099,8 @@ ConstantProvider.prototype.createDebugFilter = function() {
           'id': 'blocklyDebugFilter' + this.randomIdentifier,
           'height': '160%',
           'width': '180%',
-          y: '-30%',
-          x: '-40%',
+          'y': '-30%',
+          'x': '-40%',
         },
         this.defs_);
     // Set all gaussian blur pixels to 1 opacity before applying flood

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -252,10 +252,10 @@ MarkerSvg.prototype.showWithBlockPrevOutput_ = function(curNode) {
   const markerOffset = this.constants_.CURSOR_BLOCK_PADDING;
 
   if (block.previousConnection) {
-    let connectionShape = this.constants_.shapeFor(block.previousConnection);
+    const connectionShape = this.constants_.shapeFor(block.previousConnection);
     this.positionPrevious_(width, markerOffset, markerHeight, connectionShape);
   } else if (block.outputConnection) {
-    let connectionShape = this.constants_.shapeFor(block.outputConnection);
+    const connectionShape = this.constants_.shapeFor(block.outputConnection);
     this.positionOutput_(width, height, connectionShape);
   } else {
     this.positionBlock_(width, markerOffset, markerHeight);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -471,11 +471,19 @@ ConstantProvider.prototype.makeStartHat = function() {
 ConstantProvider.prototype.makeHexagonal = function() {
   const maxWidth = this.MAX_DYNAMIC_CONNECTION_SHAPE_WIDTH;
 
-  // The main path for the hexagonal connection shape is made out of two lines.
-  // The lines are defined with relative positions and require the block height.
-  // The 'up' and 'down' versions of the paths are the same, but the Y sign
-  // flips.  The 'left' and 'right' versions of the path are also the same, but
-  // the X sign flips.
+  /**
+   * Make the main path for the hexagonal connection shape out of two lines.
+   * The lines are defined with relative positions and require the block height.
+   * The 'up' and 'down' versions of the paths are the same, but the Y sign
+   * flips.  The 'left' and 'right' versions of the path are also the same, but
+   * the X sign flips.
+   * @param {number} height The height of the block the connection is on.
+   * @param {boolean} up True if the path should be drawn from bottom to top,
+   *     false otherwise.
+   * @param {boolean} right True if the path is for the right side of the
+   *     block.
+   * @return {string} A path fragment describing a rounded connection.
+   */
   function makeMainPath(height, up, right) {
     const halfHeight = height / 2;
     const width = halfHeight > maxWidth ? maxWidth : halfHeight;
@@ -527,14 +535,22 @@ ConstantProvider.prototype.makeRounded = function() {
   const maxWidth = this.MAX_DYNAMIC_CONNECTION_SHAPE_WIDTH;
   const maxHeight = maxWidth * 2;
 
-  // The main path for the rounded connection shape is made out of two arcs and
-  // a line that joins them.  The arcs are defined with relative positions.
-  // Usually, the height of the block is split between the two arcs. In the case
-  // where the height of the block exceeds the maximum height, a line is drawn
-  // in between the two arcs.
-  // The 'up' and 'down' versions of the paths are the same, but the Y sign
-  // flips.  The 'up' and 'right' versions of the path flip the sweep-flag
-  // which moves the arc at negative angles.
+  /**
+   * Make the main path for the rounded connection shape out of two arcs and
+   * a line that joins them.  The arcs are defined with relative positions.
+   * Usually, the height of the block is split between the two arcs. In the case
+   * where the height of the block exceeds the maximum height, a line is drawn
+   * in between the two arcs.
+   * The 'up' and 'down' versions of the paths are the same, but the Y sign
+   * flips.  The 'up' and 'right' versions of the path flip the sweep-flag
+   * which moves the arc at negative angles.
+   * @param {number} blockHeight The height of the block the connection is on.
+   * @param {boolean} up True if the path should be drawn from bottom to top,
+   *     false otherwise.
+   * @param {boolean} right True if the path is for the right side of the
+   *     block.
+   * @return {string} A path fragment describing a rounded connection.
+   */
   function makeMainPath(blockHeight, up, right) {
     const remainingHeight =
         blockHeight > maxHeight ? blockHeight - maxHeight : 0;
@@ -589,12 +605,20 @@ ConstantProvider.prototype.makeRounded = function() {
 ConstantProvider.prototype.makeSquared = function() {
   const radius = this.CORNER_RADIUS;
 
-  // The main path for the squared connection shape is made out of two corners
-  // and a single line in-between (a and v). These are defined in relative
-  // positions and require the height of the block.
-  // The 'left' and 'right' versions of the paths are the same, but the Y sign
-  // flips.  The 'up' and 'down' versions of the path determine where the corner
-  // point is placed and in-turn the direction of the corners.
+  /**
+   * Make the main path for the squared connection shape out of two corners
+   * and a single line in-between (a and v). These are defined in relative
+   * positions and require the height of the block.
+   * The 'left' and 'right' versions of the paths are the same, but the Y sign
+   * flips.  The 'up' and 'down' versions of the path determine where the corner
+   * point is placed and in turn the direction of the corners.
+   * @param {number} height The height of the block the connection is on.
+   * @param {boolean} up True if the path should be drawn from bottom to top,
+   *     false otherwise.
+   * @param {boolean} right True if the path is for the right side of the
+   *     block.
+   * @return {string} A path fragment describing a squared connection.
+   */
   function makeMainPath(height, up, right) {
     const innerHeight = height - radius * 2;
     return svgPaths.arc(
@@ -692,6 +716,12 @@ ConstantProvider.prototype.makeNotch = function() {
   const halfHeight = height / 2;
   const quarterHeight = halfHeight / 2;
 
+  /**
+   * Make the main path for the notch.
+   * @param {number} dir Direction multiplier to apply to horizontal offsets
+   *     along the path. Either 1 or -1.
+   * @return {string} A path fragment describing a notch.
+   */
   function makeMainPath(dir) {
     return (
         svgPaths.curve(
@@ -799,8 +829,8 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'id': 'blocklySelectedGlowFilter' + this.randomIdentifier,
         'height': '160%',
         'width': '180%',
-        y: '-30%',
-        x: '-40%',
+        'y': '-30%',
+        'x': '-40%',
       },
       defs);
   dom.createSvgElement(
@@ -840,8 +870,8 @@ ConstantProvider.prototype.createDom = function(svg, tagName, selector) {
         'id': 'blocklyReplacementGlowFilter' + this.randomIdentifier,
         'height': '160%',
         'width': '180%',
-        y: '-30%',
-        x: '-40%',
+        'y': '-30%',
+        'x': '-40%',
       },
       defs);
   dom.createSvgElement(

--- a/core/serialization/workspaces.js
+++ b/core/serialization/workspaces.js
@@ -62,7 +62,8 @@ const load = function(state, workspace, {recordUndo = false} = {}) {
 
   const deserializers =
       Object.entries(serializerMap).sort(([, {priority: priorityA}], [
-                                           , {priority: priorityB},
+                                           ,
+                                           {priority: priorityB},
                                          ]) => priorityB - priorityA);
 
   const prevRecordUndo = eventUtils.getRecordUndo();

--- a/core/serialization/workspaces.js
+++ b/core/serialization/workspaces.js
@@ -62,7 +62,7 @@ const load = function(state, workspace, {recordUndo = false} = {}) {
 
   const deserializers =
       Object.entries(serializerMap).sort(([, {priority: priorityA}], [
-                                           , {priority: priorityB}
+                                           , {priority: priorityB},
                                          ]) => priorityB - priorityA);
 
   const prevRecordUndo = eventUtils.getRecordUndo();

--- a/core/serialization/workspaces.js
+++ b/core/serialization/workspaces.js
@@ -60,11 +60,8 @@ const load = function(state, workspace, {recordUndo = false} = {}) {
     return;
   }
 
-  const deserializers =
-      Object.entries(serializerMap).sort(([, {priority: priorityA}], [
-                                           ,
-                                           {priority: priorityB},
-                                         ]) => priorityB - priorityA);
+  const deserializers = Object.entries(serializerMap)
+                            .sort((a, b) => b[1].priority - a[1].priority);
 
   const prevRecordUndo = eventUtils.getRecordUndo();
   eventUtils.setRecordUndo(recordUndo);

--- a/core/theme/classic.js
+++ b/core/theme/classic.js
@@ -20,7 +20,7 @@ goog.module('Blockly.Themes.Classic');
 const {Theme} = goog.require('Blockly.Theme');
 
 
-let defaultBlockStyles = {
+const defaultBlockStyles = {
   'colour_blocks': {'colourPrimary': '20'},
   'list_blocks': {'colourPrimary': '260'},
   'logic_blocks': {'colourPrimary': '210'},
@@ -33,7 +33,7 @@ let defaultBlockStyles = {
   'hat_blocks': {'colourPrimary': '330', 'hat': 'cap'},
 };
 
-let categoryStyles = {
+const categoryStyles = {
   'colour_category': {'colour': '20'},
   'list_category': {'colour': '260'},
   'logic_category': {'colour': '210'},

--- a/core/theme/zelos.js
+++ b/core/theme/zelos.js
@@ -18,7 +18,7 @@ goog.module('Blockly.Themes.Zelos');
 const {Theme} = goog.require('Blockly.Theme');
 
 
-let defaultBlockStyles = {
+const defaultBlockStyles = {
   'colour_blocks': {
     'colourPrimary': '#CF63CF',
     'colourSecondary': '#C94FC9',
@@ -72,7 +72,7 @@ let defaultBlockStyles = {
   },
 };
 
-let categoryStyles = {
+const categoryStyles = {
   'colour_category': {'colour': '#CF63CF'},
   'list_category': {'colour': '#9966FF'},
   'logic_category': {'colour': '#4C97FF'},

--- a/core/touch.js
+++ b/core/touch.js
@@ -159,12 +159,13 @@ exports.shouldHandleEvent = shouldHandleEvent;
  * @alias Blockly.Touch.getTouchIdentifierFromEvent
  */
 const getTouchIdentifierFromEvent = function(e) {
-  return e.pointerId !== undefined ? e.pointerId :
+  return e.pointerId !== undefined ?
+      e.pointerId :
       (e.changedTouches && e.changedTouches[0] &&
        e.changedTouches[0].identifier !== undefined &&
        e.changedTouches[0].identifier !== null) ?
-                                     e.changedTouches[0].identifier :
-                                     'mouse';
+      e.changedTouches[0].identifier :
+      'mouse';
 };
 exports.getTouchIdentifierFromEvent = getTouchIdentifierFromEvent;
 

--- a/core/touch.js
+++ b/core/touch.js
@@ -159,13 +159,12 @@ exports.shouldHandleEvent = shouldHandleEvent;
  * @alias Blockly.Touch.getTouchIdentifierFromEvent
  */
 const getTouchIdentifierFromEvent = function(e) {
-  return e.pointerId !== undefined ?
-      e.pointerId :
+  return e.pointerId !== undefined ? e.pointerId :
       (e.changedTouches && e.changedTouches[0] &&
        e.changedTouches[0].identifier !== undefined &&
        e.changedTouches[0].identifier !== null) ?
-      e.changedTouches[0].identifier :
-      'mouse';
+                                     e.changedTouches[0].identifier :
+                                     'mouse';
 };
 exports.getTouchIdentifierFromEvent = getTouchIdentifierFromEvent;
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -482,7 +482,7 @@ const is3dSupported = function() {
   // Add it to the body to get the computed style.
   document.body.insertBefore(el, null);
 
-  for (let t in transforms) {
+  for (const t in transforms) {
     if (el.style[t] !== undefined) {
       el.style[t] = 'translate3d(1px,1px,1px)';
       const computedStyle = global.globalThis['getComputedStyle'](el);

--- a/core/variable_map.js
+++ b/core/variable_map.js
@@ -339,9 +339,9 @@ VariableMap.prototype.getVariableById = function(id) {
  */
 VariableMap.prototype.getVariablesOfType = function(type) {
   type = type || '';
-  const variable_list = this.variableMap_[type];
-  if (variable_list) {
-    return variable_list.slice();
+  const variableList = this.variableMap_[type];
+  if (variableList) {
+    return variableList.slice();
   }
   return [];
 };
@@ -379,11 +379,11 @@ VariableMap.prototype.getVariableTypes = function(ws) {
  * @return {!Array<!VariableModel>} List of variable models.
  */
 VariableMap.prototype.getAllVariables = function() {
-  let all_variables = [];
+  let allVariables = [];
   for (const key in this.variableMap_) {
-    all_variables = all_variables.concat(this.variableMap_[key]);
+    allVariables = allVariables.concat(this.variableMap_[key]);
   }
-  return all_variables;
+  return allVariables;
 };
 
 /**

--- a/core/variables_dynamic.js
+++ b/core/variables_dynamic.js
@@ -26,23 +26,23 @@ const {VariableModel} = goog.require('Blockly.VariableModel');
 const {Workspace} = goog.requireType('Blockly.Workspace');
 
 
-const onCreateVariableButtonClick_String = function(button) {
+const stringButtonClickHandler = function(button) {
   Variables.createVariableButtonHandler(
       button.getTargetWorkspace(), undefined, 'String');
 };
-exports.onCreateVariableButtonClick_String = onCreateVariableButtonClick_String;
+exports.onCreateVariableButtonClick_String = stringButtonClickHandler;
 
-const onCreateVariableButtonClick_Number = function(button) {
+const numberButtonClickHandler = function(button) {
   Variables.createVariableButtonHandler(
       button.getTargetWorkspace(), undefined, 'Number');
 };
-exports.onCreateVariableButtonClick_Number = onCreateVariableButtonClick_Number;
+exports.onCreateVariableButtonClick_Number = numberButtonClickHandler;
 
-const onCreateVariableButtonClick_Colour = function(button) {
+const colourButtonClickHandler = function(button) {
   Variables.createVariableButtonHandler(
       button.getTargetWorkspace(), undefined, 'Colour');
 };
-exports.onCreateVariableButtonClick_Colour = onCreateVariableButtonClick_Colour;
+exports.onCreateVariableButtonClick_Colour = colourButtonClickHandler;
 
 /**
  * Construct the elements (blocks and button) required by the flyout for the
@@ -67,11 +67,11 @@ const flyoutCategory = function(workspace) {
   xmlList.push(button);
 
   workspace.registerButtonCallback(
-      'CREATE_VARIABLE_STRING', onCreateVariableButtonClick_String);
+      'CREATE_VARIABLE_STRING', stringButtonClickHandler);
   workspace.registerButtonCallback(
-      'CREATE_VARIABLE_NUMBER', onCreateVariableButtonClick_Number);
+      'CREATE_VARIABLE_NUMBER', numberButtonClickHandler);
   workspace.registerButtonCallback(
-      'CREATE_VARIABLE_COLOUR', onCreateVariableButtonClick_Colour);
+      'CREATE_VARIABLE_COLOUR', colourButtonClickHandler);
 
 
   const blockList = flyoutCategoryBlocks(workspace);

--- a/tests/playgrounds/screenshot.js
+++ b/tests/playgrounds/screenshot.js
@@ -75,12 +75,11 @@ function workspaceToSvg_(workspace, callback, customCss) {
   svg.setAttribute("style", 'background-color: transparent');
 
   const css = [].slice.call(document.head.querySelectorAll('style'))
-      .filter(function(el) {
-        return /\.blocklySvg/.test(el.innerText) ||
-        (el.id.indexOf('blockly-') === 0);
-      }).map(function(el) {
-        return el.innerText;
-      }).join('\n');
+                  .filter(
+                      (el) => /\.blocklySvg/.test(el.innerText) ||
+                          (el.id.indexOf('blockly-') === 0))
+                  .map((el) => el.innerText)
+                  .join('\n');
   const style = document.createElement('style');
   style.innerHTML = css + '\n' + customCss;
   svg.insertBefore(style, svg.firstChild);

--- a/tests/playgrounds/screenshot.js
+++ b/tests/playgrounds/screenshot.js
@@ -45,7 +45,6 @@ function svgToPng_(data, width, height, callback) {
  * @param {string=} customCss Custom CSS to append to the SVG.
  */
 function workspaceToSvg_(workspace, callback, customCss) {
-
   // Go through all text areas and set their value.
   const textAreas = document.getElementsByTagName("textarea");
   for (let i = 0; i < textAreas.length; i++) {
@@ -62,7 +61,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
   const clone = blockCanvas.cloneNode(true);
   clone.removeAttribute('transform');
 
-  const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
   svg.appendChild(clone);
   svg.setAttribute('viewBox',
@@ -76,9 +75,12 @@ function workspaceToSvg_(workspace, callback, customCss) {
   svg.setAttribute("style", 'background-color: transparent');
 
   const css = [].slice.call(document.head.querySelectorAll('style'))
-      .filter(function(el) { return /\.blocklySvg/.test(el.innerText) ||
-        (el.id.indexOf('blockly-') === 0); }).map(function(el) {
-        return el.innerText; }).join('\n');
+      .filter(function(el) {
+        return /\.blocklySvg/.test(el.innerText) ||
+        (el.id.indexOf('blockly-') === 0);
+      }).map(function(el) {
+        return el.innerText;
+      }).join('\n');
   const style = document.createElement('style');
   style.innerHTML = css + '\n' + customCss;
   svg.insertBefore(style, svg.firstChild);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5160

### Proposed Changes

Fixes lint problems that come up when I enable `eslint-config-google`, including issues with the following rules:
- `comma-spacing`
- `key-spacing`
- `camelcase`
- `padded-blocks`
- `prefer-const`
- `brace-style`
- `one-var`
- `quote-props`
- `comma-dangle`

In a second commit I ran clang-format.

#### Behavior Before Change

No change

#### Behavior After Change

No chang

### Reason for Changes

Fix lint to get closer to using a standard eslint config.

### Test Coverage

Tested by
- installing `eslint-config-google`
- adding `tests/mocha/*` to `.eslintignore`
- disabling rules that I was not fixing on this pass
- adding a custom configuration for the camelcase rule to allow prefixes that we use

### Additional Information

Remaining issues in core consist of:
- `new-cap`, which we just need to disable
- `guard-for-in`, which requires us to take a look at 21 places where we use `for-in` loops
- `prefer-spread`, which I didn't understand well enough to fix today
- `require-jsdoc`, because there are some errors on jsdoc for constructors in the serializer
- `no-invalid-this`
