### PR TITLE
fix: setting null for font styles on a theme

### DIFF
--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -623,15 +623,15 @@ ConstantProvider.prototype.setDynamicProperties_ = function(theme) {
  */
 ConstantProvider.prototype.setFontConstants_ = function(theme) {
   this.FIELD_TEXT_FONTFAMILY =
-      theme.fontStyle && theme.fontStyle['family'] !== undefined ?
+      theme.fontStyle && theme.fontStyle['family'] != undefined ?
       theme.fontStyle['family'] :
       this.FIELD_TEXT_FONTFAMILY;
   this.FIELD_TEXT_FONTWEIGHT =
-      theme.fontStyle && theme.fontStyle['weight'] !== undefined ?
+      theme.fontStyle && theme.fontStyle['weight'] != undefined ?
       theme.fontStyle['weight'] :
       this.FIELD_TEXT_FONTWEIGHT;
   this.FIELD_TEXT_FONTSIZE =
-      theme.fontStyle && theme.fontStyle['size'] !== undefined ?
+      theme.fontStyle && theme.fontStyle['size'] != undefined ?
       theme.fontStyle['size'] :
       this.FIELD_TEXT_FONTSIZE;
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -622,15 +622,15 @@ ConstantProvider.prototype.setDynamicProperties_ = function(theme) {
  * @protected
  */
 ConstantProvider.prototype.setFontConstants_ = function(theme) {
-  if (theme.fontStyle && theme.fontStyle['family'] && theme.fontStyle['family'] !== undefined) {
+  if (theme.fontStyle && theme.fontStyle['family']) {
     this.FIELD_TEXT_FONTFAMILY = theme.fontStyle['family'];
   }
 
-  if (theme.fontStyle && theme.fontStyle['weight'] && theme.fontStyle['weight'] !== undefined) {
+  if (theme.fontStyle && theme.fontStyle['weight']) {
     this.FIELD_TEXT_FONTWEIGHT = theme.fontStyle['weight'];
   }
 
-  if (theme.fontStyle && theme.fontStyle['size'] && theme.fontStyle['size'] !== undefined) {
+  if (theme.fontStyle && theme.fontStyle['size']) {
     this.FIELD_TEXT_FONTSIZE = theme.fontStyle['size'];
   }
 

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -622,18 +622,17 @@ ConstantProvider.prototype.setDynamicProperties_ = function(theme) {
  * @protected
  */
 ConstantProvider.prototype.setFontConstants_ = function(theme) {
-  this.FIELD_TEXT_FONTFAMILY =
-      theme.fontStyle && theme.fontStyle['family'] != undefined ?
-      theme.fontStyle['family'] :
-      this.FIELD_TEXT_FONTFAMILY;
-  this.FIELD_TEXT_FONTWEIGHT =
-      theme.fontStyle && theme.fontStyle['weight'] != undefined ?
-      theme.fontStyle['weight'] :
-      this.FIELD_TEXT_FONTWEIGHT;
-  this.FIELD_TEXT_FONTSIZE =
-      theme.fontStyle && theme.fontStyle['size'] != undefined ?
-      theme.fontStyle['size'] :
-      this.FIELD_TEXT_FONTSIZE;
+  if (theme.fontStyle && theme.fontStyle['family'] && theme.fontStyle['family'] !== undefined) {
+    this.FIELD_TEXT_FONTFAMILY = theme.fontStyle['family'];
+  }
+
+  if (theme.fontStyle && theme.fontStyle['weight'] && theme.fontStyle['weight'] !== undefined) {
+    this.FIELD_TEXT_FONTWEIGHT = theme.fontStyle['weight'];
+  }
+
+  if (theme.fontStyle && theme.fontStyle['size'] && theme.fontStyle['size'] !== undefined) {
+    this.FIELD_TEXT_FONTSIZE = theme.fontStyle['size'];
+  }
 
   const fontMetrics = dom.measureFontMetrics(
       'Hg', this.FIELD_TEXT_FONTSIZE + 'pt', this.FIELD_TEXT_FONTWEIGHT,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Fixes #5830.

### Proposed Changes

This was introduced in #5599. We could go back to using `!=` however I'm not sure if someone would try to 'fix' this again in the future so I think the proposed fix is safer. 

The original functionality would break if a developer set it as an ''. This fix covers that case as well as when a user passes `null` or `undefined`.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
