### PR TITLE
chore: fix dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,5 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     labels:
-      - "chore"
-      - "dependencies"
+      - "PR: chore"
+      - "PR: dependencies"


### PR DESCRIPTION
I changed the labels after the last dependabot update, so it keeps adding comments that it can't find the labels "chore" and "dependencies". This fixes it.

Note that it's against master.