### PR TITLE
chore(deps): updates the block-test devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "jsdom": "15.2.1"
       },
       "devDependencies": {
-        "@blockly/block-test": "^1.0.0",
+        "@blockly/block-test": "^2.0.0",
         "@blockly/dev-tools": "^3.0.1",
         "@blockly/theme-modern": "^2.1.1",
         "@wdio/selenium-standalone-service": "^7.10.1",
@@ -152,15 +152,15 @@
       }
     },
     "node_modules/@blockly/block-test": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.1.5.tgz",
-      "integrity": "sha512-lSDPuwOIEn8DLOzOLu/xNX6U4E4ps+9o5epxJ1JXxBjHqIBw7ghihHfsvuZ1c+rSsBnKGgwBzh5odq6ynIV2GQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
+      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "2 - 6"
+        "blockly": "^7.20211209.0"
       }
     },
     "node_modules/@blockly/dev-tools": {
@@ -183,18 +183,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "blockly": "^7.20211209.0"
-      }
-    },
-    "node_modules/@blockly/dev-tools/node_modules/@blockly/block-test": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
-      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^7.20211209.0"
@@ -237,15 +225,15 @@
       }
     },
     "node_modules/@blockly/theme-modern": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-2.1.24.tgz",
-      "integrity": "sha512-glTi5qhHr+S87S1skWG8Sre+DYeSIBG3j+YBbwwRX9k3zYtGO+W7sOdJ9DsBJj8NVukPpV1RhQhu5rt93Pp2rw==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-2.1.25.tgz",
+      "integrity": "sha512-CeImJoVh0Kv9O7GAlCzhrL5UDZRxe94H9ib1mGVi/eWweGA2ruU3pR/TLjg9d5oCuBbqaaGEsXEoZMiraE8pZQ==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "3.20200123.0 - 6"
+        "blockly": "3.20200123.0 - 7"
       }
     },
     "node_modules/@blockly/theme-tritanopia": {
@@ -306,15 +294,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map/node_modules/through2": {
@@ -551,9 +530,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "version": "16.11.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.14.tgz",
+      "integrity": "sha512-mK6BKLpL0bG6v2CxHbm0ed6RcZrAtTHBTd/ZpnlVPVa3HkumsqLE4BC4u6TQ8D7pnrRbOU0am6epuALs+Ncnzw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -639,9 +618,9 @@
       "dev": true
     },
     "node_modules/@wdio/cli": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.16.10.tgz",
-      "integrity": "sha512-VYip4i1SKRwsTiLd9I5EaHP7l+5F4jStQ5JulejEbYDHor6NEcakGsF+m6JAzHZgxs9QcskNxLr8tBveXM/b7w==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.16.12.tgz",
+      "integrity": "sha512-9te5d2+fA33lNafvJ/RMhQiRFrjAMLsxgFVZQ4dNba/tkN9vSO4BeFV8npcXKdRxtDtW/uEVbumJa+zC/QU6Dg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -653,10 +632,10 @@
         "@types/lodash.union": "^4.6.6",
         "@types/node": "^16.11.1",
         "@types/recursive-readdir": "^2.2.0",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "async-exit-hook": "^2.0.1",
         "chalk": "^4.0.0",
         "chokidar": "^3.0.0",
@@ -669,7 +648,7 @@
         "lodash.union": "^4.6.0",
         "mkdirp": "^1.0.4",
         "recursive-readdir": "^2.2.2",
-        "webdriverio": "7.16.10",
+        "webdriverio": "7.16.12",
         "yargs": "^17.0.0",
         "yarn-install": "^1.0.0"
       },
@@ -681,13 +660,13 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.3.tgz",
-      "integrity": "sha512-YbpeZAeEncyJrsKxfAwjhNbDUf/ZrMB2Io3PYnH3RQjEEo5lYlO15aUt9uJx09W5h8hBPcrj7CfUC5yNkFZJhw==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.11.tgz",
+      "integrity": "sha512-sIk9FINQfXohuDONb8RA1uv+29XvUw6OBHfaaU7/c9gfKiOWiRczdfiLqfySZRwYgEgNhzCw5vHIogTry1h+xQ==",
       "dev": true,
       "dependencies": {
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       },
@@ -720,29 +699,29 @@
       }
     },
     "node_modules/@wdio/repl": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.16.3.tgz",
