### PR TITLE
fix: Use correct namespace for svgMath functions

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -110,7 +110,7 @@ exports.isTargetInput = isTargetInput;
 const getRelativeXY = function(element) {
   deprecation.warn(
       'Blockly.utils.getRelativeXY', 'December 2021', 'December 2022',
-      'Blockly.svgMath.getRelativeXY');
+      'Blockly.utils.svgMath.getRelativeXY');
   return svgMath.getRelativeXY(element);
 };
 exports.getRelativeXY = getRelativeXY;
@@ -128,7 +128,7 @@ exports.getRelativeXY = getRelativeXY;
 const getInjectionDivXY = function(element) {
   deprecation.warn(
       'Blockly.utils.getInjectionDivXY_', 'December 2021', 'December 2022',
-      'Blockly.svgMath.getInjectionDivXY');
+      'Blockly.utils.svgMath.getInjectionDivXY');
   return svgMath.getInjectionDivXY(element);
 };
 exports.getInjectionDivXY_ = getInjectionDivXY;
@@ -261,7 +261,7 @@ exports.genUid = genUid;
 const is3dSupported = function() {
   deprecation.warn(
       'Blockly.utils.is3dSupported', 'December 2021', 'December 2022',
-      'Blockly.svgMath.is3dSupported');
+      'Blockly.utils.svgMath.is3dSupported');
   return svgMath.is3dSupported();
 };
 exports.is3dSupported = is3dSupported;
@@ -278,7 +278,7 @@ exports.is3dSupported = is3dSupported;
 const getViewportBBox = function() {
   deprecation.warn(
       'Blockly.utils.getViewportBBox', 'December 2021', 'December 2022',
-      'Blockly.svgMath.getViewportBBox');
+      'Blockly.utils.svgMath.getViewportBBox');
   return svgMath.getViewportBBox();
 };
 exports.getViewportBBox = getViewportBBox;
@@ -309,7 +309,7 @@ exports.arrayRemove = arrayRemove;
 const getDocumentScroll = function() {
   deprecation.warn(
       'Blockly.utils.getDocumentScroll', 'December 2021', 'December 2022',
-      'Blockly.svgMath.getDocumentScroll');
+      'Blockly.utils.svgMath.getDocumentScroll');
   return svgMath.getDocumentScroll();
 };
 exports.getDocumentScroll = getDocumentScroll;
@@ -344,7 +344,7 @@ exports.getBlockTypeCounts = getBlockTypeCounts;
 const screenToWsCoordinates = function(ws, screenCoordinates) {
   deprecation.warn(
       'Blockly.utils.screenToWsCoordinates', 'December 2021', 'December 2022',
-      'Blockly.svgMath.screenToWsCoordinates');
+      'Blockly.utils.svgMath.screenToWsCoordinates');
   return svgMath.screenToWsCoordinates(ws, screenCoordinates);
 };
 exports.screenToWsCoordinates = screenToWsCoordinates;

--- a/core/utils/svg_math.js
+++ b/core/utils/svg_math.js
@@ -51,7 +51,7 @@ const XY_STYLE_REGEX =
  * its parent.  Only for SVG elements and children (e.g. rect, g, path).
  * @param {!Element} element SVG element to find the coordinates of.
  * @return {!Coordinate} Object with .x and .y properties.
- * @alias Blockly.svgMath.getRelativeXY
+ * @alias Blockly.utils.svgMath.getRelativeXY
  */
 const getRelativeXY = function(element) {
   const xy = new Coordinate(0, 0);
@@ -96,7 +96,7 @@ exports.getRelativeXY = getRelativeXY;
  *     not a child of the div Blockly was injected into, the behaviour is
  *     undefined.
  * @return {!Coordinate} Object with .x and .y properties.
- * @alias Blockly.svgMath.getInjectionDivXY
+ * @alias Blockly.utils.svgMath.getInjectionDivXY
  */
 const getInjectionDivXY = function(element) {
   let x = 0;
@@ -119,7 +119,7 @@ exports.getInjectionDivXY = getInjectionDivXY;
  * Check if 3D transforms are supported by adding an element
  * and attempting to set the property.
  * @return {boolean} True if 3D transforms are supported.
- * @alias Blockly.svgMath.is3dSupported
+ * @alias Blockly.utils.svgMath.is3dSupported
  */
 const is3dSupported = function() {
   if (is3dSupported.cached_ !== undefined) {
@@ -172,7 +172,7 @@ exports.is3dSupported = is3dSupported;
  * scroll into account.
  * @return {!Rect} An object containing window width, height, and
  *     scroll position in window coordinates.
- * @alias Blockly.svgMath.getViewportBBox
+ * @alias Blockly.utils.svgMath.getViewportBBox
  * @package
  */
 const getViewportBBox = function() {
@@ -188,7 +188,7 @@ exports.getViewportBBox = getViewportBBox;
  * Gets the document scroll distance as a coordinate object.
  * Copied from Closure's goog.dom.getDocumentScroll.
  * @return {!Coordinate} Object with values 'x' and 'y'.
- * @alias Blockly.svgMath.getDocumentScroll
+ * @alias Blockly.utils.svgMath.getDocumentScroll
  */
 const getDocumentScroll = function() {
   const el = document.documentElement;
@@ -210,7 +210,7 @@ exports.getDocumentScroll = getDocumentScroll;
  * @param {!Coordinate} screenCoordinates The screen coordinates to
  * be converted to workspace coordinates
  * @return {!Coordinate} The workspace coordinates.
- * @alias Blockly.svgMath.screenToWsCoordinates
+ * @alias Blockly.utils.svgMath.screenToWsCoordinates
  */
 const screenToWsCoordinates = function(ws, screenCoordinates) {
   const screenX = screenCoordinates.x;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

### Reason for Changes

The namespace for certain utils function was incorrectly listed as `Blockly.svgMath` rather than `Blockly.utils.svgMath`. This affects:
- The deprecation notices for functions moved out of Blockly.utils direct namespace
- The JsDoc for these functions on devsite

### Documentation

We can regenerate the JsDoc script to have these corrected on devsite (unless Aaron already fixed it manually, haven't checked)

### Additional Information

This should be cherry-picked into a patch release for v7, because currently the deprecation warnings tell people to use a function that does not exist.
