### PR TITLE
fix: bad order of checks for setting flyout visibility

### DIFF
--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -968,7 +968,7 @@ Toolbox.prototype.selectItemByPosition = function(position) {
  * @protected
  */
 Toolbox.prototype.updateFlyout_ = function(oldItem, newItem) {
-  if ((oldItem === newItem && !newItem.isCollapsible()) || !newItem ||
+  if (!newItem || (oldItem === newItem && !newItem.isCollapsible()) ||
       !newItem.getContents().length) {
     this.flyout_.hide();
   } else {

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -204,8 +204,8 @@ suite('InsertionMarkers', function() {
   });
   suite('Serialization', function() {
     setup(function() {
-      this.assertXml = function(xml, expectXml) {
-        Blockly.Xml.domToWorkspace(xml, this.workspace);
+      this.assertXml = function(xmlIn, expectXml) {
+        Blockly.Xml.domToWorkspace(xmlIn, this.workspace);
         let block = this.workspace.getBlockById('insertion');
         block.setInsertionMarker(true);
         let xml = Blockly.Xml.workspaceToDom(this.workspace);

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -418,6 +418,10 @@ suite('Toolbox', function() {
     test('No new item -> Should close flyout', function() {
       testHideFlyout(this.toolbox, null, null);
     });
+    test('Old item but no new item -> Should close flyout', function() {
+      let oldItem = getNonCollapsibleItem(this.toolbox);
+      testHideFlyout(this.toolbox, oldItem, null);
+    });
     test('Select collapsible item -> Should close flyout', function() {
       let newItem = getCollapsibleItem(this.toolbox);
       testHideFlyout(this.toolbox, null, newItem);

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -407,7 +407,6 @@ suite('Toolbox', function() {
 
     function testHideFlyout(toolbox, oldItem, newItem) {
       let updateFlyoutStub = sinon.stub(toolbox.flyout_, 'hide');
-      const newItem = getNonCollapsibleItem(toolbox);
       toolbox.updateFlyout_(oldItem, newItem);
       sinon.assert.called(updateFlyoutStub);
     }


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

No issue filed.

### Proposed Changes

- Fix redeclares in helper functions in tests.
- Fix a bug in flyout visibility logic that was masked by a bad test

#### Behavior Before Change

Calling `Toolbox.prototype.updateFlyout_` with `null` for both `oldItem` and `newItem` tried to access `isCollapsible()` on `null` and failed.

#### Behavior After Change

If `newItem` is null the flyout is hidden.

### Reason for Changes

I fixed a suspicious redeclaration of a variable in a test, which unearthed this bug.

### Test Coverage
Tested by 'No new item -> Should close flyout' in `toolbox_test.js`.
Added a test for 'Old item but no new item -> Should close flyout' in `toolbox_tests.js`.
