### PR TITLE
fix: Quote Msg prop name to survive compile

### DIFF
--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -108,13 +108,13 @@ Blockly.Constants.Variables.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MIXIN = {
     } else {
       if (this.type === 'variables_get' || this.type === 'variables_get_reporter') {
         const renameOption = {
-          text: Blockly.Msg.RENAME_VARIABLE,
+          text: Blockly.Msg['RENAME_VARIABLE'],
           enabled: true,
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this),
         };
         const name = this.getField('VAR').getText();
         const deleteOption = {
-          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          text: Blockly.Msg['DELETE_VARIABLE'].replace('%1', name),
           enabled: true,
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this),
         };

--- a/blocks/variables_dynamic.js
+++ b/blocks/variables_dynamic.js
@@ -109,13 +109,13 @@ Blockly.Constants.VariablesDynamic.CUSTOM_CONTEXT_MENU_VARIABLE_GETTER_SETTER_MI
       if (this.type === 'variables_get_dynamic' ||
        this.type === 'variables_get_reporter_dynamic') {
         const renameOption = {
-          text: Blockly.Msg.RENAME_VARIABLE,
+          text: Blockly.Msg['RENAME_VARIABLE'],
           enabled: true,
           callback: Blockly.Constants.Variables.RENAME_OPTION_CALLBACK_FACTORY(this),
         };
         const name = this.getField('VAR').getText();
         const deleteOption = {
-          text: Blockly.Msg.DELETE_VARIABLE.replace('%1', name),
+          text: Blockly.Msg['DELETE_VARIABLE'].replace('%1', name),
           enabled: true,
           callback: Blockly.Constants.Variables.DELETE_OPTION_CALLBACK_FACTORY(this),
         };


### PR DESCRIPTION
This is the context menu of a variable-get block in the flyout.
Detected via error logging in Blockly Games.