### PR TITLE
Proper rendering of blocks during and after dragging

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -890,6 +890,10 @@ BlockSvg.prototype.dispose = function(healStack, animate) {
     // The block has already been deleted.
     return;
   }
+  
+  // BUG(#5788): Disposing of a block while dragging without rendering during/
+  //     after drag can cause blocks to appear out of place.
+  this.workspace.addToDragRenderQueue(this.getRootBlock(), true, true);
   Tooltip.dispose();
   Tooltip.unbindMouseEvents(this.pathObject.svgPath);
   dom.startTextWidthCache();

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1054,6 +1054,9 @@ BlockSvg.prototype.setCommentText = function(text) {
     this.render();
     // Adding or removing a comment icon will cause the block to change shape.
     this.bumpNeighbours();
+    // BUG(#4959): Adding or removing a comment icon while dragging without
+    //     rendering during/after drag can cause blocks to appear out of place.
+    this.workspace.addToDragRenderQueue(this, true, true);
   }
 };
 

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1505,7 +1505,7 @@ WorkspaceSvg.prototype.render = function() {
  * @param {Blockly.Events.Abstract} e
  * @private
  */
-Blockly.WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
+WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
   if (e.type === Blockly.Events.BLOCK_DRAG) {
     this.blockDragRenderQueue_.forEach(blockBumpPair => {
       const block = blockBumpPair.block;
@@ -1534,7 +1534,7 @@ Blockly.WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
  * @param {boolean=} bumpNeighbours If true, calls bumpNeighbors on drag for
  *     this block (and descendants if allDescendants is true).
  */
-Blockly.WorkspaceSvg.prototype.addToDragRenderQueue = function(block, addDescendants, bumpNeighbours) {
+WorkspaceSvg.prototype.addToDragRenderQueue = function(block, addDescendants, bumpNeighbours) {
   if (!this.isDragging()) {
     return;
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1518,7 +1518,7 @@ WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
       }
     });
 
-    if (!e.isStart) {
+    if (e.type === Blockly.Events.BLOCK_DRAG && !e.isStart) {
       this.blockDragRenderQueue_ = [];
       this.removeChangeListener(this.renderOnDragListener_);
       this.renderOnDragListener_ = null;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1506,7 +1506,7 @@ WorkspaceSvg.prototype.render = function() {
  * @private
  */
 WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
-  if ([Blockly.Events.BLOCK_DRAG, Block.Events.BLOCK_DELETE]
+  if ([Blockly.Events.BLOCK_DRAG, Blockly.Events.BLOCK_DELETE]
       .includes(e.type)) {
     this.blockDragRenderQueue_.forEach(blockBumpPair => {
       const block = blockBumpPair.block;

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1506,7 +1506,8 @@ WorkspaceSvg.prototype.render = function() {
  * @private
  */
 WorkspaceSvg.prototype.renderBlocksOnDrag_ = function(e) {
-  if (e.type === Blockly.Events.BLOCK_DRAG) {
+  if ([Blockly.Events.BLOCK_DRAG, Block.Events.BLOCK_DELETE]
+      .includes(e.type)) {
     this.blockDragRenderQueue_.forEach(blockBumpPair => {
       const block = blockBumpPair.block;
       if (block.workspace === this) { // block hasn't been disposed


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#4959 and #5788 (partially)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Allows methods that cause block displacement issues during/after dragging to request that the workspace render the potentially displaced blocks on relevant events up to and including the end of the drag.
* Allows comments to be removed/blocks to be disposed of while dragging workspace without causing block displacements.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Removing comments/deleting blocks while dragging caused blocks to appear displaced.  (See: #4959 and #5788.)

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Blocks no longer appear displaced during/after dragging.


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Performing certain actions while dragging blocks can cause the appearance of major block displacements so to avoid these problems, they may be deferred as follows: https://github.com/google/blockly/blob/6128f2dfd485ed2ff6d0be13b7e2558190678e2e/core/block_svg.js#L1088-L1099
This pull request represents an attempt to simplify code by allowing these types of function calls to be made during dragging.  At the same time, the hope is to do this without sacrificing performance by minimizing render calls to the blocks that may actually be affected during the events for which this can occur and only doing so on appropriate events during the drag.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

Tested on Blockly Playground.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No extra documentation is necessary, but it may be helpful to specify how the added function `addToDragRenderQueue` can be used to eliminate some of these dragging rendering issues.

### Additional Information

<!-- Anything else we should know? -->
This is very much a draft, but suggestions on whether this approach is useful or any other comments are very much welcome! 
