### PR TITLE
fix: change getCandidate_ and showInsertionMarker_ to be more dynamic

### DIFF
--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -433,8 +433,8 @@ InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
 
   // It's possible that a block has added or removed connections during a drag,
   // (e.g. in a drag/move event handler), so let's update the available
-  // connections. Note that this will be called en every move while dragging, so
-  // ir might cause slowness, especially if the block stack is large.  If so,
+  // connections. Note that this will be called on every move while dragging, so
+  // it might cause slowness, especially if the block stack is large.  If so,
   // maybe it could be made more efficient.
   this.updateAvailableConnections();
 

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -435,8 +435,11 @@ InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
   // (e.g. in a drag/move event handler), so let's update the available
   // connections. Note that this will be called on every move while dragging, so
   // it might cause slowness, especially if the block stack is large.  If so,
-  // maybe it could be made more efficient.
-  this.updateAvailableConnections();
+  // maybe it could be made more efficient. Also note that we won't update the
+  // connections if we've already connected the insertion marker to a block.
+  if (!this.markerConnection_ || !this.markerConnection_.isConnected()) {
+    this.updateAvailableConnections();
+  }
 
   for (let i = 0; i < this.availableConnections_.length; i++) {
     const myConnection = this.availableConnections_[i];

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -432,10 +432,10 @@ InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
   let candidateLocal = null;
 
   // It's possible that a block has added or removed connections during a drag,
-  // (e.g. in a drag/move event handler), so let's update the available connections.
-  // Note that this will be called en every move while dragging, so ir might
-  // cause slowness, especially if the block stack is large.  If so, maybe it
-  // could be made more efficient.
+  // (e.g. in a drag/move event handler), so let's update the available
+  // connections. Note that this will be called en every move while dragging, so
+  // ir might cause slowness, especially if the block stack is large.  If so,
+  // maybe it could be made more efficient.
   this.updateAvailableConnections();
 
   for (let i = 0; i < this.availableConnections_.length; i++) {
@@ -630,11 +630,11 @@ InsertionMarkerManager.prototype.showInsertionMarker_ = function() {
     imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);
   } catch (e) {
     // It's possible that the number of connections on the local block has
-    // changed since the insertion marker was originally created.  Let's recreate
-    // the insertion marker and try again.
-    // In theory we could probably recreate the marker block (e.g. in getCandidate_),
-    // which is called more often during the drag, but creating a block that
-    // often might be too slow, so we only do it if necessary.
+    // changed since the insertion marker was originally created.  Let's
+    // recreate the insertion marker and try again. In theory we could probably
+    // recreate the marker block (e.g. in getCandidate_), which is called more
+    // often during the drag, but creating a block that often might be too slow,
+    // so we only do it if necessary.
     this.firstMarker_ = this.createMarkerBlock_(this.topBlock_);
     imBlock = isLastInStack ? this.lastMarker_ : this.firstMarker_;
     imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -431,6 +431,13 @@ InsertionMarkerManager.prototype.getCandidate_ = function(dxy) {
   let candidateClosest = null;
   let candidateLocal = null;
 
+  // It's possible that a block has added or removed connections during a drag,
+  // (e.g. in a drag/move event handler), so let's update the available connections.
+  // Note that this will be called en every move while dragging, so ir might
+  // cause slowness, especially if the block stack is large.  If so, maybe it
+  // could be made more efficient.
+  this.updateAvailableConnections();
+
   for (let i = 0; i < this.availableConnections_.length; i++) {
     const myConnection = this.availableConnections_[i];
     const neighbour = myConnection.closest(radius, dxy);
@@ -617,8 +624,21 @@ InsertionMarkerManager.prototype.showInsertionMarker_ = function() {
   const closest = this.closestConnection_;
 
   const isLastInStack = this.lastOnStack_ && local === this.lastOnStack_;
-  const imBlock = isLastInStack ? this.lastMarker_ : this.firstMarker_;
-  const imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);
+  let imBlock = isLastInStack ? this.lastMarker_ : this.firstMarker_;
+  let imConn;
+  try {
+    imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);
+  } catch (e) {
+    // It's possible that the number of connections on the local block has
+    // changed since the insertion marker was originally created.  Let's recreate
+    // the insertion marker and try again.
+    // In theory we could probably recreate the marker block (e.g. in getCandidate_),
+    // which is called more often during the drag, but creating a block that
+    // often might be too slow, so we only do it if necessary.
+    this.firstMarker_ = this.createMarkerBlock_(this.topBlock_);
+    imBlock = isLastInStack ? this.lastMarker_ : this.firstMarker_;
+    imConn = imBlock.getMatchingConnection(local.getSourceBlock(), local);
+  }
 
   if (imConn === this.markerConnection_) {
     throw Error(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Resolves #5720

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

It allows changes the insertion marker manager to handle a block which changes its connections while it is being dragged (e.g. by a drag/move event handler).

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

The insertion marker manager would throw an error due to mismatched connections when dragging a block which has changed its connectors during a drag.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

The insertion marker manager no longer throws an error due to mismatched connections when dragging a block which has changed its connectors during a drag.  More specifically, it updates its set of available connections and its marker block more dynamically.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

I would like to be able to create a "chameleon" block which would have previous, next and output connections when
created, so that it could be used as either a value or a statement. Once it is actually connected it would change to an appropriate shape depending on its context. When it is dragged out of its connection I would like it to be able to change back to a state where it has all the connectors again.  This requires that the insertion marker manager be able to handle the changed block.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I did a bunch of manual testing in a playground whereby I created a "chameleon" block and dragged in and out of a variety of other blocks.

I also ensured that the existing Blockly tests passed.

I would like to create some new tests for this behavior, but it is unclear to me how and where to do that.  I would appreciate some guidance on that, if you deem such test necessary.

<!-- Tested on: -->
* Desktop Chrome 
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

There are no documentation changes required that I know of.

### Additional Information

<!-- Anything else we should know? -->

I realize that there are some performance implications to these changes.  I've tried to minimize them, but if there is more that I can do, please let me know.