### PR TITLE
fix(tests): Fix & reenable the advanced compilation test

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -742,7 +742,7 @@ exports.zelos = zelos;
 // Blockly.Msg module - so make sure it is, but only if there is not
 // yet a Blockly global variable.
 if (!('Blockly' in globalThis)) {
-  globalThis['Blockly'] = {Msg};
+  globalThis['Blockly'] = {'Msg': Msg};
 }
 
 // Temporary hack to copy accessor properties from exports to the

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -11,16 +11,8 @@ goog.require('Blockly');
 goog.require('Blockly.geras.Renderer');
 goog.require('Blockly.VerticalFlyout');
 // Blocks
-goog.require('Blockly.Constants.Logic');
-goog.require('Blockly.Constants.Loops');
-goog.require('Blockly.Constants.Math');
-goog.require('Blockly.Constants.TestBlocks');
-goog.require('Blockly.Constants.Text');
-goog.require('Blockly.Constants.Lists');
-goog.require('Blockly.Constants.Colour');
-goog.require('Blockly.Constants.Variables');
-goog.require('Blockly.Constants.VariablesDynamic');
-goog.require('Blockly.blocks.procedures');
+goog.require('Blockly.blocks.all');
+goog.require('Blockly.blocks.testBlocks');
 
 Main.init = function() {
   Blockly.inject('blocklyDiv', {

--- a/tests/compile/test_blocks.js
+++ b/tests/compile/test_blocks.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Constants.TestBlocks');
+goog.provide('Blockly.blocks.testBlocks');
 
 goog.require('Blockly');
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -76,8 +76,8 @@ run_test_command "package" "npm run package"
 # Run Node tests.
 run_test_command "node" "./node_modules/.bin/mocha tests/node --config tests/node/.mocharc.js"
 
-# # Attempt advanced compilation of a Blockly app.
-# run_test_command "advanced_compile" "npm run test:compile:advanced"
+# Attempt advanced compilation of a Blockly app.
+run_test_command "advanced_compile" "npm run test:compile:advanced"
 
 
 # End of tests.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Fixes #5602.

### Proposed Changes

* Fix advanced compilation test:

  - Fix loading of blocks in `tests/compile/main.js` caused by recent `goog.module`-ification work.
  - Fix problem caused by ADVANCED_OPTIMISATIONS renaming the `Msg` property on the fake `Blockly` object created by the translation-loading hack in `blockly.js`.

* Reenable advanced compilation test 

#### Behavior Before Change

Test was disabled and if run manually produced un-loadable code.

#### Behavior After Change

Test enabled, runs as part of `npm test`, and produces code that loads and works correctly.

### Reason for Changes

We like tests.

### Test Coverage


Tested on:
* `npm test`
* Desktop Chrome
