### PR TITLE
fix: Don't try to set text fields to null on cancel

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -316,7 +316,10 @@ FieldTextInput.prototype.showEditor_ = function(_opt_e, opt_quietInput) {
  */
 FieldTextInput.prototype.showPromptEditor_ = function() {
   dialog.prompt(Msg['CHANGE_VALUE_TITLE'], this.getText(), function(text) {
-    this.setValue(this.getValueFromEditorText_(text));
+    // Text is null if user pressed cancel button.
+    if (text !== null) {
+      this.setValue(this.getValueFromEditorText_(text));
+    }
   }.bind(this));
 };
 


### PR DESCRIPTION
Mobile users get a window.prompt as an input, if they press the cancel button the return value is null.  Don't attempt to set the value of the field to null.

Caused errors in the custom note field which inherits from FieldTextInput.  Detected in Blockly Games Music.