-      "integrity": "sha512-aFpWyAIuPo6VVmkotZDWXMzd4qw3gD+xAhB6blNrMCZKWnz9+HqZnuGGc6pmiyuc5yFzb9wF22tnIxuyTyH7yA==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.16.11.tgz",
+      "integrity": "sha512-wcKkb8L4VmotiE00wxn+RybG5FIUu4Ll7VvLM+DRd9TqEs1IEYwqKLaZKEP1lo/O2nKdcYFHtiAYZ9hon9947Q==",
       "dev": true,
       "dependencies": {
-        "@wdio/utils": "7.16.3"
+        "@wdio/utils": "7.16.11"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@wdio/selenium-standalone-service": {
-      "version": "7.16.6",
-      "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-7.16.6.tgz",
-      "integrity": "sha512-KWoVzoOkOSnXlCNQj13yniaSJLbVPQJkytXam/MKy6CKsnQqeLt+6E3DvcdUhP+fRfvh5AzZrMNLer8Rv4hXhg==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-7.16.11.tgz",
+      "integrity": "sha512-UDstN2qk0OcwR0Tl93L5NCgfmOk3rOS6V4lAm50OwhiKMvjQkJtIZkFzvdCvXs+Y2oSidUHhCr6ChM3X3Nb+RQ==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.1",
         "@types/node": "^16.11.1",
         "@types/selenium-standalone": "^7.0.0",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "fs-extra": "^10.0.0",
         "selenium-standalone": "^8.0.3"
       },
@@ -754,9 +733,9 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.3.tgz",
-      "integrity": "sha512-iJLtJrOJZSJrXR1zseCkVWUFs477FngjWz2HTMfGHR69LzfmxC0RNagemjZuLTfhTqWp/FBbqaA/F+7xJdNKag==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.11.tgz",
+      "integrity": "sha512-OFVTFEB6qdG84Y+cOWIacV0loGMgq2SF/rGGlGxai89V3UQxzCFTYVoAx6odAuSNZ37wmfWCykyAR/lAlMItoQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "^16.11.1",
@@ -767,13 +746,13 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.3.tgz",
-      "integrity": "sha512-/662h5Z7B5TejHN6GiW96PAKuTPi/xcAGmtjA9ozRBI2/0eHSccDfNEaBgTTjLqqEgGAXylHcOuxHOrKx2ddJw==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.11.tgz",
+      "integrity": "sha512-qeXHREZJ7mz3C2cWGOmFG6MS6njp1js4f8zca3iqxaorWshwkrlNsps3B1iTHfkvK6oWnmc2Q0o5CrtLZl0LkA==",
       "dev": true,
       "dependencies": {
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "p-iteration": "^1.1.8"
       },
       "engines": {
@@ -902,6 +881,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1508,9 +1500,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "6.20210701.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-6.20210701.0.tgz",
-      "integrity": "sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==",
+      "version": "7.20211209.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.1.tgz",
+      "integrity": "sha512-TzrE55MUhBuUZ3vaCmnBJsbmR5sh2LnYl36ZkK/Jd0yHqb/2ZMxXY8pHyqHu2ZUWwGVcaJM9qK7c2Yk6TfxyEA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2227,9 +2219,9 @@
       }
     },
     "node_modules/closure-calculate-chunks": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/closure-calculate-chunks/-/closure-calculate-chunks-3.0.2.tgz",
