### PR TITLE
chore: remove references to JSON extraction

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Colour blocks for Blockly.
- *
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -28,7 +23,7 @@ goog.require('Blockly.FieldLabel');
  */
 Blockly.Constants.Colour.HUE = 20;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for colour picker.
   {
     "type": "colour_picker",
@@ -117,4 +112,4 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "style": "colour_blocks",
     "tooltip": "%{BKY_COLOUR_BLEND_TOOLTIP}",
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview List blocks for Blockly.
- *
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -28,7 +23,7 @@ goog.require('Blockly.Mutator');
  */
 Blockly.Constants.Lists.HUE = 260;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for creating an empty list
   // The 'list_create_with' block is preferred as it is more flexible.
   // <block type="lists_create_with">
@@ -111,7 +106,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "%{BKY_LISTS_LENGTH_TOOLTIP}",
     "helpUrl": "%{BKY_LISTS_LENGTH_HELPURL}",
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 Blockly.Blocks['lists_create_with'] = {
   /**

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Logic blocks for Blockly.
- *
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -29,7 +24,7 @@ goog.require('Blockly.Mutator');
  */
 Blockly.Constants.Logic.HUE = 210;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for boolean data type: true and false.
   {
     "type": "logic_boolean",
@@ -226,9 +221,6 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_LOGIC_TERNARY_HELPURL}",
     "extensions": ["logic_ternary"],
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
-
-Blockly.defineBlocksWithJsonArray([ // Mutator blocks. Do not extract.
   // Block representing the if statement in the controls_if mutator.
   {
     "type": "controls_if_if",

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Loop blocks for Blockly.
- *
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -31,7 +26,7 @@ goog.require('Blockly.Warning');
  */
 Blockly.Constants.Loops.HUE = 120;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for repeat n times (external number).
   {
     "type": "controls_repeat_ext",
@@ -200,7 +195,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       "controls_flow_in_loop_check",
     ],
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 /**
  * Tooltips for the 'controls_whileUntil' block, keyed by MODE value.

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Math blocks for Blockly.
- *
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -30,7 +25,7 @@ goog.require('Blockly.FieldVariable');
  */
 Blockly.Constants.Math.HUE = 230;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for numeric value.
   {
     "type": "math_number",
@@ -384,7 +379,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "tooltip": "%{BKY_MATH_ATAN2_TOOLTIP}",
     "helpUrl": "%{BKY_MATH_ATAN2_HELPURL}",
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 /**
  * Mapping of math block OP value to tooltip message for blocks

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -27,7 +27,7 @@ goog.require('Blockly.Mutator');
  */
 Blockly.Constants.Text.HUE = 160;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for text value
   {
     "type": "text",
@@ -222,7 +222,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "inputsInline": true,
     "mutator": "text_charAt_mutator",
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 Blockly.Blocks['text_getSubstring'] = {
   /**

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Variable blocks for Blockly.
-
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -28,7 +23,7 @@ goog.require('Blockly.FieldVariable');
  */
 Blockly.Constants.Variables.HUE = 330;
 
-Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for variable getter.
   {
     "type": "variables_get",
@@ -68,7 +63,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_VARIABLES_SET_HELPURL}",
     "extensions": ["contextMenu_variableSetterGetter"],
   },
-]);  // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 /**
  * Mixin to add context menu items to create getter/setter blocks for this

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -6,11 +6,6 @@
 
 /**
  * @fileoverview Variable blocks for Blockly.
-
- * This file is scraped to extract a .json file of block definitions. The array
- * passed to defineBlocksWithJsonArray(..) must be strict JSON: double quotes
- * only, no outside references, no functions, no trailing commas, etc. The one
- * exception is end-of-line comments, which the scraper will remove.
  */
 'use strict';
 
@@ -27,7 +22,7 @@ goog.require('Blockly.FieldVariable');
  */
 Blockly.Constants.VariablesDynamic.HUE = 310;
 
-Blockly.defineBlocksWithJsonArray([ // BEGIN JSON EXTRACT
+Blockly.defineBlocksWithJsonArray([
   // Block for variable getter.
   {
     "type": "variables_get_dynamic",
@@ -64,7 +59,7 @@ Blockly.defineBlocksWithJsonArray([ // BEGIN JSON EXTRACT
     "helpUrl": "%{BKY_VARIABLES_SET_HELPURL}",
     "extensions": ["contextMenu_variableDynamicSetterGetter"],
   },
-]); // END JSON EXTRACT (Do not delete this comment.)
+]);
 
 /**
  * Mixin to add context menu items to create getter/setter blocks for this


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Progress toward https://github.com/google/blockly/issues/5597

### Proposed Changes

Remove all references to JSON extraction in blocks files.

#### Behavior Before Change
No change.

#### Behavior After Change

No change.

### Reason for Changes

The reason we made the JSON block definition format in the first place was so that you could define blocks in one place and have them work across Android, iOS, and web. At the time we were building Android and iOS versions of Blockly.

There was a script that scraped the block definitions in google/blockly and copied JSON block definitions into the Android and iOS repositories.

JSON is still helpful for simple blocks, but we're no longer developing Android or iOS and these comments are outdated and confusing.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
