### PR TITLE
refactor: convert some js block generators to goog.module

### DIFF
--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -25,8 +25,7 @@ const strRegExp = /^\s*'([^']|\\')*'\s*$/;
  * Leave string literals alone.
  * @param {string} value Code evaluating to a value.
  * @return {Array<string|number>} Array containing code evaluating to a string
- *     and
- *    the order of the returned code.[string, number]
+ *     and the order of the returned code.[string, number]
  */
 const forceString = function(value) {
   if (strRegExp.test(value)) {

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -6,14 +6,13 @@
 
 /**
  * @fileoverview Generating JavaScript for text blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.JavaScript.texts');
-goog.module.declareLegacyNamespace();
 
-goog.require('Blockly.JavaScript');
+const JavaScript = goog.require('Blockly.JavaScript');
+const {NameType} = goog.require('Blockly.Names');
 
 
 /**
@@ -31,9 +30,9 @@ const strRegExp = /^\s*'([^']|\\')*'\s*$/;
  */
 const forceString = function(value) {
   if (strRegExp.test(value)) {
-    return [value, Blockly.JavaScript.ORDER_ATOMIC];
+    return [value, JavaScript.ORDER_ATOMIC];
   }
-  return ['String(' + value + ')', Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return ['String(' + value + ')', JavaScript.ORDER_FUNCTION_CALL];
 };
 
 /**
@@ -55,161 +54,161 @@ const getSubstringIndex = function(stringName, where, opt_at) {
   }
 };
 
-Blockly.JavaScript['text'] = function(block) {
+JavaScript['text'] = function(block) {
   // Text value.
-  const code = Blockly.JavaScript.quote_(block.getFieldValue('TEXT'));
-  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+  const code = JavaScript.quote_(block.getFieldValue('TEXT'));
+  return [code, JavaScript.ORDER_ATOMIC];
 };
 
-Blockly.JavaScript['text_multiline'] = function(block) {
+JavaScript['text_multiline'] = function(block) {
   // Text value.
-  const code = Blockly.JavaScript.multiline_quote_(block.getFieldValue('TEXT'));
-  const order = code.indexOf('+') !== -1 ? Blockly.JavaScript.ORDER_ADDITION :
-      Blockly.JavaScript.ORDER_ATOMIC;
+  const code = JavaScript.multiline_quote_(block.getFieldValue('TEXT'));
+  const order = code.indexOf('+') !== -1 ? JavaScript.ORDER_ADDITION :
+      JavaScript.ORDER_ATOMIC;
   return [code, order];
 };
 
-Blockly.JavaScript['text_join'] = function(block) {
+JavaScript['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   switch (block.itemCount_) {
     case 0:
-      return ['\'\'', Blockly.JavaScript.ORDER_ATOMIC];
+      return ['\'\'', JavaScript.ORDER_ATOMIC];
     case 1: {
-      const element = Blockly.JavaScript.valueToCode(block, 'ADD0',
-          Blockly.JavaScript.ORDER_NONE) || '\'\'';
+      const element = JavaScript.valueToCode(block, 'ADD0',
+          JavaScript.ORDER_NONE) || '\'\'';
       const codeAndOrder = forceString(element);
       return codeAndOrder;
     }
     case 2: {
-      const element0 = Blockly.JavaScript.valueToCode(block, 'ADD0',
-          Blockly.JavaScript.ORDER_NONE) || '\'\'';
-      const element1 = Blockly.JavaScript.valueToCode(block, 'ADD1',
-          Blockly.JavaScript.ORDER_NONE) || '\'\'';
+      const element0 = JavaScript.valueToCode(block, 'ADD0',
+          JavaScript.ORDER_NONE) || '\'\'';
+      const element1 = JavaScript.valueToCode(block, 'ADD1',
+          JavaScript.ORDER_NONE) || '\'\'';
       const code = forceString(element0)[0] +
           ' + ' + forceString(element1)[0];
-      return [code, Blockly.JavaScript.ORDER_ADDITION];
+      return [code, JavaScript.ORDER_ADDITION];
     }
     default: {
       const elements = new Array(block.itemCount_);
       for (let i = 0; i < block.itemCount_; i++) {
-        elements[i] = Blockly.JavaScript.valueToCode(block, 'ADD' + i,
-            Blockly.JavaScript.ORDER_NONE) || '\'\'';
+        elements[i] = JavaScript.valueToCode(block, 'ADD' + i,
+            JavaScript.ORDER_NONE) || '\'\'';
       }
       const code = '[' + elements.join(',') + '].join(\'\')';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
   }
 };
 
-Blockly.JavaScript['text_append'] = function(block) {
+JavaScript['text_append'] = function(block) {
   // Append to a variable in place.
-  const varName = Blockly.JavaScript.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  const value = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
+  const varName = JavaScript.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const value = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_NONE) || '\'\'';
   const code = varName + ' += ' +
       forceString(value)[0] + ';\n';
   return code;
 };
 
-Blockly.JavaScript['text_length'] = function(block) {
+JavaScript['text_length'] = function(block) {
   // String or array length.
-  const text = Blockly.JavaScript.valueToCode(block, 'VALUE',
-      Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
-  return [text + '.length', Blockly.JavaScript.ORDER_MEMBER];
+  const text = JavaScript.valueToCode(block, 'VALUE',
+      JavaScript.ORDER_MEMBER) || '\'\'';
+  return [text + '.length', JavaScript.ORDER_MEMBER];
 };
 
-Blockly.JavaScript['text_isEmpty'] = function(block) {
+JavaScript['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const text = Blockly.JavaScript.valueToCode(block, 'VALUE',
-      Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
-  return ['!' + text + '.length', Blockly.JavaScript.ORDER_LOGICAL_NOT];
+  const text = JavaScript.valueToCode(block, 'VALUE',
+      JavaScript.ORDER_MEMBER) || '\'\'';
+  return ['!' + text + '.length', JavaScript.ORDER_LOGICAL_NOT];
 };
 
-Blockly.JavaScript['text_indexOf'] = function(block) {
+JavaScript['text_indexOf'] = function(block) {
   // Search the text for a substring.
   const operator = block.getFieldValue('END') === 'FIRST' ?
       'indexOf' : 'lastIndexOf';
-  const substring = Blockly.JavaScript.valueToCode(block, 'FIND',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  const text = Blockly.JavaScript.valueToCode(block, 'VALUE',
-      Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
+  const substring = JavaScript.valueToCode(block, 'FIND',
+      JavaScript.ORDER_NONE) || '\'\'';
+  const text = JavaScript.valueToCode(block, 'VALUE',
+      JavaScript.ORDER_MEMBER) || '\'\'';
   const code = text + '.' + operator + '(' + substring + ')';
   // Adjust index if using one-based indices.
   if (block.workspace.options.oneBasedIndex) {
-    return [code + ' + 1', Blockly.JavaScript.ORDER_ADDITION];
+    return [code + ' + 1', JavaScript.ORDER_ADDITION];
   }
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_charAt'] = function(block) {
+JavaScript['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const textOrder = (where === 'RANDOM') ? Blockly.JavaScript.ORDER_NONE :
-      Blockly.JavaScript.ORDER_MEMBER;
-  const text = Blockly.JavaScript.valueToCode(block, 'VALUE',
+  const textOrder = (where === 'RANDOM') ? JavaScript.ORDER_NONE :
+      JavaScript.ORDER_MEMBER;
+  const text = JavaScript.valueToCode(block, 'VALUE',
       textOrder) || '\'\'';
   switch (where) {
     case 'FIRST': {
       const code = text + '.charAt(0)';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
     case 'LAST': {
       const code = text + '.slice(-1)';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
     case 'FROM_START': {
-      const at = Blockly.JavaScript.getAdjusted(block, 'AT');
+      const at = JavaScript.getAdjusted(block, 'AT');
       // Adjust index if using one-based indices.
       const code = text + '.charAt(' + at + ')';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
     case 'FROM_END': {
-      const at = Blockly.JavaScript.getAdjusted(block, 'AT', 1, true);
+      const at = JavaScript.getAdjusted(block, 'AT', 1, true);
       const code = text + '.slice(' + at + ').charAt(0)';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
     case 'RANDOM': {
-      const functionName = Blockly.JavaScript.provideFunction_(
+      const functionName = JavaScript.provideFunction_(
           'textRandomLetter',
-          ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
+          ['function ' + JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(text) {',
            '  var x = Math.floor(Math.random() * text.length);',
            '  return text[x];',
            '}']);
       const code = functionName + '(' + text + ')';
-      return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+      return [code, JavaScript.ORDER_FUNCTION_CALL];
     }
   }
   throw Error('Unhandled option (text_charAt).');
 };
 
-Blockly.JavaScript['text_getSubstring'] = function(block) {
+JavaScript['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
   const requiresLengthCall = (where1 !== 'FROM_END' && where1 !== 'LAST' &&
       where2 !== 'FROM_END' && where2 !== 'LAST');
-  const textOrder = requiresLengthCall ? Blockly.JavaScript.ORDER_MEMBER :
-      Blockly.JavaScript.ORDER_NONE;
-  const text = Blockly.JavaScript.valueToCode(block, 'STRING',
+  const textOrder = requiresLengthCall ? JavaScript.ORDER_MEMBER :
+      JavaScript.ORDER_NONE;
+  const text = JavaScript.valueToCode(block, 'STRING',
       textOrder) || '\'\'';
   let code;
   if (where1 === 'FIRST' && where2 === 'LAST') {
     code = text;
-    return [code, Blockly.JavaScript.ORDER_NONE];
+    return [code, JavaScript.ORDER_NONE];
   } else if (text.match(/^'?\w+'?$/) || requiresLengthCall) {
     // If the text is a variable or literal or doesn't require a call for
     // length, don't generate a helper function.
     let at1;
     switch (where1) {
       case 'FROM_START':
-        at1 = Blockly.JavaScript.getAdjusted(block, 'AT1');
+        at1 = JavaScript.getAdjusted(block, 'AT1');
         break;
       case 'FROM_END':
-        at1 = Blockly.JavaScript.getAdjusted(block, 'AT1', 1, false,
-            Blockly.JavaScript.ORDER_SUBTRACTION);
+        at1 = JavaScript.getAdjusted(block, 'AT1', 1, false,
+            JavaScript.ORDER_SUBTRACTION);
         at1 = text + '.length - ' + at1;
         break;
       case 'FIRST':
@@ -221,11 +220,11 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
     let at2;
     switch (where2) {
       case 'FROM_START':
-        at2 = Blockly.JavaScript.getAdjusted(block, 'AT2', 1);
+        at2 = JavaScript.getAdjusted(block, 'AT2', 1);
         break;
       case 'FROM_END':
-        at2 = Blockly.JavaScript.getAdjusted(block, 'AT2', 0, false,
-            Blockly.JavaScript.ORDER_SUBTRACTION);
+        at2 = JavaScript.getAdjusted(block, 'AT2', 0, false,
+            JavaScript.ORDER_SUBTRACTION);
         at2 = text + '.length - ' + at2;
         break;
       case 'LAST':
@@ -236,13 +235,13 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
     }
     code = text + '.slice(' + at1 + ', ' + at2 + ')';
   } else {
-    const at1 = Blockly.JavaScript.getAdjusted(block, 'AT1');
-    const at2 = Blockly.JavaScript.getAdjusted(block, 'AT2');
+    const at1 = JavaScript.getAdjusted(block, 'AT1');
+    const at2 = JavaScript.getAdjusted(block, 'AT2');
     const wherePascalCase = {'FIRST': 'First', 'LAST': 'Last',
       'FROM_START': 'FromStart', 'FROM_END': 'FromEnd'};
-    const functionName = Blockly.JavaScript.provideFunction_(
+    const functionName = JavaScript.provideFunction_(
         'subsequence' + wherePascalCase[where1] + wherePascalCase[where2], [
-          'function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
+          'function ' + JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(sequence' +
               // The value for 'FROM_END' and'FROM_START' depends on `at` so
               // we add it as a parameter.
@@ -263,10 +262,10 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
         ((where2 === 'FROM_END' || where2 === 'FROM_START') ? ', ' + at2 : '') +
         ')';
   }
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_changeCase'] = function(block) {
+JavaScript['text_changeCase'] = function(block) {
   // Change capitalization.
   const OPERATORS = {
     'UPPERCASE': '.toUpperCase()',
@@ -274,9 +273,9 @@ Blockly.JavaScript['text_changeCase'] = function(block) {
     'TITLECASE': null
   };
   const operator = OPERATORS[block.getFieldValue('CASE')];
-  const textOrder = operator ? Blockly.JavaScript.ORDER_MEMBER :
-      Blockly.JavaScript.ORDER_NONE;
-  const text = Blockly.JavaScript.valueToCode(block, 'TEXT',
+  const textOrder = operator ? JavaScript.ORDER_MEMBER :
+      JavaScript.ORDER_NONE;
+  const text = JavaScript.valueToCode(block, 'TEXT',
       textOrder) || '\'\'';
   let code;
   if (operator) {
@@ -284,9 +283,9 @@ Blockly.JavaScript['text_changeCase'] = function(block) {
     code = text + operator;
   } else {
     // Title case is not a native JavaScript function.  Define one.
-    const functionName = Blockly.JavaScript.provideFunction_(
+    const functionName = JavaScript.provideFunction_(
         'textToTitleCase',
-        ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
+        ['function ' + JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
             '(str) {',
          '  return str.replace(/\\S+/g,',
          '      function(txt) {return txt[0].toUpperCase() + ' +
@@ -294,10 +293,10 @@ Blockly.JavaScript['text_changeCase'] = function(block) {
          '}']);
     code = functionName + '(' + text + ')';
   }
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_trim'] = function(block) {
+JavaScript['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {
     'LEFT': ".replace(/^[\\s\\xa0]+/, '')",
@@ -305,47 +304,47 @@ Blockly.JavaScript['text_trim'] = function(block) {
     'BOTH': '.trim()'
   };
   const operator = OPERATORS[block.getFieldValue('MODE')];
-  const text = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
-  return [text + operator, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  const text = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_MEMBER) || '\'\'';
+  return [text + operator, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_print'] = function(block) {
+JavaScript['text_print'] = function(block) {
   // Print statement.
-  const msg = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
+  const msg = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_NONE) || '\'\'';
   return 'window.alert(' + msg + ');\n';
 };
 
-Blockly.JavaScript['text_prompt_ext'] = function(block) {
+JavaScript['text_prompt_ext'] = function(block) {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
     // Internal message.
-    msg = Blockly.JavaScript.quote_(block.getFieldValue('TEXT'));
+    msg = JavaScript.quote_(block.getFieldValue('TEXT'));
   } else {
     // External message.
-    msg = Blockly.JavaScript.valueToCode(block, 'TEXT',
-        Blockly.JavaScript.ORDER_NONE) || '\'\'';
+    msg = JavaScript.valueToCode(block, 'TEXT',
+        JavaScript.ORDER_NONE) || '\'\'';
   }
   let code = 'window.prompt(' + msg + ')';
   const toNumber = block.getFieldValue('TYPE') === 'NUMBER';
   if (toNumber) {
     code = 'Number(' + code + ')';
   }
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_prompt'] = Blockly.JavaScript['text_prompt_ext'];
+JavaScript['text_prompt'] = JavaScript['text_prompt_ext'];
 
-Blockly.JavaScript['text_count'] = function(block) {
-  const text = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  const sub = Blockly.JavaScript.valueToCode(block, 'SUB',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  const functionName = Blockly.JavaScript.provideFunction_(
+JavaScript['text_count'] = function(block) {
+  const text = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_NONE) || '\'\'';
+  const sub = JavaScript.valueToCode(block, 'SUB',
+      JavaScript.ORDER_NONE) || '\'\'';
+  const functionName = JavaScript.provideFunction_(
       'textCount',
-      ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
           '(haystack, needle) {',
        '  if (needle.length === 0) {',
        '    return haystack.length + 1;',
@@ -354,21 +353,21 @@ Blockly.JavaScript['text_count'] = function(block) {
        '  }',
        '}']);
   const code = functionName + '(' + text + ', ' + sub + ')';
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_replace'] = function(block) {
-  const text = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  const from = Blockly.JavaScript.valueToCode(block, 'FROM',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
-  const to = Blockly.JavaScript.valueToCode(block, 'TO',
-      Blockly.JavaScript.ORDER_NONE) || '\'\'';
+JavaScript['text_replace'] = function(block) {
+  const text = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_NONE) || '\'\'';
+  const from = JavaScript.valueToCode(block, 'FROM',
+      JavaScript.ORDER_NONE) || '\'\'';
+  const to = JavaScript.valueToCode(block, 'TO',
+      JavaScript.ORDER_NONE) || '\'\'';
   // The regex escaping code below is taken from the implementation of
   // goog.string.regExpEscape.
-  const functionName = Blockly.JavaScript.provideFunction_(
+  const functionName = JavaScript.provideFunction_(
       'textReplace',
-      ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
           '(haystack, needle, replacement) {',
        '  needle = ' +
            'needle.replace(/([-()\\[\\]{}+?*.$\\^|,:#<!\\\\])/g,"\\\\$1")',
@@ -376,12 +375,12 @@ Blockly.JavaScript['text_replace'] = function(block) {
        '  return haystack.replace(new RegExp(needle, \'g\'), replacement);',
        '}']);
   const code = functionName + '(' + text + ', ' + from + ', ' + to + ')';
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-Blockly.JavaScript['text_reverse'] = function(block) {
-  const text = Blockly.JavaScript.valueToCode(block, 'TEXT',
-      Blockly.JavaScript.ORDER_MEMBER) || '\'\'';
+JavaScript['text_reverse'] = function(block) {
+  const text = JavaScript.valueToCode(block, 'TEXT',
+      JavaScript.ORDER_MEMBER) || '\'\'';
   const code = text + '.split(\'\').reverse().join(\'\')';
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  return [code, JavaScript.ORDER_FUNCTION_CALL];
 };

--- a/generators/javascript/variables.js
+++ b/generators/javascript/variables.js
@@ -6,28 +6,27 @@
 
 /**
  * @fileoverview Generating JavaScript for variable blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
-goog.provide('Blockly.JavaScript.variables');
+goog.module('Blockly.JavaScript.variables');
 
-goog.require('Blockly.JavaScript');
+const JavaScript = goog.require('Blockly.JavaScript');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.JavaScript['variables_get'] = function(block) {
+JavaScript['variables_get'] = function(block) {
   // Variable getter.
-  const code = Blockly.JavaScript.nameDB_.getName(block.getFieldValue('VAR'),
-      Blockly.VARIABLE_CATEGORY_NAME);
-  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+  const code = JavaScript.nameDB_.getName(block.getFieldValue('VAR'),
+      NameType.VARIABLE);
+  return [code, JavaScript.ORDER_ATOMIC];
 };
 
-Blockly.JavaScript['variables_set'] = function(block) {
+JavaScript['variables_set'] = function(block) {
   // Variable setter.
-  const argument0 = Blockly.JavaScript.valueToCode(
-                        block, 'VALUE', Blockly.JavaScript.ORDER_ASSIGNMENT) ||
-      '0';
-  const varName = Blockly.JavaScript.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
+  const argument0 = JavaScript.valueToCode(
+                        block, 'VALUE', JavaScript.ORDER_ASSIGNMENT) || '0';
+  const varName = JavaScript.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + argument0 + ';\n';
 };

--- a/generators/javascript/variables_dynamic.js
+++ b/generators/javascript/variables_dynamic.js
@@ -6,18 +6,16 @@
 
 /**
  * @fileoverview Generating JavaScript for dynamic variable blocks.
- * @suppress {extraRequire}
  */
 'use strict';
 
-goog.provide('Blockly.JavaScript.variablesDynamic');
+goog.module('Blockly.JavaScript.variablesDynamic');
 
-goog.require('Blockly.JavaScript');
+const JavaScript = goog.require('Blockly.JavaScript');
+/** @suppress {extraRequire} */
 goog.require('Blockly.JavaScript.variables');
 
 
 // JavaScript is dynamically typed.
-Blockly.JavaScript['variables_get_dynamic'] =
-    Blockly.JavaScript['variables_get'];
-Blockly.JavaScript['variables_set_dynamic'] =
-    Blockly.JavaScript['variables_set'];
+JavaScript['variables_get_dynamic'] = JavaScript['variables_get'];
+JavaScript['variables_set_dynamic'] = JavaScript['variables_set'];

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -286,7 +286,7 @@ goog.addDependency('../../generators/javascript/loops.js', ['Blockly.JavaScript.
 goog.addDependency('../../generators/javascript/math.js', ['Blockly.JavaScript.math'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/procedures.js', ['Blockly.JavaScript.procedures'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScript.variables'], ['Blockly.JavaScript'], {'lang': 'es6'});
+goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScript.variables'], ['Blockly.JavaScript', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables']);
 goog.addDependency('../../generators/lua.js', ['Blockly.Lua'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/lua/all.js', ['Blockly.Lua.all'], ['Blockly.Lua.colour', 'Blockly.Lua.lists', 'Blockly.Lua.logic', 'Blockly.Lua.loops', 'Blockly.Lua.math', 'Blockly.Lua.procedures', 'Blockly.Lua.texts', 'Blockly.Lua.variables', 'Blockly.Lua.variablesDynamic'], {'module': 'goog'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -285,7 +285,7 @@ goog.addDependency('../../generators/javascript/logic.js', ['Blockly.JavaScript.
 goog.addDependency('../../generators/javascript/loops.js', ['Blockly.JavaScript.loops'], ['Blockly.JavaScript', 'Blockly.loopMixin', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/math.js', ['Blockly.JavaScript.math'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/procedures.js', ['Blockly.JavaScript.procedures'], ['Blockly.JavaScript'], {'lang': 'es6'});
-goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript'], {'lang': 'es6'});
+goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScript.variables'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables']);
 goog.addDependency('../../generators/lua.js', ['Blockly.Lua'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -287,7 +287,7 @@ goog.addDependency('../../generators/javascript/math.js', ['Blockly.JavaScript.m
 goog.addDependency('../../generators/javascript/procedures.js', ['Blockly.JavaScript.procedures'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScript.variables'], ['Blockly.JavaScript', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables']);
+goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/lua.js', ['Blockly.Lua'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/lua/all.js', ['Blockly.Lua.all'], ['Blockly.Lua.colour', 'Blockly.Lua.lists', 'Blockly.Lua.logic', 'Blockly.Lua.loops', 'Blockly.Lua.math', 'Blockly.Lua.procedures', 'Blockly.Lua.texts', 'Blockly.Lua.variables', 'Blockly.Lua.variablesDynamic'], {'module': 'goog'});
 goog.addDependency('../../generators/lua/colour.js', ['Blockly.Lua.colour'], ['Blockly.Lua'], {'lang': 'es6'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -285,7 +285,7 @@ goog.addDependency('../../generators/javascript/logic.js', ['Blockly.JavaScript.
 goog.addDependency('../../generators/javascript/loops.js', ['Blockly.JavaScript.loops'], ['Blockly.JavaScript', 'Blockly.loopMixin', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/math.js', ['Blockly.JavaScript.math'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/procedures.js', ['Blockly.JavaScript.procedures'], ['Blockly.JavaScript'], {'lang': 'es6'});
-goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/javascript/text.js', ['Blockly.JavaScript.texts'], ['Blockly.JavaScript', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScript.variables'], ['Blockly.JavaScript'], {'lang': 'es6'});
 goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables']);
 goog.addDependency('../../generators/lua.js', ['Blockly.Lua'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Part of #5598

### Proposed Changes
Changes three files to goog.module and adds missing requires:
- `generators/javascript/text.js`
- `generators/javascript/variables.js`
- `generators/javascript/variables_dynamic.js`