### PR TITLE
chore: add command to launch mocha tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "start": "http-server ./ -o /tests/playground.html -c-1",
     "test": "tests/run_all_tests.sh",
     "test:generators": "tests/scripts/run_generators.sh",
+    "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest",
     "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Improves workflow for local testing

### Proposed Changes

Adds the command `npm run tests:mocha:interactive`, which launches a server and opens the mocha index page.

### Reason for Changes

Reduce friction in testing--when I see test failures in my mocha tests on the command line, my next move is usually to open the mocha test page so I can start debugging.

### Test Coverage

Ran command locally

### Documentation


### Additional Information

<!-- Anything else we should know? -->
