### PR TITLE
chore: apply prefer-const rule fixes in mocha tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "blockly",
       "version": "7.20211209.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -73,12 +73,12 @@ suite('ASTNode', function() {
     ]);
     this.workspace = new Blockly.Workspace();
     this.cursor = this.workspace.cursor;
-    let statementInput1 = this.workspace.newBlock('input_statement');
-    let statementInput2 = this.workspace.newBlock('input_statement');
-    let statementInput3 = this.workspace.newBlock('input_statement');
-    let statementInput4 = this.workspace.newBlock('input_statement');
-    let fieldWithOutput = this.workspace.newBlock('field_input');
-    let valueInput = this.workspace.newBlock('value_input');
+    const statementInput1 = this.workspace.newBlock('input_statement');
+    const statementInput2 = this.workspace.newBlock('input_statement');
+    const statementInput3 = this.workspace.newBlock('input_statement');
+    const statementInput4 = this.workspace.newBlock('input_statement');
+    const fieldWithOutput = this.workspace.newBlock('field_input');
+    const valueInput = this.workspace.newBlock('value_input');
 
     statementInput1.nextConnection.connect(statementInput2.previousConnection);
     statementInput1.inputList[0].connection
@@ -101,69 +101,69 @@ suite('ASTNode', function() {
 
   suite('HelperFunctions', function() {
     test('findNextForInput_', function() {
-      let input = this.blocks.statementInput1.inputList[0];
-      let input2 = this.blocks.statementInput1.inputList[1];
-      let connection = input.connection;
-      let node = ASTNode.createConnectionNode(connection);
-      let newASTNode = node.findNextForInput_(input);
+      const input = this.blocks.statementInput1.inputList[0];
+      const input2 = this.blocks.statementInput1.inputList[1];
+      const connection = input.connection;
+      const node = ASTNode.createConnectionNode(connection);
+      const newASTNode = node.findNextForInput_(input);
       chai.assert.equal(newASTNode.getLocation(), input2.connection);
     });
 
     test('findPrevForInput_', function() {
-      let input = this.blocks.statementInput1.inputList[0];
-      let input2 = this.blocks.statementInput1.inputList[1];
-      let connection = input2.connection;
-      let node = ASTNode.createConnectionNode(connection);
-      let newASTNode = node.findPrevForInput_(input2);
+      const input = this.blocks.statementInput1.inputList[0];
+      const input2 = this.blocks.statementInput1.inputList[1];
+      const connection = input2.connection;
+      const node = ASTNode.createConnectionNode(connection);
+      const newASTNode = node.findPrevForInput_(input2);
       chai.assert.equal(newASTNode.getLocation(), input.connection);
     });
 
     test('findNextForField_', function() {
-      let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-      let field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
-      let node = ASTNode.createFieldNode(field);
-      let newASTNode = node.findNextForField_(field);
+      const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+      const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
+      const node = ASTNode.createFieldNode(field);
+      const newASTNode = node.findNextForField_(field);
       chai.assert.equal(newASTNode.getLocation(), field2);
     });
 
     test('findPrevForField_', function() {
-      let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-      let field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
-      let node = ASTNode.createFieldNode(field2);
-      let newASTNode = node.findPrevForField_(field2);
+      const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+      const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
+      const node = ASTNode.createFieldNode(field2);
+      const newASTNode = node.findPrevForField_(field2);
       chai.assert.equal(newASTNode.getLocation(), field);
     });
 
     test('navigateBetweenStacks_Forward', function() {
-      let node = new ASTNode(
+      const node = new ASTNode(
           ASTNode.types.NEXT, this.blocks.statementInput1.nextConnection);
-      let newASTNode = node.navigateBetweenStacks_(true);
+      const newASTNode = node.navigateBetweenStacks_(true);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
 
     test('navigateBetweenStacks_Backward', function() {
-      let node = new ASTNode(
+      const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
-      let newASTNode = node.navigateBetweenStacks_(false);
+      const newASTNode = node.navigateBetweenStacks_(false);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_', function() {
-      let node = new ASTNode(
+      const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput2);
-      let newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput2);
+      const newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput2);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_OneBlock', function() {
-      let node = new ASTNode(
+      const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
-      let newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput4);
+      const newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
     test('findFirstFieldOrInput_', function() {
-      let node = new ASTNode(
+      const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
-      let field = this.blocks.statementInput4.inputList[0].fieldRow[0];
-      let newASTNode = node.findFirstFieldOrInput_(this.blocks.statementInput4);
+      const field = this.blocks.statementInput4.inputList[0].fieldRow[0];
+      const newASTNode = node.findFirstFieldOrInput_(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), field);
     });
 
@@ -287,33 +287,33 @@ suite('ASTNode', function() {
         "helpUrl": "",
         "nextStatement": null
       }]);
-      let noNextConnection = this.workspace.newBlock('top_connection');
-      let fieldAndInputs = this.workspace.newBlock('fields_and_input');
-      let twoFields = this.workspace.newBlock('two_fields');
-      let fieldAndInputs2 = this.workspace.newBlock('fields_and_input2');
-      let noPrevConnection = this.workspace.newBlock('start_block');
+      const noNextConnection = this.workspace.newBlock('top_connection');
+      const fieldAndInputs = this.workspace.newBlock('fields_and_input');
+      const twoFields = this.workspace.newBlock('two_fields');
+      const fieldAndInputs2 = this.workspace.newBlock('fields_and_input2');
+      const noPrevConnection = this.workspace.newBlock('start_block');
       this.blocks.noNextConnection = noNextConnection;
       this.blocks.fieldAndInputs = fieldAndInputs;
       this.blocks.twoFields = twoFields;
       this.blocks.fieldAndInputs2 = fieldAndInputs2;
       this.blocks.noPrevConnection = noPrevConnection;
 
-      let dummyInput = this.workspace.newBlock('dummy_input');
-      let dummyInputValue = this.workspace.newBlock('dummy_inputValue');
-      let fieldWithOutput2 = this.workspace.newBlock('field_input');
+      const dummyInput = this.workspace.newBlock('dummy_input');
+      const dummyInputValue = this.workspace.newBlock('dummy_inputValue');
+      const fieldWithOutput2 = this.workspace.newBlock('field_input');
       this.blocks.dummyInput = dummyInput;
       this.blocks.dummyInputValue = dummyInputValue;
       this.blocks.fieldWithOutput2 = fieldWithOutput2;
 
-      let secondBlock = this.workspace.newBlock('input_statement');
-      let outputNextBlock = this.workspace.newBlock('output_next');
+      const secondBlock = this.workspace.newBlock('input_statement');
+      const outputNextBlock = this.workspace.newBlock('output_next');
       this.blocks.secondBlock = secondBlock;
       this.blocks.outputNextBlock = outputNextBlock;
     });
     suite('Next', function() {
       setup(function() {
         this.singleBlockWorkspace = new Blockly.Workspace();
-        let singleBlock = this.singleBlockWorkspace.newBlock('two_fields');
+        const singleBlock = this.singleBlockWorkspace.newBlock('two_fields');
         this.blocks.singleBlock = singleBlock;
       });
       teardown(function() {
@@ -321,192 +321,192 @@ suite('ASTNode', function() {
       });
 
       test('fromPreviousToBlock', function() {
-        let prevConnection = this.blocks.statementInput1.previousConnection;
-        let node = ASTNode.createConnectionNode(prevConnection);
-        let nextNode = node.next();
+        const prevConnection = this.blocks.statementInput1.previousConnection;
+        const node = ASTNode.createConnectionNode(prevConnection);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToNext', function() {
-        let nextConnection = this.blocks.statementInput1.nextConnection;
-        let node = ASTNode.createBlockNode(this.blocks.statementInput1);
-        let nextNode = node.next();
+        const nextConnection = this.blocks.statementInput1.nextConnection;
+        const node = ASTNode.createBlockNode(this.blocks.statementInput1);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), nextConnection);
       });
       test('fromBlockToNull', function() {
-        let node = ASTNode.createBlockNode(this.blocks.noNextConnection);
-        let nextNode = node.next();
+        const node = ASTNode.createBlockNode(this.blocks.noNextConnection);
+        const nextNode = node.next();
         chai.assert.isNull(nextNode);
       });
       test('fromNextToPrevious', function() {
-        let nextConnection = this.blocks.statementInput1.nextConnection;
-        let prevConnection = this.blocks.statementInput2.previousConnection;
-        let node = ASTNode.createConnectionNode(nextConnection);
-        let nextNode = node.next();
+        const nextConnection = this.blocks.statementInput1.nextConnection;
+        const prevConnection = this.blocks.statementInput2.previousConnection;
+        const node = ASTNode.createConnectionNode(nextConnection);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), prevConnection);
       });
       test('fromNextToNull', function() {
-        let nextConnection = this.blocks.statementInput2.nextConnection;
-        let node = ASTNode.createConnectionNode(nextConnection);
-        let nextNode = node.next();
+        const nextConnection = this.blocks.statementInput2.nextConnection;
+        const node = ASTNode.createConnectionNode(nextConnection);
+        const nextNode = node.next();
         chai.assert.isNull(nextNode);
       });
       test('fromInputToInput', function() {
-        let input = this.blocks.statementInput1.inputList[0];
-        let inputConnection = this.blocks.statementInput1.inputList[1].connection;
-        let node = ASTNode.createInputNode(input);
-        let nextNode = node.next();
+        const input = this.blocks.statementInput1.inputList[0];
+        const inputConnection = this.blocks.statementInput1.inputList[1].connection;
+        const node = ASTNode.createInputNode(input);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromInputToStatementInput', function() {
-        let input = this.blocks.fieldAndInputs2.inputList[1];
-        let inputConnection = this.blocks.fieldAndInputs2.inputList[2].connection;
-        let node = ASTNode.createInputNode(input);
-        let nextNode = node.next();
+        const input = this.blocks.fieldAndInputs2.inputList[1];
+        const inputConnection = this.blocks.fieldAndInputs2.inputList[2].connection;
+        const node = ASTNode.createInputNode(input);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromInputToField', function() {
-        let input = this.blocks.fieldAndInputs2.inputList[0];
-        let field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
-        let node = ASTNode.createInputNode(input);
-        let nextNode = node.next();
+        const input = this.blocks.fieldAndInputs2.inputList[0];
+        const field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
+        const node = ASTNode.createInputNode(input);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), field);
       });
       test('fromInputToNull', function() {
-        let input = this.blocks.fieldAndInputs2.inputList[2];
-        let node = ASTNode.createInputNode(input);
-        let nextNode = node.next();
+        const input = this.blocks.fieldAndInputs2.inputList[2];
+        const node = ASTNode.createInputNode(input);
+        const nextNode = node.next();
         chai.assert.isNull(nextNode);
       });
       test('fromOutputToBlock', function() {
-        let output = this.blocks.fieldWithOutput.outputConnection;
-        let node = ASTNode.createConnectionNode(output);
-        let nextNode = node.next();
+        const output = this.blocks.fieldWithOutput.outputConnection;
+        const node = ASTNode.createConnectionNode(output);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), this.blocks.fieldWithOutput);
       });
       test('fromFieldToInput', function() {
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[1];
-        let inputConnection = this.blocks.statementInput1.inputList[0].connection;
-        let node = ASTNode.createFieldNode(field);
-        let nextNode = node.next();
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[1];
+        const inputConnection = this.blocks.statementInput1.inputList[0].connection;
+        const node = ASTNode.createFieldNode(field);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromFieldToField', function() {
-        let field = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let field2 = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
-        let nextNode = node.next();
+        const field = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const field2 = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), field2);
       });
       test('fromFieldToNull', function() {
-        let field = this.blocks.twoFields.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let nextNode = node.next();
+        const field = this.blocks.twoFields.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const nextNode = node.next();
         chai.assert.isNull(nextNode);
       });
       test('fromStackToStack', function() {
-        let node = ASTNode.createStackNode(this.blocks.statementInput1);
-        let nextNode = node.next();
+        const node = ASTNode.createStackNode(this.blocks.statementInput1);
+        const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), this.blocks.statementInput4);
         chai.assert.equal(nextNode.getType(), ASTNode.types.STACK);
       });
       test('fromStackToNull', function() {
-        let node = ASTNode.createStackNode(this.blocks.singleBlock);
-        let nextNode = node.next();
+        const node = ASTNode.createStackNode(this.blocks.singleBlock);
+        const nextNode = node.next();
         chai.assert.isNull(nextNode);
       });
     });
 
     suite('Previous', function() {
       test('fromPreviousToNull', function() {
-        let prevConnection = this.blocks.statementInput1.previousConnection;
-        let node = ASTNode.createConnectionNode(prevConnection);
-        let prevNode = node.prev();
+        const prevConnection = this.blocks.statementInput1.previousConnection;
+        const node = ASTNode.createConnectionNode(prevConnection);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromPreviousToNext', function() {
-        let prevConnection = this.blocks.statementInput2.previousConnection;
-        let node = ASTNode.createConnectionNode(prevConnection);
-        let prevNode = node.prev();
-        let nextConnection = this.blocks.statementInput1.nextConnection;
+        const prevConnection = this.blocks.statementInput2.previousConnection;
+        const node = ASTNode.createConnectionNode(prevConnection);
+        const prevNode = node.prev();
+        const nextConnection = this.blocks.statementInput1.nextConnection;
         chai.assert.equal(prevNode.getLocation(), nextConnection);
       });
       test('fromPreviousToInput', function() {
-        let prevConnection = this.blocks.statementInput3.previousConnection;
-        let node = ASTNode.createConnectionNode(prevConnection);
-        let prevNode = node.prev();
+        const prevConnection = this.blocks.statementInput3.previousConnection;
+        const node = ASTNode.createConnectionNode(prevConnection);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromBlockToPrevious', function() {
-        let node = ASTNode.createBlockNode(this.blocks.statementInput1);
-        let prevNode = node.prev();
-        let prevConnection = this.blocks.statementInput1.previousConnection;
+        const node = ASTNode.createBlockNode(this.blocks.statementInput1);
+        const prevNode = node.prev();
+        const prevConnection = this.blocks.statementInput1.previousConnection;
         chai.assert.equal(prevNode.getLocation(), prevConnection);
       });
       test('fromBlockToNull', function() {
-        let node = ASTNode.createBlockNode(this.blocks.noPrevConnection);
-        let prevNode = node.prev();
+        const node = ASTNode.createBlockNode(this.blocks.noPrevConnection);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromBlockToOutput', function() {
-        let node = ASTNode.createBlockNode(this.blocks.fieldWithOutput);
-        let prevNode = node.prev();
-        let outputConnection = this.blocks.fieldWithOutput.outputConnection;
+        const node = ASTNode.createBlockNode(this.blocks.fieldWithOutput);
+        const prevNode = node.prev();
+        const outputConnection = this.blocks.fieldWithOutput.outputConnection;
         chai.assert.equal(prevNode.getLocation(), outputConnection);
       });
       test('fromNextToBlock', function() {
-        let nextConnection = this.blocks.statementInput1.nextConnection;
-        let node = ASTNode.createConnectionNode(nextConnection);
-        let prevNode = node.prev();
+        const nextConnection = this.blocks.statementInput1.nextConnection;
+        const node = ASTNode.createConnectionNode(nextConnection);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromInputToField', function() {
-        let input = this.blocks.statementInput1.inputList[0];
-        let node = ASTNode.createInputNode(input);
-        let prevNode = node.prev();
+        const input = this.blocks.statementInput1.inputList[0];
+        const node = ASTNode.createInputNode(input);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), input.fieldRow[1]);
       });
       test('fromInputToNull', function() {
-        let input = this.blocks.fieldAndInputs2.inputList[0];
-        let node = ASTNode.createInputNode(input);
-        let prevNode = node.prev();
+        const input = this.blocks.fieldAndInputs2.inputList[0];
+        const node = ASTNode.createInputNode(input);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromInputToInput', function() {
-        let input = this.blocks.fieldAndInputs2.inputList[2];
-        let inputConnection = this.blocks.fieldAndInputs2.inputList[1].connection;
-        let node = ASTNode.createInputNode(input);
-        let prevNode = node.prev();
+        const input = this.blocks.fieldAndInputs2.inputList[2];
+        const inputConnection = this.blocks.fieldAndInputs2.inputList[1].connection;
+        const node = ASTNode.createInputNode(input);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), inputConnection);
       });
       test('fromOutputToNull', function() {
-        let output = this.blocks.fieldWithOutput.outputConnection;
-        let node = ASTNode.createConnectionNode(output);
-        let prevNode = node.prev();
+        const output = this.blocks.fieldWithOutput.outputConnection;
+        const node = ASTNode.createConnectionNode(output);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromFieldToNull', function() {
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let prevNode = node.prev();
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const prevNode = node.prev();
         chai.assert.isNull(prevNode);
       });
       test('fromFieldToInput', function() {
-        let field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
-        let inputConnection = this.blocks.fieldAndInputs2.inputList[0].connection;
-        let node = ASTNode.createFieldNode(field);
-        let prevNode = node.prev();
+        const field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
+        const inputConnection = this.blocks.fieldAndInputs2.inputList[0].connection;
+        const node = ASTNode.createFieldNode(field);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), inputConnection);
       });
       test('fromFieldToField', function() {
-        let field = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
-        let field2 = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let prevNode = node.prev();
+        const field = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
+        const field2 = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), field2);
       });
       test('fromStackToStack', function() {
-        let node = ASTNode.createStackNode(this.blocks.statementInput4);
-        let prevNode = node.prev();
+        const node = ASTNode.createStackNode(this.blocks.statementInput4);
+        const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
         chai.assert.equal(prevNode.getType(), ASTNode.types.STACK);
       });
@@ -521,98 +521,98 @@ suite('ASTNode', function() {
       });
 
       test('fromInputToOutput', function() {
-        let input = this.blocks.statementInput1.inputList[0];
-        let node = ASTNode.createInputNode(input);
-        let inNode = node.in();
-        let outputConnection = this.blocks.fieldWithOutput.outputConnection;
+        const input = this.blocks.statementInput1.inputList[0];
+        const node = ASTNode.createInputNode(input);
+        const inNode = node.in();
+        const outputConnection = this.blocks.fieldWithOutput.outputConnection;
         chai.assert.equal(inNode.getLocation(), outputConnection);
       });
       test('fromInputToNull', function() {
-        let input = this.blocks.statementInput2.inputList[0];
-        let node = ASTNode.createInputNode(input);
-        let inNode = node.in();
+        const input = this.blocks.statementInput2.inputList[0];
+        const node = ASTNode.createInputNode(input);
+        const inNode = node.in();
         chai.assert.isNull(inNode);
       });
       test('fromInputToPrevious', function() {
-        let input = this.blocks.statementInput2.inputList[1];
-        let previousConnection = this.blocks.statementInput3.previousConnection;
-        let node = ASTNode.createInputNode(input);
-        let inNode = node.in();
+        const input = this.blocks.statementInput2.inputList[1];
+        const previousConnection = this.blocks.statementInput3.previousConnection;
+        const node = ASTNode.createInputNode(input);
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), previousConnection);
       });
       test('fromBlockToInput', function() {
-        let input = this.blocks.valueInput.inputList[0];
-        let node = ASTNode.createBlockNode(this.blocks.valueInput);
-        let inNode = node.in();
+        const input = this.blocks.valueInput.inputList[0];
+        const node = ASTNode.createBlockNode(this.blocks.valueInput);
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), input.connection);
       });
       test('fromBlockToField', function() {
-        let node = ASTNode.createBlockNode(this.blocks.statementInput1);
-        let inNode = node.in();
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        const node = ASTNode.createBlockNode(this.blocks.statementInput1);
+        const inNode = node.in();
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         chai.assert.equal(inNode.getLocation(), field);
       });
       test('fromBlockToPrevious', function() {
-        let prevConnection = this.blocks.statementInput4.previousConnection;
-        let node = ASTNode.createStackNode(this.blocks.statementInput4);
-        let inNode = node.in();
+        const prevConnection = this.blocks.statementInput4.previousConnection;
+        const node = ASTNode.createStackNode(this.blocks.statementInput4);
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), prevConnection);
         chai.assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
       });
       test('fromBlockToNull_DummyInput', function() {
-        let node = ASTNode.createBlockNode(this.blocks.dummyInput);
-        let inNode = node.in();
+        const node = ASTNode.createBlockNode(this.blocks.dummyInput);
+        const inNode = node.in();
         chai.assert.isNull(inNode);
       });
       test('fromBlockToInput_DummyInputValue', function() {
-        let node = ASTNode.createBlockNode(this.blocks.dummyInputValue);
-        let inputConnection = this.blocks.dummyInputValue.inputList[1].connection;
-        let inNode = node.in();
+        const node = ASTNode.createBlockNode(this.blocks.dummyInputValue);
+        const inputConnection = this.blocks.dummyInputValue.inputList[1].connection;
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), inputConnection);
       });
       test('fromOuputToNull', function() {
-        let output = this.blocks.fieldWithOutput.outputConnection;
-        let node = ASTNode.createConnectionNode(output);
-        let inNode = node.in();
+        const output = this.blocks.fieldWithOutput.outputConnection;
+        const node = ASTNode.createConnectionNode(output);
+        const inNode = node.in();
         chai.assert.isNull(inNode);
       });
       test('fromFieldToNull', function() {
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let inNode = node.in();
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const inNode = node.in();
         chai.assert.isNull(inNode);
       });
       test('fromWorkspaceToStack', function() {
-        let coordinate = new Blockly.utils.Coordinate(100, 100);
-        let node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
-        let inNode = node.in();
+        const coordinate = new Blockly.utils.Coordinate(100, 100);
+        const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), this.workspace.getTopBlocks()[0]);
         chai.assert.equal(inNode.getType(), ASTNode.types.STACK);
       });
       test('fromWorkspaceToNull', function() {
-        let coordinate = new Blockly.utils.Coordinate(100, 100);
-        let node = ASTNode.createWorkspaceNode(
+        const coordinate = new Blockly.utils.Coordinate(100, 100);
+        const node = ASTNode.createWorkspaceNode(
             this.emptyWorkspace, coordinate);
-        let inNode = node.in();
+        const inNode = node.in();
         chai.assert.isNull(inNode);
       });
       test('fromStackToPrevious', function() {
-        let node = ASTNode.createStackNode(this.blocks.statementInput1);
-        let previous = this.blocks.statementInput1.previousConnection;
-        let inNode = node.in();
+        const node = ASTNode.createStackNode(this.blocks.statementInput1);
+        const previous = this.blocks.statementInput1.previousConnection;
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), previous);
         chai.assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
       });
       test('fromStackToOutput', function() {
-        let node = ASTNode.createStackNode(this.blocks.fieldWithOutput2);
-        let output = this.blocks.fieldWithOutput2.outputConnection;
-        let inNode = node.in();
+        const node = ASTNode.createStackNode(this.blocks.fieldWithOutput2);
+        const output = this.blocks.fieldWithOutput2.outputConnection;
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), output);
         chai.assert.equal(inNode.getType(), ASTNode.types.OUTPUT);
       });
       test('fromStackToBlock', function() {
-        let node = ASTNode.createStackNode(this.blocks.dummyInput);
-        let inNode = node.in();
+        const node = ASTNode.createStackNode(this.blocks.dummyInput);
+        const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), this.blocks.dummyInput);
         chai.assert.equal(inNode.getType(), ASTNode.types.BLOCK);
       });
@@ -620,86 +620,86 @@ suite('ASTNode', function() {
 
     suite('Out', function() {
       setup(function() {
-        let secondBlock = this.blocks.secondBlock;
-        let outputNextBlock = this.blocks.outputNextBlock;
+        const secondBlock = this.blocks.secondBlock;
+        const outputNextBlock = this.blocks.outputNextBlock;
         this.blocks.noPrevConnection.nextConnection.connect(secondBlock.previousConnection);
         secondBlock.inputList[0].connection
             .connect(outputNextBlock.outputConnection);
       });
 
       test('fromInputToBlock', function() {
-        let input = this.blocks.statementInput1.inputList[0];
-        let node = ASTNode.createInputNode(input);
-        let outNode = node.out();
+        const input = this.blocks.statementInput1.inputList[0];
+        const node = ASTNode.createInputNode(input);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.BLOCK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromOutputToInput', function() {
-        let output = this.blocks.fieldWithOutput.outputConnection;
-        let node = ASTNode.createConnectionNode(output);
-        let outNode = node.out();
+        const output = this.blocks.fieldWithOutput.outputConnection;
+        const node = ASTNode.createConnectionNode(output);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(),
             this.blocks.statementInput1.inputList[0].connection);
       });
       test('fromOutputToStack', function() {
-        let output = this.blocks.fieldWithOutput2.outputConnection;
-        let node = ASTNode.createConnectionNode(output);
-        let outNode = node.out();
+        const output = this.blocks.fieldWithOutput2.outputConnection;
+        const node = ASTNode.createConnectionNode(output);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromFieldToBlock', function() {
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
-        let outNode = node.out();
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.BLOCK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromStackToWorkspace', function() {
-        let stub = sinon.stub(this.blocks.statementInput4,
+        const stub = sinon.stub(this.blocks.statementInput4,
             "getRelativeToSurfaceXY").returns({x: 10, y:10});
-        let node = ASTNode.createStackNode(this.blocks.statementInput4);
-        let outNode = node.out();
+        const node = ASTNode.createStackNode(this.blocks.statementInput4);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.WORKSPACE);
         chai.assert.equal(outNode.wsCoordinate_.x, 10);
         chai.assert.equal(outNode.wsCoordinate_.y, -10);
         stub.restore();
       });
       test('fromPreviousToInput', function() {
-        let previous = this.blocks.statementInput3.previousConnection;
-        let inputConnection = this.blocks.statementInput2.inputList[1].connection;
-        let node = ASTNode.createConnectionNode(previous);
-        let outNode = node.out();
+        const previous = this.blocks.statementInput3.previousConnection;
+        const inputConnection = this.blocks.statementInput2.inputList[1].connection;
+        const node = ASTNode.createConnectionNode(previous);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromPreviousToStack', function() {
-        let previous = this.blocks.statementInput2.previousConnection;
-        let node = ASTNode.createConnectionNode(previous);
-        let outNode = node.out();
+        const previous = this.blocks.statementInput2.previousConnection;
+        const node = ASTNode.createConnectionNode(previous);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToInput', function() {
-        let next = this.blocks.statementInput3.nextConnection;
-        let inputConnection = this.blocks.statementInput2.inputList[1].connection;
-        let node = ASTNode.createConnectionNode(next);
-        let outNode = node.out();
+        const next = this.blocks.statementInput3.nextConnection;
+        const inputConnection = this.blocks.statementInput2.inputList[1].connection;
+        const node = ASTNode.createConnectionNode(next);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromNextToStack', function() {
-        let next = this.blocks.statementInput2.nextConnection;
-        let node = ASTNode.createConnectionNode(next);
-        let outNode = node.out();
+        const next = this.blocks.statementInput2.nextConnection;
+        const node = ASTNode.createConnectionNode(next);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToStack_NoPreviousConnection', function() {
-        let next = this.blocks.secondBlock.nextConnection;
-        let node = ASTNode.createConnectionNode(next);
-        let outNode = node.out();
+        const next = this.blocks.secondBlock.nextConnection;
+        const node = ASTNode.createConnectionNode(next);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.noPrevConnection);
       });
@@ -708,42 +708,42 @@ suite('ASTNode', function() {
        * next connection attached to an input.
        */
       test('fromNextToInput_OutputAndPreviousConnection', function() {
-        let next = this.blocks.outputNextBlock.nextConnection;
-        let node = ASTNode.createConnectionNode(next);
-        let outNode = node.out();
+        const next = this.blocks.outputNextBlock.nextConnection;
+        const node = ASTNode.createConnectionNode(next);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(),
             this.blocks.secondBlock.inputList[0].connection);
       });
       test('fromBlockToStack', function() {
-        let node = ASTNode.createBlockNode(this.blocks.statementInput2);
-        let outNode = node.out();
+        const node = ASTNode.createBlockNode(this.blocks.statementInput2);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToInput', function() {
-        let input = this.blocks.statementInput2.inputList[1].connection;
-        let node = ASTNode.createBlockNode(this.blocks.statementInput3);
-        let outNode = node.out();
+        const input = this.blocks.statementInput2.inputList[1].connection;
+        const node = ASTNode.createBlockNode(this.blocks.statementInput3);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), input);
       });
       test('fromTopBlockToStack', function() {
-        let node = ASTNode.createBlockNode(this.blocks.statementInput1);
-        let outNode = node.out();
+        const node = ASTNode.createBlockNode(this.blocks.statementInput1);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToStack_OutputConnection', function() {
-        let node = ASTNode.createBlockNode(this.blocks.fieldWithOutput2);
-        let outNode = node.out();
+        const node = ASTNode.createBlockNode(this.blocks.fieldWithOutput2);
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
         chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromBlockToInput_OutputConnection', function() {
-        let node = ASTNode.createBlockNode(this.blocks.outputNextBlock);
-        let inputConnection = this.blocks.secondBlock.inputList[0].connection;
-        let outNode = node.out();
+        const node = ASTNode.createBlockNode(this.blocks.outputNextBlock);
+        const inputConnection = this.blocks.secondBlock.inputList[0].connection;
+        const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
         chai.assert.equal(outNode.getLocation(), inputConnection);
       });
@@ -751,29 +751,29 @@ suite('ASTNode', function() {
 
     suite('createFunctions', function() {
       test('createFieldNode', function() {
-        let field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-        let node = ASTNode.createFieldNode(field);
+        const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
+        const node = ASTNode.createFieldNode(field);
         chai.assert.equal(node.getLocation(), field);
         chai.assert.equal(node.getType(), ASTNode.types.FIELD);
         chai.assert.isFalse(node.isConnection());
       });
       test('createConnectionNode', function() {
-        let prevConnection = this.blocks.statementInput4.previousConnection;
-        let node = ASTNode.createConnectionNode(prevConnection);
+        const prevConnection = this.blocks.statementInput4.previousConnection;
+        const node = ASTNode.createConnectionNode(prevConnection);
         chai.assert.equal(node.getLocation(), prevConnection);
         chai.assert.equal(node.getType(), ASTNode.types.PREVIOUS);
         chai.assert.isTrue(node.isConnection());
       });
       test('createInputNode', function() {
-        let input = this.blocks.statementInput1.inputList[0];
-        let node = ASTNode.createInputNode(input);
+        const input = this.blocks.statementInput1.inputList[0];
+        const node = ASTNode.createInputNode(input);
         chai.assert.equal(node.getLocation(), input.connection);
         chai.assert.equal(node.getType(), ASTNode.types.INPUT);
         chai.assert.isTrue(node.isConnection());
       });
       test('createWorkspaceNode', function() {
-        let coordinate = new Blockly.utils.Coordinate(100, 100);
-        let node = ASTNode
+        const coordinate = new Blockly.utils.Coordinate(100, 100);
+        const node = ASTNode
             .createWorkspaceNode(this.workspace, coordinate);
         chai.assert.equal(node.getLocation(), this.workspace);
         chai.assert.equal(node.getType(), ASTNode.types.WORKSPACE);
@@ -781,26 +781,26 @@ suite('ASTNode', function() {
         chai.assert.isFalse(node.isConnection());
       });
       test('createStatementConnectionNode', function() {
-        let nextConnection = this.blocks.statementInput1.inputList[1].connection;
-        let inputConnection = this.blocks.statementInput1.inputList[1].connection;
-        let node = ASTNode.createConnectionNode(nextConnection);
+        const nextConnection = this.blocks.statementInput1.inputList[1].connection;
+        const inputConnection = this.blocks.statementInput1.inputList[1].connection;
+        const node = ASTNode.createConnectionNode(nextConnection);
         chai.assert.equal(node.getLocation(), inputConnection);
         chai.assert.equal(node.getType(), ASTNode.types.INPUT);
         chai.assert.isTrue(node.isConnection());
       });
       test('createTopNode-previous', function() {
-        let block = this.blocks.statementInput1;
-        let topNode = ASTNode.createTopNode(block);
+        const block = this.blocks.statementInput1;
+        const topNode = ASTNode.createTopNode(block);
         chai.assert.equal(topNode.getLocation(), block.previousConnection);
       });
       test('createTopNode-block', function() {
-        let block = this.blocks.noPrevConnection;
-        let topNode = ASTNode.createTopNode(block);
+        const block = this.blocks.noPrevConnection;
+        const topNode = ASTNode.createTopNode(block);
         chai.assert.equal(topNode.getLocation(), block);
       });
       test('createTopNode-output', function() {
-        let block = this.blocks.outputNextBlock;
-        let topNode = ASTNode.createTopNode(block);
+        const block = this.blocks.outputNextBlock;
+        const topNode = ASTNode.createTopNode(block);
         chai.assert.equal(topNode.getLocation(), block.outputConnection);
       });
     });

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -11,7 +11,7 @@ suite('Block JSON initialization', function() {
   suite('validateTokens_', function() {
     setup(function() {
       this.assertError = function(tokens, count, error) {
-        let block = {
+        const block = {
           type: 'test',
           validateTokens_: Blockly.Block.prototype.validateTokens_,
         };
@@ -21,7 +21,7 @@ suite('Block JSON initialization', function() {
       };
 
       this.assertNoError = function(tokens, count) {
-        let block = {
+        const block = {
           type: 'test',
           validateTokens_: Blockly.Block.prototype.validateTokens_,
         };
@@ -68,7 +68,7 @@ suite('Block JSON initialization', function() {
   suite('interpolateArguments_', function() {
     setup(function() {
       this.assertInterpolation = function(tokens, args, lastAlign, elements) {
-        let block = {
+        const block = {
           type: 'test',
           interpolateArguments_: Blockly.Block.prototype.interpolateArguments_,
           stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
@@ -304,7 +304,7 @@ suite('Block JSON initialization', function() {
           });
 
       this.assertField = function(json, expectedType) {
-        let block = {
+        const block = {
           type: 'test',
           fieldFromJson_: Blockly.Block.prototype.fieldFromJson_,
           stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
@@ -432,12 +432,12 @@ suite('Block JSON initialization', function() {
 
   suite('inputFromJson_', function() {
     setup(function() {
-      let Input = function(type) {
+      const Input = function(type) {
         this.type = type;
         this.setCheck = sinon.fake();
         this.setAlign = sinon.fake();
       };
-      let Block = function() {
+      const Block = function() {
         this.type = 'test';
         this.appendDummyInput = sinon.fake.returns(new Input());
         this.appendValueInput = sinon.fake.returns(new Input());
@@ -446,8 +446,8 @@ suite('Block JSON initialization', function() {
       };
 
       this.assertInput = function(json, type, check, align) {
-        let block = new Block();
-        let input = block.inputFromJson_(json);
+        const block = new Block();
+        const input = block.inputFromJson_(json);
         switch (type) {
           case 'input_dummy':
             chai.assert.isTrue(block.appendDummyInput.calledOnce,

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -55,10 +55,10 @@ suite('Blocks', function() {
   });
 
   function createTestBlocks(workspace, isRow) {
-    let blockType = isRow ? 'row_block' : 'stack_block';
-    let blockA = workspace.newBlock(blockType);
-    let blockB = workspace.newBlock(blockType);
-    let blockC = workspace.newBlock(blockType);
+    const blockType = isRow ? 'row_block' : 'stack_block';
+    const blockA = workspace.newBlock(blockType);
+    const blockB = workspace.newBlock(blockType);
+    const blockC = workspace.newBlock(blockType);
 
     if (isRow) {
       blockA.inputList[0].connection.connect(blockB.outputConnection);
@@ -121,7 +121,7 @@ suite('Blocks', function() {
         assertUnpluggedHealed(this.blocks);
       });
       test('Heal with bad checks', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
 
         // A and C can't connect, but both can connect to B.
         blocks.A.inputList[0].connection.setCheck('type1');
@@ -132,21 +132,21 @@ suite('Blocks', function() {
         assertUnpluggedHealFailed(blocks);
       });
       test('Parent has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to parent
         blocks.A.appendValueInput("INPUT").setCheck(null);
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
       test('Middle has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to middle block
         blocks.B.appendValueInput("INPUT").setCheck(null);
         blocks.B.unplug(true);
         assertUnpluggedHealed(blocks);
       });
       test('Child has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to child block
         blocks.C.appendValueInput("INPUT").setCheck(null);
         // Child block input count doesn't matter.
@@ -154,7 +154,7 @@ suite('Blocks', function() {
         assertUnpluggedHealed(blocks);
       });
       test('Child is shadow', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         blocks.C.setShadow(true);
         blocks.B.unplug(true);
         // Even though we're asking to heal, it will appear as if it has not
@@ -176,7 +176,7 @@ suite('Blocks', function() {
         assertUnpluggedHealed(this.blocks);
       });
       test('Heal with bad checks', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // A and C can't connect, but both can connect to B.
         blocks.A.nextConnection.setCheck('type1');
         blocks.C.previousConnection.setCheck('type2');
@@ -187,7 +187,7 @@ suite('Blocks', function() {
         assertUnpluggedHealFailed(blocks);
       });
       test('Child is shadow', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         blocks.C.setShadow(true);
         blocks.B.unplug(true);
         // Even though we're asking to heal, it will appear as if it has not
@@ -241,7 +241,7 @@ suite('Blocks', function() {
         assertDisposedHealed(this.blocks);
       });
       test('Heal with bad checks', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
 
         // A and C can't connect, but both can connect to B.
         blocks.A.inputList[0].connection.setCheck('type1');
@@ -252,21 +252,21 @@ suite('Blocks', function() {
         assertDisposedHealFailed(blocks);
       });
       test('Parent has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to parent
         blocks.A.appendValueInput("INPUT").setCheck(null);
         blocks.B.dispose(true);
         assertDisposedHealed(blocks);
       });
       test('Middle has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to middle block
         blocks.B.appendValueInput("INPUT").setCheck(null);
         blocks.B.dispose(true);
         assertDisposedHealed(blocks);
       });
       test('Child has multiple inputs', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // Add extra input to child block
         blocks.C.appendValueInput("INPUT").setCheck(null);
         // Child block input count doesn't matter.
@@ -274,7 +274,7 @@ suite('Blocks', function() {
         assertDisposedHealed(blocks);
       });
       test('Child is shadow', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         blocks.C.setShadow(true);
         blocks.B.dispose(true);
         // Even though we're asking to heal, it will appear as if it has not
@@ -296,7 +296,7 @@ suite('Blocks', function() {
         assertDisposedHealed(this.blocks);
       });
       test('Heal with bad checks', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         // A and C can't connect, but both can connect to B.
         blocks.A.nextConnection.setCheck('type1');
         blocks.C.previousConnection.setCheck('type2');
@@ -307,7 +307,7 @@ suite('Blocks', function() {
         assertDisposedHealFailed(blocks);
       });
       test('Child is shadow', function() {
-        let blocks = this.blocks;
+        const blocks = this.blocks;
         blocks.C.setShadow(true);
         blocks.B.dispose(true);
         // Even though we're asking to heal, it will appear as if it has not
@@ -342,7 +342,7 @@ suite('Blocks', function() {
         chai.assert.isNull(this.blockA.getInput('VALUE'));
       });
       test('Block Connected', function() {
-        let blockB = this.workspace.newBlock('row_block');
+        const blockB = this.workspace.newBlock('row_block');
         this.blockA.getInput('VALUE').connection
             .connect(blockB.outputConnection);
 
@@ -351,7 +351,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.blockA.getChildren().length, 0);
       });
       test('Shadow Connected', function() {
-        let blockB = this.workspace.newBlock('row_block');
+        const blockB = this.workspace.newBlock('row_block');
         blockB.setShadow(true);
         this.blockA.getInput('VALUE').connection
             .connect(blockB.outputConnection);
@@ -371,7 +371,7 @@ suite('Blocks', function() {
         chai.assert.isNull(this.blockA.getInput('STATEMENT'));
       });
       test('Block Connected', function() {
-        let blockB = this.workspace.newBlock('stack_block');
+        const blockB = this.workspace.newBlock('stack_block');
         this.blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
 
@@ -380,7 +380,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.blockA.getChildren().length, 0);
       });
       test('Shadow Connected', function() {
-        let blockB = this.workspace.newBlock('stack_block');
+        const blockB = this.workspace.newBlock('stack_block');
         blockB.setShadow(true);
         this.blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
@@ -426,7 +426,7 @@ suite('Blocks', function() {
     suite('Deserialization', function() {
       setup(function() {
         this.deserializationHelper = function(text) {
-          let dom = Blockly.Xml.textToDom(text);
+          const dom = Blockly.Xml.textToDom(text);
           Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
           this.assertConnectionsEmpty();
           this.clock.runAll();
@@ -626,7 +626,7 @@ suite('Blocks', function() {
     });
     suite('Programmatic Block Creation', function() {
       test('Stack', function() {
-        let block = this.workspace.newBlock('stack_block');
+        const block = this.workspace.newBlock('stack_block');
         this.assertConnectionsEmpty();
         block.initSvg();
         block.render();
@@ -635,7 +635,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Row', function() {
-        let block = this.workspace.newBlock('row_block');
+        const block = this.workspace.newBlock('row_block');
         this.assertConnectionsEmpty();
         block.initSvg();
         block.render();
@@ -644,7 +644,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Statement', function() {
-        let block = this.workspace.newBlock('statement_block');
+        const block = this.workspace.newBlock('statement_block');
         this.assertConnectionsEmpty();
         block.initSvg();
         block.render();
@@ -655,7 +655,7 @@ suite('Blocks', function() {
     });
     suite('setCollapsed', function() {
       test('Stack', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="stack_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -671,7 +671,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Multi-Stack', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="stack_block">' +
             '  <next>' +
             '    <block type="stack_block">' +
@@ -696,7 +696,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 3);
       });
       test('Row', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="row_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -712,7 +712,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Multi-Row', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="row_block">' +
             '  <value name="INPUT">' +
             '    <block type="row_block">' +
@@ -763,7 +763,7 @@ suite('Blocks', function() {
       test('Multi-Row Double Collapse', function() {
         // Collapse middle -> Collapse top ->
         // Uncollapse top -> Uncollapse middle
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="row_block">' +
             '  <value name="INPUT">' +
             '    <block type="row_block">' +
@@ -778,7 +778,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getOutputs().length, 3);
         chai.assert.equal(this.getInputs().length, 3);
 
-        let middleBlock = block.getInputTargetBlock('INPUT');
+        const middleBlock = block.getInputTargetBlock('INPUT');
         middleBlock.setCollapsed(true);
         chai.assert.equal(this.getOutputs().length, 2);
         chai.assert.equal(this.getInputs().length, 1);
@@ -796,7 +796,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 3);
       });
       test('Statement', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -812,7 +812,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 2);
       });
       test('Multi-Statement', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block">' +
@@ -863,7 +863,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Double Collapse', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block">' +
@@ -879,7 +879,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getPrevious().length, 3);
         chai.assert.equal(this.getNext().length, 6);
 
-        let middleBlock = block.getInputTargetBlock('STATEMENT');
+        const middleBlock = block.getInputTargetBlock('STATEMENT');
         middleBlock.setCollapsed(true);
         chai.assert.equal(this.getPrevious().length, 2);
         chai.assert.equal(this.getNext().length, 3);
@@ -989,7 +989,7 @@ suite('Blocks', function() {
     });
     suite('Remove Connections Programmatically', function() {
       test('Output', function() {
-        let block = createRenderedBlock(this.workspace, 'row_block');
+        const block = createRenderedBlock(this.workspace, 'row_block');
 
         block.setOutput(false);
 
@@ -997,7 +997,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Value', function() {
-        let block = createRenderedBlock(this.workspace, 'row_block');
+        const block = createRenderedBlock(this.workspace, 'row_block');
 
         block.removeInput('INPUT');
 
@@ -1005,7 +1005,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 0);
       });
       test('Previous', function() {
-        let block = createRenderedBlock(this.workspace, 'stack_block');
+        const block = createRenderedBlock(this.workspace, 'stack_block');
 
         block.setPreviousStatement(false);
 
@@ -1013,7 +1013,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Next', function() {
-        let block = createRenderedBlock(this.workspace, 'stack_block');
+        const block = createRenderedBlock(this.workspace, 'stack_block');
 
         block.setNextStatement(false);
 
@@ -1021,7 +1021,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 0);
       });
       test('Statement', function() {
-        let block = createRenderedBlock(this.workspace, 'statement_block');
+        const block = createRenderedBlock(this.workspace, 'statement_block');
 
         block.removeInput('STATEMENT');
 
@@ -1031,7 +1031,7 @@ suite('Blocks', function() {
     });
     suite('Add Connections Programmatically', function() {
       test('Output', function() {
-        let block = createRenderedBlock(this.workspace, 'empty_block');
+        const block = createRenderedBlock(this.workspace, 'empty_block');
         // this.workspace.newBlock('empty_block');
         // block.initSvg();
         // block.render();
@@ -1041,7 +1041,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getOutputs().length, 1);
       });
       test('Value', function() {
-        let block = this.workspace.newBlock('empty_block');
+        const block = this.workspace.newBlock('empty_block');
         block.initSvg();
         block.render();
 
@@ -1050,7 +1050,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Previous', function() {
-        let block = this.workspace.newBlock('empty_block');
+        const block = this.workspace.newBlock('empty_block');
         block.initSvg();
         block.render();
 
@@ -1059,7 +1059,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getPrevious().length, 1);
       });
       test('Next', function() {
-        let block = this.workspace.newBlock('empty_block');
+        const block = this.workspace.newBlock('empty_block');
         block.initSvg();
         block.render();
 
@@ -1068,7 +1068,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Statement', function() {
-        let block = this.workspace.newBlock('empty_block');
+        const block = this.workspace.newBlock('empty_block');
         block.initSvg();
         block.render();
 
@@ -1081,16 +1081,16 @@ suite('Blocks', function() {
   suite('Comments', function() {
     suite('Set/Get Text', function() {
       function assertCommentEvent(eventSpy, oldValue, newValue) {
-        let calls = eventSpy.getCalls();
-        let event = calls[calls.length - 1].args[0];
+        const calls = eventSpy.getCalls();
+        const event = calls[calls.length - 1].args[0];
         chai.assert.equal(event.type, eventUtils.BLOCK_CHANGE);
         chai.assert.equal(event.element, 'comment');
         chai.assert.equal(event.oldValue, oldValue);
         chai.assert.equal(event.newValue, newValue);
       }
       function assertNoCommentEvent(eventSpy) {
-        let calls = eventSpy.getCalls();
-        let event = calls[calls.length - 1].args[0];
+        const calls = eventSpy.getCalls();
+        const event = calls[calls.length - 1].args[0];
         chai.assert.notEqual(event.type, eventUtils.BLOCK_CHANGE);
       }
       setup(function() {
@@ -1165,7 +1165,7 @@ suite('Blocks', function() {
         });
         test('Set While Visible - Editable', function() {
           this.block.setCommentText('test1');
-          let icon = this.block.getCommentIcon();
+          const icon = this.block.getCommentIcon();
           icon.setVisible(true);
 
           this.block.setCommentText('test2');
@@ -1177,7 +1177,7 @@ suite('Blocks', function() {
           this.block.setCommentText('test1');
           // Restored up by call to sinon.restore() in sharedTestTeardown()
           sinon.stub(this.block, 'isEditable').returns(false);
-          let icon = this.block.getCommentIcon();
+          const icon = this.block.getCommentIcon();
           icon.setVisible(true);
 
           this.block.setCommentText('test2');
@@ -1188,7 +1188,7 @@ suite('Blocks', function() {
         });
         test('Get Text While Editing', function() {
           this.block.setCommentText('test1');
-          let icon = this.block.getCommentIcon();
+          const icon = this.block.getCommentIcon();
           icon.setVisible(true);
           icon.textarea_.value = 'test2';
           icon.textarea_.dispatchEvent(new Event('input'));
@@ -1220,20 +1220,20 @@ suite('Blocks', function() {
       chai.assert.throws(this.block.getFieldValue.bind(this.block), TypeError);
     });
     test('Getting Field with Wrong Type', function() {
-      let testFunction = function() {
+      const testFunction = function() {
         return 'TEXT';
       };
-      let inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
         chai.assert.throws(this.block.getField.bind(this.block, inputs[i]),
             TypeError);
       }
     });
     test('Getting Value of Field with Wrong Type', function() {
-      let testFunction = function() {
+      const testFunction = function() {
         return 'TEXT';
       };
-      let inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
         chai.assert.throws(
             this.block.getFieldValue.bind(this.block, inputs[i]), TypeError);
@@ -1248,10 +1248,10 @@ suite('Blocks', function() {
       chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test'));
     });
     test('Setting Field with Wrong Type', function() {
-      let testFunction = function() {
+      const testFunction = function() {
         return 'TEXT';
       };
-      let inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
         chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test',
             inputs[i]), TypeError);
@@ -1269,7 +1269,7 @@ suite('Blocks', function() {
       });
 
       test('Has Icon', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block"/>'
         ), this.workspace);
         block.setCommentText('test text');
@@ -1279,14 +1279,14 @@ suite('Blocks', function() {
         chai.assert.isFalse(block.comment.isVisible());
       });
       test('Child Has Icon', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block"/>' +
             '  </statement>' +
             '</block>'
         ), this.workspace);
-        let childBlock = block.getInputTargetBlock('STATEMENT');
+        const childBlock = block.getInputTargetBlock('STATEMENT');
         childBlock.setCommentText('test text');
         childBlock.comment.setVisible(true);
         chai.assert.isTrue(childBlock.comment.isVisible());
@@ -1294,14 +1294,14 @@ suite('Blocks', function() {
         chai.assert.isFalse(childBlock.comment.isVisible());
       });
       test('Next Block Has Icon', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="statement_block">' +
             '  <next>' +
             '    <block type="statement_block"/>' +
             '  </next>' +
             '</block>'
         ), this.workspace);
-        let nextBlock = block.getNextBlock();
+        const nextBlock = block.getNextBlock();
         nextBlock.setCommentText('test text');
         nextBlock.comment.setVisible(true);
         chai.assert.isTrue(nextBlock.comment.isVisible());
@@ -1322,7 +1322,7 @@ suite('Blocks', function() {
           chai.assert.isFalse(field.isVisible());
         }
       }
-      let icons = block.getIcons();
+      const icons = block.getIcons();
       for (let i = 0, icon; (icon = icons[i]); i++) {
         chai.assert.isFalse(icon.isVisible());
       }
@@ -1355,7 +1355,7 @@ suite('Blocks', function() {
     function isBlockHidden(block) {
       let node = block.getSvgRoot();
       do {
-        let visible = node.style.display != 'none';
+        const visible = node.style.display != 'none';
         if (!visible) {
           return true;
         }
@@ -1388,8 +1388,8 @@ suite('Blocks', function() {
     });
     suite('Connecting and Disconnecting', function() {
       test('Connect Block to Next', function() {
-        let blockA = createRenderedBlock(this.workspace, 'stack_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'stack_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1397,8 +1397,8 @@ suite('Blocks', function() {
         assertNotCollapsed(blockB);
       });
       test('Connect Block to Value Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1409,8 +1409,8 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockB));
       });
       test('Connect Block to Statement Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1422,9 +1422,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockB));
       });
       test('Connect Block to Child of Collapsed - Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
-        let blockC = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockC = createRenderedBlock(this.workspace, 'row_block');
 
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
@@ -1439,9 +1439,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Child of Collapsed - Next', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
-        let blockC = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
@@ -1457,9 +1457,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Value Input Already Taken', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
-        let blockC = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockC = createRenderedBlock(this.workspace, 'row_block');
 
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
@@ -1476,9 +1476,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Statement Input Already Taken', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
-        let blockC = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
@@ -1497,9 +1497,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block with Child - Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
-        let blockC = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockC = createRenderedBlock(this.workspace, 'row_block');
 
         blockB.getInput('INPUT').connection.connect(blockC.outputConnection);
         blockA.setCollapsed(true);
@@ -1514,9 +1514,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block with Child - Statement', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
-        let blockC = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockB.nextConnection.connect(blockC.previousConnection);
         blockA.setCollapsed(true);
@@ -1532,8 +1532,8 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block from Value Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
 
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
@@ -1543,8 +1543,8 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockB));
       });
       test('Disconnect Block from Statement Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
@@ -1555,9 +1555,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockB));
       });
       test('Disconnect Block from Child of Collapsed - Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
-        let blockC = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockC = createRenderedBlock(this.workspace, 'row_block');
 
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockB.getInput('INPUT').connection.connect(blockC.outputConnection);
@@ -1570,9 +1570,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block from Child of Collapsed - Next', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
-        let blockC = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
@@ -1586,9 +1586,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block with Child - Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'row_block');
-        let blockB = createRenderedBlock(this.workspace, 'row_block');
-        let blockC = createRenderedBlock(this.workspace, 'row_block');
+        const blockA = createRenderedBlock(this.workspace, 'row_block');
+        const blockB = createRenderedBlock(this.workspace, 'row_block');
+        const blockC = createRenderedBlock(this.workspace, 'row_block');
 
         blockB.getInput('INPUT').connection.connect(blockC.outputConnection);
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
@@ -1602,9 +1602,9 @@ suite('Blocks', function() {
         chai.assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block with Child - Statement', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
-        let blockC = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockB.nextConnection.connect(blockC.previousConnection);
         blockA.getInput('STATEMENT').connection
@@ -1621,7 +1621,7 @@ suite('Blocks', function() {
     });
     suite('Adding and Removing Block Parts', function() {
       test('Add Previous Connection', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.setPreviousStatement(true);
@@ -1629,7 +1629,7 @@ suite('Blocks', function() {
         chai.assert.isNotNull(blockA.previousConnection);
       });
       test('Add Next Connection', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.setNextStatement(true);
@@ -1637,7 +1637,7 @@ suite('Blocks', function() {
         chai.assert.isNotNull(blockA.nextConnection);
       });
       test('Add Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.appendDummyInput('NAME');
@@ -1645,25 +1645,25 @@ suite('Blocks', function() {
         chai.assert.isNotNull(blockA.getInput('NAME'));
       });
       test('Add Field', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
-        let input = blockA.appendDummyInput('NAME');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const input = blockA.appendDummyInput('NAME');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         input.appendField(new Blockly.FieldLabel('test'), 'FIELD');
         assertCollapsed(blockA);
-        let field = blockA.getField('FIELD');
+        const field = blockA.getField('FIELD');
         chai.assert.isNotNull(field);
         chai.assert.equal(field.getText(), 'test');
       });
       test('Add Icon', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.setCommentText('test');
         assertCollapsed(blockA);
       });
       test('Remove Previous Connection', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setPreviousStatement(true);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1672,7 +1672,7 @@ suite('Blocks', function() {
         chai.assert.isNull(blockA.previousConnection);
       });
       test('Remove Next Connection', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setNextStatement(true);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1681,7 +1681,7 @@ suite('Blocks', function() {
         chai.assert.isNull(blockA.nextConnection);
       });
       test('Remove Input', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.appendDummyInput('NAME');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1690,18 +1690,18 @@ suite('Blocks', function() {
         chai.assert.isNull(blockA.getInput('NAME'));
       });
       test('Remove Field', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
-        let input = blockA.appendDummyInput('NAME');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const input = blockA.appendDummyInput('NAME');
         input.appendField(new Blockly.FieldLabel('test'), 'FIELD');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         input.removeField('FIELD');
         assertCollapsed(blockA);
-        let field = blockA.getField('FIELD');
+        const field = blockA.getField('FIELD');
         chai.assert.isNull(field);
       });
       test('Remove Icon', function() {
-        let blockA = createRenderedBlock(this.workspace, 'empty_block');
+        const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCommentText('test');
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1711,30 +1711,30 @@ suite('Blocks', function() {
     });
     suite('Renaming Vars', function() {
       test('Simple Rename', function() {
-        let blockA = createRenderedBlock(this.workspace, 'variable_block');
+        const blockA = createRenderedBlock(this.workspace, 'variable_block');
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA, 'x');
 
-        let variable = this.workspace.getVariable('x', '');
+        const variable = this.workspace.getVariable('x', '');
         this.workspace.renameVariableById(variable.getId(), 'y');
         assertCollapsed(blockA, 'y');
       });
       test('Coalesce, Different Case', function() {
-        let blockA = createRenderedBlock(this.workspace, 'variable_block');
+        const blockA = createRenderedBlock(this.workspace, 'variable_block');
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA, 'x');
 
-        let variable = this.workspace.createVariable('y');
+        const variable = this.workspace.createVariable('y');
         this.workspace.renameVariableById(variable.getId(), 'X');
         assertCollapsed(blockA, 'X');
       });
     });
     suite('Disabled Blocks', function() {
       test('Children of Collapsed Blocks Should Enable Properly', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
         // Disable the block and collapse it.
@@ -1750,8 +1750,8 @@ suite('Blocks', function() {
         chai.assert.isFalse(blockB.getSvgRoot().classList.contains('blocklyDisabled'));
       });
       test('Children of Collapsed Block Should Not Update', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
 
@@ -1759,7 +1759,7 @@ suite('Blocks', function() {
         blockA.setEnabled(false);
         blockA.setCollapsed(true);
 
-        let blockUpdateDisabled = sinon.stub(blockB, 'updateDisabled');
+        const blockUpdateDisabled = sinon.stub(blockB, 'updateDisabled');
 
         // Enable the block before expanding it.
         blockA.setEnabled(true);
@@ -1769,8 +1769,8 @@ suite('Blocks', function() {
         sinon.assert.notCalled(blockUpdateDisabled);
       });
       test('Disabled Children of Collapsed Blocks Should Stay Disabled', function() {
-        let blockA = createRenderedBlock(this.workspace, 'statement_block');
-        let blockB = createRenderedBlock(this.workspace, 'stack_block');
+        const blockA = createRenderedBlock(this.workspace, 'statement_block');
+        const blockB = createRenderedBlock(this.workspace, 'stack_block');
         blockA.getInput('STATEMENT').connection
             .connect(blockB.previousConnection);
 
@@ -1854,7 +1854,7 @@ suite('Blocks', function() {
     });
   });
   suite('toString', function() {
-    let toStringTests = [
+    const toStringTests = [
       {
         name: 'statement block',
         xml: '<block type="controls_repeat_ext">' +
@@ -1966,7 +1966,7 @@ suite('Blocks', function() {
     // Create mocha test cases for each toString test.
     toStringTests.forEach(function(t) {
       test(t.name, function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(t.xml),
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(t.xml),
             this.workspace);
         chai.assert.equal(block.toString(), t.toString);
       });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -83,7 +83,7 @@ suite('Comments', function() {
           this.block.id);
     });
     test('Not Editable -> Editable', function() {
-      let editableStub = sinon.stub(this.block, 'isEditable').returns(false);
+      const editableStub = sinon.stub(this.block, 'isEditable').returns(false);
 
       this.comment.setVisible(true);
 
@@ -103,7 +103,7 @@ suite('Comments', function() {
       sinon.restore();
     });
     function assertBubbleSize(comment, height, width) {
-      let size = comment.getBubbleSize();
+      const size = comment.getBubbleSize();
       chai.assert.equal(size.height, height);
       chai.assert.equal(size.width, width);
     }
@@ -112,7 +112,7 @@ suite('Comments', function() {
     }
     test('Set Size While Visible', function() {
       this.comment.setVisible(true);
-      let bubbleSizeSpy = sinon.spy(this.comment.bubble_, 'setBubbleSize');
+      const bubbleSizeSpy = sinon.spy(this.comment.bubble_, 'setBubbleSize');
 
       assertBubbleSizeDefault(this.comment);
       this.comment.setBubbleSize(100, 100);

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -27,7 +27,7 @@ suite('Connection checker', function() {
     }
 
     test('Target Null', function() {
-      let connection = new Blockly.Connection({}, Blockly.INPUT_VALUE);
+      const connection = new Blockly.Connection({}, Blockly.INPUT_VALUE);
       assertReasonHelper(
           this.checker,
           connection,
@@ -35,9 +35,9 @@ suite('Connection checker', function() {
           Blockly.Connection.REASON_TARGET_NULL);
     });
     test('Target Self', function() {
-      let block = {workspace: 1};
-      let connection1 = new Blockly.Connection(block, Blockly.INPUT_VALUE);
-      let connection2 = new Blockly.Connection(block, Blockly.OUTPUT_VALUE);
+      const block = {workspace: 1};
+      const connection1 = new Blockly.Connection(block, Blockly.INPUT_VALUE);
+      const connection2 = new Blockly.Connection(block, Blockly.OUTPUT_VALUE);
 
       assertReasonHelper(
           this.checker,
@@ -46,9 +46,9 @@ suite('Connection checker', function() {
           Blockly.Connection.REASON_SELF_CONNECTION);
     });
     test('Different Workspaces', function() {
-      let connection1 = new Blockly.Connection(
+      const connection1 = new Blockly.Connection(
           {workspace: 1}, Blockly.INPUT_VALUE);
-      let connection2 = new Blockly.Connection(
+      const connection2 = new Blockly.Connection(
           {workspace: 2}, Blockly.OUTPUT_VALUE);
 
       assertReasonHelper(
@@ -61,10 +61,10 @@ suite('Connection checker', function() {
       setup(function() {
         // We have to declare each separately so that the connections belong
         // on different blocks.
-        let prevBlock = { isShadow: function() {}};
-        let nextBlock = { isShadow: function() {}};
-        let outBlock = { isShadow: function() {}};
-        let inBlock = { isShadow: function() {}};
+        const prevBlock = { isShadow: function() {}};
+        const nextBlock = { isShadow: function() {}};
+        const outBlock = { isShadow: function() {}};
+        const inBlock = { isShadow: function() {}};
         this.previous = new Blockly.Connection(
             prevBlock, Blockly.PREVIOUS_STATEMENT);
         this.next = new Blockly.Connection(
@@ -161,10 +161,10 @@ suite('Connection checker', function() {
     });
     suite('Shadows', function() {
       test('Previous Shadow', function() {
-        let prevBlock = { isShadow: function() { return true; }};
-        let nextBlock = { isShadow: function() { return false; }};
-        let prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
-        let next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
+        const prevBlock = { isShadow: function() { return true; }};
+        const nextBlock = { isShadow: function() { return false; }};
+        const prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
+        const next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
 
         assertReasonHelper(
             this.checker,
@@ -173,10 +173,10 @@ suite('Connection checker', function() {
             Blockly.Connection.CAN_CONNECT);
       });
       test('Next Shadow', function() {
-        let prevBlock = { isShadow: function() { return false; }};
-        let nextBlock = { isShadow: function() { return true; }};
-        let prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
-        let next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
+        const prevBlock = { isShadow: function() { return false; }};
+        const nextBlock = { isShadow: function() { return true; }};
+        const prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
+        const next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
 
         assertReasonHelper(
             this.checker,
@@ -185,10 +185,10 @@ suite('Connection checker', function() {
             Blockly.Connection.REASON_SHADOW_PARENT);
       });
       test('Prev and Next Shadow', function() {
-        let prevBlock = { isShadow: function() { return true; }};
-        let nextBlock = { isShadow: function() { return true; }};
-        let prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
-        let next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
+        const prevBlock = { isShadow: function() { return true; }};
+        const nextBlock = { isShadow: function() { return true; }};
+        const prev = new Blockly.Connection(prevBlock, Blockly.PREVIOUS_STATEMENT);
+        const next = new Blockly.Connection(nextBlock, Blockly.NEXT_STATEMENT);
 
         assertReasonHelper(
             this.checker,
@@ -197,10 +197,10 @@ suite('Connection checker', function() {
             Blockly.Connection.CAN_CONNECT);
       });
       test('Output Shadow', function() {
-        let outBlock = { isShadow: function() { return true; }};
-        let inBlock = { isShadow: function() { return false; }};
-        let outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
-        let inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
+        const outBlock = { isShadow: function() { return true; }};
+        const inBlock = { isShadow: function() { return false; }};
+        const outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
+        const inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
 
         assertReasonHelper(
             this.checker,
@@ -209,10 +209,10 @@ suite('Connection checker', function() {
             Blockly.Connection.CAN_CONNECT);
       });
       test('Input Shadow', function() {
-        let outBlock = { isShadow: function() { return false; }};
-        let inBlock = { isShadow: function() { return true; }};
-        let outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
-        let inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
+        const outBlock = { isShadow: function() { return false; }};
+        const inBlock = { isShadow: function() { return true; }};
+        const outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
+        const inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
 
         assertReasonHelper(
             this.checker,
@@ -221,10 +221,10 @@ suite('Connection checker', function() {
             Blockly.Connection.REASON_SHADOW_PARENT);
       });
       test('Output and Input Shadow', function() {
-        let outBlock = { isShadow: function() { return true; }};
-        let inBlock = { isShadow: function() { return true; }};
-        let outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
-        let inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
+        const outBlock = { isShadow: function() { return true; }};
+        const inBlock = { isShadow: function() { return true; }};
+        const outCon = new Blockly.Connection(outBlock, Blockly.OUTPUT_VALUE);
+        const inCon = new Blockly.Connection(inBlock, Blockly.INPUT_VALUE);
 
         assertReasonHelper(
             this.checker,

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -15,18 +15,18 @@ suite('Connection Database', function() {
     this.database = new Blockly.ConnectionDB(new Blockly.ConnectionChecker());
 
     this.assertOrder = function() {
-      let length = this.database.connections_.length;
+      const length = this.database.connections_.length;
       for (let i = 1; i < length; i++) {
         chai.assert.isAtMost(this.database.connections_[i - 1].y,
             this.database.connections_[i].y);
       }
     };
     this.createConnection = function(x, y, type, opt_database) {
-      let workspace = {
+      const workspace = {
         connectionDBList: []
       };
       workspace.connectionDBList[type] = opt_database || this.database;
-      let connection = new Blockly.RenderedConnection(
+      const connection = new Blockly.RenderedConnection(
           {workspace: workspace}, type);
       connection.x = x;
       connection.y = y;
@@ -34,7 +34,7 @@ suite('Connection Database', function() {
     };
     this.createSimpleTestConnections = function() {
       for (let i = 0; i < 10; i++) {
-        let connection = this.createConnection(0, i, Blockly.PREVIOUS_STATEMENT);
+        const connection = this.createConnection(0, i, Blockly.PREVIOUS_STATEMENT);
         this.database.addConnection(connection, i);
       }
     };
@@ -43,11 +43,11 @@ suite('Connection Database', function() {
     sharedTestTeardown.call(this);
   });
   test('Add Connection', function() {
-    let y2 = {y: 2};
-    let y4 = {y: 4};
-    let y1 = {y: 1};
-    let y3a = {y: 3};
-    let y3b = {y: 3};
+    const y2 = {y: 2};
+    const y4 = {y: 4};
+    const y1 = {y: 1};
+    const y3a = {y: 3};
+    const y3b = {y: 3};
 
     this.database.addConnection(y2, 2);
     chai.assert.sameOrderedMembers(
@@ -71,12 +71,12 @@ suite('Connection Database', function() {
 
   });
   test('Remove Connection', function() {
-    let y2 = {y: 2};
-    let y4 = {y: 4};
-    let y1 = {y: 1};
-    let y3a = {y: 3};
-    let y3b = {y: 3};
-    let y3c = {y: 3};
+    const y2 = {y: 2};
+    const y4 = {y: 4};
+    const y1 = {y: 1};
+    const y3a = {y: 3};
+    const y3b = {y: 3};
+    const y3c = {y: 3};
 
     this.database.addConnection(y2, 2);
     this.database.addConnection(y4, 4);
@@ -113,76 +113,76 @@ suite('Connection Database', function() {
   });
   suite('Get Neighbors', function() {
     test('Empty Database', function() {
-      let connection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
+      const connection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       chai.assert.isEmpty(this.database.getNeighbours(connection), 100);
     });
     test('Block At Top', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 4);
+      const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.sameMembers(neighbors, this.database.connections_.slice(0, 5));
     });
     test('Block In Middle', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(0, 4, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 4, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 2);
+      const neighbors = this.database.getNeighbours(checkConnection, 2);
       chai.assert.sameMembers(neighbors, this.database.connections_.slice(2, 7));
     });
     test('Block At End', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(0, 9, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 9, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 4);
+      const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.sameMembers(neighbors, this.database.connections_.slice(5, 10));
     });
     test('Out of Range X', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(10, 9, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(10, 9, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 4);
+      const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.isEmpty(neighbors);
     });
     test('Out of Range Y', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(0, 19, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 19, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 4);
+      const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.isEmpty(neighbors);
     });
     test('Out of Range Diagonal', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createConnection(-2, -2, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(-2, -2, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
-      let neighbors = this.database.getNeighbours(checkConnection, 2);
+      const neighbors = this.database.getNeighbours(checkConnection, 2);
       chai.assert.isEmpty(neighbors);
     });
   });
   suite('Ordering', function() {
     test('Simple', function() {
       for (let i = 0; i < 10; i++) {
-        let connection = this.createConnection(0, i, Blockly.NEXT_STATEMENT);
+        const connection = this.createConnection(0, i, Blockly.NEXT_STATEMENT);
         this.database.addConnection(connection, i);
       }
       this.assertOrder();
     });
     test('Quasi-Random', function() {
-      let xCoords = [-29, -47, -77, 2, 43, 34, -59, -52, -90, -36, -91, 38,
+      const xCoords = [-29, -47, -77, 2, 43, 34, -59, -52, -90, -36, -91, 38,
         87, -20, 60, 4, -57, 65, -37, -81, 57, 58, -96, 1, 67, -79, 34, 93,
         -90, -99, -62, 4, 11, -36, -51, -72, 3, -50, -24, -45, -92, -38, 37,
         24, -47, -73, 79, -20, 99, 43, -10, -87, 19, 35, -62, -36, 49, 86,
         -24, -47, -89, 33, -44, 25, -73, -91, 85, 6, 0, 89, -94, 36, -35, 84,
         -9, 96, -21, 52, 10, -95, 7, -67, -70, 62, 9, -40, -95, -9, -94, 55,
         57, -96, 55, 8, -48, -57, -87, 81, 23, 65];
-      let yCoords = [-81, 82, 5, 47, 30, 57, -12, 28, 38, 92, -25, -20, 23,
+      const yCoords = [-81, 82, 5, 47, 30, 57, -12, 28, 38, 92, -25, -20, 23,
         -51, 73, -90, 8, 28, -51, -15, 81, -60, -6, -16, 77, -62, -42, -24,
         35, 95, -46, -7, 61, -16, 14, 91, 57, -38, 27, -39, 92, 47, -98, 11,
         -33, -72, 64, 38, -64, -88, -35, -59, -76, -94, 45, -25, -100, -95,
@@ -190,9 +190,9 @@ suite('Connection Database', function() {
         -23, 5, -2, -13, -9, 48, 74, -97, -11, 35, -79, -16, -77, 83, -57,
         -53, 35, -44, 100, -27, -15, 5, 39, 33, -19, -20, -95];
 
-      let length = xCoords.length;
+      const length = xCoords.length;
       for (let i = 0; i < length; i++) {
-        let connection = this.createConnection(xCoords[i], yCoords[i],
+        const connection = this.createConnection(xCoords[i], yCoords[i],
             Blockly.NEXT_STATEMENT);
         this.database.addConnection(connection, yCoords[i]);
       }
@@ -215,22 +215,22 @@ suite('Connection Database', function() {
           });
 
       this.createCheckConnection = function(x, y) {
-        let checkConnection = this.createConnection(x, y, Blockly.NEXT_STATEMENT,
+        const checkConnection = this.createConnection(x, y, Blockly.NEXT_STATEMENT,
             new Blockly.ConnectionDB());
         return checkConnection;
       };
     });
     test('Empty Database', function() {
-      let checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       chai.assert.isNull(this.database.searchForClosest(
           checkConnection, 100, {x: 0, y: 0}).connection);
     });
     test('Too Far', function() {
-      let connection = this.createConnection(0, 100, Blockly.PREVIOUS_STATEMENT);
+      const connection = this.createConnection(0, 100, Blockly.PREVIOUS_STATEMENT);
       this.database.addConnection(connection, 100);
 
-      let checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
+      const checkConnection = this.createConnection(0, 0, Blockly.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       chai.assert.isNull(this.database.searchForClosest(
           checkConnection, 50, {x: 0, y: 0}).connection);
@@ -238,32 +238,32 @@ suite('Connection Database', function() {
     test('Single in Range', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createCheckConnection(0, 14);
+      const checkConnection = this.createCheckConnection(0, 14);
 
-      let last = this.database.connections_[9];
-      let closest = this.database.searchForClosest(
+      const last = this.database.connections_[9];
+      const closest = this.database.searchForClosest(
           checkConnection, 5, {x: 0, y: 0}).connection;
       chai.assert.equal(last, closest);
     });
     test('Many in Range', function() {
       this.createSimpleTestConnections();
 
-      let checkConnection = this.createCheckConnection(0, 10);
+      const checkConnection = this.createCheckConnection(0, 10);
 
-      let last = this.database.connections_[9];
-      let closest = this.database.searchForClosest(
+      const last = this.database.connections_[9];
+      const closest = this.database.searchForClosest(
           checkConnection, 5, {x: 0, y: 0}).connection;
       chai.assert.equal(last, closest);
     });
     test('No Y-Coord Priority', function() {
-      let connection1 = this.createConnection(6, 6, Blockly.PREVIOUS_STATEMENT);
+      const connection1 = this.createConnection(6, 6, Blockly.PREVIOUS_STATEMENT);
       this.database.addConnection(connection1, 6);
-      let connection2 = this.createConnection(5, 5, Blockly.PREVIOUS_STATEMENT);
+      const connection2 = this.createConnection(5, 5, Blockly.PREVIOUS_STATEMENT);
       this.database.addConnection(connection2, 5);
 
-      let checkConnection = this.createCheckConnection(4, 6);
+      const checkConnection = this.createCheckConnection(4, 6);
 
-      let closest = this.database.searchForClosest(
+      const closest = this.database.searchForClosest(
           checkConnection, 3, {x: 0, y: 0}).connection;
       chai.assert.equal(connection2, closest);
     });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -15,11 +15,11 @@ suite('Connection', function() {
     this.workspace = sinon.createStubInstance(Blockly.Workspace);
     this.workspace.connectionChecker = new Blockly.ConnectionChecker();
     this.createConnection = function(type) {
-      let block = {
+      const block = {
         workspace: this.workspace,
         isShadow: function() { return false; }
       };
-      let connection = new Blockly.Connection(block, type);
+      const connection = new Blockly.Connection(block, type);
       return connection;
     };
   });
@@ -29,9 +29,9 @@ suite('Connection', function() {
   });
 
   test('Deprecated - canConnectWithReason passes', function() {
-    let deprecateWarnSpy = createDeprecationWarningStub();
-    let conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
-    let conn2 = this.createConnection(Blockly.NEXT_NAME);
+    const deprecateWarnSpy = createDeprecationWarningStub();
+    const conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    const conn2 = this.createConnection(Blockly.NEXT_NAME);
     chai.assert.equal(conn1.canConnectWithReason(conn2),
         Blockly.Connection.CAN_CONNECT);
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
@@ -39,9 +39,9 @@ suite('Connection', function() {
   });
 
   test('Deprecated - canConnectWithReason fails', function() {
-    let deprecateWarnSpy = createDeprecationWarningStub();
-    let conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
-    let conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
+    const deprecateWarnSpy = createDeprecationWarningStub();
+    const conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    const conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
     chai.assert.equal(conn1.canConnectWithReason(conn2),
         Blockly.Connection.REASON_WRONG_TYPE);
     assertSingleDeprecationWarningCall(deprecateWarnSpy,
@@ -49,9 +49,9 @@ suite('Connection', function() {
   });
 
   test('Deprecated - checkConnection passes', function() {
-    let deprecateWarnSpy = createDeprecationWarningStub();
-    let conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
-    let conn2 = this.createConnection(Blockly.NEXT_NAME);
+    const deprecateWarnSpy = createDeprecationWarningStub();
+    const conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    const conn2 = this.createConnection(Blockly.NEXT_NAME);
     chai.assert.doesNotThrow(function() {
       conn1.checkConnection(conn2);
     });
@@ -60,9 +60,9 @@ suite('Connection', function() {
   });
 
   test('Deprecated - checkConnection fails', function() {
-    let deprecateWarnSpy = createDeprecationWarningStub();
-    let conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
-    let conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
+    const deprecateWarnSpy = createDeprecationWarningStub();
+    const conn1 = this.createConnection(Blockly.PREVIOUS_NAME);
+    const conn2 = this.createConnection(Blockly.OUTPUT_VALUE);
     chai.assert.throws(function() {
       conn1.checkConnection(conn2);
     });
@@ -81,27 +81,27 @@ suite('Connection', function() {
     }
 
     function assertInputHasBlock(parent, inputName, isShadow, opt_name) {
-      let block = parent.getInputTargetBlock(inputName);
+      const block = parent.getInputTargetBlock(inputName);
       chai.assert.exists(block,
           `expected block ${opt_name || ''} to be attached to ${inputName}`);
       assertBlockMatches(block, isShadow, opt_name);
     }
 
     function assertNextHasBlock(parent, isShadow, opt_name) {
-      let block = parent.getNextBlock();
+      const block = parent.getNextBlock();
       chai.assert.exists(block,
           `expected block ${opt_name || ''} to be attached to next connection`);
       assertBlockMatches(block, isShadow, opt_name);
     }
 
     function assertInputNotHasBlock(parent, inputName) {
-      let block = parent.getInputTargetBlock(inputName);
+      const block = parent.getInputTargetBlock(inputName);
       chai.assert.notExists(block,
           `expected block ${block && block.id} to not be attached to ${inputName}`);
     }
 
     function assertNextNotHasBlock(parent) {
-      let block = parent.getNextBlock();
+      const block = parent.getNextBlock();
       chai.assert.notExists(block,
           `expected block ${block && block.id} to not be attached to next connection`);
     }
@@ -114,7 +114,7 @@ suite('Connection', function() {
       chai.assert.equal(actualXml, xmlText);
     }
 
-    let testSuites = [
+    const testSuites = [
       {
         title: 'Rendered',
         createWorkspace: () => {
@@ -151,29 +151,29 @@ suite('Connection', function() {
           suite('Add - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block" id="id1"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
@@ -202,8 +202,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block" id="id1">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
@@ -250,8 +250,8 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="id1"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
@@ -280,8 +280,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="id1">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
@@ -328,8 +328,8 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block" id="id1"/>'
               );
               parent.nextConnection.setShadowDom(xml);
@@ -356,8 +356,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block" id="id1">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
@@ -402,7 +402,7 @@ suite('Connection', function() {
           suite('Add - With Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlocks(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <block type="row_block" id="idA"/>' +
@@ -413,7 +413,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlocks(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <block type="statement_block" id="idA"/>' +
@@ -424,7 +424,7 @@ suite('Connection', function() {
             }
 
             function createStackBlocks(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <block type="stack_block" id="idA"/>' +
@@ -435,8 +435,8 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block" id="id1"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
@@ -467,8 +467,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block" id="id1">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
@@ -518,8 +518,8 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="id1"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
@@ -550,8 +550,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block" id="id1">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
@@ -602,8 +602,8 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block" id="id1"/>'
               );
               parent.nextConnection.setShadowDom(xml);
@@ -632,8 +632,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlocks(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlocks(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block" id="id1">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
@@ -681,21 +681,21 @@ suite('Connection', function() {
           suite('Add - With Shadow Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block" id="id0"/>'
               ), workspace);
               return block;
@@ -968,7 +968,7 @@ suite('Connection', function() {
           suite('Remove - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="idA"/>' +
@@ -979,7 +979,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="idA"/>' +
@@ -990,7 +990,7 @@ suite('Connection', function() {
             }
 
             function createStackBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="idA"/>' +
@@ -1001,7 +1001,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.setShadowDom(null);
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
@@ -1017,7 +1017,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection.setShadowDom(null);
               assertInputNotHasBlock(parent, 'STATEMENT');
               assertSerialization(
@@ -1033,7 +1033,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowDom(null);
               assertNextNotHasBlock(parent);
               assertSerialization(
@@ -1052,7 +1052,7 @@ suite('Connection', function() {
           suite('Remove - Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="idA"/>' +
@@ -1064,7 +1064,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="idA"/>' +
@@ -1076,7 +1076,7 @@ suite('Connection', function() {
             }
 
             function createStackBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="idA"/>' +
@@ -1088,7 +1088,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.setShadowDom(null);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -1106,7 +1106,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection.setShadowDom(null);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
@@ -1124,7 +1124,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowDom(null);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -1145,34 +1145,34 @@ suite('Connection', function() {
           suite('Add - Connect & Disconnect - Remove', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="row_block"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="statement_block"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                   '<block type="stack_block"/>'
               ), workspace);
               return block;
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', true);
-              let child = createRowBlock(this.workspace);
+              const child = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.connect(child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -1182,8 +1182,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createRowBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="row_block">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block"/>' +
@@ -1194,7 +1194,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
-              let child = createRowBlock(this.workspace);
+              const child = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.connect(child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -1206,13 +1206,13 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .connect(child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
@@ -1223,8 +1223,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStatementBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="statement_block">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
@@ -1235,7 +1235,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .connect(child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
@@ -1248,13 +1248,13 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block"/>'
               );
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.nextConnection.connect(child.previousConnection);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -1264,8 +1264,8 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlock(this.workspace);
-              let xml = Blockly.Xml.textToDom(
+              const parent = createStackBlock(this.workspace);
+              const xml = Blockly.Xml.textToDom(
                   '<shadow type="stack_block" id="parent">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="child"/>' +
@@ -1275,7 +1275,7 @@ suite('Connection', function() {
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.nextConnection.connect(child.previousConnection);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -1356,7 +1356,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection
                   .setShadowState({'type': 'row_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'INPUT', true);
@@ -1384,7 +1384,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.setShadowState({
                 'type': 'row_block',
                 'id': 'id1',
@@ -1436,7 +1436,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .setShadowState({'type': 'statement_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'NAME', true);
@@ -1464,7 +1464,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Statment', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection.setShadowState({
                 'type': 'statement_block',
                 'id': 'id1',
@@ -1516,7 +1516,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection
                   .setShadowState({'type': 'stack_block', 'id': 'id1'});
               assertNextHasBlock(parent, true);
@@ -1541,7 +1541,7 @@ suite('Connection', function() {
               );
             });
             test('Multiple Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowState({
                 'type': 'stack_block',
                 'id': 'id1',
@@ -1638,7 +1638,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlocks(this.workspace);
+              const parent = createRowBlocks(this.workspace);
               parent.getInput('INPUT').connection
                   .setShadowState({'type': 'row_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'INPUT', false);
@@ -1668,7 +1668,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlocks(this.workspace);
+              const parent = createRowBlocks(this.workspace);
               parent.getInput('INPUT').connection.setShadowState(
                   {
                     'type': 'row_block',
@@ -1725,7 +1725,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
+              const parent = createStatementBlocks(this.workspace);
               parent.getInput('NAME').connection
                   .setShadowState({'type': 'statement_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'NAME', false);
@@ -1755,7 +1755,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
+              const parent = createStatementBlocks(this.workspace);
               parent.getInput('NAME').connection.setShadowState(
                   {
                     'type': 'statement_block',
@@ -1813,7 +1813,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlocks(this.workspace);
+              const parent = createStackBlocks(this.workspace);
               parent.nextConnection
                   .setShadowState({'type': 'stack_block', 'id': 'id1'});
               assertNextHasBlock(parent, false);
@@ -1841,7 +1841,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlocks(this.workspace);
+              const parent = createStackBlocks(this.workspace);
               parent.nextConnection.setShadowState(
                   {
                     'type': 'stack_block',
@@ -1909,7 +1909,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection
                   .setShadowState({'type': 'row_block', 'id': '1'});
               assertInputHasBlock(parent, 'INPUT', true, '1');
@@ -1940,7 +1940,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.setShadowState(
                   {
                     'type': 'row_block',
@@ -2011,7 +2011,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .setShadowState({'type': 'statement_block', 'id': '1'});
               assertInputHasBlock(parent, 'NAME', true, '1');
@@ -2042,7 +2042,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection.setShadowState(
                   {
                     'type': 'statement_block',
@@ -2113,7 +2113,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection
                   .setShadowState({'type': 'stack_block', 'id': '1'});
               assertNextHasBlock(parent, true, '1');
@@ -2142,7 +2142,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowState(
                   {
                     'type': 'stack_block',
@@ -2255,7 +2255,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlocks(this.workspace);
+              const parent = createRowBlocks(this.workspace);
               parent.getInput('INPUT').connection.setShadowState(null);
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
@@ -2271,7 +2271,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
+              const parent = createStatementBlocks(this.workspace);
               parent.getInput('NAME').connection.setShadowState(null);
               assertInputNotHasBlock(parent, 'NAME');
               assertSerialization(
@@ -2287,7 +2287,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlocks(this.workspace);
+              const parent = createStackBlocks(this.workspace);
               parent.nextConnection.setShadowState(null);
               assertNextNotHasBlock(parent);
               assertSerialization(
@@ -2367,7 +2367,7 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlocks(this.workspace);
+              const parent = createRowBlocks(this.workspace);
               parent.getInput('INPUT').connection.setShadowState(null);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -2385,7 +2385,7 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlocks(this.workspace);
+              const parent = createStatementBlocks(this.workspace);
               parent.getInput('NAME').connection.setShadowState(null);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
@@ -2403,7 +2403,7 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlocks(this.workspace);
+              const parent = createStackBlocks(this.workspace);
               parent.nextConnection.setShadowState(null);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -2439,11 +2439,11 @@ suite('Connection', function() {
             }
 
             test('Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection
                   .setShadowState({'type': 'row_block'});
               assertInputHasBlock(parent, 'INPUT', true);
-              let child = createRowBlock(this.workspace);
+              const child = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.connect(child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -2453,7 +2453,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Value', function() {
-              let parent = createRowBlock(this.workspace);
+              const parent = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.setShadowState({
                 'type': 'row_block',
                 'inputs': {
@@ -2467,7 +2467,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
-              let child = createRowBlock(this.workspace);
+              const child = createRowBlock(this.workspace);
               parent.getInput('INPUT').connection.connect(child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
@@ -2479,11 +2479,11 @@ suite('Connection', function() {
             });
 
             test('Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .setShadowState({'type': 'statement_block'});
               assertInputHasBlock(parent, 'NAME', true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .connect(child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
@@ -2494,7 +2494,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Statement', function() {
-              let parent = createStatementBlock(this.workspace);
+              const parent = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection.setShadowState({
                 'type': 'statement_block',
                 'inputs': {
@@ -2508,7 +2508,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.getInput('NAME').connection
                   .connect(child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
@@ -2521,9 +2521,9 @@ suite('Connection', function() {
             });
 
             test('Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowState({'type': 'stack_block'});
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.nextConnection.connect(child.previousConnection);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -2533,7 +2533,7 @@ suite('Connection', function() {
             });
 
             test('Multiple Next', function() {
-              let parent = createStackBlock(this.workspace);
+              const parent = createStackBlock(this.workspace);
               parent.nextConnection.setShadowState({
                 'type': 'stack_block',
                 'next': {
@@ -2544,7 +2544,7 @@ suite('Connection', function() {
               });
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
-              let child = createStatementBlock(this.workspace);
+              const child = createStatementBlock(this.workspace);
               parent.nextConnection.connect(child.previousConnection);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
@@ -2786,9 +2786,9 @@ suite('Connection', function() {
 
     suite('Disconnect from old parent', function() {
       test('Value', function() {
-        let oldParent = this.workspace.newBlock('row_block');
-        let newParent = this.workspace.newBlock('row_block');
-        let child = this.workspace.newBlock('row_block');
+        const oldParent = this.workspace.newBlock('row_block');
+        const newParent = this.workspace.newBlock('row_block');
+        const child = this.workspace.newBlock('row_block');
 
         oldParent.getInput('INPUT').connection.connect(child.outputConnection);
         newParent.getInput('INPUT').connection.connect(child.outputConnection);
@@ -2799,9 +2799,9 @@ suite('Connection', function() {
       });
 
       test('Statement', function() {
-        let oldParent = this.workspace.newBlock('statement_block');
-        let newParent = this.workspace.newBlock('statement_block');
-        let child = this.workspace.newBlock('stack_block');
+        const oldParent = this.workspace.newBlock('statement_block');
+        const newParent = this.workspace.newBlock('statement_block');
+        const child = this.workspace.newBlock('stack_block');
 
         oldParent.getInput('NAME').connection
             .connect(child.previousConnection);
@@ -2814,9 +2814,9 @@ suite('Connection', function() {
       });
 
       test('Next', function() {
-        let oldParent = this.workspace.newBlock('stack_block');
-        let newParent = this.workspace.newBlock('stack_block');
-        let child = this.workspace.newBlock('stack_block');
+        const oldParent = this.workspace.newBlock('stack_block');
+        const newParent = this.workspace.newBlock('stack_block');
+        const child = this.workspace.newBlock('stack_block');
 
         oldParent.nextConnection.connect(child.previousConnection);
         newParent.nextConnection.connect(child.previousConnection);
@@ -2828,9 +2828,9 @@ suite('Connection', function() {
 
     suite('Shadow dissolves', function() {
       test('Value', function() {
-        let newParent = this.workspace.newBlock('row_block');
-        let child = this.workspace.newBlock('row_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('row_block');
+        const child = this.workspace.newBlock('row_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="row_block"/>'
         );
         newParent.getInput('INPUT').connection.setShadowDom(xml);
@@ -2843,9 +2843,9 @@ suite('Connection', function() {
       });
 
       test('Statement', function() {
-        let newParent = this.workspace.newBlock('statement_block');
-        let child = this.workspace.newBlock('stack_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('statement_block');
+        const child = this.workspace.newBlock('stack_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.getInput('NAME').connection.setShadowDom(xml);
@@ -2861,9 +2861,9 @@ suite('Connection', function() {
       });
 
       test('Next', function() {
-        let newParent = this.workspace.newBlock('stack_block');
-        let child = this.workspace.newBlock('stack_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('stack_block');
+        const child = this.workspace.newBlock('stack_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.nextConnection.setShadowDom(xml);
@@ -2878,9 +2878,9 @@ suite('Connection', function() {
 
     suite('Saving shadow values', function() {
       test('Value', function() {
-        let newParent = this.workspace.newBlock('row_block');
-        let child = this.workspace.newBlock('row_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('row_block');
+        const child = this.workspace.newBlock('row_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="row_block"/>'
         );
         newParent.getInput('INPUT').connection.setShadowDom(xml);
@@ -2896,9 +2896,9 @@ suite('Connection', function() {
       });
 
       test('Statement', function() {
-        let newParent = this.workspace.newBlock('statement_block');
-        let child = this.workspace.newBlock('stack_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('statement_block');
+        const child = this.workspace.newBlock('stack_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.getInput('NAME').connection.setShadowDom(xml);
@@ -2916,9 +2916,9 @@ suite('Connection', function() {
       });
 
       test('Next', function() {
-        let newParent = this.workspace.newBlock('stack_block');
-        let child = this.workspace.newBlock('stack_block');
-        let xml = Blockly.Xml.textToDom(
+        const newParent = this.workspace.newBlock('stack_block');
+        const child = this.workspace.newBlock('stack_block');
+        const xml = Blockly.Xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.nextConnection.setShadowDom(xml);
@@ -2938,9 +2938,9 @@ suite('Connection', function() {
       suite('Value', function() {
         suite('No available spots', function() {
           test('No connection', function() {
-            let parent = this.workspace.newBlock('row_block');
-            let oldChild = this.workspace.newBlock('row_block');
-            let newChild = this.workspace.newBlock('row_block_noend');
+            const parent = this.workspace.newBlock('row_block');
+            const oldChild = this.workspace.newBlock('row_block');
+            const newChild = this.workspace.newBlock('row_block_noend');
             parent.getInput('INPUT').connection
                 .connect(oldChild.outputConnection);
 
@@ -2956,9 +2956,9 @@ suite('Connection', function() {
           });
 
           test('All statements', function() {
-            let parent = this.workspace.newBlock('row_block');
-            let oldChild = this.workspace.newBlock('row_block');
-            let newChild = this.workspace.newBlock('output_to_statements');
+            const parent = this.workspace.newBlock('row_block');
+            const oldChild = this.workspace.newBlock('row_block');
+            const newChild = this.workspace.newBlock('output_to_statements');
             parent.getInput('INPUT').connection
                 .connect(oldChild.outputConnection);
 
@@ -2974,9 +2974,9 @@ suite('Connection', function() {
           });
 
           test('Bad checks', function() {
-            let parent = this.workspace.newBlock('row_block');
-            let oldChild = this.workspace.newBlock('row_block');
-            let newChild = this.workspace.newBlock('row_block_2to1');
+            const parent = this.workspace.newBlock('row_block');
+            const oldChild = this.workspace.newBlock('row_block');
+            const newChild = this.workspace.newBlock('row_block_2to1');
             parent.getInput('INPUT').connection
                 .connect(oldChild.outputConnection);
 
@@ -3224,9 +3224,9 @@ suite('Connection', function() {
       suite('Statement', function() {
         suite('No shadows', function() {
           test('Simple', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
 
@@ -3243,10 +3243,10 @@ suite('Connection', function() {
           });
 
           test('Bad check in between', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild1 = this.workspace.newBlock('stack_block_1to2');
-            let newChild2 = this.workspace.newBlock('stack_block_2to1');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild1 = this.workspace.newBlock('stack_block_1to2');
+            const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
@@ -3264,12 +3264,12 @@ suite('Connection', function() {
           });
 
           test('Bad check at end', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_1to2');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
@@ -3284,12 +3284,12 @@ suite('Connection', function() {
           });
 
           test('No end connection', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_noend');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_noend');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
@@ -3305,12 +3305,12 @@ suite('Connection', function() {
 
         suite('Shadows', function() {
           test('Simple', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
@@ -3328,14 +3328,14 @@ suite('Connection', function() {
           });
 
           test('Bad check in between', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild1 = this.workspace.newBlock('stack_block_1to2');
-            let newChild2 = this.workspace.newBlock('stack_block_2to1');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild1 = this.workspace.newBlock('stack_block_1to2');
+            const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild2.nextConnection.setShadowDom(xml);
@@ -3353,16 +3353,16 @@ suite('Connection', function() {
           });
 
           test('Bad check at end', function() {
-            let parent = this.workspace.newBlock('statement_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_1to2');
+            const parent = this.workspace.newBlock('statement_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block_2to1"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.getInput('NAME').connection
                 .connect(newChild.previousConnection);
@@ -3382,9 +3382,9 @@ suite('Connection', function() {
       suite('Next', function() {
         suite('No shadows', function() {
           test('Simple', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block');
             parent.nextConnection.connect(oldChild.previousConnection);
 
             parent.nextConnection.connect(newChild.previousConnection);
@@ -3397,10 +3397,10 @@ suite('Connection', function() {
           });
 
           test('Bad check in between', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild1 = this.workspace.newBlock('stack_block_1to2');
-            let newChild2 = this.workspace.newBlock('stack_block_2to1');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild1 = this.workspace.newBlock('stack_block_1to2');
+            const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.nextConnection.connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
 
@@ -3414,11 +3414,11 @@ suite('Connection', function() {
           });
 
           test('Bad check at end', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_1to2');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.nextConnection.connect(oldChild.previousConnection);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 
@@ -3430,11 +3430,11 @@ suite('Connection', function() {
           });
 
           test('No end connection', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_noend');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_noend');
             parent.nextConnection.connect(oldChild.previousConnection);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 
@@ -3447,11 +3447,11 @@ suite('Connection', function() {
 
         suite('Shadows', function() {
           test('Simple', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block');
             parent.nextConnection.connect(oldChild.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
@@ -3466,13 +3466,13 @@ suite('Connection', function() {
           });
 
           test('Bad check in between', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild1 = this.workspace.newBlock('stack_block_1to2');
-            let newChild2 = this.workspace.newBlock('stack_block_2to1');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild1 = this.workspace.newBlock('stack_block_1to2');
+            const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.nextConnection.connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild2.nextConnection.setShadowDom(xml);
@@ -3487,15 +3487,15 @@ suite('Connection', function() {
           });
 
           test('Bad check at end', function() {
-            let parent = this.workspace.newBlock('stack_block');
-            let oldChild = this.workspace.newBlock('stack_block');
-            let newChild = this.workspace.newBlock('stack_block_1to2');
+            const parent = this.workspace.newBlock('stack_block');
+            const oldChild = this.workspace.newBlock('stack_block');
+            const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.nextConnection.connect(oldChild.previousConnection);
-            let xml = Blockly.Xml.textToDom(
+            const xml = Blockly.Xml.textToDom(
                 '<shadow type="stack_block_2to1"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
-            let spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -14,7 +14,7 @@ suite('Context Menu Items', function() {
     sharedTestSetup.call(this);
 
     // Creates a WorkspaceSVG
-    let toolbox = document.getElementById('toolbox-categories');
+    const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
 
     // Declare a new registry to ensure default options are called.
@@ -38,7 +38,7 @@ suite('Context Menu Items', function() {
       });
 
       test('Disabled when nothing to undo', function() {
-        let precondition = this.undoOption.preconditionFn(this.scope);
+        const precondition = this.undoOption.preconditionFn(this.scope);
         chai.assert.equal(precondition, 'disabled',
             'Should be disabled when there is nothing to undo');
       });
@@ -46,7 +46,7 @@ suite('Context Menu Items', function() {
       test('Enabled when something to undo', function() {
         // Create a new block, which should be undoable.
         this.workspace.newBlock('text');
-        let precondition = this.undoOption.preconditionFn(this.scope);
+        const precondition = this.undoOption.preconditionFn(this.scope);
         chai.assert.equal(precondition, 'enabled',
             'Should be enabled when there are actions to undo');
       });
@@ -72,7 +72,7 @@ suite('Context Menu Items', function() {
       test('Disabled when nothing to redo', function() {
         // Create a new block. There should be something to undo, but not redo.
         this.workspace.newBlock('text');
-        let precondition = this.redoOption.preconditionFn(this.scope);
+        const precondition = this.redoOption.preconditionFn(this.scope);
         chai.assert.equal(precondition, 'disabled',
             'Should be disabled when there is nothing to redo');
       });
@@ -81,7 +81,7 @@ suite('Context Menu Items', function() {
         // Create a new block, then undo it, which means there is something to redo.
         this.workspace.newBlock('text');
         this.workspace.undo(false);
-        let precondition = this.redoOption.preconditionFn(this.scope);
+        const precondition = this.redoOption.preconditionFn(this.scope);
         chai.assert.equal(precondition, 'enabled',
             'Should be enabled when there are actions to redo');
       });
@@ -142,7 +142,7 @@ suite('Context Menu Items', function() {
 
       test('Enabled when uncollapsed blocks', function() {
         this.workspace.newBlock('text');
-        let block2 = this.workspace.newBlock('text');
+        const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
         chai.assert.equal(this.collapseOption.preconditionFn(this.scope), 'enabled',
             'Should be enabled when any blocks are expanded');
@@ -155,7 +155,7 @@ suite('Context Menu Items', function() {
       });
 
       test('Hidden when no collapse option', function() {
-        let workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
+        const workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
         this.scope.workspace = workspaceWithOptions;
 
         try {
@@ -168,8 +168,8 @@ suite('Context Menu Items', function() {
 
       test('Collapses all blocks', function() {
         // All blocks should be collapsed, even if some already were.
-        let block1 = this.workspace.newBlock('text');
-        let block2 = this.workspace.newBlock('text');
+        const block1 = this.workspace.newBlock('text');
+        const block2 = this.workspace.newBlock('text');
         // Need to render block to properly collapse it.
         block1.initSvg();
         block1.render();
@@ -196,7 +196,7 @@ suite('Context Menu Items', function() {
 
       test('Enabled when collapsed blocks', function() {
         this.workspace.newBlock('text');
-        let block2 = this.workspace.newBlock('text');
+        const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
 
         chai.assert.equal(this.expandOption.preconditionFn(this.scope), 'enabled',
@@ -210,7 +210,7 @@ suite('Context Menu Items', function() {
       });
 
       test('Hidden when no collapse option', function() {
-        let workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
+        const workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
         this.scope.workspace = workspaceWithOptions;
 
         try {
@@ -223,8 +223,8 @@ suite('Context Menu Items', function() {
 
       test('Expands all blocks', function() {
         // All blocks should be expanded, even if some already were.
-        let block1 = this.workspace.newBlock('text');
-        let block2 = this.workspace.newBlock('text');
+        const block1 = this.workspace.newBlock('text');
+        const block2 = this.workspace.newBlock('text');
         // Need to render block to properly collapse it.
         block2.initSvg();
         block2.render();
@@ -260,7 +260,7 @@ suite('Context Menu Items', function() {
 
       test('Deletes all blocks after confirming', function() {
         // Mocks the confirmation dialog and calls the callback with 'true' simulating ok.
-        let confirmStub = sinon.stub(
+        const confirmStub = sinon.stub(
           Blockly.dialog, 'confirm').callsArgWith(1, true);
 
         this.workspace.newBlock('text');
@@ -273,7 +273,7 @@ suite('Context Menu Items', function() {
 
       test('Does not delete blocks if not confirmed', function() {
         // Mocks the confirmation dialog and calls the callback with 'false' simulating cancel.
-        let confirmStub = sinon.stub(
+        const confirmStub = sinon.stub(
           Blockly.dialog, 'confirm').callsArgWith(1, false);
 
         this.workspace.newBlock('text');
@@ -285,7 +285,7 @@ suite('Context Menu Items', function() {
       });
 
       test('No dialog for single block', function() {
-        let confirmStub = sinon.stub(Blockly.dialog, 'confirm');
+        const confirmStub = sinon.stub(Blockly.dialog, 'confirm');
         this.workspace.newBlock('text');
         this.deleteOption.callback(this.scope);
         this.clock.runAll();
@@ -335,7 +335,7 @@ suite('Context Menu Items', function() {
       });
 
       test('Calls duplicate', function() {
-        let spy = sinon.spy(Blockly.clipboard, 'duplicate');
+        const spy = sinon.spy(Blockly.clipboard, 'duplicate');
 
         this.duplicateOption.callback(this.scope);
 
@@ -358,7 +358,7 @@ suite('Context Menu Items', function() {
       });
 
       test('Hidden for IE', function() {
-        let oldState = Blockly.utils.userAgent.IE;
+        const oldState = Blockly.utils.userAgent.IE;
         try {
           Blockly.utils.userAgent.IE = true;
           chai.assert.equal(this.commentOption.preconditionFn(this.scope), 'hidden');

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -60,11 +60,11 @@ suite('Cursor', function() {
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {});
     this.cursor = this.workspace.getCursor();
-    let blockA = this.workspace.newBlock('input_statement');
-    let blockB = this.workspace.newBlock('input_statement');
-    let blockC = this.workspace.newBlock('input_statement');
-    let blockD = this.workspace.newBlock('input_statement');
-    let blockE = this.workspace.newBlock('field_input');
+    const blockA = this.workspace.newBlock('input_statement');
+    const blockB = this.workspace.newBlock('input_statement');
+    const blockC = this.workspace.newBlock('input_statement');
+    const blockD = this.workspace.newBlock('input_statement');
+    const blockE = this.workspace.newBlock('field_input');
 
     blockA.nextConnection.connect(blockB.previousConnection);
     blockA.inputList[0].connection.connect(blockE.outputConnection);
@@ -83,44 +83,44 @@ suite('Cursor', function() {
   });
 
   test('Next - From a Previous skip over next connection and block', function() {
-    let prevNode = ASTNode.createConnectionNode(this.blocks.A.previousConnection);
+    const prevNode = ASTNode.createConnectionNode(this.blocks.A.previousConnection);
     this.cursor.setCurNode(prevNode);
     this.cursor.next();
-    let curNode = this.cursor.getCurNode();
+    const curNode = this.cursor.getCurNode();
     chai.assert.equal(curNode.getLocation(), this.blocks.B.previousConnection);
   });
   test('Next - From last block in a stack go to next connection', function() {
-    let prevNode = ASTNode.createConnectionNode(this.blocks.B.previousConnection);
+    const prevNode = ASTNode.createConnectionNode(this.blocks.B.previousConnection);
     this.cursor.setCurNode(prevNode);
     this.cursor.next();
-    let curNode = this.cursor.getCurNode();
+    const curNode = this.cursor.getCurNode();
     chai.assert.equal(curNode.getLocation(), this.blocks.B.nextConnection);
   });
 
   test('In - From output connection', function() {
-    let fieldBlock = this.blocks.E;
-    let outputNode = ASTNode.createConnectionNode(fieldBlock.outputConnection);
+    const fieldBlock = this.blocks.E;
+    const outputNode = ASTNode.createConnectionNode(fieldBlock.outputConnection);
     this.cursor.setCurNode(outputNode);
     this.cursor.in();
-    let curNode = this.cursor.getCurNode();
+    const curNode = this.cursor.getCurNode();
     chai.assert.equal(curNode.getLocation(), fieldBlock.inputList[0].fieldRow[0]);
   });
 
   test('Prev - From previous connection skip over next connection', function() {
-    let prevConnection = this.blocks.B.previousConnection;
-    let prevConnectionNode = ASTNode.createConnectionNode(prevConnection);
+    const prevConnection = this.blocks.B.previousConnection;
+    const prevConnectionNode = ASTNode.createConnectionNode(prevConnection);
     this.cursor.setCurNode(prevConnectionNode);
     this.cursor.prev();
-    let curNode = this.cursor.getCurNode();
+    const curNode = this.cursor.getCurNode();
     chai.assert.equal(curNode.getLocation(), this.blocks.A.previousConnection);
   });
 
   test('Out - From field skip over block node', function() {
-    let field = this.blocks.E.inputList[0].fieldRow[0];
-    let fieldNode = ASTNode.createFieldNode(field);
+    const field = this.blocks.E.inputList[0].fieldRow[0];
+    const fieldNode = ASTNode.createFieldNode(field);
     this.cursor.setCurNode(fieldNode);
     this.cursor.out();
-    let curNode = this.cursor.getCurNode();
+    const curNode = this.cursor.getCurNode();
     chai.assert.equal(curNode.getLocation(), this.blocks.E.outputConnection);
   });
 });

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -36,7 +36,7 @@ suite('DropDownDiv', function() {
       sharedTestTeardown.call(this);
     });
     test('Below, in Bounds', function() {
-      let metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 0, 50, -10);
+      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 0, 50, -10);
       // "Above" in value actually means below in render.
       chai.assert.isAtLeast(metrics.initialY, 0);
       chai.assert.isAbove(metrics.finalY, 0);
@@ -44,7 +44,7 @@ suite('DropDownDiv', function() {
       chai.assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function() {
-      let metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
+      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
       // "Below" in value actually means above in render.
       chai.assert.isAtMost(metrics.initialY, 100);
       chai.assert.isBelow(metrics.finalY, 100);
@@ -52,7 +52,7 @@ suite('DropDownDiv', function() {
       chai.assert.isFalse(metrics.arrowAtTop);
     });
     test('Below, out of Bounds', function() {
-      let metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
+      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
       // "Above" in value actually means below in render.
       chai.assert.isAtLeast(metrics.initialY, 60);
       chai.assert.isAbove(metrics.finalY, 60);
@@ -60,7 +60,7 @@ suite('DropDownDiv', function() {
       chai.assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function() {
-      let metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
+      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
       // "Below" in value actually means above in render.
       chai.assert.isAtMost(metrics.initialY, 100);
       chai.assert.isBelow(metrics.finalY, 100);
@@ -69,7 +69,7 @@ suite('DropDownDiv', function() {
     });
     test('No Solution, Render At Top', function() {
       this.clientHeightStub.get(function() { return 100; });
-      let metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
+      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
       // "Above" in value actually means below in render.
       chai.assert.equal(metrics.initialY, 0);
       chai.assert.equal(metrics.finalY, 0);

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -57,7 +57,7 @@ suite('Events', function() {
 
   suite('Constructors', function() {
     test('Abstract', function() {
-      let event = new Blockly.Events.Abstract();
+      const event = new Blockly.Events.Abstract();
       assertEventEquals(event, undefined, undefined, undefined, {
         'recordUndo': true,
         'group': ''
@@ -65,7 +65,7 @@ suite('Events', function() {
     });
 
     test('UI event without block', function() {
-      let event = new Blockly.Events.UiBase(this.workspace.id);
+      const event = new Blockly.Events.UiBase(this.workspace.id);
       assertEventEquals(event, undefined, this.workspace.id, undefined, {
         'recordUndo': false,
         'group': '',
@@ -73,7 +73,7 @@ suite('Events', function() {
     });
 
     test('Click without block', function() {
-      let event = new Blockly.Events.Click(null, this.workspace.id, 'workspace');
+      const event = new Blockly.Events.Click(null, this.workspace.id, 'workspace');
       assertEventEquals(event, Blockly.Events.CLICK, this.workspace.id, null, {
         'targetType': 'workspace',
         'recordUndo': false,
@@ -82,9 +82,9 @@ suite('Events', function() {
     });
 
     test('Old UI event without block', function() {
-      let TEST_GROUP_ID = 'testGroup';
+      const TEST_GROUP_ID = 'testGroup';
       eventUtils.setGroup(TEST_GROUP_ID);
-      let event = new Blockly.Events.Ui(null, 'foo', 'bar', 'baz');
+      const event = new Blockly.Events.Ui(null, 'foo', 'bar', 'baz');
       assertEventEquals(event, Blockly.Events.UI, '', null, {
         'element': 'foo',
         'oldValue': 'bar',
@@ -105,7 +105,7 @@ suite('Events', function() {
       });
 
       test('Block base', function() {
-        let event = new Blockly.Events.BlockBase(this.block);
+        const event = new Blockly.Events.BlockBase(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, undefined,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -117,7 +117,7 @@ suite('Events', function() {
       });
 
       test('Block create', function() {
-        let event = new Blockly.Events.BlockCreate(this.block);
+        const event = new Blockly.Events.BlockCreate(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.BLOCK_CREATE,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -128,7 +128,7 @@ suite('Events', function() {
       });
 
       test('Block delete', function() {
-        let event = new Blockly.Events.BlockDelete(this.block);
+        const event = new Blockly.Events.BlockDelete(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.BLOCK_DELETE,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -139,9 +139,9 @@ suite('Events', function() {
       });
 
       test('Old UI event with block', function() {
-        let TEST_GROUP_ID = 'testGroup';
+        const TEST_GROUP_ID = 'testGroup';
         eventUtils.setGroup(TEST_GROUP_ID);
-        let event = new Blockly.Events.Ui(this.block, 'foo', 'bar', 'baz');
+        const event = new Blockly.Events.Ui(this.block, 'foo', 'bar', 'baz');
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.UI, this.workspace.id,
             this.TEST_BLOCK_ID,
@@ -155,9 +155,9 @@ suite('Events', function() {
       });
 
       test('Click with block', function() {
-        let TEST_GROUP_ID = 'testGroup';
+        const TEST_GROUP_ID = 'testGroup';
         eventUtils.setGroup(TEST_GROUP_ID);
-        let event = new Blockly.Events.Click(this.block, null, 'block');
+        const event = new Blockly.Events.Click(this.block, null, 'block');
         assertEventEquals(event, Blockly.Events.CLICK, this.workspace.id,
             this.TEST_BLOCK_ID, {
               'targetType': 'block',
@@ -168,10 +168,10 @@ suite('Events', function() {
 
       suite('Block Move', function() {
         test('by coordinate', function() {
-          let coordinate = new Blockly.utils.Coordinate(3, 4);
+          const coordinate = new Blockly.utils.Coordinate(3, 4);
           this.block.xy_ = coordinate;
 
-          let event = new Blockly.Events.BlockMove(this.block);
+          const event = new Blockly.Events.BlockMove(this.block);
           sinon.assert.calledOnce(this.genUidStub);
           assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
               this.TEST_BLOCK_ID, {
@@ -188,7 +188,7 @@ suite('Events', function() {
             this.parentBlock = createSimpleTestBlock(this.workspace);
             this.block.parentBlock_ = this.parentBlock;
             this.block.xy_ = new Blockly.utils.Coordinate(3, 4);
-            let event = new Blockly.Events.BlockMove(this.block);
+            const event = new Blockly.Events.BlockMove(this.block);
             sinon.assert.calledTwice(this.genUidStub);
             assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
                 this.TEST_BLOCK_ID, {
@@ -218,7 +218,7 @@ suite('Events', function() {
       });
 
       test('Block base', function() {
-        let event = new Blockly.Events.BlockBase(this.block);
+        const event = new Blockly.Events.BlockBase(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, undefined,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -230,7 +230,7 @@ suite('Events', function() {
       });
 
       test('Block change', function() {
-        let event = new Blockly.Events.BlockChange(
+        const event = new Blockly.Events.BlockChange(
             this.block, 'field', 'FIELD_NAME', 'old', 'new');
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.BLOCK_CHANGE,
@@ -247,7 +247,7 @@ suite('Events', function() {
       });
 
       test('Block create', function() {
-        let event = new Blockly.Events.BlockCreate(this.block);
+        const event = new Blockly.Events.BlockCreate(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.BLOCK_CREATE,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -258,7 +258,7 @@ suite('Events', function() {
       });
 
       test('Block delete', function() {
-        let event = new Blockly.Events.BlockDelete(this.block);
+        const event = new Blockly.Events.BlockDelete(this.block);
         sinon.assert.calledOnce(this.genUidStub);
         assertEventEquals(event, Blockly.Events.BLOCK_DELETE,
             this.workspace.id, this.TEST_BLOCK_ID,
@@ -273,7 +273,7 @@ suite('Events', function() {
           this.parentBlock = createSimpleTestBlock(this.workspace);
           this.block.parentBlock_ = this.parentBlock;
           this.block.xy_ = new Blockly.utils.Coordinate(3, 4);
-          let event = new Blockly.Events.BlockMove(this.block);
+          const event = new Blockly.Events.BlockMove(this.block);
           sinon.assert.calledTwice(this.genUidStub);
           assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
               this.TEST_BLOCK_ID,
@@ -302,7 +302,7 @@ suite('Events', function() {
       });
 
       test('Block change', function() {
-        let event = new Blockly.Events.BlockChange(
+        const event = new Blockly.Events.BlockChange(
             this.block, 'field', 'VAR', 'id1', 'id2');
         assertEventEquals(event, Blockly.Events.BLOCK_CHANGE, this.workspace.id,
             this.TEST_BLOCK_ID,
@@ -319,8 +319,8 @@ suite('Events', function() {
   });
 
   suite('Serialization', function() {
-    let safeStringify = (json) => {
-      let cache = [];
+    const safeStringify = (json) => {
+      const cache = [];
       return JSON.stringify(json, (key, value) => {
         if (typeof value == 'object' && value != null) {
           if (cache.includes(value)) {
@@ -333,7 +333,7 @@ suite('Events', function() {
         return value;
       });
     };
-    let variableEventTestCases = [
+    const variableEventTestCases = [
       {title: 'Var create', class: Blockly.Events.VarCreate,
         getArgs: (thisObj) => [thisObj.variable],
         getExpectedJson: () => ({type: 'var_create', varId: 'id1',
@@ -347,7 +347,7 @@ suite('Events', function() {
         getExpectedJson: () => ({type: 'var_rename', varId: 'id1',
           oldName: 'name1', newName: 'name2'})},
     ];
-    let uiEventTestCases = [
+    const uiEventTestCases = [
       {title: 'Bubble open', class: Blockly.Events.BubbleOpen,
         getArgs: (thisObj) => [thisObj.block, true, 'mutator'],
         getExpectedJson: (thisObj) => ({type: 'bubble_open', isOpen: true,
@@ -439,7 +439,7 @@ suite('Events', function() {
         getExpectedJson: () => ({type: 'viewport_change', viewTop: 0,
           viewLeft: 0, scale: 1.2, oldScale: 1})},
     ];
-    let blockEventTestCases = [
+    const blockEventTestCases = [
       {
         title: 'Block change',
         class: Blockly.Events.BlockChange,
@@ -553,13 +553,13 @@ suite('Events', function() {
         })
       },
     ];
-    let workspaceEventTestCases = [
+    const workspaceEventTestCases = [
       {title: 'Finished Loading', class: Blockly.Events.FinishedLoading,
         getArgs: (thisObj) => [thisObj.workspace],
         getExpectedJson: (thisObj) => ({type: 'finished_loading',
           workspaceId: thisObj.workspace.id})},
     ];
-    let workspaceCommentEventTestCases = [
+    const workspaceCommentEventTestCases = [
       {title: 'Comment change', class: Blockly.Events.CommentChange,
         getArgs: (thisObj) => [thisObj.comment, 'bar', 'foo'],
         getExpectedJson: (thisObj) => ({type: 'comment_change',
@@ -580,7 +580,7 @@ suite('Events', function() {
         getExpectedJson: (thisObj) => ({type: 'comment_move',
           commentId: thisObj.comment.id, oldCoordinate: '0,0'})},
     ];
-    let testSuites = [
+    const testSuites = [
       {title: 'Variable events', testCases: variableEventTestCases,
         setup: (thisObj) => {
           thisObj.variable =
@@ -615,9 +615,9 @@ suite('Events', function() {
         suite('fromJson', function() {
           testSuite.testCases.forEach((testCase) => {
             test(testCase.title, function() {
-              let event = new testCase.class(...testCase.getArgs(this));
-              let event2 = new testCase.class();
-              let json = event.toJson();
+              const event = new testCase.class(...testCase.getArgs(this));
+              const event2 = new testCase.class();
+              const json = event.toJson();
               event2.fromJson(json);
 
               chai.assert.equal(
@@ -629,9 +629,9 @@ suite('Events', function() {
           testSuite.testCases.forEach((testCase) => {
             if (testCase.getExpectedJson) {
               test(testCase.title, function() {
-                let event = new testCase.class(...testCase.getArgs(this));
-                let json = event.toJson();
-                let expectedJson = testCase.getExpectedJson(this);
+                const event = new testCase.class(...testCase.getArgs(this));
+                const json = event.toJson();
+                const expectedJson = testCase.getExpectedJson(this);
 
                 chai.assert.equal(
                     safeStringify(json), safeStringify(expectedJson));
@@ -657,7 +657,7 @@ suite('Events', function() {
      * @param {!string} id The expected id of the variable.
      */
     function checkVariableValues(container, name, type, id) {
-      let variable = container.getVariableById(id);
+      const variable = container.getVariableById(id);
       chai.assert.isDefined(variable);
       chai.assert.equal(name, variable.name);
       chai.assert.equal(type, variable.type);
@@ -666,7 +666,7 @@ suite('Events', function() {
 
     suite('Constructors', function() {
       test('Var base', function() {
-        let event = new Blockly.Events.VarBase(this.variable);
+        const event = new Blockly.Events.VarBase(this.variable);
         assertEventEquals(event, undefined, this.workspace.id, undefined, {
           'varId': 'id1',
           'recordUndo': true,
@@ -675,7 +675,7 @@ suite('Events', function() {
       });
 
       test('Var create', function() {
-        let event = new Blockly.Events.VarCreate(this.variable);
+        const event = new Blockly.Events.VarCreate(this.variable);
         assertEventEquals(event, Blockly.Events.VAR_CREATE, this.workspace.id,
             undefined,
             {
@@ -688,7 +688,7 @@ suite('Events', function() {
       });
 
       test('Var delete', function() {
-        let event = new Blockly.Events.VarDelete(this.variable);
+        const event = new Blockly.Events.VarDelete(this.variable);
         assertEventEquals(event, Blockly.Events.VAR_DELETE, this.workspace.id,
             undefined,
             {
@@ -701,7 +701,7 @@ suite('Events', function() {
       });
 
       test('Var rename', function() {
-        let event = new Blockly.Events.VarRename(this.variable, 'name2');
+        const event = new Blockly.Events.VarRename(this.variable, 'name2');
         assertEventEquals(event, Blockly.Events.VAR_RENAME, this.workspace.id,
             undefined,
             {
@@ -716,24 +716,24 @@ suite('Events', function() {
 
     suite('Run Forward', function() {
       test('Var create', function() {
-        let json = {type: "var_create", varId: "id2", varType: "type2",
+        const json = {type: "var_create", varId: "id2", varType: "type2",
           varName: "name2"};
-        let event = eventUtils.fromJson(json, this.workspace);
-        let x = this.workspace.getVariableById('id2');
+        const event = eventUtils.fromJson(json, this.workspace);
+        const x = this.workspace.getVariableById('id2');
         chai.assert.isNull(x);
         event.run(true);
         assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       });
 
       test('Var delete', function() {
-        let event = new Blockly.Events.VarDelete(this.variable);
+        const event = new Blockly.Events.VarDelete(this.variable);
         chai.assert.isNotNull(this.workspace.getVariableById('id1'));
         event.run(true);
         chai.assert.isNull(this.workspace.getVariableById('id1'));
       });
 
       test('Var rename', function() {
-        let event = new Blockly.Events.VarRename(this.variable, 'name2');
+        const event = new Blockly.Events.VarRename(this.variable, 'name2');
         event.run(true);
         chai.assert.isNull(this.workspace.getVariable('name1'));
         checkVariableValues(this.workspace, 'name2', 'type1', 'id1');
@@ -741,22 +741,22 @@ suite('Events', function() {
     });
     suite('Run Backward', function() {
       test('Var create', function() {
-        let event = new Blockly.Events.VarCreate(this.variable);
+        const event = new Blockly.Events.VarCreate(this.variable);
         chai.assert.isNotNull(this.workspace.getVariableById('id1'));
         event.run(false);
       });
 
       test('Var delete', function() {
-        let json = {type: "var_delete", varId: "id2", varType: "type2",
+        const json = {type: "var_delete", varId: "id2", varType: "type2",
           varName: "name2"};
-        let event = eventUtils.fromJson(json, this.workspace);
+        const event = eventUtils.fromJson(json, this.workspace);
         chai.assert.isNull(this.workspace.getVariableById('id2'));
         event.run(false);
         assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       });
 
       test('Var rename', function() {
-        let event = new Blockly.Events.VarRename(this.variable, 'name2');
+        const event = new Blockly.Events.VarRename(this.variable, 'name2');
         event.run(false);
         chai.assert.isNull(this.workspace.getVariable('name2'));
         checkVariableValues(this.workspace, 'name1', 'type1', 'id1');
@@ -778,14 +778,14 @@ suite('Events', function() {
     }
 
     test('No removed, order unchanged', function() {
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [
         new Blockly.Events.BlockCreate(block),
         new Blockly.Events.BlockMove(block),
         new Blockly.Events.BlockChange(block, 'field', 'VAR', 'id1', 'id2'),
         new Blockly.Events.Click(block)
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
@@ -795,25 +795,25 @@ suite('Events', function() {
     });
 
     test('Different blocks no removed', function() {
-      let block1 = this.workspace.newBlock('field_variable_test_block', '1');
-      let block2 = this.workspace.newBlock('field_variable_test_block', '2');
-      let events = [
+      const block1 = this.workspace.newBlock('field_variable_test_block', '1');
+      const block2 = this.workspace.newBlock('field_variable_test_block', '2');
+      const events = [
         new Blockly.Events.BlockCreate(block1),
         new Blockly.Events.BlockMove(block1),
         new Blockly.Events.BlockCreate(block2),
         new Blockly.Events.BlockMove(block2)
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
     });
 
     test('Forward', function() {
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [ new Blockly.Events.BlockCreate(block) ];
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [ new Blockly.Events.BlockCreate(block) ];
       addMoveEvent(events, block, 1, 1);
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 2);  // duplicate moves should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
@@ -823,12 +823,12 @@ suite('Events', function() {
     });
 
     test('Backward', function() {
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [ new Blockly.Events.BlockCreate(block) ];
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [ new Blockly.Events.BlockCreate(block) ];
       addMoveEvent(events, block, 1, 1);
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
-      let filteredEvents = eventUtils.filter(events, false);
+      const filteredEvents = eventUtils.filter(events, false);
       chai.assert.equal(filteredEvents.length, 2);  // duplicate event should have been removed.
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
@@ -838,34 +838,34 @@ suite('Events', function() {
     });
 
     test('Merge block move events', function() {
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [];
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [];
       addMoveEvent(events, block, 0, 0);
       addMoveEvent(events, block, 1, 1);
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 1);  // second move event merged into first
       chai.assert.equal(filteredEvents[0].newCoordinate.x, 1);
       chai.assert.equal(filteredEvents[0].newCoordinate.y, 1);
     });
 
     test('Merge block change events', function() {
-      let block1 = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [
+      const block1 = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [
         new Blockly.Events.BlockChange(block1, 'field', 'VAR', 'item', 'item1'),
         new Blockly.Events.BlockChange(block1, 'field', 'VAR', 'item1', 'item2')
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
       chai.assert.equal(filteredEvents[0].oldValue, 'item');
       chai.assert.equal(filteredEvents[0].newValue, 'item2');
     });
 
     test('Merge viewport change events', function() {
-      let events = [
+      const events = [
         new Blockly.Events.ViewportChange(1, 2, 3, this.workspace, 4),
         new Blockly.Events.ViewportChange(5, 6, 7, this.workspace, 8)
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
       chai.assert.equal(filteredEvents[0].viewTop, 5);
       chai.assert.equal(filteredEvents[0].viewLeft, 6);
@@ -874,10 +874,10 @@ suite('Events', function() {
     });
 
     test('Merge ui events', function() {
-      let block1 = this.workspace.newBlock('field_variable_test_block', '1');
-      let block2 = this.workspace.newBlock('field_variable_test_block', '2');
-      let block3 = this.workspace.newBlock('field_variable_test_block', '3');
-      let events = [
+      const block1 = this.workspace.newBlock('field_variable_test_block', '1');
+      const block2 = this.workspace.newBlock('field_variable_test_block', '2');
+      const block3 = this.workspace.newBlock('field_variable_test_block', '3');
+      const events = [
         new Blockly.Events.BubbleOpen(block1, true, 'comment'),
         new Blockly.Events.Click(block1),
         new Blockly.Events.BubbleOpen(block2, true, 'mutator'),
@@ -885,7 +885,7 @@ suite('Events', function() {
         new Blockly.Events.BubbleOpen(block3, true, 'warning'),
         new Blockly.Events.Click(block3)
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       // click event merged into corresponding *Open event
       chai.assert.equal(filteredEvents.length, 3);
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BubbleOpen);
@@ -899,12 +899,12 @@ suite('Events', function() {
     test('Colliding events not dropped', function() {
       // Tests that events that collide on a (event, block, workspace) tuple
       // but cannot be merged do not get dropped during filtering.
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
-      let events = [
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
+      const events = [
         new Blockly.Events.Click(block),
         new Blockly.Events.Ui(block, 'stackclick', undefined, undefined)
       ];
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       // click and stackclick should both exist
       chai.assert.equal(filteredEvents.length, 2);
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.Click);
@@ -919,12 +919,12 @@ suite('Events', function() {
       // that two move events that do get merged (disconnecting and
       // reconnecting a block in response to a mutator change) are filtered
       // from the queue.
-      let block = this.workspace.newBlock('field_variable_test_block', '1');
+      const block = this.workspace.newBlock('field_variable_test_block', '1');
       block.setParent(null);
-      let events = [];
+      const events = [];
       addMoveEventParent(events, block, null);
       addMoveEventParent(events, block, null);
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       // The two events should be merged, but because nothing has changed
       // they will be filtered out.
       chai.assert.equal(filteredEvents.length, 0);
@@ -936,16 +936,16 @@ suite('Events', function() {
       // See github.com/google/blockly/pull/1892 for a worked example showing
       // how merging non-consecutive events can fail when replacing a shadow
       // block.
-      let block1 = createSimpleTestBlock(this.workspace);
-      let block2 = createSimpleTestBlock(this.workspace);
+      const block1 = createSimpleTestBlock(this.workspace);
+      const block2 = createSimpleTestBlock(this.workspace);
 
-      let events = [];
+      const events = [];
       addMoveEvent(events, block1, 1, 1);
       addMoveEvent(events, block2, 1, 1);
       events.push(new Blockly.Events.BlockDelete(block2));
       addMoveEvent(events, block1, 2, 2);
 
-      let filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events, true);
       // Nothing should have merged.
       chai.assert.equal(filteredEvents.length, 4);
       // test that the order hasn't changed
@@ -964,23 +964,23 @@ suite('Events', function() {
     test('Block dispose triggers Delete', function() {
       let workspaceSvg;
       try {
-        let toolbox = document.getElementById('toolbox-categories');
+        const toolbox = document.getElementById('toolbox-categories');
         workspaceSvg = Blockly.inject('blocklyDiv', {toolbox: toolbox});
-        let TEST_BLOCK_ID = 'test_block_id';
-        let genUidStub = createGenUidStubWithReturns(
+        const TEST_BLOCK_ID = 'test_block_id';
+        const genUidStub = createGenUidStubWithReturns(
             [TEST_BLOCK_ID, 'test_group_id']);
 
-        let block = workspaceSvg.newBlock('');
+        const block = workspaceSvg.newBlock('');
         block.initSvg();
         block.setCommentText('test comment');
-        let expectedOldXml = Blockly.Xml.blockToDomWithXY(block);
-        let expectedId = block.id;
+        const expectedOldXml = Blockly.Xml.blockToDomWithXY(block);
+        const expectedId = block.id;
 
         // Run all queued events.
         this.clock.runAll();
 
         this.eventsFireSpy.resetHistory();
-        let changeListenerSpy = createFireChangeListenerSpy(workspaceSvg);
+        const changeListenerSpy = createFireChangeListenerSpy(workspaceSvg);
         block.dispose();
 
         // Run all queued events.
@@ -1007,13 +1007,13 @@ suite('Events', function() {
     });
 
     test('New block new var', function() {
-      let TEST_BLOCK_ID = 'test_block_id';
-      let TEST_GROUP_ID = 'test_group_id';
-      let TEST_VAR_ID = 'test_var_id';
-      let genUidStub = createGenUidStubWithReturns(
+      const TEST_BLOCK_ID = 'test_block_id';
+      const TEST_GROUP_ID = 'test_group_id';
+      const TEST_VAR_ID = 'test_var_id';
+      const genUidStub = createGenUidStubWithReturns(
           [TEST_BLOCK_ID, TEST_GROUP_ID, TEST_VAR_ID]);
-      let _ = this.workspace.newBlock('field_variable_test_block');
-      let TEST_VAR_NAME = 'item';  //  As defined in block's json.
+      const _ = this.workspace.newBlock('field_variable_test_block');
+      const TEST_VAR_NAME = 'item';  //  As defined in block's json.
 
       // Run all queued events.
       this.clock.runAll();
@@ -1043,18 +1043,18 @@ suite('Events', function() {
     });
 
     test('New block new var xml', function() {
-      let TEST_GROUP_ID = 'test_group_id';
-      let genUidStub = createGenUidStubWithReturns(TEST_GROUP_ID);
-      let dom = Blockly.Xml.textToDom(
+      const TEST_GROUP_ID = 'test_group_id';
+      const genUidStub = createGenUidStubWithReturns(TEST_GROUP_ID);
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="field_variable_test_block" id="test_block_id">' +
           '    <field name="VAR" id="test_var_id">name1</field>' +
           '  </block>' +
           '</xml>');
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      let TEST_BLOCK_ID = 'test_block_id';
-      let TEST_VAR_ID = 'test_var_id';
-      let TEST_VAR_NAME = 'name1';
+      const TEST_BLOCK_ID = 'test_block_id';
+      const TEST_VAR_ID = 'test_var_id';
+      const TEST_VAR_NAME = 'name1';
 
       // Run all queued events.
       this.clock.runAll();
@@ -1095,7 +1095,7 @@ suite('Events', function() {
   suite('Disable orphans', function() {
     setup(function() {
       // disableOrphans needs a WorkspaceSVG
-      let toolbox = document.getElementById('toolbox-categories');
+      const toolbox = document.getElementById('toolbox-categories');
       this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     });
     teardown(function() {
@@ -1103,7 +1103,7 @@ suite('Events', function() {
     });
     test('Created orphan block is disabled', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
-      let block = this.workspace.newBlock('controls_for');
+      const block = this.workspace.newBlock('controls_for');
       block.initSvg();
       block.render();
 
@@ -1117,7 +1117,7 @@ suite('Events', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
 
       // Procedure block is never an orphan
-      let functionBlock = this.workspace.newBlock('procedures_defnoreturn');
+      const functionBlock = this.workspace.newBlock('procedures_defnoreturn');
       functionBlock.initSvg();
       functionBlock.render();
 
@@ -1129,11 +1129,11 @@ suite('Events', function() {
     });
     test('Moving a block to top-level disables it', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
-      let functionBlock = this.workspace.newBlock('procedures_defnoreturn');
+      const functionBlock = this.workspace.newBlock('procedures_defnoreturn');
       functionBlock.initSvg();
       functionBlock.render();
 
-      let block = this.workspace.newBlock('controls_for');
+      const block = this.workspace.newBlock('controls_for');
       block.initSvg();
       block.render();
 
@@ -1151,11 +1151,11 @@ suite('Events', function() {
     });
     test('Giving block a parent enables it', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
-      let functionBlock = this.workspace.newBlock('procedures_defnoreturn');
+      const functionBlock = this.workspace.newBlock('procedures_defnoreturn');
       functionBlock.initSvg();
       functionBlock.render();
 
-      let block = this.workspace.newBlock('controls_for');
+      const block = this.workspace.newBlock('controls_for');
       block.initSvg();
       block.render();
 
@@ -1170,11 +1170,11 @@ suite('Events', function() {
     });
     test('disableOrphans events are not undoable', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
-      let functionBlock = this.workspace.newBlock('procedures_defnoreturn');
+      const functionBlock = this.workspace.newBlock('procedures_defnoreturn');
       functionBlock.initSvg();
       functionBlock.render();
 
-      let block = this.workspace.newBlock('controls_for');
+      const block = this.workspace.newBlock('controls_for');
       block.initSvg();
       block.render();
 
@@ -1187,7 +1187,7 @@ suite('Events', function() {
       // Fire all events
       this.clock.runAll();
 
-      let disabledEvents = this.workspace.getUndoStack().filter(function(e) {
+      const disabledEvents = this.workspace.getUndoStack().filter(function(e) {
         return e.element === 'disabled';
       });
       chai.assert.isEmpty(disabledEvents,

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -18,7 +18,7 @@ suite('Extensions', function() {
   teardown(function() {
     sharedTestTeardown.call(this);
     for (let i = 0; i < this.extensionsCleanup_.length; i++) {
-      let extension = this.extensionsCleanup_[i];
+      const extension = this.extensionsCleanup_[i];
       delete Blockly.Extensions.TEST_ONLY.allExtensions[extension];
     }
   });
@@ -29,7 +29,7 @@ suite('Extensions', function() {
 
     chai.assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_before']);
-    let beforeCallback = sinon.spy();
+    const beforeCallback = sinon.spy();
     // Extension defined before the block type is defined.
     Blockly.Extensions.register('extensions_test_before', beforeCallback);
 
@@ -41,7 +41,7 @@ suite('Extensions', function() {
 
     chai.assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_after']);
-    let afterCallback = sinon.spy();
+    const afterCallback = sinon.spy();
     // Extension defined after the block type (but before instantiation).
     Blockly.Extensions.register('extensions_test_after', afterCallback);
 
@@ -54,7 +54,7 @@ suite('Extensions', function() {
     sinon.assert.notCalled(beforeCallback);
     sinon.assert.notCalled(afterCallback);
 
-    let block = new Blockly.Block(this.workspace, 'extension_test_block');
+    const block = new Blockly.Block(this.workspace, 'extension_test_block');
 
     sinon.assert.calledOnce(beforeCallback);
     sinon.assert.calledOnce(afterCallback);
@@ -63,8 +63,8 @@ suite('Extensions', function() {
   });
 
   test('Parent tooltip when inline', function() {
-    let defaultTooltip = "defaultTooltip";
-    let parentTooltip = "parentTooltip";
+    const defaultTooltip = "defaultTooltip";
+    const parentTooltip = "parentTooltip";
     Blockly.defineBlocksWithJsonArray([
       {
         "type": "test_parent_tooltip_when_inline",
@@ -86,7 +86,7 @@ suite('Extensions', function() {
       }
     ]);
 
-    let block =
+    const block =
         new Blockly.Block(this.workspace, 'test_parent_tooltip_when_inline');
 
     // Tooltip is dynamic after extension initialization.
@@ -94,7 +94,7 @@ suite('Extensions', function() {
     chai.assert.equal(block.tooltip(), defaultTooltip);
 
     // Tooltip is normal before connected to parent.
-    let parent = new Blockly.Block(this.workspace, 'test_parent');
+    const parent = new Blockly.Block(this.workspace, 'test_parent');
     chai.assert.equal(parent.tooltip, parentTooltip);
     chai.assert.notExists(parent.inputsInline);
 
@@ -117,7 +117,7 @@ suite('Extensions', function() {
     test('Basic', function() {
       this.extensionsCleanup_.push('mixin_test');
 
-      let testMixin = {
+      const testMixin = {
         field: 'FIELD',
         method: function() {
           console.log('TEXT_MIXIN method()');
@@ -139,7 +139,7 @@ suite('Extensions', function() {
         "extensions": ["mixin_test"]
       }]);
 
-      let block = new Blockly.Block(this.workspace, 'test_block_mixin');
+      const block = new Blockly.Block(this.workspace, 'test_block_mixin');
 
       chai.assert.equal(testMixin.field, block.field);
       chai.assert.equal(testMixin.method, block.method);
@@ -174,7 +174,7 @@ suite('Extensions', function() {
               }
             });
 
-        let block = new Blockly.Block(this.workspace, 'mutator_test_block');
+        const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
         // Make sure all of the functions were installed correctly.
         chai.assert.equal(block.domToMutation(), 'domToMutationFn');
@@ -197,7 +197,7 @@ suite('Extensions', function() {
         Blockly.Events.disable();
         chai.assert.isUndefined(
             Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test']);
-        let helperFunctionSpy = sinon.spy();
+        const helperFunctionSpy = sinon.spy();
         Blockly.Extensions.registerMutator('extensions_test',
             {
               domToMutation: function() {
@@ -210,7 +210,7 @@ suite('Extensions', function() {
             helperFunctionSpy
         );
 
-        let _ = new Blockly.Block(this.workspace, 'mutator_test_block');
+        const _ = new Blockly.Block(this.workspace, 'mutator_test_block');
 
         sinon.assert.calledOnce(helperFunctionSpy);
       });
@@ -239,7 +239,7 @@ suite('Extensions', function() {
               }
             });
 
-        let block = new Blockly.Block(this.workspace, 'mutator_test_block');
+        const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
         // Make sure all of the functions were installed correctly.
         chai.assert.equal(block.domToMutation(), 'domToMutationFn');
@@ -260,16 +260,16 @@ suite('Extensions', function() {
 
       chai.assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['missing_extension']);
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'missing_extension_block');
+        const _ = new Blockly.Block(workspace, 'missing_extension_block');
       });
     });
 
     test('Mixin overwrites local value', function() {
       this.extensionsCleanup_.push('mixin_bad_inputList');
 
-      let TEST_MIXIN_BAD_INPUTLIST = {
+      const TEST_MIXIN_BAD_INPUTLIST = {
         inputList: 'bad inputList'  // Defined in constructor
       };
 
@@ -288,16 +288,16 @@ suite('Extensions', function() {
         "extensions": ["mixin_bad_inputList"]
       }]);
 
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'test_block_bad_inputList');
+        const _ = new Blockly.Block(workspace, 'test_block_bad_inputList');
       }, /inputList/);
     });
 
     test('Mixin overwrites prototype', function() {
       this.extensionsCleanup_.push('mixin_bad_colour_');
 
-      let TEST_MIXIN_BAD_COLOUR = {
+      const TEST_MIXIN_BAD_COLOUR = {
         colour_: 'bad colour_' // Defined on prototype
       };
 
@@ -316,9 +316,9 @@ suite('Extensions', function() {
         "extensions": ["mixin_bad_colour_"]
       }]);
 
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'test_block_bad_colour');
+        const _ = new Blockly.Block(workspace, 'test_block_bad_colour');
       }, /colour_/);
     });
 
@@ -346,9 +346,9 @@ suite('Extensions', function() {
             }
           });
 
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'mutator_test_block');
+        const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
       chai.assert.isNotNull(
@@ -379,9 +379,9 @@ suite('Extensions', function() {
             }
           });
 
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'mutator_test_block');
+        const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
       chai.assert.isNotNull(
@@ -406,9 +406,9 @@ suite('Extensions', function() {
         return 'extensions_test_fn';
       });
 
-      let workspace = this.workspace;
+      const workspace = this.workspace;
       chai.assert.throws(function() {
-        let _ = new Blockly.Block(workspace, 'mutator_test_block');
+        const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
       chai.assert.isNotNull(

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -20,7 +20,7 @@ suite('Angle Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
@@ -36,14 +36,14 @@ suite('Angle Fields', function() {
    * @type {!Array<!FieldCreationTestCase>}
    */
 
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'Integer', value: 1, expectedValue: 1},
     {title: 'Float', value: 1.5, expectedValue: 1.5},
     {title: 'Integer String', value: '1', expectedValue: 1},
     {title: 'Float String', value: '1.5', expectedValue: 1.5},
     {title: '> 360°', value: 362, expectedValue: 2},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'angle': testCase.value};
   };
@@ -54,12 +54,12 @@ suite('Angle Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = 0;
+  const defaultFieldValue = 0;
   /**
    * Asserts that the field property values are set to default.
    * @param {FieldTemplate} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue);
   };
   /**
@@ -67,7 +67,7 @@ suite('Angle Fields', function() {
    * @param {!Blockly.FieldAngle} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue);
   };
 
@@ -93,7 +93,7 @@ suite('Angle Fields', function() {
       });
     });
     suite('Value -> New Value', function() {
-      let initialValue = 1;
+      const initialValue = 1;
       setup(function() {
         this.field = new Blockly.FieldAngle(initialValue);
       });
@@ -117,7 +117,7 @@ suite('Angle Fields', function() {
     teardown(function() {
       sinon.restore();
     });
-    let testSuites = [
+    const testSuites = [
       {title: 'Null Validator',
         validator:
             function() {
@@ -155,13 +155,13 @@ suite('Angle Fields', function() {
   suite('Customizations', function() {
     suite('Clockwise', function() {
       test('JS Configuration', function() {
-        let field = new Blockly.FieldAngle(0, null, {
+        const field = new Blockly.FieldAngle(0, null, {
           clockwise: true
         });
         chai.assert.isTrue(field.clockwise_);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           clockwise: true
         });
@@ -172,19 +172,19 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.CLOCKWISE = true;
-        let field = new Blockly.FieldAngle();
+        const field = new Blockly.FieldAngle();
         chai.assert.isTrue(field.clockwise_);
       });
     });
     suite('Offset', function() {
       test('JS Configuration', function() {
-        let field = new Blockly.FieldAngle(0, null, {
+        const field = new Blockly.FieldAngle(0, null, {
           offset: 90
         });
         chai.assert.equal(field.offset_, 90);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           offset: 90
         });
@@ -195,7 +195,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.OFFSET = 90;
-        let field = new Blockly.FieldAngle();
+        const field = new Blockly.FieldAngle();
         chai.assert.equal(field.offset_, 90);
       });
       test('Null', function() {
@@ -203,7 +203,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.OFFSET = 90;
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           offset: null
         });
@@ -212,13 +212,13 @@ suite('Angle Fields', function() {
     });
     suite('Wrap', function() {
       test('JS Configuration', function() {
-        let field = new Blockly.FieldAngle(0, null, {
+        const field = new Blockly.FieldAngle(0, null, {
           wrap: 180
         });
         chai.assert.equal(field.wrap_, 180);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           wrap: 180
         });
@@ -229,7 +229,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.WRAP = 180;
-        let field = new Blockly.FieldAngle();
+        const field = new Blockly.FieldAngle();
         chai.assert.equal(field.wrap_, 180);
       });
       test('Null', function() {
@@ -237,7 +237,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.WRAP = 180;
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           wrap: null
         });
@@ -246,13 +246,13 @@ suite('Angle Fields', function() {
     });
     suite('Round', function() {
       test('JS Configuration', function() {
-        let field = new Blockly.FieldAngle(0, null, {
+        const field = new Blockly.FieldAngle(0, null, {
           round: 30
         });
         chai.assert.equal(field.round_, 30);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           round: 30
         });
@@ -263,7 +263,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.ROUND = 30;
-        let field = new Blockly.FieldAngle();
+        const field = new Blockly.FieldAngle();
         chai.assert.equal(field.round_, 30);
       });
       test('Null', function() {
@@ -271,7 +271,7 @@ suite('Angle Fields', function() {
         // runtime (since they are constants) but for testing purposes we
         // can do this.
         Blockly.FieldAngle.ROUND = 30;
-        let field = Blockly.FieldAngle.fromJson({
+        const field = Blockly.FieldAngle.fromJson({
           value: 0,
           round: null
         });
@@ -281,14 +281,14 @@ suite('Angle Fields', function() {
     suite('Mode', function() {
       suite('Compass', function() {
         test('JS Configuration', function() {
-          let field = new Blockly.FieldAngle(0, null, {
+          const field = new Blockly.FieldAngle(0, null, {
             mode: 'compass'
           });
           chai.assert.equal(field.offset_, 90);
           chai.assert.isTrue(field.clockwise_);
         });
         test('JS Configuration', function() {
-          let field = Blockly.FieldAngle.fromJson({
+          const field = Blockly.FieldAngle.fromJson({
             value: 0,
             mode: 'compass'
           });
@@ -298,14 +298,14 @@ suite('Angle Fields', function() {
       });
       suite('Protractor', function() {
         test('JS Configuration', function() {
-          let field = new Blockly.FieldAngle(0, null, {
+          const field = new Blockly.FieldAngle(0, null, {
             mode: 'protractor'
           });
           chai.assert.equal(field.offset_, 0);
           chai.assert.isFalse(field.clockwise_);
         });
         test('JS Configuration', function() {
-          let field = Blockly.FieldAngle.fromJson({
+          const field = Blockly.FieldAngle.fromJson({
             value: 0,
             mode: 'protractor'
           });

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -20,7 +20,7 @@ suite('Checkbox Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
@@ -34,7 +34,7 @@ suite('Checkbox Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'Boolean true', value: true, expectedValue: 'TRUE',
       expectedText: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'FALSE',
@@ -44,7 +44,7 @@ suite('Checkbox Fields', function() {
     {title: 'String FALSE', value: 'FALSE', expectedValue: 'FALSE',
       expectedText: 'false'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'checked': testCase.value};
   };
@@ -55,12 +55,12 @@ suite('Checkbox Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = 'FALSE';
+  const defaultFieldValue = 'FALSE';
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldCheckbox} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(
         field, defaultFieldValue, defaultFieldValue.toLowerCase());
   };
@@ -69,7 +69,7 @@ suite('Checkbox Fields', function() {
    * @param {!Blockly.FieldCheckbox} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(
         field, testCase.expectedValue, testCase.expectedValue.toLowerCase());
   };
@@ -102,7 +102,7 @@ suite('Checkbox Fields', function() {
     setup(function() {
       this.field = new Blockly.FieldCheckbox(true);
     });
-    let testSuites = [
+    const testSuites = [
       {title: 'Null Validator',
         validator:
             function() {
@@ -166,40 +166,40 @@ suite('Checkbox Fields', function() {
         chai.assert(field.textContent_.nodeValue, char);
       }
       test('Constant', function() {
-        let checkChar = Blockly.FieldCheckbox.CHECK_CHAR;
+        const checkChar = Blockly.FieldCheckbox.CHECK_CHAR;
         // Note: Developers shouldn't actually do this. IMO they should change
         // the file and then recompile. But this is fine for testing.
         Blockly.FieldCheckbox.CHECK_CHAR = '\u2661';
-        let field = new Blockly.FieldCheckbox(true);
+        const field = new Blockly.FieldCheckbox(true);
         assertCharacter(field, '\u2661');
         Blockly.FieldCheckbox.CHECK_CHAR = checkChar;
       });
       test('JS Constructor', function() {
-        let field = new Blockly.FieldCheckbox(true, null, {
+        const field = new Blockly.FieldCheckbox(true, null, {
           checkCharacter: '\u2661'
         });
         assertCharacter(field, '\u2661');
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldCheckbox.fromJson({
+        const field = Blockly.FieldCheckbox.fromJson({
           checkCharacter: '\u2661'
         });
         assertCharacter(field, '\u2661');
       });
       test('setCheckCharacter', function() {
-        let field = new Blockly.FieldCheckbox();
+        const field = new Blockly.FieldCheckbox();
         assertCharacter(field, Blockly.FieldCheckbox.CHECK_CHAR);
         field.setCheckCharacter('\u2661');
         // Don't call assertCharacter b/c we don't want to re-initialize.
         chai.assert.equal(field.textContent_.nodeValue, '\u2661');
       });
       test('setCheckCharacter Before Init', function() {
-        let field = new Blockly.FieldCheckbox();
+        const field = new Blockly.FieldCheckbox();
         field.setCheckCharacter('\u2661');
         assertCharacter(field, '\u2661');
       });
       test('Remove Custom Character', function() {
-        let field = new Blockly.FieldCheckbox(true, null, {
+        const field = new Blockly.FieldCheckbox(true, null, {
           'checkCharacter': '\u2661'
         });
         assertCharacter(field, '\u2661');

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -20,7 +20,7 @@ suite('Colour Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
@@ -35,7 +35,7 @@ suite('Colour Fields', function() {
    * @type {!Array<!FieldCreationTestCase>}
    */
 
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: '#AAAAAA', value: '#AAAAAA', expectedValue: '#aaaaaa',
       expectedText: '#aaa'},
     {title: '#aaaaaa', value: '#aaaaaa', expectedValue: '#aaaaaa',
@@ -57,7 +57,7 @@ suite('Colour Fields', function() {
     {title: 'red', value: 'red', expectedValue: '#ff0000',
       expectedText: '#f00'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'colour': testCase.value};
   };
@@ -68,15 +68,15 @@ suite('Colour Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = Blockly.FieldColour.COLOURS[0];
+  const defaultFieldValue = Blockly.FieldColour.COLOURS[0];
   /**
    * The expected default text for the field being tested.
    * @type {*}
    */
-  let defaultTextValue = (
+  const defaultTextValue = (
     function() {
       let expectedText = defaultFieldValue;
-      let m = defaultFieldValue.match(/^#(.)\1(.)\2(.)\3$/);
+      const m = defaultFieldValue.match(/^#(.)\1(.)\2(.)\3$/);
       if (m) {
         expectedText = '#' + m[1] + m[2] + m[3];
       }
@@ -86,7 +86,7 @@ suite('Colour Fields', function() {
    * Asserts that the field property values are set to default.
    * @param {FieldTemplate} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue, defaultTextValue);
   };
   /**
@@ -94,7 +94,7 @@ suite('Colour Fields', function() {
    * @param {!Blockly.FieldAngle} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(
         field, testCase.expectedValue, testCase.expectedText);
   };
@@ -138,7 +138,7 @@ suite('Colour Fields', function() {
     setup(function() {
       this.field = new Blockly.FieldColour('#aaaaaa');
     });
-    let testSuites = [
+    const testSuites = [
       {title: 'Null Validator',
         validator:
             function() {
@@ -194,13 +194,13 @@ suite('Colour Fields', function() {
         }
       }
       test('Constants', function() {
-        let colours = Blockly.FieldColour.COLOURS;
-        let titles = Blockly.FieldColour.TITLES;
+        const colours = Blockly.FieldColour.COLOURS;
+        const titles = Blockly.FieldColour.TITLES;
         // Note: Developers shouldn't actually do this. IMO they should
         // change the file and then recompile. But this is fine for testing.
         Blockly.FieldColour.COLOURS = ['#aaaaaa'];
         Blockly.FieldColour.TITLES = ['grey'];
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
 
         assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
 
@@ -208,14 +208,14 @@ suite('Colour Fields', function() {
         Blockly.FieldColour.TITLES = titles;
       });
       test('JS Constructor', function() {
-        let field = new Blockly.FieldColour('#aaaaaa', null, {
+        const field = new Blockly.FieldColour('#aaaaaa', null, {
           colourOptions: ['#aaaaaa'],
           colourTitles: ['grey']
         });
         assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldColour.fromJson({
+        const field = Blockly.FieldColour.fromJson({
           colour: '#aaaaaa',
           colourOptions: ['#aaaaaa'],
           colourTitles: ['grey']
@@ -223,24 +223,24 @@ suite('Colour Fields', function() {
         assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
       });
       test('setColours', function() {
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
         field.setColours(['#aaaaaa'], ['grey']);
         assertColoursAndTitles(field, ['#aaaaaa'], ['grey']);
       });
       test('Titles Undefined', function() {
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
         field.setColours(['#aaaaaa']);
         assertColoursAndTitles(field, ['#aaaaaa'], ['#aaaaaa']);
       });
       test('Some Titles Undefined', function() {
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
         field.setColours(['#aaaaaa', '#ff0000'], ['grey']);
         assertColoursAndTitles(field,
             ['#aaaaaa', '#ff0000'], ['grey', '#ff0000']);
       });
       // This is kinda derpy behavior, but I wanted to document it.
       test('Overwriting Colours While Leaving Titles', function() {
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
         field.setColours(['#aaaaaa'], ['grey']);
         field.setColours(['#ff0000']);
         assertColoursAndTitles(field, ['#ff0000'], ['grey']);
@@ -252,31 +252,31 @@ suite('Colour Fields', function() {
         chai.assert.equal(field.picker_.firstChild.children.length, columns);
       }
       test('Constants', function() {
-        let columns = Blockly.FieldColour.COLUMNS;
+        const columns = Blockly.FieldColour.COLUMNS;
         // Note: Developers shouldn't actually do this. IMO they should edit
         // the file and then recompile. But this is fine for testing.
         Blockly.FieldColour.COLUMNS = 3;
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
 
         assertColumns(field, 3);
 
         Blockly.FieldColour.COLUMNS = columns;
       });
       test('JS Constructor', function() {
-        let field = new Blockly.FieldColour('#ffffff', null, {
+        const field = new Blockly.FieldColour('#ffffff', null, {
           columns: 3
         });
         assertColumns(field, 3);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldColour.fromJson({
+        const field = Blockly.FieldColour.fromJson({
           'colour': '#ffffff',
           'columns': 3
         });
         assertColumns(field, 3);
       });
       test('setColumns', function() {
-        let field = new Blockly.FieldColour();
+        const field = new Blockly.FieldColour();
         field.setColumns(3);
         assertColumns(field, 3);
       });

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -30,7 +30,7 @@ suite('Dropdown Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueCreationTestCases = [
+  const invalidValueCreationTestCases = [
     {title: 'Undefined', args: [undefined]},
     {title: 'Array Items not Arrays', args: [undefined]},
     {title: 'Array Items with Invalid IDs',
@@ -42,7 +42,7 @@ suite('Dropdown Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueCreationTestCases = [
+  const validValueCreationTestCases = [
     {title: 'Text Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
       args: [[['a', 'A'], ['b', 'B'], ['c', 'C']]]},
     {title: 'Image Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
@@ -62,7 +62,7 @@ suite('Dropdown Fields', function() {
           [{ src:'scrC', alt:'c' }, 'C']];
       }]},
   ];
-  let addJson = function(testCase) {
+  const addJson = function(testCase) {
     testCase.json = {'options': testCase.args[0]};
   };
   invalidValueCreationTestCases.forEach(addJson);
@@ -73,7 +73,7 @@ suite('Dropdown Fields', function() {
    * @param {!Blockly.FieldDropdown} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue, testCase.expectedText);
   };
 
@@ -89,7 +89,7 @@ suite('Dropdown Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueSetValueTestCases = [
+  const invalidValueSetValueTestCases = [
     {title: 'Null', value: null},
     {title: 'Undefined', value: undefined},
     {title: 'Invalid ID', value: 'bad'},
@@ -98,7 +98,7 @@ suite('Dropdown Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldValueTestCase>}
    */
-  let validValueSetValueTestCases = [
+  const validValueSetValueTestCases = [
     {title: 'Valid ID', value: 'B', expectedValue: 'B', expectedText: 'b'},
   ];
 

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -20,7 +20,7 @@ suite('Image Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined Src', value: undefined, args: [undefined, 1, 1]},
     {title: 'Undefined Size', value: 'src', args: ['src', undefined, undefined]},
     {title: 'Zero Size', value: 'src', args: ['src', 0, 0]},
@@ -30,7 +30,7 @@ suite('Image Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueCreationTestCases = [
+  const validValueCreationTestCases = [
     {title: 'With Alt', value: 'src', expectedValue: 'src',
       args: ['src', 1, 1, 'alt'], expectedText: 'alt'},
     {title: 'Without Alt', value: 'src', expectedValue: 'src',
@@ -40,7 +40,7 @@ suite('Image Fields', function() {
    * Adds json property to test cases based on args property.
    * @param {!Array<!FieldCreationTestCase>} testCase The test case to modify.
    */
-  let addJson = function(testCase) {
+  const addJson = function(testCase) {
     testCase.json = {'src': testCase.args[0], 'width': testCase.args[1],
       'height': testCase.args[2]};
     if (testCase.args[3]) {
@@ -55,7 +55,7 @@ suite('Image Fields', function() {
    * @param {!Blockly.FieldImage} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue, testCase.expectedText);
   };
 
@@ -71,7 +71,7 @@ suite('Image Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldValueTestCase>}
    */
-  let validValueSetValueTestCases = [
+  const validValueSetValueTestCases = [
     {title: 'Good src', value: 'newSrc', expectedValue: 'newSrc',
       expectedText: 'alt'},
   ];
@@ -92,27 +92,27 @@ suite('Image Fields', function() {
         };
       });
       test('JS Constructor', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
+        const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
         chai.assert.equal(field.clickHandler_, this.onClick);
       });
       test('setOnClickHandler', function() {
-        let field = new Blockly.FieldImage('src', 10, 10);
+        const field = new Blockly.FieldImage('src', 10, 10);
         field.setOnClickHandler(this.onClick);
         chai.assert.equal(field.clickHandler_, this.onClick);
       });
       test('Remove Click Handler', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
+        const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
         field.setOnClickHandler(null);
         chai.assert.isNull(field.clickHandler_);
       });
     });
     suite('Alt', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, 'alt');
+        const field = new Blockly.FieldImage('src', 10, 10, 'alt');
         chai.assert.equal(field.altText_, 'alt');
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldImage.fromJson({
+        const field = Blockly.FieldImage.fromJson({
           src: 'src',
           width: 10,
           height: 10,
@@ -138,25 +138,25 @@ suite('Image Fields', function() {
         });
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
+        const field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
           alt: 'alt'
         });
         chai.assert.equal(field.altText_, 'alt');
       });
       test('JS Configuration - Ignore', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
+        const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: 'configAlt'
         });
         chai.assert.equal(field.altText_, 'configAlt');
       });
       test('JS Configuration - Ignore - \'\'', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, '', null, null, {
+        const field = new Blockly.FieldImage('src', 10, 10, '', null, null, {
           alt: 'configAlt'
         });
         chai.assert.equal(field.altText_, 'configAlt');
       });
       test('JS Configuration - Ignore - Config \'\'', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
+        const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: ''
         });
         chai.assert.equal(field.altText_, '');
@@ -164,11 +164,11 @@ suite('Image Fields', function() {
     });
     suite('Flip RTL', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, null, true);
+        const field = new Blockly.FieldImage('src', 10, 10, null, null, true);
         chai.assert.isTrue(field.getFlipRtl());
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldImage.fromJson({
+        const field = Blockly.FieldImage.fromJson({
           src: 'src',
           width: 10,
           height: 10,
@@ -177,19 +177,19 @@ suite('Image Fields', function() {
         chai.assert.isTrue(field.getFlipRtl());
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
+        const field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
           flipRtl: true
         });
         chai.assert.isTrue(field.getFlipRtl());
       });
       test('JS Configuration - Ignore - True', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, null, true, {
+        const field = new Blockly.FieldImage('src', 10, 10, null, null, true, {
           flipRtl: false
         });
         chai.assert.isFalse(field.getFlipRtl());
       });
       test('JS Configuration - Ignore - False', function() {
-        let field = new Blockly.FieldImage('src', 10, 10, null, null, false, {
+        const field = new Blockly.FieldImage('src', 10, 10, null, null, false, {
           flipRtl: true
         });
         chai.assert.isTrue(field.getFlipRtl());

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -20,7 +20,7 @@ suite('Label Serializable Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
   ];
@@ -28,7 +28,7 @@ suite('Label Serializable Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'String', value: 'value', expectedValue: 'value'},
     {title: 'Boolean true', value: true, expectedValue: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'false'},
@@ -36,7 +36,7 @@ suite('Label Serializable Fields', function() {
     {title: 'Number (Falsy)', value: 0, expectedValue: '0'},
     {title: 'NaN', value: NaN, expectedValue: 'NaN'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'text': testCase.value};
   };
@@ -47,12 +47,12 @@ suite('Label Serializable Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = '';
+  const defaultFieldValue = '';
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldLabelSerializable} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue);
   };
   /**
@@ -60,7 +60,7 @@ suite('Label Serializable Fields', function() {
    * @param {!Blockly.FieldLabelSerializable} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue);
   };
 
@@ -86,7 +86,7 @@ suite('Label Serializable Fields', function() {
       });
     });
     suite('Value -> New Value', function() {
-      let initialValue = 'oldValue';
+      const initialValue = 'oldValue';
       setup(function() {
         this.field = new Blockly.FieldLabelSerializable(initialValue);
       });
@@ -122,43 +122,43 @@ suite('Label Serializable Fields', function() {
           labelField.textElement_, cssClass));
     }
     test('JS Constructor', function() {
-      let field = new Blockly.FieldLabelSerializable('text', 'testClass');
+      const field = new Blockly.FieldLabelSerializable('text', 'testClass');
       assertHasClass(field, 'testClass');
     });
     test('JSON Definition', function() {
-      let field = Blockly.FieldLabelSerializable.fromJson({
+      const field = Blockly.FieldLabelSerializable.fromJson({
         class: 'testClass'
       });
       assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Simple', function() {
-      let field = new Blockly.FieldLabelSerializable('text', null, {
+      const field = new Blockly.FieldLabelSerializable('text', null, {
         class: 'testClass'
       });
       assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Ignore', function() {
-      let field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
+      const field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
         class: 'configClass'
       });
       assertDoesNotHaveClass(field, 'paramClass');
       assertHasClass(field, 'configClass');
     });
     test('JS Configuration - Ignore - \'\'', function() {
-      let field = new Blockly.FieldLabelSerializable('text', '', {
+      const field = new Blockly.FieldLabelSerializable('text', '', {
         class: 'configClass'
       });
       assertHasClass(field, 'configClass');
     });
     test('JS Configuration - Ignore - Config \'\'', function() {
-      let field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
+      const field = new Blockly.FieldLabelSerializable('text', 'paramClass', {
         class: ''
       });
       assertDoesNotHaveClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {
-        let field = new Blockly.FieldLabelSerializable();
+        const field = new Blockly.FieldLabelSerializable();
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement(
             Blockly.utils.Svg.G, {}, null);
         field.constants_ = {
@@ -171,12 +171,12 @@ suite('Label Serializable Fields', function() {
             field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
-        let field = new Blockly.FieldLabelSerializable();
+        const field = new Blockly.FieldLabelSerializable();
         field.setClass('testClass');
         assertHasClass(field, 'testClass');
       });
       test('Remove Class', function() {
-        let field = new Blockly.FieldLabelSerializable('text', null, {
+        const field = new Blockly.FieldLabelSerializable('text', null, {
           class: 'testClass'
         });
         assertHasClass(field, 'testClass');

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -20,7 +20,7 @@ suite('Label Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
   ];
@@ -28,7 +28,7 @@ suite('Label Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'String', value: 'value', expectedValue: 'value'},
     {title: 'Boolean true', value: true, expectedValue: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'false'},
@@ -36,7 +36,7 @@ suite('Label Fields', function() {
     {title: 'Number (Falsy)', value: 0, expectedValue: '0'},
     {title: 'NaN', value: NaN, expectedValue: 'NaN'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'text': testCase.value};
   };
@@ -47,12 +47,12 @@ suite('Label Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = '';
+  const defaultFieldValue = '';
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldLabel} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue);
   };
   /**
@@ -60,7 +60,7 @@ suite('Label Fields', function() {
    * @param {!Blockly.FieldLabel} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue);
   };
 
@@ -86,7 +86,7 @@ suite('Label Fields', function() {
       });
     });
     suite('Value -> New Value', function() {
-      let initialValue = 'oldValue';
+      const initialValue = 'oldValue';
       setup(function() {
         this.field = new Blockly.FieldLabel(initialValue);
       });
@@ -123,43 +123,43 @@ suite('Label Fields', function() {
     }
 
     test('JS Constructor', function() {
-      let field = new Blockly.FieldLabel('text', 'testClass');
+      const field = new Blockly.FieldLabel('text', 'testClass');
       assertHasClass(field, 'testClass');
     });
     test('JSON Definition', function() {
-      let field = Blockly.FieldLabel.fromJson({
+      const field = Blockly.FieldLabel.fromJson({
         class: 'testClass'
       });
       assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Simple', function() {
-      let field = new Blockly.FieldLabel('text', null, {
+      const field = new Blockly.FieldLabel('text', null, {
         class: 'testClass'
       });
       assertHasClass(field, 'testClass');
     });
     test('JS Configuration - Ignore', function() {
-      let field = new Blockly.FieldLabel('text', 'paramClass', {
+      const field = new Blockly.FieldLabel('text', 'paramClass', {
         class: 'configClass'
       });
       assertDoesNotHaveClass(field, 'paramClass');
       assertHasClass(field, 'configClass');
     });
     test('JS Configuration - Ignore - \'\'', function() {
-      let field = new Blockly.FieldLabel('text', '', {
+      const field = new Blockly.FieldLabel('text', '', {
         class: 'configClass'
       });
       assertHasClass(field, 'configClass');
     });
     test('JS Configuration - Ignore - Config \'\'', function() {
-      let field = new Blockly.FieldLabel('text', 'paramClass', {
+      const field = new Blockly.FieldLabel('text', 'paramClass', {
         class: ''
       });
       assertDoesNotHaveClass(field, 'paramClass');
     });
     suite('setClass', function() {
       test('setClass', function() {
-        let field = new Blockly.FieldLabel();
+        const field = new Blockly.FieldLabel();
         field.fieldGroup_ = Blockly.utils.dom.createSvgElement(
             Blockly.utils.Svg.G, {}, null);
         field.constants_ = {
@@ -172,12 +172,12 @@ suite('Label Fields', function() {
             field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
-        let field = new Blockly.FieldLabel();
+        const field = new Blockly.FieldLabel();
         field.setClass('testClass');
         assertHasClass(field, 'testClass');
       });
       test('Remove Class', function() {
-        let field = new Blockly.FieldLabel('text', null, {
+        const field = new Blockly.FieldLabel('text', null, {
           class: 'testClass'
         });
         assertHasClass(field, 'testClass');

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -20,7 +20,7 @@ suite('Multiline Input Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
   ];
@@ -28,7 +28,7 @@ suite('Multiline Input Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'Empty string', value: '', expectedValue: ''},
     {title: 'String no newline', value: 'value', expectedValue: 'value'},
     {title: 'String with newline', value: 'bark bark\n bark bark bark\n bark bar bark bark\n', expectedValue: 'bark bark\n bark bark bark\n bark bar bark bark\n'},
@@ -38,7 +38,7 @@ suite('Multiline Input Fields', function() {
     {title: 'Number (Falsy)', value: 0, expectedValue: '0'},
     {title: 'NaN', value: NaN, expectedValue: 'NaN'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'text': testCase.value};
   };
@@ -49,12 +49,12 @@ suite('Multiline Input Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = '';
+  const defaultFieldValue = '';
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldMultilineInput} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue);
   };
   /**
@@ -62,7 +62,7 @@ suite('Multiline Input Fields', function() {
    * @param {!Blockly.FieldMultilineInput} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue);
   };
 
@@ -88,7 +88,7 @@ suite('Multiline Input Fields', function() {
       });
     });
     suite('Value -> New Value', function() {
-      let initialValue = 'oldValue';
+      const initialValue = 'oldValue';
       setup(function() {
         this.field = new Blockly.FieldMultilineInput(initialValue);
       });
@@ -108,8 +108,8 @@ suite('Multiline Input Fields', function() {
     });
     const createBlockFn = (value) => {
       return (workspace) => {
-        let block = workspace.newBlock('text_multiline');
-        let textField = block.getField('TEXT');
+        const block = workspace.newBlock('text_multiline');
+        const textField = block.getField('TEXT');
         textField.setValue(value);
         return block;
       };

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -20,7 +20,7 @@ suite('Number Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
@@ -30,7 +30,7 @@ suite('Number Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'Integer', value: 1, expectedValue: 1},
     {title: 'Float', value: 1.5, expectedValue: 1.5},
     {title: 'Integer String', value: '1', expectedValue: 1},
@@ -41,7 +41,7 @@ suite('Number Fields', function() {
     {title: 'Negative Infinity String', value: '-Infinity',
       expectedValue: -Infinity},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = Array(4).fill(testCase.value);
     testCase.json = {'value': testCase.value, 'min': testCase.value,
       'max': testCase.value, 'precision': testCase.value};
@@ -53,7 +53,7 @@ suite('Number Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = 0;
+  const defaultFieldValue = 0;
   /**
    * Asserts that the field property values are as expected.
    * @param {!Blockly.FieldNumber} field The field to check.
@@ -74,7 +74,7 @@ suite('Number Fields', function() {
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldNumber} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     assertNumberField(field, -Infinity, Infinity, 0, defaultFieldValue);
   };
   /**
@@ -82,7 +82,7 @@ suite('Number Fields', function() {
    * @param {!Blockly.FieldNumber} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     assertNumberField(
         field, testCase.expectedValue, testCase.expectedValue,
         testCase.expectedValue, testCase.expectedValue);
@@ -105,7 +105,7 @@ suite('Number Fields', function() {
           validValueTestCases, invalidValueTestCases, defaultFieldValue);
     });
     suite('Value -> New Value', function() {
-      let initialValue = 1;
+      const initialValue = 1;
       setup(function() {
         this.field = new Blockly.FieldNumber(initialValue);
       });
@@ -113,7 +113,7 @@ suite('Number Fields', function() {
           validValueTestCases, invalidValueTestCases, initialValue);
     });
     suite('Constraints', function() {
-      let testCases = [
+      const testCases = [
         {title: 'Float', json: {}, value: 123.456, expectedValue: 123.456},
         {title: '0.01', json: {precision: .01}, value: 123.456,
           expectedValue: 123.46},
@@ -129,19 +129,19 @@ suite('Number Fields', function() {
       suite('Precision', function() {
         testHelpers.runTestCases(testCases, function(testCase) {
           return function() {
-            let field = Blockly.FieldNumber.fromJson(testCase.json);
+            const field = Blockly.FieldNumber.fromJson(testCase.json);
             field.setValue(testCase.value);
             testHelpers.assertFieldValue(field, testCase.expectedValue);
           };
         });
         test('Null', function() {
-          let field = Blockly.FieldNumber.fromJson({precision: null});
+          const field = Blockly.FieldNumber.fromJson({precision: null});
           chai.assert.equal(field.getPrecision(), 0);
         });
       });
-      let setValueBoundsTestFn = function(testCase) {
+      const setValueBoundsTestFn = function(testCase) {
         return function() {
-          let field = Blockly.FieldNumber.fromJson(testCase.json);
+          const field = Blockly.FieldNumber.fromJson(testCase.json);
           testCase.values.forEach(function(value, i) {
             field.setValue(value);
             testHelpers.assertFieldValue(
@@ -150,7 +150,7 @@ suite('Number Fields', function() {
         };
       };
       suite('Min', function() {
-        let testCases = [
+        const testCases = [
           {title: '-10', json: {min: -10}, values: [-20, 0, 20],
             expectedValues: [-10, 0, 20]},
           {title: '0', json: {min: 0}, values: [-20, 0, 20],
@@ -160,12 +160,12 @@ suite('Number Fields', function() {
         ];
         testHelpers.runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function() {
-          let field = Blockly.FieldNumber.fromJson({min: null});
+          const field = Blockly.FieldNumber.fromJson({min: null});
           chai.assert.equal(field.getMin(), -Infinity);
         });
       });
       suite('Max', function() {
-        let testCases = [
+        const testCases = [
           {title: '-10', json: {max: -10}, values: [-20, 0, 20],
             expectedValues: [-20, -10, -10]},
           {title: '0', json: {max: 0}, values: [-20, 0, 20],
@@ -175,7 +175,7 @@ suite('Number Fields', function() {
         ];
         testHelpers.runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function() {
-          let field = Blockly.FieldNumber.fromJson({max: null});
+          const field = Blockly.FieldNumber.fromJson({max: null});
           chai.assert.equal(field.getMax(), Infinity);
         });
       });
@@ -192,7 +192,7 @@ suite('Number Fields', function() {
     teardown(function() {
       sinon.restore();
     });
-    let testSuites = [
+    const testSuites = [
       {title: 'Null Validator',
         validator:
             function() {
@@ -230,34 +230,34 @@ suite('Number Fields', function() {
   suite('Customizations', function() {
     suite('Min', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldNumber(0, -10);
+        const field = new Blockly.FieldNumber(0, -10);
         assertNumberField(field, -10, Infinity, 0, 0);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldNumber.fromJson({
+        const field = Blockly.FieldNumber.fromJson({
           min: -10,
         });
         assertNumberField(field, -10, Infinity, 0, 0);
       });
       test('Set Constraints', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setConstraints(-10);
         assertNumberField(field, -10, Infinity, 0, 0);
       });
       test('Set Min', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setMin(-10);
         assertNumberField(field, -10, Infinity, 0, 0);
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, undefined, undefined, undefined, undefined, {
               min: -10
             });
         assertNumberField(field, -10, Infinity, 0, 0);
       });
       test('JS Configuration - Ignore', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, -1, undefined, undefined, undefined, {
               min: -10
             });
@@ -266,34 +266,34 @@ suite('Number Fields', function() {
     });
     suite('Max', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldNumber(0, undefined, 10);
+        const field = new Blockly.FieldNumber(0, undefined, 10);
         assertNumberField(field, -Infinity, 10, 0, 0);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldNumber.fromJson({
+        const field = Blockly.FieldNumber.fromJson({
           max: 10,
         });
         assertNumberField(field, -Infinity, 10, 0, 0);
       });
       test('Set Constraints', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setConstraints(undefined, 10);
         assertNumberField(field, -Infinity, 10, 0, 0);
       });
       test('Set Max', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setMax(10);
         assertNumberField(field, -Infinity, 10, 0, 0);
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, undefined, undefined, undefined, undefined, {
               max: 10
             });
         assertNumberField(field, -Infinity, 10, 0, 0);
       });
       test('JS Configuration - Ignore', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, undefined, 1, undefined, undefined, {
               max: 10
             });
@@ -302,34 +302,34 @@ suite('Number Fields', function() {
     });
     suite('Precision', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldNumber(0, undefined, undefined, 1);
+        const field = new Blockly.FieldNumber(0, undefined, undefined, 1);
         assertNumberField(field, -Infinity, Infinity, 1, 0);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldNumber.fromJson({
+        const field = Blockly.FieldNumber.fromJson({
           precision: 1,
         });
         assertNumberField(field, -Infinity, Infinity, 1, 0);
       });
       test('Set Constraints', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setConstraints(undefined, undefined, 1);
         assertNumberField(field, -Infinity, Infinity, 1, 0);
       });
       test('Set Precision', function() {
-        let field = new Blockly.FieldNumber();
+        const field = new Blockly.FieldNumber();
         field.setPrecision(1);
         assertNumberField(field, -Infinity, Infinity, 1, 0);
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, undefined, undefined, undefined, undefined, {
               precision: 1
             });
         assertNumberField(field, -Infinity, Infinity, 1, 0);
       });
       test('JS Configuration - Ignore', function() {
-        let field = new Blockly.FieldNumber(
+        const field = new Blockly.FieldNumber(
             undefined, undefined, undefined, .5, undefined, {
               precision: 1
             });

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -38,7 +38,7 @@ suite('Field Registry', function() {
       }, 'Invalid name');
     });
     test('No fromJson', function() {
-      let fromJson = CustomFieldType.fromJson;
+      const fromJson = CustomFieldType.fromJson;
       delete CustomFieldType.fromJson;
       chai.assert.throws(function() {
         Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
@@ -46,7 +46,7 @@ suite('Field Registry', function() {
       CustomFieldType.fromJson = fromJson;
     });
     test('fromJson not a function', function() {
-      let fromJson = CustomFieldType.fromJson;
+      const fromJson = CustomFieldType.fromJson;
       CustomFieldType.fromJson = true;
       chai.assert.throws(function() {
         Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
@@ -58,24 +58,24 @@ suite('Field Registry', function() {
     test('Simple', function() {
       Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
 
-      let json = {
+      const json = {
         type: 'field_custom_test',
         value: 'ok'
       };
 
-      let field = Blockly.fieldRegistry.fromJson(json);
+      const field = Blockly.fieldRegistry.fromJson(json);
 
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');
     });
     test('Not Registered', function() {
-      let json = {
+      const json = {
         type: 'field_custom_test',
         value: 'ok'
       };
 
-      let spy = sinon.stub(console, 'warn');
-      let field = Blockly.fieldRegistry.fromJson(json);
+      const spy = sinon.stub(console, 'warn');
+      const field = Blockly.fieldRegistry.fromJson(json);
       chai.assert.isNull(field);
       chai.assert.isTrue(spy.called);
       spy.restore();
@@ -83,12 +83,12 @@ suite('Field Registry', function() {
     test('Case Different', function() {
       Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
 
-      let json = {
+      const json = {
         type: 'FIELD_CUSTOM_TEST',
         value: 'ok'
       };
 
-      let field = Blockly.fieldRegistry.fromJson(json);
+      const field = Blockly.fieldRegistry.fromJson(json);
       
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -47,27 +47,27 @@ suite('Abstract Fields', function() {
     /* Test Backwards Compatibility */
     test('Editable Default(true), Serializable Default(false)', function() {
       // An old default field should be serialized.
-      let field = new FieldDefault();
-      let stub = sinon.stub(console, 'warn');
+      const field = new FieldDefault();
+      const stub = sinon.stub(console, 'warn');
       chai.assert.isTrue(field.isSerializable());
       sinon.assert.calledOnce(stub);
       stub.restore();
     });
     test('Editable False, Serializable Default(false)', function() {
       // An old non-editable field should not be serialized.
-      let field = new FieldFalseDefault();
+      const field = new FieldFalseDefault();
       chai.assert.isFalse(field.isSerializable());
     });
     /* Test Other Cases */
     test('Editable Default(true), Serializable True', function() {
       // A field that is both editable and serializable should be serialized.
-      let field = new FieldDefaultTrue();
+      const field = new FieldDefaultTrue();
       chai.assert.isTrue(field.isSerializable());
     });
     test('Editable False, Serializable True', function() {
       // A field that is not editable, but overrides serializable to true
       // should be serialized (e.g. field_label_serializable)
-      let field = new FieldFalseTrue();
+      const field = new FieldFalseTrue();
       chai.assert.isTrue(field.isSerializable());
     });
   });
@@ -596,22 +596,22 @@ suite('Abstract Fields', function() {
 
     suite('Tooltip', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.Field('value', null, {
+        const field = new Blockly.Field('value', null, {
           tooltip: 'test tooltip',
         });
         chai.assert.equal(field.tooltip_, 'test tooltip');
       });
       test('JS Constructor - Dynamic', function() {
-        let returnTooltip = function() {
+        const returnTooltip = function() {
           return 'dynamic tooltip text';
         };
-        let field = new Blockly.Field('value', null, {
+        const field = new Blockly.Field('value', null, {
           tooltip: returnTooltip
         });
         chai.assert.equal(field.tooltip_, returnTooltip);
       });
       test('JSON Definition', function() {
-        let field = CustomField.fromJson({
+        const field = CustomField.fromJson({
           tooltip: "test tooltip"
         });
         chai.assert.equal(field.tooltip_, 'test tooltip');
@@ -622,13 +622,13 @@ suite('Abstract Fields', function() {
           Blockly.Msg['TOOLTIP'] = 'test tooltip';
         });
         test('JS Constructor', function() {
-          let field = new Blockly.Field('value', null, {
+          const field = new Blockly.Field('value', null, {
             tooltip: '%{BKY_TOOLTIP}',
           });
           chai.assert.equal(field.tooltip_, 'test tooltip');
         });
         test('JSON Definition', function() {
-          let field = CustomField.fromJson({
+          const field = CustomField.fromJson({
             tooltip: "%{BKY_TOOLTIP}"
           });
           chai.assert.equal(field.tooltip_, 'test tooltip');
@@ -646,53 +646,53 @@ suite('Abstract Fields', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               field.setTooltip('tooltip');
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
             },
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
         test('After Append', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
               field.setTooltip('tooltip');
             },
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
         test('After Block Creation', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
             },
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           field.setTooltip('tooltip');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
@@ -700,7 +700,7 @@ suite('Abstract Fields', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               field.setTooltip(this.tooltipFunc);
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
@@ -710,19 +710,19 @@ suite('Abstract Fields', function() {
               return this.getFieldValue('TOOLTIP');
             }
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block.tooltipFunc);
         });
         test('Element', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               field.setTooltip(this.element);
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
@@ -731,47 +731,47 @@ suite('Abstract Fields', function() {
               tooltip: 'tooltip'
             }
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block.element);
         });
         test('Null', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               field.setTooltip(null);
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
             },
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block);
         });
         test('Undefined', function() {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
           Blockly.Blocks['tooltip'] = {
             init: function() {
-              let field = new Blockly.FieldTextInput('default');
+              const field = new Blockly.FieldTextInput('default');
               this.appendDummyInput()
                   .appendField(field, 'TOOLTIP');
             },
           };
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
           ).children[0], this.workspace);
-          let field = block.getField('TOOLTIP');
+          const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block);
         });
       });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -20,7 +20,7 @@ suite('Text Input Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
   ];
@@ -28,7 +28,7 @@ suite('Text Input Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'String', value: 'value', expectedValue: 'value'},
     {title: 'Boolean true', value: true, expectedValue: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'false'},
@@ -36,7 +36,7 @@ suite('Text Input Fields', function() {
     {title: 'Number (Falsy)', value: 0, expectedValue: '0'},
     {title: 'NaN', value: NaN, expectedValue: 'NaN'},
   ];
-  let addArgsAndJson = function(testCase) {
+  const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
     testCase.json = {'text': testCase.value};
   };
@@ -47,12 +47,12 @@ suite('Text Input Fields', function() {
    * The expected default value for the field being tested.
    * @type {*}
    */
-  let defaultFieldValue = '';
+  const defaultFieldValue = '';
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldTextInput} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, defaultFieldValue);
   };
   /**
@@ -60,7 +60,7 @@ suite('Text Input Fields', function() {
    * @param {!Blockly.FieldTextInput} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, testCase.expectedValue);
   };
 
@@ -86,7 +86,7 @@ suite('Text Input Fields', function() {
       });
     });
     suite('Value -> New Value', function() {
-      let initialValue = 'oldValue';
+      const initialValue = 'oldValue';
       setup(function() {
         this.field = new Blockly.FieldTextInput(initialValue);
       });
@@ -111,7 +111,7 @@ suite('Text Input Fields', function() {
     teardown(function() {
       sinon.restore();
     });
-    let testSuites = [
+    const testSuites = [
       {title: 'Null Validator',
         validator:
             function() {
@@ -151,7 +151,7 @@ suite('Text Input Fields', function() {
     suite('Spellcheck', function() {
       setup(function() {
         this.prepField = function(field) {
-          let workspace = {
+          const workspace = {
             getScale: function() {
               return 1;
             },
@@ -190,29 +190,29 @@ suite('Text Input Fields', function() {
         }
       });
       test('Default', function() {
-        let field = new Blockly.FieldTextInput('test');
+        const field = new Blockly.FieldTextInput('test');
         this.assertSpellcheck(field, true);
       });
       test('JS Constructor', function() {
-        let field = new Blockly.FieldTextInput('test', null, {
+        const field = new Blockly.FieldTextInput('test', null, {
           spellcheck: false
         });
         this.assertSpellcheck(field, false);
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldTextInput.fromJson({
+        const field = Blockly.FieldTextInput.fromJson({
           text: 'test',
           spellcheck: false
         });
         this.assertSpellcheck(field, false);
       });
       test('setSpellcheck Editor Hidden', function() {
-        let field = new Blockly.FieldTextInput('test');
+        const field = new Blockly.FieldTextInput('test');
         field.setSpellcheck(false);
         this.assertSpellcheck(field, false);
       });
       test('setSpellcheck Editor Shown', function() {
-        let field = new Blockly.FieldTextInput('test');
+        const field = new Blockly.FieldTextInput('test');
         this.prepField(field);
         field.showEditor_();
         field.setSpellcheck(false);

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -10,8 +10,8 @@ const {createGenUidStubWithReturns, createTestBlock, defineRowBlock, sharedTestS
 
 
 suite('Variable Fields', function() {
-  let FAKE_VARIABLE_NAME = 'default_name';
-  let FAKE_ID = 'id1';
+  const FAKE_VARIABLE_NAME = 'default_name';
+  const FAKE_ID = 'id1';
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
@@ -26,7 +26,7 @@ suite('Variable Fields', function() {
    * Configuration for field creation tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueCreationTestCases = [
+  const invalidValueCreationTestCases = [
     {title: 'Undefined', value: undefined, args: [undefined]},
     {title: 'Null', value: null, args: [null]},
     {title: 'Boolean true', value: true, args: [true]},
@@ -39,35 +39,35 @@ suite('Variable Fields', function() {
    * Configuration for field creation tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueCreationTestCases = [
+  const validValueCreationTestCases = [
     {title: 'String', value: 'id2', args: ['name2'],
       expectedValue: 'id2', expectedText: 'name2'},
   ];
-  let addJson = function(testCase) {
+  const addJson = function(testCase) {
     testCase.json = {'variable': testCase.args[0]};
   };
   invalidValueCreationTestCases.forEach(addJson);
   validValueCreationTestCases.forEach(addJson);
 
-  let initVariableField = (workspace, fieldVariable) => {
-    let mockBlock = createTestBlock();
+  const initVariableField = (workspace, fieldVariable) => {
+    const mockBlock = createTestBlock();
     mockBlock.workspace = workspace;
     fieldVariable.setSourceBlock(mockBlock);
 
     // No view to initialize, but still need to init the model.
-    let genUidStub = createGenUidStubWithReturns(FAKE_ID);
+    const genUidStub = createGenUidStubWithReturns(FAKE_ID);
     fieldVariable.initModel();
     genUidStub.restore();
 
     return fieldVariable;
   };
-  let customCreateWithJs = function(testCase) {
-    let fieldVariable = testCase ? new Blockly.FieldVariable(...testCase.args) :
+  const customCreateWithJs = function(testCase) {
+    const fieldVariable = testCase ? new Blockly.FieldVariable(...testCase.args) :
         new Blockly.FieldVariable();
     return initVariableField(this.workspace, fieldVariable);
   };
-  let customCreateWithJson = function(testCase) {
-    let fieldVariable = testCase ?
+  const customCreateWithJson = function(testCase) {
+    const fieldVariable = testCase ?
         Blockly.FieldVariable.fromJson(testCase.json) :
         Blockly.FieldVariable.fromJson({});
     return initVariableField(this.workspace, fieldVariable);
@@ -77,12 +77,12 @@ suite('Variable Fields', function() {
    * The expected default name for the field being tested.
    * @type {*}
    */
-  let defaultFieldName = FAKE_VARIABLE_NAME;
+  const defaultFieldName = FAKE_VARIABLE_NAME;
   /**
    * Asserts that the field property values are set to default.
    * @param {!Blockly.FieldVariable} field The field to check.
    */
-  let assertFieldDefault = function(field) {
+  const assertFieldDefault = function(field) {
     testHelpers.assertFieldValue(field, FAKE_ID, defaultFieldName);
   };
   /**
@@ -90,7 +90,7 @@ suite('Variable Fields', function() {
    * @param {!Blockly.FieldVariable} field The field to check.
    * @param {!FieldValueTestCase} testCase The test case.
    */
-  let validTestCaseAssertField = function(field, testCase) {
+  const validTestCaseAssertField = function(field, testCase) {
     testHelpers.assertFieldValue(field, FAKE_ID, testCase.expectedText);
   };
 
@@ -106,7 +106,7 @@ suite('Variable Fields', function() {
 
   suite('initModel', function() {
     test('No Value Before InitModel', function() {
-      let fieldVariable = new Blockly.FieldVariable('name1');
+      const fieldVariable = new Blockly.FieldVariable('name1');
       chai.assert.equal(fieldVariable.getText(), '');
       chai.assert.isNull(fieldVariable.getValue());
     });
@@ -117,7 +117,7 @@ suite('Variable Fields', function() {
    * Configuration for field tests with invalid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let invalidValueTestCases = [
+  const invalidValueTestCases = [
     ...invalidValueCreationTestCases,
     {title: 'Variable does not exist', value: 'id3', args: ['name2'],
       expectedValue: 'id2', expectedText: 'name2'},
@@ -126,7 +126,7 @@ suite('Variable Fields', function() {
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
-  let validValueTestCases = [
+  const validValueTestCases = [
     {title: 'New variable ID', value: 'id2', args: ['name2'],
       expectedValue: 'id2', expectedText: 'name2'},
   ];
@@ -154,8 +154,8 @@ suite('Variable Fields', function() {
   });
 
   suite('Dropdown options', function() {
-    let assertDropdownContents = (fieldVariable, expectedVarOptions) => {
-      let dropdownOptions = Blockly.FieldVariable.dropdownCreate.call(
+    const assertDropdownContents = (fieldVariable, expectedVarOptions) => {
+      const dropdownOptions = Blockly.FieldVariable.dropdownCreate.call(
           fieldVariable);
       // Expect variable options, a rename option, and a delete option.
       chai.assert.lengthOf(dropdownOptions, expectedVarOptions.length + 2);
@@ -172,14 +172,14 @@ suite('Variable Fields', function() {
       this.workspace.createVariable('name1', '', 'id1');
       this.workspace.createVariable('name2', '', 'id2');
       // Expect that the dropdown options will contain the variables that exist
-      let fieldVariable = initVariableField(
+      const fieldVariable = initVariableField(
           this.workspace, new Blockly.FieldVariable('name2'));
       assertDropdownContents(fieldVariable,
           [['name1', 'id1'], ['name2', 'id2']]);
     });
     test('Contains variables created after field', function() {
       // Expect that the dropdown options will contain the variables that exist
-      let fieldVariable = initVariableField(
+      const fieldVariable = initVariableField(
           this.workspace, new Blockly.FieldVariable('name1'));
       // Expect that variables created after field creation will show up too.
       this.workspace.createVariable('name2', '', 'id2');
@@ -190,7 +190,7 @@ suite('Variable Fields', function() {
       this.workspace.createVariable('name1', '', 'id1');
       this.workspace.createVariable('name2', '', 'id2');
       // Expect that the dropdown options will contain the variables that exist
-      let fieldVariable = initVariableField(
+      const fieldVariable = initVariableField(
           this.workspace, new Blockly.FieldVariable('name1'));
       // Expect that variables created after field creation will show up too.
       this.workspace.createVariable('name3', '', 'id3');
@@ -245,13 +245,13 @@ suite('Variable Fields', function() {
   suite('Customizations', function() {
     suite('Types and Default Types', function() {
       test('JS Constructor', function() {
-        let field = new Blockly.FieldVariable(
+        const field = new Blockly.FieldVariable(
             'test', undefined, ['Type1'], 'Type1');
         chai.assert.deepEqual(field.variableTypes, ['Type1']);
         chai.assert.equal(field.defaultType_, 'Type1');
       });
       test('JSON Definition', function() {
-        let field = Blockly.FieldVariable.fromJson({
+        const field = Blockly.FieldVariable.fromJson({
           variable: 'test',
           variableTypes: ['Type1'],
           defaultType: 'Type1'
@@ -260,7 +260,7 @@ suite('Variable Fields', function() {
         chai.assert.equal(field.defaultType_, 'Type1');
       });
       test('JS Configuration - Simple', function() {
-        let field = new Blockly.FieldVariable(
+        const field = new Blockly.FieldVariable(
             'test', undefined, undefined, undefined, {
               variableTypes: ['Type1'],
               defaultType: 'Type1'
@@ -269,7 +269,7 @@ suite('Variable Fields', function() {
         chai.assert.equal(field.defaultType_, 'Type1');
       });
       test('JS Configuration - Ignore', function() {
-        let field = new Blockly.FieldVariable(
+        const field = new Blockly.FieldVariable(
             'test', undefined, ['Type2'], 'Type2', {
               variableTypes: ['Type1'],
               defaultType: 'Type1'
@@ -287,16 +287,16 @@ suite('Variable Fields', function() {
     test('variableTypes is undefined', function() {
       // Expect that since variableTypes is undefined, only type empty string
       // will be returned (regardless of what types are available on the workspace).
-      let fieldVariable = new Blockly.FieldVariable('name1');
-      let resultTypes = fieldVariable.getVariableTypes_();
+      const fieldVariable = new Blockly.FieldVariable('name1');
+      const resultTypes = fieldVariable.getVariableTypes_();
       chai.assert.deepEqual(resultTypes, ['']);
     });
     test('variableTypes is explicit', function() {
       // Expect that since variableTypes is defined, it will be the return
       // value, regardless of what types are available on the workspace.
-      let fieldVariable = new Blockly.FieldVariable(
+      const fieldVariable = new Blockly.FieldVariable(
           'name1', null, ['type1', 'type2'], 'type1');
-      let resultTypes = fieldVariable.getVariableTypes_();
+      const resultTypes = fieldVariable.getVariableTypes_();
       chai.assert.deepEqual(resultTypes, ['type1', 'type2']);
       chai.assert.equal(fieldVariable.defaultType_, 'type1',
           'Default type was wrong');
@@ -305,19 +305,19 @@ suite('Variable Fields', function() {
       // Expect all variable types to be returned.
       // The field does not need to be initialized to do this--it just needs
       // a pointer to the workspace.
-      let fieldVariable = new Blockly.FieldVariable('name1');
-      let mockBlock = createTestBlock();
+      const fieldVariable = new Blockly.FieldVariable('name1');
+      const mockBlock = createTestBlock();
       mockBlock.workspace = this.workspace;
       fieldVariable.setSourceBlock(mockBlock);
       fieldVariable.variableTypes = null;
 
-      let resultTypes = fieldVariable.getVariableTypes_();
+      const resultTypes = fieldVariable.getVariableTypes_();
       // The empty string is always one of the options.
       chai.assert.deepEqual(resultTypes, ['type1', 'type2', '']);
     });
     test('variableTypes is the empty list', function() {
-      let fieldVariable = new Blockly.FieldVariable('name1');
-      let mockBlock = createTestBlock();
+      const fieldVariable = new Blockly.FieldVariable('name1');
+      const mockBlock = createTestBlock();
       mockBlock.workspace = this.workspace;
       fieldVariable.setSourceBlock(mockBlock);
       fieldVariable.variableTypes = [];
@@ -329,12 +329,12 @@ suite('Variable Fields', function() {
   });
   suite('Default types', function() {
     test('Default type exists', function() {
-      let fieldVariable = new Blockly.FieldVariable(null, null, ['b'], 'b');
+      const fieldVariable = new Blockly.FieldVariable(null, null, ['b'], 'b');
       chai.assert.equal(fieldVariable.defaultType_, 'b',
           'The variable field\'s default type should be "b"');
     });
     test('No default type', function() {
-      let fieldVariable = new Blockly.FieldVariable(null);
+      const fieldVariable = new Blockly.FieldVariable(null);
       chai.assert.equal(fieldVariable.defaultType_, '', 'The variable field\'s default type should be the empty string');
       chai.assert.isNull(fieldVariable.variableTypes,
           'The variable field\'s allowed types should be null');
@@ -454,7 +454,7 @@ suite('Variable Fields', function() {
 
     test('ID', function() {
       this.workspace.createVariable('test', '', 'id1');
-      let block = Blockly.serialization.blocks.append({
+      const block = Blockly.serialization.blocks.append({
         'type': 'variables_get',
         'fields': {
           'VAR': {
@@ -463,14 +463,14 @@ suite('Variable Fields', function() {
         }
       },
       this.workspace);
-      let variable = block.getField('VAR').getVariable();
+      const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, '');
       chai.assert.equal(variable.getId(), 'id1');
     });
 
     test('Name, untyped', function() {
-      let block = Blockly.serialization.blocks.append({
+      const block = Blockly.serialization.blocks.append({
         'type': 'variables_get',
         'fields': {
           'VAR': {
@@ -479,14 +479,14 @@ suite('Variable Fields', function() {
         }
       },
       this.workspace);
-      let variable = block.getField('VAR').getVariable();
+      const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, '');
       chai.assert.equal(variable.getId(), 'id2');
     });
 
     test('Name, typed', function() {
-      let block = Blockly.serialization.blocks.append({
+      const block = Blockly.serialization.blocks.append({
         'type': 'variables_get',
         'fields': {
           'VAR': {
@@ -496,7 +496,7 @@ suite('Variable Fields', function() {
         }
       },
       this.workspace);
-      let variable = block.getField('VAR').getVariable();
+      const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, 'string');
       chai.assert.equal(variable.getId(), 'id2');

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -63,7 +63,7 @@ suite('Flyout', function() {
       });
       suite('toolbox flyout', function() {
         setup(function() {
-          let toolbox = document.getElementById('toolbox-categories');
+          const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv',
               {
                 toolbox: toolbox
@@ -170,7 +170,7 @@ suite('Flyout', function() {
       });
       suite('toolbox flyout', function() {
         setup(function() {
-          let toolbox = document.getElementById('toolbox-categories');
+          const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv',
               {
                 toolbox: toolbox,
@@ -247,21 +247,21 @@ suite('Flyout', function() {
     });
 
     function checkFlyoutInfo(flyoutSpy) {
-      let flyoutInfo = flyoutSpy.returnValues[0];
-      let contents = flyoutInfo.contents;
-      let gaps = flyoutInfo.gaps;
+      const flyoutInfo = flyoutSpy.returnValues[0];
+      const contents = flyoutInfo.contents;
+      const gaps = flyoutInfo.gaps;
 
-      let expectedGaps = [20, 24, 24];
+      const expectedGaps = [20, 24, 24];
       chai.assert.deepEqual(gaps, expectedGaps);
 
       chai.assert.equal(contents.length, 3, 'Contents');
 
       chai.assert.equal(contents[0].type, 'block', 'Contents');
-      let block = contents[0]['block'];
+      const block = contents[0]['block'];
       chai.assert.instanceOf(block, Blockly.BlockSvg);
       chai.assert.equal(block.getFieldValue('OP'), 'NEQ');
-      let childA = block.getInputTargetBlock('A');
-      let childB = block.getInputTargetBlock('B');
+      const childA = block.getInputTargetBlock('A');
+      const childB = block.getInputTargetBlock('B');
       chai.assert.isTrue(childA.isShadow());
       chai.assert.isFalse(childB.isShadow());
       chai.assert.equal(childA.getFieldValue('NUM'), 1);
@@ -281,7 +281,7 @@ suite('Flyout', function() {
       });
 
       test('NodeList', function() {
-        let nodeList = document.getElementById('toolbox-simple').childNodes;
+        const nodeList = document.getElementById('toolbox-simple').childNodes;
         this.flyout.show(nodeList);
         checkFlyoutInfo(this.createFlyoutSpy);
       });
@@ -352,14 +352,14 @@ suite('Flyout', function() {
         this.flyout = this.workspace.getFlyout();
 
         this.assertDisabled = function(disabled) {
-          let block = this.flyout.getWorkspace().getTopBlocks(false)[0];
+          const block = this.flyout.getWorkspace().getTopBlocks(false)[0];
           chai.assert.equal(!block.isEnabled(), disabled);
         };
       });
 
       suite('XML', function() {
         test('True string', function() {
-          let xml = Blockly.Xml.textToDom(
+          const xml = Blockly.Xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="true"></block>' +
               '</xml>'
@@ -369,7 +369,7 @@ suite('Flyout', function() {
         });
 
         test('False string', function() {
-          let xml = Blockly.Xml.textToDom(
+          const xml = Blockly.Xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="false"></block>' +
               '</xml>'
@@ -380,7 +380,7 @@ suite('Flyout', function() {
 
         test('Disabled string', function() {
           // The XML system supports this for some reason!?
-          let xml = Blockly.Xml.textToDom(
+          const xml = Blockly.Xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="disabled"></block>' +
               '</xml>'
@@ -390,7 +390,7 @@ suite('Flyout', function() {
         });
 
         test('Different string', function() {
-          let xml = Blockly.Xml.textToDom(
+          const xml = Blockly.Xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="random"></block>' +
               '</xml>'
@@ -402,7 +402,7 @@ suite('Flyout', function() {
 
       suite('JSON', function() {
         test('All undefined', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -413,7 +413,7 @@ suite('Flyout', function() {
         });
 
         test('Enabled true', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -425,7 +425,7 @@ suite('Flyout', function() {
         });
 
         test('Enabled false', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -437,7 +437,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled true string', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -449,7 +449,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled false string', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -461,7 +461,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled string', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -473,7 +473,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled true value', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -485,7 +485,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled false value', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -497,7 +497,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled different string', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',
@@ -509,7 +509,7 @@ suite('Flyout', function() {
         });
 
         test('Disabled empty string', function() {
-          let json = [
+          const json = [
             {
               'kind': 'block',
               'type': 'text_print',

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -66,8 +66,8 @@ suite('Generator', function() {
         "output": null,
         "nextStatement": null
       }]);
-      let rowBlock = this.workspace.newBlock('row_block');
-      let stackBlock = this.workspace.newBlock('stack_block');
+      const rowBlock = this.workspace.newBlock('row_block');
+      const stackBlock = this.workspace.newBlock('stack_block');
 
       this.blockToCodeTest = function(
           generator, blockDisabled, opt_thisOnly,
@@ -77,12 +77,12 @@ suite('Generator', function() {
         rowBlock.nextConnection.connect(stackBlock.previousConnection);
         rowBlock.disabled = blockDisabled;
 
-        let code = generator.blockToCode(rowBlock, opt_thisOnly);
+        const code = generator.blockToCode(rowBlock, opt_thisOnly);
         chai.assert.equal(code, expectedCode, opt_message);
       };
     });
 
-    let testCase = [
+    const testCase = [
       [Blockly.Dart, 'Dart'],
       [Blockly.JavaScript, 'JavaScript'],
       [Blockly.Lua, 'Lua'],
@@ -91,8 +91,8 @@ suite('Generator', function() {
 
     suite('Trivial', function() {
       testCase.forEach(function(testCase) {
-        let generator = testCase[0];
-        let name = testCase[1];
+        const generator = testCase[0];
+        const name = testCase[1];
         test(name, function() {
           generator.init(this.workspace);
           this.blockToCodeTest(generator, false, true, 'row_block');
@@ -104,8 +104,8 @@ suite('Generator', function() {
 
     suite('Disabled block', function() {
       testCase.forEach(function(testCase) {
-        let generator = testCase[0];
-        let name = testCase[1];
+        const generator = testCase[0];
+        const name = testCase[1];
         test(name, function() {
           this.blockToCodeTest(generator, true, true, '');
           this.blockToCodeTest(generator, true, false, 'stack_block', 'thisOnly=false');
@@ -126,9 +126,9 @@ suite('Generator', function() {
           "previousStatement": null,
           "nextStatement": null
         }]);
-        let blockA = this.workspace.newBlock('test_loop_block');
-        let blockB = this.workspace.newBlock('test_loop_block');
-        let blockC = this.workspace.newBlock('test_loop_block');
+        const blockA = this.workspace.newBlock('test_loop_block');
+        const blockB = this.workspace.newBlock('test_loop_block');
+        const blockC = this.workspace.newBlock('test_loop_block');
         this.loopTest = function(
             generator, opt_thisOnly, expectedCode, opt_message) {
           generator.test_loop_block = function(block){
@@ -137,14 +137,14 @@ suite('Generator', function() {
           blockA.getInput('DO').connection.connect(blockB.previousConnection);
           blockA.nextConnection.connect(blockC.previousConnection);
 
-          let code = generator.blockToCode(blockA, opt_thisOnly);
+          const code = generator.blockToCode(blockA, opt_thisOnly);
           chai.assert.equal(code, expectedCode, opt_message);
         };
       });
 
       testCase.forEach(function(testCase) {
-        let generator = testCase[0];
-        let name = testCase[1];
+        const generator = testCase[0];
+        const name = testCase[1];
         test(name, function() {
           this.loopTest(generator, true, '{  {}}');
           this.loopTest(generator, false, '{  {}}{}', 'thisOnly=false');

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -11,20 +11,20 @@ const {assertEventFired, assertEventNotFired, defineBasicBlockWithField, dispatc
 
 suite('Gesture', function() {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub){
-    let field = block.getField('NAME');
-    let eventTarget = field.getClickTarget_();
+    const field = block.getField('NAME');
+    const eventTarget = field.getClickTarget_();
     chai.assert.exists(eventTarget,
         'Precondition: missing click target for field');
 
     eventsFireStub.resetHistory();
     dispatchPointerEvent(eventTarget, 'pointerdown');
 
-    let fieldWorkspace = field.sourceBlock_.workspace;
+    const fieldWorkspace = field.sourceBlock_.workspace;
     // Gestures triggered on flyouts are stored on targetWorkspace.
-    let gestureWorkspace = fieldWorkspace.targetWorkspace || fieldWorkspace;
-    let gesture = gestureWorkspace.currentGesture_;
+    const gestureWorkspace = fieldWorkspace.targetWorkspace || fieldWorkspace;
+    const gesture = gestureWorkspace.currentGesture_;
     chai.assert.exists(gesture, 'Gesture exists after pointerdown.');
-    let isFieldClickSpy = sinon.spy(gesture, 'isFieldClick_');
+    const isFieldClickSpy = sinon.spy(gesture, 'isFieldClick_');
 
     dispatchPointerEvent(eventTarget, 'pointerup');
     dispatchPointerEvent(eventTarget, 'click');
@@ -45,7 +45,7 @@ suite('Gesture', function() {
   setup(function() {
     sharedTestSetup.call(this);
     defineBasicBlockWithField();
-    let toolbox = document.getElementById('gesture-test-toolbox');
+    const toolbox = document.getElementById('gesture-test-toolbox');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
   });
 
@@ -54,14 +54,14 @@ suite('Gesture', function() {
   });
 
   test('Constructor', function() {
-    let e = { id: 'dummy_test_event'};
-    let gesture = new Blockly.Gesture(e, this.workspace);
+    const e = { id: 'dummy_test_event'};
+    const gesture = new Blockly.Gesture(e, this.workspace);
     chai.assert.equal(gesture.mostRecentEvent_, e);
     chai.assert.equal(gesture.creatorWorkspace_, this.workspace);
   });
 
   test('Field click - Click in workspace', function() {
-    let block = this.workspace.newBlock('test_field_block');
+    const block = this.workspace.newBlock('test_field_block');
     block.initSvg();
     block.render();
 
@@ -69,22 +69,22 @@ suite('Gesture', function() {
   });
 
   test('Field click - Auto close flyout', function() {
-    let flyout = this.workspace.flyout_;
+    const flyout = this.workspace.flyout_;
     chai.assert.exists(this.workspace.flyout_,
         'Precondition: missing flyout');
     flyout.autoClose = true;
 
-    let block = getTopFlyoutBlock(flyout);
+    const block = getTopFlyoutBlock(flyout);
     testGestureIsFieldClick(block, false, this.eventsFireStub);
   });
 
   test('Field click - Always open flyout', function() {
-    let flyout = this.workspace.flyout_;
+    const flyout = this.workspace.flyout_;
     chai.assert.exists(this.workspace.flyout_,
         'Precondition: missing flyout');
     flyout.autoClose = false;
 
-    let block = getTopFlyoutBlock(flyout);
+    const block = getTopFlyoutBlock(flyout);
     testGestureIsFieldClick(block, true, this.eventsFireStub);
   });
 });

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -39,13 +39,13 @@ suite('Inputs', function() {
   suite('Insert Field At', function() {
     suite('Index Bounds', function() {
       test('< 0', function() {
-        let field = new Blockly.FieldLabel('field');
+        const field = new Blockly.FieldLabel('field');
         chai.assert.throws(function() {
           this.dummy.insertFieldAt(-1, field);
         });
       });
       test('> length', function() {
-        let field = new Blockly.FieldLabel('field');
+        const field = new Blockly.FieldLabel('field');
         chai.assert.throws(function() {
           this.dummy.insertFieldAt(1, field);
         });
@@ -54,7 +54,7 @@ suite('Inputs', function() {
     suite('Values', function() {
       // We're mostly just testing that it doesn't throw errors.
       test('Field', function() {
-        let field = new Blockly.FieldLabel('field');
+        const field = new Blockly.FieldLabel('field');
         this.dummy.insertFieldAt(0, field);
         chai.assert.equal(this.dummy.fieldRow[0], field);
       });
@@ -91,25 +91,25 @@ suite('Inputs', function() {
     });
     suite('Prefixes and Suffixes', function() {
       test('Prefix', function() {
-        let field = new Blockly.FieldLabel('field');
-        let prefix = new Blockly.FieldLabel('prefix');
+        const field = new Blockly.FieldLabel('field');
+        const prefix = new Blockly.FieldLabel('prefix');
         field.prefixField = prefix;
 
         this.dummy.appendField(field);
         chai.assert.deepEqual(this.dummy.fieldRow, [prefix, field]);
       });
       test('Suffix', function() {
-        let field = new Blockly.FieldLabel('field');
-        let suffix = new Blockly.FieldLabel('suffix');
+        const field = new Blockly.FieldLabel('field');
+        const suffix = new Blockly.FieldLabel('suffix');
         field.suffixField = suffix;
 
         this.dummy.appendField(field);
         chai.assert.deepEqual(this.dummy.fieldRow, [field, suffix]);
       });
       test('Prefix and Suffix', function() {
-        let field = new Blockly.FieldLabel('field');
-        let prefix = new Blockly.FieldLabel('prefix');
-        let suffix = new Blockly.FieldLabel('suffix');
+        const field = new Blockly.FieldLabel('field');
+        const prefix = new Blockly.FieldLabel('prefix');
+        const suffix = new Blockly.FieldLabel('suffix');
         field.prefixField = prefix;
         field.suffixField = suffix;
 
@@ -117,7 +117,7 @@ suite('Inputs', function() {
         chai.assert.deepEqual(this.dummy.fieldRow, [prefix, field, suffix]);
       });
       test('Dropdown - Prefix', function() {
-        let field = new Blockly.FieldDropdown(
+        const field = new Blockly.FieldDropdown(
             [
               ['prefix option1', 'OPTION1'],
               ['prefix option2', 'OPTION2']
@@ -128,7 +128,7 @@ suite('Inputs', function() {
         chai.assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Suffix', function() {
-        let field = new Blockly.FieldDropdown(
+        const field = new Blockly.FieldDropdown(
             [
               ['option1 suffix', 'OPTION1'],
               ['option2 suffix', 'OPTION2']
@@ -139,7 +139,7 @@ suite('Inputs', function() {
         chai.assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Prefix and Suffix', function() {
-        let field = new Blockly.FieldDropdown(
+        const field = new Blockly.FieldDropdown(
             [
               ['prefix option1 suffix', 'OPTION1'],
               ['prefix option2 suffix', 'OPTION2']
@@ -152,9 +152,9 @@ suite('Inputs', function() {
     });
     suite('Field Initialization', function() {
       test('Rendered', function() {
-        let field = new Blockly.FieldLabel('field');
-        let setBlockSpy = sinon.spy(field, 'setSourceBlock');
-        let initSpy = sinon.spy(field, 'init');
+        const field = new Blockly.FieldLabel('field');
+        const setBlockSpy = sinon.spy(field, 'setSourceBlock');
+        const initSpy = sinon.spy(field, 'init');
 
         this.dummy.insertFieldAt(0, field);
         sinon.assert.calledOnce(setBlockSpy);
@@ -169,9 +169,9 @@ suite('Inputs', function() {
       // TODO: InsertFieldAt does not properly handle initialization in
       //  headless mode.
       test.skip('Headless', function() {
-        let field = new Blockly.FieldLabel('field');
-        let setBlockSpy = sinon.spy(field, 'setSourceBlock');
-        let initModelSpy = sinon.spy(field, 'initModel');
+        const field = new Blockly.FieldLabel('field');
+        const setBlockSpy = sinon.spy(field, 'setSourceBlock');
+        const initModelSpy = sinon.spy(field, 'initModel');
 
         this.block.rendered = false;
 
@@ -194,8 +194,8 @@ suite('Inputs', function() {
       });
     });
     test('Rendered', function() {
-      let field = new Blockly.FieldLabel('field');
-      let disposeSpy = sinon.spy(field, 'dispose');
+      const field = new Blockly.FieldLabel('field');
+      const disposeSpy = sinon.spy(field, 'dispose');
       this.dummy.appendField(field, 'FIELD');
 
       this.renderStub.resetHistory();
@@ -207,8 +207,8 @@ suite('Inputs', function() {
       sinon.assert.calledOnce(this.bumpNeighboursStub);
     });
     test('Headless', function() {
-      let field = new Blockly.FieldLabel('field');
-      let disposeSpy = sinon.spy(field, 'dispose');
+      const field = new Blockly.FieldLabel('field');
+      const disposeSpy = sinon.spy(field, 'dispose');
       this.dummy.appendField(field, 'FIELD');
 
       this.renderStub.resetHistory();

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -53,9 +53,9 @@ suite('InsertionMarkers', function() {
         return 'stack[' + block.id + '];\n';
       };
       Blockly.JavaScript['row_block'] = function(block) {
-        let value = Blockly.JavaScript
+        const value = Blockly.JavaScript
             .valueToCode(block, 'INPUT', Blockly.JavaScript.ORDER_NONE);
-        let code = 'row[' + block.id + '](' + value + ')';
+        const code = 'row[' + block.id + '](' + value + ')';
         return [code, Blockly.JavaScript.ORDER_NONE];
       };
       Blockly.JavaScript['statement_block'] = function(block) {
@@ -65,9 +65,9 @@ suite('InsertionMarkers', function() {
 
       this.assertGen = function(xml, expectedCode) {
         Blockly.Xml.domToWorkspace(xml, this.workspace);
-        let block = this.workspace.getBlockById('insertion');
+        const block = this.workspace.getBlockById('insertion');
         block.isInsertionMarker_ = true;
-        let code = Blockly.JavaScript.workspaceToCode(this.workspace);
+        const code = Blockly.JavaScript.workspaceToCode(this.workspace);
         chai.assert.equal(code, expectedCode);
       };
     });
@@ -77,7 +77,7 @@ suite('InsertionMarkers', function() {
       delete Blockly.JavaScript['statement_block'];
     });
     test('Marker Surrounds', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="insertion">' +
           '    <statement name="STATEMENT">' +
@@ -88,7 +88,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
@@ -99,7 +99,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed and Surrounds', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
@@ -118,7 +118,7 @@ suite('InsertionMarkers', function() {
           '};\n');
     });
     test('Marker Prev', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion">' +
           '    <next>' +
@@ -129,7 +129,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Next', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a">' +
           '    <next>' +
@@ -140,7 +140,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Middle of Stack', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a">' +
           '    <next>' +
@@ -157,7 +157,7 @@ suite('InsertionMarkers', function() {
           'stack[b];\n');
     });
     test('Marker On Output', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="insertion">' +
           '    <value name="INPUT">' +
@@ -168,7 +168,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker On Input', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
@@ -179,7 +179,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker Middle of Row', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
@@ -194,7 +194,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a](row[b]());\n');
     });
     test('Marker Detatched', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a"/>' +
@@ -206,7 +206,7 @@ suite('InsertionMarkers', function() {
     setup(function() {
       this.assertXml = function(xmlIn, expectXml) {
         Blockly.Xml.domToWorkspace(xmlIn, this.workspace);
-        let block = this.workspace.getBlockById('insertion');
+        const block = this.workspace.getBlockById('insertion');
         block.setInsertionMarker(true);
         let xml = Blockly.Xml.workspaceToDom(this.workspace);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
@@ -215,7 +215,7 @@ suite('InsertionMarkers', function() {
       };
     });
     test('Marker Surrounds', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="insertion" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -231,7 +231,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Enclosed', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -245,7 +245,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Enclosed and Surrounds', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -267,7 +267,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Prev', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion" x="20" y="20">' +
           '    <next>' +
@@ -283,7 +283,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Next', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
@@ -297,7 +297,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Middle of Stack', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
@@ -319,7 +319,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker On Output', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="insertion" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -335,7 +335,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker On Input', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -349,7 +349,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Middle of Row', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -371,7 +371,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Detatched', function() {
-      let xml = Blockly.Xml.textToDom(
+      const xml = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a" x="20" y="20"/>' +

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -690,7 +690,7 @@ suite('JSO Deserialization', function() {
         init: function() { },
 
         mutationToDom: function() {
-          let container = Blockly.utils.xml.createElement('mutation');
+          const container = Blockly.utils.xml.createElement('mutation');
           container.setAttribute('value', 'some value');
           return container;
         },

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -212,7 +212,7 @@ suite('JSO Serialization', function() {
       test('Xml hooks', function() {
         const block = this.workspace.newBlock('row_block');
         block.mutationToDom = function() {
-          let container = Blockly.utils.xml.createElement('mutation');
+          const container = Blockly.utils.xml.createElement('mutation');
           container.setAttribute('value', 'some value');
           return container;
         };
@@ -703,28 +703,28 @@ suite('JSO Serialization', function() {
     suite('Do full serialization', function() {
       suite('True', function() {
         test('Single block', function() {
-          let block = this.workspace.newBlock('variables_get');
-          let jso = Blockly.serialization.blocks.save(block);
+          const block = this.workspace.newBlock('variables_get');
+          const jso = Blockly.serialization.blocks.save(block);
           chai.assert.deepEqual(
               jso['fields']['VAR'], {'id': 'id2', 'name': 'item', 'type': ''});
         });
 
         test('Input block', function() {
-          let block = this.workspace.newBlock('row_block');
-          let childBlock = this.workspace.newBlock('variables_get');
+          const block = this.workspace.newBlock('row_block');
+          const childBlock = this.workspace.newBlock('variables_get');
           block.getInput('INPUT').connection.connect(
               childBlock.outputConnection);
-          let jso = Blockly.serialization.blocks.save(block);
+          const jso = Blockly.serialization.blocks.save(block);
           chai.assert.deepEqual(
               jso['inputs']['INPUT']['block']['fields']['VAR'],
               {'id': 'id4', 'name': 'item', 'type': ''});
         });
 
         test('Next block', function() {
-          let block = this.workspace.newBlock('stack_block');
-          let childBlock = this.workspace.newBlock('variables_set');
+          const block = this.workspace.newBlock('stack_block');
+          const childBlock = this.workspace.newBlock('variables_set');
           block.nextConnection.connect(childBlock.previousConnection);
-          let jso = Blockly.serialization.blocks.save(block);
+          const jso = Blockly.serialization.blocks.save(block);
           chai.assert.deepEqual(
               jso['next']['block']['fields']['VAR'],
               {'id': 'id4', 'name': 'item', 'type': ''});
@@ -733,8 +733,8 @@ suite('JSO Serialization', function() {
 
       suite('False', function() {
         test('Single block', function() {
-          let block = this.workspace.newBlock('variables_get');
-          let jso = Blockly.serialization.blocks.save(
+          const block = this.workspace.newBlock('variables_get');
+          const jso = Blockly.serialization.blocks.save(
               block, {doFullSerialization: false});
           chai.assert.deepEqual(jso['fields']['VAR'], {'id': 'id2'});
           chai.assert.isUndefined(jso['fields']['VAR']['name']);
@@ -742,11 +742,11 @@ suite('JSO Serialization', function() {
         });
 
         test('Input block', function() {
-          let block = this.workspace.newBlock('row_block');
-          let childBlock = this.workspace.newBlock('variables_get');
+          const block = this.workspace.newBlock('row_block');
+          const childBlock = this.workspace.newBlock('variables_get');
           block.getInput('INPUT').connection.connect(
               childBlock.outputConnection);
-          let jso = Blockly.serialization.blocks.save(
+          const jso = Blockly.serialization.blocks.save(
               block, {doFullSerialization: false});
           chai.assert.deepEqual(
               jso['inputs']['INPUT']['block']['fields']['VAR'], {'id': 'id4'});
@@ -757,10 +757,10 @@ suite('JSO Serialization', function() {
         });
 
         test('Next block', function() {
-          let block = this.workspace.newBlock('stack_block');
-          let childBlock = this.workspace.newBlock('variables_set');
+          const block = this.workspace.newBlock('stack_block');
+          const childBlock = this.workspace.newBlock('variables_set');
           block.nextConnection.connect(childBlock.previousConnection);
-          let jso = Blockly.serialization.blocks.save(
+          const jso = Blockly.serialization.blocks.save(
               block, {doFullSerialization: false});
           chai.assert.deepEqual(
               jso['next']['block']['fields']['VAR'], {'id': 'id4'});

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -22,7 +22,7 @@ suite('JSON Block Definitions', function() {
   suite('defineBlocksWithJsonArray', function() {
     test('Basic block', function() {
       /**  Ensure a block can be instantiated from a JSON definition.  */
-      let BLOCK_TYPE = 'test_json_minimal';
+      const BLOCK_TYPE = 'test_json_minimal';
       let block;
       assertNoWarnings(() => {
         Blockly.defineBlocksWithJsonArray([{
@@ -36,12 +36,12 @@ suite('JSON Block Definitions', function() {
     });
 
     test('Null or undefined type id', function() {
-      let BLOCK_TYPE1 = 'test_json_before_bad_blocks';
-      let BLOCK_TYPE2 = 'test_json_after_bad_blocks';
+      const BLOCK_TYPE1 = 'test_json_before_bad_blocks';
+      const BLOCK_TYPE2 = 'test_json_after_bad_blocks';
 
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
-      let blockTypeCount = Object.keys(Blockly.Blocks).length;
+      const blockTypeCount = Object.keys(Blockly.Blocks).length;
 
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
@@ -58,12 +58,12 @@ suite('JSON Block Definitions', function() {
     });
 
     test('Null item', function() {
-      let BLOCK_TYPE1 = 'test_block_before_null';
-      let BLOCK_TYPE2 = 'test_block_after_null';
+      const BLOCK_TYPE1 = 'test_block_before_null';
+      const BLOCK_TYPE2 = 'test_block_after_null';
 
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
-      let blockTypeCount = Object.keys(Blockly.Blocks).length;
+      const blockTypeCount = Object.keys(Blockly.Blocks).length;
 
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
@@ -85,12 +85,12 @@ suite('JSON Block Definitions', function() {
     });
 
     test('Undefined item', function() {
-      let BLOCK_TYPE1 = 'test_block_before_undefined';
-      let BLOCK_TYPE2 = 'test_block_after_undefined';
+      const BLOCK_TYPE1 = 'test_block_before_undefined';
+      const BLOCK_TYPE2 = 'test_block_after_undefined';
 
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
       chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
-      let blockTypeCount = Object.keys(Blockly.Blocks).length;
+      const blockTypeCount = Object.keys(Blockly.Blocks).length;
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
           {
@@ -111,33 +111,33 @@ suite('JSON Block Definitions', function() {
     });
 
     test('message0 creates input', function() {
-      let BLOCK_TYPE = 'test_json_message0';
-      let MESSAGE0 = 'message0';
+      const BLOCK_TYPE = 'test_json_message0';
+      const MESSAGE0 = 'message0';
       Blockly.defineBlocksWithJsonArray([{
         "type": BLOCK_TYPE,
         "message0": MESSAGE0
       }]);
 
-      let block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
+      const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
-      let textField = block.inputList[0].fieldRow[0];
+      const textField = block.inputList[0].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE0, textField.getText());
     });
 
     test('message1 and message0 creates two inputs', function() {
       /**  Ensure message1 creates a new input.  */
-      let BLOCK_TYPE = 'test_json_message1';
-      let MESSAGE0 = 'message0';
-      let MESSAGE1 = 'message1';
+      const BLOCK_TYPE = 'test_json_message1';
+      const MESSAGE0 = 'message0';
+      const MESSAGE1 = 'message1';
       Blockly.defineBlocksWithJsonArray([{
         "type": BLOCK_TYPE,
         "message0": MESSAGE0,
         "message1": MESSAGE1
       }]);
 
-      let block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
+      const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       chai.assert.equal(block.inputList.length, 2);
 
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
@@ -152,9 +152,9 @@ suite('JSON Block Definitions', function() {
     });
 
     test('Message string is dereferenced', function() {
-      let BLOCK_TYPE = 'test_json_message0_i18n';
-      let MESSAGE0 = '%{BKY_MESSAGE}';
-      let MESSAGE = 'message';
+      const BLOCK_TYPE = 'test_json_message0_i18n';
+      const MESSAGE0 = '%{BKY_MESSAGE}';
+      const MESSAGE = 'message';
 
       addMessageToCleanup(this.sharedCleanup, 'MESSAGE');
       Blockly.Msg['MESSAGE'] = MESSAGE;
@@ -163,21 +163,21 @@ suite('JSON Block Definitions', function() {
         "message0": MESSAGE0
       }]);
 
-      let block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
+      const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
-      let textField = block.inputList[0].fieldRow[0];
+      const textField = block.inputList[0].fieldRow[0];
       chai.assert.equal(Blockly.FieldLabel, textField.constructor);
       chai.assert.equal(MESSAGE, textField.getText());
     });
 
     test('Dropdown', function() {
-      let BLOCK_TYPE = 'test_json_dropdown';
-      let FIELD_NAME = 'FIELD_NAME';
-      let LABEL0 = 'LABEL0';
-      let VALUE0 = 'VALUE0';
-      let LABEL1 = 'LABEL1';
-      let VALUE1 = 'VALUE1';
+      const BLOCK_TYPE = 'test_json_dropdown';
+      const FIELD_NAME = 'FIELD_NAME';
+      const LABEL0 = 'LABEL0';
+      const VALUE0 = 'VALUE0';
+      const LABEL1 = 'LABEL1';
+      const VALUE1 = 'VALUE1';
       Blockly.defineBlocksWithJsonArray([{
         "type": BLOCK_TYPE,
         "message0": "%1",
@@ -193,15 +193,15 @@ suite('JSON Block Definitions', function() {
         ]
       }]);
 
-      let block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
+      const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
-      let dropdown = block.inputList[0].fieldRow[0];
+      const dropdown = block.inputList[0].fieldRow[0];
       chai.assert.equal(dropdown, block.getField(FIELD_NAME));
       chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);
       chai.assert.equal(VALUE0, dropdown.getValue());
 
-      let options = dropdown.getOptions();
+      const options = dropdown.getOptions();
       chai.assert.equal(LABEL0, options[0][0]);
       chai.assert.equal(VALUE0, options[0][1]);
       chai.assert.equal(LABEL1, options[1][0]);
@@ -210,31 +210,31 @@ suite('JSON Block Definitions', function() {
 
 
     test('Dropdown with images', function() {
-      let BLOCK_TYPE = 'test_json_dropdown';
-      let FIELD_NAME = 'FIELD_NAME';
-      let IMAGE1_ALT_TEXT = 'Localized message.';
+      const BLOCK_TYPE = 'test_json_dropdown';
+      const FIELD_NAME = 'FIELD_NAME';
+      const IMAGE1_ALT_TEXT = 'Localized message.';
       addMessageToCleanup(this.sharedCleanup, 'ALT_TEXT');
       Blockly.Msg['ALT_TEXT'] = IMAGE1_ALT_TEXT;
-      let IMAGE0 = {
+      const IMAGE0 = {
         'width': 12,
         'height': 34,
         'src': 'http://image0.src',
         'alt': 'IMAGE0 alt text'
       };
-      let VALUE0 = 'VALUE0';
-      let IMAGE1 = {
+      const VALUE0 = 'VALUE0';
+      const IMAGE1 = {
         'width': 56,
         'height': 78,
         'src': 'http://image1.src',
         'alt': '%{BKY_ALT_TEXT}'
       };
-      let VALUE1 = 'VALUE1';
-      let IMAGE2 = {
+      const VALUE1 = 'VALUE1';
+      const IMAGE2 = {
         'width': 90,
         'height': 123,
         'src': 'http://image2.src'
       };
-      let VALUE2 = 'VALUE2';
+      const VALUE2 = 'VALUE2';
 
       Blockly.defineBlocksWithJsonArray([{
         "type": BLOCK_TYPE,
@@ -252,10 +252,10 @@ suite('JSON Block Definitions', function() {
         ]
       }]);
 
-      let block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
+      const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       chai.assert.equal(block.inputList.length, 1);
       chai.assert.equal(block.inputList[0].fieldRow.length, 1);
-      let dropdown = block.inputList[0].fieldRow[0];
+      const dropdown = block.inputList[0].fieldRow[0];
       chai.assert.equal(dropdown, block.getField(FIELD_NAME));
       chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);
       chai.assert.equal(VALUE0, dropdown.getValue());
@@ -266,18 +266,18 @@ suite('JSON Block Definitions', function() {
         chai.assert.equal(actualImage.src, expectedImage.src);
       }
 
-      let options = dropdown.getOptions();
-      let image0 = options[0][0];
+      const options = dropdown.getOptions();
+      const image0 = options[0][0];
       assertImageEquals(IMAGE0, image0);
       chai.assert.equal(IMAGE0.alt, image0.alt);
       chai.assert.equal(options[0][1], VALUE0);
 
-      let image1 = options[1][0];
+      const image1 = options[1][0];
       assertImageEquals(IMAGE1, image1);
       chai.assert.equal(IMAGE1.alt, IMAGE1_ALT_TEXT);  // Via Msg reference
       chai.assert.equal(VALUE1, options[1][1]);
 
-      let image2 = options[2][0];
+      const image2 = options[2][0];
       assertImageEquals(IMAGE1, image1);
       chai.assert.notExists(image2.alt);  // No alt specified.
       chai.assert.equal(VALUE2, options[2][1]);

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -33,7 +33,7 @@ suite('Key Down', function() {
    * @param {string=} opt_name An optional name for the test case.
    */
   function runReadOnlyTest(keyEvent, opt_name) {
-    let name = opt_name ? opt_name : 'Not called when readOnly is true';
+    const name = opt_name ? opt_name : 'Not called when readOnly is true';
     test(name, function() {
       this.workspace.options.readOnly = true;
       document.dispatchEvent(keyEvent);
@@ -53,7 +53,7 @@ suite('Key Down', function() {
     });
     runReadOnlyTest(createKeyDownEvent(Blockly.utils.KeyCodes.ESC));
     test('Not called when focus is on an HTML input', function() {
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
       const input = document.createElement('textarea');
       input.dispatchEvent(event);
       sinon.assert.notCalled(this.hideChaffSpy);
@@ -72,15 +72,15 @@ suite('Key Down', function() {
       setSelectedBlock(this.workspace);
       this.deleteSpy = sinon.spy(Blockly.common.getSelected(), 'dispose');
     });
-    let testCases = [
+    const testCases = [
       ['Delete', createKeyDownEvent(Blockly.utils.KeyCodes.DELETE)],
       ['Backspace', createKeyDownEvent(Blockly.utils.KeyCodes.BACKSPACE)]
     ];
     // Delete a block.
     suite('Simple', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           document.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.hideChaffSpy);
@@ -91,8 +91,8 @@ suite('Key Down', function() {
     // Do not delete a block if workspace is in readOnly mode.
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         runReadOnlyTest(keyEvent, testCaseName);
       });
     });
@@ -105,7 +105,7 @@ suite('Key Down', function() {
       this.hideChaffSpy = sinon.spy(
         Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
-    let testCases = [
+    const testCases = [
       ['Control C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.CTRL])],
       ['Meta C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.META])],
       ['Alt C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.ALT])]
@@ -113,8 +113,8 @@ suite('Key Down', function() {
     // Copy a block.
     suite('Simple', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           document.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.copySpy);
@@ -125,16 +125,16 @@ suite('Key Down', function() {
     // Do not copy a block if a workspace is in readonly mode.
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         runReadOnlyTest(keyEvent, testCaseName);
       });
     });
     // Do not copy a block if a gesture is in progress.
     suite('Gesture in progress', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
           document.dispatchEvent(keyEvent);
@@ -146,8 +146,8 @@ suite('Key Down', function() {
     // Do not copy a block if is is not deletable.
     suite('Block is not deletable', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           sinon.stub(Blockly.common.getSelected(), 'isDeletable').returns(false);
           document.dispatchEvent(keyEvent);
@@ -159,8 +159,8 @@ suite('Key Down', function() {
     // Do not copy a block if it is not movable.
     suite('Block is not movable', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           sinon.stub(Blockly.common.getSelected(), 'isMovable').returns(false);
           document.dispatchEvent(keyEvent);
@@ -177,7 +177,7 @@ suite('Key Down', function() {
       this.hideChaffSpy = sinon.spy(
         Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
-    let testCases = [
+    const testCases = [
       ['Control Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL])],
       ['Meta Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META])],
       ['Alt Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT])]
@@ -185,8 +185,8 @@ suite('Key Down', function() {
     // Undo.
     suite('Simple', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           document.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.undoSpy);
@@ -198,8 +198,8 @@ suite('Key Down', function() {
     // Do not undo if a gesture is in progress.
     suite('Gesture in progress', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
           document.dispatchEvent(keyEvent);
@@ -211,8 +211,8 @@ suite('Key Down', function() {
     // Do not undo if the workspace is in readOnly mode.
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         runReadOnlyTest(keyEvent, testCaseName);
       });
     });
@@ -224,7 +224,7 @@ suite('Key Down', function() {
       this.hideChaffSpy = sinon.spy(
         Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
-    let testCases = [
+    const testCases = [
       ['Control Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT])],
       ['Meta Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META, Blockly.utils.KeyCodes.SHIFT])],
       ['Alt Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT, Blockly.utils.KeyCodes.SHIFT])]
@@ -232,8 +232,8 @@ suite('Key Down', function() {
     // Undo.
     suite('Simple', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           document.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.redoSpy);
@@ -245,8 +245,8 @@ suite('Key Down', function() {
     // Do not undo if a gesture is in progress.
     suite('Gesture in progress', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         test(testCaseName, function() {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
           document.dispatchEvent(keyEvent);
@@ -258,8 +258,8 @@ suite('Key Down', function() {
     // Do not undo if the workspace is in readOnly mode.
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
-        let testCaseName = testCase[0];
-        let keyEvent = testCase[1];
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
         runReadOnlyTest(keyEvent, testCaseName);
       });
     });

--- a/tests/mocha/logic_ternary_test.js
+++ b/tests/mocha/logic_ternary_test.js
@@ -129,56 +129,56 @@ suite('Logic ternary', function() {
     });
     suite('No parent', function() {
       test('Attach inputs same type', function() {
-        let string1 = this.workspace.newBlock('text');
-        let string2 = this.workspace.newBlock('text_charAt');
+        const string1 = this.workspace.newBlock('text');
+        const string2 = this.workspace.newBlock('text_charAt');
 
         connectInputsAndCheckConnections(this.block, string1, string2);
       });
       test('Attach inputs different types', function() {
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectInputsAndCheckConnections(this.block, string, number);
       });
     });
     suite('With parent already attached', function() {
       test('Attach inputs same type with matching parent', function() {
-        let parent = this.workspace.newBlock('text_trim');
+        const parent = this.workspace.newBlock('text_trim');
 
         connectParentAndCheckConnections(this.block, parent, 'TEXT');
 
-        let string1 = this.workspace.newBlock('text');
-        let string2 = this.workspace.newBlock('text_charAt');
+        const string1 = this.workspace.newBlock('text');
+        const string2 = this.workspace.newBlock('text_charAt');
 
         connectInputsAndCheckConnections(this.block, string1, string2, parent);
       });
       test('Attach inputs different types with unchecked parent', function() {
-        let parent = this.workspace.newBlock('text_print');
+        const parent = this.workspace.newBlock('text_print');
 
         connectParentAndCheckConnections(this.block, parent, 'TEXT');
 
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectInputsAndCheckConnections(this.block, string, number, parent);
       });
       test('Attach inputs different types with permissive parent', function() {
-        let parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
-        let string = this.workspace.newBlock('text');
-        let array = this.workspace.newBlock('lists_create_empty');
+        const string = this.workspace.newBlock('text');
+        const array = this.workspace.newBlock('lists_create_empty');
 
         connectInputsAndCheckConnections(this.block, string, array, parent);
       });
       test('Attach mismatch type to then causes break with parent', function() {
-        let parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectElseInputAndCheckConnections(this.block, string, null, parent);
 
@@ -188,12 +188,12 @@ suite('Logic ternary', function() {
             'Disconnected from parent');
       });
       test('Attach mismatch type to else causes break with parent', function() {
-        let parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectThenInputAndCheckConnections(this.block, string, null, parent);
 
@@ -205,44 +205,44 @@ suite('Logic ternary', function() {
     });
     suite('Attaching parent after inputs', function() {
       test('Unchecked parent with inputs different types', function() {
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectInputsAndCheckConnections(this.block, string, number);
 
-        let parent = this.workspace.newBlock('text_print');
+        const parent = this.workspace.newBlock('text_print');
         connectParentAndCheckConnections(
             this.block, parent, 'TEXT', string, number);
       });
       test('Permissive parent with inputs different types', function() {
-        let string = this.workspace.newBlock('text');
-        let array = this.workspace.newBlock('lists_create_empty');
+        const string = this.workspace.newBlock('text');
+        const array = this.workspace.newBlock('lists_create_empty');
 
         connectInputsAndCheckConnections(this.block, string, array);
 
-        let parent = this.workspace.newBlock('text_print');
+        const parent = this.workspace.newBlock('text_print');
         connectParentAndCheckConnections(
             this.block, parent, 'TEXT', string, array);
       });
       test('Mismatch with then causes break with then', function() {
-        let number = this.workspace.newBlock('math_number');
-        let string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
 
         connectInputsAndCheckConnections(this.block, number, string);
 
-        let parent = this.workspace.newBlock('text_trim');
+        const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(
             this.block, parent, 'TEXT', null, string);
         chai.assert.equal(number.getRootBlock(), number,
             'Input THEN disconnected');
       });
       test('Mismatch with else causes break with else', function() {
-        let string = this.workspace.newBlock('text');
-        let number = this.workspace.newBlock('math_number');
+        const string = this.workspace.newBlock('text');
+        const number = this.workspace.newBlock('math_number');
 
         connectInputsAndCheckConnections(this.block, string, number);
 
-        let parent = this.workspace.newBlock('text_trim');
+        const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(this.block, parent, 'TEXT', string);
         chai.assert.equal(number.getRootBlock(), number,
             'Input ELSE disconnected');

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -10,8 +10,8 @@ const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers
 
 
 suite('Metrics', function() {
-  let SCROLL_X = 10;
-  let SCROLL_Y = 10;
+  const SCROLL_X = 10;
+  const SCROLL_Y = 10;
   function assertDimensionsMatch(toCheck, left, top, width, height) {
     chai.assert.equal(top, toCheck.top, 'Top did not match.');
     chai.assert.equal(left, toCheck.left, 'Left did not match.');
@@ -62,7 +62,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(true);
       this.getFlyoutStub.returns(false);
 
-      let absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
+      const absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
 
       assertDimensionsMatch(absoluteMetrics, 107, 0);
     });
@@ -72,7 +72,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(true);
       this.getFlyoutStub.returns(false);
 
-      let absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
+      const absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
 
       assertDimensionsMatch(absoluteMetrics, 0, 107);
     });
@@ -82,7 +82,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(false);
       this.getFlyoutStub.returns(true);
 
-      let absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
+      const absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
 
       assertDimensionsMatch(absoluteMetrics, 107, 0);
     });
@@ -92,7 +92,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(false);
       this.getFlyoutStub.returns(true);
 
-      let absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
+      const absoluteMetrics = this.metricsManager.getAbsoluteMetrics();
 
       assertDimensionsMatch(absoluteMetrics, 0, 107);
     });
@@ -119,7 +119,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(true);
       this.getFlyoutStub.returns(false);
 
-      let viewMetrics = this.metricsManager.getViewMetrics();
+      const viewMetrics = this.metricsManager.getViewMetrics();
 
       assertDimensionsMatch(viewMetrics, -SCROLL_X, -SCROLL_Y, 393, 500);
     });
@@ -130,7 +130,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(true);
       this.getFlyoutStub.returns(false);
 
-      let viewMetrics = this.metricsManager.getViewMetrics();
+      const viewMetrics = this.metricsManager.getViewMetrics();
 
       assertDimensionsMatch(viewMetrics, -SCROLL_X, -SCROLL_Y, 500, 393);
     });
@@ -141,7 +141,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(false);
       this.getFlyoutStub.returns(true);
 
-      let viewMetrics = this.metricsManager.getViewMetrics();
+      const viewMetrics = this.metricsManager.getViewMetrics();
 
       assertDimensionsMatch(viewMetrics, -SCROLL_X, -SCROLL_Y, 393, 500);
     });
@@ -152,13 +152,13 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(false);
       this.getFlyoutStub.returns(true);
 
-      let viewMetrics = this.metricsManager.getViewMetrics();
+      const viewMetrics = this.metricsManager.getViewMetrics();
 
       assertDimensionsMatch(viewMetrics, -SCROLL_X, -SCROLL_Y, 500, 393);
     });
     test('Get view metrics in workspace coordinates ', function() {
-      let scale = 2;
-      let getWorkspaceCoordinates = true;
+      const scale = 2;
+      const getWorkspaceCoordinates = true;
 
       this.ws.scale = scale;
       this.toolboxMetricsStub.returns({});
@@ -167,7 +167,7 @@ suite('Metrics', function() {
       this.getToolboxStub.returns(false);
       this.getFlyoutStub.returns(true);
 
-      let viewMetrics =
+      const viewMetrics =
           this.metricsManager.getViewMetrics(getWorkspaceCoordinates);
 
       assertDimensionsMatch(
@@ -178,158 +178,158 @@ suite('Metrics', function() {
 
   suite('getContentMetrics', function() {
     test('Empty in ws coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Empty zoom-in in ws coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Empty zoom-out in ws coordinates', function() {
-      let ws = makeMockWs(.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Non empty at origin ws coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(1, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 100, 100);
     });
     test('Non empty at origin zoom-in ws coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(2, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 100, 100);
     });
     test('Non empty at origin zoom-out ws coordinates', function() {
-      let ws = makeMockWs(.5, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(.5, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 0, 0, 100, 100);
     });
     test('Non empty positive origin ws coordinates', function() {
-      let ws = makeMockWs(1, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(1, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, 10, 10, 100, 100);
     });
     test('Non empty positive origin zoom-in ws coordinates', function() {
-      let ws = makeMockWs(2, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(2, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       // 1 ws unit = 2 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 10, 10, 100, 100);
     });
     test('Non empty positive origin zoom-out ws coordinates', function() {
-      let ws = makeMockWs(.5, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(.5, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       // 1 ws unit = 0.5 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 10, 10, 100, 100);
     });
     test('Non empty negative origin ws coordinates', function() {
-      let ws = makeMockWs(1, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(1, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       // Pixel and ws units are the same at default zoom.
       assertDimensionsMatch(contentMetrics, -10, -10, 100, 100);
     });
     test('Non empty negative origin zoom-in ws coordinates', function() {
-      let ws = makeMockWs(2, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(2, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, -10, -10, 100, 100);
     });
     test('Non empty negative origin zoom-out ws coordinates', function() {
-      let ws = makeMockWs(.5, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(true);
+      const ws = makeMockWs(.5, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(true);
       assertDimensionsMatch(contentMetrics, -10, -10, 100, 100);
     });
     test('Empty in pixel coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Empty zoom-in in pixel coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Empty zoom-out in pixel coordinates', function() {
-      let ws = makeMockWs(.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       assertDimensionsMatch(contentMetrics, 0, 0, 0, 0);
     });
     test('Non empty at origin pixel coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(1, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // Pixel and ws units are the same at default zoom.
       assertDimensionsMatch(contentMetrics, 0, 0, 100, 100);
     });
     test('Non empty at origin zoom-in pixel coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(2, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 2 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 0, 0, 200, 200);
     });
     test('Non empty at origin zoom-out pixel coordinates', function() {
-      let ws = makeMockWs(.5, 0, 0, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(.5, 0, 0, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 0.5 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 0, 0, 50, 50);
     });
     test('Non empty positive origin pixel coordinates', function() {
-      let ws = makeMockWs(1, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(1, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // Pixel and ws units are the same at default zoom.
       assertDimensionsMatch(contentMetrics, 10, 10, 100, 100);
     });
     test('Non empty positive origin zoom-in pixel coordinates', function() {
-      let ws = makeMockWs(2, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(2, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 2 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 20, 20, 200, 200);
     });
     test('Non empty positive origin zoom-out pixel coordinates', function() {
-      let ws = makeMockWs(.5, 10, 10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(.5, 10, 10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 0.5 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, 5, 5, 50, 50);
     });
     test('Non empty negative origin pixel coordinates', function() {
-      let ws = makeMockWs(1, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(1, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // Pixel and ws units are the same at default zoom.
       assertDimensionsMatch(contentMetrics, -10, -10, 100, 100);
     });
     test('Non empty negative origin zoom-in pixel coordinates', function() {
-      let ws = makeMockWs(2, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(2, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 2 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, -20, -20, 200, 200);
     });
     test('Non empty negative origin zoom-out pixel coordinates', function() {
-      let ws = makeMockWs(.5, -10, -10, 100, 100);
-      let metricsManager = new Blockly.MetricsManager(ws);
-      let contentMetrics = metricsManager.getContentMetrics(false);
+      const ws = makeMockWs(.5, -10, -10, 100, 100);
+      const metricsManager = new Blockly.MetricsManager(ws);
+      const contentMetrics = metricsManager.getContentMetrics(false);
       // 1 ws unit = 0.5 pixels at this zoom level.
       assertDimensionsMatch(contentMetrics, -5, -5, 50, 50);
     });
@@ -337,168 +337,168 @@ suite('Metrics', function() {
 
   suite('getScrollMetrics', function() {
     test('Empty workspace in ws coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
     });
     test('Empty workspace zoom-in in ws coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -100, -100, 200, 200);
     });
     test('Empty workspace zoom-out in ws coordinates', function() {
-      let ws = makeMockWs(0.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(0.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -400, -400, 800, 800);
     });
     test('Non empty workspace in ws coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
     });
     test('Non empty workspace zoom-in in ws coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -25, -25, 175, 175);
     });
     test('Non empty workspace zoom-out in ws coordinates', function() {
-      let ws = makeMockWs(0.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(0.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -100, -100, 700, 700);
     });
     test('Empty workspace in pixel coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
     });
     test('Empty workspace zoom-in in pixel coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
     });
     test('Empty workspace zoom-out in pixel coordinates', function() {
-      let ws = makeMockWs(0.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(0.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
+      const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
     });
     test('Non empty workspace in pixel coordinates', function() {
-      let ws = makeMockWs(1, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(1, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
     });
     test('Non empty workspace zoom-in in pixel coordinates', function() {
-      let ws = makeMockWs(2, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(2, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
     });
     test('Non empty workspace zoom-out in pixel coordinates', function() {
-      let ws = makeMockWs(0.5, 0, 0, 0, 0);
-      let metricsManager = new Blockly.MetricsManager(ws);
+      const ws = makeMockWs(0.5, 0, 0, 0, 0);
+      const metricsManager = new Blockly.MetricsManager(ws);
       // The location of the viewport.
-      let mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
+      const mockViewMetrics = {top: 0, left: 0, width: 200, height: 200};
       // The bounding box around the blocks on the screen.
-      let mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
+      const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      let contentMetrics =
+      const contentMetrics =
           metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -28,9 +28,9 @@ suite('Mutator', function() {
     });
 
     test('No change', function() {
-      let block = createRenderedBlock(this.workspace, 'xml_block');
+      const block = createRenderedBlock(this.workspace, 'xml_block');
       block.mutator.setVisible(true);
-      let mutatorWorkspace = block.mutator.getWorkspace();
+      const mutatorWorkspace = block.mutator.getWorkspace();
       // Trigger mutator change listener.
       createRenderedBlock(mutatorWorkspace, 'checkbox_block');
       chai.assert.isTrue(
@@ -41,9 +41,9 @@ suite('Mutator', function() {
     });
 
     test('XML', function() {
-      let block = createRenderedBlock(this.workspace, 'xml_block');
+      const block = createRenderedBlock(this.workspace, 'xml_block');
       block.mutator.setVisible(true);
-      let mutatorWorkspace = block.mutator.getWorkspace();
+      const mutatorWorkspace = block.mutator.getWorkspace();
       mutatorWorkspace.getBlockById('check_block')
           .setFieldValue('TRUE', 'CHECK');
       chai.assert.isTrue(
@@ -55,9 +55,9 @@ suite('Mutator', function() {
     });
 
     test('JSO', function() {
-      let block = createRenderedBlock(this.workspace, 'jso_block');
+      const block = createRenderedBlock(this.workspace, 'jso_block');
       block.mutator.setVisible(true);
-      let mutatorWorkspace = block.mutator.getWorkspace();
+      const mutatorWorkspace = block.mutator.getWorkspace();
       mutatorWorkspace.getBlockById('check_block')
           .setFieldValue('TRUE', 'CHECK');
       chai.assert.isTrue(

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -18,7 +18,7 @@ suite('Names', function() {
   });
 
   test('Safe name', function() {
-    let varDB = new Blockly.Names('window,door');
+    const varDB = new Blockly.Names('window,door');
     chai.assert.equal(varDB.safeName_(''), 'unnamed', 'SafeName empty.');
     chai.assert.equal(varDB.safeName_('foobar'), 'foobar', 'SafeName ok.');
     chai.assert.equal(varDB.safeName_('9lives'), 'my_9lives', 'SafeName number start.');
@@ -28,7 +28,7 @@ suite('Names', function() {
   });
 
   test('Get name', function() {
-    let varDB = new Blockly.Names('window,door');
+    const varDB = new Blockly.Names('window,door');
     chai.assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name add #1.');
     chai.assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1.');
     chai.assert.equal(varDB.getName('Foo bar', 'var'), 'Foo_bar2', 'Name add #2.');
@@ -43,7 +43,7 @@ suite('Names', function() {
   });
 
   test('Get distinct name', function() {
-    let varDB = new Blockly.Names('window,door');
+    const varDB = new Blockly.Names('window,door');
     chai.assert.equal(varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar',
         'Name distinct #1.');
     chai.assert.equal(varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar2',

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -26,12 +26,12 @@ suite('Procedures', function() {
 
   suite('allProcedures', function() {
     test('Only Procedures', function() {
-      let noReturnBlock = new Blockly.Block(this.workspace, 'procedures_defnoreturn');
+      const noReturnBlock = new Blockly.Block(this.workspace, 'procedures_defnoreturn');
       noReturnBlock.setFieldValue('no return', 'NAME');
-      let returnBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
+      const returnBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
       returnBlock.setFieldValue('return', 'NAME');
 
-      let allProcedures = Blockly.Procedures.allProcedures(this.workspace);
+      const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
       chai.assert.lengthOf(allProcedures, 2);
 
       chai.assert.lengthOf(allProcedures[0], 1);
@@ -41,15 +41,15 @@ suite('Procedures', function() {
       chai.assert.equal(allProcedures[1][0][0], 'return');
     });
     test('Multiple Blocks', function() {
-      let noReturnBlock = new Blockly.Block(this.workspace, 'procedures_defnoreturn');
+      const noReturnBlock = new Blockly.Block(this.workspace, 'procedures_defnoreturn');
       noReturnBlock.setFieldValue('no return', 'NAME');
-      let returnBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
+      const returnBlock = new Blockly.Block(this.workspace, 'procedures_defreturn');
       returnBlock.setFieldValue('return', 'NAME');
-      let returnBlock2 = new Blockly.Block(this.workspace, 'procedures_defreturn');
+      const returnBlock2 = new Blockly.Block(this.workspace, 'procedures_defreturn');
       returnBlock2.setFieldValue('return2', 'NAME');
-      let _ = new Blockly.Block(this.workspace, 'controls_if');
+      const _ = new Blockly.Block(this.workspace, 'controls_if');
 
-      let allProcedures = Blockly.Procedures.allProcedures(this.workspace);
+      const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
       chai.assert.lengthOf(allProcedures, 2);
 
       chai.assert.lengthOf(allProcedures[0], 1);
@@ -60,8 +60,8 @@ suite('Procedures', function() {
       chai.assert.equal(allProcedures[1][1][0], 'return2');
     });
     test('No Procedures', function() {
-      let _ = new Blockly.Block(this.workspace, 'controls_if');
-      let allProcedures = Blockly.Procedures.allProcedures(this.workspace);
+      const _ = new Blockly.Block(this.workspace, 'controls_if');
+      const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
       chai.assert.lengthOf(allProcedures, 2);
       chai.assert.lengthOf(allProcedures[0], 0, 'No procedures_defnoreturn blocks expected');
       chai.assert.lengthOf(allProcedures[1], 0, 'No procedures_defreturn blocks expected');
@@ -78,7 +78,7 @@ suite('Procedures', function() {
 
   suite('Enable/Disable', function() {
     setup(function() {
-      let toolbox = document.getElementById('toolbox-categories');
+      const toolbox = document.getElementById('toolbox-categories');
       this.workspaceSvg = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     });
     teardown(function() {
@@ -87,7 +87,7 @@ suite('Procedures', function() {
     });
     suite('Inherited disabled', function() {
       setup(function() {
-        let dom = Blockly.Xml.textToDom(
+        const dom = Blockly.Xml.textToDom(
             '<xml xmlns="https://developers.google.com/blockly/xml">' +
             '<block type="procedures_defreturn" id="bar-def">' +
             '<field name="NAME">bar</field>' +
@@ -234,7 +234,7 @@ suite('Procedures', function() {
     }
     suite('no name renamed to unnamed', function() {
       test('defnoreturn and defreturn', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_defnoreturn"/>
                 <block type="procedures_defreturn"/>
@@ -244,7 +244,7 @@ suite('Procedures', function() {
             this.workspace, ['unnamed'], ['unnamed2'], false);
       });
       test('defreturn and defnoreturn', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_defreturn"/>
                 <block type="procedures_defnoreturn"/>
@@ -254,7 +254,7 @@ suite('Procedures', function() {
             this.workspace, ['unnamed2'], ['unnamed'], false);
       });
       test('callnoreturn (no def in xml)', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callnoreturn"/>
               </xml>`);
@@ -263,7 +263,7 @@ suite('Procedures', function() {
             this.workspace, ['unnamed'], [], true);
       });
       test('callreturn (no def in xml)', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callreturn"/>
               </xml>`);
@@ -272,7 +272,7 @@ suite('Procedures', function() {
             this.workspace, [], ['unnamed'], true);
       });
       test('callnoreturn and callreturn (no def in xml)', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callnoreturn"/>
                 <block type="procedures_callreturn"/>
@@ -282,7 +282,7 @@ suite('Procedures', function() {
             this.workspace, ['unnamed'], ['unnamed2'], true);
       });
       test('callreturn and callnoreturn (no def in xml)', function() {
-        let xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.Xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callreturn"/>
                 <block type="procedures_callnoreturn"/>
@@ -295,7 +295,7 @@ suite('Procedures', function() {
     suite('caller param mismatch', function() {
       test.skip('callreturn with missing args', function() {
         // TODO: How do we want it to behave in this situation?
-        let defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -303,7 +303,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        let callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="procedures_callreturn">' +
             '  <mutation name="do something"/>' +
             '</block>'
@@ -313,7 +313,7 @@ suite('Procedures', function() {
       });
       test.skip('callreturn with bad args', function() {
         // TODO: How do we want it to behave in this situation?
-        let defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -321,7 +321,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        let callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_callreturn">
               <mutation name="do something">
                 <arg name="y"></arg>
@@ -333,7 +333,7 @@ suite('Procedures', function() {
       });
       test.skip('callnoreturn with missing args', function() {
         // TODO: How do we want it to behave in this situation?
-        let defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -341,7 +341,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        let callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="procedures_callnoreturn">' +
             '  <mutation name="do something"/>' +
             '</block>'
@@ -351,7 +351,7 @@ suite('Procedures', function() {
       });
       test.skip('callnoreturn with bad args', function() {
         // TODO: How do we want it to behave in this situation?
-        let defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -359,7 +359,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        let callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_callnoreturn">
               <mutation name="do something">
                 <arg name="y"></arg>
@@ -401,18 +401,18 @@ suite('Procedures', function() {
 
     test('Custom procedure block', function() {
       // Do not require procedures to be the built-in procedures.
-      let defBlock = new Blockly.Block(this.workspace, 'new_proc');
-      let def = Blockly.Procedures.getDefinition('test', this.workspace);
+      const defBlock = new Blockly.Block(this.workspace, 'new_proc');
+      const def = Blockly.Procedures.getDefinition('test', this.workspace);
       chai.assert.equal(def, defBlock);
     });
 
     test('Stacked procedures', function() {
-      let blockA = new Blockly.Block(this.workspace, 'nested_proc');
-      let blockB = new Blockly.Block(this.workspace, 'nested_proc');
+      const blockA = new Blockly.Block(this.workspace, 'nested_proc');
+      const blockB = new Blockly.Block(this.workspace, 'nested_proc');
       blockA.name = 'a';
       blockB.name = 'b';
       blockA.nextConnection.connect(blockB.previousConnection);
-      let def = Blockly.Procedures.getDefinition('b', this.workspace);
+      const def = Blockly.Procedures.getDefinition('b', this.workspace);
       chai.assert.equal(def, blockB);
     });
   });
@@ -479,7 +479,7 @@ suite('Procedures', function() {
               this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('Simple, Input', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
@@ -492,7 +492,7 @@ suite('Procedures', function() {
               this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('lower -> CAPS', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
@@ -507,7 +507,7 @@ suite('Procedures', function() {
         test('CAPS -> lower', function() {
           this.defBlock.setFieldValue('PROC NAME', 'NAME');
           this.callBlock.setFieldValue('PROC NAME', 'NAME');
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'PROC NAME';
           defInput.htmlInput_.untypedDefaultValue_ = 'PROC NAME';
@@ -520,7 +520,7 @@ suite('Procedures', function() {
               this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
@@ -533,7 +533,7 @@ suite('Procedures', function() {
               this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace then Text', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
@@ -548,7 +548,7 @@ suite('Procedures', function() {
               this.callBlock.getFieldValue('NAME'), 'proc name 2');
         });
         test('Set Empty', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
@@ -563,14 +563,14 @@ suite('Procedures', function() {
               Blockly.Msg['UNNAMED_KEY']);
         });
         test('Set Empty, and Create New', function() {
-          let defInput = this.defBlock.getField('NAME');
+          const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = Object.create(null);
           defInput.htmlInput_.oldValue_ = 'proc name';
           defInput.htmlInput_.untypedDefaultValue_ = 'proc name';
 
           defInput.htmlInput_.value = '';
           defInput.onHtmlInputChange_(null);
-          let newDefBlock = new Blockly.Block(this.workspace, testSuite.defType);
+          const newDefBlock = new Blockly.Block(this.workspace, testSuite.defType);
           newDefBlock.setFieldValue('new name', 'NAME');
           chai.assert.equal(
               this.defBlock.getFieldValue('NAME'),
@@ -589,18 +589,18 @@ suite('Procedures', function() {
           this.callBlock.setFieldValue('proc name', 'NAME');
         });
         test('Simple', function() {
-          let callers =
+          const callers =
               Blockly.Procedures.getCallers('proc name', this.workspace);
           chai.assert.equal(callers.length, 1);
           chai.assert.equal(callers[0], this.callBlock);
         });
         test('Multiple Callers', function() {
-          let caller2 = new Blockly.Block(this.workspace, testSuite.callType);
+          const caller2 = new Blockly.Block(this.workspace, testSuite.callType);
           caller2.setFieldValue('proc name', 'NAME');
-          let caller3 = new Blockly.Block(this.workspace, testSuite.callType);
+          const caller3 = new Blockly.Block(this.workspace, testSuite.callType);
           caller3.setFieldValue('proc name', 'NAME');
 
-          let callers =
+          const callers =
               Blockly.Procedures.getCallers('proc name', this.workspace);
           chai.assert.equal(callers.length, 3);
           chai.assert.equal(callers[0], this.callBlock);
@@ -608,12 +608,12 @@ suite('Procedures', function() {
           chai.assert.equal(callers[2], caller3);
         });
         test('Multiple Procedures', function() {
-          let def2 = new Blockly.Block(this.workspace, testSuite.defType);
+          const def2 = new Blockly.Block(this.workspace, testSuite.defType);
           def2.setFieldValue('proc name2', 'NAME');
-          let caller2 = new Blockly.Block(this.workspace, testSuite.callType);
+          const caller2 = new Blockly.Block(this.workspace, testSuite.callType);
           caller2.setFieldValue('proc name2', 'NAME');
 
-          let callers =
+          const callers =
               Blockly.Procedures.getCallers('proc name', this.workspace);
           chai.assert.equal(callers.length, 1);
           chai.assert.equal(callers[0], this.callBlock);
@@ -628,17 +628,17 @@ suite('Procedures', function() {
         // caller should still be returned for a differently-cased procedure.
         test('Call Different Case', function() {
           this.callBlock.setFieldValue('PROC NAME', 'NAME');
-          let callers =
+          const callers =
               Blockly.Procedures.getCallers('proc name', this.workspace);
           chai.assert.equal(callers.length, 1);
           chai.assert.equal(callers[0], this.callBlock);
         });
         test('Multiple Workspaces', function() {
-          let workspace = new Blockly.Workspace();
+          const workspace = new Blockly.Workspace();
           try {
-            let def2 = new Blockly.Block(workspace, testSuite.defType);
+            const def2 = new Blockly.Block(workspace, testSuite.defType);
             def2.setFieldValue('proc name', 'NAME');
-            let caller2 = new Blockly.Block(workspace, testSuite.callType);
+            const caller2 = new Blockly.Block(workspace, testSuite.callType);
             caller2.setFieldValue('proc name', 'NAME');
 
             let callers =
@@ -663,26 +663,26 @@ suite('Procedures', function() {
           this.callBlock.setFieldValue('proc name', 'NAME');
         });
         test('Simple', function() {
-          let def =
+          const def =
               Blockly.Procedures.getDefinition('proc name', this.workspace);
           chai.assert.equal(def, this.defBlock);
         });
         test('Multiple Procedures', function() {
-          let def2 = new Blockly.Block(this.workspace, testSuite.defType);
+          const def2 = new Blockly.Block(this.workspace, testSuite.defType);
           def2.setFieldValue('proc name2', 'NAME');
-          let caller2 = new Blockly.Block(this.workspace, testSuite.callType);
+          const caller2 = new Blockly.Block(this.workspace, testSuite.callType);
           caller2.setFieldValue('proc name2', 'NAME');
 
-          let def =
+          const def =
               Blockly.Procedures.getDefinition('proc name', this.workspace);
           chai.assert.equal(def, this.defBlock);
         });
         test('Multiple Workspaces', function() {
-          let workspace = new Blockly.Workspace();
+          const workspace = new Blockly.Workspace();
           try {
-            let def2 = new Blockly.Block(workspace, testSuite.defType);
+            const def2 = new Blockly.Block(workspace, testSuite.defType);
             def2.setFieldValue('proc name', 'NAME');
-            let caller2 = new Blockly.Block(workspace, testSuite.callType);
+            const caller2 = new Blockly.Block(workspace, testSuite.callType);
             caller2.setFieldValue('proc name', 'NAME');
 
             let def =
@@ -699,7 +699,7 @@ suite('Procedures', function() {
 
       suite('Enable/Disable', function() {
         setup(function() {
-          let toolbox = document.getElementById('toolbox-categories');
+          const toolbox = document.getElementById('toolbox-categories');
           this.workspaceSvg = Blockly.inject('blocklyDiv', {toolbox: toolbox});
         });
         teardown(function() {
@@ -731,7 +731,7 @@ suite('Procedures', function() {
                 '</block>' +
                 '</xml>');
         setup(function() {
-          let dom = Blockly.Xml.textToDom(domText);
+          const dom = Blockly.Xml.textToDom(domText);
 
           Blockly.Xml.appendDomToWorkspace(dom, this.workspaceSvg);
           this.barDef = this.workspaceSvg.getBlockById('bar-def');
@@ -752,7 +752,7 @@ suite('Procedures', function() {
                 'Callers are disabled when their definition is disabled (call ' +
                 i + ')');
           }
-          let firedEvents = this.workspaceSvg.undoStack_;
+          const firedEvents = this.workspaceSvg.undoStack_;
           chai.assert.equal(firedEvents.length, 3,
               'An event was fired for the definition and each caller');
           for (let i = 0; i < 3; i++) {
@@ -789,7 +789,7 @@ suite('Procedures', function() {
                 'Callers are disabled when their definition is disabled (call ' +
                 i + ')');
           }
-          let firedEvents = this.workspaceSvg.undoStack_;
+          const firedEvents = this.workspaceSvg.undoStack_;
           chai.assert.equal(firedEvents.length, 2,
               'An event was fired for the definition and the enabled caller');
           for (let i = 0; i < 2; i++) {
@@ -830,13 +830,13 @@ suite('Procedures', function() {
         suite('Composition', function() {
           suite('Statements', function() {
             function setStatementValue(mainWorkspace, defBlock, value) {
-              let mutatorWorkspace = new Blockly.Workspace(
+              const mutatorWorkspace = new Blockly.Workspace(
                   new Blockly.Options({
                     parentWorkspace: mainWorkspace
                   }));
               defBlock.decompose(mutatorWorkspace);
-              let containerBlock = mutatorWorkspace.getTopBlocks()[0];
-              let statementField = containerBlock.getField('STATEMENTS');
+              const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+              const statementField = containerBlock.getField('STATEMENTS');
               statementField.setValue(value);
               defBlock.compose(containerBlock);
             }
@@ -850,21 +850,21 @@ suite('Procedures', function() {
                 chai.assert.isFalse(this.defBlock.hasStatements_);
               });
               test('Saving Statements', function() {
-                let blockXml = Blockly.Xml.textToDom(
+                const blockXml = Blockly.Xml.textToDom(
                     '<block type="procedures_defreturn">' +
                     '  <statement name="STACK">' +
                     '    <block type="procedures_ifreturn" id="test"></block>' +
                     '  </statement> ' +
                     '</block>'
                 );
-                let defBlock = Blockly.Xml.domToBlock(blockXml, this.workspace);
+                const defBlock = Blockly.Xml.domToBlock(blockXml, this.workspace);
                 setStatementValue(this.workspace, defBlock, false);
                 chai.assert.isNull(defBlock.getInput('STACK'));
                 setStatementValue(this.workspace, defBlock, true);
                 chai.assert.isNotNull(defBlock.getInput('STACK'));
-                let statementBlocks = defBlock.getChildren();
+                const statementBlocks = defBlock.getChildren();
                 chai.assert.equal(statementBlocks.length, 1);
-                let block = statementBlocks[0];
+                const block = statementBlocks[0];
                 chai.assert.equal(block.type, 'procedures_ifreturn');
                 chai.assert.equal(block.id, 'test');
               });
@@ -898,12 +898,12 @@ suite('Procedures', function() {
               }
             }
             test('Simple Add Arg', function() {
-              let args = ['arg1'];
+              const args = ['arg1'];
               createMutator.call(this, args);
               assertArgs.call(this, args);
             });
             test('Multiple Args', function() {
-              let args = ['arg1', 'arg2', 'arg3'];
+              const args = ['arg1', 'arg2', 'arg3'];
               createMutator.call(this, args);
               assertArgs.call(this, args);
             });
@@ -927,14 +927,14 @@ suite('Procedures', function() {
             });
             // Test case for #1958
             test('Set Arg Empty', function() {
-              let args = ['arg1'];
+              const args = ['arg1'];
               createMutator.call(this, args);
               this.argBlock.setFieldValue('', 'NAME');
               this.defBlock.compose(this.containerBlock);
               assertArgs.call(this, args);
             });
             test('Whitespace', function() {
-              let args = ['arg1'];
+              const args = ['arg1'];
               createMutator.call(this, args);
               this.argBlock.setFieldValue(' ', 'NAME');
               this.defBlock.compose(this.containerBlock);
@@ -947,7 +947,7 @@ suite('Procedures', function() {
               assertArgs.call(this, ['text']);
             });
             test('<>', function() {
-              let args = ['<>'];
+              const args = ['<>'];
               createMutator.call(this, args);
               assertArgs.call(this, args);
             });
@@ -957,45 +957,45 @@ suite('Procedures', function() {
           suite('Statements', function() {
             if (testSuite.defType === 'procedures_defreturn') {
               test('Has Statement Input', function() {
-                let mutatorWorkspace = new Blockly.Workspace(
+                const mutatorWorkspace = new Blockly.Workspace(
                     new Blockly.Options({
                       parentWorkspace: this.workspace
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                let statementInput = mutatorWorkspace.getTopBlocks()[0]
+                const statementInput = mutatorWorkspace.getTopBlocks()[0]
                     .getInput('STATEMENT_INPUT');
                 chai.assert.isNotNull(statementInput);
               });
               test('Has Statements', function() {
                 this.defBlock.hasStatements_ = true;
-                let mutatorWorkspace = new Blockly.Workspace(
+                const mutatorWorkspace = new Blockly.Workspace(
                     new Blockly.Options({
                       parentWorkspace: this.workspace
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                let statementValue = mutatorWorkspace.getTopBlocks()[0]
+                const statementValue = mutatorWorkspace.getTopBlocks()[0]
                     .getField('STATEMENTS').getValueBoolean();
                 chai.assert.isTrue(statementValue);
               });
               test('No Has Statements', function() {
                 this.defBlock.hasStatements_ = false;
-                let mutatorWorkspace = new Blockly.Workspace(
+                const mutatorWorkspace = new Blockly.Workspace(
                     new Blockly.Options({
                       parentWorkspace: this.workspace
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                let statementValue = mutatorWorkspace.getTopBlocks()[0]
+                const statementValue = mutatorWorkspace.getTopBlocks()[0]
                     .getField('STATEMENTS').getValueBoolean();
                 chai.assert.isFalse(statementValue);
               });
             } else {
               test('Has no Statement Input', function() {
-                let mutatorWorkspace = new Blockly.Workspace(
+                const mutatorWorkspace = new Blockly.Workspace(
                     new Blockly.Options({
                       parentWorkspace: this.workspace
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                let statementInput = mutatorWorkspace.getTopBlocks()[0]
+                const statementInput = mutatorWorkspace.getTopBlocks()[0]
                     .getInput('STATEMENT_INPUT');
                 chai.assert.isNull(statementInput);
               });
@@ -1004,17 +1004,17 @@ suite('Procedures', function() {
           suite('Untyped Arguments', function() {
             function assertArguments(argumentsArray) {
               this.defBlock.arguments_ = argumentsArray;
-              let mutatorWorkspace = new Blockly.Workspace(
+              const mutatorWorkspace = new Blockly.Workspace(
                   new Blockly.Options({
                     parentWorkspace: this.workspace
                   }));
               this.defBlock.decompose(mutatorWorkspace);
-              let argBlocks = mutatorWorkspace.getBlocksByType('procedures_mutatorarg');
+              const argBlocks = mutatorWorkspace.getBlocksByType('procedures_mutatorarg');
               chai.assert.equal(argBlocks.length, argumentsArray.length);
 
               for (let i = 0; i < argumentsArray.length; i++) {
-                let argString = argumentsArray[i];
-                let argBlockValue = argBlocks[i].getFieldValue('NAME');
+                const argString = argumentsArray[i];
+                const argBlockValue = argBlocks[i].getFieldValue('NAME');
                 chai.assert.equal(argBlockValue, argString);
               }
             }

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -10,7 +10,7 @@ const {assertWarnings, sharedTestSetup, sharedTestTeardown} = goog.require('Bloc
 
 
 suite('Registry', function() {
-  let TestClass = function() {};
+  const TestClass = function() {};
   TestClass.prototype.testMethod = function() {
     return 'something';
   };
@@ -238,19 +238,19 @@ suite('Registry', function() {
     });
 
     test('Simple - Plugin name given', function() {
-      let testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), TestClass);
     });
 
     test('Simple - Plugin class given', function() {
       this.options.plugins['test'] = TestClass;
-      let testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), TestClass);
     });
 
     test('No Plugin Name Given', function() {
       delete this.options['plugins']['test'];
-      let testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), this.defaultClass);
     });
 

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -41,7 +41,7 @@ function SerializerTestSuite(title) {
 }
 SerializerTestSuite.prototype = new testHelpers.TestSuite();
 
-let Serializer = new SerializerTestSuite('Serializer');
+const Serializer = new SerializerTestSuite('Serializer');
 
 // TODO: Make sure all of these properties are documented ad exported properly.
 Serializer.Empty = new SerializerTestCase('Empty',
@@ -1776,7 +1776,7 @@ Serializer.testSuites = [
   Serializer.Mutations,
 ];
 
-let runSerializerTestSuite = (serializer, deserializer, testSuite) => {
+const runSerializerTestSuite = (serializer, deserializer, testSuite) => {
   const workspaces = Blockly.serialization.workspaces;
 
   const createTestFunction = function(test) {
@@ -1788,7 +1788,7 @@ let runSerializerTestSuite = (serializer, deserializer, testSuite) => {
         this.workspace.clear();
         workspaces.load(deserializer(save), this.workspace);
       }
-      let newXml = Blockly.Xml.workspaceToDom(this.workspace);
+      const newXml = Blockly.Xml.workspaceToDom(this.workspace);
       chai.assert.equal(Blockly.Xml.domToText(newXml), test.xml);
     };
   };

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -21,18 +21,18 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('Registering', function() {
     test('Registering a shortcut', function() {
-      let testShortcut = {'name': 'test_shortcut'};
+      const testShortcut = {'name': 'test_shortcut'};
       this.registry.register(testShortcut, true);
-      let shortcut = this.registry.registry_['test_shortcut'];
+      const shortcut = this.registry.registry_['test_shortcut'];
       chai.assert.equal(shortcut.name, 'test_shortcut');
     });
     test('Registers shortcut with same name', function() {
-      let registry = this.registry;
-      let testShortcut = {'name': 'test_shortcut'};
+      const registry = this.registry;
+      const testShortcut = {'name': 'test_shortcut'};
 
       registry.registry_['test_shortcut'] = [testShortcut];
 
-      let shouldThrow = function() {
+      const shouldThrow = function() {
         registry.register(testShortcut);
       };
       chai.assert.throws(
@@ -42,16 +42,16 @@ suite('Keyboard Shortcut Registry Test', function() {
     test(
         'Registers shortcut with same name opt_allowOverrides=true',
         function() {
-          let registry = this.registry;
-          let testShortcut = {'name': 'test_shortcut'};
-          let otherShortcut = {
+          const registry = this.registry;
+          const testShortcut = {'name': 'test_shortcut'};
+          const otherShortcut = {
             'name': 'test_shortcut',
             'callback': function() {}
           };
 
           registry.registry_['test_shortcut'] = [testShortcut];
 
-          let shouldNotThrow = function() {
+          const shouldNotThrow = function() {
             registry.register(otherShortcut, true);
           };
           chai.assert.doesNotThrow(shouldNotThrow);
@@ -61,41 +61,41 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('Unregistering', function() {
     test('Unregistering a shortcut', function() {
-      let testShortcut = {'name': 'test_shortcut'};
+      const testShortcut = {'name': 'test_shortcut'};
       this.registry.registry_['test'] = [testShortcut];
       chai.assert.isOk(this.registry.registry_['test']);
       this.registry.unregister('test', 'test_shortcut');
       chai.assert.isUndefined(this.registry.registry_['test']);
     });
     test('Unregistering a nonexistent shortcut', function() {
-      let consoleStub = sinon.stub(console, 'warn');
+      const consoleStub = sinon.stub(console, 'warn');
       chai.assert.isUndefined(this.registry.registry_['test']);
 
-      let registry = this.registry;
+      const registry = this.registry;
       chai.assert.isFalse(registry.unregister('test', 'test_shortcut'));
       sinon.assert.calledOnceWithExactly(consoleStub, 'Keyboard shortcut with name "test" not found.');
     });
     test('Unregistering a shortcut with key mappings', function() {
-      let testShortcut = {'name': 'test_shortcut'};
+      const testShortcut = {'name': 'test_shortcut'};
       this.registry.keyMap_['keyCode'] = ['test_shortcut'];
       this.registry.registry_['test_shortcut'] = testShortcut;
 
       this.registry.unregister('test_shortcut');
 
-      let shortcut = this.registry.registry_['test'];
-      let keyMappings = this.registry.keyMap_['keyCode'];
+      const shortcut = this.registry.registry_['test'];
+      const keyMappings = this.registry.keyMap_['keyCode'];
       chai.assert.isUndefined(shortcut);
       chai.assert.isUndefined(keyMappings);
     });
     test('Unregistering a shortcut with colliding key mappings', function() {
-      let testShortcut = {'name': 'test_shortcut'};
+      const testShortcut = {'name': 'test_shortcut'};
       this.registry.keyMap_['keyCode'] = ['test_shortcut', 'other_shortcutt'];
       this.registry.registry_['test_shortcut'] = testShortcut;
 
       this.registry.unregister('test_shortcut');
 
-      let shortcut = this.registry.registry_['test'];
-      let keyMappings = this.registry.keyMap_['keyCode'];
+      const shortcut = this.registry.registry_['test'];
+      const keyMappings = this.registry.keyMap_['keyCode'];
       chai.assert.lengthOf(keyMappings, 1);
       chai.assert.isUndefined(shortcut);
     });
@@ -107,7 +107,7 @@ suite('Keyboard Shortcut Registry Test', function() {
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
-      let shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap_['keyCode'];
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
     });
@@ -117,7 +117,7 @@ suite('Keyboard Shortcut Registry Test', function() {
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut', true);
 
-      let shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap_['keyCode'];
       chai.assert.lengthOf(shortcutNames, 2);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
       chai.assert.equal(shortcutNames[1], 'test_shortcut_2');
@@ -126,8 +126,8 @@ suite('Keyboard Shortcut Registry Test', function() {
       this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
       this.registry.keyMap_['keyCode'] = ['test_shortcut_2'];
 
-      let registry = this.registry;
-      let shouldThrow = function() {
+      const registry = this.registry;
+      const shouldThrow = function() {
         registry.addKeyMapping('keyCode', 'test_shortcut');
       };
       chai.assert.throws(
@@ -141,10 +141,10 @@ suite('Keyboard Shortcut Registry Test', function() {
       this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
       this.registry.keyMap_['keyCode'] = ['test_shortcut', 'test_shortcut_2'];
 
-      let isRemoved =
+      const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      let shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap_['keyCode'];
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut_2');
       chai.assert.isTrue(isRemoved);
@@ -155,14 +155,14 @@ suite('Keyboard Shortcut Registry Test', function() {
 
       this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      let shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap_['keyCode'];
       chai.assert.isUndefined(shortcutNames);
     });
     test('Removes a key map that does not exist opt_quiet=false', function() {
-      let consoleStub = sinon.stub(console, 'warn');
+      const consoleStub = sinon.stub(console, 'warn');
       this.registry.keyMap_['keyCode'] = ['test_shortcut_2'];
 
-      let isRemoved =
+      const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
       chai.assert.isFalse(isRemoved);
@@ -173,9 +173,9 @@ suite('Keyboard Shortcut Registry Test', function() {
     test(
         'Removes a key map that does not exist from empty key mapping opt_quiet=false',
         function() {
-          let consoleStub = sinon.stub(console, 'warn');
+          const consoleStub = sinon.stub(console, 'warn');
 
-          let isRemoved =
+          const isRemoved =
               this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
           chai.assert.isFalse(isRemoved);
@@ -193,26 +193,26 @@ suite('Keyboard Shortcut Registry Test', function() {
     });
     test('Gets a copy of the key map', function() {
       this.registry.keyMap_['keyCode'] = ['a'];
-      let keyMapCopy = this.registry.getKeyMap();
+      const keyMapCopy = this.registry.getKeyMap();
       keyMapCopy['keyCode'] = ['b'];
       chai.assert.equal(this.registry.keyMap_['keyCode'][0], 'a');
     });
     test('Gets a copy of the registry', function() {
       this.registry.registry_['shortcutName'] = {'name': 'shortcutName'};
-      let registrycopy = this.registry.getRegistry();
+      const registrycopy = this.registry.getRegistry();
       registrycopy['shortcutName']['name'] = 'shortcutName1';
       chai.assert.equal(
           this.registry.registry_['shortcutName']['name'], 'shortcutName');
     });
     test('Gets keyboard shortcuts from a key code', function() {
       this.registry.keyMap_['keyCode'] = ['shortcutName'];
-      let shortcutNames = this.registry.getShortcutNamesByKeyCode('keyCode');
+      const shortcutNames = this.registry.getShortcutNamesByKeyCode('keyCode');
       chai.assert.equal(shortcutNames[0], 'shortcutName');
     });
     test('Gets keycodes by shortcut name', function() {
       this.registry.keyMap_['keyCode'] = ['shortcutName'];
       this.registry.keyMap_['keyCode1'] = ['shortcutName'];
-      let shortcutNames =
+      const shortcutNames =
           this.registry.getKeyCodesByShortcutName('shortcutName');
       chai.assert.lengthOf(shortcutNames, 2);
       chai.assert.equal(shortcutNames[0], 'keyCode');
@@ -241,23 +241,23 @@ suite('Keyboard Shortcut Registry Test', function() {
           addShortcut(this.registry, this.testShortcut, Blockly.utils.KeyCodes.C, true);
     });
     test('Execute a shortcut from event', function() {
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(this.callBackStub);
     });
     test('No shortcut executed from event', function() {
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.D);
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.D);
       chai.assert.isFalse(this.registry.onKeyDown(this.workspace, event));
     });
     test('No precondition available - execute callback', function() {
       delete this.testShortcut['precondition'];
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(this.callBackStub);
     });
     test('Execute all shortcuts in list', function() {
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
-      let testShortcut2 = {
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      const testShortcut2 = {
         'name': 'test_shortcut_2',
         'callback': function() {
           return false;
@@ -266,15 +266,15 @@ suite('Keyboard Shortcut Registry Test', function() {
           return false;
         }
       };
-      let testShortcut2Stub =
+      const testShortcut2Stub =
           addShortcut(this.registry, testShortcut2, Blockly.utils.KeyCodes.C, false);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
       sinon.assert.calledOnce(this.callBackStub);
     });
     test('Stop executing shortcut when event is handled', function() {
-      let event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
-      let testShortcut2 = {
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      const testShortcut2 = {
         'name': 'test_shortcut_2',
         'callback': function() {
           return false;
@@ -283,7 +283,7 @@ suite('Keyboard Shortcut Registry Test', function() {
           return false;
         }
       };
-      let testShortcut2Stub =
+      const testShortcut2Stub =
           addShortcut(this.registry, testShortcut2, Blockly.utils.KeyCodes.C, true);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
@@ -293,31 +293,31 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('createSerializedKey', function() {
     test('Serialize key', function() {
-      let serializedKey =
+      const serializedKey =
           this.registry.createSerializedKey(Blockly.utils.KeyCodes.A);
       chai.assert.equal(serializedKey, '65');
     });
 
     test('Serialize key code and modifier', function() {
-      let serializedKey = this.registry.createSerializedKey(
+      const serializedKey = this.registry.createSerializedKey(
           Blockly.utils.KeyCodes.A, [Blockly.utils.KeyCodes.CTRL]);
       chai.assert.equal(serializedKey, 'Control+65');
     });
     test('Serialize only a modifier', function() {
-      let serializedKey = this.registry.createSerializedKey(
+      const serializedKey = this.registry.createSerializedKey(
           null, [Blockly.utils.KeyCodes.CTRL]);
       chai.assert.equal(serializedKey, 'Control');
     });
     test('Serialize multiple modifiers', function() {
-      let serializedKey = this.registry.createSerializedKey(
+      const serializedKey = this.registry.createSerializedKey(
           null, [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]);
       chai.assert.equal(serializedKey, 'Shift+Control');
     });
     test('Order of modifiers should result in same serialized key', function() {
-      let serializedKey = this.registry.createSerializedKey(
+      const serializedKey = this.registry.createSerializedKey(
           null, [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]);
       chai.assert.equal(serializedKey, 'Shift+Control');
-      let serializedKeyNewOrder = this.registry.createSerializedKey(
+      const serializedKeyNewOrder = this.registry.createSerializedKey(
           null, [Blockly.utils.KeyCodes.SHIFT, Blockly.utils.KeyCodes.CTRL]);
       chai.assert.equal(serializedKeyNewOrder, 'Shift+Control');
     });
@@ -325,32 +325,32 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('serializeKeyEvent', function() {
     test('Serialize key', function() {
-      let mockEvent = createKeyDownEvent(Blockly.utils.KeyCodes.A);
-      let serializedKey = this.registry.serializeKeyEvent_(mockEvent);
+      const mockEvent = createKeyDownEvent(Blockly.utils.KeyCodes.A);
+      const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, '65');
     });
     test('Serialize key code and modifier', function() {
-      let mockEvent = createKeyDownEvent(
+      const mockEvent = createKeyDownEvent(
           Blockly.utils.KeyCodes.A, [Blockly.utils.KeyCodes.CTRL]);
-      let serializedKey = this.registry.serializeKeyEvent_(mockEvent);
+      const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, 'Control+65');
     });
     test('Serialize only a modifier', function() {
-      let mockEvent =
+      const mockEvent =
           createKeyDownEvent(null, [Blockly.utils.KeyCodes.CTRL]);
-      let serializedKey = this.registry.serializeKeyEvent_(mockEvent);
+      const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, 'Control');
     });
     test('Serialize multiple modifiers', function() {
-      let mockEvent = createKeyDownEvent(
+      const mockEvent = createKeyDownEvent(
           null,
           [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]);
-      let serializedKey = this.registry.serializeKeyEvent_(mockEvent);
+      const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, 'Shift+Control');
     });
     test('Throw error when incorrect modifier', function() {
-      let registry = this.registry;
-      let shouldThrow = function() {
+      const registry = this.registry;
+      const shouldThrow = function() {
         registry.createSerializedKey(Blockly.utils.KeyCodes.K, ['s']);
       };
       chai.assert.throws(shouldThrow, Error, 's is not a valid modifier key.');

--- a/tests/mocha/test_helpers.js
+++ b/tests/mocha/test_helpers.js
@@ -20,7 +20,7 @@ const {Blocks} = goog.require('Blockly.blocks');
  * @param {!string} id The expected id of the variable.
  */
 function assertVariableValues(container, name, type, id) {
-  let variable = container.getVariableById(id);
+  const variable = container.getVariableById(id);
   chai.assert.isDefined(variable);
   chai.assert.equal(variable.name, name);
   chai.assert.equal(variable.type, type);
@@ -38,7 +38,7 @@ function assertWarnings(innerFunc, messages) {
   if (!Array.isArray(messages)) {
     messages = [messages];
   }
-  let warnings = testHelpers.captureWarnings(innerFunc);
+  const warnings = testHelpers.captureWarnings(innerFunc);
   chai.assert.lengthOf(warnings, messages.length);
   messages.forEach((message, i) => {
     chai.assert.match(warnings[i], message);
@@ -101,7 +101,7 @@ function workspaceTeardown(workspace) {
     workspace.dispose();
     this.clock.runAll();  // Run all remaining queued setTimeout calls.
   } catch (e) {
-    let testRef = this.currentTest || this.test;
+    const testRef = this.currentTest || this.test;
     console.error(testRef.fullTitle() + '\n', e);
   }
 }
@@ -115,7 +115,7 @@ exports.workspaceTeardown = workspaceTeardown;
  * @private
  */
 function createEventsFireStubFireImmediately_(clock) {
-  let stub = sinon.stub(eventUtils, 'fire');
+  const stub = sinon.stub(eventUtils, 'fire');
   stub.callsFake(function(event) {
     // Call original method.
     stub.wrappedMethod.call(this, ...arguments);
@@ -158,7 +158,7 @@ exports.addBlockTypeToCleanup = addBlockTypeToCleanup;
  * @private
  */
 function wrapDefineBlocksWithJsonArrayWithCleanup_(sharedCleanupObj) {
-  let stub = sinon.stub(Blockly, 'defineBlocksWithJsonArray');
+  const stub = sinon.stub(Blockly, 'defineBlocksWithJsonArray');
   stub.callsFake(function(jsonArray) {
     if (jsonArray) {
       jsonArray.forEach((jsonBlock) => {
@@ -215,7 +215,7 @@ exports.sharedTestSetup = sharedTestSetup;
  * outermost suite using sharedTestTeardown.call(this).
  */
 function sharedTestTeardown() {
-  let testRef = this.currentTest || this.test;
+  const testRef = this.currentTest || this.test;
   if (!this.sharedSetupCalled_) {
     console.error('"' + testRef.fullTitle() + '" did not call sharedTestSetup');
   }
@@ -250,11 +250,11 @@ function sharedTestTeardown() {
     this.sharedSetupSandbox_.restore();
     sinon.restore();
 
-    let blockTypes = this.sharedCleanup.blockTypesCleanup_;
+    const blockTypes = this.sharedCleanup.blockTypesCleanup_;
     for (let i = 0; i < blockTypes.length; i++) {
       delete Blocks[blockTypes[i]];
     }
-    let messages = this.sharedCleanup.messagesCleanup_;
+    const messages = this.sharedCleanup.messagesCleanup_;
     for (let i = 0; i < messages.length; i++) {
       delete Blockly.Msg[messages[i]];
     }
@@ -274,7 +274,7 @@ exports.sharedTestTeardown = sharedTestTeardown;
  * @return {!SinonStub} The created stub.
  */
 function createGenUidStubWithReturns(returnIds) {
-  let stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, "genUid");
+  const stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, "genUid");
   if (Array.isArray(returnIds)) {
     for (let i = 0; i < returnIds.length; i++) {
       stub.onCall(i).returns(returnIds[i]);
@@ -305,7 +305,7 @@ exports.createFireChangeListenerSpy = createFireChangeListenerSpy;
  * @private
  */
 function assertXmlPropertyEqual_(xmlValue, expectedValue, message) {
-  let value = Blockly.Xml.domToText(xmlValue);
+  const value = Blockly.Xml.domToText(xmlValue);
   if (expectedValue instanceof Node) {
     expectedValue = Blockly.Xml.domToText(expectedValue);
   }
@@ -321,8 +321,8 @@ function assertXmlPropertyEqual_(xmlValue, expectedValue, message) {
  */
 function assertXmlProperties_(obj, expectedXmlProperties) {
   Object.keys(expectedXmlProperties).map((key) => {
-    let value = obj[key];
-    let expectedValue = expectedXmlProperties[key];
+    const value = obj[key];
+    const expectedValue = expectedXmlProperties[key];
     if (expectedValue === undefined) {
       chai.assert.isUndefined(value,
           'Expected ' + key + ' property to be undefined');
@@ -365,8 +365,8 @@ function assertEventEquals(event, expectedType,
   chai.assert.equal(event.blockId, expectedBlockId,
       prependMessage + 'block id');
   Object.keys(expectedProperties).map((key) => {
-    let value = event[key];
-    let expectedValue = expectedProperties[key];
+    const value = event[key];
+    const expectedValue = expectedProperties[key];
     if (expectedValue === undefined) {
       chai.assert.isUndefined(value, prependMessage + key);
       return;
@@ -405,7 +405,7 @@ function assertEventFired(spy, instanceType, expectedProperties,
     workspaceId: expectedWorkspaceId,
     blockId: expectedBlockId,
   }, expectedProperties);
-  let expectedEvent =
+  const expectedEvent =
       sinon.match.instanceOf(instanceType).and(sinon.match(expectedProperties));
   sinon.assert.calledWith(spy, expectedEvent);
 }
@@ -430,7 +430,7 @@ function assertEventNotFired(spy, instanceType, expectedProperties,
   if (expectedBlockId !== undefined) {
     expectedProperties.blockId = expectedBlockId;
   }
-  let expectedEvent =
+  const expectedEvent =
       sinon.match.instanceOf(instanceType).and(sinon.match(expectedProperties));
   sinon.assert.neverCalledWith(spy, expectedEvent);
 }
@@ -444,8 +444,8 @@ exports.assertEventNotFired = assertEventNotFired;
  * @private
  */
 function splitByXmlProperties_(properties) {
-  let xmlProperties = {};
-  let nonXmlProperties = {};
+  const xmlProperties = {};
+  const nonXmlProperties = {};
   Object.keys(properties).forEach((key) => {
     if (isXmlProperty_(key)) {
       xmlProperties[key] = properties[key];
@@ -471,14 +471,14 @@ function splitByXmlProperties_(properties) {
  */
 function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
     expectedWorkspaceId, expectedBlockId) {
-  let nthCall = spy.getCall(n);
-  let splitProperties = splitByXmlProperties_(expectedProperties);
-  let nonXmlProperties = splitProperties[0];
-  let xmlProperties = splitProperties[1];
+  const nthCall = spy.getCall(n);
+  const splitProperties = splitByXmlProperties_(expectedProperties);
+  const nonXmlProperties = splitProperties[0];
+  const xmlProperties = splitProperties[1];
 
   assertEventFired(nthCall, instanceType, nonXmlProperties, expectedWorkspaceId,
       expectedBlockId);
-  let eventArg = nthCall.firstArg;
+  const eventArg = nthCall.firstArg;
   assertXmlProperties_(eventArg, xmlProperties);
 }
 exports.assertNthCallEventArgEquals = assertNthCallEventArgEquals;
@@ -568,7 +568,7 @@ function defineMutatorBlocks() {
     hasInput: false,
 
     mutationToDom: function() {
-      let mutation = Blockly.utils.xml.createElement('mutation');
+      const mutation = Blockly.utils.xml.createElement('mutation');
       mutation.setAttribute('hasInput', this.hasInput);
       return mutation;
     },
@@ -579,7 +579,7 @@ function defineMutatorBlocks() {
     },
 
     decompose: function(workspace) {
-      let topBlock = workspace.newBlock('checkbox_block', 'check_block');
+      const topBlock = workspace.newBlock('checkbox_block', 'check_block');
       topBlock.initSvg();
       topBlock.render();
       return topBlock;
@@ -613,7 +613,7 @@ function defineMutatorBlocks() {
     },
 
     decompose: function(workspace) {
-      let topBlock = workspace.newBlock('checkbox_block', 'check_block');
+      const topBlock = workspace.newBlock('checkbox_block', 'check_block');
       topBlock.initSvg();
       topBlock.render();
       return topBlock;
@@ -653,7 +653,7 @@ function createTestBlock() {
 exports.createTestBlock = createTestBlock;
 
 function createRenderedBlock(workspaceSvg, type) {
-  let block = workspaceSvg.newBlock(type);
+  const block = workspaceSvg.newBlock(type);
   block.initSvg();
   block.render();
   return block;
@@ -692,7 +692,7 @@ exports.dispatchPointerEvent = dispatchPointerEvent;
  * @return {!KeyboardEvent} The mocked keydown event.
  */
 function createKeyDownEvent(keyCode, modifiers) {
-  let event = {
+  const event = {
     keyCode: keyCode,
   };
   if (modifiers && modifiers.length > 0) {

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -68,37 +68,37 @@ suite('Theme', function() {
   }
 
   function stringifyAndCompare(val1, val2) {
-    let stringVal1 = JSON.stringify(val1);
-    let stringVal2 = JSON.stringify(val2);
+    const stringVal1 = JSON.stringify(val1);
+    const stringVal2 = JSON.stringify(val2);
     chai.assert.equal(stringVal1, stringVal2);
   }
 
   test('Set All BlockStyles', function() {
-    let theme = new Blockly.Theme('test', createBlockStyles());
+    const theme = new Blockly.Theme('test', createBlockStyles());
     stringifyAndCompare(createBlockStyles(), theme.blockStyles);
-    let blockStyles = createMultipleBlockStyles();
-    for (let key in blockStyles) {
+    const blockStyles = createMultipleBlockStyles();
+    for (const key in blockStyles) {
       theme.blockStyles[key] = blockStyles[key];
     }
     stringifyAndCompare(createMultipleBlockStyles(), theme.blockStyles);
   });
 
   test('Get All BlockStyles', function() {
-    let theme = new Blockly.Theme('test', createMultipleBlockStyles());
-    let allBlocks = theme.blockStyles;
+    const theme = new Blockly.Theme('test', createMultipleBlockStyles());
+    const allBlocks = theme.blockStyles;
     stringifyAndCompare(createMultipleBlockStyles(), allBlocks);
   });
 
   test('Get BlockStyles', function() {
-    let theme = new Blockly.Theme('test', createBlockStyles());
-    let blockStyle = theme.blockStyles['styleOne'];
+    const theme = new Blockly.Theme('test', createBlockStyles());
+    const blockStyle = theme.blockStyles['styleOne'];
 
     stringifyAndCompare(blockStyle, createBlockStyles().styleOne);
   });
 
   test('Set BlockStyle Update', function() {
-    let theme = new Blockly.Theme('test', createBlockStyles());
-    let blockStyle = createBlockStyles();
+    const theme = new Blockly.Theme('test', createBlockStyles());
+    const blockStyle = createBlockStyles();
     blockStyle.styleOne.colourPrimary = '#00ff00';
 
     theme.blockStyles['styleOne'] = blockStyle.styleOne;
@@ -107,8 +107,8 @@ suite('Theme', function() {
   });
 
   test('Set BlockStyle Add', function() {
-    let theme = new Blockly.Theme('test', createBlockStyles());
-    let blockStyle = createMultipleBlockStyles();
+    const theme = new Blockly.Theme('test', createBlockStyles());
+    const blockStyle = createMultipleBlockStyles();
 
     theme.blockStyles['styleTwo'] = blockStyle.styleTwo;
 
@@ -119,13 +119,13 @@ suite('Theme', function() {
     defineThemeTestBlocks();
     let workspace;
     try {
-      let blockStyles = createBlockStyles();
-      let theme = new Blockly.Theme('themeName', blockStyles);
+      const blockStyles = createBlockStyles();
+      const theme = new Blockly.Theme('themeName', blockStyles);
       workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
-      let blockA = workspace.newBlock('stack_block');
+      const blockA = workspace.newBlock('stack_block');
 
       blockA.setStyle = function() {this.styleName_ = 'styleTwo';};
-      let refreshToolboxSelectionStub =
+      const refreshToolboxSelectionStub =
           sinon.stub(workspace, 'refreshToolboxSelection');
       blockA.styleName_ = 'styleOne';
 
@@ -158,8 +158,8 @@ suite('Theme', function() {
     });
 
     test('Null', function() {
-      let inputStyle = null;
-      let expectedOutput = {
+      const inputStyle = null;
+      const expectedOutput = {
         "colourPrimary": "#000000",
         "colourSecondary": "#999999",
         "colourTertiary": "#4d4d4d",
@@ -170,8 +170,8 @@ suite('Theme', function() {
     });
 
     test('Empty', function() {
-      let inputStyle = {};
-      let expectedOutput = {
+      const inputStyle = {};
+      const expectedOutput = {
         "colourPrimary": "#000000",
         "colourSecondary": "#999999",
         "colourTertiary": "#4d4d4d",
@@ -182,10 +182,10 @@ suite('Theme', function() {
     });
 
     test('Incomplete hex', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "#012345"
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#012345",
         "colourSecondary": "#99a7b5",
         "colourTertiary": "#4d657d",
@@ -196,13 +196,13 @@ suite('Theme', function() {
     });
 
     test('Complete hex', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "#aaaaaa",
         "colourSecondary": "#bbbbbb",
         "colourTertiary": "#cccccc",
         "hat": 'cap'
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#aaaaaa",
         "colourSecondary": "#bbbbbb",
         "colourTertiary": "#cccccc",
@@ -213,12 +213,12 @@ suite('Theme', function() {
     });
 
     test('Complete hue', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "20",
         "colourSecondary": "40",
         "colourTertiary": "60",
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#a5745b",
         "colourSecondary": "#a58c5b",
         "colourTertiary": "#a5a55b",
@@ -229,10 +229,10 @@ suite('Theme', function() {
     });
 
     test('Incomplete hue', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "20",
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#a5745b",
         "colourSecondary": "#dbc7bd",
         "colourTertiary": "#c09e8c",
@@ -243,12 +243,12 @@ suite('Theme', function() {
     });
 
     test('Complete css colour name', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "red",
         "colourSecondary": "white",
         "colourTertiary": "blue"
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#ff0000",
         "colourSecondary": "#ffffff",
         "colourTertiary": "#0000ff",
@@ -259,10 +259,10 @@ suite('Theme', function() {
     });
 
     test('Incomplete css colour name', function() {
-      let inputStyle = {
+      const inputStyle = {
         "colourPrimary": "black",
       };
-      let expectedOutput = {
+      const expectedOutput = {
         "colourPrimary": "#000000",
         "colourSecondary": "#999999",
         "colourTertiary": "#4d4d4d",

--- a/tests/mocha/toolbox_helper.js
+++ b/tests/mocha/toolbox_helper.js
@@ -180,7 +180,7 @@ exports.getDeeplyNestedJSON = getDeeplyNestedJSON;
  * @return {Array<Node>} Array holding xml elements for a toolbox.
  */
 function getXmlArray() {
-  let block = Blockly.Xml.textToDom(
+  const block = Blockly.Xml.textToDom(
       `<block type="logic_compare">
         <field name="OP">NEQ</field>
         <value name="A">
@@ -194,9 +194,9 @@ function getXmlArray() {
           </block>
         </value>
       </block>`);
-  let separator = Blockly.Xml.textToDom('<sep gap="20"></sep>');
-  let button = Blockly.Xml.textToDom('<button text="insert" callbackkey="insertConnectionRows"></button>');
-  let label = Blockly.Xml.textToDom('<label text="tooltips"></label>');
+  const separator = Blockly.Xml.textToDom('<sep gap="20"></sep>');
+  const button = Blockly.Xml.textToDom('<button text="insert" callbackkey="insertConnectionRows"></button>');
+  const label = Blockly.Xml.textToDom('<label text="tooltips"></label>');
   return [block, separator, button, label];
 }
 exports.getXmlArray = getXmlArray;
@@ -214,8 +214,8 @@ function getInjectedToolbox() {
    * Category: NestedCategory
    *   Category: NestedItemOne
    */
-  let toolboxXml = document.getElementById('toolbox-test');
-  let workspace = Blockly.inject('blocklyDiv',
+  const toolboxXml = document.getElementById('toolbox-test');
+  const workspace = Blockly.inject('blocklyDiv',
       {
         toolbox: toolboxXml
       });
@@ -224,8 +224,8 @@ function getInjectedToolbox() {
 exports.getInjectedToolbox = getInjectedToolbox;
 
 function getBasicToolbox() {
-  let workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
-  let toolbox = new Blockly.Toolbox(workspace);
+  const workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
+  const toolbox = new Blockly.Toolbox(workspace);
   toolbox.HtmlDiv = document.createElement('div');
   toolbox.flyout_ = sinon.createStubInstance(Blockly.VerticalFlyout);
   return toolbox;
@@ -233,9 +233,9 @@ function getBasicToolbox() {
 exports.getBasicToolbox = getBasicToolbox;
 
 function getCollapsibleItem(toolbox) {
-  let contents = toolbox.contents_;
+  const contents = toolbox.contents_;
   for (let i = 0; i < contents.length; i++) {
-    let item = contents[i];
+    const item = contents[i];
     if (item.isCollapsible()) {
       return item;
     }
@@ -244,9 +244,9 @@ function getCollapsibleItem(toolbox) {
 exports.getCollapsibleItem = getCollapsibleItem;
 
 function getNonCollapsibleItem(toolbox) {
-  let contents = toolbox.contents_;
+  const contents = toolbox.contents_;
   for (let i = 0; i < contents.length; i++) {
-    let item = contents[i];
+    const item = contents[i];
     if (!item.isCollapsible()) {
       return item;
     }

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -33,14 +33,14 @@ suite('Toolbox', function() {
       chai.assert.isDefined(this.toolbox.HtmlDiv);
     });
     test('Init called -> HtmlDiv is inserted before parent node', function() {
-      let toolboxDiv = Blockly.getMainWorkspace().getInjectionDiv().childNodes[0];
+      const toolboxDiv = Blockly.getMainWorkspace().getInjectionDiv().childNodes[0];
       chai.assert.equal(toolboxDiv.className,
           'blocklyToolboxDiv blocklyNonSelectable');
     });
     test('Init called -> Toolbox is subscribed to background and foreground colour', function() {
-      let themeManager = this.toolbox.workspace_.getThemeManager();
-      let themeManagerSpy = sinon.spy(themeManager, 'subscribe');
-      let componentManager = this.toolbox.workspace_.getComponentManager();
+      const themeManager = this.toolbox.workspace_.getThemeManager();
+      const themeManagerSpy = sinon.spy(themeManager, 'subscribe');
+      const componentManager = this.toolbox.workspace_.getComponentManager();
       sinon.stub(componentManager, 'addComponent');
       this.toolbox.init();
       sinon.assert.calledWith(themeManagerSpy, this.toolbox.HtmlDiv,
@@ -49,14 +49,14 @@ suite('Toolbox', function() {
           'toolboxForegroundColour', 'color');
     });
     test('Init called -> Render is called', function() {
-      let renderSpy = sinon.spy(this.toolbox, 'render');
-      let componentManager = this.toolbox.workspace_.getComponentManager();
+      const renderSpy = sinon.spy(this.toolbox, 'render');
+      const componentManager = this.toolbox.workspace_.getComponentManager();
       sinon.stub(componentManager, 'addComponent');
       this.toolbox.init();
       sinon.assert.calledOnce(renderSpy);
     });
     test('Init called -> Flyout is initialized', function() {
-      let componentManager = this.toolbox.workspace_.getComponentManager();
+      const componentManager = this.toolbox.workspace_.getComponentManager();
       sinon.stub(componentManager, 'addComponent');
       this.toolbox.init();
       chai.assert.isDefined(this.toolbox.flyout_);
@@ -71,7 +71,7 @@ suite('Toolbox', function() {
       this.toolbox.dispose();
     });
     test('Render called with valid toolboxDef -> Contents are created', function() {
-      let positionStub = sinon.stub(this.toolbox, 'position');
+      const positionStub = sinon.stub(this.toolbox, 'position');
       this.toolbox.render({'contents': [
         {'kind': 'category', 'contents': []},
         {'kind': 'category', 'contents': []}
@@ -81,8 +81,8 @@ suite('Toolbox', function() {
     });
     // TODO: Uncomment once implemented.
     test.skip('Toolbox definition with both blocks and categories -> Should throw an error', function() {
-      let toolbox = this.toolbox;
-      let badToolboxDef = [
+      const toolbox = this.toolbox;
+      const badToolboxDef = [
         {
           "kind": "block"
         },
@@ -97,11 +97,11 @@ suite('Toolbox', function() {
     // TODO: Uncomment once implemented.
     test.skip('Expanded set to true for a non collapsible toolbox item -> Should open flyout', function() {
       this.toolbox.render(this.toolboxXml);
-      let selectedNode = this.toolbox.tree_.children_[0];
+      const selectedNode = this.toolbox.tree_.children_[0];
       chai.assert.isTrue(selectedNode.selected_);
     });
     test('JSON toolbox definition -> Should create toolbox with contents', function() {
-      let jsonDef = {'contents' : [
+      const jsonDef = {'contents' : [
         {
           "kind": "category",
           "contents": [
@@ -141,20 +141,20 @@ suite('Toolbox', function() {
     });
 
     test('Toolbox clicked -> Should close flyout', function() {
-      let hideChaffStub = sinon.stub(
+      const hideChaffStub = sinon.stub(
         Blockly.WorkspaceSvg.prototype, "hideChaff");
-      let evt = new MouseEvent('click', {});
+      const evt = new MouseEvent('click', {});
       this.toolbox.HtmlDiv.dispatchEvent(evt);
       sinon.assert.calledOnce(hideChaffStub);
     });
     test('Category clicked -> Should select category', function() {
-      let categoryXml = document.getElementsByClassName('blocklyTreeRow')[0];
-      let evt = {
+      const categoryXml = document.getElementsByClassName('blocklyTreeRow')[0];
+      const evt = {
         'target': categoryXml
       };
-      let item = this.toolbox.contentMap_[categoryXml.getAttribute('id')];
-      let setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');
-      let onClickSpy = sinon.spy(item, 'onClick');
+      const item = this.toolbox.contentMap_[categoryXml.getAttribute('id')];
+      const setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');
+      const onClickSpy = sinon.spy(item, 'onClick');
       this.toolbox.onClick_(evt);
       sinon.assert.calledOnce(setSelectedSpy);
       sinon.assert.calledOnce(onClickSpy);
@@ -177,9 +177,9 @@ suite('Toolbox', function() {
     }
 
     function testCorrectFunctionCalled(toolbox, keyCode, funcName) {
-      let event = createKeyDownMock(keyCode);
-      let preventDefaultEvent = sinon.stub(event, 'preventDefault');
-      let selectMethodStub = sinon.stub(toolbox, funcName);
+      const event = createKeyDownMock(keyCode);
+      const preventDefaultEvent = sinon.stub(event, 'preventDefault');
+      const selectMethodStub = sinon.stub(toolbox, funcName);
       selectMethodStub.returns(true);
       toolbox.onKeyDown_(event);
       sinon.assert.called(selectMethodStub);
@@ -200,17 +200,17 @@ suite('Toolbox', function() {
     });
     test('Enter button is pushed -> Should toggle expandedd', function() {
       this.toolbox.selectedItem_ = getCollapsibleItem(this.toolbox);
-      let toggleExpandedStub = sinon.stub(this.toolbox.selectedItem_, 'toggleExpanded');
-      let event = createKeyDownMock(Blockly.utils.KeyCodes.ENTER);
-      let preventDefaultEvent = sinon.stub(event, 'preventDefault');
+      const toggleExpandedStub = sinon.stub(this.toolbox.selectedItem_, 'toggleExpanded');
+      const event = createKeyDownMock(Blockly.utils.KeyCodes.ENTER);
+      const preventDefaultEvent = sinon.stub(event, 'preventDefault');
       this.toolbox.onKeyDown_(event);
       sinon.assert.called(toggleExpandedStub);
       sinon.assert.called(preventDefaultEvent);
     });
     test('Enter button is pushed when no item is selected -> Should not call prevent default', function() {
       this.toolbox.selectedItem_ = null;
-      let event = createKeyDownMock(Blockly.utils.KeyCodes.ENTER);
-      let preventDefaultEvent = sinon.stub(event, 'preventDefault');
+      const event = createKeyDownMock(Blockly.utils.KeyCodes.ENTER);
+      const preventDefaultEvent = sinon.stub(event, 'preventDefault');
       this.toolbox.onKeyDown_(event);
       sinon.assert.notCalled(preventDefaultEvent);
     });
@@ -227,29 +227,29 @@ suite('Toolbox', function() {
     suite('selectChild_', function() {
       test('No item is selected -> Should not handle event', function() {
         this.toolbox.selectedItem_ = null;
-        let handled = this.toolbox.selectChild_();
+        const handled = this.toolbox.selectChild_();
         chai.assert.isFalse(handled);
       });
       test('Selected item is not collapsible -> Should not handle event', function() {
         this.toolbox.selectedItem_ = getNonCollapsibleItem(this.toolbox);
-        let handled = this.toolbox.selectChild_();
+        const handled = this.toolbox.selectChild_();
         chai.assert.isFalse(handled);
       });
       test('Selected item is collapsible -> Should expand', function() {
-        let collapsibleItem = getCollapsibleItem(this.toolbox);
+        const collapsibleItem = getCollapsibleItem(this.toolbox);
         this.toolbox.selectedItem_ = collapsibleItem;
-        let handled = this.toolbox.selectChild_();
+        const handled = this.toolbox.selectChild_();
         chai.assert.isTrue(handled);
         chai.assert.isTrue(collapsibleItem.isExpanded());
         chai.assert.equal(this.toolbox.selectedItem_, collapsibleItem);
       });
 
       test('Selected item is expanded -> Should select child', function() {
-        let collapsibleItem = getCollapsibleItem(this.toolbox);
+        const collapsibleItem = getCollapsibleItem(this.toolbox);
         collapsibleItem.expanded_ = true;
-        let selectNextStub = sinon.stub(this.toolbox, 'selectNext_');
+        const selectNextStub = sinon.stub(this.toolbox, 'selectNext_');
         this.toolbox.selectedItem_ = collapsibleItem;
-        let handled = this.toolbox.selectChild_();
+        const handled = this.toolbox.selectChild_();
         chai.assert.isTrue(handled);
         sinon.assert.called(selectNextStub);
       });
@@ -258,22 +258,22 @@ suite('Toolbox', function() {
     suite('selectParent_', function() {
       test('No item selected -> Should not handle event', function() {
         this.toolbox.selectedItem_ = null;
-        let handled = this.toolbox.selectParent_();
+        const handled = this.toolbox.selectParent_();
         chai.assert.isFalse(handled);
       });
       test('Selected item is expanded -> Should collapse', function() {
-        let collapsibleItem = getCollapsibleItem(this.toolbox);
+        const collapsibleItem = getCollapsibleItem(this.toolbox);
         collapsibleItem.expanded_ = true;
         this.toolbox.selectedItem_ = collapsibleItem;
-        let handled = this.toolbox.selectParent_();
+        const handled = this.toolbox.selectParent_();
         chai.assert.isTrue(handled);
         chai.assert.isFalse(collapsibleItem.isExpanded());
         chai.assert.equal(this.toolbox.selectedItem_, collapsibleItem);
       });
       test('Selected item is not expanded -> Should get parent', function() {
-        let childItem = getChildItem(this.toolbox);
+        const childItem = getChildItem(this.toolbox);
         this.toolbox.selectedItem_ = childItem;
-        let handled = this.toolbox.selectParent_();
+        const handled = this.toolbox.selectParent_();
         chai.assert.isTrue(handled);
         chai.assert.equal(this.toolbox.selectedItem_, childItem.getParent());
       });
@@ -282,29 +282,29 @@ suite('Toolbox', function() {
     suite('selectNext_', function() {
       test('No item is selected -> Should not handle event', function() {
         this.toolbox.selectedItem_ = null;
-        let handled = this.toolbox.selectNext_();
+        const handled = this.toolbox.selectNext_();
         chai.assert.isFalse(handled);
       });
       test('Next item is selectable -> Should select next item', function() {
-        let item = this.toolbox.contents_[0];
+        const item = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectNext_();
+        const handled = this.toolbox.selectNext_();
         chai.assert.isTrue(handled);
         chai.assert.equal(this.toolbox.selectedItem_, this.toolbox.contents_[1]);
       });
       test('Selected item is last item -> Should not handle event', function() {
-        let item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
+        const item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectNext_();
+        const handled = this.toolbox.selectNext_();
         chai.assert.isFalse(handled);
         chai.assert.equal(this.toolbox.selectedItem_, item);
       });
       test('Selected item is collapsed -> Should skip over its children', function() {
-        let item = getCollapsibleItem(this.toolbox);
-        let childItem = item.flyoutItems_[0];
+        const item = getCollapsibleItem(this.toolbox);
+        const childItem = item.flyoutItems_[0];
         item.expanded_ = false;
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectNext_();
+        const handled = this.toolbox.selectNext_();
         chai.assert.isTrue(handled);
         chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
       });
@@ -313,32 +313,32 @@ suite('Toolbox', function() {
     suite('selectPrevious', function() {
       test('No item is selected -> Should not handle event', function() {
         this.toolbox.selectedItem_ = null;
-        let handled = this.toolbox.selectPrevious_();
+        const handled = this.toolbox.selectPrevious_();
         chai.assert.isFalse(handled);
       });
       test('Selected item is first item -> Should not handle event', function() {
-        let item = this.toolbox.contents_[0];
+        const item = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectPrevious_();
+        const handled = this.toolbox.selectPrevious_();
         chai.assert.isFalse(handled);
         chai.assert.equal(this.toolbox.selectedItem_, item);
       });
       test('Previous item is selectable -> Should select previous item', function() {
-        let item = this.toolbox.contents_[1];
-        let prevItem = this.toolbox.contents_[0];
+        const item = this.toolbox.contents_[1];
+        const prevItem = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectPrevious_();
+        const handled = this.toolbox.selectPrevious_();
         chai.assert.isTrue(handled);
         chai.assert.equal(this.toolbox.selectedItem_, prevItem);
       });
       test('Previous item is collapsed -> Should skip over children of the previous item', function() {
-        let childItem = getChildItem(this.toolbox);
-        let parentItem = childItem.getParent();
-        let parentIdx = this.toolbox.contents_.indexOf(parentItem);
+        const childItem = getChildItem(this.toolbox);
+        const parentItem = childItem.getParent();
+        const parentIdx = this.toolbox.contents_.indexOf(parentItem);
         // Gets the item after the parent.
-        let item = this.toolbox.contents_[parentIdx + 1];
+        const item = this.toolbox.contents_[parentIdx + 1];
         this.toolbox.selectedItem_ = item;
-        let handled = this.toolbox.selectPrevious_();
+        const handled = this.toolbox.selectPrevious_();
         chai.assert.isTrue(handled);
         chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
       });
@@ -355,7 +355,7 @@ suite('Toolbox', function() {
 
     function setupSetSelected(toolbox, oldItem, newItem) {
       toolbox.selectedItem_ = oldItem;
-      let newItemStub = sinon.stub(newItem, 'setSelected');
+      const newItemStub = sinon.stub(newItem, 'setSelected');
       toolbox.setSelectedItem(newItem);
       return newItemStub;
     }
@@ -363,36 +363,36 @@ suite('Toolbox', function() {
     test('Selected item and new item are null -> Should not update the flyout', function() {
       this.selectedItem_ = null;
       this.toolbox.setSelectedItem(null);
-      let updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
+      const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
       sinon.assert.notCalled(updateFlyoutStub);
     });
     test('New item is not selectable -> Should not update the flyout', function() {
-      let separator = getSeparator(this.toolbox);
+      const separator = getSeparator(this.toolbox);
       this.toolbox.setSelectedItem(separator);
-      let updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
+      const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
       sinon.assert.notCalled(updateFlyoutStub);
     });
     test('Select an item with no children -> Should select item', function() {
-      let oldItem = getCollapsibleItem(this.toolbox);
-      let oldItemStub = sinon.stub(oldItem, 'setSelected');
-      let newItem = getNonCollapsibleItem(this.toolbox);
-      let newItemStub = setupSetSelected(this.toolbox, oldItem, newItem);
+      const oldItem = getCollapsibleItem(this.toolbox);
+      const oldItemStub = sinon.stub(oldItem, 'setSelected');
+      const newItem = getNonCollapsibleItem(this.toolbox);
+      const newItemStub = setupSetSelected(this.toolbox, oldItem, newItem);
       sinon.assert.calledWith(oldItemStub, false);
       sinon.assert.calledWith(newItemStub, true);
     });
     test('Select previously selected item with no children -> Should deselect', function() {
-      let newItem = getNonCollapsibleItem(this.toolbox);
-      let newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
+      const newItem = getNonCollapsibleItem(this.toolbox);
+      const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
       sinon.assert.calledWith(newItemStub, false);
     });
     test('Select collapsible item -> Should select item', function() {
-      let newItem = getCollapsibleItem(this.toolbox);
-      let newItemStub = setupSetSelected(this.toolbox, null, newItem);
+      const newItem = getCollapsibleItem(this.toolbox);
+      const newItemStub = setupSetSelected(this.toolbox, null, newItem);
       sinon.assert.calledWith(newItemStub, true);
     });
     test('Select previously selected collapsible item -> Should not deselect', function() {
-      let newItem = getCollapsibleItem(this.toolbox);
-      let newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
+      const newItem = getCollapsibleItem(this.toolbox);
+      const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
       sinon.assert.notCalled(newItemStub);
     });
   });
@@ -406,30 +406,30 @@ suite('Toolbox', function() {
     });
 
     function testHideFlyout(toolbox, oldItem, newItem) {
-      let updateFlyoutStub = sinon.stub(toolbox.flyout_, 'hide');
+      const updateFlyoutStub = sinon.stub(toolbox.flyout_, 'hide');
       toolbox.updateFlyout_(oldItem, newItem);
       sinon.assert.called(updateFlyoutStub);
     }
 
     test('Select previously selected item -> Should close flyout', function() {
-      let newItem = getNonCollapsibleItem(this.toolbox);
+      const newItem = getNonCollapsibleItem(this.toolbox);
       testHideFlyout(this.toolbox, newItem, newItem);
     });
     test('No new item -> Should close flyout', function() {
       testHideFlyout(this.toolbox, null, null);
     });
     test('Old item but no new item -> Should close flyout', function() {
-      let oldItem = getNonCollapsibleItem(this.toolbox);
+      const oldItem = getNonCollapsibleItem(this.toolbox);
       testHideFlyout(this.toolbox, oldItem, null);
     });
     test('Select collapsible item -> Should close flyout', function() {
-      let newItem = getCollapsibleItem(this.toolbox);
+      const newItem = getCollapsibleItem(this.toolbox);
       testHideFlyout(this.toolbox, null, newItem);
     });
     test('Select selectable item -> Should open flyout', function() {
-      let showFlyoutstub = sinon.stub(this.toolbox.flyout_, 'show');
-      let scrollToStartFlyout = sinon.stub(this.toolbox.flyout_, 'scrollToStart');
-      let newItem = getNonCollapsibleItem(this.toolbox);
+      const showFlyoutstub = sinon.stub(this.toolbox.flyout_, 'show');
+      const scrollToStartFlyout = sinon.stub(this.toolbox.flyout_, 'scrollToStart');
+      const newItem = getNonCollapsibleItem(this.toolbox);
       this.toolbox.updateFlyout_(null, newItem);
       sinon.assert.called(showFlyoutstub);
       sinon.assert.called(scrollToStartFlyout);
@@ -439,7 +439,7 @@ suite('Toolbox', function() {
   suite('position', function() {
     setup(function() {
       this.toolbox = getBasicToolbox();
-      let metricsStub = sinon.stub(this.toolbox.workspace_, 'getMetrics');
+      const metricsStub = sinon.stub(this.toolbox.workspace_, 'getMetrics');
       metricsStub.returns({});
     });
 
@@ -454,14 +454,14 @@ suite('Toolbox', function() {
       chai.assert.equal(toolbox.width_, toolbox.HtmlDiv.offsetWidth, 'Check width');
     }
     test('HtmlDiv is not created -> Should not resize', function() {
-      let toolbox = this.toolbox;
+      const toolbox = this.toolbox;
       toolbox.HtmlDiv = null;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       chai.assert.equal(toolbox.height_, 0);
     });
     test('Horizontal toolbox at top -> Should anchor horizontal toolbox to top', function() {
-      let toolbox = this.toolbox;
+      const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.TOP;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
@@ -469,7 +469,7 @@ suite('Toolbox', function() {
       chai.assert.equal(toolbox.HtmlDiv.style.top, '0px', 'Check top');
     });
     test('Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom', function() {
-      let toolbox = this.toolbox;
+      const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.BOTTOM;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
@@ -477,7 +477,7 @@ suite('Toolbox', function() {
       chai.assert.equal(toolbox.HtmlDiv.style.bottom, '0px', 'Check bottom');
     });
     test('Vertical toolbox at right -> Should anchor to right', function() {
-      let toolbox = this.toolbox;
+      const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.RIGHT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
@@ -485,7 +485,7 @@ suite('Toolbox', function() {
       checkVerticalToolbox(toolbox);
     });
     test('Vertical toolbox at left -> Should anchor to left', function() {
-      let toolbox = this.toolbox;
+      const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.LEFT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
@@ -501,8 +501,8 @@ suite('Toolbox', function() {
     });
 
     function checkValue(actual, expected, value) {
-      let actualVal = actual[value];
-      let expectedVal = expected[value];
+      const actualVal = actual[value];
+      const expectedVal = expected[value];
       chai.assert.equal(actualVal.toUpperCase(), expectedVal.toUpperCase(), 'Checking value for: ' + value);
     }
     function checkContents(actualContents, expectedContents) {
@@ -519,8 +519,8 @@ suite('Toolbox', function() {
       checkContents(actual.contents, expected.contents);
     }
     function checkCategoryToolbox(actual, expected) {
-      let actualContents = actual['contents'];
-      let expectedContents = expected['contents'];
+      const actualContents = actual['contents'];
+      const expectedContents = expected['contents'];
       chai.assert.equal(actualContents.length, expectedContents.length);
       for (let i = 0; i < expected.length; i++) {
         checkCategory(actualContents[i], expected[i]);
@@ -532,24 +532,24 @@ suite('Toolbox', function() {
 
     suite('parseToolbox', function() {
       test('Category Toolbox: JSON', function() {
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.categoryToolboxJSON);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.categoryToolboxJSON);
         chai.assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: JSON', function() {
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.simpleToolboxJSON);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.simpleToolboxJSON);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
       test('Category Toolbox: xml', function() {
-        let toolboxXml = document.getElementById('toolbox-categories');
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
+        const toolboxXml = document.getElementById('toolbox-categories');
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
         chai.assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: xml', function() {
-        let toolboxXml = document.getElementById('toolbox-simple');
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
+        const toolboxXml = document.getElementById('toolbox-simple');
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
@@ -559,7 +559,7 @@ suite('Toolbox', function() {
         toolbox += '  <block type="controls_whileUntil"></block>';
         toolbox += '</xml>';
 
-        let toolboxJson = {
+        const toolboxJson = {
           'contents': [
             {
               'kind': 'block',
@@ -572,7 +572,7 @@ suite('Toolbox', function() {
           ]
         };
 
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
@@ -582,7 +582,7 @@ suite('Toolbox', function() {
         toolbox += '  <category name="b"></category>';
         toolbox += '</xml>';
 
-        let toolboxJson = {
+        const toolboxJson = {
           'contents': [
             {
               'kind': 'category',
@@ -595,29 +595,29 @@ suite('Toolbox', function() {
           ]
         };
 
-        let toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
     });
     suite('parseFlyout', function() {
       test('Array of Nodes', function() {
-        let xmlList = getXmlArray();
-        let flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(xmlList);
+        const xmlList = getXmlArray();
+        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(xmlList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('NodeList', function() {
-        let nodeList = document.getElementById('toolbox-simple').childNodes;
-        let flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(nodeList);
+        const nodeList = document.getElementById('toolbox-simple').childNodes;
+        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(nodeList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('List of json', function() {
-        let jsonList = this.simpleToolboxJSON['contents'];
-        let flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(jsonList);
+        const jsonList = this.simpleToolboxJSON['contents'];
+        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(jsonList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('Json', function() {
-        let flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(this.simpleToolboxJSON);
+        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(this.simpleToolboxJSON);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
     });
@@ -631,9 +631,9 @@ suite('Toolbox', function() {
     });
     test('Child categories visible if all ancestors expanded', function() {
       this.toolbox.render(getDeeplyNestedJSON());
-      let outerCategory = this.toolbox.contents_[0];
-      let middleCategory = this.toolbox.contents_[1];
-      let innerCategory = this.toolbox.contents_[2];
+      const outerCategory = this.toolbox.contents_[0];
+      const middleCategory = this.toolbox.contents_[1];
+      const innerCategory = this.toolbox.contents_[2];
 
       outerCategory.toggleExpanded();
       middleCategory.toggleExpanded();
@@ -644,8 +644,8 @@ suite('Toolbox', function() {
     });
     test('Child categories not visible if any ancestor not expanded', function() {
       this.toolbox.render(getDeeplyNestedJSON());
-      let middleCategory = this.toolbox.contents_[1];
-      let innerCategory = this.toolbox.contents_[2];
+      const middleCategory = this.toolbox.contents_[1];
+      const innerCategory = this.toolbox.contents_[2];
 
       // Don't expand the outermost category
       // Even though the direct parent of inner is expanded, it shouldn't be visible

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -40,7 +40,7 @@ suite('Tooltip', function() {
       delete Blockly.Blocks["test_block"];
     });
 
-    let tooltipText = 'testTooltip';
+    const tooltipText = 'testTooltip';
 
     function assertTooltip(obj) {
       chai.assert.equal(obj.getTooltip(), tooltipText);

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -16,12 +16,12 @@ suite("Trashcan", function() {
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         xmlString + '</xml>');
     xml = xml.children[0];
-    let block = Blockly.Xml.domToBlock(xml, workspace);
-    let event = new Blockly.Events.BlockDelete(block);
+    const block = Blockly.Xml.domToBlock(xml, workspace);
+    const event = new Blockly.Events.BlockDelete(block);
     eventUtils.fire(event);
   }
   function fireNonDeleteEvent(workspace, oldXml) {
-    let event = new Blockly.Events.Abstract();
+    const event = new Blockly.Events.Abstract();
     event.type = 'test_field_block';
     event.workspaceId = workspace.id;
     if (oldXml) {
@@ -86,7 +86,7 @@ suite("Trashcan", function() {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
       chai.assert.equal(this.trashcan.contents_.length, 1);
       // Stub flyout interaction.
-      let showFlyoutStub = sinon.stub(this.trashcan.flyout, "show");
+      const showFlyoutStub = sinon.stub(this.trashcan.flyout, "show");
 
       simulateClick(this.trashcan.svgGroup_);
 
@@ -101,7 +101,7 @@ suite("Trashcan", function() {
     test("Click outside trashcan - fires trashcanClose", function() {
       sinon.stub(this.trashcan.flyout, 'isVisible').returns(true);
       // Stub flyout interaction.
-      let hideFlyoutStub = sinon.stub(this.trashcan.flyout, "hide");
+      const hideFlyoutStub = sinon.stub(this.trashcan.flyout, "hide");
 
       simulateClick(this.workspace.svgGroup_);
 

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -18,10 +18,10 @@ suite('Utils', function() {
   });
 
   test('genUid', function() {
-    let uuids = {};
+    const uuids = {};
     chai.assert.equal([1, 2, 3].indexOf(4), -1);
     for (let i = 0; i < 1000; i++) {
-      let uuid = Blockly.utils.idGenerator.genUid();
+      const uuid = Blockly.utils.idGenerator.genUid();
       chai.assert.isFalse(uuid in uuids, 'UUID different: ' + uuid);
       uuids[uuid] = true;
     }
@@ -229,7 +229,7 @@ suite('Utils', function() {
   });
 
   test('arrayRemove', function() {
-    let arr = [1, 2, 3, 2];
+    const arr = [1, 2, 3, 2];
     chai.assert.isFalse(Blockly.utils.arrayRemove(arr, 0), 'Remove Not found');
     chai.assert.equal(arr.join(','), '1,2,3,2', 'Remove Not found result');
     chai.assert.isTrue(Blockly.utils.arrayRemove(arr, 2), 'Remove item');
@@ -239,7 +239,7 @@ suite('Utils', function() {
   });
 
   test('XY_REGEX_', function() {
-    let regex = Blockly.utils.getRelativeXY.XY_REGEX_;
+    const regex = Blockly.utils.getRelativeXY.XY_REGEX_;
     let m;
     m = 'INVALID'.match(regex);
     chai.assert.isNull(m);
@@ -266,7 +266,7 @@ suite('Utils', function() {
   });
 
   test('XY_STYLE_REGEX_', function() {
-    let regex = Blockly.utils.getRelativeXY.XY_STYLE_REGEX_;
+    const regex = Blockly.utils.getRelativeXY.XY_STYLE_REGEX_;
     let m;
     m = 'INVALID'.match(regex);
     chai.assert.isNull(m);
@@ -314,7 +314,7 @@ suite('Utils', function() {
 
   suite('DOM', function() {
     test('addClass', function() {
-      let p = document.createElement('p');
+      const p = document.createElement('p');
       Blockly.utils.dom.addClass(p, 'one');
       chai.assert.equal(p.className, 'one', 'Adding "one"');
       Blockly.utils.dom.addClass(p, 'one');
@@ -328,7 +328,7 @@ suite('Utils', function() {
     });
 
     test('hasClass', function() {
-      let p = document.createElement('p');
+      const p = document.createElement('p');
       p.className = ' one three  two three  ';
       chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'one'), 'Has "one"');
       chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'two'), 'Has "two"');
@@ -338,7 +338,7 @@ suite('Utils', function() {
     });
 
     test('removeClass', function() {
-      let p = document.createElement('p');
+      const p = document.createElement('p');
       p.className = ' one three  two three  ';
       Blockly.utils.dom.removeClass(p, 'two');
       chai.assert.equal(p.className, 'one three three', 'Removing "two"');
@@ -419,7 +419,7 @@ suite('Utils', function() {
 
   suite('Math', function() {
     test('toRadians', function() {
-      let quarter = Math.PI / 2;
+      const quarter = Math.PI / 2;
       chai.assert.equal(Blockly.utils.math.toRadians(-90), -quarter, '-90');
       chai.assert.equal(Blockly.utils.math.toRadians(0), 0, '0');
       chai.assert.equal(Blockly.utils.math.toRadians(90), quarter, '90');
@@ -430,7 +430,7 @@ suite('Utils', function() {
     });
 
     test('toDegrees', function() {
-      let quarter = Math.PI / 2;
+      const quarter = Math.PI / 2;
       chai.assert.equal(Blockly.utils.math.toDegrees(-quarter), -90, '-90');
       chai.assert.equal(Blockly.utils.math.toDegrees(0), 0, '0');
       chai.assert.equal(Blockly.utils.math.toDegrees(quarter), 90, '90');

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -53,7 +53,7 @@ suite('Variable Map', function() {
       // Assert there is only one variable in the this.variableMap.
       let keys = Object.keys(this.variableMap.variableMap_);
       chai.assert.equal(keys.length, 1);
-      let varMapLength = this.variableMap.variableMap_[keys[0]].length;
+      const varMapLength = this.variableMap.variableMap_[keys[0]].length;
       chai.assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type2', 'id2');
@@ -105,7 +105,7 @@ suite('Variable Map', function() {
     suite('Error cases', function() {
       test('Id already exists', function() {
         this.variableMap.createVariable('name1', 'type1', 'id1');
-        let variableMap = this.variableMap;
+        const variableMap = this.variableMap;
         chai.assert.throws(function() {
           variableMap.createVariable('name2', 'type2', 'id1');
         }, /"id1".*in use/);
@@ -114,7 +114,7 @@ suite('Variable Map', function() {
 
       test('Mismatched id', function() {
         this.variableMap.createVariable('name1', 'type1', 'id1');
-        let variableMap = this.variableMap;
+        const variableMap = this.variableMap;
         chai.assert.throws(function() {
           variableMap.createVariable('name1', 'type1', 'id2');
         }, /"name1".*in use/);
@@ -123,7 +123,7 @@ suite('Variable Map', function() {
 
       test('Mismatched type', function() {
         this.variableMap.createVariable('name1', 'type1', 'id1');
-        let variableMap = this.variableMap;
+        const variableMap = this.variableMap;
         chai.assert.throws(function() {
           variableMap.createVariable('name1', 'type2', 'id1');
         });
@@ -135,12 +135,12 @@ suite('Variable Map', function() {
 
   suite('getVariable', function() {
     test('By name and type', function() {
-      let var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
-      let var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
-      let var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
-      let result1 = this.variableMap.getVariable('name1', 'type1');
-      let result2 = this.variableMap.getVariable('name2', 'type1');
-      let result3 = this.variableMap.getVariable('name3', 'type2');
+      const var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
+      const var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
+      const var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
+      const result1 = this.variableMap.getVariable('name1', 'type1');
+      const result2 = this.variableMap.getVariable('name2', 'type1');
+      const result3 = this.variableMap.getVariable('name3', 'type2');
 
       // Searching by name + type is correct.
       chai.assert.equal(result1, var1);
@@ -154,19 +154,19 @@ suite('Variable Map', function() {
     });
 
     test('Not found', function() {
-      let result = this.variableMap.getVariable('name1');
+      const result = this.variableMap.getVariable('name1');
       chai.assert.isNull(result);
     });
   });
 
   suite('getVariableById', function() {
     test('Trivial', function() {
-      let var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
-      let var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
-      let var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
-      let result1 = this.variableMap.getVariableById('id1');
-      let result2 = this.variableMap.getVariableById('id2');
-      let result3 = this.variableMap.getVariableById('id3');
+      const var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
+      const var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
+      const var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
+      const result1 = this.variableMap.getVariableById('id1');
+      const result2 = this.variableMap.getVariableById('id2');
+      const result3 = this.variableMap.getVariableById('id3');
 
       chai.assert.equal(result1, var1);
       chai.assert.equal(result2, var2);
@@ -174,7 +174,7 @@ suite('Variable Map', function() {
     });
 
     test('Not found', function() {
-      let result = this.variableMap.getVariableById('id1');
+      const result = this.variableMap.getVariableById('id1');
       chai.assert.isNull(result);
     });
   });
@@ -185,70 +185,70 @@ suite('Variable Map', function() {
       this.variableMap.createVariable('name2', 'type1', 'id2');
       this.variableMap.createVariable('name3', 'type2', 'id3');
       this.variableMap.createVariable('name4', 'type3', 'id4');
-      let resultArray = this.variableMap.getVariableTypes();
+      const resultArray = this.variableMap.getVariableTypes();
       // The empty string is always an option.
       chai.assert.deepEqual(resultArray, ['type1', 'type2', 'type3', '']);
     });
 
     test('None', function() {
       // The empty string is always an option.
-      let resultArray = this.variableMap.getVariableTypes();
+      const resultArray = this.variableMap.getVariableTypes();
       chai.assert.deepEqual(resultArray, ['']);
     });
   });
 
   suite('getVariablesOfType', function() {
     test('Trivial', function() {
-      let var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
-      let var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
+      const var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
+      const var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
       this.variableMap.createVariable('name3', 'type2', 'id3');
       this.variableMap.createVariable('name4', 'type3', 'id4');
-      let resultArray1 = this.variableMap.getVariablesOfType('type1');
-      let resultArray2 = this.variableMap.getVariablesOfType('type5');
+      const resultArray1 = this.variableMap.getVariablesOfType('type1');
+      const resultArray2 = this.variableMap.getVariablesOfType('type5');
       chai.assert.deepEqual(resultArray1, [var1, var2]);
       chai.assert.deepEqual(resultArray2, []);
     });
 
     test('Null', function() {
-      let var1 = this.variableMap.createVariable('name1', '', 'id1');
-      let var2 = this.variableMap.createVariable('name2', '', 'id2');
-      let var3 = this.variableMap.createVariable('name3', '', 'id3');
+      const var1 = this.variableMap.createVariable('name1', '', 'id1');
+      const var2 = this.variableMap.createVariable('name2', '', 'id2');
+      const var3 = this.variableMap.createVariable('name3', '', 'id3');
       this.variableMap.createVariable('name4', 'type1', 'id4');
-      let resultArray = this.variableMap.getVariablesOfType(null);
+      const resultArray = this.variableMap.getVariablesOfType(null);
       chai.assert.deepEqual(resultArray, [var1, var2, var3]);
     });
 
     test('Empty string', function() {
-      let var1 = this.variableMap.createVariable('name1', null, 'id1');
-      let var2 = this.variableMap.createVariable('name2', null, 'id2');
-      let resultArray = this.variableMap.getVariablesOfType('');
+      const var1 = this.variableMap.createVariable('name1', null, 'id1');
+      const var2 = this.variableMap.createVariable('name2', null, 'id2');
+      const resultArray = this.variableMap.getVariablesOfType('');
       chai.assert.deepEqual(resultArray, [var1, var2]);
     });
 
     test('Deleted', function() {
-      let variable = this.variableMap.createVariable('name1', null, 'id1');
+      const variable = this.variableMap.createVariable('name1', null, 'id1');
       this.variableMap.deleteVariable(variable);
-      let resultArray = this.variableMap.getVariablesOfType('');
+      const resultArray = this.variableMap.getVariablesOfType('');
       chai.assert.deepEqual(resultArray, []);
     });
 
     test('Does not exist', function() {
-      let resultArray = this.variableMap.getVariablesOfType('type1');
+      const resultArray = this.variableMap.getVariablesOfType('type1');
       chai.assert.deepEqual(resultArray, []);
     });
   });
 
   suite('getAllVariables', function() {
     test('Trivial', function() {
-      let var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
-      let var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
-      let var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
-      let resultArray = this.variableMap.getAllVariables();
+      const var1 = this.variableMap.createVariable('name1', 'type1', 'id1');
+      const var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
+      const var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
+      const resultArray = this.variableMap.getAllVariables();
       chai.assert.deepEqual(resultArray, [var1, var2, var3]);
     });
 
     test('None', function() {
-      let resultArray = this.variableMap.getAllVariables();
+      const resultArray = this.variableMap.getAllVariables();
       chai.assert.deepEqual(resultArray, []);
     });
   });

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -20,7 +20,7 @@ suite('Variable Model', function() {
   });
 
   test('Trivial', function() {
-    let variable = new Blockly.VariableModel(
+    const variable = new Blockly.VariableModel(
         this.workspace, 'test', 'test_type', 'test_id');
     chai.assert.equal(variable.name, 'test');
     chai.assert.equal(variable.type, 'test_type');
@@ -28,19 +28,19 @@ suite('Variable Model', function() {
   });
 
   test('Null type', function() {
-    let variable = new Blockly.VariableModel(
+    const variable = new Blockly.VariableModel(
         this.workspace, 'test', null, 'test_id');
     chai.assert.equal(variable.type, '');
   });
 
   test('Undefined type', function() {
-    let variable = new Blockly.VariableModel(
+    const variable = new Blockly.VariableModel(
         this.workspace, 'test', undefined, 'test_id');
     chai.assert.equal(variable.type, '');
   });
 
   test('Null id', function() {
-    let variable = new Blockly.VariableModel(
+    const variable = new Blockly.VariableModel(
         this.workspace, 'test', 'test_type', null);
     chai.assert.equal(variable.name, 'test');
     chai.assert.equal(variable.type, 'test_type');
@@ -48,7 +48,7 @@ suite('Variable Model', function() {
   });
 
   test('Undefined id', function() {
-    let variable = new Blockly.VariableModel(
+    const variable = new Blockly.VariableModel(
         this.workspace, 'test', 'test_type', undefined);
     chai.assert.equal(variable.name, 'test');
     chai.assert.equal(variable.type, 'test_type');
@@ -56,7 +56,7 @@ suite('Variable Model', function() {
   });
 
   test('Only name provided', function() {
-    let variable = new Blockly.VariableModel(this.workspace, 'test');
+    const variable = new Blockly.VariableModel(this.workspace, 'test');
     chai.assert.equal(variable.name, 'test');
     chai.assert.equal(variable.type, '');
     chai.assert.exists(variable.id_);

--- a/tests/mocha/variables_test.js
+++ b/tests/mocha/variables_test.js
@@ -44,7 +44,7 @@ suite('Variables', function() {
   function createTestVarBlock(workspace, variable_id) {
     // Turn off events to avoid testing XML at the same time.
     Blockly.Events.disable();
-    let block = new Blockly.Block(workspace, 'get_var_block');
+    const block = new Blockly.Block(workspace, 'get_var_block');
     block.inputList[0].fieldRow[0].setValue(variable_id);
     Blockly.Events.enable();
     return block;
@@ -56,7 +56,7 @@ suite('Variables', function() {
       createTestVarBlock(this.workspace, '2');
       createTestVarBlock(this.workspace, '3');
 
-      let result = Blockly.Variables.allUsedVarModels(this.workspace);
+      const result = Blockly.Variables.allUsedVarModels(this.workspace);
       chai.assert.equal(result.length, 3,
           'Expected three variables in the list of used variables');
     });
@@ -64,7 +64,7 @@ suite('Variables', function() {
     test('Some unused', function() {
       createTestVarBlock(this.workspace, '2');
 
-      let result = Blockly.Variables.allUsedVarModels(this.workspace);
+      const result = Blockly.Variables.allUsedVarModels(this.workspace);
       chai.assert.equal(result.length, 1,
           'Expected one variable in the list of used variables');
       chai.assert.equal(result[0].getId(), '2',
@@ -75,7 +75,7 @@ suite('Variables', function() {
       createTestVarBlock(this.workspace, '2');
       createTestVarBlock(this.workspace, '2');
 
-      let result = Blockly.Variables.allUsedVarModels(this.workspace);
+      const result = Blockly.Variables.allUsedVarModels(this.workspace);
       // Using the same variable multiple times should not change the number of
       // elements in the list.
       chai.assert.equal(result.length, 1,
@@ -85,7 +85,7 @@ suite('Variables', function() {
     });
 
     test('All unused', function() {
-      let result = Blockly.Variables.allUsedVarModels(this.workspace);
+      const result = Blockly.Variables.allUsedVarModels(this.workspace);
       chai.assert.equal(result.length, 0,
           'Expected no variables in the list of used variables');
     });
@@ -93,12 +93,12 @@ suite('Variables', function() {
 
   suite('getVariable', function() {
     test('By id', function() {
-      let var1 = this.workspace.createVariable('name1', 'type1', 'id1');
-      let var2 = this.workspace.createVariable('name2', 'type1', 'id2');
-      let var3 = this.workspace.createVariable('name3', 'type2', 'id3');
-      let result1 = Blockly.Variables.getVariable(this.workspace, 'id1');
-      let result2 = Blockly.Variables.getVariable(this.workspace, 'id2');
-      let result3 = Blockly.Variables.getVariable(this.workspace, 'id3');
+      const var1 = this.workspace.createVariable('name1', 'type1', 'id1');
+      const var2 = this.workspace.createVariable('name2', 'type1', 'id2');
+      const var3 = this.workspace.createVariable('name3', 'type2', 'id3');
+      const result1 = Blockly.Variables.getVariable(this.workspace, 'id1');
+      const result2 = Blockly.Variables.getVariable(this.workspace, 'id2');
+      const result3 = Blockly.Variables.getVariable(this.workspace, 'id3');
 
       chai.assert.equal(var1, result1);
       chai.assert.equal(var2, result2);
@@ -106,14 +106,14 @@ suite('Variables', function() {
     });
 
     test('By name and type', function() {
-      let var1 = this.workspace.createVariable('name1', 'type1', 'id1');
-      let var2 = this.workspace.createVariable('name2', 'type1', 'id2');
-      let var3 = this.workspace.createVariable('name3', 'type2', 'id3');
-      let result1 =
+      const var1 = this.workspace.createVariable('name1', 'type1', 'id1');
+      const var2 = this.workspace.createVariable('name2', 'type1', 'id2');
+      const var3 = this.workspace.createVariable('name3', 'type2', 'id3');
+      const result1 =
           Blockly.Variables.getVariable(this.workspace, null, 'name1', 'type1');
-      let result2 =
+      const result2 =
           Blockly.Variables.getVariable(this.workspace, null, 'name2', 'type1');
-      let result3 =
+      const result3 =
           Blockly.Variables.getVariable(this.workspace, null, 'name3', 'type2');
 
       // Searching by name + type is correct.
@@ -123,14 +123,14 @@ suite('Variables', function() {
     });
 
     test('Bad id with name and type fallback', function() {
-      let var1 = this.workspace.createVariable('name1', 'type1', 'id1');
-      let var2 = this.workspace.createVariable('name2', 'type1', 'id2');
-      let var3 = this.workspace.createVariable('name3', 'type2', 'id3');
-      let result1 =
+      const var1 = this.workspace.createVariable('name1', 'type1', 'id1');
+      const var2 = this.workspace.createVariable('name2', 'type1', 'id2');
+      const var3 = this.workspace.createVariable('name3', 'type2', 'id3');
+      const result1 =
           Blockly.Variables.getVariable(this.workspace, 'badId', 'name1', 'type1');
-      let result2 =
+      const result2 =
           Blockly.Variables.getVariable(this.workspace, 'badId', 'name2', 'type1');
-      let result3 =
+      const result3 =
           Blockly.Variables.getVariable(this.workspace, 'badId', 'name3', 'type2');
 
       // Searching by ID failed, but falling back onto name + type is correct.

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -45,7 +45,7 @@ suite('WidgetDiv', function() {
           anchorBBox, rtl, expectedX, expectedY, expectedHeight) {
         Blockly.WidgetDiv.positionWithAnchor(
             this.viewportBBox, anchorBBox, this.widgetSize, rtl);
-        let style = Blockly.WidgetDiv.getDiv().style;
+        const style = Blockly.WidgetDiv.getDiv().style;
         chai.assert.equal(style.left, expectedX + 'px', 'Left');
         chai.assert.equal(style.top, expectedY + 'px', 'Top');
         chai.assert.equal(style.height, expectedHeight + 'px', 'Height');
@@ -55,57 +55,57 @@ suite('WidgetDiv', function() {
     suite('LTR', function() {
       test('noConflict', function() {
         // Anchor placed in the middle.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed just below at the left side of the
         // anchor.
-        let expectedX = anchorBBox.left;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = anchorBBox.left;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
   
       test('topConflict', function() {
         // Anchor close to the top.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 50, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed just below the anchor.
-        let expectedX = anchorBBox.left;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = anchorBBox.left;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
   
       test('bottomConflict', function() {
         // Anchor placed close to the bottom.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 900, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed just above the anchor.
-        let expectedX = anchorBBox.left;
-        let expectedY = anchorBBox.top - this.widgetSize.height;
+        const expectedX = anchorBBox.left;
+        const expectedY = anchorBBox.top - this.widgetSize.height;
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
   
       test('leftConflict', function() {
         // Anchor placed close to the left side.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(50, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed at the anchor.
-        let expectedX = anchorBBox.left;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = anchorBBox.left;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
   
       test('rightConflict', function() {
         // Anchor placed close to the right side.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(950, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed as far right as possible--at the edge of
         // the screen.
-        let expectedX = this.viewportBBox.width - this.widgetSize.width;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = this.viewportBBox.width - this.widgetSize.width;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
@@ -113,57 +113,57 @@ suite('WidgetDiv', function() {
     suite('RTL', function() {
       test('noConflict', function() {
         // Anchor placed in the middle
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed at the right side of the anchor.
-        let expectedX = anchorBBox.right - this.widgetSize.width;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = anchorBBox.right - this.widgetSize.width;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, true, expectedX, expectedY, this.widgetSize.height);
       });
 
       test('topConflict', function() {
         // Anchor close to the top.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 50, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed just below the anchor.
-        let expectedX = anchorBBox.right - this.widgetSize.width;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = anchorBBox.right - this.widgetSize.width;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, true, expectedX, expectedY, this.widgetSize.height);
       });
 
       test('bottomConflict', function() {
         // Anchor placed close to the bottom.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(500, 900, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed just above the anchor.
-        let expectedX = anchorBBox.right - this.widgetSize.width;
-        let expectedY = anchorBBox.top - this.widgetSize.height;
+        const expectedX = anchorBBox.right - this.widgetSize.width;
+        const expectedY = anchorBBox.top - this.widgetSize.height;
         this.testWidgetPosition(
             anchorBBox, true, expectedX, expectedY, this.widgetSize.height);
       });
 
       test('leftConflict', function() {
         // Anchor placed close to the left side.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(10, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed as far left as possible--at the edge of
         // the screen.
-        let expectedX = 0;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = 0;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, true, expectedX, expectedY, this.widgetSize.height);
       });
 
       test('rightConflict', function() {
         // Anchor placed close to the right side.
-        let anchorBBox =
+        const anchorBBox =
             makeBBox(950, 500, this.anchorSize.width, this.anchorSize.height);
         // The widget div should be placed as far right as possible--at the edge of
         // the screen.
-        let expectedX = this.viewportBBox.width - this.widgetSize.width;
-        let expectedY = anchorBBox.top + this.anchorSize.height;
+        const expectedX = this.viewportBBox.width - this.widgetSize.width;
+        const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
             anchorBBox, true, expectedX, expectedY, this.widgetSize.height);
       });

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -26,7 +26,7 @@ suite('Workspace comment', function() {
     });
 
     test('One comment', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       chai.assert.equal(this.workspace.getTopComments(true).length, 1);
       chai.assert.equal(this.workspace.commentDB_['comment id'], comment);
@@ -46,7 +46,7 @@ suite('Workspace comment', function() {
     });
 
     test('After dispose', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       chai.assert.equal(this.workspace.getTopComments(true).length, 0);
@@ -60,7 +60,7 @@ suite('Workspace comment', function() {
     });
 
     test('One comment', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       chai.assert.equal(this.workspace.getTopComments(false).length, 1);
       chai.assert.equal(this.workspace.commentDB_['comment id'], comment);
@@ -80,7 +80,7 @@ suite('Workspace comment', function() {
     });
 
     test('After dispose', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       chai.assert.equal(this.workspace.getTopComments(false).length, 0);
@@ -90,7 +90,7 @@ suite('Workspace comment', function() {
 
   suite('getCommentById', function() {
     test('Trivial', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       chai.assert.equal(this.workspace.getCommentById(comment.id), comment);
     });
@@ -104,7 +104,7 @@ suite('Workspace comment', function() {
     });
 
     test('After dispose', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       chai.assert.isNull(this.workspace.getCommentById(comment.id));
@@ -113,7 +113,7 @@ suite('Workspace comment', function() {
 
   suite('dispose', function() {
     test('Called twice', function() {
-      let comment = new Blockly.WorkspaceComment(
+      const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       // Nothing should go wrong the second time dispose is called.
@@ -152,14 +152,14 @@ suite('Workspace comment', function() {
     });
 
     test('Initial position', function() {
-      let xy = this.comment.getXY();
+      const xy = this.comment.getXY();
       chai.assert.equal(xy.x, 0, 'Initial X position');
       chai.assert.equal(xy.y, 0, 'Initial Y position');
     });
 
     test('moveBy', function() {
       this.comment.moveBy(10, 100);
-      let xy = this.comment.getXY();
+      const xy = this.comment.getXY();
       chai.assert.equal(xy.x, 10, 'New X position');
       chai.assert.equal(xy.y, 100, 'New Y position');
     });

--- a/tests/mocha/workspace_helpers.js
+++ b/tests/mocha/workspace_helpers.js
@@ -35,22 +35,22 @@ function testAWorkspace() {
   });
 
   function assertBlockVarModelName(workspace, blockIndex, name) {
-    let block = workspace.topBlocks_[blockIndex];
+    const block = workspace.topBlocks_[blockIndex];
     chai.assert.exists(block, 'Block at topBlocks_[' + blockIndex + ']');
-    let varModel = block.getVarModels()[0];
+    const varModel = block.getVarModels()[0];
     chai.assert.exists(varModel,
         'VariableModel for block at topBlocks_[' + blockIndex + ']');
-    let blockVarName = varModel.name;
+    const blockVarName = varModel.name;
     chai.assert.equal(blockVarName, name,
         'VariableModel name for block at topBlocks_[' + blockIndex + ']');
   }
 
   function createVarBlocksNoEvents(workspace, ids) {
-    let blocks = [];
+    const blocks = [];
     // Turn off events to avoid testing XML at the same time.
     eventUtils.disable();
     for (let i = 0, id; (id = ids[i]); i++) {
-      let block = new Blockly.Block(workspace, 'get_var_block');
+      const block = new Blockly.Block(workspace, 'get_var_block');
       block.inputList[0].fieldRow[0].setValue(id);
       blocks.push(block);
     }
@@ -67,7 +67,7 @@ function testAWorkspace() {
 
       this.workspace.clear();
       chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      let varMapLength =
+      const varMapLength =
           Object.keys(this.workspace.variableMap_.variableMap_).length;
       chai.assert.equal(varMapLength, 0);
     });
@@ -78,7 +78,7 @@ function testAWorkspace() {
 
       this.workspace.clear();
       chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      let varMapLength =
+      const varMapLength =
           Object.keys(this.workspace.variableMap_.variableMap_).length;
       chai.assert.equal(varMapLength, 0);
     });
@@ -95,12 +95,12 @@ function testAWorkspace() {
 
     test('deleteVariableById(id2) one usage', function() {
       // Deleting variable one usage should not trigger confirm dialog.
-      let stub =
+      const stub =
           sinon.stub(Blockly.dialog, "confirm").callsArgWith(1, true);
       this.workspace.deleteVariableById('id2');
 
       sinon.assert.notCalled(stub);
-      let variable = this.workspace.getVariableById('id2');
+      const variable = this.workspace.getVariableById('id2');
       chai.assert.isNull(variable);
       assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
       assertBlockVarModelName(this.workspace, 0, 'name1');
@@ -108,12 +108,12 @@ function testAWorkspace() {
 
     test('deleteVariableById(id1) multiple usages confirm', function() {
       // Deleting variable with multiple usages triggers confirm dialog.
-      let stub =
+      const stub =
           sinon.stub(Blockly.dialog, "confirm").callsArgWith(1, true);
       this.workspace.deleteVariableById('id1');
 
       sinon.assert.calledOnce(stub);
-      let variable = this.workspace.getVariableById('id1');
+      const variable = this.workspace.getVariableById('id1');
       chai.assert.isNull(variable);
       assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       assertBlockVarModelName(this.workspace, 0, 'name2');
@@ -121,7 +121,7 @@ function testAWorkspace() {
 
     test('deleteVariableById(id1) multiple usages cancel', function() {
       // Deleting variable with multiple usages triggers confirm dialog.
-      let stub =
+      const stub =
           sinon.stub(Blockly.dialog, "confirm").callsArgWith(1, false);
       this.workspace.deleteVariableById('id1');
 
@@ -176,7 +176,7 @@ function testAWorkspace() {
         // The second variable should remain unchanged.
         assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
         // The first variable should have been deleted.
-        let variable = this.workspace.getVariableById('id1');
+        const variable = this.workspace.getVariableById('id1');
         chai.assert.isNull(variable);
         // There should only be one variable left.
         chai.assert.equal(this.workspace.getAllVariables().length, 1);
@@ -210,7 +210,7 @@ function testAWorkspace() {
         // The second variable should be updated.
         assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
         // The first variable should have been deleted.
-        let variable = this.workspace.getVariableById('id1');
+        const variable = this.workspace.getVariableById('id1');
         chai.assert.isNull(variable);
         // There should only be one variable left.
         chai.assert.equal(this.workspace.getAllVariables().length, 1);
@@ -249,7 +249,7 @@ function testAWorkspace() {
     });
 
     test('Flat workspace one block after dispose', function() {
-      let blockA = this.workspace.newBlock('');
+      const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
       chai.assert.equal(this.workspace.getTopBlocks(true).length, 1);
@@ -283,7 +283,7 @@ function testAWorkspace() {
     });
 
     test('Flat workspace one block after dispose', function() {
-      let blockA = this.workspace.newBlock('');
+      const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
       chai.assert.equal(this.workspace.getTopBlocks(false).length, 1);
@@ -319,7 +319,7 @@ function testAWorkspace() {
     });
 
     test('Flat workspace one block after dispose', function() {
-      let blockA = this.workspace.newBlock('');
+      const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
       chai.assert.equal(this.workspace.getAllBlocks(true).length, 1);
@@ -486,26 +486,26 @@ function testAWorkspace() {
 
     test('Under block limit and no instance limit', function() {
       this.workspace.options.maxBlocks = 3;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isTrue(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('At block limit and no instance limit', function() {
       this.workspace.options.maxBlocks = 2;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('Over block limit of 0 and no instance limit', function() {
       this.workspace.options.maxBlocks = 0;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('Over block limit but under instance limit', function() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 3');
     });
@@ -513,7 +513,7 @@ function testAWorkspace() {
     test('Over block limit of 0 but under instance limit', function() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 0 and maxInstances limit 3');
     });
@@ -521,7 +521,7 @@ function testAWorkspace() {
     test('Over block limit but at instance limit', function() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 2;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 2');
     });
@@ -529,7 +529,7 @@ function testAWorkspace() {
     test('Over block limit and over instance limit', function() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 1');
     });
@@ -537,7 +537,7 @@ function testAWorkspace() {
     test('Over block limit of 0 and over instance limit', function() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 0 and maxInstances limit 1');
     });
@@ -545,7 +545,7 @@ function testAWorkspace() {
     test('Over block limit and over instance limit of 0', function() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 0');
     });
@@ -553,7 +553,7 @@ function testAWorkspace() {
     test('Over block limit of 0 and over instance limit of 0', function() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      let typeCountsMap = {'get_var_block': 1};
+      const typeCountsMap = {'get_var_block': 1};
       chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
   });
@@ -640,8 +640,8 @@ function testAWorkspace() {
      * @param {!Element} expected the expected node.
      */
     function assertNodesEqual(actual, expected) {
-      let actualString = '\n' + Blockly.Xml.domToPrettyText(actual) + '\n';
-      let expectedString = '\n' + Blockly.Xml.domToPrettyText(expected) + '\n';
+      const actualString = '\n' + Blockly.Xml.domToPrettyText(actual) + '\n';
+      const expectedString = '\n' + Blockly.Xml.domToPrettyText(expected) + '\n';
 
       chai.assert.equal(actual.tagName, expected.tagName);
       for (let i = 0, attr; (attr = expected.attributes[i]); i++) {
@@ -698,11 +698,11 @@ function testAWorkspace() {
       });
 
       function testUndoDelete(xmlText) {
-        let xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.Xml.textToDom(xmlText);
         Blockly.Xml.domToBlock(xml, this.workspace);
         this.workspace.getTopBlocks()[0].dispose(false);
         this.workspace.undo();
-        let newXml = Blockly.Xml.workspaceToDom(this.workspace);
+        const newXml = Blockly.Xml.workspaceToDom(this.workspace);
         assertNodesEqual(newXml.firstChild, xml);
       }
 
@@ -821,20 +821,20 @@ function testAWorkspace() {
       });
 
       function testUndoConnect(xmlText, parentId, childId, func) {
-        let xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.Xml.textToDom(xmlText);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
 
-        let parent = this.workspace.getBlockById(parentId);
-        let child = this.workspace.getBlockById(childId);
+        const parent = this.workspace.getBlockById(parentId);
+        const child = this.workspace.getBlockById(childId);
         func.call(this, parent, child);
         this.workspace.undo();
 
-        let newXml = Blockly.Xml.workspaceToDom(this.workspace);
+        const newXml = Blockly.Xml.workspaceToDom(this.workspace);
         assertNodesEqual(newXml, xml);
       }
 
       test('Stack', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1"></block>' +
             '  <block type="stack_block" id="2"></block>' +
@@ -846,7 +846,7 @@ function testAWorkspace() {
       });
 
       test('Row', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1"></block>' +
             '  <block type="row_block" id="2"></block>' +
@@ -858,7 +858,7 @@ function testAWorkspace() {
       });
 
       test('Statement', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1"></block>' +
             '  <block type="stack_block" id="2"></block>' +
@@ -871,7 +871,7 @@ function testAWorkspace() {
       });
 
       test('Stack w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
@@ -887,7 +887,7 @@ function testAWorkspace() {
       });
 
       test('Row w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
@@ -903,7 +903,7 @@ function testAWorkspace() {
       });
 
       test('Statement w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
@@ -920,7 +920,7 @@ function testAWorkspace() {
       });
 
       test('Stack w/ shadow', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
@@ -936,7 +936,7 @@ function testAWorkspace() {
       });
 
       test('Row w/ shadow', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
@@ -952,7 +952,7 @@ function testAWorkspace() {
       });
 
       test('Statement w/ shadow', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
@@ -1011,10 +1011,10 @@ function testAWorkspace() {
       });
 
       function testUndoDisconnect(xmlText, childId) {
-        let xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.Xml.textToDom(xmlText);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
 
-        let child = this.workspace.getBlockById(childId);
+        const child = this.workspace.getBlockById(childId);
         if (child.outputConnection) {
           child.outputConnection.disconnect();
         } else {
@@ -1022,12 +1022,12 @@ function testAWorkspace() {
         }
         this.workspace.undo();
 
-        let newXml = Blockly.Xml.workspaceToDom(this.workspace);
+        const newXml = Blockly.Xml.workspaceToDom(this.workspace);
         assertNodesEqual(newXml, xml);
       }
 
       test('Stack', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
@@ -1039,7 +1039,7 @@ function testAWorkspace() {
       });
 
       test('Row', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
@@ -1051,7 +1051,7 @@ function testAWorkspace() {
       });
 
       test('Statement', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
@@ -1063,7 +1063,7 @@ function testAWorkspace() {
       });
 
       test('Stack w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
@@ -1079,7 +1079,7 @@ function testAWorkspace() {
       });
 
       test('Row w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
@@ -1095,7 +1095,7 @@ function testAWorkspace() {
       });
 
       test('Statement w/ child', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
@@ -1113,7 +1113,7 @@ function testAWorkspace() {
       test('Stack w/ shadow', function() {
         // TODO: For some reason on next connections shadows are
         //   serialized second.
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
@@ -1129,7 +1129,7 @@ function testAWorkspace() {
       });
 
       test('Row w/ shadow', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
@@ -1145,7 +1145,7 @@ function testAWorkspace() {
       });
 
       test('Statement w/ shadow', function() {
-        let xml =
+        const xml =
             '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
@@ -1296,13 +1296,13 @@ function testAWorkspace() {
         test('Delete same variable twice no usages', function() {
           this.workspace.createVariable('name1', 'type1', 'id1');
           this.workspace.deleteVariableById('id1');
-          let workspace = this.workspace;
+          const workspace = this.workspace;
           assertWarnings(() => {
             workspace.deleteVariableById('id1');
           }, /Can't delete/);
 
           // Check the undoStack only recorded one delete event.
-          let undoStack = this.workspace.undoStack_;
+          const undoStack = this.workspace.undoStack_;
           chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
           chai.assert.notEqual(undoStack[undoStack.length - 2].type, 'var_delete');
 
@@ -1323,13 +1323,13 @@ function testAWorkspace() {
           this.workspace.createVariable('name1', 'type1', 'id1');
           createVarBlocksNoEvents(this.workspace, ['id1']);
           this.workspace.deleteVariableById('id1');
-          let workspace = this.workspace;
+          const workspace = this.workspace;
           assertWarnings(() => {
             workspace.deleteVariableById('id1');
           }, /Can't delete/);
 
           // Check the undoStack only recorded one delete event.
-          let undoStack = this.workspace.undoStack_;
+          const undoStack = this.workspace.undoStack_;
           chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
           chai.assert.equal(undoStack[undoStack.length - 2].type, 'delete');
           chai.assert.notEqual(undoStack[undoStack.length - 3].type, 'var_delete');

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -13,7 +13,7 @@ const {testAWorkspace} = goog.require('Blockly.test.workspaceHelpers');
 suite('WorkspaceSvg', function() {
   setup(function() {
     sharedTestSetup.call(this);
-    let toolbox = document.getElementById('toolbox-categories');
+    const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     Blockly.defineBlocksWithJsonArray([{
       'type': 'simple_test_block',
@@ -37,12 +37,12 @@ suite('WorkspaceSvg', function() {
   });
 
   test('dispose of WorkspaceSvg without dom throws no error', function() {
-    let ws = new Blockly.WorkspaceSvg(new Blockly.Options({}));
+    const ws = new Blockly.WorkspaceSvg(new Blockly.Options({}));
     ws.dispose();
   });
 
   test('appendDomToWorkspace alignment', function() {
-    let dom = Blockly.Xml.textToDom(
+    const dom = Blockly.Xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         '  <block type="math_random_float" inline="true" x="21" y="23">' +
         '  </block>' +
@@ -53,7 +53,7 @@ suite('WorkspaceSvg', function() {
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
     chai.assert.equal(this.workspace.getAllBlocks(false).length, 2,
         'Block count');
-    let blocks = this.workspace.getAllBlocks(false);
+    const blocks = this.workspace.getAllBlocks(false);
     chai.assert.equal(blocks[0].getRelativeToSurfaceXY().x, 21,
         'Block 1 position x');
     chai.assert.equal(blocks[0].getRelativeToSurfaceXY().y, 23,
@@ -67,7 +67,7 @@ suite('WorkspaceSvg', function() {
   });
 
   test('Replacing shadow disposes svg', function() {
-    let dom = Blockly.Xml.textToDom(
+    const dom = Blockly.Xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         '<block type="test_val_in">' +
         '<value name="NAME">' +
@@ -77,15 +77,15 @@ suite('WorkspaceSvg', function() {
         '</xml>');
 
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    let blocks = this.workspace.getAllBlocks(false);
+    const blocks = this.workspace.getAllBlocks(false);
     chai.assert.equal(blocks.length, 2, 'Block count');
-    let shadowBlock = blocks[1];
+    const shadowBlock = blocks[1];
     chai.assert.exists(shadowBlock.getSvgRoot());
 
-    let block = this.workspace.newBlock('simple_test_block');
+    const block = this.workspace.newBlock('simple_test_block');
     block.initSvg();
 
-    let inputConnection =
+    const inputConnection =
         this.workspace.getTopBlocks()[0].getInput('NAME').connection;
     inputConnection.connect(block.outputConnection);
     chai.assert.exists(block.getSvgRoot());
@@ -152,7 +152,7 @@ suite('WorkspaceSvg', function() {
       this.workspace.variableMap_ = this.targetWorkspace.getVariableMap();
 
       Blockly.Events.disable();
-      let block = new Blockly.Block(this.workspace, 'get_var_block');
+      const block = new Blockly.Block(this.workspace, 'get_var_block');
       block.inputList[0].fieldRow[0].setValue('1');
       Blockly.Events.enable();
 
@@ -176,8 +176,8 @@ suite('WorkspaceSvg', function() {
     }
     function assertViewportEventFired(eventsFireStub, changeListenerSpy,
         workspace, expectedEventCount = 1) {
-      let metrics = workspace.getMetrics();
-      let expectedProperties = {
+      const metrics = workspace.getMetrics();
+      const expectedProperties = {
         scale: workspace.scale,
         oldScale: 1,
         viewTop: metrics.viewTop,
@@ -233,7 +233,7 @@ suite('WorkspaceSvg', function() {
             this.clock);
       });
       test('zoomToFit', function() {
-        let block = this.workspace.newBlock('stack_block');
+        const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
         runViewportEventTest(() => this.workspace.zoomToFit(),
@@ -243,7 +243,7 @@ suite('WorkspaceSvg', function() {
     });
     suite('scroll', function() {
       test('centerOnBlock', function() {
-        let block = this.workspace.newBlock('stack_block');
+        const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
         runViewportEventTest(() => this.workspace.zoomToFit(block.id),
@@ -263,7 +263,7 @@ suite('WorkspaceSvg', function() {
     });
     suite('Blocks triggering viewport changes', function() {
       test('block move that triggers scroll', function() {
-        let block = this.workspace.newBlock('stack_block');
+        const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
         this.clock.runAll();
@@ -285,7 +285,7 @@ suite('WorkspaceSvg', function() {
                 '<block type="controls_if" x="288" y="238"></block>' +
                 '</xml>'),
             this.workspace);
-        let xmlDom = Blockly.Xml.textToDom(
+        const xmlDom = Blockly.Xml.textToDom(
             '<block type="controls_if" x="188" y="163"></block>');
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
@@ -309,7 +309,7 @@ suite('WorkspaceSvg', function() {
                 '<block type="controls_if" x="75" y="75"></block>' +
                 '</xml>'),
             this.workspace);
-        let xmlDom = Blockly.Xml.textToDom(
+        const xmlDom = Blockly.Xml.textToDom(
             '<block type="controls_if" x="0" y="0"></block>');
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
@@ -323,7 +323,7 @@ suite('WorkspaceSvg', function() {
       });
       test.skip('domToWorkspace multiple blocks triggers one viewport event', function() {
         // TODO: Un-skip after adding filtering for consecutive viewport events.
-        let addingMultipleBlocks = () => {
+        const addingMultipleBlocks = () => {
           Blockly.Xml.domToWorkspace(
               Blockly.Xml.textToDom(
                   '<xml xmlns="https://developers.google.com/blockly/xml">' +

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -10,24 +10,24 @@ const {addBlockTypeToCleanup, assertVariableValues, createGenUidStubWithReturns,
 
 
 suite('XML', function() {
-  let assertSimpleFieldDom = function(fieldDom, name, text) {
+  const assertSimpleFieldDom = function(fieldDom, name, text) {
     chai.assert.equal(text, fieldDom.textContent);
     chai.assert.equal(name, fieldDom.getAttribute('name'));
   };
-  let assertNonSerializingFieldDom = function(fieldDom) {
+  const assertNonSerializingFieldDom = function(fieldDom) {
     chai.assert.isUndefined(fieldDom.childNodes[0]);
   };
-  let assertNonVariableField = function(fieldDom, name, text) {
+  const assertNonVariableField = function(fieldDom, name, text) {
     assertSimpleFieldDom(fieldDom, name, text);
     chai.assert.isNull(fieldDom.getAttribute('id'), 'id');
     chai.assert.isNull(fieldDom.getAttribute('variabletype'), 'variabletype');
   };
-  let assertVariableDomField = function(fieldDom, name, type, id, text) {
+  const assertVariableDomField = function(fieldDom, name, type, id, text) {
     assertSimpleFieldDom(fieldDom, name, text);
     chai.assert.equal(fieldDom.getAttribute('variabletype'), type);
     chai.assert.equal(fieldDom.getAttribute('id'), id);
   };
-  let assertVariableDom = function(fieldDom, type, id, text) {
+  const assertVariableDom = function(fieldDom, type, id, text) {
     chai.assert.equal(fieldDom.getAttribute('type'), type);
     chai.assert.equal(fieldDom.getAttribute('id'), id);
     chai.assert.equal(fieldDom.textContent, text);
@@ -74,7 +74,7 @@ suite('XML', function() {
   });
   suite('textToDom', function() {
     test('Basic', function() {
-      let dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const dom = Blockly.Xml.textToDom(this.complexXmlText);
       chai.assert.equal(dom.nodeName, 'xml', 'XML tag');
       chai.assert.equal(dom.getElementsByTagName('block').length, 6, 'Block tags');
     });
@@ -99,9 +99,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_angle_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'ANGLE', '90');
       });
       test('Checkbox', function() {
@@ -116,9 +116,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_checkbox_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'CHECKBOX', 'TRUE');
       });
       test('Colour', function() {
@@ -133,9 +133,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_colour_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'COLOUR', '#000099');
       });
       test('Dropdown', function() {
@@ -163,9 +163,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_dropdown_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'DROPDOWN', 'A');
       });
       test('Image', function() {
@@ -183,9 +183,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_image_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block);
+        const resultFieldDom = Blockly.Xml.blockToDom(block);
         assertNonSerializingFieldDom(resultFieldDom);
       });
       test('Label', function() {
@@ -200,9 +200,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_label_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block);
+        const resultFieldDom = Blockly.Xml.blockToDom(block);
         assertNonSerializingFieldDom(resultFieldDom);
       });
       test('Label Serializable', function() {
@@ -217,9 +217,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_label_serializable_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'LABEL', 'default');
       });
       test('Number', function() {
@@ -234,9 +234,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_number_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'NUMBER', '97');
       });
       test('Text Input', function() {
@@ -251,9 +251,9 @@ suite('XML', function() {
             }
           ],
         }]);
-        let block = new Blockly.Block(this.workspace,
+        const block = new Blockly.Block(this.workspace,
             'field_text_input_test_block');
-        let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+        const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'TEXT', 'default');
       });
       suite('Variable Fields', function() {
@@ -272,18 +272,18 @@ suite('XML', function() {
         });
         test('Variable Trivial', function() {
           this.workspace.createVariable('name1', '', 'id1');
-          let block = new Blockly.Block(this.workspace,
+          const block = new Blockly.Block(this.workspace,
               'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('id1');
-          let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+          const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
           assertVariableDomField(resultFieldDom, 'VAR', null, 'id1', 'name1');
         });
         test('Variable Typed', function() {
           this.workspace.createVariable('name1', 'string', 'id1');
-          let block = new Blockly.Block(this.workspace,
+          const block = new Blockly.Block(this.workspace,
               'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('id1');
-          let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+          const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
           assertVariableDomField(resultFieldDom, 'VAR', 'string', 'id1', 'name1');
         });
         test('Variable Default Case', function() {
@@ -291,12 +291,12 @@ suite('XML', function() {
           this.workspace.createVariable('name1');
 
           Blockly.Events.disable();
-          let block = new Blockly.Block(this.workspace,
+          const block = new Blockly.Block(this.workspace,
               'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('1');
           Blockly.Events.enable();
 
-          let resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
+          const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
           // Expect type is null and ID is '1' since we don't specify type and ID.
           assertVariableDomField(resultFieldDom, 'VAR', null, '1', 'name1');
         });
@@ -311,18 +311,18 @@ suite('XML', function() {
         });
         test('Text', function() {
           this.block.setCommentText('test text');
-          let xml = Blockly.Xml.blockToDom(this.block);
-          let commentXml = xml.firstChild;
+          const xml = Blockly.Xml.blockToDom(this.block);
+          const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
           chai.assert.equal(commentXml.innerHTML, 'test text');
         });
         test('No Text', function() {
-          let xml = Blockly.Xml.blockToDom(this.block);
+          const xml = Blockly.Xml.blockToDom(this.block);
           chai.assert.isNull(xml.firstChild);
         });
         test('Empty Text', function() {
           this.block.setCommentText('');
-          let xml = Blockly.Xml.blockToDom(this.block);
+          const xml = Blockly.Xml.blockToDom(this.block);
           chai.assert.isNull(xml.firstChild);
         });
       });
@@ -339,25 +339,25 @@ suite('XML', function() {
         });
         test('Text', function() {
           this.block.setCommentText('test text');
-          let xml = Blockly.Xml.blockToDom(this.block);
-          let commentXml = xml.firstChild;
+          const xml = Blockly.Xml.blockToDom(this.block);
+          const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
           chai.assert.equal(commentXml.innerHTML, 'test text');
         });
         test('No Text', function() {
-          let xml = Blockly.Xml.blockToDom(this.block);
+          const xml = Blockly.Xml.blockToDom(this.block);
           chai.assert.isNull(xml.firstChild);
         });
         test('Empty Text', function() {
           this.block.setCommentText('');
-          let xml = Blockly.Xml.blockToDom(this.block);
+          const xml = Blockly.Xml.blockToDom(this.block);
           chai.assert.isNull(xml.firstChild);
         });
         test('Size', function() {
           this.block.setCommentText('test text');
           this.block.getCommentIcon().setBubbleSize(100, 200);
-          let xml = Blockly.Xml.blockToDom(this.block);
-          let commentXml = xml.firstChild;
+          const xml = Blockly.Xml.blockToDom(this.block);
+          const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
           chai.assert.equal(commentXml.getAttribute('w'), 100);
           chai.assert.equal(commentXml.getAttribute('h'), 200);
@@ -365,15 +365,15 @@ suite('XML', function() {
         test('Pinned True', function() {
           this.block.setCommentText('test text');
           this.block.getCommentIcon().setVisible(true);
-          let xml = Blockly.Xml.blockToDom(this.block);
-          let commentXml = xml.firstChild;
+          const xml = Blockly.Xml.blockToDom(this.block);
+          const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
           chai.assert.equal(commentXml.getAttribute('pinned'), 'true');
         });
         test('Pinned False', function() {
           this.block.setCommentText('test text');
-          let xml = Blockly.Xml.blockToDom(this.block);
-          let commentXml = xml.firstChild;
+          const xml = Blockly.Xml.blockToDom(this.block);
+          const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
           chai.assert.equal(commentXml.getAttribute('pinned'), 'false');
         });
@@ -401,10 +401,10 @@ suite('XML', function() {
     test('One Variable', function() {
       createGenUidStubWithReturns('1');
       this.workspace.createVariable('name1');
-      let resultDom =
+      const resultDom =
           Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
       chai.assert.equal(resultDom.children.length, 1);
-      let resultVariableDom = resultDom.children[0];
+      const resultVariableDom = resultDom.children[0];
       chai.assert.equal(resultVariableDom.textContent, 'name1');
       chai.assert.isNull(resultVariableDom.getAttribute('type'));
       chai.assert.equal(resultVariableDom.getAttribute('id'), '1');
@@ -415,11 +415,11 @@ suite('XML', function() {
       // If events are enabled during block construction, it will create a
       // default variable.
       Blockly.Events.disable();
-      let block = new Blockly.Block(this.workspace, 'field_variable_test_block');
+      const block = new Blockly.Block(this.workspace, 'field_variable_test_block');
       block.inputList[0].fieldRow[0].setValue('id1');
       Blockly.Events.enable();
 
-      let resultDom = Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
+      const resultDom = Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
       chai.assert.equal(resultDom.children.length, 2);
       assertVariableDom(resultDom.children[0], null, 'id1',
           'name1');
@@ -427,23 +427,23 @@ suite('XML', function() {
           'name2');
     });
     test('No variables', function() {
-      let resultDom =
+      const resultDom =
           Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
       chai.assert.equal(resultDom.children.length, 0);
     });
   });
   suite('domToText', function() {
     test('Round tripping', function() {
-      let dom = Blockly.Xml.textToDom(this.complexXmlText);
-      let text = Blockly.Xml.domToText(dom);
+      const dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const text = Blockly.Xml.domToText(dom);
       chai.assert.equal(text.replace(/\s+/g, ''),
           this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
     });
   });
   suite('domToPrettyText', function() {
     test('Round tripping', function() {
-      let dom = Blockly.Xml.textToDom(this.complexXmlText);
-      let text = Blockly.Xml.domToPrettyText(dom);
+      const dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const text = Blockly.Xml.domToPrettyText(dom);
       chai.assert.equal(text.replace(/\s+/g, ''),
           this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
     });
@@ -458,7 +458,7 @@ suite('XML', function() {
     suite('Dynamic Category Blocks', function() {
       test('Untyped Variables', function() {
         this.workspace.createVariable('name1', '', 'id1');
-        let blocksArray =
+        const blocksArray =
             Blockly.Variables.flyoutCategoryBlocks(this.workspace);
         for (let i = 0, xml; (xml = blocksArray[i]); i++) {
           Blockly.Xml.domToBlock(xml, this.workspace);
@@ -468,7 +468,7 @@ suite('XML', function() {
         this.workspace.createVariable('name1', 'String', 'id1');
         this.workspace.createVariable('name2', 'Number', 'id2');
         this.workspace.createVariable('name3', 'Colour', 'id3');
-        let blocksArray =
+        const blocksArray =
             Blockly.VariablesDynamic.flyoutCategoryBlocks(this.workspace);
         for (let i = 0, xml; (xml = blocksArray[i]); i++) {
           Blockly.Xml.domToBlock(xml, this.workspace);
@@ -478,7 +478,7 @@ suite('XML', function() {
     suite('Comments', function() {
       suite('Headless', function() {
         test('Text', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -486,7 +486,7 @@ suite('XML', function() {
           chai.assert.equal(block.getCommentText(), 'test text');
         });
         test('No Text', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment></comment>' +
               '</block>'
@@ -494,7 +494,7 @@ suite('XML', function() {
           chai.assert.equal(block.getCommentText(), '');
         });
         test('Size', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment w="100" h="200">test text</comment>' +
               '</block>'
@@ -503,7 +503,7 @@ suite('XML', function() {
               {width: 100, height: 200});
         });
         test('Pinned True', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment pinned="true">test text</comment>' +
               '</block>'
@@ -511,7 +511,7 @@ suite('XML', function() {
           chai.assert.isTrue(block.commentModel.pinned);
         });
         test('Pinned False', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment pinned="false">test text</comment>' +
               '</block>'
@@ -519,7 +519,7 @@ suite('XML', function() {
           chai.assert.isFalse(block.commentModel.pinned);
         });
         test('Pinned Undefined', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -536,7 +536,7 @@ suite('XML', function() {
         });
 
         test('Text', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -545,7 +545,7 @@ suite('XML', function() {
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('No Text', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment></comment>' +
               '</block>'
@@ -554,7 +554,7 @@ suite('XML', function() {
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('Size', function() {
-          let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
               '<block type="empty_block">' +
               '  <comment w="100" h="200">test text</comment>' +
               '</block>'
@@ -567,7 +567,7 @@ suite('XML', function() {
         });
         suite('Pinned', function() {
           test('Pinned True', function() {
-            let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment pinned="true">test text</comment>' +
                 '</block>'
@@ -578,7 +578,7 @@ suite('XML', function() {
             chai.assert.isTrue(block.getCommentIcon().isVisible());
           });
           test('Pinned False', function() {
-            let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment pinned="false">test text</comment>' +
                 '</block>'
@@ -589,7 +589,7 @@ suite('XML', function() {
             chai.assert.isFalse(block.getCommentIcon().isVisible());
           });
           test('Pinned Undefined', function() {
-            let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment>test text</comment>' +
                 '</block>'
@@ -623,7 +623,7 @@ suite('XML', function() {
     });
     test('Backwards compatibility', function() {
       createGenUidStubWithReturns('1');
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="field_variable_test_block" id="block_id">' +
           '    <field name="VAR">name1</field>' +
@@ -634,7 +634,7 @@ suite('XML', function() {
       assertVariableValues(this.workspace, 'name1', '', '1');
     });
     test('Variables at top', function() {
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable type="type1" id="id1">name1</variable>' +
@@ -652,7 +652,7 @@ suite('XML', function() {
       assertVariableValues(this.workspace, 'name3', '', 'id3');
     });
     test('Variables at top duplicated variables tag', function() {
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '  </variables>' +
@@ -664,7 +664,7 @@ suite('XML', function() {
       });
     });
     test('Variables at top missing type', function() {
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable id="id1">name1</variable>' +
@@ -678,7 +678,7 @@ suite('XML', function() {
       });
     });
     test('Variables at top mismatch block type', function() {
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable type="type1" id="id1">name1</variable>' +
@@ -708,21 +708,21 @@ suite('XML', function() {
       workspaceTeardown.call(this, this.workspace);
     });
     test('Headless', function() {
-      let dom = Blockly.Xml.textToDom(
+      const dom = Blockly.Xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="test_block" inline="true" x="21" y="23">' +
           '  </block>' +
           '</xml>');
       Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
       chai.assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
-      let newBlockIds = Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
+      const newBlockIds = Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
       chai.assert.equal(this.workspace.getAllBlocks(false).length, 2, 'Block count');
       chai.assert.equal(newBlockIds.length, 1, 'Number of new block ids');
     });
   });
   suite('workspaceToDom -> domToWorkspace -> workspaceToDom', function() {
     setup(function() {
-      let options = {
+      const options = {
         comments: true
       };
       this.renderedWorkspace = Blockly.inject('blocklyDiv', options);
@@ -733,19 +733,19 @@ suite('XML', function() {
       workspaceTeardown.call(this, this.renderedWorkspace);
       workspaceTeardown.call(this, this.headlessWorkspace);
     });
-    let assertRoundTrip = function(originWs, targetWs) {
-      let originXml = Blockly.Xml.workspaceToDom(originWs);
+    const assertRoundTrip = function(originWs, targetWs) {
+      const originXml = Blockly.Xml.workspaceToDom(originWs);
       Blockly.Xml.domToWorkspace(originXml, targetWs);
-      let targetXml = Blockly.Xml.workspaceToDom(targetWs);
+      const targetXml = Blockly.Xml.workspaceToDom(targetWs);
 
-      let expectedXmlText = Blockly.Xml.domToText(originXml);
-      let actualXmlText = Blockly.Xml.domToText(targetXml);
+      const expectedXmlText = Blockly.Xml.domToText(originXml);
+      const actualXmlText = Blockly.Xml.domToText(targetXml);
 
       chai.assert.equal(actualXmlText, expectedXmlText);
     };
     suite('Rendered -> XML -> Headless -> XML', function() {
       test('Comment', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="empty_block"/>'
         ), this.renderedWorkspace);
         block.setCommentText('test text');
@@ -756,7 +756,7 @@ suite('XML', function() {
     });
     suite('Headless -> XML -> Rendered -> XML', function() {
       test('Comment', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             '<block type="empty_block"/>'
         ), this.headlessWorkspace);
         block.setCommentText('test text');
@@ -771,11 +771,11 @@ suite('XML', function() {
   });
   suite('generateVariableFieldDom', function() {
     test('Case Sensitive', function() {
-      let varId = 'testId';
-      let type = 'testType';
-      let name = 'testName';
+      const varId = 'testId';
+      const type = 'testType';
+      const name = 'testName';
 
-      let mockVariableModel = {
+      const mockVariableModel = {
         type: type,
         name: name,
         getId: function() {
@@ -783,9 +783,9 @@ suite('XML', function() {
         }
       };
 
-      let generatedXml = Blockly.Xml.domToText(
+      const generatedXml = Blockly.Xml.domToText(
           Blockly.Variables.generateVariableFieldDom(mockVariableModel));
-      let expectedXml =
+      const expectedXml =
           '<field xmlns="https://developers.google.com/blockly/xml"' +
           ' name="VAR"' +
           ' id="' + varId + '"' +


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5160

### Proposed Changes

Change `let` to `const` in 2146 places in mocha tests.

Steps to create this PR:
- Add `/core/*` to `.eslintignore` to ensure changes do not apply in core (to avoid conflicts with other PRs)
- Add `"prefer-const": ["error"]` as a rule in `.eslintrc`
- Run `npm run lint -- --fix`

#### Behavior Before Change

No change.

#### Behavior After Change

No change.

### Reason for Changes

Progress in using a standard eslint config.

### Test Coverage

Mocha tests.

### Documentation
None

### Additional Information

I found and fixed a bug with https://github.com/google/blockly/pull/5681 while working on this PR.