### PR TITLE
fix: procedure param edits breaking undo

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -419,7 +419,10 @@ Mutator.prototype.updateWorkspace_ = function() {
 
   // When the mutator's workspace changes, update the source block.
   if (this.rootBlock_.workspace === this.workspace_) {
-    eventUtils.setGroup(true);
+    const existingGroup = eventUtils.getGroup();
+    if (!existingGroup) {
+      eventUtils.setGroup(true);
+    }
     const block = /** @type {!BlockSvg} */ (this.block_);
     const oldExtraState = BlockChange.getExtraBlockState_(block);
 
@@ -444,11 +447,12 @@ Mutator.prototype.updateWorkspace_ = function() {
       eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
           block, 'mutation', null, oldExtraState, newExtraState));
       // Ensure that any bump is part of this mutation's event group.
-      const group = eventUtils.getGroup();
+      const mutationGroup = eventUtils.getGroup();
       setTimeout(function() {
-        eventUtils.setGroup(group);
+        const oldGroup = eventUtils.getGroup();
+        eventUtils.setGroup(mutationGroup);
         block.bumpNeighbours();
-        eventUtils.setGroup(false);
+        eventUtils.setGroup(oldGroup);
       }, internalConstants.BUMP_DELAY);
     }
 
@@ -457,7 +461,7 @@ Mutator.prototype.updateWorkspace_ = function() {
     if (!this.workspace_.isDragging()) {
       this.resizeBubble_();
     }
-    eventUtils.setGroup(false);
+    eventUtils.setGroup(existingGroup);
   }
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #5439 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds proper handling of groups to the mutator so that it doesn't clobber things and break undo. Basically we now make sure to check for existing groups, and reset to them after starting new groups if necessary.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Event groups are global, even though events are specific to a given workspace. So what we want is for all of the events related to editing a parameter to be a part of the group started by editing that field in the mutator workspace.

These changes make sure that is the case, by making sure the mutator does not clobber existing event groups.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

* Parameter edits are undone with a single undo.
* Mutator edits still undo and redo properly (tested with controls_if and lists_create_with)
* Neighbor bumps triggered by mutator edits are still grouped properly (tested with lists_create_with)

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
