### PR TITLE
fix: allow undefined color in toolbox definition

### DIFF
--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -424,7 +424,7 @@ ToolboxCategory.prototype.parseColour_ = function(colourValue) {
   // Decode the colour for any potential message references
   // (eg. `%{BKY_MATH_HUE}`).
   const colour = parsing.replaceMessageReferences(colourValue);
-  if (colour === null || colour === '') {
+  if (colour == null || colour === '') {
     // No attribute. No colour.
     return '';
   } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Toolbox definition with undefined colour attribute would give warning: "Toolbox category "If" has unrecognized colour attribute: undefined"

### Proposed Changes

Allows undefined as value

### Reason for Changes

This was introduced in #5599 . `== null` is allowed when testing for undefined and null values so changed it back.

### Test Coverage

Tested in block factory which was previously showing this warning, no longer.

### Documentation

### Additional Information

<!-- Anything else we should know? -->