-      "integrity": "sha512-nCpUyKcCF+Izk1CzobGu2HdHrlXAVguiM2gpmwW2UX+JAAJyPKyyYJPnIIifZ2wVuxZBG4FlVWjV69y8TOa5Bg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/closure-calculate-chunks/-/closure-calculate-chunks-3.0.3.tgz",
+      "integrity": "sha512-xtDmQORvSXfgT+6Xkde1RYTHsowCwqyHL92WdG4ZJKJ4bpu+A9yWK32kr4gInZEKRSAS0QrCrkXQJq4bOD5cJA==",
       "dev": true,
       "dependencies": {
         "acorn": "8.x",
@@ -2432,15 +2424,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/concat-with-sourcemaps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/concurrently": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.4.0.tgz",
@@ -2639,15 +2622,6 @@
       "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
       "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
-    },
-    "node_modules/css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/cssom": {
       "version": "0.4.4",
@@ -2970,21 +2944,21 @@
       }
     },
     "node_modules/devtools": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.16.10.tgz",
-      "integrity": "sha512-43uB3t6uNjWsqiQKRLY7axFLuMdKqlQxq6N3FWCfBKl9We1oygkGkE7Scnushdbc4lk7QwGXBC1DQ83dCgA5Gw==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.16.12.tgz",
+      "integrity": "sha512-gKe2DV1VkcZ4omTEss3cTeVg/ZmAUkJArAQp22ceDEbeE6AYYDeCpFDlZmbVgsjMxh+gY2mU5IWQlRIY/7Vyrg==",
       "dev": true,
       "dependencies": {
         "@types/node": "^16.11.1",
         "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "chrome-launcher": "^0.15.0",
         "edge-paths": "^2.1.0",
-        "puppeteer-core": "^11.0.0",
+        "puppeteer-core": "^13.0.0",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.1",
         "uuid": "^8.0.0"
@@ -2994,9 +2968,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.944179",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.944179.tgz",
-      "integrity": "sha512-oqBbLKuCAkEqqsWn0rsfkjy79F0/QTQR/rlijZzeHInJfDRPYwP0D04NiQX9MQmucrAyRWGseY0b/ff0yhQdXg==",
+      "version": "0.0.948846",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.948846.tgz",
+      "integrity": "sha512-5fGyt9xmMqUl2VI7+rnUkKCiAQIpLns8sfQtTENy5L70ktbNw0Z3TFJ1JoFNYdx/jffz4YXU45VF75wKZD7sZQ==",
       "dev": true
     },
     "node_modules/devtools/node_modules/uuid": {
@@ -3273,6 +3247,14 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/escodegen/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3307,15 +3289,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/escodegen/node_modules/type-check": {
@@ -3409,15 +3382,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
@@ -3504,15 +3468,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -3525,19 +3480,11 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
         "node": ">=4.0"
       }
@@ -4667,18 +4614,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globals/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -5399,15 +5334,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/gulp-sourcemaps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/gulp-sourcemaps/node_modules/through2": {
@@ -8913,15 +8839,6 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9034,13 +8951,13 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-11.0.0.tgz",
-      "integrity": "sha512-hfQ39KNP0qKplQ86iaCNXHH9zpWlV01UFdggt2qffgWeCBF9KMavwP/k/iK/JidPPWfOnKZhDLSHZVSUr73DtA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.0.0.tgz",
+      "integrity": "sha512-JJvGCuUNpONaFK/1tizyVthfqkEaiTCteL9HkdxN3//P9cVa+YnehlKIoJCStiKRaa3CjRu/dIJftA5XJ2EGrQ==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.2",
-        "devtools-protocol": "0.0.901419",
+        "devtools-protocol": "0.0.937139",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "node-fetch": "2.6.5",
@@ -9074,9 +8991,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.901419",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+      "version": "0.0.937139",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
+      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
       "dev": true
     },
     "node_modules/puppeteer-core/node_modules/node-fetch": {
@@ -9927,18 +9844,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -10242,6 +10147,15 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/snapdragon/node_modules/source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -10256,10 +10170,10 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11081,11 +10995,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11100,9 +11013,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11514,6 +11427,15 @@
         "source-map": "^0.5.1"
       }
     },
