### PR TITLE
fix: multi-playground should use goog.require to get blocks

### DIFF
--- a/tests/multi_playground.html
+++ b/tests/multi_playground.html
@@ -5,14 +5,11 @@
 <title>Multi-toolbox Playground</title>
 <script src="../blockly_uncompressed.js"></script>
 <script src="../msg/messages.js"></script>
-<script src="../blocks/logic.js"></script>
-<script src="../blocks/loops.js"></script>
-<script src="../blocks/math.js"></script>
-<script src="../blocks/text.js"></script>
-<script src="../blocks/lists.js"></script>
-<script src="../blocks/colour.js"></script>
-<script src="../blocks/variables.js"></script>
-<script src="../blocks/procedures.js"></script>
+
+<script>
+// Custom requires for the playground.
+goog.require('Blockly.blocks.all');
+</script>
 <script>
 'use strict';
 var options = {


### PR DESCRIPTION
# The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Broken multi-playground.

### Proposed Changes

Uses `goog.require` instead of bare script tags to load blocks in a playground that runs in uncompressed mode.

#### Behavior Before Change

multi-playground was broken with an error in the console: 
> Uncaught Error: Module Blockly.blocks.logic has been loaded incorrectly. Note, modules cannot be loaded as normal scripts. They require some kind of pre-processing step. You're likely trying to load a module via a script tag or as a part of a concatenated bundle without rewriting the module. For more info see: https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide.

#### Behavior After Change

Error is gone and playgrounds work.

### Reason for Changes

Modules can't be loaded in bare script tags.
