### PR TITLE
chore(build): add a script to run the ts compiler and send the new files to closure compiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,7 @@ module.exports = {
   buildLangfiles: buildTasks.langfiles,
   buildCompiled: buildTasks.compiled,
   buildAdvancedCompilationTest: buildTasks.advancedCompilationTest,
+  buildTs: buildTasks.buildTypescript,
   // TODO(5621): Re-enable once typings generation is fixed.
   // checkin: gulp.parallel(buildTasks.checkinBuilt, typings.checkinTypings),
   checkin: gulp.parallel(buildTasks.checkinBuilt),

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:compressed": "npm run build:compiled",
     "build:deps": "gulp buildDeps",
     "build:langfiles": "gulp buildLangfiles",
-    "build:ts": "gulp buildTs && gulp build --compileTs",
+    "build-ts": "gulp buildTs && gulp build --compileTs",
     "bump": "npm --no-git-tag-version version 4.$(date +'%Y%m%d').0",
     "clean": "gulp clean",
     "clean:build": "gulp cleanBuildDir",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:compressed": "npm run build:compiled",
     "build:deps": "gulp buildDeps",
     "build:langfiles": "gulp buildLangfiles",
+    "build:ts": "gulp buildTs && gulp build --compileTs",
     "bump": "npm --no-git-tag-version version 4.$(date +'%Y%m%d').0",
     "clean": "gulp clean",
     "clean:build": "gulp cleanBuildDir",

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -230,7 +230,7 @@ function buildDeps(done) {
       'node_modules/google-closure-library/closure/goog' :
       'closure/goog';
 
-  const coreDir = argv.compileTs ? TSC_OUTPUT_DIR + '/core' : 'core';
+  const coreDir = argv.compileTs ? path.join(TSC_OUTPUT_DIR, 'core') : 'core';
   const roots = [
     closurePath,
     coreDir,
@@ -358,7 +358,7 @@ return ${NAMESPACE_OBJECT}.${chunk.exports};
  */
 function getChunkOptions() {
   if (argv.compileTs) {
-    chunks[0].entry = TSC_OUTPUT_DIR + '/core/blockly.js';
+    chunks[0].entry = path.join(TSC_OUTPUT_DIR, chunks[0].entry);
   }
   const cccArgs = [
     '--closure-library-base-js-path ./closure/goog/base_minimal.js',
@@ -467,19 +467,11 @@ const pathSepRegExp = new RegExp(path.sep.replace(/\\/, '\\\\'), "g");
  */
 function flattenCorePaths(pathObject) {
   const dirs = pathObject.dirname.split(path.sep);
-
-  if (argv.compileTs) {
-    if (dirs[2] === 'core') {
-      pathObject.dirname = 'build/ts/core';
-      pathObject.basename =
-          dirs.slice(3).concat(pathObject.basename).join('-slash-');
-    }
-  } else {
-    if (dirs[0] === 'core') {
-      pathObject.dirname = dirs[0];
-      pathObject.basename =
-          dirs.slice(1).concat(pathObject.basename).join('-slash-');
-    }
+  const coreIndex = argv.compileTs ? 2 : 0;
+  if (dirs[coreIndex] === 'core') {
+    pathObject.dirname = path.join(...dirs.slice(0, coreIndex + 1));
+    pathObject.basename =
+        dirs.slice(coreIndex + 1).concat(pathObject.basename).join('-slash-');
   }
 }
 

--- a/scripts/gulpfiles/config.js
+++ b/scripts/gulpfiles/config.js
@@ -15,7 +15,7 @@ var path = require('path');
 //
 // TODO(#5007): If you modify these values, you must also modify the
 // corresponding values in the following files:
-// 
+//
 // - tests/scripts/compile_typings.sh
 // - tests/scripts/check_metadata.sh
 module.exports = {
@@ -28,4 +28,8 @@ module.exports = {
 
   // Directory to write typings output to.
   TYPINGS_BUILD_DIR: path.join('build', 'typings'),
+
+  // Directory where typescript compiler output can be found.
+  // Matches the value in tsconfig.json: outDir
+  TSC_OUTPUT_DIR: path.join('build', 'ts'),
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,14 @@
 {
-  // Change this to match your project
   "include": [
     "core/**/*",
     "closure/goog/base_minimal.js",
-    //"typings/templates/blockly-header.d.ts",
-    //"typings/templates/blockly-interfaces.d.ts",
   ],
   "compilerOptions": {
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
     "allowJs": true,
-    // checkJs: true,
 
+    // Enable the next few options for type declarations.
     // Generate d.ts files
     //"declaration": true,
     // Types should go into this directory.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "outDir": "build/ts",
     "module": "ES2015",
     "moduleResolution": "node",
-    "target": "ES2015",
+    "target": "ES2020",
     "strict": true,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  // Change this to match your project
+  "include": [
+    "core/**/*",
+    "closure/goog/base_minimal.js",
+    //"typings/templates/blockly-header.d.ts",
+    //"typings/templates/blockly-interfaces.d.ts",
+  ],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // checkJs: true,
+
+    // Generate d.ts files
+    //"declaration": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    //"declarationDir": "build/ts/declarations",
+
+    "outDir": "build/ts",
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "target": "ES2015",
+    "strict": true,
+  }
+}


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5892

### Proposed Changes

- Adds a `tsconfig.json` telling the typescript compiler a few critical things: where the input code is, where the output code goes, and that it should read existing js files. 
- Adds a gulp task that runs the typescript compiler
- Adds a flag, `compileTs`, that controls where the build tasks look for source files. By default build uses the files in `core`. When `compileTs` is set, it uses the files in `build/ts/core`.
- Adds a script in `package.json` that runs the ts compiler and then runs build with the appropriate flag set.

Note that the `compileTs` flag is a hack designed to let me set up compilation without properly passing parameters through the build tasks. 
The default behaviour is currently to just run the closure compiler on the code in `core`. Ideally by the end of the quarter the default behaviour will be to run the closure compiler on the code generated by the typescript compiler, and this option will go away entirely. If possible I want to avoid having multiple compilation setups (with different source code) at the end of the quarter.

I did chat with Chris about this and we agreed it's a reasonable hack to get compilation going.


### Test Coverage
Tested by running locally and confirming that `deps` gets updated, and that I can open the playground and use the code (uncompiled) and open a demo and use the code (compiled).


### Additional Information

The tsconfig here does not enable generation of declarations (`.d.ts` files) because there are currently 85 errors that block declaration export.