+    "node_modules/vinyl-sourcemaps-apply/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/vinyl/node_modules/replace-ext": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
@@ -11552,17 +11474,17 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "7.16.9",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.9.tgz",
-      "integrity": "sha512-6bpiyE3/1ncgyNM/RwzEWjpxu2NLYyeYNu/97OMEwFMDV8EqvlZh3wFnODi6tY0K5t4dEryIPiyjF3MDVySRAg==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.11.tgz",
+      "integrity": "sha512-6nBOXae4xuBH4Nqvi/zvtwjnxSLTONBpxOiRJtQ68CYTYv5+w3m8CsaWy3HbK/0XXa++NYl62bDNn70OGEKb+Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^16.11.1",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
@@ -11572,25 +11494,25 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.16.10.tgz",
-      "integrity": "sha512-Idsn0084HqcqHa5/BW/75dwFEitSDi/hhXk+GRA0wZkVU7woE8ZKACsMS270kOADgXYU9XJBT8jo6YM3R3Sa+Q==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.16.12.tgz",
+      "integrity": "sha512-pRKDRnfaE3xrNPI4TFT3kEf29l9aS6BylQOoX6DHM6gla8Xf/4seykWn1uJOCP71M9cvL8uuTZRTkfNTLGJcdQ==",
       "dev": true,
       "dependencies": {
         "@types/aria-query": "^5.0.0",
         "@types/node": "^16.11.1",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/repl": "7.16.3",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/repl": "7.16.11",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "archiver": "^5.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.16.10",
-        "devtools-protocol": "^0.0.944179",
+        "devtools": "7.16.12",
+        "devtools-protocol": "^0.0.948846",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
@@ -11599,12 +11521,12 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.zip": "^4.2.0",
         "minimatch": "^3.0.4",
-        "puppeteer-core": "^11.0.0",
+        "puppeteer-core": "^13.0.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
-        "webdriver": "7.16.9"
+        "webdriver": "7.16.11"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12099,9 +12021,9 @@
       }
     },
     "@blockly/block-test": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.1.5.tgz",
-      "integrity": "sha512-lSDPuwOIEn8DLOzOLu/xNX6U4E4ps+9o5epxJ1JXxBjHqIBw7ghihHfsvuZ1c+rSsBnKGgwBzh5odq6ynIV2GQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
+      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
       "dev": true,
       "requires": {}
     },
@@ -12122,15 +12044,6 @@
         "lodash.merge": "^4.6.2",
         "monaco-editor": "^0.20.0",
         "sinon": "^9.0.2"
-      },
-      "dependencies": {
-        "@blockly/block-test": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
-          "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "@blockly/theme-dark": {
@@ -12155,9 +12068,9 @@
       "requires": {}
     },
     "@blockly/theme-modern": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-2.1.24.tgz",
-      "integrity": "sha512-glTi5qhHr+S87S1skWG8Sre+DYeSIBG3j+YBbwwRX9k3zYtGO+W7sOdJ9DsBJj8NVukPpV1RhQhu5rt93Pp2rw==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-2.1.25.tgz",
+      "integrity": "sha512-CeImJoVh0Kv9O7GAlCzhrL5UDZRxe94H9ib1mGVi/eWweGA2ruU3pR/TLjg9d5oCuBbqaaGEsXEoZMiraE8pZQ==",
       "dev": true,
       "requires": {}
     },
@@ -12202,12 +12115,6 @@
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "through2": {
@@ -12430,9 +12337,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "version": "16.11.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.14.tgz",
+      "integrity": "sha512-mK6BKLpL0bG6v2CxHbm0ed6RcZrAtTHBTd/ZpnlVPVa3HkumsqLE4BC4u6TQ8D7pnrRbOU0am6epuALs+Ncnzw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -12518,9 +12425,9 @@
       "dev": true
     },
     "@wdio/cli": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.16.10.tgz",
-      "integrity": "sha512-VYip4i1SKRwsTiLd9I5EaHP7l+5F4jStQ5JulejEbYDHor6NEcakGsF+m6JAzHZgxs9QcskNxLr8tBveXM/b7w==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.16.12.tgz",
+      "integrity": "sha512-9te5d2+fA33lNafvJ/RMhQiRFrjAMLsxgFVZQ4dNba/tkN9vSO4BeFV8npcXKdRxtDtW/uEVbumJa+zC/QU6Dg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -12532,10 +12439,10 @@
         "@types/lodash.union": "^4.6.6",
         "@types/node": "^16.11.1",
         "@types/recursive-readdir": "^2.2.0",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "async-exit-hook": "^2.0.1",
         "chalk": "^4.0.0",
         "chokidar": "^3.0.0",
