### PR TITLE
fix: Don't throw if drag surface is empty.

### DIFF
--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -252,11 +252,14 @@ BlockDragSurfaceSvg.prototype.getWsTranslation = function() {
  *     being moved to a different surface.
  */
 BlockDragSurfaceSvg.prototype.clearAndHide = function(opt_newSurface) {
-  if (opt_newSurface) {
-    // appendChild removes the node from this.dragGroup_
-    opt_newSurface.appendChild(this.getCurrentBlock());
-  } else {
-    this.dragGroup_.removeChild(this.getCurrentBlock());
+  const currentBlockElement = this.getCurrentBlock();
+  if (currentBlockElement) {
+    if (opt_newSurface) {
+      // appendChild removes the node from this.dragGroup_
+      opt_newSurface.appendChild(currentBlockElement);
+    } else {
+      this.dragGroup_.removeChild(currentBlockElement);
+    }
   }
   this.SVG_.style.display = 'none';
   if (this.dragGroup_.childNodes.length) {


### PR DESCRIPTION
Observed this error in Blockly Games Bird 6 (Chrome OS):
`Uncaught TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.`
~It has only shown up once, and I can't reproduce,~ but it looks like the drag surface was being cleared while empty.  Maybe some weird multi-touch race-condition on a Chromebook?

Open question: Leave the code as is so that the error is thrown and visible, or suppress it?