### PR TITLE
chore(deps): bump @blockly/block-test from 1.1.5 to 2.0.1 (#5836)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "jsdom": "15.2.1"
       },
       "devDependencies": {
-        "@blockly/block-test": "^1.0.0",
+        "@blockly/block-test": "^2.0.1",
         "@blockly/dev-tools": "^3.0.1",
         "@blockly/theme-modern": "^2.1.1",
         "@wdio/selenium-standalone-service": "^7.10.1",
@@ -276,15 +276,15 @@
       }
     },
     "node_modules/@blockly/block-test": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.1.5.tgz",
-      "integrity": "sha512-lSDPuwOIEn8DLOzOLu/xNX6U4E4ps+9o5epxJ1JXxBjHqIBw7ghihHfsvuZ1c+rSsBnKGgwBzh5odq6ynIV2GQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
+      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "2 - 6"
+        "blockly": "^7.20211209.0"
       }
     },
     "node_modules/@blockly/dev-tools": {
@@ -307,18 +307,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "blockly": "^7.20211209.0"
-      }
-    },
-    "node_modules/@blockly/dev-tools/node_modules/@blockly/block-test": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
-      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^7.20211209.0"
@@ -12500,9 +12488,9 @@
       }
     },
     "@blockly/block-test": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.1.5.tgz",
-      "integrity": "sha512-lSDPuwOIEn8DLOzOLu/xNX6U4E4ps+9o5epxJ1JXxBjHqIBw7ghihHfsvuZ1c+rSsBnKGgwBzh5odq6ynIV2GQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
+      "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
       "dev": true,
       "requires": {}
     },
@@ -12523,15 +12511,6 @@
         "lodash.merge": "^4.6.2",
         "monaco-editor": "^0.20.0",
         "sinon": "^9.0.2"
-      },
-      "dependencies": {
-        "@blockly/block-test": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.1.tgz",
-          "integrity": "sha512-d8E109UEWTtFv1bfy5paQNk9HYdZDWH5S7qkCrlKTtSatPDt8f3SGCr/lu8JC086/LhjRafgX1RTa0uwJIDDdg==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "@blockly/theme-dark": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@blockly/block-test": "^1.0.0",
+    "@blockly/block-test": "^2.0.1",
     "@blockly/dev-tools": "^3.0.1",
     "@blockly/theme-modern": "^2.1.1",
     "@wdio/selenium-standalone-service": "^7.10.1",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

## The details
### Resolves
Clearing node_modules and removing the package-lock causes build errors because the block-test version is not updated correctly.
<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes
Cherry pick #5836 from develop.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