@@ -12548,19 +12455,19 @@
         "lodash.union": "^4.6.0",
         "mkdirp": "^1.0.4",
         "recursive-readdir": "^2.2.2",
-        "webdriverio": "7.16.10",
+        "webdriverio": "7.16.12",
         "yargs": "^17.0.0",
         "yarn-install": "^1.0.0"
       }
     },
     "@wdio/config": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.3.tgz",
-      "integrity": "sha512-YbpeZAeEncyJrsKxfAwjhNbDUf/ZrMB2Io3PYnH3RQjEEo5lYlO15aUt9uJx09W5h8hBPcrj7CfUC5yNkFZJhw==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.11.tgz",
+      "integrity": "sha512-sIk9FINQfXohuDONb8RA1uv+29XvUw6OBHfaaU7/c9gfKiOWiRczdfiLqfySZRwYgEgNhzCw5vHIogTry1h+xQ==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       }
@@ -12584,34 +12491,34 @@
       "dev": true
     },
     "@wdio/repl": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.16.3.tgz",
-      "integrity": "sha512-aFpWyAIuPo6VVmkotZDWXMzd4qw3gD+xAhB6blNrMCZKWnz9+HqZnuGGc6pmiyuc5yFzb9wF22tnIxuyTyH7yA==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.16.11.tgz",
+      "integrity": "sha512-wcKkb8L4VmotiE00wxn+RybG5FIUu4Ll7VvLM+DRd9TqEs1IEYwqKLaZKEP1lo/O2nKdcYFHtiAYZ9hon9947Q==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "7.16.3"
+        "@wdio/utils": "7.16.11"
       }
     },
     "@wdio/selenium-standalone-service": {
-      "version": "7.16.6",
-      "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-7.16.6.tgz",
-      "integrity": "sha512-KWoVzoOkOSnXlCNQj13yniaSJLbVPQJkytXam/MKy6CKsnQqeLt+6E3DvcdUhP+fRfvh5AzZrMNLer8Rv4hXhg==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-7.16.11.tgz",
+      "integrity": "sha512-UDstN2qk0OcwR0Tl93L5NCgfmOk3rOS6V4lAm50OwhiKMvjQkJtIZkFzvdCvXs+Y2oSidUHhCr6ChM3X3Nb+RQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.1",
         "@types/node": "^16.11.1",
         "@types/selenium-standalone": "^7.0.0",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "fs-extra": "^10.0.0",
         "selenium-standalone": "^8.0.3"
       }
     },
     "@wdio/types": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.3.tgz",
-      "integrity": "sha512-iJLtJrOJZSJrXR1zseCkVWUFs477FngjWz2HTMfGHR69LzfmxC0RNagemjZuLTfhTqWp/FBbqaA/F+7xJdNKag==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.11.tgz",
+      "integrity": "sha512-OFVTFEB6qdG84Y+cOWIacV0loGMgq2SF/rGGlGxai89V3UQxzCFTYVoAx6odAuSNZ37wmfWCykyAR/lAlMItoQ==",
       "dev": true,
       "requires": {
         "@types/node": "^16.11.1",
@@ -12619,13 +12526,13 @@
       }
     },
     "@wdio/utils": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.3.tgz",
-      "integrity": "sha512-/662h5Z7B5TejHN6GiW96PAKuTPi/xcAGmtjA9ozRBI2/0eHSccDfNEaBgTTjLqqEgGAXylHcOuxHOrKx2ddJw==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.11.tgz",
+      "integrity": "sha512-qeXHREZJ7mz3C2cWGOmFG6MS6njp1js4f8zca3iqxaorWshwkrlNsps3B1iTHfkvK6oWnmc2Q0o5CrtLZl0LkA==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.16.0",
-        "@wdio/types": "7.16.3",
+        "@wdio/types": "7.16.11",
         "p-iteration": "^1.1.8"
       }
     },
