### PR TITLE
fix: Stop throwing error when PointerEvent.pageX is 0.

### DIFF
--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -323,8 +323,8 @@ TouchGesture.prototype.getTouchPoint = function(e) {
     return null;
   }
   return new Coordinate(
-      (e.pageX ? e.pageX : e.changedTouches[0].pageX),
-      (e.pageY ? e.pageY : e.changedTouches[0].pageY));
+      (e.changedTouches ? e.changedTouches[0].pageX : e.pageX),
+      (e.changedTouches ? e.changedTouches[0].pageY : e.pageY));
 };
 
 exports.TouchGesture = TouchGesture;


### PR DESCRIPTION
The e.pageX (and .pageY) checks aren't strict enough.  0 is a perfectly valid coordinate.

Checking for the existence of changedTouches is an easier way to distinguishing a PointerEvent from a TouchEvent.

Resolves #5688.  Found from client-side error logging on Blockly Games.
