### PR TITLE
refactor: convert some block generators to goog.module

### DIFF
--- a/generators/lua/colour.js
+++ b/generators/lua/colour.js
@@ -11,46 +11,46 @@
 
 goog.module('Blockly.Lua.colour');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
 
 
-Blockly.Lua['colour_picker'] = function(block) {
+Lua['colour_picker'] = function(block) {
   // Colour picker.
-  const code = Blockly.Lua.quote_(block.getFieldValue('COLOUR'));
-  return [code, Blockly.Lua.ORDER_ATOMIC];
+  const code = Lua.quote_(block.getFieldValue('COLOUR'));
+  return [code, Lua.ORDER_ATOMIC];
 };
 
-Blockly.Lua['colour_random'] = function(block) {
+Lua['colour_random'] = function(block) {
   // Generate a random colour.
   const code = 'string.format("#%06x", math.random(0, 2^24 - 1))';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['colour_rgb'] = function(block) {
+Lua['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'colour_rgb',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(r, g, b)',
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(r, g, b)',
        '  r = math.floor(math.min(100, math.max(0, r)) * 2.55 + .5)',
        '  g = math.floor(math.min(100, math.max(0, g)) * 2.55 + .5)',
        '  b = math.floor(math.min(100, math.max(0, b)) * 2.55 + .5)',
        '  return string.format("#%02x%02x%02x", r, g, b)',
        'end']);
-  const r = Blockly.Lua.valueToCode(block, 'RED',
-      Blockly.Lua.ORDER_NONE) || 0;
-  const g = Blockly.Lua.valueToCode(block, 'GREEN',
-      Blockly.Lua.ORDER_NONE) || 0;
-  const b = Blockly.Lua.valueToCode(block, 'BLUE',
-      Blockly.Lua.ORDER_NONE) || 0;
+  const r = Lua.valueToCode(block, 'RED',
+      Lua.ORDER_NONE) || 0;
+  const g = Lua.valueToCode(block, 'GREEN',
+      Lua.ORDER_NONE) || 0;
+  const b = Lua.valueToCode(block, 'BLUE',
+      Lua.ORDER_NONE) || 0;
   const code = functionName + '(' + r + ', ' + g + ', ' + b + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['colour_blend'] = function(block) {
+Lua['colour_blend'] = function(block) {
   // Blend two colours together.
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'colour_blend',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
            '(colour1, colour2, ratio)',
        '  local r1 = tonumber(string.sub(colour1, 2, 3), 16)',
        '  local r2 = tonumber(string.sub(colour2, 2, 3), 16)',
@@ -64,12 +64,12 @@ Blockly.Lua['colour_blend'] = function(block) {
        '  local b = math.floor(b1 * (1 - ratio) + b2 * ratio + .5)',
        '  return string.format("#%02x%02x%02x", r, g, b)',
        'end']);
-  const colour1 = Blockly.Lua.valueToCode(block, 'COLOUR1',
-      Blockly.Lua.ORDER_NONE) || '\'#000000\'';
-  const colour2 = Blockly.Lua.valueToCode(block, 'COLOUR2',
-      Blockly.Lua.ORDER_NONE) || '\'#000000\'';
-  const ratio = Blockly.Lua.valueToCode(block, 'RATIO',
-      Blockly.Lua.ORDER_NONE) || 0;
+  const colour1 = Lua.valueToCode(block, 'COLOUR1',
+      Lua.ORDER_NONE) || '\'#000000\'';
+  const colour2 = Lua.valueToCode(block, 'COLOUR2',
+      Lua.ORDER_NONE) || '\'#000000\'';
+  const ratio = Lua.valueToCode(block, 'RATIO',
+      Lua.ORDER_NONE) || 0;
   const code = functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/colour.js
+++ b/generators/lua/colour.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.colour');
+goog.module('Blockly.Lua.colour');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/colour.js
+++ b/generators/lua/colour.js
@@ -28,48 +28,42 @@ Lua['colour_random'] = function(block) {
 
 Lua['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
-  const functionName = Lua.provideFunction_(
-      'colour_rgb',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(r, g, b)',
-       '  r = math.floor(math.min(100, math.max(0, r)) * 2.55 + .5)',
-       '  g = math.floor(math.min(100, math.max(0, g)) * 2.55 + .5)',
-       '  b = math.floor(math.min(100, math.max(0, b)) * 2.55 + .5)',
-       '  return string.format("#%02x%02x%02x", r, g, b)',
-       'end']);
-  const r = Lua.valueToCode(block, 'RED',
-      Lua.ORDER_NONE) || 0;
-  const g = Lua.valueToCode(block, 'GREEN',
-      Lua.ORDER_NONE) || 0;
-  const b = Lua.valueToCode(block, 'BLUE',
-      Lua.ORDER_NONE) || 0;
+  const functionName = Lua.provideFunction_('colour_rgb', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(r, g, b)',
+    '  r = math.floor(math.min(100, math.max(0, r)) * 2.55 + .5)',
+    '  g = math.floor(math.min(100, math.max(0, g)) * 2.55 + .5)',
+    '  b = math.floor(math.min(100, math.max(0, b)) * 2.55 + .5)',
+    '  return string.format("#%02x%02x%02x", r, g, b)', 'end'
+  ]);
+  const r = Lua.valueToCode(block, 'RED', Lua.ORDER_NONE) || 0;
+  const g = Lua.valueToCode(block, 'GREEN', Lua.ORDER_NONE) || 0;
+  const b = Lua.valueToCode(block, 'BLUE', Lua.ORDER_NONE) || 0;
   const code = functionName + '(' + r + ', ' + g + ', ' + b + ')';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['colour_blend'] = function(block) {
   // Blend two colours together.
-  const functionName = Lua.provideFunction_(
-      'colour_blend',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-           '(colour1, colour2, ratio)',
-       '  local r1 = tonumber(string.sub(colour1, 2, 3), 16)',
-       '  local r2 = tonumber(string.sub(colour2, 2, 3), 16)',
-       '  local g1 = tonumber(string.sub(colour1, 4, 5), 16)',
-       '  local g2 = tonumber(string.sub(colour2, 4, 5), 16)',
-       '  local b1 = tonumber(string.sub(colour1, 6, 7), 16)',
-       '  local b2 = tonumber(string.sub(colour2, 6, 7), 16)',
-       '  local ratio = math.min(1, math.max(0, ratio))',
-       '  local r = math.floor(r1 * (1 - ratio) + r2 * ratio + .5)',
-       '  local g = math.floor(g1 * (1 - ratio) + g2 * ratio + .5)',
-       '  local b = math.floor(b1 * (1 - ratio) + b2 * ratio + .5)',
-       '  return string.format("#%02x%02x%02x", r, g, b)',
-       'end']);
-  const colour1 = Lua.valueToCode(block, 'COLOUR1',
-      Lua.ORDER_NONE) || '\'#000000\'';
-  const colour2 = Lua.valueToCode(block, 'COLOUR2',
-      Lua.ORDER_NONE) || '\'#000000\'';
-  const ratio = Lua.valueToCode(block, 'RATIO',
-      Lua.ORDER_NONE) || 0;
-  const code = functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const functionName = Lua.provideFunction_('colour_blend', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(colour1, colour2, ratio)',
+    '  local r1 = tonumber(string.sub(colour1, 2, 3), 16)',
+    '  local r2 = tonumber(string.sub(colour2, 2, 3), 16)',
+    '  local g1 = tonumber(string.sub(colour1, 4, 5), 16)',
+    '  local g2 = tonumber(string.sub(colour2, 4, 5), 16)',
+    '  local b1 = tonumber(string.sub(colour1, 6, 7), 16)',
+    '  local b2 = tonumber(string.sub(colour2, 6, 7), 16)',
+    '  local ratio = math.min(1, math.max(0, ratio))',
+    '  local r = math.floor(r1 * (1 - ratio) + r2 * ratio + .5)',
+    '  local g = math.floor(g1 * (1 - ratio) + g2 * ratio + .5)',
+    '  local b = math.floor(b1 * (1 - ratio) + b2 * ratio + .5)',
+    '  return string.format("#%02x%02x%02x", r, g, b)', 'end'
+  ]);
+  const colour1 =
+      Lua.valueToCode(block, 'COLOUR1', Lua.ORDER_NONE) || '\'#000000\'';
+  const colour2 =
+      Lua.valueToCode(block, 'COLOUR2', Lua.ORDER_NONE) || '\'#000000\'';
+  const ratio = Lua.valueToCode(block, 'RATIO', Lua.ORDER_NONE) || 0;
+  const code =
+      functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
   return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.lists');
+goog.module('Blockly.Lua.lists');
 
 goog.require('Blockly.Lua');
 
@@ -105,9 +105,8 @@ Blockly.Lua['lists_indexOf'] = function(block) {
  * @param {string} where The method of indexing, selected by dropdown in Blockly
  * @param {string=} opt_at The optional offset when indexing from start/end.
  * @return {string|undefined} Index expression.
- * @private
  */
-Blockly.Lua.lists.getIndex_ = function(listName, where, opt_at) {
+const getListIndex = function(listName, where, opt_at) {
   if (where === 'FIRST') {
     return '1';
   } else if (where === 'FROM_END') {
@@ -128,7 +127,7 @@ Blockly.Lua['lists_getIndex'] = function(block) {
   const where = block.getFieldValue('WHERE') || 'FROM_START';
   const list = Blockly.Lua.valueToCode(block, 'VALUE', Blockly.Lua.ORDER_HIGH) ||
       '({})';
-  const getIndex_ = Blockly.Lua.lists.getIndex_;
+  const getIndex_ = getIndex_;
 
   // If `list` would be evaluated more than once (which is the case for LAST,
   // FROM_END, and RANDOM) and is non-trivial, make sure to access it only once.
@@ -152,25 +151,27 @@ Blockly.Lua['lists_getIndex'] = function(block) {
           '1';
       let functionName;
       if (mode === 'GET') {
-        functionName = Blockly.Lua.provideFunction_(
-            'list_get_' + where.toLowerCase(),
-            ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
-                // The value for 'FROM_END' and'FROM_START' depends on `at` so
-                // we add it as a parameter.
-                ((where === 'FROM_END' || where === 'FROM_START') ?
-                    ', at)' : ')'),
-             '  return t[' + getIndex_('t', where, 'at') + ']',
-             'end']);
+        functionName =
+            Blockly.Lua.provideFunction_('list_get_' + where.toLowerCase(), [
+              'function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+                  // The value for 'FROM_END' and'FROM_START' depends on `at` so
+                  // we add it as a parameter.
+                  ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
+                                                                      ')'),
+              '  return t[' + getListIndex('t', where, 'at') + ']', 'end'
+            ]);
       } else {  // `mode` === 'GET_REMOVE'
-        functionName = Blockly.Lua.provideFunction_(
-            'list_remove_' + where.toLowerCase(),
-            ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
-                // The value for 'FROM_END' and'FROM_START' depends on `at` so
-                // we add it as a parameter.
-                ((where === 'FROM_END' || where === 'FROM_START') ?
-                    ', at)' : ')'),
-             '  return table.remove(t, ' + getIndex_('t', where, 'at') + ')',
-             'end']);
+        functionName =
+            Blockly.Lua.provideFunction_('list_remove_' + where.toLowerCase(), [
+              'function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+                  // The value for 'FROM_END' and'FROM_START' depends on `at` so
+                  // we add it as a parameter.
+                  ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
+                                                                      ')'),
+              '  return table.remove(t, ' + getListIndex('t', where, 'at') +
+                  ')',
+              'end'
+            ]);
       }
       const code = functionName + '(' + list +
           // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
@@ -211,7 +212,7 @@ Blockly.Lua['lists_setIndex'] = function(block) {
       Blockly.Lua.ORDER_ADDITIVE) || '1';
   const value = Blockly.Lua.valueToCode(block, 'TO',
       Blockly.Lua.ORDER_NONE) || 'None';
-  const getIndex_ = Blockly.Lua.lists.getIndex_;
+  const getIndex_ = getIndex_;
 
   let code = '';
   // If `list` would be evaluated more than once (which is the case for LAST,
@@ -247,7 +248,7 @@ Blockly.Lua['lists_getSublist'] = function(block) {
       Blockly.Lua.ORDER_NONE) || '1';
   const at2 = Blockly.Lua.valueToCode(block, 'AT2',
       Blockly.Lua.ORDER_NONE) || '1';
-  const getIndex_ = Blockly.Lua.lists.getIndex_;
+  const getIndex_ = getIndex_;
 
   const functionName = Blockly.Lua.provideFunction_(
       'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(),

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -6,76 +6,76 @@
 
 /**
  * @fileoverview Generating Lua for list blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.lists');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.Lua['lists_create_empty'] = function(block) {
+Lua['lists_create_empty'] = function(block) {
   // Create an empty list.
-  return ['{}', Blockly.Lua.ORDER_HIGH];
+  return ['{}', Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_create_with'] = function(block) {
+Lua['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
-    elements[i] = Blockly.Lua.valueToCode(block, 'ADD' + i,
-        Blockly.Lua.ORDER_NONE) || 'None';
+    elements[i] = Lua.valueToCode(block, 'ADD' + i,
+        Lua.ORDER_NONE) || 'None';
   }
   const code = '{' + elements.join(', ') + '}';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_repeat'] = function(block) {
+Lua['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'create_list_repeated',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(item, count)',
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(item, count)',
        '  local t = {}',
        '  for i = 1, count do',
        '    table.insert(t, item)',
        '  end',
        '  return t',
        'end']);
-  const element = Blockly.Lua.valueToCode(block, 'ITEM',
-      Blockly.Lua.ORDER_NONE) || 'None';
-  const repeatCount = Blockly.Lua.valueToCode(block, 'NUM',
-      Blockly.Lua.ORDER_NONE) || '0';
+  const element = Lua.valueToCode(block, 'ITEM',
+      Lua.ORDER_NONE) || 'None';
+  const repeatCount = Lua.valueToCode(block, 'NUM',
+      Lua.ORDER_NONE) || '0';
   const code = functionName + '(' + element + ', ' + repeatCount + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_length'] = function(block) {
+Lua['lists_length'] = function(block) {
   // String or array length.
-  const list = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_UNARY) || '{}';
-  return ['#' + list, Blockly.Lua.ORDER_UNARY];
+  const list = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_UNARY) || '{}';
+  return ['#' + list, Lua.ORDER_UNARY];
 };
 
-Blockly.Lua['lists_isEmpty'] = function(block) {
+Lua['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const list = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_UNARY) || '{}';
+  const list = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_UNARY) || '{}';
   const code = '#' + list + ' == 0';
-  return [code, Blockly.Lua.ORDER_RELATIONAL];
+  return [code, Lua.ORDER_RELATIONAL];
 };
 
-Blockly.Lua['lists_indexOf'] = function(block) {
+Lua['lists_indexOf'] = function(block) {
   // Find an item in the list.
-  const item = Blockly.Lua.valueToCode(block, 'FIND',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const list = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_NONE) || '{}';
+  const item = Lua.valueToCode(block, 'FIND',
+      Lua.ORDER_NONE) || '\'\'';
+  const list = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_NONE) || '{}';
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'first_index',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
          '  for k, v in ipairs(t) do',
          '    if v == elem then',
          '      return k',
@@ -84,9 +84,9 @@ Blockly.Lua['lists_indexOf'] = function(block) {
          '  return 0',
          'end']);
   } else {
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'last_index',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
          '  for i = #t, 1, -1 do',
          '    if t[i] == elem then',
          '      return i',
@@ -96,7 +96,7 @@ Blockly.Lua['lists_indexOf'] = function(block) {
          'end']);
   }
   const code = functionName + '(' + list + ', ' + item + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
 /**
@@ -120,12 +120,12 @@ const getListIndex = function(listName, where, opt_at) {
   }
 };
 
-Blockly.Lua['lists_getIndex'] = function(block) {
+Lua['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const list = Blockly.Lua.valueToCode(block, 'VALUE', Blockly.Lua.ORDER_HIGH) ||
+  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_HIGH) ||
       '({})';
   const getIndex_ = getIndex_;
 
@@ -136,24 +136,24 @@ Blockly.Lua['lists_getIndex'] = function(block) {
     // `list` is an expression, so we may not evaluate it more than once.
     if (mode === 'REMOVE') {
       // We can use multiple statements.
-      const atOrder = (where === 'FROM_END') ? Blockly.Lua.ORDER_ADDITIVE :
-          Blockly.Lua.ORDER_NONE;
-      let at = Blockly.Lua.valueToCode(block, 'AT', atOrder) || '1';
-      const listVar = Blockly.Lua.nameDB_.getDistinctName(
-          'tmp_list', Blockly.VARIABLE_CATEGORY_NAME);
+      const atOrder = (where === 'FROM_END') ? Lua.ORDER_ADDITIVE :
+          Lua.ORDER_NONE;
+      let at = Lua.valueToCode(block, 'AT', atOrder) || '1';
+      const listVar = Lua.nameDB_.getDistinctName(
+          'tmp_list', NameType.VARIABLE);
       at = getIndex_(listVar, where, at);
       const code = listVar + ' = ' + list + '\n' +
           'table.remove(' + listVar + ', ' + at + ')\n';
       return code;
     } else {
       // We need to create a procedure to avoid reevaluating values.
-      const at = Blockly.Lua.valueToCode(block, 'AT', Blockly.Lua.ORDER_NONE) ||
+      const at = Lua.valueToCode(block, 'AT', Lua.ORDER_NONE) ||
           '1';
       let functionName;
       if (mode === 'GET') {
         functionName =
-            Blockly.Lua.provideFunction_('list_get_' + where.toLowerCase(), [
-              'function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+            Lua.provideFunction_('list_get_' + where.toLowerCase(), [
+              'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
                   // The value for 'FROM_END' and'FROM_START' depends on `at` so
                   // we add it as a parameter.
                   ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
@@ -162,8 +162,8 @@ Blockly.Lua['lists_getIndex'] = function(block) {
             ]);
       } else {  // `mode` === 'GET_REMOVE'
         functionName =
-            Blockly.Lua.provideFunction_('list_remove_' + where.toLowerCase(), [
-              'function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+            Lua.provideFunction_('list_remove_' + where.toLowerCase(), [
+              'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
                   // The value for 'FROM_END' and'FROM_START' depends on `at` so
                   // we add it as a parameter.
                   ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
@@ -178,22 +178,22 @@ Blockly.Lua['lists_getIndex'] = function(block) {
           // pass it.
           ((where === 'FROM_END' || where === 'FROM_START') ? ', ' + at : '') +
           ')';
-      return [code, Blockly.Lua.ORDER_HIGH];
+      return [code, Lua.ORDER_HIGH];
     }
   } else {
     // Either `list` is a simple variable, or we only need to refer to `list`
     // once.
     const atOrder = (mode === 'GET' && where === 'FROM_END') ?
-        Blockly.Lua.ORDER_ADDITIVE : Blockly.Lua.ORDER_NONE;
-    let at = Blockly.Lua.valueToCode(block, 'AT', atOrder) || '1';
+        Lua.ORDER_ADDITIVE : Lua.ORDER_NONE;
+    let at = Lua.valueToCode(block, 'AT', atOrder) || '1';
     at = getIndex_(list, where, at);
     if (mode === 'GET') {
       const code = list + '[' + at + ']';
-      return [code, Blockly.Lua.ORDER_HIGH];
+      return [code, Lua.ORDER_HIGH];
     } else {
       const code = 'table.remove(' + list + ', ' + at + ')';
       if (mode === 'GET_REMOVE') {
-        return [code, Blockly.Lua.ORDER_HIGH];
+        return [code, Lua.ORDER_HIGH];
       } else {  // `mode` === 'REMOVE'
         return code + '\n';
       }
@@ -201,17 +201,17 @@ Blockly.Lua['lists_getIndex'] = function(block) {
   }
 };
 
-Blockly.Lua['lists_setIndex'] = function(block) {
+Lua['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
-  let list = Blockly.Lua.valueToCode(block, 'LIST',
-      Blockly.Lua.ORDER_HIGH) || '{}';
+  let list = Lua.valueToCode(block, 'LIST',
+      Lua.ORDER_HIGH) || '{}';
   const mode = block.getFieldValue('MODE') || 'SET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const at = Blockly.Lua.valueToCode(block, 'AT',
-      Blockly.Lua.ORDER_ADDITIVE) || '1';
-  const value = Blockly.Lua.valueToCode(block, 'TO',
-      Blockly.Lua.ORDER_NONE) || 'None';
+  const at = Lua.valueToCode(block, 'AT',
+      Lua.ORDER_ADDITIVE) || '1';
+  const value = Lua.valueToCode(block, 'TO',
+      Lua.ORDER_NONE) || 'None';
   const getIndex_ = getIndex_;
 
   let code = '';
@@ -221,8 +221,8 @@ Blockly.Lua['lists_setIndex'] = function(block) {
       !list.match(/^\w+$/)) {
     // `list` is an expression, so we may not evaluate it more than once.
     // We can use multiple statements.
-    const listVar = Blockly.Lua.nameDB_.getDistinctName(
-        'tmp_list', Blockly.VARIABLE_CATEGORY_NAME);
+    const listVar = Lua.nameDB_.getDistinctName(
+        'tmp_list', NameType.VARIABLE);
     code = listVar + ' = ' + list + '\n';
     list = listVar;
   }
@@ -238,21 +238,21 @@ Blockly.Lua['lists_setIndex'] = function(block) {
   return code + '\n';
 };
 
-Blockly.Lua['lists_getSublist'] = function(block) {
+Lua['lists_getSublist'] = function(block) {
   // Get sublist.
-  const list = Blockly.Lua.valueToCode(block, 'LIST',
-      Blockly.Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(block, 'LIST',
+      Lua.ORDER_NONE) || '{}';
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
-  const at1 = Blockly.Lua.valueToCode(block, 'AT1',
-      Blockly.Lua.ORDER_NONE) || '1';
-  const at2 = Blockly.Lua.valueToCode(block, 'AT2',
-      Blockly.Lua.ORDER_NONE) || '1';
+  const at1 = Lua.valueToCode(block, 'AT1',
+      Lua.ORDER_NONE) || '1';
+  const at2 = Lua.valueToCode(block, 'AT2',
+      Lua.ORDER_NONE) || '1';
   const getIndex_ = getIndex_;
 
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(),
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(source' +
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(source' +
           // The value for 'FROM_END' and'FROM_START' depends on `at` so
           // we add it as a parameter.
           ((where1 === 'FROM_END' || where1 === 'FROM_START') ? ', at1' : '') +
@@ -272,19 +272,19 @@ Blockly.Lua['lists_getSublist'] = function(block) {
       ((where1 === 'FROM_END' || where1 === 'FROM_START') ? ', ' + at1 : '') +
       ((where2 === 'FROM_END' || where2 === 'FROM_START') ? ', ' + at2 : '') +
       ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_sort'] = function(block) {
+Lua['lists_sort'] = function(block) {
   // Block for sorting a list.
-  const list = Blockly.Lua.valueToCode(
-      block, 'LIST', Blockly.Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(
+      block, 'LIST', Lua.ORDER_NONE) || '{}';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
   const type = block.getFieldValue('TYPE');
 
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'list_sort',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
           '(list, typev, direction)',
        '  local t = {}',
        '  for n,v in pairs(list) do table.insert(t, v) end', // Shallow-copy.
@@ -308,24 +308,24 @@ Blockly.Lua['lists_sort'] = function(block) {
 
   const code = functionName +
       '(' + list + ',"' + type + '", ' + direction + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_split'] = function(block) {
+Lua['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
-  let input = Blockly.Lua.valueToCode(block, 'INPUT',
-      Blockly.Lua.ORDER_NONE);
-  const delimiter = Blockly.Lua.valueToCode(block, 'DELIM',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  let input = Lua.valueToCode(block, 'INPUT',
+      Lua.ORDER_NONE);
+  const delimiter = Lua.valueToCode(block, 'DELIM',
+      Lua.ORDER_NONE) || '\'\'';
   const mode = block.getFieldValue('MODE');
   let functionName;
   if (mode === 'SPLIT') {
     if (!input) {
       input = '\'\'';
     }
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'list_string_split',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
             '(input, delim)',
          '  local t = {}',
          '  local pos = 1',
@@ -350,16 +350,16 @@ Blockly.Lua['lists_split'] = function(block) {
     throw Error('Unknown mode: ' + mode);
   }
   const code = functionName + '(' + input + ', ' + delimiter + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['lists_reverse'] = function(block) {
+Lua['lists_reverse'] = function(block) {
   // Block for reversing a list.
-  const list = Blockly.Lua.valueToCode(block, 'LIST',
-      Blockly.Lua.ORDER_NONE) || '{}';
-  const functionName = Blockly.Lua.provideFunction_(
+  const list = Lua.valueToCode(block, 'LIST',
+      Lua.ORDER_NONE) || '{}';
+  const functionName = Lua.provideFunction_(
       'list_reverse',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(input)',
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(input)',
        '  local reversed = {}',
        '  for i = #input, 1, -1 do',
        '    table.insert(reversed, input[i])',
@@ -367,5 +367,5 @@ Blockly.Lua['lists_reverse'] = function(block) {
        '  return reversed',
        'end']);
   const code = functionName + '(' + list + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -24,8 +24,7 @@ Lua['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
-    elements[i] = Lua.valueToCode(block, 'ADD' + i,
-        Lua.ORDER_NONE) || 'None';
+    elements[i] = Lua.valueToCode(block, 'ADD' + i, Lua.ORDER_NONE) || 'None';
   }
   const code = '{' + elements.join(', ') + '}';
   return [code, Lua.ORDER_HIGH];
@@ -33,67 +32,47 @@ Lua['lists_create_with'] = function(block) {
 
 Lua['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
-  const functionName = Lua.provideFunction_(
-      'create_list_repeated',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(item, count)',
-       '  local t = {}',
-       '  for i = 1, count do',
-       '    table.insert(t, item)',
-       '  end',
-       '  return t',
-       'end']);
-  const element = Lua.valueToCode(block, 'ITEM',
-      Lua.ORDER_NONE) || 'None';
-  const repeatCount = Lua.valueToCode(block, 'NUM',
-      Lua.ORDER_NONE) || '0';
+  const functionName = Lua.provideFunction_('create_list_repeated', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(item, count)',
+    '  local t = {}', '  for i = 1, count do', '    table.insert(t, item)',
+    '  end', '  return t', 'end'
+  ]);
+  const element = Lua.valueToCode(block, 'ITEM', Lua.ORDER_NONE) || 'None';
+  const repeatCount = Lua.valueToCode(block, 'NUM', Lua.ORDER_NONE) || '0';
   const code = functionName + '(' + element + ', ' + repeatCount + ')';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['lists_length'] = function(block) {
   // String or array length.
-  const list = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_UNARY) || '{}';
+  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '{}';
   return ['#' + list, Lua.ORDER_UNARY];
 };
 
 Lua['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const list = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_UNARY) || '{}';
+  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '{}';
   const code = '#' + list + ' == 0';
   return [code, Lua.ORDER_RELATIONAL];
 };
 
 Lua['lists_indexOf'] = function(block) {
   // Find an item in the list.
-  const item = Lua.valueToCode(block, 'FIND',
-      Lua.ORDER_NONE) || '\'\'';
-  const list = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_NONE) || '{}';
+  const item = Lua.valueToCode(block, 'FIND', Lua.ORDER_NONE) || '\'\'';
+  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '{}';
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = Lua.provideFunction_(
-        'first_index',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
-         '  for k, v in ipairs(t) do',
-         '    if v == elem then',
-         '      return k',
-         '    end',
-         '  end',
-         '  return 0',
-         'end']);
+    functionName = Lua.provideFunction_('first_index', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
+      '  for k, v in ipairs(t) do', '    if v == elem then', '      return k',
+      '    end', '  end', '  return 0', 'end'
+    ]);
   } else {
-    functionName = Lua.provideFunction_(
-        'last_index',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
-         '  for i = #t, 1, -1 do',
-         '    if t[i] == elem then',
-         '      return i',
-         '    end',
-         '  end',
-         '  return 0',
-         'end']);
+    functionName = Lua.provideFunction_('last_index', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t, elem)',
+      '  for i = #t, 1, -1 do', '    if t[i] == elem then', '      return i',
+      '    end', '  end', '  return 0', 'end'
+    ]);
   }
   const code = functionName + '(' + list + ', ' + item + ')';
   return [code, Lua.ORDER_HIGH];
@@ -125,8 +104,7 @@ Lua['lists_getIndex'] = function(block) {
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_HIGH) ||
-      '({})';
+  const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_HIGH) || '({})';
   const getIndex_ = getIndex_;
 
   // If `list` would be evaluated more than once (which is the case for LAST,
@@ -136,30 +114,28 @@ Lua['lists_getIndex'] = function(block) {
     // `list` is an expression, so we may not evaluate it more than once.
     if (mode === 'REMOVE') {
       // We can use multiple statements.
-      const atOrder = (where === 'FROM_END') ? Lua.ORDER_ADDITIVE :
-          Lua.ORDER_NONE;
+      const atOrder =
+          (where === 'FROM_END') ? Lua.ORDER_ADDITIVE : Lua.ORDER_NONE;
       let at = Lua.valueToCode(block, 'AT', atOrder) || '1';
-      const listVar = Lua.nameDB_.getDistinctName(
-          'tmp_list', NameType.VARIABLE);
+      const listVar =
+          Lua.nameDB_.getDistinctName('tmp_list', NameType.VARIABLE);
       at = getIndex_(listVar, where, at);
       const code = listVar + ' = ' + list + '\n' +
           'table.remove(' + listVar + ', ' + at + ')\n';
       return code;
     } else {
       // We need to create a procedure to avoid reevaluating values.
-      const at = Lua.valueToCode(block, 'AT', Lua.ORDER_NONE) ||
-          '1';
+      const at = Lua.valueToCode(block, 'AT', Lua.ORDER_NONE) || '1';
       let functionName;
       if (mode === 'GET') {
-        functionName =
-            Lua.provideFunction_('list_get_' + where.toLowerCase(), [
-              'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
-                  // The value for 'FROM_END' and'FROM_START' depends on `at` so
-                  // we add it as a parameter.
-                  ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
-                                                                      ')'),
-              '  return t[' + getListIndex('t', where, 'at') + ']', 'end'
-            ]);
+        functionName = Lua.provideFunction_('list_get_' + where.toLowerCase(), [
+          'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+              // The value for 'FROM_END' and'FROM_START' depends on `at` so
+              // we add it as a parameter.
+              ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
+                                                                  ')'),
+          '  return t[' + getListIndex('t', where, 'at') + ']', 'end'
+        ]);
       } else {  // `mode` === 'GET_REMOVE'
         functionName =
             Lua.provideFunction_('list_remove_' + where.toLowerCase(), [
@@ -184,7 +160,8 @@ Lua['lists_getIndex'] = function(block) {
     // Either `list` is a simple variable, or we only need to refer to `list`
     // once.
     const atOrder = (mode === 'GET' && where === 'FROM_END') ?
-        Lua.ORDER_ADDITIVE : Lua.ORDER_NONE;
+        Lua.ORDER_ADDITIVE :
+        Lua.ORDER_NONE;
     let at = Lua.valueToCode(block, 'AT', atOrder) || '1';
     at = getIndex_(list, where, at);
     if (mode === 'GET') {
@@ -204,14 +181,11 @@ Lua['lists_getIndex'] = function(block) {
 Lua['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
-  let list = Lua.valueToCode(block, 'LIST',
-      Lua.ORDER_HIGH) || '{}';
+  let list = Lua.valueToCode(block, 'LIST', Lua.ORDER_HIGH) || '{}';
   const mode = block.getFieldValue('MODE') || 'SET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const at = Lua.valueToCode(block, 'AT',
-      Lua.ORDER_ADDITIVE) || '1';
-  const value = Lua.valueToCode(block, 'TO',
-      Lua.ORDER_NONE) || 'None';
+  const at = Lua.valueToCode(block, 'AT', Lua.ORDER_ADDITIVE) || '1';
+  const value = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || 'None';
   const getIndex_ = getIndex_;
 
   let code = '';
@@ -221,8 +195,7 @@ Lua['lists_setIndex'] = function(block) {
       !list.match(/^\w+$/)) {
     // `list` is an expression, so we may not evaluate it more than once.
     // We can use multiple statements.
-    const listVar = Lua.nameDB_.getDistinctName(
-        'tmp_list', NameType.VARIABLE);
+    const listVar = Lua.nameDB_.getDistinctName('tmp_list', NameType.VARIABLE);
     code = listVar + ' = ' + list + '\n';
     list = listVar;
   }
@@ -232,40 +205,37 @@ Lua['lists_setIndex'] = function(block) {
     // LAST is a special case, because we want to insert
     // *after* not *before*, the existing last element.
     code += 'table.insert(' + list + ', ' +
-        (getIndex_(list, where, at) + (where === 'LAST' ? ' + 1' : '')) +
-        ', ' + value + ')';
+        (getIndex_(list, where, at) + (where === 'LAST' ? ' + 1' : '')) + ', ' +
+        value + ')';
   }
   return code + '\n';
 };
 
 Lua['lists_getSublist'] = function(block) {
   // Get sublist.
-  const list = Lua.valueToCode(block, 'LIST',
-      Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
-  const at1 = Lua.valueToCode(block, 'AT1',
-      Lua.ORDER_NONE) || '1';
-  const at2 = Lua.valueToCode(block, 'AT2',
-      Lua.ORDER_NONE) || '1';
+  const at1 = Lua.valueToCode(block, 'AT1', Lua.ORDER_NONE) || '1';
+  const at2 = Lua.valueToCode(block, 'AT2', Lua.ORDER_NONE) || '1';
   const getIndex_ = getIndex_;
 
   const functionName = Lua.provideFunction_(
-      'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(),
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(source' +
-          // The value for 'FROM_END' and'FROM_START' depends on `at` so
-          // we add it as a parameter.
-          ((where1 === 'FROM_END' || where1 === 'FROM_START') ? ', at1' : '') +
-          ((where2 === 'FROM_END' || where2 === 'FROM_START') ? ', at2' : '') +
-          ')',
-       '  local t = {}',
-       '  local start = ' + getIndex_('source', where1, 'at1'),
-       '  local finish = ' + getIndex_('source', where2, 'at2'),
-       '  for i = start, finish do',
-       '    table.insert(t, source[i])',
-       '  end',
-       '  return t',
-       'end']);
+      'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(), [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(source' +
+            // The value for 'FROM_END' and'FROM_START' depends on `at` so
+            // we add it as a parameter.
+            ((where1 === 'FROM_END' || where1 === 'FROM_START') ? ', at1' :
+                                                                  '') +
+            ((where2 === 'FROM_END' || where2 === 'FROM_START') ? ', at2' :
+                                                                  '') +
+            ')',
+        '  local t = {}',
+        '  local start = ' + getIndex_('source', where1, 'at1'),
+        '  local finish = ' + getIndex_('source', where2, 'at2'),
+        '  for i = start, finish do', '    table.insert(t, source[i])', '  end',
+        '  return t', 'end'
+      ]);
   const code = functionName + '(' + list +
       // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
       // pass it.
@@ -277,70 +247,57 @@ Lua['lists_getSublist'] = function(block) {
 
 Lua['lists_sort'] = function(block) {
   // Block for sorting a list.
-  const list = Lua.valueToCode(
-      block, 'LIST', Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
   const type = block.getFieldValue('TYPE');
 
-  const functionName = Lua.provideFunction_(
-      'list_sort',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-          '(list, typev, direction)',
-       '  local t = {}',
-       '  for n,v in pairs(list) do table.insert(t, v) end', // Shallow-copy.
-       '  local compareFuncs = {',
-       '    NUMERIC = function(a, b)',
-       '      return (tonumber(tostring(a)) or 0)',
-       '          < (tonumber(tostring(b)) or 0) end,',
-       '    TEXT = function(a, b)',
-       '      return tostring(a) < tostring(b) end,',
-       '    IGNORE_CASE = function(a, b)',
-       '      return string.lower(tostring(a)) < string.lower(tostring(b)) end',
-       '  }',
-       '  local compareTemp = compareFuncs[typev]',
-       '  local compare = compareTemp',
-       '  if direction == -1',
-       '  then compare = function(a, b) return compareTemp(b, a) end',
-       '  end',
-       '  table.sort(t, compare)',
-       '  return t',
-       'end']);
+  const functionName = Lua.provideFunction_('list_sort', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(list, typev, direction)',
+    '  local t = {}',
+    '  for n,v in pairs(list) do table.insert(t, v) end',  // Shallow-copy.
+    '  local compareFuncs = {',
+    '    NUMERIC = function(a, b)',
+    '      return (tonumber(tostring(a)) or 0)',
+    '          < (tonumber(tostring(b)) or 0) end,',
+    '    TEXT = function(a, b)',
+    '      return tostring(a) < tostring(b) end,',
+    '    IGNORE_CASE = function(a, b)',
+    '      return string.lower(tostring(a)) < string.lower(tostring(b)) end',
+    '  }',
+    '  local compareTemp = compareFuncs[typev]',
+    '  local compare = compareTemp',
+    '  if direction == -1',
+    '  then compare = function(a, b) return compareTemp(b, a) end',
+    '  end',
+    '  table.sort(t, compare)',
+    '  return t',
+    'end'
+  ]);
 
-  const code = functionName +
-      '(' + list + ',"' + type + '", ' + direction + ')';
+  const code =
+      functionName + '(' + list + ',"' + type + '", ' + direction + ')';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
-  let input = Lua.valueToCode(block, 'INPUT',
-      Lua.ORDER_NONE);
-  const delimiter = Lua.valueToCode(block, 'DELIM',
-      Lua.ORDER_NONE) || '\'\'';
+  let input = Lua.valueToCode(block, 'INPUT', Lua.ORDER_NONE);
+  const delimiter = Lua.valueToCode(block, 'DELIM', Lua.ORDER_NONE) || '\'\'';
   const mode = block.getFieldValue('MODE');
   let functionName;
   if (mode === 'SPLIT') {
     if (!input) {
       input = '\'\'';
     }
-    functionName = Lua.provideFunction_(
-        'list_string_split',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-            '(input, delim)',
-         '  local t = {}',
-         '  local pos = 1',
-         '  while true do',
-         '    next_delim = string.find(input, delim, pos)',
-         '    if next_delim == nil then',
-         '      table.insert(t, string.sub(input, pos))',
-         '      break',
-         '    else',
-         '      table.insert(t, string.sub(input, pos, next_delim-1))',
-         '      pos = next_delim + #delim',
-         '    end',
-         '  end',
-         '  return t',
-         'end']);
+    functionName = Lua.provideFunction_('list_string_split', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(input, delim)',
+      '  local t = {}', '  local pos = 1', '  while true do',
+      '    next_delim = string.find(input, delim, pos)',
+      '    if next_delim == nil then',
+      '      table.insert(t, string.sub(input, pos))', '      break',
+      '    else', '      table.insert(t, string.sub(input, pos, next_delim-1))',
+      '      pos = next_delim + #delim', '    end', '  end', '  return t', 'end'
+    ]);
   } else if (mode === 'JOIN') {
     if (!input) {
       input = '{}';
@@ -355,17 +312,12 @@ Lua['lists_split'] = function(block) {
 
 Lua['lists_reverse'] = function(block) {
   // Block for reversing a list.
-  const list = Lua.valueToCode(block, 'LIST',
-      Lua.ORDER_NONE) || '{}';
-  const functionName = Lua.provideFunction_(
-      'list_reverse',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(input)',
-       '  local reversed = {}',
-       '  for i = #input, 1, -1 do',
-       '    table.insert(reversed, input[i])',
-       '  end',
-       '  return reversed',
-       'end']);
+  const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
+  const functionName = Lua.provideFunction_('list_reverse', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(input)',
+    '  local reversed = {}', '  for i = #input, 1, -1 do',
+    '    table.insert(reversed, input[i])', '  end', '  return reversed', 'end'
+  ]);
   const code = functionName + '(' + list + ')';
   return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.logic');
+goog.module('Blockly.Lua.logic');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -23,16 +23,16 @@ Lua['controls_if'] = function(block) {
     code += Lua.injectId(Lua.STATEMENT_PREFIX, block);
   }
   do {
-    const conditionCode = Lua.valueToCode(block, 'IF' + n,
-        Lua.ORDER_NONE) || 'false';
+    const conditionCode =
+        Lua.valueToCode(block, 'IF' + n, Lua.ORDER_NONE) || 'false';
     let branchCode = Lua.statementToCode(block, 'DO' + n);
     if (Lua.STATEMENT_SUFFIX) {
       branchCode = Lua.prefixLines(
-          Lua.injectId(Lua.STATEMENT_SUFFIX, block),
-          Lua.INDENT) + branchCode;
+                       Lua.injectId(Lua.STATEMENT_SUFFIX, block), Lua.INDENT) +
+          branchCode;
     }
-    code += (n > 0 ? 'else' : '') +
-        'if ' + conditionCode + ' then\n' + branchCode;
+    code +=
+        (n > 0 ? 'else' : '') + 'if ' + conditionCode + ' then\n' + branchCode;
     n++;
   } while (block.getInput('IF' + n));
 
@@ -40,8 +40,8 @@ Lua['controls_if'] = function(block) {
     let branchCode = Lua.statementToCode(block, 'ELSE');
     if (Lua.STATEMENT_SUFFIX) {
       branchCode = Lua.prefixLines(
-          Lua.injectId(Lua.STATEMENT_SUFFIX, block),
-          Lua.INDENT) + branchCode;
+                       Lua.injectId(Lua.STATEMENT_SUFFIX, block), Lua.INDENT) +
+          branchCode;
     }
     code += 'else\n' + branchCode;
   }
@@ -52,19 +52,11 @@ Lua['controls_ifelse'] = Lua['controls_if'];
 
 Lua['logic_compare'] = function(block) {
   // Comparison operator.
-  const OPERATORS = {
-    'EQ': '==',
-    'NEQ': '~=',
-    'LT': '<',
-    'LTE': '<=',
-    'GT': '>',
-    'GTE': '>='
-  };
+  const OPERATORS =
+      {'EQ': '==', 'NEQ': '~=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
   const operator = OPERATORS[block.getFieldValue('OP')];
-  const argument0 = Lua.valueToCode(block, 'A',
-      Lua.ORDER_RELATIONAL) || '0';
-  const argument1 = Lua.valueToCode(block, 'B',
-      Lua.ORDER_RELATIONAL) || '0';
+  const argument0 = Lua.valueToCode(block, 'A', Lua.ORDER_RELATIONAL) || '0';
+  const argument1 = Lua.valueToCode(block, 'B', Lua.ORDER_RELATIONAL) || '0';
   const code = argument0 + ' ' + operator + ' ' + argument1;
   return [code, Lua.ORDER_RELATIONAL];
 };
@@ -72,8 +64,7 @@ Lua['logic_compare'] = function(block) {
 Lua['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
-  const order = (operator === 'and') ? Lua.ORDER_AND :
-      Lua.ORDER_OR;
+  const order = (operator === 'and') ? Lua.ORDER_AND : Lua.ORDER_OR;
   let argument0 = Lua.valueToCode(block, 'A', order);
   let argument1 = Lua.valueToCode(block, 'B', order);
   if (!argument0 && !argument1) {
@@ -96,8 +87,7 @@ Lua['logic_operation'] = function(block) {
 
 Lua['logic_negate'] = function(block) {
   // Negation.
-  const argument0 = Lua.valueToCode(block, 'BOOL',
-      Lua.ORDER_UNARY) || 'true';
+  const argument0 = Lua.valueToCode(block, 'BOOL', Lua.ORDER_UNARY) || 'true';
   const code = 'not ' + argument0;
   return [code, Lua.ORDER_UNARY];
 };
@@ -115,12 +105,9 @@ Lua['logic_null'] = function(block) {
 
 Lua['logic_ternary'] = function(block) {
   // Ternary operator.
-  const value_if = Lua.valueToCode(block, 'IF',
-      Lua.ORDER_AND) || 'false';
-  const value_then = Lua.valueToCode(block, 'THEN',
-      Lua.ORDER_AND) || 'nil';
-  const value_else = Lua.valueToCode(block, 'ELSE',
-      Lua.ORDER_OR) || 'nil';
+  const value_if = Lua.valueToCode(block, 'IF', Lua.ORDER_AND) || 'false';
+  const value_then = Lua.valueToCode(block, 'THEN', Lua.ORDER_AND) || 'nil';
+  const value_else = Lua.valueToCode(block, 'ELSE', Lua.ORDER_OR) || 'nil';
   const code = value_if + ' and ' + value_then + ' or ' + value_else;
   return [code, Lua.ORDER_OR];
 };

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -11,46 +11,46 @@
 
 goog.module('Blockly.Lua.logic');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
 
 
-Blockly.Lua['controls_if'] = function(block) {
+Lua['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '';
-  if (Blockly.Lua.STATEMENT_PREFIX) {
+  if (Lua.STATEMENT_PREFIX) {
     // Automatic prefix insertion is switched off for this block.  Add manually.
-    code += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_PREFIX, block);
+    code += Lua.injectId(Lua.STATEMENT_PREFIX, block);
   }
   do {
-    const conditionCode = Blockly.Lua.valueToCode(block, 'IF' + n,
-        Blockly.Lua.ORDER_NONE) || 'false';
-    let branchCode = Blockly.Lua.statementToCode(block, 'DO' + n);
-    if (Blockly.Lua.STATEMENT_SUFFIX) {
-      branchCode = Blockly.Lua.prefixLines(
-          Blockly.Lua.injectId(Blockly.Lua.STATEMENT_SUFFIX, block),
-          Blockly.Lua.INDENT) + branchCode;
+    const conditionCode = Lua.valueToCode(block, 'IF' + n,
+        Lua.ORDER_NONE) || 'false';
+    let branchCode = Lua.statementToCode(block, 'DO' + n);
+    if (Lua.STATEMENT_SUFFIX) {
+      branchCode = Lua.prefixLines(
+          Lua.injectId(Lua.STATEMENT_SUFFIX, block),
+          Lua.INDENT) + branchCode;
     }
     code += (n > 0 ? 'else' : '') +
         'if ' + conditionCode + ' then\n' + branchCode;
     n++;
   } while (block.getInput('IF' + n));
 
-  if (block.getInput('ELSE') || Blockly.Lua.STATEMENT_SUFFIX) {
-    let branchCode = Blockly.Lua.statementToCode(block, 'ELSE');
-    if (Blockly.Lua.STATEMENT_SUFFIX) {
-      branchCode = Blockly.Lua.prefixLines(
-          Blockly.Lua.injectId(Blockly.Lua.STATEMENT_SUFFIX, block),
-          Blockly.Lua.INDENT) + branchCode;
+  if (block.getInput('ELSE') || Lua.STATEMENT_SUFFIX) {
+    let branchCode = Lua.statementToCode(block, 'ELSE');
+    if (Lua.STATEMENT_SUFFIX) {
+      branchCode = Lua.prefixLines(
+          Lua.injectId(Lua.STATEMENT_SUFFIX, block),
+          Lua.INDENT) + branchCode;
     }
     code += 'else\n' + branchCode;
   }
   return code + 'end\n';
 };
 
-Blockly.Lua['controls_ifelse'] = Blockly.Lua['controls_if'];
+Lua['controls_ifelse'] = Lua['controls_if'];
 
-Blockly.Lua['logic_compare'] = function(block) {
+Lua['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS = {
     'EQ': '==',
@@ -61,21 +61,21 @@ Blockly.Lua['logic_compare'] = function(block) {
     'GTE': '>='
   };
   const operator = OPERATORS[block.getFieldValue('OP')];
-  const argument0 = Blockly.Lua.valueToCode(block, 'A',
-      Blockly.Lua.ORDER_RELATIONAL) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'B',
-      Blockly.Lua.ORDER_RELATIONAL) || '0';
+  const argument0 = Lua.valueToCode(block, 'A',
+      Lua.ORDER_RELATIONAL) || '0';
+  const argument1 = Lua.valueToCode(block, 'B',
+      Lua.ORDER_RELATIONAL) || '0';
   const code = argument0 + ' ' + operator + ' ' + argument1;
-  return [code, Blockly.Lua.ORDER_RELATIONAL];
+  return [code, Lua.ORDER_RELATIONAL];
 };
 
-Blockly.Lua['logic_operation'] = function(block) {
+Lua['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
-  const order = (operator === 'and') ? Blockly.Lua.ORDER_AND :
-      Blockly.Lua.ORDER_OR;
-  let argument0 = Blockly.Lua.valueToCode(block, 'A', order);
-  let argument1 = Blockly.Lua.valueToCode(block, 'B', order);
+  const order = (operator === 'and') ? Lua.ORDER_AND :
+      Lua.ORDER_OR;
+  let argument0 = Lua.valueToCode(block, 'A', order);
+  let argument1 = Lua.valueToCode(block, 'B', order);
   if (!argument0 && !argument1) {
     // If there are no arguments, then the return value is false.
     argument0 = 'false';
@@ -94,33 +94,33 @@ Blockly.Lua['logic_operation'] = function(block) {
   return [code, order];
 };
 
-Blockly.Lua['logic_negate'] = function(block) {
+Lua['logic_negate'] = function(block) {
   // Negation.
-  const argument0 = Blockly.Lua.valueToCode(block, 'BOOL',
-      Blockly.Lua.ORDER_UNARY) || 'true';
+  const argument0 = Lua.valueToCode(block, 'BOOL',
+      Lua.ORDER_UNARY) || 'true';
   const code = 'not ' + argument0;
-  return [code, Blockly.Lua.ORDER_UNARY];
+  return [code, Lua.ORDER_UNARY];
 };
 
-Blockly.Lua['logic_boolean'] = function(block) {
+Lua['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
-  return [code, Blockly.Lua.ORDER_ATOMIC];
+  return [code, Lua.ORDER_ATOMIC];
 };
 
-Blockly.Lua['logic_null'] = function(block) {
+Lua['logic_null'] = function(block) {
   // Null data type.
-  return ['nil', Blockly.Lua.ORDER_ATOMIC];
+  return ['nil', Lua.ORDER_ATOMIC];
 };
 
-Blockly.Lua['logic_ternary'] = function(block) {
+Lua['logic_ternary'] = function(block) {
   // Ternary operator.
-  const value_if = Blockly.Lua.valueToCode(block, 'IF',
-      Blockly.Lua.ORDER_AND) || 'false';
-  const value_then = Blockly.Lua.valueToCode(block, 'THEN',
-      Blockly.Lua.ORDER_AND) || 'nil';
-  const value_else = Blockly.Lua.valueToCode(block, 'ELSE',
-      Blockly.Lua.ORDER_OR) || 'nil';
+  const value_if = Lua.valueToCode(block, 'IF',
+      Lua.ORDER_AND) || 'false';
+  const value_then = Lua.valueToCode(block, 'THEN',
+      Lua.ORDER_AND) || 'nil';
+  const value_else = Lua.valueToCode(block, 'ELSE',
+      Lua.ORDER_OR) || 'nil';
   const code = value_if + ' and ' + value_then + ' or ' + value_else;
-  return [code, Blockly.Lua.ORDER_OR];
+  return [code, Lua.ORDER_OR];
 };

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -32,9 +32,8 @@ const CONTINUE_STATEMENT = 'goto continue\n';
  *
  * @param {string} branch Generated code of the loop body
  * @return {string} Generated label or '' if unnecessary
- * @private
  */
-Lua.addContinueLabel_ = function(branch) {
+const addContinueLabel = function(branch) {
   if (branch.indexOf(CONTINUE_STATEMENT) !== -1) {
     // False positives are possible (e.g. a string literal), but are harmless.
     return branch + Lua.INDENT + '::continue::\n';
@@ -60,7 +59,7 @@ Lua['controls_repeat_ext'] = function(block) {
   }
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
-  branch = Lua.addContinueLabel_(branch);
+  branch = addContinueLabel(branch);
   const loopVar = Lua.nameDB_.getDistinctName('count', NameType.VARIABLE);
   const code =
       'for ' + loopVar + ' = 1, ' + repeats + ' do\n' + branch + 'end\n';
@@ -78,7 +77,7 @@ Lua['controls_whileUntil'] = function(block) {
       'false';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
-  branch = Lua.addContinueLabel_(branch);
+  branch = addContinueLabel(branch);
   if (until) {
     argument0 = 'not ' + argument0;
   }
@@ -94,7 +93,7 @@ Lua['controls_for'] = function(block) {
   const increment = Lua.valueToCode(block, 'BY', Lua.ORDER_NONE) || '1';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
-  branch = Lua.addContinueLabel_(branch);
+  branch = addContinueLabel(branch);
   let code = '';
   let incValue;
   if (stringUtils.isNumber(startVar) && stringUtils.isNumber(endVar) &&
@@ -132,7 +131,7 @@ Lua['controls_forEach'] = function(block) {
   const argument0 = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
-  branch = Lua.addContinueLabel_(branch);
+  branch = addContinueLabel(branch);
   const code = 'for _, ' + variable0 + ' in ipairs(' + argument0 + ') do \n' +
       branch + 'end\n';
   return code;

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -6,14 +6,14 @@
 
 /**
  * @fileoverview Generating Lua for loop blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.loops');
 
-goog.require('Blockly.Lua');
-goog.require('Blockly.utils.string');
+const Lua = goog.require('Blockly.Lua');
+const stringUtils = goog.require('Blockly.utils.string');
+const {NameType} = goog.require('Blockly.Names');
 
 
 /**
@@ -22,7 +22,7 @@ goog.require('Blockly.utils.string');
  * the appropriate label can be put at the end of the loop body.
  * @const {string}
  */
-Blockly.Lua.CONTINUE_STATEMENT = 'goto continue\n';
+const CONTINUE_STATEMENT = 'goto continue\n';
 
 /**
  * If the loop body contains a "goto continue" statement, add a continue label
@@ -34,16 +34,16 @@ Blockly.Lua.CONTINUE_STATEMENT = 'goto continue\n';
  * @return {string} Generated label or '' if unnecessary
  * @private
  */
-Blockly.Lua.addContinueLabel_ = function(branch) {
-  if (branch.indexOf(Blockly.Lua.CONTINUE_STATEMENT) !== -1) {
+Lua.addContinueLabel_ = function(branch) {
+  if (branch.indexOf(CONTINUE_STATEMENT) !== -1) {
     // False positives are possible (e.g. a string literal), but are harmless.
-    return branch + Blockly.Lua.INDENT + '::continue::\n';
+    return branch + Lua.INDENT + '::continue::\n';
   } else {
     return branch;
   }
 };
 
-Blockly.Lua['controls_repeat_ext'] = function(block) {
+Lua['controls_repeat_ext'] = function(block) {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -51,58 +51,58 @@ Blockly.Lua['controls_repeat_ext'] = function(block) {
     repeats = String(Number(block.getFieldValue('TIMES')));
   } else {
     // External number.
-    repeats = Blockly.Lua.valueToCode(block, 'TIMES',
-        Blockly.Lua.ORDER_NONE) || '0';
+    repeats = Lua.valueToCode(block, 'TIMES',
+        Lua.ORDER_NONE) || '0';
   }
-  if (Blockly.utils.string.isNumber(repeats)) {
+  if (stringUtils.isNumber(repeats)) {
     repeats = parseInt(repeats, 10);
   } else {
     repeats = 'math.floor(' + repeats + ')';
   }
-  let branch = Blockly.Lua.statementToCode(block, 'DO');
-  branch = Blockly.Lua.addLoopTrap(branch, block);
-  branch = Blockly.Lua.addContinueLabel_(branch);
-  const loopVar = Blockly.Lua.nameDB_.getDistinctName(
-      'count', Blockly.VARIABLE_CATEGORY_NAME);
+  let branch = Lua.statementToCode(block, 'DO');
+  branch = Lua.addLoopTrap(branch, block);
+  branch = Lua.addContinueLabel_(branch);
+  const loopVar = Lua.nameDB_.getDistinctName(
+      'count', NameType.VARIABLE);
   const code = 'for ' + loopVar + ' = 1, ' + repeats + ' do\n' +
       branch + 'end\n';
   return code;
 };
 
-Blockly.Lua['controls_repeat'] = Blockly.Lua['controls_repeat_ext'];
+Lua['controls_repeat'] = Lua['controls_repeat_ext'];
 
-Blockly.Lua['controls_whileUntil'] = function(block) {
+Lua['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
-  let argument0 = Blockly.Lua.valueToCode(block, 'BOOL',
-      until ? Blockly.Lua.ORDER_UNARY :
-      Blockly.Lua.ORDER_NONE) || 'false';
-  let branch = Blockly.Lua.statementToCode(block, 'DO');
-  branch = Blockly.Lua.addLoopTrap(branch, block);
-  branch = Blockly.Lua.addContinueLabel_(branch);
+  let argument0 = Lua.valueToCode(block, 'BOOL',
+      until ? Lua.ORDER_UNARY :
+      Lua.ORDER_NONE) || 'false';
+  let branch = Lua.statementToCode(block, 'DO');
+  branch = Lua.addLoopTrap(branch, block);
+  branch = Lua.addContinueLabel_(branch);
   if (until) {
     argument0 = 'not ' + argument0;
   }
   return 'while ' + argument0 + ' do\n' + branch + 'end\n';
 };
 
-Blockly.Lua['controls_for'] = function(block) {
+Lua['controls_for'] = function(block) {
   // For loop.
-  const variable0 = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  const startVar = Blockly.Lua.valueToCode(block, 'FROM',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const endVar = Blockly.Lua.valueToCode(block, 'TO',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const increment = Blockly.Lua.valueToCode(block, 'BY',
-      Blockly.Lua.ORDER_NONE) || '1';
-  let branch = Blockly.Lua.statementToCode(block, 'DO');
-  branch = Blockly.Lua.addLoopTrap(branch, block);
-  branch = Blockly.Lua.addContinueLabel_(branch);
+  const variable0 = Lua.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const startVar = Lua.valueToCode(block, 'FROM',
+      Lua.ORDER_NONE) || '0';
+  const endVar = Lua.valueToCode(block, 'TO',
+      Lua.ORDER_NONE) || '0';
+  const increment = Lua.valueToCode(block, 'BY',
+      Lua.ORDER_NONE) || '1';
+  let branch = Lua.statementToCode(block, 'DO');
+  branch = Lua.addLoopTrap(branch, block);
+  branch = Lua.addContinueLabel_(branch);
   let code = '';
   let incValue;
-  if (Blockly.utils.string.isNumber(startVar) && Blockly.utils.string.isNumber(endVar) &&
-      Blockly.utils.string.isNumber(increment)) {
+  if (stringUtils.isNumber(startVar) && stringUtils.isNumber(endVar) &&
+      stringUtils.isNumber(increment)) {
     // All arguments are simple numbers.
     const up = Number(startVar) <= Number(endVar);
     const step = Math.abs(Number(increment));
@@ -111,16 +111,16 @@ Blockly.Lua['controls_for'] = function(block) {
     code = '';
     // Determine loop direction at start, in case one of the bounds
     // changes during loop execution.
-    incValue = Blockly.Lua.nameDB_.getDistinctName(
-        variable0 + '_inc', Blockly.VARIABLE_CATEGORY_NAME);
+    incValue = Lua.nameDB_.getDistinctName(
+        variable0 + '_inc', NameType.VARIABLE);
     code += incValue + ' = ';
-    if (Blockly.utils.string.isNumber(increment)) {
+    if (stringUtils.isNumber(increment)) {
       code += Math.abs(increment) + '\n';
     } else {
       code += 'math.abs(' + increment + ')\n';
     }
     code += 'if (' + startVar + ') > (' + endVar + ') then\n';
-    code += Blockly.Lua.INDENT + incValue + ' = -' + incValue + '\n';
+    code += Lua.INDENT + incValue + ' = -' + incValue + '\n';
     code += 'end\n';
   }
   code += 'for ' + variable0 + ' = ' + startVar + ', ' + endVar +
@@ -129,46 +129,46 @@ Blockly.Lua['controls_for'] = function(block) {
   return code;
 };
 
-Blockly.Lua['controls_forEach'] = function(block) {
+Lua['controls_forEach'] = function(block) {
   // For each loop.
-  const variable0 = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  const argument0 = Blockly.Lua.valueToCode(block, 'LIST',
-      Blockly.Lua.ORDER_NONE) || '{}';
-  let branch = Blockly.Lua.statementToCode(block, 'DO');
-  branch = Blockly.Lua.addLoopTrap(branch, block);
-  branch = Blockly.Lua.addContinueLabel_(branch);
+  const variable0 = Lua.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 = Lua.valueToCode(block, 'LIST',
+      Lua.ORDER_NONE) || '{}';
+  let branch = Lua.statementToCode(block, 'DO');
+  branch = Lua.addLoopTrap(branch, block);
+  branch = Lua.addContinueLabel_(branch);
   const code = 'for _, ' + variable0 + ' in ipairs(' + argument0 + ') do \n' +
       branch + 'end\n';
   return code;
 };
 
-Blockly.Lua['controls_flow_statements'] = function(block) {
+Lua['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
-  if (Blockly.Lua.STATEMENT_PREFIX) {
+  if (Lua.STATEMENT_PREFIX) {
     // Automatic prefix insertion is switched off for this block.  Add manually.
-    xfix += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_PREFIX, block);
+    xfix += Lua.injectId(Lua.STATEMENT_PREFIX, block);
   }
-  if (Blockly.Lua.STATEMENT_SUFFIX) {
+  if (Lua.STATEMENT_SUFFIX) {
     // Inject any statement suffix here since the regular one at the end
     // will not get executed if the break/continue is triggered.
-    xfix += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_SUFFIX, block);
+    xfix += Lua.injectId(Lua.STATEMENT_SUFFIX, block);
   }
-  if (Blockly.Lua.STATEMENT_PREFIX) {
+  if (Lua.STATEMENT_PREFIX) {
     const loop = block.getSurroundLoop();
     if (loop && !loop.suppressPrefixSuffix) {
       // Inject loop's statement prefix here since the regular one at the end
       // of the loop will not get executed if 'continue' is triggered.
       // In the case of 'break', a prefix is needed due to the loop's suffix.
-      xfix += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_PREFIX, loop);
+      xfix += Lua.injectId(Lua.STATEMENT_PREFIX, loop);
     }
   }
   switch (block.getFieldValue('FLOW')) {
     case 'BREAK':
       return xfix + 'break\n';
     case 'CONTINUE':
-      return xfix + Blockly.Lua.CONTINUE_STATEMENT;
+      return xfix + CONTINUE_STATEMENT;
   }
   throw Error('Unknown flow statement.');
 };

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.loops');
+goog.module('Blockly.Lua.loops');
 
 goog.require('Blockly.Lua');
 goog.require('Blockly.utils.string');

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -51,8 +51,7 @@ Lua['controls_repeat_ext'] = function(block) {
     repeats = String(Number(block.getFieldValue('TIMES')));
   } else {
     // External number.
-    repeats = Lua.valueToCode(block, 'TIMES',
-        Lua.ORDER_NONE) || '0';
+    repeats = Lua.valueToCode(block, 'TIMES', Lua.ORDER_NONE) || '0';
   }
   if (stringUtils.isNumber(repeats)) {
     repeats = parseInt(repeats, 10);
@@ -62,10 +61,9 @@ Lua['controls_repeat_ext'] = function(block) {
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
   branch = Lua.addContinueLabel_(branch);
-  const loopVar = Lua.nameDB_.getDistinctName(
-      'count', NameType.VARIABLE);
-  const code = 'for ' + loopVar + ' = 1, ' + repeats + ' do\n' +
-      branch + 'end\n';
+  const loopVar = Lua.nameDB_.getDistinctName('count', NameType.VARIABLE);
+  const code =
+      'for ' + loopVar + ' = 1, ' + repeats + ' do\n' + branch + 'end\n';
   return code;
 };
 
@@ -74,9 +72,10 @@ Lua['controls_repeat'] = Lua['controls_repeat_ext'];
 Lua['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
-  let argument0 = Lua.valueToCode(block, 'BOOL',
-      until ? Lua.ORDER_UNARY :
-      Lua.ORDER_NONE) || 'false';
+  let argument0 =
+      Lua.valueToCode(
+          block, 'BOOL', until ? Lua.ORDER_UNARY : Lua.ORDER_NONE) ||
+      'false';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
   branch = Lua.addContinueLabel_(branch);
@@ -88,14 +87,11 @@ Lua['controls_whileUntil'] = function(block) {
 
 Lua['controls_for'] = function(block) {
   // For loop.
-  const variable0 = Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
-  const startVar = Lua.valueToCode(block, 'FROM',
-      Lua.ORDER_NONE) || '0';
-  const endVar = Lua.valueToCode(block, 'TO',
-      Lua.ORDER_NONE) || '0';
-  const increment = Lua.valueToCode(block, 'BY',
-      Lua.ORDER_NONE) || '1';
+  const variable0 =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
+  const startVar = Lua.valueToCode(block, 'FROM', Lua.ORDER_NONE) || '0';
+  const endVar = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || '0';
+  const increment = Lua.valueToCode(block, 'BY', Lua.ORDER_NONE) || '1';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
   branch = Lua.addContinueLabel_(branch);
@@ -111,8 +107,8 @@ Lua['controls_for'] = function(block) {
     code = '';
     // Determine loop direction at start, in case one of the bounds
     // changes during loop execution.
-    incValue = Lua.nameDB_.getDistinctName(
-        variable0 + '_inc', NameType.VARIABLE);
+    incValue =
+        Lua.nameDB_.getDistinctName(variable0 + '_inc', NameType.VARIABLE);
     code += incValue + ' = ';
     if (stringUtils.isNumber(increment)) {
       code += Math.abs(increment) + '\n';
@@ -123,18 +119,17 @@ Lua['controls_for'] = function(block) {
     code += Lua.INDENT + incValue + ' = -' + incValue + '\n';
     code += 'end\n';
   }
-  code += 'for ' + variable0 + ' = ' + startVar + ', ' + endVar +
-      ', ' + incValue;
+  code +=
+      'for ' + variable0 + ' = ' + startVar + ', ' + endVar + ', ' + incValue;
   code += ' do\n' + branch + 'end\n';
   return code;
 };
 
 Lua['controls_forEach'] = function(block) {
   // For each loop.
-  const variable0 = Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
-  const argument0 = Lua.valueToCode(block, 'LIST',
-      Lua.ORDER_NONE) || '{}';
+  const variable0 =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   let branch = Lua.statementToCode(block, 'DO');
   branch = Lua.addLoopTrap(branch, block);
   branch = Lua.addContinueLabel_(branch);

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.math');
+goog.module('Blockly.Lua.math');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -6,62 +6,62 @@
 
 /**
  * @fileoverview Generating Lua for math blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.math');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.Lua['math_number'] = function(block) {
+Lua['math_number'] = function(block) {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
-  const order = code < 0 ? Blockly.Lua.ORDER_UNARY :
-              Blockly.Lua.ORDER_ATOMIC;
+  const order = code < 0 ? Lua.ORDER_UNARY :
+              Lua.ORDER_ATOMIC;
   return [code, order];
 };
 
-Blockly.Lua['math_arithmetic'] = function(block) {
+Lua['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
-    ADD: [' + ', Blockly.Lua.ORDER_ADDITIVE],
-    MINUS: [' - ', Blockly.Lua.ORDER_ADDITIVE],
-    MULTIPLY: [' * ', Blockly.Lua.ORDER_MULTIPLICATIVE],
-    DIVIDE: [' / ', Blockly.Lua.ORDER_MULTIPLICATIVE],
-    POWER: [' ^ ', Blockly.Lua.ORDER_EXPONENTIATION]
+    ADD: [' + ', Lua.ORDER_ADDITIVE],
+    MINUS: [' - ', Lua.ORDER_ADDITIVE],
+    MULTIPLY: [' * ', Lua.ORDER_MULTIPLICATIVE],
+    DIVIDE: [' / ', Lua.ORDER_MULTIPLICATIVE],
+    POWER: [' ^ ', Lua.ORDER_EXPONENTIATION]
   };
   const tuple = OPERATORS[block.getFieldValue('OP')];
   const operator = tuple[0];
   const order = tuple[1];
-  const argument0 = Blockly.Lua.valueToCode(block, 'A', order) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'B', order) || '0';
+  const argument0 = Lua.valueToCode(block, 'A', order) || '0';
+  const argument1 = Lua.valueToCode(block, 'B', order) || '0';
   const code = argument0 + operator + argument1;
   return [code, order];
 };
 
-Blockly.Lua['math_single'] = function(block) {
+Lua['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let arg;
   if (operator === 'NEG') {
     // Negation is a special case given its different operator precedence.
-    arg = Blockly.Lua.valueToCode(block, 'NUM',
-        Blockly.Lua.ORDER_UNARY) || '0';
-    return ['-' + arg, Blockly.Lua.ORDER_UNARY];
+    arg = Lua.valueToCode(block, 'NUM',
+        Lua.ORDER_UNARY) || '0';
+    return ['-' + arg, Lua.ORDER_UNARY];
   }
   if (operator === 'POW10') {
-    arg = Blockly.Lua.valueToCode(block, 'NUM',
-        Blockly.Lua.ORDER_EXPONENTIATION) || '0';
-    return ['10 ^ ' + arg, Blockly.Lua.ORDER_EXPONENTIATION];
+    arg = Lua.valueToCode(block, 'NUM',
+        Lua.ORDER_EXPONENTIATION) || '0';
+    return ['10 ^ ' + arg, Lua.ORDER_EXPONENTIATION];
   }
   if (operator === 'ROUND') {
-    arg = Blockly.Lua.valueToCode(block, 'NUM',
-        Blockly.Lua.ORDER_ADDITIVE) || '0';
+    arg = Lua.valueToCode(block, 'NUM',
+        Lua.ORDER_ADDITIVE) || '0';
   } else {
-    arg = Blockly.Lua.valueToCode(block, 'NUM',
-        Blockly.Lua.ORDER_NONE) || '0';
+    arg = Lua.valueToCode(block, 'NUM',
+        Lua.ORDER_NONE) || '0';
   }
 
   let code;
@@ -112,34 +112,34 @@ Blockly.Lua['math_single'] = function(block) {
     default:
       throw Error('Unknown math operator: ' + operator);
   }
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['math_constant'] = function(block) {
+Lua['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
-    PI: ['math.pi', Blockly.Lua.ORDER_HIGH],
-    E: ['math.exp(1)', Blockly.Lua.ORDER_HIGH],
-    GOLDEN_RATIO: ['(1 + math.sqrt(5)) / 2', Blockly.Lua.ORDER_MULTIPLICATIVE],
-    SQRT2: ['math.sqrt(2)', Blockly.Lua.ORDER_HIGH],
-    SQRT1_2: ['math.sqrt(1 / 2)', Blockly.Lua.ORDER_HIGH],
-    INFINITY: ['math.huge', Blockly.Lua.ORDER_HIGH]
+    PI: ['math.pi', Lua.ORDER_HIGH],
+    E: ['math.exp(1)', Lua.ORDER_HIGH],
+    GOLDEN_RATIO: ['(1 + math.sqrt(5)) / 2', Lua.ORDER_MULTIPLICATIVE],
+    SQRT2: ['math.sqrt(2)', Lua.ORDER_HIGH],
+    SQRT1_2: ['math.sqrt(1 / 2)', Lua.ORDER_HIGH],
+    INFINITY: ['math.huge', Lua.ORDER_HIGH]
   };
   return CONSTANTS[block.getFieldValue('CONSTANT')];
 };
 
-Blockly.Lua['math_number_property'] = function(block) {
+Lua['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  const number_to_check = Blockly.Lua.valueToCode(block, 'NUMBER_TO_CHECK',
-      Blockly.Lua.ORDER_MULTIPLICATIVE) || '0';
+  const number_to_check = Lua.valueToCode(block, 'NUMBER_TO_CHECK',
+      Lua.ORDER_MULTIPLICATIVE) || '0';
   const dropdown_property = block.getFieldValue('PROPERTY');
   let code;
   if (dropdown_property === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
-    const functionName = Blockly.Lua.provideFunction_(
+    const functionName = Lua.provideFunction_(
         'math_isPrime',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(n)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(n)',
          '  -- https://en.wikipedia.org/wiki/Primality_test#Naive_methods',
          '  if n == 2 or n == 3 then',
          '    return true',
@@ -158,7 +158,7 @@ Blockly.Lua['math_number_property'] = function(block) {
          '  return true',
          'end']);
     code = functionName + '(' + number_to_check + ')';
-    return [code, Blockly.Lua.ORDER_HIGH];
+    return [code, Lua.ORDER_HIGH];
   }
   switch (dropdown_property) {
     case 'EVEN':
@@ -177,12 +177,12 @@ Blockly.Lua['math_number_property'] = function(block) {
       code = number_to_check + ' < 0';
       break;
     case 'DIVISIBLE_BY': {
-      const divisor = Blockly.Lua.valueToCode(block, 'DIVISOR',
-          Blockly.Lua.ORDER_MULTIPLICATIVE);
+      const divisor = Lua.valueToCode(block, 'DIVISOR',
+          Lua.ORDER_MULTIPLICATIVE);
       // If 'divisor' is some code that evals to 0, Lua will produce a nan.
       // Let's produce nil if we can determine this at compile-time.
       if (!divisor || divisor === '0') {
-        return ['nil', Blockly.Lua.ORDER_ATOMIC];
+        return ['nil', Lua.ORDER_ATOMIC];
       }
       // The normal trick to implement ?: with and/or doesn't work here:
       //   divisor == 0 and nil or number_to_check % divisor == 0
@@ -191,35 +191,35 @@ Blockly.Lua['math_number_property'] = function(block) {
       break;
     }
   }
-  return [code, Blockly.Lua.ORDER_RELATIONAL];
+  return [code, Lua.ORDER_RELATIONAL];
 };
 
-Blockly.Lua['math_change'] = function(block) {
+Lua['math_change'] = function(block) {
   // Add to a variable in place.
-  const argument0 = Blockly.Lua.valueToCode(block, 'DELTA',
-      Blockly.Lua.ORDER_ADDITIVE) || '0';
-  const varName = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
+  const argument0 = Lua.valueToCode(block, 'DELTA',
+      Lua.ORDER_ADDITIVE) || '0';
+  const varName = Lua.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + varName + ' + ' + argument0 + '\n';
 };
 
 // Rounding functions have a single operand.
-Blockly.Lua['math_round'] = Blockly.Lua['math_single'];
+Lua['math_round'] = Lua['math_single'];
 // Trigonometry functions have a single operand.
-Blockly.Lua['math_trig'] = Blockly.Lua['math_single'];
+Lua['math_trig'] = Lua['math_single'];
 
-Blockly.Lua['math_on_list'] = function(block) {
+Lua['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
-  const list = Blockly.Lua.valueToCode(block, 'LIST',
-      Blockly.Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(block, 'LIST',
+      Lua.ORDER_NONE) || '{}';
   let functionName;
 
   // Functions needed in more than one case.
   function provideSum() {
-    return Blockly.Lua.provideFunction_(
+    return Lua.provideFunction_(
         'math_sum',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
          '  local result = 0',
          '  for _, v in ipairs(t) do',
          '    result = result + v',
@@ -235,9 +235,9 @@ Blockly.Lua['math_on_list'] = function(block) {
 
     case 'MIN':
       // Returns 0 for the empty list.
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_min',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  if #t == 0 then',
            '    return 0',
            '  end',
@@ -253,9 +253,9 @@ Blockly.Lua['math_on_list'] = function(block) {
 
     case 'AVERAGE':
       // Returns 0 for the empty list.
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_average',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  if #t == 0 then',
            '    return 0',
            '  end',
@@ -265,9 +265,9 @@ Blockly.Lua['math_on_list'] = function(block) {
 
     case 'MAX':
       // Returns 0 for the empty list.
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_max',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  if #t == 0 then',
            '    return 0',
            '  end',
@@ -282,10 +282,10 @@ Blockly.Lua['math_on_list'] = function(block) {
       break;
 
     case 'MEDIAN':
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_median',
           // This operation excludes non-numbers.
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  -- Source: http://lua-users.org/wiki/SimpleStats',
            '  if #t == 0 then',
            '    return 0',
@@ -306,12 +306,12 @@ Blockly.Lua['math_on_list'] = function(block) {
       break;
 
     case 'MODE':
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_modes',
           // As a list of numbers can contain more than one mode,
           // the returned result is provided as an array.
           // The Lua version includes non-numbers.
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  -- Source: http://lua-users.org/wiki/SimpleStats',
            '  local counts={}',
            '  for _, v in ipairs(t) do',
@@ -338,9 +338,9 @@ Blockly.Lua['math_on_list'] = function(block) {
       break;
 
     case 'STD_DEV':
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_standard_deviation',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  local m',
            '  local vm',
            '  local total = 0',
@@ -360,9 +360,9 @@ Blockly.Lua['math_on_list'] = function(block) {
       break;
 
     case 'RANDOM':
-      functionName = Blockly.Lua.provideFunction_(
+      functionName = Lua.provideFunction_(
           'math_random_list',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
            '  if #t == 0 then',
            '    return nil',
            '  end',
@@ -373,53 +373,53 @@ Blockly.Lua['math_on_list'] = function(block) {
     default:
       throw Error('Unknown operator: ' + func);
   }
-  return [functionName + '(' + list + ')', Blockly.Lua.ORDER_HIGH];
+  return [functionName + '(' + list + ')', Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['math_modulo'] = function(block) {
+Lua['math_modulo'] = function(block) {
   // Remainder computation.
-  const argument0 = Blockly.Lua.valueToCode(block, 'DIVIDEND',
-      Blockly.Lua.ORDER_MULTIPLICATIVE) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'DIVISOR',
-      Blockly.Lua.ORDER_MULTIPLICATIVE) || '0';
+  const argument0 = Lua.valueToCode(block, 'DIVIDEND',
+      Lua.ORDER_MULTIPLICATIVE) || '0';
+  const argument1 = Lua.valueToCode(block, 'DIVISOR',
+      Lua.ORDER_MULTIPLICATIVE) || '0';
   const code = argument0 + ' % ' + argument1;
-  return [code, Blockly.Lua.ORDER_MULTIPLICATIVE];
+  return [code, Lua.ORDER_MULTIPLICATIVE];
 };
 
-Blockly.Lua['math_constrain'] = function(block) {
+Lua['math_constrain'] = function(block) {
   // Constrain a number between two limits.
-  const argument0 = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'LOW',
-      Blockly.Lua.ORDER_NONE) || '-math.huge';
-  const argument2 = Blockly.Lua.valueToCode(block, 'HIGH',
-      Blockly.Lua.ORDER_NONE) || 'math.huge';
+  const argument0 = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_NONE) || '0';
+  const argument1 = Lua.valueToCode(block, 'LOW',
+      Lua.ORDER_NONE) || '-math.huge';
+  const argument2 = Lua.valueToCode(block, 'HIGH',
+      Lua.ORDER_NONE) || 'math.huge';
   const code = 'math.min(math.max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['math_random_int'] = function(block) {
+Lua['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
-  const argument0 = Blockly.Lua.valueToCode(block, 'FROM',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'TO',
-      Blockly.Lua.ORDER_NONE) || '0';
+  const argument0 = Lua.valueToCode(block, 'FROM',
+      Lua.ORDER_NONE) || '0';
+  const argument1 = Lua.valueToCode(block, 'TO',
+      Lua.ORDER_NONE) || '0';
   const code = 'math.random(' + argument0 + ', ' + argument1 + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['math_random_float'] = function(block) {
+Lua['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
-  return ['math.random()', Blockly.Lua.ORDER_HIGH];
+  return ['math.random()', Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['math_atan2'] = function(block) {
+Lua['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
-  const argument0 = Blockly.Lua.valueToCode(block, 'X',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const argument1 = Blockly.Lua.valueToCode(block, 'Y',
-      Blockly.Lua.ORDER_NONE) || '0';
+  const argument0 = Lua.valueToCode(block, 'X',
+      Lua.ORDER_NONE) || '0';
+  const argument1 = Lua.valueToCode(block, 'Y',
+      Lua.ORDER_NONE) || '0';
   return ['math.deg(math.atan2(' + argument1 + ', ' + argument0 + '))',
-      Blockly.Lua.ORDER_HIGH];
+      Lua.ORDER_HIGH];
 };

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -18,8 +18,7 @@ const {NameType} = goog.require('Blockly.Names');
 Lua['math_number'] = function(block) {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
-  const order = code < 0 ? Lua.ORDER_UNARY :
-              Lua.ORDER_ATOMIC;
+  const order = code < 0 ? Lua.ORDER_UNARY : Lua.ORDER_ATOMIC;
   return [code, order];
 };
 
@@ -47,21 +46,17 @@ Lua['math_single'] = function(block) {
   let arg;
   if (operator === 'NEG') {
     // Negation is a special case given its different operator precedence.
-    arg = Lua.valueToCode(block, 'NUM',
-        Lua.ORDER_UNARY) || '0';
+    arg = Lua.valueToCode(block, 'NUM', Lua.ORDER_UNARY) || '0';
     return ['-' + arg, Lua.ORDER_UNARY];
   }
   if (operator === 'POW10') {
-    arg = Lua.valueToCode(block, 'NUM',
-        Lua.ORDER_EXPONENTIATION) || '0';
+    arg = Lua.valueToCode(block, 'NUM', Lua.ORDER_EXPONENTIATION) || '0';
     return ['10 ^ ' + arg, Lua.ORDER_EXPONENTIATION];
   }
   if (operator === 'ROUND') {
-    arg = Lua.valueToCode(block, 'NUM',
-        Lua.ORDER_ADDITIVE) || '0';
+    arg = Lua.valueToCode(block, 'NUM', Lua.ORDER_ADDITIVE) || '0';
   } else {
-    arg = Lua.valueToCode(block, 'NUM',
-        Lua.ORDER_NONE) || '0';
+    arg = Lua.valueToCode(block, 'NUM', Lua.ORDER_NONE) || '0';
   }
 
   let code;
@@ -131,32 +126,26 @@ Lua['math_constant'] = function(block) {
 Lua['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  const number_to_check = Lua.valueToCode(block, 'NUMBER_TO_CHECK',
-      Lua.ORDER_MULTIPLICATIVE) || '0';
+  const number_to_check =
+      Lua.valueToCode(block, 'NUMBER_TO_CHECK', Lua.ORDER_MULTIPLICATIVE) ||
+      '0';
   const dropdown_property = block.getFieldValue('PROPERTY');
   let code;
   if (dropdown_property === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
-    const functionName = Lua.provideFunction_(
-        'math_isPrime',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(n)',
-         '  -- https://en.wikipedia.org/wiki/Primality_test#Naive_methods',
-         '  if n == 2 or n == 3 then',
-         '    return true',
-         '  end',
-         '  -- False if n is NaN, negative, is 1, or not whole.',
-         '  -- And false if n is divisible by 2 or 3.',
-         '  if not(n > 1) or n % 1 ~= 0 or n % 2 == 0 or n % 3 == 0 then',
-         '    return false',
-         '  end',
-         '  -- Check all the numbers of form 6k +/- 1, up to sqrt(n).',
-         '  for x = 6, math.sqrt(n) + 1.5, 6 do',
-         '    if n % (x - 1) == 0 or n % (x + 1) == 0 then',
-         '      return false',
-         '    end',
-         '  end',
-         '  return true',
-         'end']);
+    const functionName = Lua.provideFunction_('math_isPrime', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(n)',
+      '  -- https://en.wikipedia.org/wiki/Primality_test#Naive_methods',
+      '  if n == 2 or n == 3 then', '    return true', '  end',
+      '  -- False if n is NaN, negative, is 1, or not whole.',
+      '  -- And false if n is divisible by 2 or 3.',
+      '  if not(n > 1) or n % 1 ~= 0 or n % 2 == 0 or n % 3 == 0 then',
+      '    return false', '  end',
+      '  -- Check all the numbers of form 6k +/- 1, up to sqrt(n).',
+      '  for x = 6, math.sqrt(n) + 1.5, 6 do',
+      '    if n % (x - 1) == 0 or n % (x + 1) == 0 then', '      return false',
+      '    end', '  end', '  return true', 'end'
+    ]);
     code = functionName + '(' + number_to_check + ')';
     return [code, Lua.ORDER_HIGH];
   }
@@ -177,8 +166,8 @@ Lua['math_number_property'] = function(block) {
       code = number_to_check + ' < 0';
       break;
     case 'DIVISIBLE_BY': {
-      const divisor = Lua.valueToCode(block, 'DIVISOR',
-          Lua.ORDER_MULTIPLICATIVE);
+      const divisor =
+          Lua.valueToCode(block, 'DIVISOR', Lua.ORDER_MULTIPLICATIVE);
       // If 'divisor' is some code that evals to 0, Lua will produce a nan.
       // Let's produce nil if we can determine this at compile-time.
       if (!divisor || divisor === '0') {
@@ -196,10 +185,9 @@ Lua['math_number_property'] = function(block) {
 
 Lua['math_change'] = function(block) {
   // Add to a variable in place.
-  const argument0 = Lua.valueToCode(block, 'DELTA',
-      Lua.ORDER_ADDITIVE) || '0';
-  const varName = Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 = Lua.valueToCode(block, 'DELTA', Lua.ORDER_ADDITIVE) || '0';
+  const varName =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + varName + ' + ' + argument0 + '\n';
 };
 
@@ -211,21 +199,16 @@ Lua['math_trig'] = Lua['math_single'];
 Lua['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
-  const list = Lua.valueToCode(block, 'LIST',
-      Lua.ORDER_NONE) || '{}';
+  const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   let functionName;
 
   // Functions needed in more than one case.
   function provideSum() {
-    return Lua.provideFunction_(
-        'math_sum',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-         '  local result = 0',
-         '  for _, v in ipairs(t) do',
-         '    result = result + v',
-         '  end',
-         '  return result',
-         'end']);
+    return Lua.provideFunction_('math_sum', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+      '  local result = 0', '  for _, v in ipairs(t) do',
+      '    result = result + v', '  end', '  return result', 'end'
+    ]);
   }
 
   switch (func) {
@@ -235,74 +218,49 @@ Lua['math_on_list'] = function(block) {
 
     case 'MIN':
       // Returns 0 for the empty list.
-      functionName = Lua.provideFunction_(
-          'math_min',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  if #t == 0 then',
-           '    return 0',
-           '  end',
-           '  local result = math.huge',
-           '  for _, v in ipairs(t) do',
-           '    if v < result then',
-           '      result = v',
-           '    end',
-           '  end',
-           '  return result',
-           'end']);
+      functionName = Lua.provideFunction_('math_min', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+        '  if #t == 0 then', '    return 0', '  end',
+        '  local result = math.huge', '  for _, v in ipairs(t) do',
+        '    if v < result then', '      result = v', '    end', '  end',
+        '  return result', 'end'
+      ]);
       break;
 
     case 'AVERAGE':
       // Returns 0 for the empty list.
-      functionName = Lua.provideFunction_(
-          'math_average',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  if #t == 0 then',
-           '    return 0',
-           '  end',
-           '  return ' + provideSum() + '(t) / #t',
-           'end']);
+      functionName = Lua.provideFunction_('math_average', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+        '  if #t == 0 then', '    return 0', '  end',
+        '  return ' + provideSum() + '(t) / #t', 'end'
+      ]);
       break;
 
     case 'MAX':
       // Returns 0 for the empty list.
-      functionName = Lua.provideFunction_(
-          'math_max',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  if #t == 0 then',
-           '    return 0',
-           '  end',
-           '  local result = -math.huge',
-           '  for _, v in ipairs(t) do',
-           '    if v > result then',
-           '      result = v',
-           '    end',
-           '  end',
-           '  return result',
-           'end']);
+      functionName = Lua.provideFunction_('math_max', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+        '  if #t == 0 then', '    return 0', '  end',
+        '  local result = -math.huge', '  for _, v in ipairs(t) do',
+        '    if v > result then', '      result = v', '    end', '  end',
+        '  return result', 'end'
+      ]);
       break;
 
     case 'MEDIAN':
       functionName = Lua.provideFunction_(
           'math_median',
           // This operation excludes non-numbers.
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  -- Source: http://lua-users.org/wiki/SimpleStats',
-           '  if #t == 0 then',
-           '    return 0',
-           '  end',
-           '  local temp={}',
-           '  for _, v in ipairs(t) do',
-           '    if type(v) == "number" then',
-           '      table.insert(temp, v)',
-           '    end',
-           '  end',
-           '  table.sort(temp)',
-           '  if #temp % 2 == 0 then',
-           '    return (temp[#temp/2] + temp[(#temp/2)+1]) / 2',
-           '  else',
-           '    return temp[math.ceil(#temp/2)]',
-           '  end',
-           'end']);
+          [
+            'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+            '  -- Source: http://lua-users.org/wiki/SimpleStats',
+            '  if #t == 0 then', '    return 0', '  end', '  local temp={}',
+            '  for _, v in ipairs(t) do', '    if type(v) == "number" then',
+            '      table.insert(temp, v)', '    end', '  end',
+            '  table.sort(temp)', '  if #temp % 2 == 0 then',
+            '    return (temp[#temp/2] + temp[(#temp/2)+1]) / 2', '  else',
+            '    return temp[math.ceil(#temp/2)]', '  end', 'end'
+          ]);
       break;
 
     case 'MODE':
@@ -311,63 +269,52 @@ Lua['math_on_list'] = function(block) {
           // As a list of numbers can contain more than one mode,
           // the returned result is provided as an array.
           // The Lua version includes non-numbers.
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  -- Source: http://lua-users.org/wiki/SimpleStats',
-           '  local counts={}',
-           '  for _, v in ipairs(t) do',
-           '    if counts[v] == nil then',
-           '      counts[v] = 1',
-           '    else',
-           '      counts[v] = counts[v] + 1',
-           '    end',
-           '  end',
-           '  local biggestCount = 0',
-           '  for _, v  in pairs(counts) do',
-           '    if v > biggestCount then',
-           '      biggestCount = v',
-           '    end',
-           '  end',
-           '  local temp={}',
-           '  for k, v in pairs(counts) do',
-           '    if v == biggestCount then',
-           '      table.insert(temp, k)',
-           '    end',
-           '  end',
-           '  return temp',
-           'end']);
+          [
+            'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+            '  -- Source: http://lua-users.org/wiki/SimpleStats',
+            '  local counts={}',
+            '  for _, v in ipairs(t) do',
+            '    if counts[v] == nil then',
+            '      counts[v] = 1',
+            '    else',
+            '      counts[v] = counts[v] + 1',
+            '    end',
+            '  end',
+            '  local biggestCount = 0',
+            '  for _, v  in pairs(counts) do',
+            '    if v > biggestCount then',
+            '      biggestCount = v',
+            '    end',
+            '  end',
+            '  local temp={}',
+            '  for k, v in pairs(counts) do',
+            '    if v == biggestCount then',
+            '      table.insert(temp, k)',
+            '    end',
+            '  end',
+            '  return temp',
+            'end'
+          ]);
       break;
 
     case 'STD_DEV':
-      functionName = Lua.provideFunction_(
-          'math_standard_deviation',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  local m',
-           '  local vm',
-           '  local total = 0',
-           '  local count = 0',
-           '  local result',
-           '  m = #t == 0 and 0 or ' + provideSum() + '(t) / #t',
-           '  for _, v in ipairs(t) do',
-           "    if type(v) == 'number' then",
-           '      vm = v - m',
-           '      total = total + (vm * vm)',
-           '      count = count + 1',
-           '    end',
-           '  end',
-           '  result = math.sqrt(total / (count-1))',
-           '  return result',
-           'end']);
+      functionName = Lua.provideFunction_('math_standard_deviation', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)', '  local m',
+        '  local vm', '  local total = 0', '  local count = 0',
+        '  local result', '  m = #t == 0 and 0 or ' + provideSum() + '(t) / #t',
+        '  for _, v in ipairs(t) do', '    if type(v) == \'number\' then',
+        '      vm = v - m', '      total = total + (vm * vm)',
+        '      count = count + 1', '    end', '  end',
+        '  result = math.sqrt(total / (count-1))', '  return result', 'end'
+      ]);
       break;
 
     case 'RANDOM':
-      functionName = Lua.provideFunction_(
-          'math_random_list',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
-           '  if #t == 0 then',
-           '    return nil',
-           '  end',
-           '  return t[math.random(#t)]',
-           'end']);
+      functionName = Lua.provideFunction_('math_random_list', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(t)',
+        '  if #t == 0 then', '    return nil', '  end',
+        '  return t[math.random(#t)]', 'end'
+      ]);
       break;
 
     default:
@@ -378,22 +325,21 @@ Lua['math_on_list'] = function(block) {
 
 Lua['math_modulo'] = function(block) {
   // Remainder computation.
-  const argument0 = Lua.valueToCode(block, 'DIVIDEND',
-      Lua.ORDER_MULTIPLICATIVE) || '0';
-  const argument1 = Lua.valueToCode(block, 'DIVISOR',
-      Lua.ORDER_MULTIPLICATIVE) || '0';
+  const argument0 =
+      Lua.valueToCode(block, 'DIVIDEND', Lua.ORDER_MULTIPLICATIVE) || '0';
+  const argument1 =
+      Lua.valueToCode(block, 'DIVISOR', Lua.ORDER_MULTIPLICATIVE) || '0';
   const code = argument0 + ' % ' + argument1;
   return [code, Lua.ORDER_MULTIPLICATIVE];
 };
 
 Lua['math_constrain'] = function(block) {
   // Constrain a number between two limits.
-  const argument0 = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_NONE) || '0';
-  const argument1 = Lua.valueToCode(block, 'LOW',
-      Lua.ORDER_NONE) || '-math.huge';
-  const argument2 = Lua.valueToCode(block, 'HIGH',
-      Lua.ORDER_NONE) || 'math.huge';
+  const argument0 = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '0';
+  const argument1 =
+      Lua.valueToCode(block, 'LOW', Lua.ORDER_NONE) || '-math.huge';
+  const argument2 =
+      Lua.valueToCode(block, 'HIGH', Lua.ORDER_NONE) || 'math.huge';
   const code = 'math.min(math.max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
   return [code, Lua.ORDER_HIGH];
@@ -401,10 +347,8 @@ Lua['math_constrain'] = function(block) {
 
 Lua['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
-  const argument0 = Lua.valueToCode(block, 'FROM',
-      Lua.ORDER_NONE) || '0';
-  const argument1 = Lua.valueToCode(block, 'TO',
-      Lua.ORDER_NONE) || '0';
+  const argument0 = Lua.valueToCode(block, 'FROM', Lua.ORDER_NONE) || '0';
+  const argument1 = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || '0';
   const code = 'math.random(' + argument0 + ', ' + argument1 + ')';
   return [code, Lua.ORDER_HIGH];
 };
@@ -416,10 +360,9 @@ Lua['math_random_float'] = function(block) {
 
 Lua['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
-  const argument0 = Lua.valueToCode(block, 'X',
-      Lua.ORDER_NONE) || '0';
-  const argument1 = Lua.valueToCode(block, 'Y',
-      Lua.ORDER_NONE) || '0';
-  return ['math.deg(math.atan2(' + argument1 + ', ' + argument0 + '))',
-      Lua.ORDER_HIGH];
+  const argument0 = Lua.valueToCode(block, 'X', Lua.ORDER_NONE) || '0';
+  const argument1 = Lua.valueToCode(block, 'Y', Lua.ORDER_NONE) || '0';
+  return [
+    'math.deg(math.atan2(' + argument1 + ', ' + argument0 + '))', Lua.ORDER_HIGH
+  ];
 };

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -6,107 +6,107 @@
 
 /**
  * @fileoverview Generating Lua for procedure blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.procedures');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.Lua['procedures_defreturn'] = function(block) {
+Lua['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
-  const funcName = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
+  const funcName = Lua.nameDB_.getName(
+      block.getFieldValue('NAME'), NameType.PROCEDURE);
   let xfix1 = '';
-  if (Blockly.Lua.STATEMENT_PREFIX) {
-    xfix1 += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_PREFIX, block);
+  if (Lua.STATEMENT_PREFIX) {
+    xfix1 += Lua.injectId(Lua.STATEMENT_PREFIX, block);
   }
-  if (Blockly.Lua.STATEMENT_SUFFIX) {
-    xfix1 += Blockly.Lua.injectId(Blockly.Lua.STATEMENT_SUFFIX, block);
+  if (Lua.STATEMENT_SUFFIX) {
+    xfix1 += Lua.injectId(Lua.STATEMENT_SUFFIX, block);
   }
   if (xfix1) {
-    xfix1 = Blockly.Lua.prefixLines(xfix1, Blockly.Lua.INDENT);
+    xfix1 = Lua.prefixLines(xfix1, Lua.INDENT);
   }
   let loopTrap = '';
-  if (Blockly.Lua.INFINITE_LOOP_TRAP) {
-    loopTrap = Blockly.Lua.prefixLines(
-        Blockly.Lua.injectId(Blockly.Lua.INFINITE_LOOP_TRAP, block),
-        Blockly.Lua.INDENT);
+  if (Lua.INFINITE_LOOP_TRAP) {
+    loopTrap = Lua.prefixLines(
+        Lua.injectId(Lua.INFINITE_LOOP_TRAP, block),
+        Lua.INDENT);
   }
-  let branch = Blockly.Lua.statementToCode(block, 'STACK');
-  let returnValue = Blockly.Lua.valueToCode(block, 'RETURN',
-      Blockly.Lua.ORDER_NONE) || '';
+  let branch = Lua.statementToCode(block, 'STACK');
+  let returnValue = Lua.valueToCode(block, 'RETURN',
+      Lua.ORDER_NONE) || '';
   let xfix2 = '';
   if (branch && returnValue) {
     // After executing the function body, revisit this block for the return.
     xfix2 = xfix1;
   }
   if (returnValue) {
-    returnValue = Blockly.Lua.INDENT + 'return ' + returnValue + '\n';
+    returnValue = Lua.INDENT + 'return ' + returnValue + '\n';
   } else if (!branch) {
     branch = '';
   }
   const args = [];
   const variables = block.getVars();
   for (let i = 0; i < variables.length; i++) {
-    args[i] = Blockly.Lua.nameDB_.getName(variables[i],
-        Blockly.VARIABLE_CATEGORY_NAME);
+    args[i] = Lua.nameDB_.getName(variables[i],
+        NameType.VARIABLE);
   }
   let code = 'function ' + funcName + '(' + args.join(', ') + ')\n' +
       xfix1 + loopTrap + branch + xfix2 + returnValue + 'end\n';
-  code = Blockly.Lua.scrub_(block, code);
+  code = Lua.scrub_(block, code);
   // Add % so as not to collide with helper functions in definitions list.
-  Blockly.Lua.definitions_['%' + funcName] = code;
+  Lua.definitions_['%' + funcName] = code;
   return null;
 };
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-Blockly.Lua['procedures_defnoreturn'] =
-    Blockly.Lua['procedures_defreturn'];
+Lua['procedures_defnoreturn'] =
+    Lua['procedures_defreturn'];
 
-Blockly.Lua['procedures_callreturn'] = function(block) {
+Lua['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
-  const funcName = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('NAME'), Blockly.PROCEDURE_CATEGORY_NAME);
+  const funcName = Lua.nameDB_.getName(
+      block.getFieldValue('NAME'), NameType.PROCEDURE);
   const args = [];
   const variables = block.getVars();
   for (let i = 0; i < variables.length; i++) {
-    args[i] = Blockly.Lua.valueToCode(block, 'ARG' + i,
-        Blockly.Lua.ORDER_NONE) || 'nil';
+    args[i] = Lua.valueToCode(block, 'ARG' + i,
+        Lua.ORDER_NONE) || 'nil';
   }
   const code = funcName + '(' + args.join(', ') + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['procedures_callnoreturn'] = function(block) {
+Lua['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = Blockly.Lua['procedures_callreturn'](block);
+  const tuple = Lua['procedures_callreturn'](block);
   return tuple[0] + '\n';
 };
 
-Blockly.Lua['procedures_ifreturn'] = function(block) {
+Lua['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
-  const condition = Blockly.Lua.valueToCode(block, 'CONDITION',
-      Blockly.Lua.ORDER_NONE) || 'false';
+  const condition = Lua.valueToCode(block, 'CONDITION',
+      Lua.ORDER_NONE) || 'false';
   let code = 'if ' + condition + ' then\n';
-  if (Blockly.Lua.STATEMENT_SUFFIX) {
+  if (Lua.STATEMENT_SUFFIX) {
     // Inject any statement suffix here since the regular one at the end
     // will not get executed if the return is triggered.
-    code += Blockly.Lua.prefixLines(
-        Blockly.Lua.injectId(Blockly.Lua.STATEMENT_SUFFIX, block),
-        Blockly.Lua.INDENT);
+    code += Lua.prefixLines(
+        Lua.injectId(Lua.STATEMENT_SUFFIX, block),
+        Lua.INDENT);
   }
   if (block.hasReturnValue_) {
-    const value = Blockly.Lua.valueToCode(block, 'VALUE',
-        Blockly.Lua.ORDER_NONE) || 'nil';
-    code += Blockly.Lua.INDENT + 'return ' + value + '\n';
+    const value = Lua.valueToCode(block, 'VALUE',
+        Lua.ORDER_NONE) || 'nil';
+    code += Lua.INDENT + 'return ' + value + '\n';
   } else {
-    code += Blockly.Lua.INDENT + 'return\n';
+    code += Lua.INDENT + 'return\n';
   }
   code += 'end\n';
   return code;

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.procedures');
+goog.module('Blockly.Lua.procedures');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -17,8 +17,8 @@ const {NameType} = goog.require('Blockly.Names');
 
 Lua['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
-  const funcName = Lua.nameDB_.getName(
-      block.getFieldValue('NAME'), NameType.PROCEDURE);
+  const funcName =
+      Lua.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
   let xfix1 = '';
   if (Lua.STATEMENT_PREFIX) {
     xfix1 += Lua.injectId(Lua.STATEMENT_PREFIX, block);
@@ -32,12 +32,10 @@ Lua['procedures_defreturn'] = function(block) {
   let loopTrap = '';
   if (Lua.INFINITE_LOOP_TRAP) {
     loopTrap = Lua.prefixLines(
-        Lua.injectId(Lua.INFINITE_LOOP_TRAP, block),
-        Lua.INDENT);
+        Lua.injectId(Lua.INFINITE_LOOP_TRAP, block), Lua.INDENT);
   }
   let branch = Lua.statementToCode(block, 'STACK');
-  let returnValue = Lua.valueToCode(block, 'RETURN',
-      Lua.ORDER_NONE) || '';
+  let returnValue = Lua.valueToCode(block, 'RETURN', Lua.ORDER_NONE) || '';
   let xfix2 = '';
   if (branch && returnValue) {
     // After executing the function body, revisit this block for the return.
@@ -51,11 +49,10 @@ Lua['procedures_defreturn'] = function(block) {
   const args = [];
   const variables = block.getVars();
   for (let i = 0; i < variables.length; i++) {
-    args[i] = Lua.nameDB_.getName(variables[i],
-        NameType.VARIABLE);
+    args[i] = Lua.nameDB_.getName(variables[i], NameType.VARIABLE);
   }
-  let code = 'function ' + funcName + '(' + args.join(', ') + ')\n' +
-      xfix1 + loopTrap + branch + xfix2 + returnValue + 'end\n';
+  let code = 'function ' + funcName + '(' + args.join(', ') + ')\n' + xfix1 +
+      loopTrap + branch + xfix2 + returnValue + 'end\n';
   code = Lua.scrub_(block, code);
   // Add % so as not to collide with helper functions in definitions list.
   Lua.definitions_['%' + funcName] = code;
@@ -64,18 +61,16 @@ Lua['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-Lua['procedures_defnoreturn'] =
-    Lua['procedures_defreturn'];
+Lua['procedures_defnoreturn'] = Lua['procedures_defreturn'];
 
 Lua['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
-  const funcName = Lua.nameDB_.getName(
-      block.getFieldValue('NAME'), NameType.PROCEDURE);
+  const funcName =
+      Lua.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
   const args = [];
   const variables = block.getVars();
   for (let i = 0; i < variables.length; i++) {
-    args[i] = Lua.valueToCode(block, 'ARG' + i,
-        Lua.ORDER_NONE) || 'nil';
+    args[i] = Lua.valueToCode(block, 'ARG' + i, Lua.ORDER_NONE) || 'nil';
   }
   const code = funcName + '(' + args.join(', ') + ')';
   return [code, Lua.ORDER_HIGH];
@@ -91,19 +86,17 @@ Lua['procedures_callnoreturn'] = function(block) {
 
 Lua['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
-  const condition = Lua.valueToCode(block, 'CONDITION',
-      Lua.ORDER_NONE) || 'false';
+  const condition =
+      Lua.valueToCode(block, 'CONDITION', Lua.ORDER_NONE) || 'false';
   let code = 'if ' + condition + ' then\n';
   if (Lua.STATEMENT_SUFFIX) {
     // Inject any statement suffix here since the regular one at the end
     // will not get executed if the return is triggered.
-    code += Lua.prefixLines(
-        Lua.injectId(Lua.STATEMENT_SUFFIX, block),
-        Lua.INDENT);
+    code +=
+        Lua.prefixLines(Lua.injectId(Lua.STATEMENT_SUFFIX, block), Lua.INDENT);
   }
   if (block.hasReturnValue_) {
-    const value = Lua.valueToCode(block, 'VALUE',
-        Lua.ORDER_NONE) || 'nil';
+    const value = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || 'nil';
     code += Lua.INDENT + 'return ' + value + '\n';
   } else {
     code += Lua.INDENT + 'return\n';

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -24,8 +24,8 @@ Lua['text'] = function(block) {
 Lua['text_multiline'] = function(block) {
   // Text value.
   const code = Lua.multiline_quote_(block.getFieldValue('TEXT'));
-  const order = code.indexOf('..') !== -1 ? Lua.ORDER_CONCATENATION :
-      Lua.ORDER_ATOMIC;
+  const order =
+      code.indexOf('..') !== -1 ? Lua.ORDER_CONCATENATION : Lua.ORDER_ATOMIC;
   return [code, order];
 };
 
@@ -34,22 +34,20 @@ Lua['text_join'] = function(block) {
   if (block.itemCount_ === 0) {
     return ['\'\'', Lua.ORDER_ATOMIC];
   } else if (block.itemCount_ === 1) {
-    const element = Lua.valueToCode(block, 'ADD0',
-        Lua.ORDER_NONE) || '\'\'';
+    const element = Lua.valueToCode(block, 'ADD0', Lua.ORDER_NONE) || '\'\'';
     const code = 'tostring(' + element + ')';
     return [code, Lua.ORDER_HIGH];
   } else if (block.itemCount_ === 2) {
-    const element0 = Lua.valueToCode(block, 'ADD0',
-        Lua.ORDER_CONCATENATION) || '\'\'';
-    const element1 = Lua.valueToCode(block, 'ADD1',
-        Lua.ORDER_CONCATENATION) || '\'\'';
+    const element0 =
+        Lua.valueToCode(block, 'ADD0', Lua.ORDER_CONCATENATION) || '\'\'';
+    const element1 =
+        Lua.valueToCode(block, 'ADD1', Lua.ORDER_CONCATENATION) || '\'\'';
     const code = element0 + ' .. ' + element1;
     return [code, Lua.ORDER_CONCATENATION];
   } else {
     const elements = [];
     for (let i = 0; i < block.itemCount_; i++) {
-      elements[i] = Lua.valueToCode(block, 'ADD' + i,
-          Lua.ORDER_NONE) || '\'\'';
+      elements[i] = Lua.valueToCode(block, 'ADD' + i, Lua.ORDER_NONE) || '\'\'';
     }
     const code = 'table.concat({' + elements.join(', ') + '})';
     return [code, Lua.ORDER_HIGH];
@@ -58,58 +56,44 @@ Lua['text_join'] = function(block) {
 
 Lua['text_append'] = function(block) {
   // Append to a variable in place.
-  const varName = Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
-  const value = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_CONCATENATION) || '\'\'';
+  const varName =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
+  const value =
+      Lua.valueToCode(block, 'TEXT', Lua.ORDER_CONCATENATION) || '\'\'';
   return varName + ' = ' + varName + ' .. ' + value + '\n';
 };
 
 Lua['text_length'] = function(block) {
   // String or array length.
-  const text = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_UNARY) || '\'\'';
+  const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '\'\'';
   return ['#' + text, Lua.ORDER_UNARY];
 };
 
 Lua['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const text = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_UNARY) || '\'\'';
+  const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '\'\'';
   return ['#' + text + ' == 0', Lua.ORDER_RELATIONAL];
 };
 
 Lua['text_indexOf'] = function(block) {
   // Search the text for a substring.
-  const substring = Lua.valueToCode(block, 'FIND',
-      Lua.ORDER_NONE) || '\'\'';
-  const text = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_NONE) || '\'\'';
+  const substring = Lua.valueToCode(block, 'FIND', Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '\'\'';
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = Lua.provideFunction_(
-        'firstIndexOf',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-             '(str, substr) ',
-         '  local i = string.find(str, substr, 1, true)',
-         '  if i == nil then',
-         '    return 0',
-         '  else',
-         '    return i',
-         '  end',
-         'end']);
+    functionName = Lua.provideFunction_('firstIndexOf', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str, substr) ',
+      '  local i = string.find(str, substr, 1, true)', '  if i == nil then',
+      '    return 0', '  else', '    return i', '  end', 'end'
+    ]);
   } else {
-    functionName = Lua.provideFunction_(
-        'lastIndexOf',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-             '(str, substr)',
-         '  local i = string.find(string.reverse(str), ' +
-             'string.reverse(substr), 1, true)',
-         '  if i then',
-         '    return #str + 2 - i - #substr',
-         '  end',
-         '  return 0',
-         'end']);
+    functionName = Lua.provideFunction_('lastIndexOf', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str, substr)',
+      '  local i = string.find(string.reverse(str), ' +
+          'string.reverse(substr), 1, true)',
+      '  if i then', '    return #str + 2 - i - #substr', '  end', '  return 0',
+      'end'
+    ]);
   }
   const code = functionName + '(' + text + ', ' + substring + ')';
   return [code, Lua.ORDER_HIGH];
@@ -119,19 +103,16 @@ Lua['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const atOrder = (where === 'FROM_END') ? Lua.ORDER_UNARY :
-      Lua.ORDER_NONE;
+  const atOrder = (where === 'FROM_END') ? Lua.ORDER_UNARY : Lua.ORDER_NONE;
   const at = Lua.valueToCode(block, 'AT', atOrder) || '1';
-  const text = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '\'\'';
   let code;
   if (where === 'RANDOM') {
-    const functionName = Lua.provideFunction_(
-        'text_random_letter',
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
-         '  local index = math.random(string.len(str))',
-         '  return string.sub(str, index, index)',
-         'end']);
+    const functionName = Lua.provideFunction_('text_random_letter', [
+      'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
+      '  local index = math.random(string.len(str))',
+      '  return string.sub(str, index, index)', 'end'
+    ]);
     code = functionName + '(' + text + ')';
   } else {
     let start;
@@ -152,12 +133,10 @@ Lua['text_charAt'] = function(block) {
       code = 'string.sub(' + text + ', ' + start + ', ' + start + ')';
     } else {
       // use function to avoid reevaluation
-      const functionName = Lua.provideFunction_(
-          'text_char_at',
-          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
-               '(str, index)',
-           '  return string.sub(str, index, index)',
-           'end']);
+      const functionName = Lua.provideFunction_('text_char_at', [
+        'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str, index)',
+        '  return string.sub(str, index, index)', 'end'
+      ]);
       code = functionName + '(' + text + ', ' + start + ')';
     }
   }
@@ -166,13 +145,11 @@ Lua['text_charAt'] = function(block) {
 
 Lua['text_getSubstring'] = function(block) {
   // Get substring.
-  const text = Lua.valueToCode(block, 'STRING',
-      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'STRING', Lua.ORDER_NONE) || '\'\'';
 
   // Get start index.
   const where1 = block.getFieldValue('WHERE1');
-  const at1Order = (where1 === 'FROM_END') ? Lua.ORDER_UNARY :
-      Lua.ORDER_NONE;
+  const at1Order = (where1 === 'FROM_END') ? Lua.ORDER_UNARY : Lua.ORDER_NONE;
   const at1 = Lua.valueToCode(block, 'AT1', at1Order) || '1';
   let start;
   if (where1 === 'FIRST') {
@@ -187,8 +164,7 @@ Lua['text_getSubstring'] = function(block) {
 
   // Get end index.
   const where2 = block.getFieldValue('WHERE2');
-  const at2Order = (where2 === 'FROM_END') ? Lua.ORDER_UNARY :
-      Lua.ORDER_NONE;
+  const at2Order = (where2 === 'FROM_END') ? Lua.ORDER_UNARY : Lua.ORDER_NONE;
   const at2 = Lua.valueToCode(block, 'AT2', at2Order) || '1';
   let end;
   if (where2 === 'LAST') {
@@ -207,8 +183,7 @@ Lua['text_getSubstring'] = function(block) {
 Lua['text_changeCase'] = function(block) {
   // Change capitalization.
   const operator = block.getFieldValue('CASE');
-  const text = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
   let functionName;
   if (operator === 'UPPERCASE') {
     functionName = 'string.upper';
@@ -220,23 +195,16 @@ Lua['text_changeCase'] = function(block) {
         // There are shorter versions at
         // http://lua-users.org/wiki/SciteTitleCase
         // that do not preserve whitespace.
-        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
-         '  local buf = {}',
-         '  local inWord = false',
-         '  for i = 1, #str do',
-         '    local c = string.sub(str, i, i)',
-         '    if inWord then',
-         '      table.insert(buf, string.lower(c))',
-         '      if string.find(c, "%s") then',
-         '        inWord = false',
-         '      end',
-         '    else',
-         '      table.insert(buf, string.upper(c))',
-         '      inWord = true',
-         '    end',
-         '  end',
-         '  return table.concat(buf)',
-         'end']);
+        [
+          'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
+          '  local buf = {}', '  local inWord = false', '  for i = 1, #str do',
+          '    local c = string.sub(str, i, i)', '    if inWord then',
+          '      table.insert(buf, string.lower(c))',
+          '      if string.find(c, "%s") then', '        inWord = false',
+          '      end', '    else', '      table.insert(buf, string.upper(c))',
+          '      inWord = true', '    end', '  end',
+          '  return table.concat(buf)', 'end'
+        ]);
   }
   const code = functionName + '(' + text + ')';
   return [code, Lua.ORDER_HIGH];
@@ -244,22 +212,16 @@ Lua['text_changeCase'] = function(block) {
 
 Lua['text_trim'] = function(block) {
   // Trim spaces.
-  const OPERATORS = {
-    LEFT: '^%s*(,-)',
-    RIGHT: '(.-)%s*$',
-    BOTH: '^%s*(.-)%s*$'
-  };
+  const OPERATORS = {LEFT: '^%s*(,-)', RIGHT: '(.-)%s*$', BOTH: '^%s*(.-)%s*$'};
   const operator = OPERATORS[block.getFieldValue('MODE')];
-  const text = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
   const code = 'string.gsub(' + text + ', "' + operator + '", "%1")';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['text_print'] = function(block) {
   // Print statement.
-  const msg = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
+  const msg = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
   return 'print(' + msg + ')\n';
 };
 
@@ -271,17 +233,13 @@ Lua['text_prompt_ext'] = function(block) {
     msg = Lua.quote_(block.getFieldValue('TEXT'));
   } else {
     // External message.
-    msg = Lua.valueToCode(block, 'TEXT',
-        Lua.ORDER_NONE) || '\'\'';
+    msg = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
   }
 
-  const functionName = Lua.provideFunction_(
-      'text_prompt',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(msg)',
-       '  io.write(msg)',
-       '  io.flush()',
-       '  return io.read()',
-       'end']);
+  const functionName = Lua.provideFunction_('text_prompt', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(msg)', '  io.write(msg)',
+    '  io.flush()', '  return io.read()', 'end'
+  ]);
   let code = functionName + '(' + msg + ')';
 
   const toNumber = block.getFieldValue('TYPE') === 'NUMBER';
@@ -294,68 +252,59 @@ Lua['text_prompt_ext'] = function(block) {
 Lua['text_prompt'] = Lua['text_prompt_ext'];
 
 Lua['text_count'] = function(block) {
-  const text = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
-  const sub = Lua.valueToCode(block, 'SUB',
-      Lua.ORDER_NONE) || '\'\'';
-  const functionName = Lua.provideFunction_(
-      'text_count',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_
-        + '(haystack, needle)',
-        '  if #needle == 0 then',
-        '    return #haystack + 1',
-        '  end',
-        '  local i = 1',
-        '  local count = 0',
-        '  while true do',
-        '    i = string.find(haystack, needle, i, true)',
-        '    if i == nil then',
-        '      break',
-        '    end',
-        '    count = count + 1',
-        '    i = i + #needle',
-        '  end',
-        '  return count',
-        'end',
-      ]);
+  const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
+  const sub = Lua.valueToCode(block, 'SUB', Lua.ORDER_NONE) || '\'\'';
+  const functionName = Lua.provideFunction_('text_count', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(haystack, needle)',
+    '  if #needle == 0 then',
+    '    return #haystack + 1',
+    '  end',
+    '  local i = 1',
+    '  local count = 0',
+    '  while true do',
+    '    i = string.find(haystack, needle, i, true)',
+    '    if i == nil then',
+    '      break',
+    '    end',
+    '    count = count + 1',
+    '    i = i + #needle',
+    '  end',
+    '  return count',
+    'end',
+  ]);
   const code = functionName + '(' + text + ', ' + sub + ')';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['text_replace'] = function(block) {
-  const text = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
-  const from = Lua.valueToCode(block, 'FROM',
-      Lua.ORDER_NONE) || '\'\'';
-  const to = Lua.valueToCode(block, 'TO',
-      Lua.ORDER_NONE) || '\'\'';
-  const functionName = Lua.provideFunction_(
-      'text_replace',
-      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_
-        + '(haystack, needle, replacement)',
-        '  local buf = {}',
-        '  local i = 1',
-        '  while i <= #haystack do',
-        '    if string.sub(haystack, i, i + #needle - 1) == needle then',
-        '      for j = 1, #replacement do',
-        '        table.insert(buf, string.sub(replacement, j, j))',
-        '      end',
-        '      i = i + #needle',
-        '    else',
-        '      table.insert(buf, string.sub(haystack, i, i))',
-        '      i = i + 1',
-        '    end',
-        '  end',
-        '  return table.concat(buf)',
-        'end',
-      ]);
+  const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
+  const from = Lua.valueToCode(block, 'FROM', Lua.ORDER_NONE) || '\'\'';
+  const to = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || '\'\'';
+  const functionName = Lua.provideFunction_('text_replace', [
+    'function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
+        '(haystack, needle, replacement)',
+    '  local buf = {}',
+    '  local i = 1',
+    '  while i <= #haystack do',
+    '    if string.sub(haystack, i, i + #needle - 1) == needle then',
+    '      for j = 1, #replacement do',
+    '        table.insert(buf, string.sub(replacement, j, j))',
+    '      end',
+    '      i = i + #needle',
+    '    else',
+    '      table.insert(buf, string.sub(haystack, i, i))',
+    '      i = i + 1',
+    '    end',
+    '  end',
+    '  return table.concat(buf)',
+    'end',
+  ]);
   const code = functionName + '(' + text + ', ' + from + ', ' + to + ')';
   return [code, Lua.ORDER_HIGH];
 };
 
 Lua['text_reverse'] = function(block) {
-  const text = Lua.valueToCode(block, 'TEXT',
-      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || '\'\'';
   const code = 'string.reverse(' + text + ')';
   return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.texts');
+goog.module('Blockly.Lua.texts');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -6,90 +6,90 @@
 
 /**
  * @fileoverview Generating Lua for text blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.texts');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.Lua['text'] = function(block) {
+Lua['text'] = function(block) {
   // Text value.
-  const code = Blockly.Lua.quote_(block.getFieldValue('TEXT'));
-  return [code, Blockly.Lua.ORDER_ATOMIC];
+  const code = Lua.quote_(block.getFieldValue('TEXT'));
+  return [code, Lua.ORDER_ATOMIC];
 };
 
-Blockly.Lua['text_multiline'] = function(block) {
+Lua['text_multiline'] = function(block) {
   // Text value.
-  const code = Blockly.Lua.multiline_quote_(block.getFieldValue('TEXT'));
-  const order = code.indexOf('..') !== -1 ? Blockly.Lua.ORDER_CONCATENATION :
-      Blockly.Lua.ORDER_ATOMIC;
+  const code = Lua.multiline_quote_(block.getFieldValue('TEXT'));
+  const order = code.indexOf('..') !== -1 ? Lua.ORDER_CONCATENATION :
+      Lua.ORDER_ATOMIC;
   return [code, order];
 };
 
-Blockly.Lua['text_join'] = function(block) {
+Lua['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   if (block.itemCount_ === 0) {
-    return ['\'\'', Blockly.Lua.ORDER_ATOMIC];
+    return ['\'\'', Lua.ORDER_ATOMIC];
   } else if (block.itemCount_ === 1) {
-    const element = Blockly.Lua.valueToCode(block, 'ADD0',
-        Blockly.Lua.ORDER_NONE) || '\'\'';
+    const element = Lua.valueToCode(block, 'ADD0',
+        Lua.ORDER_NONE) || '\'\'';
     const code = 'tostring(' + element + ')';
-    return [code, Blockly.Lua.ORDER_HIGH];
+    return [code, Lua.ORDER_HIGH];
   } else if (block.itemCount_ === 2) {
-    const element0 = Blockly.Lua.valueToCode(block, 'ADD0',
-        Blockly.Lua.ORDER_CONCATENATION) || '\'\'';
-    const element1 = Blockly.Lua.valueToCode(block, 'ADD1',
-        Blockly.Lua.ORDER_CONCATENATION) || '\'\'';
+    const element0 = Lua.valueToCode(block, 'ADD0',
+        Lua.ORDER_CONCATENATION) || '\'\'';
+    const element1 = Lua.valueToCode(block, 'ADD1',
+        Lua.ORDER_CONCATENATION) || '\'\'';
     const code = element0 + ' .. ' + element1;
-    return [code, Blockly.Lua.ORDER_CONCATENATION];
+    return [code, Lua.ORDER_CONCATENATION];
   } else {
     const elements = [];
     for (let i = 0; i < block.itemCount_; i++) {
-      elements[i] = Blockly.Lua.valueToCode(block, 'ADD' + i,
-          Blockly.Lua.ORDER_NONE) || '\'\'';
+      elements[i] = Lua.valueToCode(block, 'ADD' + i,
+          Lua.ORDER_NONE) || '\'\'';
     }
     const code = 'table.concat({' + elements.join(', ') + '})';
-    return [code, Blockly.Lua.ORDER_HIGH];
+    return [code, Lua.ORDER_HIGH];
   }
 };
 
-Blockly.Lua['text_append'] = function(block) {
+Lua['text_append'] = function(block) {
   // Append to a variable in place.
-  const varName = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
-  const value = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_CONCATENATION) || '\'\'';
+  const varName = Lua.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const value = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_CONCATENATION) || '\'\'';
   return varName + ' = ' + varName + ' .. ' + value + '\n';
 };
 
-Blockly.Lua['text_length'] = function(block) {
+Lua['text_length'] = function(block) {
   // String or array length.
-  const text = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_UNARY) || '\'\'';
-  return ['#' + text, Blockly.Lua.ORDER_UNARY];
+  const text = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_UNARY) || '\'\'';
+  return ['#' + text, Lua.ORDER_UNARY];
 };
 
-Blockly.Lua['text_isEmpty'] = function(block) {
+Lua['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const text = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_UNARY) || '\'\'';
-  return ['#' + text + ' == 0', Blockly.Lua.ORDER_RELATIONAL];
+  const text = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_UNARY) || '\'\'';
+  return ['#' + text + ' == 0', Lua.ORDER_RELATIONAL];
 };
 
-Blockly.Lua['text_indexOf'] = function(block) {
+Lua['text_indexOf'] = function(block) {
   // Search the text for a substring.
-  const substring = Blockly.Lua.valueToCode(block, 'FIND',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const text = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const substring = Lua.valueToCode(block, 'FIND',
+      Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_NONE) || '\'\'';
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'firstIndexOf',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
              '(str, substr) ',
          '  local i = string.find(str, substr, 1, true)',
          '  if i == nil then',
@@ -99,9 +99,9 @@ Blockly.Lua['text_indexOf'] = function(block) {
          '  end',
          'end']);
   } else {
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'lastIndexOf',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
              '(str, substr)',
          '  local i = string.find(string.reverse(str), ' +
              'string.reverse(substr), 1, true)',
@@ -112,23 +112,23 @@ Blockly.Lua['text_indexOf'] = function(block) {
          'end']);
   }
   const code = functionName + '(' + text + ', ' + substring + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_charAt'] = function(block) {
+Lua['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const atOrder = (where === 'FROM_END') ? Blockly.Lua.ORDER_UNARY :
-      Blockly.Lua.ORDER_NONE;
-  const at = Blockly.Lua.valueToCode(block, 'AT', atOrder) || '1';
-  const text = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const atOrder = (where === 'FROM_END') ? Lua.ORDER_UNARY :
+      Lua.ORDER_NONE;
+  const at = Lua.valueToCode(block, 'AT', atOrder) || '1';
+  const text = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_NONE) || '\'\'';
   let code;
   if (where === 'RANDOM') {
-    const functionName = Blockly.Lua.provideFunction_(
+    const functionName = Lua.provideFunction_(
         'text_random_letter',
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
          '  local index = math.random(string.len(str))',
          '  return string.sub(str, index, index)',
          'end']);
@@ -152,28 +152,28 @@ Blockly.Lua['text_charAt'] = function(block) {
       code = 'string.sub(' + text + ', ' + start + ', ' + start + ')';
     } else {
       // use function to avoid reevaluation
-      const functionName = Blockly.Lua.provideFunction_(
+      const functionName = Lua.provideFunction_(
           'text_char_at',
-          ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ +
+          ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ +
                '(str, index)',
            '  return string.sub(str, index, index)',
            'end']);
       code = functionName + '(' + text + ', ' + start + ')';
     }
   }
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_getSubstring'] = function(block) {
+Lua['text_getSubstring'] = function(block) {
   // Get substring.
-  const text = Blockly.Lua.valueToCode(block, 'STRING',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'STRING',
+      Lua.ORDER_NONE) || '\'\'';
 
   // Get start index.
   const where1 = block.getFieldValue('WHERE1');
-  const at1Order = (where1 === 'FROM_END') ? Blockly.Lua.ORDER_UNARY :
-      Blockly.Lua.ORDER_NONE;
-  const at1 = Blockly.Lua.valueToCode(block, 'AT1', at1Order) || '1';
+  const at1Order = (where1 === 'FROM_END') ? Lua.ORDER_UNARY :
+      Lua.ORDER_NONE;
+  const at1 = Lua.valueToCode(block, 'AT1', at1Order) || '1';
   let start;
   if (where1 === 'FIRST') {
     start = 1;
@@ -187,9 +187,9 @@ Blockly.Lua['text_getSubstring'] = function(block) {
 
   // Get end index.
   const where2 = block.getFieldValue('WHERE2');
-  const at2Order = (where2 === 'FROM_END') ? Blockly.Lua.ORDER_UNARY :
-      Blockly.Lua.ORDER_NONE;
-  const at2 = Blockly.Lua.valueToCode(block, 'AT2', at2Order) || '1';
+  const at2Order = (where2 === 'FROM_END') ? Lua.ORDER_UNARY :
+      Lua.ORDER_NONE;
+  const at2 = Lua.valueToCode(block, 'AT2', at2Order) || '1';
   let end;
   if (where2 === 'LAST') {
     end = -1;
@@ -201,26 +201,26 @@ Blockly.Lua['text_getSubstring'] = function(block) {
     throw Error('Unhandled option (text_getSubstring)');
   }
   const code = 'string.sub(' + text + ', ' + start + ', ' + end + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_changeCase'] = function(block) {
+Lua['text_changeCase'] = function(block) {
   // Change capitalization.
   const operator = block.getFieldValue('CASE');
-  const text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
   let functionName;
   if (operator === 'UPPERCASE') {
     functionName = 'string.upper';
   } else if (operator === 'LOWERCASE') {
     functionName = 'string.lower';
   } else if (operator === 'TITLECASE') {
-    functionName = Blockly.Lua.provideFunction_(
+    functionName = Lua.provideFunction_(
         'text_titlecase',
         // There are shorter versions at
         // http://lua-users.org/wiki/SciteTitleCase
         // that do not preserve whitespace.
-        ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
+        ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(str)',
          '  local buf = {}',
          '  local inWord = false',
          '  for i = 1, #str do',
@@ -239,10 +239,10 @@ Blockly.Lua['text_changeCase'] = function(block) {
          'end']);
   }
   const code = functionName + '(' + text + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_trim'] = function(block) {
+Lua['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {
     LEFT: '^%s*(,-)',
@@ -250,34 +250,34 @@ Blockly.Lua['text_trim'] = function(block) {
     BOTH: '^%s*(.-)%s*$'
   };
   const operator = OPERATORS[block.getFieldValue('MODE')];
-  const text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const text = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
   const code = 'string.gsub(' + text + ', "' + operator + '", "%1")';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_print'] = function(block) {
+Lua['text_print'] = function(block) {
   // Print statement.
-  const msg = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+  const msg = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
   return 'print(' + msg + ')\n';
 };
 
-Blockly.Lua['text_prompt_ext'] = function(block) {
+Lua['text_prompt_ext'] = function(block) {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
     // Internal message.
-    msg = Blockly.Lua.quote_(block.getFieldValue('TEXT'));
+    msg = Lua.quote_(block.getFieldValue('TEXT'));
   } else {
     // External message.
-    msg = Blockly.Lua.valueToCode(block, 'TEXT',
-        Blockly.Lua.ORDER_NONE) || '\'\'';
+    msg = Lua.valueToCode(block, 'TEXT',
+        Lua.ORDER_NONE) || '\'\'';
   }
 
-  const functionName = Blockly.Lua.provideFunction_(
+  const functionName = Lua.provideFunction_(
       'text_prompt',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_ + '(msg)',
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_ + '(msg)',
        '  io.write(msg)',
        '  io.flush()',
        '  return io.read()',
@@ -288,19 +288,19 @@ Blockly.Lua['text_prompt_ext'] = function(block) {
   if (toNumber) {
     code = 'tonumber(' + code + ', 10)';
   }
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_prompt'] = Blockly.Lua['text_prompt_ext'];
+Lua['text_prompt'] = Lua['text_prompt_ext'];
 
-Blockly.Lua['text_count'] = function(block) {
-  const text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const sub = Blockly.Lua.valueToCode(block, 'SUB',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const functionName = Blockly.Lua.provideFunction_(
+Lua['text_count'] = function(block) {
+  const text = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
+  const sub = Lua.valueToCode(block, 'SUB',
+      Lua.ORDER_NONE) || '\'\'';
+  const functionName = Lua.provideFunction_(
       'text_count',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_
         + '(haystack, needle)',
         '  if #needle == 0 then',
         '    return #haystack + 1',
@@ -319,19 +319,19 @@ Blockly.Lua['text_count'] = function(block) {
         'end',
       ]);
   const code = functionName + '(' + text + ', ' + sub + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_replace'] = function(block) {
-  const text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const from = Blockly.Lua.valueToCode(block, 'FROM',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const to = Blockly.Lua.valueToCode(block, 'TO',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
-  const functionName = Blockly.Lua.provideFunction_(
+Lua['text_replace'] = function(block) {
+  const text = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
+  const from = Lua.valueToCode(block, 'FROM',
+      Lua.ORDER_NONE) || '\'\'';
+  const to = Lua.valueToCode(block, 'TO',
+      Lua.ORDER_NONE) || '\'\'';
+  const functionName = Lua.provideFunction_(
       'text_replace',
-      ['function ' + Blockly.Lua.FUNCTION_NAME_PLACEHOLDER_
+      ['function ' + Lua.FUNCTION_NAME_PLACEHOLDER_
         + '(haystack, needle, replacement)',
         '  local buf = {}',
         '  local i = 1',
@@ -350,12 +350,12 @@ Blockly.Lua['text_replace'] = function(block) {
         'end',
       ]);
   const code = functionName + '(' + text + ', ' + from + ', ' + to + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };
 
-Blockly.Lua['text_reverse'] = function(block) {
-  const text = Blockly.Lua.valueToCode(block, 'TEXT',
-      Blockly.Lua.ORDER_NONE) || '\'\'';
+Lua['text_reverse'] = function(block) {
+  const text = Lua.valueToCode(block, 'TEXT',
+      Lua.ORDER_NONE) || '\'\'';
   const code = 'string.reverse(' + text + ')';
-  return [code, Blockly.Lua.ORDER_HIGH];
+  return [code, Lua.ORDER_HIGH];
 };

--- a/generators/lua/variables.js
+++ b/generators/lua/variables.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Lua.variables');
+goog.module('Blockly.Lua.variables');
 
 goog.require('Blockly.Lua');
 

--- a/generators/lua/variables.js
+++ b/generators/lua/variables.js
@@ -17,16 +17,15 @@ const {NameType} = goog.require('Blockly.Names');
 
 Lua['variables_get'] = function(block) {
   // Variable getter.
-  const code = Lua.nameDB_.getName(block.getFieldValue('VAR'),
-      NameType.VARIABLE);
+  const code =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, Lua.ORDER_ATOMIC];
 };
 
 Lua['variables_set'] = function(block) {
   // Variable setter.
-  const argument0 = Lua.valueToCode(block, 'VALUE',
-      Lua.ORDER_NONE) || '0';
-  const varName = Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '0';
+  const varName =
+      Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + argument0 + '\n';
 };

--- a/generators/lua/variables.js
+++ b/generators/lua/variables.js
@@ -6,27 +6,27 @@
 
 /**
  * @fileoverview Generating Lua for variable blocks.
- * @suppress {missingRequire}
  */
 'use strict';
 
 goog.module('Blockly.Lua.variables');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
+const {NameType} = goog.require('Blockly.Names');
 
 
-Blockly.Lua['variables_get'] = function(block) {
+Lua['variables_get'] = function(block) {
   // Variable getter.
-  const code = Blockly.Lua.nameDB_.getName(block.getFieldValue('VAR'),
-      Blockly.VARIABLE_CATEGORY_NAME);
-  return [code, Blockly.Lua.ORDER_ATOMIC];
+  const code = Lua.nameDB_.getName(block.getFieldValue('VAR'),
+      NameType.VARIABLE);
+  return [code, Lua.ORDER_ATOMIC];
 };
 
-Blockly.Lua['variables_set'] = function(block) {
+Lua['variables_set'] = function(block) {
   // Variable setter.
-  const argument0 = Blockly.Lua.valueToCode(block, 'VALUE',
-      Blockly.Lua.ORDER_NONE) || '0';
-  const varName = Blockly.Lua.nameDB_.getName(
-      block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
+  const argument0 = Lua.valueToCode(block, 'VALUE',
+      Lua.ORDER_NONE) || '0';
+  const varName = Lua.nameDB_.getName(
+      block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + argument0 + '\n';
 };

--- a/generators/lua/variables_dynamic.js
+++ b/generators/lua/variables_dynamic.js
@@ -6,13 +6,13 @@
 
 /**
  * @fileoverview Generating Lua for dynamic variable blocks.
- * @suppress {extraRequire}
  */
 'use strict';
 
-goog.provide('Blockly.Lua.variablesDynamic');
+goog.module('Blockly.Lua.variablesDynamic');
 
 goog.require('Blockly.Lua');
+/** @suppress {extraRequire} */
 goog.require('Blockly.Lua.variables');
 
 

--- a/generators/lua/variables_dynamic.js
+++ b/generators/lua/variables_dynamic.js
@@ -11,11 +11,11 @@
 
 goog.module('Blockly.Lua.variablesDynamic');
 
-goog.require('Blockly.Lua');
+const Lua = goog.require('Blockly.Lua');
 /** @suppress {extraRequire} */
 goog.require('Blockly.Lua.variables');
 
 
 // Lua is dynamically typed.
-Blockly.Lua['variables_get_dynamic'] = Blockly.Lua['variables_get'];
-Blockly.Lua['variables_set_dynamic'] = Blockly.Lua['variables_set'];
+Lua['variables_get_dynamic'] = Lua['variables_get'];
+Lua['variables_set_dynamic'] = Lua['variables_set'];

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -295,9 +295,9 @@ goog.addDependency('../../generators/lua/logic.js', ['Blockly.Lua.logic'], ['Blo
 goog.addDependency('../../generators/lua/loops.js', ['Blockly.Lua.loops'], ['Blockly.Lua', 'Blockly.Names', 'Blockly.utils.string'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/lua/math.js', ['Blockly.Lua.math'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/lua/procedures.js', ['Blockly.Lua.procedures'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
-goog.addDependency('../../generators/lua/text.js', ['Blockly.Lua.texts'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/variables.js', ['Blockly.Lua.variables'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/variables_dynamic.js', ['Blockly.Lua.variablesDynamic'], ['Blockly.Lua', 'Blockly.Lua.variables']);
+goog.addDependency('../../generators/lua/text.js', ['Blockly.Lua.texts'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/variables.js', ['Blockly.Lua.variables'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/variables_dynamic.js', ['Blockly.Lua.variablesDynamic'], ['Blockly.Lua', 'Blockly.Lua.variables'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/php.js', ['Blockly.PHP'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/php/all.js', ['Blockly.PHP.all'], ['Blockly.PHP.colour', 'Blockly.PHP.lists', 'Blockly.PHP.logic', 'Blockly.PHP.loops', 'Blockly.PHP.math', 'Blockly.PHP.procedures', 'Blockly.PHP.texts', 'Blockly.PHP.variables', 'Blockly.PHP.variablesDynamic'], {'module': 'goog'});
 goog.addDependency('../../generators/php/colour.js', ['Blockly.PHP.colour'], ['Blockly.PHP'], {'lang': 'es6'});

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -289,12 +289,12 @@ goog.addDependency('../../generators/javascript/variables.js', ['Blockly.JavaScr
 goog.addDependency('../../generators/javascript/variables_dynamic.js', ['Blockly.JavaScript.variablesDynamic'], ['Blockly.JavaScript', 'Blockly.JavaScript.variables'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/lua.js', ['Blockly.Lua'], ['Blockly.Generator', 'Blockly.Names', 'Blockly.inputTypes', 'Blockly.utils.object', 'Blockly.utils.string'], {'lang': 'es6'});
 goog.addDependency('../../generators/lua/all.js', ['Blockly.Lua.all'], ['Blockly.Lua.colour', 'Blockly.Lua.lists', 'Blockly.Lua.logic', 'Blockly.Lua.loops', 'Blockly.Lua.math', 'Blockly.Lua.procedures', 'Blockly.Lua.texts', 'Blockly.Lua.variables', 'Blockly.Lua.variablesDynamic'], {'module': 'goog'});
-goog.addDependency('../../generators/lua/colour.js', ['Blockly.Lua.colour'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/lists.js', ['Blockly.Lua.lists'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/logic.js', ['Blockly.Lua.logic'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/loops.js', ['Blockly.Lua.loops'], ['Blockly.Lua', 'Blockly.utils.string'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/math.js', ['Blockly.Lua.math'], ['Blockly.Lua'], {'lang': 'es6'});
-goog.addDependency('../../generators/lua/procedures.js', ['Blockly.Lua.procedures'], ['Blockly.Lua'], {'lang': 'es6'});
+goog.addDependency('../../generators/lua/colour.js', ['Blockly.Lua.colour'], ['Blockly.Lua'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/lists.js', ['Blockly.Lua.lists'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/logic.js', ['Blockly.Lua.logic'], ['Blockly.Lua'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/loops.js', ['Blockly.Lua.loops'], ['Blockly.Lua', 'Blockly.Names', 'Blockly.utils.string'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/math.js', ['Blockly.Lua.math'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../generators/lua/procedures.js', ['Blockly.Lua.procedures'], ['Blockly.Lua', 'Blockly.Names'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('../../generators/lua/text.js', ['Blockly.Lua.texts'], ['Blockly.Lua'], {'lang': 'es6'});
 goog.addDependency('../../generators/lua/variables.js', ['Blockly.Lua.variables'], ['Blockly.Lua'], {'lang': 'es6'});
 goog.addDependency('../../generators/lua/variables_dynamic.js', ['Blockly.Lua.variablesDynamic'], ['Blockly.Lua', 'Blockly.Lua.variables']);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5598

### Proposed Changes

Converts to goog.module with named requires, and fixes missing requires, for 
- `generators/lua/colour.js`
- `generators/lua/lists.js`
- `generators/lua/logic.js`
- `generators/lua/loops.js`
- `generators/lua/math.js`
- `generators/lua/procedures.js`
- `generators/lua/text.js`
- `generators/lua/variables.js`
- `generators/lua/variables_dynamic.js`