### PR TITLE
fix: msg imports in type definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,11 +12,11 @@
 /// <reference path="core.d.ts" />
 /// <reference path="blocks.d.ts" />
 /// <reference path="javascript.d.ts" />
-/// <reference path="msg/en.d.ts" />
+/// <reference path="msg/msg.d.ts" />
 
 import * as Blockly from './core';
 import './blocks';
 import './javascript';
-import './msg/en';
+import './msg/msg';
 
 export = Blockly;


### PR DESCRIPTION
This is a copy of https://github.com/google/blockly/pull/5846 against master, which will fix https://github.com/google/blockly/issues/5841 in the next patch release.

When we released v7 we committed to making patch releases for typescript definition errors, since our pipeline for typings was convoluted this quarter.
