### PR TITLE
chore: make Blockly.common.setSelected package and update docs

### DIFF
--- a/core/common.js
+++ b/core/common.js
@@ -76,9 +76,12 @@ const getSelected = function() {
 exports.getSelected = getSelected;
 
 /**
- * Sets the currently selected block.
+ * Sets the currently selected block. This function does not visually mark the
+ * block as selected or fire the required events. If you wish to
+ * programmatically select a block, use `BlockSvg#select`.
  * @param {?ICopyable} newSelection The newly selected block.
  * @alias Blockly.common.setSelected
+ * @package
  */
 const setSelected = function(newSelection) {
   selected = newSelection;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #5674 

### Proposed Changes

Makes `Blockly.common.setSelected` package visibility, and updates the documentation string.

### Reason for Changes

This function was added last quarter when adding get/set pairs for the properties in blockly.js. It is used to track which block is currently selected. I did not rename the function as suggested because we already have `BlockSvg.prototype.select` which updates the UI and is generally the function external developers should call in order to programmatically select a block.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
