### PR TITLE
chore(deps): Remove dependency on `babel-eslint`; simplify eslintrc for mocha tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@blockly/dev-tools": "^2.6.1",
         "@blockly/theme-modern": "^2.1.1",
         "@wdio/selenium-standalone-service": "^7.10.1",
-        "babel-eslint": "^10.1.0",
         "chai": "^4.2.0",
         "clang-format": "^1.6.0",
         "closure-calculate-chunks": "^3.0.2",
@@ -54,70 +53,6 @@
       "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -215,65 +150,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.3",
-        "@babel/types": "^7.16.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@blockly/block-test": {
@@ -1487,27 +1363,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
     },
     "node_modules/bach": {
       "version": "1.2.0",
@@ -4850,15 +4705,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -6797,18 +6643,6 @@
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dependencies": {
         "iconv-lite": "0.4.24"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/json-buffer": {
@@ -11137,15 +10971,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -12278,55 +12103,6 @@
         "@babel/highlight": "^7.16.0"
       }
     },
-    "@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
@@ -12400,50 +12176,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "@babel/parser": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.3",
-        "@babel/types": "^7.16.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      }
-    },
-    "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "@blockly/block-test": {
@@ -13410,20 +13142,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      }
     },
     "bach": {
       "version": "1.2.0",
@@ -16083,12 +15801,6 @@
         }
       }
     },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
-    },
     "glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -17638,12 +17350,6 @@
           }
         }
       }
-    },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -21177,12 +20883,6 @@
         "is-absolute": "^1.0.0",
         "is-negated-glob": "^1.0.0"
       }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@blockly/dev-tools": "^2.6.1",
     "@blockly/theme-modern": "^2.1.1",
     "@wdio/selenium-standalone-service": "^7.10.1",
-    "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "clang-format": "^1.6.0",
     "closure-calculate-chunks": "^3.0.2",

--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-    "parser": "babel-eslint",
     "env": {
         "browser": true,
         "mocha": true

--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -10,30 +10,8 @@
     },
     "rules": {
         "no-unused-vars": ["off"],
-        "es5/no-arrow-functions": ["off"],
-        "es5/no-binary-and-octal-literals": ["off"],
-        "es5/no-block-scoping": ["off"],
-        "es5/no-classes": ["off"],
-        "es5/no-computed-properties": ["off"],
-        "es5/no-default-parameters": ["off"],
-        "es5/no-destructuring": ["off"],
-        "es5/no-es6-methods": ["off"],
-        "es5/no-es6-static-methods": ["off"],
-        "es5/no-for-of": ["off"],
-        "es5/no-generators": ["off"],
-        "es5/no-modules": ["off"],
-        "es5/no-object-super": ["off"],
-        "es5/no-rest-parameters": ["off"],
-        "es5/no-shorthand-properties": ["off"],
-        "es5/no-spread": ["off"],
-        "es5/no-template-literals": ["off"],
-        "es5/no-typeof-symbol": ["off"],
-        "es5/no-unicode-code-point-escape": ["off"],
-        "es5/no-unicode-regex": ["off"],
         // Allow uncommented helper functions in tests.
         "require-jsdoc": ["off"],
-        // In mocha tests in suites, `this` is meaningful and useful.
-        "no-invalid-this": ["off"],
         "prefer-rest-params": ["off"]
     },
     "extends": "../../.eslintrc.json"


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Test failures for PR #5791.

### Proposed Changes

* Remove dev dependency on `babel-eslint` parser.
* Revert most other changes made to `tests/mocha/.eslintrc.json` in PR #4062 as they appear to no longer be needed thanks to updates to our top-level `.eslintrc.json`.

#### Behavior Before Change

When linting `tests/mocha/`, `eslint` would use the `babel-eslint` parser.

#### Behavior After Change

When linting `tests/mocha/`,  `estlint` will use its usual built-in parser.

### Reason for Changes

When dependabot submitted PR #5791, it became apparent that `eslint` version >= 8 is incompatible with `babel-eslint` v10.1.0 despite the latter not having a version restriction against it.  This is probably because v10.1.0 is the last version of the package before it was deprecated and renamed `@babel/eslint-parser`.

We could switch to using the new package, but a little more investigation determined that there is no longer any need to have `eslint` use a non-default parser for `tests/mocha/**/*.js`, so the most straight forward solution is just to remove the dependency entirely.

Along the way I also noticed that there were some other custom rules in `tests/mocha/.eslintrc.json` that do not appear to be needed any more, so I propose removing these as well.

### Test Coverage

`npm run lint` produces no errors for any file in `tests/mocha/` (unless I deliberately create a lint error in one of those files).

### Additional Information

This effectively reverts PR #4062.
