### PR TITLE
fit: Fixed the label closure on demo/blockfactory

### DIFF
--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -143,9 +143,9 @@
         <div class="dropdown">
         <button id="button_importBlocks">Import Custom Blocks</button>
           <div id="dropdownDiv_importBlocks" class="dropdown-content">
-            <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile"</input>
+            <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile"></input>
             <label for="input_importBlocksJson">From JSON</label>
-            <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile"</input>
+            <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile"></input>
             <label for="input_importBlocksJs">From Javascript</label>
           </div>
         </div>
@@ -155,7 +155,7 @@
           <div id="dropdownDiv_load" class="dropdown-content">
             <input type="file" id="input_loadToolbox" accept=".xml" class="inputfile"></input>
             <label for="input_loadToolbox">Toolbox</label>
-            <input type="file" id="input_loadPreload" accept=".xml" class="inputfile"</input>
+            <input type="file" id="input_loadPreload" accept=".xml" class="inputfile"></input>
             <label for="input_loadPreload">Workspace Blocks</label>
           </div>
         </div>

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -143,9 +143,9 @@
         <div class="dropdown">
         <button id="button_importBlocks">Import Custom Blocks</button>
           <div id="dropdownDiv_importBlocks" class="dropdown-content">
-            <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile"></input>
+            <input type="file" id="input_importBlocksJson" accept=".js, .json, .txt" class="inputfile">
             <label for="input_importBlocksJson">From JSON</label>
-            <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile"></input>
+            <input type="file" id="input_importBlocksJs" accept=".js, .txt" class="inputfile">
             <label for="input_importBlocksJs">From Javascript</label>
           </div>
         </div>
@@ -153,9 +153,9 @@
         <div class="dropdown">
         <button id="button_load">Load to Edit</button>
           <div id="dropdownDiv_load" class="dropdown-content">
-            <input type="file" id="input_loadToolbox" accept=".xml" class="inputfile"></input>
+            <input type="file" id="input_loadToolbox" accept=".xml" class="inputfile">
             <label for="input_loadToolbox">Toolbox</label>
-            <input type="file" id="input_loadPreload" accept=".xml" class="inputfile"></input>
+            <input type="file" id="input_loadPreload" accept=".xml" class="inputfile">
             <label for="input_loadPreload">Workspace Blocks</label>
           </div>
         </div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
In demo/blockfactory, I see that the input tag is not closed in demo/blockfactory/index.html, and I fixed this