### PR TITLE
chore(build): Update compiler & linter input language to ES2020

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,10 +64,17 @@
         // Blockly uses objects as maps, but uses Object.create(null) to
         // instantiate them.
         "guard-for-in": ["off"],
-        "prefer-spread": ["off"]
+        "prefer-spread": ["off"],
+        "comma-dangle": ["error", {
+            "arrays": "always-multiline",
+            "objects": "always-multiline",
+            "imports": "always-multiline",
+            "exports": "always-multiline",
+            "functions": "ignore"
+        }]
     },
     "env": {
-        "es6": true,
+        "es2020": true,
         "browser": true
     },
     "globals": {

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -453,7 +453,7 @@ function compile(options) {
   const defaultOptions = {
     compilation_level: 'SIMPLE_OPTIMIZATIONS',
     warning_level: argv.verbose ? 'VERBOSE' : 'DEFAULT',
-    language_in: 'ECMASCRIPT6_STRICT',
+    language_in: 'ECMASCRIPT_2020',
     language_out: 'ECMASCRIPT5_STRICT',
     rewrite_polyfills: true,
     hide_warnings_for: 'node_modules',

--- a/tests/node/.eslintrc.json
+++ b/tests/node/.eslintrc.json
@@ -1,8 +1,6 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 6
-    },
     "env": {
+        "node": true,
         "browser": false,
         "mocha": true
     },


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Also:

- Ensure that the `comma-dangle` rule will not be applied to function parameter lists (even when multi-line).

- Update `tests/node/.eslintrc.json` to make the environment node-specific and not pinned to es6.

### Reason for Changes

Proximately this is to allow use of spread syntax in object literals (`const foo = {...bar, baz: 'quux'}`).
