### PR TITLE
chore: declare properties in the constructor instead of at first use

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -291,6 +291,19 @@ const Block = function(workspace, prototypeName, opt_id) {
   this.rendered = null;
 
   /**
+   * String for block help, or function that returns a URL. Null for no help.
+   * @type {string|Function}
+   */
+  this.helpUrl = null;
+
+  /**
+   * A bound callback function to use when the parent workspace changes.
+   * @type {?function(Abstract)}
+   * @private
+   */
+  this.onchangeWrapper_ = null;
+
+  /**
    * A count of statement inputs on the block.
    * @type {number}
    * @package

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -209,6 +209,12 @@ const BlockSvg = function(workspace, prototypeName, opt_id) {
    */
   this.renderIsInProgress_ = false;
 
+  /**
+   * Whether mousedown events have been bound yet.
+   * @type {boolean}
+   * @private
+   */
+  this.eventsInit_ = false;
 
   /** @type {!WorkspaceSvg} */
   this.workspace = workspace;

--- a/core/comment.js
+++ b/core/comment.js
@@ -98,6 +98,28 @@ const Comment = function(block) {
    */
   this.onInputWrapper_ = null;
 
+  /**
+   * The SVG element that contains the text edit area, or null if not created.
+   * @type {?SVGForeignObjectElement}
+   * @private
+   */
+  this.foreignObject_ = null;
+
+  /**
+   * The editable text area, or null if not created.
+   * @type {?Element}
+   * @private
+   */
+  this.textarea_ = null;
+
+  /**
+   * The top-level node of the comment text, or null if not created.
+   * @type {?SVGTextElement}
+   * @private
+   */
+  this.paragraphElement_ = null;
+
+
   this.createIcon();
 };
 object.inherits(Comment, Icon);

--- a/core/icon.js
+++ b/core/icon.js
@@ -47,32 +47,33 @@ const Icon = function(block) {
    * @type {?SVGGElement}
    */
   this.iconGroup_ = null;
+
+  /**
+   * Whether this icon gets hidden when the block is collapsed.
+   * @type {boolean}
+   */
+  this.collapseHidden = true;
+
+  /**
+   * Height and width of icons.
+   * @const
+   */
+  this.SIZE = 17;
+
+  /**
+   * Bubble UI (if visible).
+   * @type {?Bubble}
+   * @protected
+   */
+  this.bubble_ = null;
+
+  /**
+   * Absolute coordinate of icon's center.
+   * @type {?Coordinate}
+   * @protected
+   */
+  this.iconXY_ = null;
 };
-
-/**
- * Does this icon get hidden when the block is collapsed.
- */
-Icon.prototype.collapseHidden = true;
-
-/**
- * Height and width of icons.
- * @const
- */
-Icon.prototype.SIZE = 17;
-
-/**
- * Bubble UI (if visible).
- * @type {?Bubble}
- * @protected
- */
-Icon.prototype.bubble_ = null;
-
-/**
- * Absolute coordinate of icon's center.
- * @type {?Coordinate}
- * @protected
- */
-Icon.prototype.iconXY_ = null;
 
 /**
  * Create the icon on the block.
@@ -197,7 +198,7 @@ Icon.prototype.getIconLocation = function() {
  */
 // TODO (#2562): Remove getCorrectedSize.
 Icon.prototype.getCorrectedSize = function() {
-  return new Size(Icon.prototype.SIZE, Icon.prototype.SIZE - 2);
+  return new Size(this.SIZE, this.SIZE - 2);
 };
 
 /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -78,6 +78,30 @@ const Mutator = function(quarkNames) {
    * @private
    */
   this.workspaceHeight_ = 0;
+
+  /**
+   * The SVG element that is the parent of the mutator workspace, or null if
+   * not created.
+   * @type {?SVGSVGElement}
+   * @private
+   */
+  this.svgDialog_ = null;
+
+  /**
+   * The root block of the mutator workspace, created by decomposing the source
+   * block.
+   * @type {?BlockSvg}
+   * @private
+   */
+  this.rootBlock_ = null;
+
+  /**
+   * Function registered on the main workspace to update the mutator contents
+   * when the main workspace changes.
+   * @type {?Function}
+   * @private
+   */
+  this.sourceListener_ = null;
 };
 object.inherits(Mutator, Icon);
 
@@ -341,12 +365,12 @@ Mutator.prototype.setVisible = function(visible) {
     this.rootBlock_.moveBy(x, margin);
     // Save the initial connections, then listen for further changes.
     if (this.block_.saveConnections) {
-      const thisMutator = this;
+      const thisRootBlock = this.rootBlock_;
       const mutatorBlock =
           /** @type {{saveConnections: function(!Block)}} */ (this.block_);
       mutatorBlock.saveConnections(this.rootBlock_);
       this.sourceListener_ = function() {
-        mutatorBlock.saveConnections(thisMutator.rootBlock_);
+        mutatorBlock.saveConnections(thisRootBlock);
       };
       this.block_.workspace.addChangeListener(this.sourceListener_);
     }

--- a/core/warning.js
+++ b/core/warning.js
@@ -45,6 +45,13 @@ const Warning = function(block) {
   this.text_ = Object.create(null);
 
   /**
+   * The top-level node of the warning text, or null if not created.
+   * @type {?SVGTextElement}
+   * @private
+   */
+  this.paragraphElement_ = null;
+
+  /**
    * Does this icon get hidden when the block is collapsed?
    * @type {boolean}
    */


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/2892

### Proposed Changes

Declare properties in the constructor and annotate appropriately, instead of declaring at first use.

I found these by adding `struct` to annotations for various classes and fixing new errors that resulted. Struct means that you can't add new properties after the constructor runs.

Not all of our classes will be able to be structs--for instance, we let people store arbitrary properties on their blocks--but it's good practice and makes it easier to later convert classes to es6. I found some of these problems when working on #5861 

#### Behavior Before Change

No change in behaviour.

### Test Coverage
Tested by running mocha and generator tests, and by playing around in the playground with a focus on comments and mutators.
