### PR TITLE
fix: Uncaught Error: Couldn't clear and hide the drag surface

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1300,6 +1300,16 @@ Blockly.WorkspaceSvg.prototype.resetDragSurface = function() {
     return;
   }
 
+  // This can happen if the user starts a drag, mouses up outside of the
+  // document where the mouseup listener is registered (e.g. outside of an
+  // iframe) and then moves the mouse back in the workspace and
+  // hover directly over the scrollbar, click once on the scrollbar,
+  // and then click on the workspace.
+  if (!this.isDragSurfaceActive_) {
+    console.warn('Tried to reset workspace drag surface twice.');
+    return;
+  }
+
   this.isDragSurfaceActive_ = false;
 
   var trans = this.workspaceDragSurface_.getSurfaceTranslation();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Issue #5759

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Drag workspace failed, mouse sticky with the interface and cannot detached.
#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Workspace can be dragged and dropped again normally.
### Reason for Changes
This change prevents the ```resetDragSurface``` function being called twice and raising the exception. 
It also maintains symmetry with the ```setupDragSurface``` function in terms of logic checks.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on: 
Desktop Chrome 

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->
