### PR TITLE
fix: fix keycodes type

### DIFF
--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -51,7 +51,7 @@ const ShortcutRegistry = function() {
 
 /**
  * Enum of valid modifiers.
- * @enum {!KeyCodes<number>}
+ * @enum {!KeyCodes}
  */
 ShortcutRegistry.modifierKeys = {
   'Shift': KeyCodes.SHIFT,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Reason for Changes

KeyCodes does not use a generic type, this is just incorrect syntax and it was broken in generated TS defs

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This is not urgent to go in before release, I've already fixed it manually in TS types and Closure hasn't complained about it 
