### PR TITLE
fix: msg imports in typedefs.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,11 +12,11 @@
 /// <reference path="core.d.ts" />
 /// <reference path="blocks.d.ts" />
 /// <reference path="javascript.d.ts" />
-/// <reference path="msg/en.d.ts" />
+/// <reference path="msg/msg.d.ts" />
 
 import * as Blockly from './core';
 import './blocks';
 import './javascript';
-import './msg/en';
+import './msg/msg';
 
 export = Blockly;


### PR DESCRIPTION
Fixes #5841 for me.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#5841 

### Proposed Changes

No visible changes, only compiler error fixes,

#### Behavior Before Change

Doesn't build.

#### Behavior After Change

Happy compilers.

Tested on:
* Desktop Chrome

But more importantly, I use bazel and typescript v4.5.4 to build.
