### PR TITLE
fix: procedure callers now remove inputs properly

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -808,7 +808,7 @@ const procedureCall = {
       }
     }
     // Remove deleted inputs.
-    for (let i = this.itemCount_; this.getInput('ARG' + i); i++) {
+    for (let i = this.arguments_.length; this.getInput('ARG' + i); i++) {
       this.removeInput('ARG' + i);
     }
     // Add 'with:' if there are parameters, remove otherwise.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes a bug where caller blocks would not update properly when an input was removed. 
This was found because of @BeksOmega tests in the block-plus-minus plugin. 🎊 
We should probably add a similar test in core. [[Filed issue](https://github.com/google/blockly/issues/5466)]

### Proposed Changes
Use `this.arguments_.length` instead of `itemCount_`. `itemCount_` is used in text & list blocks but not procedures. I think this was introduced when we were doing a [larger refactor](#5626) that included all the blocks.

#### Behavior Before Change
Remove an input on a procedure breaks the caller block.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change
Procedures work!
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
