### PR TITLE
fix: re-expose HSV_VALUE and HSV_SATURATION as settable properties on Blockly

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -444,6 +444,36 @@ Object.defineProperties(exports, {
       common.setSelected(newSelection);
     },
   },
+  /**
+   * The richness of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_SATURATION
+   * @type {number}
+   * @suppress {checkTypes}
+   */
+  HSV_SATURATION: {
+    get: function() {
+      return utils.colour.getHsvSaturation();
+    },
+    set: function(newValue) {
+      utils.colour.setHsvSaturation(newValue);
+    },
+  },
+  /**
+   * The intensity of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_VALUE
+   * @type {number}
+   * @suppress {checkTypes}
+   */
+  HSV_VALUE: {
+    get: function() {
+      return utils.colour.getHsvValue();
+    },
+    set: function(newValue) {
+      utils.colour.setHsvValue(newValue);
+    },
+  },
 });
 
 /**
@@ -639,8 +669,6 @@ exports.COLLAPSE_CHARS = internalConstants.COLLAPSE_CHARS;
 exports.LONGPRESS = internalConstants.LONGPRESS;
 exports.SOUND_LIMIT = internalConstants.SOUND_LIMIT;
 exports.DRAG_STACK = internalConstants.DRAG_STACK;
-exports.HSV_SATURATION = internalConstants.HSV_SATURATION;
-exports.HSV_VALUE = internalConstants.HSV_VALUE;
 exports.SPRITE = internalConstants.SPRITE;
 exports.DRAG_NONE = internalConstants.DRAG_NONE;
 exports.DRAG_STICKY = internalConstants.DRAG_STICKY;

--- a/core/internal_constants.js
+++ b/core/internal_constants.js
@@ -122,22 +122,6 @@ const DRAG_STACK = true;
 exports.DRAG_STACK = DRAG_STACK;
 
 /**
- * The richness of block colours, regardless of the hue.
- * Must be in the range of 0 (inclusive) to 1 (exclusive).
- * @alias Blockly.internalConstants.HSV_SATURATION
- */
-const HSV_SATURATION = 0.45;
-exports.HSV_SATURATION = HSV_SATURATION;
-
-/**
- * The intensity of block colours, regardless of the hue.
- * Must be in the range of 0 (inclusive) to 1 (exclusive).
- * @alias Blockly.internalConstants.HSV_VALUE
- */
-const HSV_VALUE = 0.65;
-exports.HSV_VALUE = HSV_VALUE;
-
-/**
  * Sprited icons and images.
  * @alias Blockly.internalConstants.SPRITE
  */

--- a/core/utils/colour.js
+++ b/core/utils/colour.js
@@ -6,21 +6,76 @@
 
 /**
  * @fileoverview Utility methods for colour manipulation.
- * These methods are not specific to Blockly, and could be factored out into
- * a JavaScript framework such as Closure.
  */
 'use strict';
 
 /**
  * Utility methods for colour manipulation.
- * These methods are not specific to Blockly, and could be factored out into
- * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.colour
  */
 goog.module('Blockly.utils.colour');
 
-const internalConstants = goog.require('Blockly.internalConstants');
+/**
+ * The richness of block colours, regardless of the hue.
+ * Must be in the range of 0 (inclusive) to 1 (exclusive).
+ * @alias Blockly.utils.colour.hsvSaturation
+ * @package
+ */
+let hsvSaturation = 0.45;
 
+/**
+ * Get the richness of block colours, regardless of the hue.
+ * @alias Blockly.utils.colour.getHsvSaturation
+ * @return {number} The current richness.
+ * @package
+ */
+const getHsvSaturation = function() {
+  return hsvSaturation;
+};
+exports.getHsvSaturation = getHsvSaturation;
+
+/**
+ * Set the richness of block colours, regardless of the hue.
+ * @param {number} newSaturation The new richness, in the range of  0
+ *     (inclusive) to 1 (exclusive)
+ * @alias Blockly.utils.colour.setHsvSaturation
+ * @package
+ */
+const setHsvSaturation = function(newSaturation) {
+  hsvSaturation = newSaturation;
+};
+exports.setHsvSaturation = setHsvSaturation;
+
+/**
+ * The intensity of block colours, regardless of the hue.
+ * Must be in the range of 0 (inclusive) to 1 (exclusive).
+ * @alias Blockly.utils.colour.hsvValue
+ * @package
+ */
+let hsvValue = 0.65;
+
+/**
+ * Get the intensity of block colours, regardless of the hue.
+ * @alias Blockly.utils.colour.getHsvValue
+ * @return {number} The current intensity.
+ * @package
+ */
+const getHsvValue = function() {
+  return hsvValue;
+};
+exports.getHsvValue = getHsvValue;
+
+/**
+ * Set the intensity of block colours, regardless of the hue.
+ * @param {number} newValue The new intensity, in the range of  0
+ *     (inclusive) to 1 (exclusive)
+ * @alias Blockly.utils.colour.setHsvValue
+ * @package
+ */
+const setHsvValue = function(newValue) {
+  hsvValue = newValue;
+};
+exports.setHsvValue = setHsvValue;
 
 /**
  * Parses a colour from a string.
@@ -228,7 +283,6 @@ exports.names = names;
  * @alias Blockly.utils.colour.hueToHex
  */
 const hueToHex = function(hue) {
-  return hsvToHex(
-      hue, internalConstants.HSV_SATURATION, internalConstants.HSV_VALUE * 255);
+  return hsvToHex(hue, hsvSaturation, hsvValue * 255);
 };
 exports.hueToHex = hueToHex;

--- a/core/utils/parsing.js
+++ b/core/utils/parsing.js
@@ -15,7 +15,6 @@
 goog.module('Blockly.utils.parsing');
 
 const colourUtils = goog.require('Blockly.utils.colour');
-const internalConstants = goog.require('Blockly.internalConstants');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Msg} = goog.require('Blockly.Msg');
 
@@ -243,8 +242,7 @@ const parseBlockColour = function(colour) {
     return {
       hue: hue,
       hex: colourUtils.hsvToHex(
-          hue, internalConstants.HSV_SATURATION,
-          internalConstants.HSV_VALUE * 255),
+          hue, colourUtils.getHsvSaturation(), colourUtils.getHsvValue() * 255),
     };
   } else {
     const hex = colourUtils.parse(dereferenced);


### PR DESCRIPTION


## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

However, this will need to be cherry-picked into a patch release.


## The details
### Resolves

Fixes the issue [reported](https://groups.google.com/g/blockly/c/Zme8UGnh0Bg) on the forum where devs can no longer set default saturation and value.

These properties were settable before goog.module-ification, and we [suggest setting them](https://developers.google.com/blockly/guides/create-custom-blocks/block-colour) in our documentation.


### Proposed Changes

- Move the two values from InternalConstants into utils/colour.js and add get and set functions.
- Update internal uses (only in utils/colour.js and utils/parsing.js)
- Add getter and setter pairs in blockly.js

Note that I marked the internal get and set functions package, because we may yet want to rearrange these.

#### Behavior Before Change

Could not set default value or saturation.

#### Behavior After Change

Can now set default value or saturation.

### Reason for Changes

Previously settable properties that are also actively in use.
Eventually we may want a more format setter for each of these properties, but this is an established pattern and it needs to continue to work.

### Test Coverage
Normal tests, plus I changed values in the playground and got this:
![image](https://user-images.githubusercontent.com/13686399/146067516-56b535fd-5cf1-45fa-b9c6-60ef8f63b02c.png)

### Additional Information

This will need to be cherry-picked into a patch release.