@@ -12717,6 +12624,15 @@
       "peer": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "ansi-gray": {
@@ -13178,9 +13094,9 @@
       }
     },
     "blockly": {
-      "version": "6.20210701.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-6.20210701.0.tgz",
-      "integrity": "sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==",
+      "version": "7.20211209.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.1.tgz",
+      "integrity": "sha512-TzrE55MUhBuUZ3vaCmnBJsbmR5sh2LnYl36ZkK/Jd0yHqb/2ZMxXY8pHyqHu2ZUWwGVcaJM9qK7c2Yk6TfxyEA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -13745,9 +13661,9 @@
       }
     },
     "closure-calculate-chunks": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/closure-calculate-chunks/-/closure-calculate-chunks-3.0.2.tgz",
-      "integrity": "sha512-nCpUyKcCF+Izk1CzobGu2HdHrlXAVguiM2gpmwW2UX+JAAJyPKyyYJPnIIifZ2wVuxZBG4FlVWjV69y8TOa5Bg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/closure-calculate-chunks/-/closure-calculate-chunks-3.0.3.tgz",
+      "integrity": "sha512-xtDmQORvSXfgT+6Xkde1RYTHsowCwqyHL92WdG4ZJKJ4bpu+A9yWK32kr4gInZEKRSAS0QrCrkXQJq4bOD5cJA==",
       "dev": true,
       "requires": {
         "acorn": "8.x",
@@ -13907,14 +13823,6 @@
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "concurrently": {
@@ -14064,14 +13972,6 @@
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
         "source-map-resolve": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "css-shorthand-properties": {
@@ -14333,21 +14233,21 @@
       "dev": true
     },
     "devtools": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.16.10.tgz",
-      "integrity": "sha512-43uB3t6uNjWsqiQKRLY7axFLuMdKqlQxq6N3FWCfBKl9We1oygkGkE7Scnushdbc4lk7QwGXBC1DQ83dCgA5Gw==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.16.12.tgz",
+      "integrity": "sha512-gKe2DV1VkcZ4omTEss3cTeVg/ZmAUkJArAQp22ceDEbeE6AYYDeCpFDlZmbVgsjMxh+gY2mU5IWQlRIY/7Vyrg==",
       "dev": true,
       "requires": {
         "@types/node": "^16.11.1",
         "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "chrome-launcher": "^0.15.0",
         "edge-paths": "^2.1.0",
-        "puppeteer-core": "^11.0.0",
+        "puppeteer-core": "^13.0.0",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.1",
         "uuid": "^8.0.0"
@@ -14362,9 +14262,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.944179",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.944179.tgz",
-      "integrity": "sha512-oqBbLKuCAkEqqsWn0rsfkjy79F0/QTQR/rlijZzeHInJfDRPYwP0D04NiQX9MQmucrAyRWGseY0b/ff0yhQdXg==",
+      "version": "0.0.948846",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.948846.tgz",
+      "integrity": "sha512-5fGyt9xmMqUl2VI7+rnUkKCiAQIpLns8sfQtTENy5L70ktbNw0Z3TFJ1JoFNYdx/jffz4YXU45VF75wKZD7sZQ==",
       "dev": true
     },
     "diff": {
@@ -14600,6 +14500,11 @@
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -14626,12 +14531,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
           "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
         },
         "type-check": {
           "version": "0.3.2",
@@ -14715,14 +14614,6 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "eslint-utils": {
@@ -14771,14 +14662,6 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "esrecurse": {
@@ -14788,20 +14671,13 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -15699,14 +15575,6 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
-        }
       }
     },
     "glogg": {
@@ -16312,12 +16180,6 @@
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "through2": {
@@ -19108,14 +18970,6 @@
       "requires": {
         "picocolors": "^0.2.1",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "prelude-ls": {
@@ -19211,13 +19065,13 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer-core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-11.0.0.tgz",
-      "integrity": "sha512-hfQ39KNP0qKplQ86iaCNXHH9zpWlV01UFdggt2qffgWeCBF9KMavwP/k/iK/JidPPWfOnKZhDLSHZVSUr73DtA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.0.0.tgz",
+      "integrity": "sha512-JJvGCuUNpONaFK/1tizyVthfqkEaiTCteL9HkdxN3//P9cVa+YnehlKIoJCStiKRaa3CjRu/dIJftA5XJ2EGrQ==",
       "dev": true,
       "requires": {
         "debug": "4.3.2",
-        "devtools-protocol": "0.0.901419",
+        "devtools-protocol": "0.0.937139",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "node-fetch": "2.6.5",
@@ -19240,9 +19094,9 @@
           }
         },
         "devtools-protocol": {
-          "version": "0.0.901419",
-          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-          "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+          "version": "0.0.937139",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
+          "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
           "dev": true
         },
         "node-fetch": {
@@ -19916,14 +19770,6 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
-        }
       }
     },
     "serialize-javascript": {
@@ -20135,6 +19981,12 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
         "source-map-resolve": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -20193,10 +20045,10 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true
     },
     "source-map-resolve": {
       "version": "0.6.0",
@@ -20892,11 +20744,10 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "peer": true
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -20905,9 +20756,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "ua-parser-js": {
@@ -21250,6 +21101,14 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "w3c-hr-time": {
@@ -21281,42 +21140,42 @@
       }
     },
     "webdriver": {
-      "version": "7.16.9",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.9.tgz",
-      "integrity": "sha512-6bpiyE3/1ncgyNM/RwzEWjpxu2NLYyeYNu/97OMEwFMDV8EqvlZh3wFnODi6tY0K5t4dEryIPiyjF3MDVySRAg==",
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.11.tgz",
+      "integrity": "sha512-6nBOXae4xuBH4Nqvi/zvtwjnxSLTONBpxOiRJtQ68CYTYv5+w3m8CsaWy3HbK/0XXa++NYl62bDNn70OGEKb+Q==",
       "dev": true,
       "requires": {
         "@types/node": "^16.11.1",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
       }
     },
     "webdriverio": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.16.10.tgz",
-      "integrity": "sha512-Idsn0084HqcqHa5/BW/75dwFEitSDi/hhXk+GRA0wZkVU7woE8ZKACsMS270kOADgXYU9XJBT8jo6YM3R3Sa+Q==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.16.12.tgz",
+      "integrity": "sha512-pRKDRnfaE3xrNPI4TFT3kEf29l9aS6BylQOoX6DHM6gla8Xf/4seykWn1uJOCP71M9cvL8uuTZRTkfNTLGJcdQ==",
       "dev": true,
       "requires": {
         "@types/aria-query": "^5.0.0",
         "@types/node": "^16.11.1",
-        "@wdio/config": "7.16.3",
+        "@wdio/config": "7.16.11",
         "@wdio/logger": "7.16.0",
         "@wdio/protocols": "7.16.7",
-        "@wdio/repl": "7.16.3",
-        "@wdio/types": "7.16.3",
-        "@wdio/utils": "7.16.3",
+        "@wdio/repl": "7.16.11",
+        "@wdio/types": "7.16.11",
+        "@wdio/utils": "7.16.11",
         "archiver": "^5.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.16.10",
-        "devtools-protocol": "^0.0.944179",
+        "devtools": "7.16.12",
+        "devtools-protocol": "^0.0.948846",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
@@ -21325,12 +21184,12 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.zip": "^4.2.0",
         "minimatch": "^3.0.4",
-        "puppeteer-core": "^11.0.0",
+        "puppeteer-core": "^13.0.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
-        "webdriver": "7.16.9"
+        "webdriver": "7.16.11"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@blockly/block-test": "^1.0.0",
+    "@blockly/block-test": "^2.0.0",
     "@blockly/dev-tools": "^3.0.1",
     "@blockly/theme-modern": "^2.1.1",
     "@wdio/selenium-standalone-service": "^7.10.1",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
Serialization category in test blocks is broken in the advanced playground since we are using an out of date version of block-test. 

It also causes problems when we remove the package-lock and try to do an `npm install` because the peer dependency of block-test does not match our current version.

### Proposed Changes
Update to the latest version of block-test.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
