### PR TITLE
feat: Delete events should animate when played.

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -397,9 +397,10 @@ Block.COLLAPSED_FIELD_NAME = constants.COLLAPSED_FIELD_NAME;
  * @param {boolean} healStack If true, then try to heal any gap by connecting
  *     the next statement with the previous statement.  Otherwise, dispose of
  *     all children of this block.
+ * @param {boolean=} _animate If true, show a disposal animation and sound.
  * @suppress {checkTypes}
  */
-Block.prototype.dispose = function(healStack) {
+Block.prototype.dispose = function(healStack, _animate) {
   if (!this.workspace) {
     // Already deleted.
     return;

--- a/core/events/events_block_create.js
+++ b/core/events/events_block_create.js
@@ -55,6 +55,12 @@ class BlockCreate extends BlockBase {
     this.ids = eventUtils.getDescendantIds(opt_block);
 
     /**
+     * Play UI effects (sound and animation)?
+     * @type {boolean}
+     */
+    this.ui = true;
+
+    /**
      * JSON representation of the block that was just created.
      * @type {!blocks.State}
      */
@@ -71,6 +77,7 @@ class BlockCreate extends BlockBase {
     json['xml'] = Xml.domToText(this.xml);
     json['ids'] = this.ids;
     json['json'] = this.json;
+    json['ui'] = this.ui;
     if (!this.recordUndo) {
       json['recordUndo'] = this.recordUndo;
     }
@@ -86,6 +93,7 @@ class BlockCreate extends BlockBase {
     this.xml = Xml.textToDom(json['xml']);
     this.ids = json['ids'];
     this.json = /** @type {!blocks.State} */ (json['json']);
+    this.ui = !!json['ui'];
     if (json['recordUndo'] !== undefined) {
       this.recordUndo = json['recordUndo'];
     }
@@ -104,7 +112,7 @@ class BlockCreate extends BlockBase {
         const id = this.ids[i];
         const block = workspace.getBlockById(id);
         if (block) {
-          block.dispose(false);
+          block.dispose(false, this.ui);
         } else if (id === this.blockId) {
           // Only complain about root-level block.
           console.warn('Can\'t uncreate non-existent block: ' + id);

--- a/core/events/events_block_delete.js
+++ b/core/events/events_block_delete.js
@@ -64,6 +64,12 @@ class BlockDelete extends BlockBase {
     this.wasShadow = opt_block.isShadow();
 
     /**
+     * Play UI effects (sound and animation)?
+     * @type {boolean}
+     */
+    this.ui = true;
+
+    /**
      * JSON representation of the block that was just deleted.
      * @type {!blocks.State}
      */
@@ -81,6 +87,7 @@ class BlockDelete extends BlockBase {
     json['ids'] = this.ids;
     json['wasShadow'] = this.wasShadow;
     json['oldJson'] = this.oldJson;
+    json['ui'] = this.ui;
     if (!this.recordUndo) {
       json['recordUndo'] = this.recordUndo;
     }
@@ -98,6 +105,7 @@ class BlockDelete extends BlockBase {
     this.wasShadow =
         json['wasShadow'] || this.oldXml.tagName.toLowerCase() === 'shadow';
     this.oldJson = /** @type {!blocks.State} */ (json['oldJson']);
+    this.ui = !!json['ui'];
     if (json['recordUndo'] !== undefined) {
       this.recordUndo = json['recordUndo'];
     }
@@ -114,7 +122,7 @@ class BlockDelete extends BlockBase {
         const id = this.ids[i];
         const block = workspace.getBlockById(id);
         if (block) {
-          block.dispose(false);
+          block.dispose(false, this.ui);
         } else if (id === this.blockId) {
           // Only complain about root-level block.
           console.warn('Can\'t delete non-existent block: ' + id);

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -469,6 +469,7 @@ suite('Events', function() {
             'x': 0,
             'y': 0,
           },
+          ui: true,
         }),
       },
       {
@@ -488,6 +489,7 @@ suite('Events', function() {
             'x': 0,
             'y': 0,
           },
+          ui: true,
           recordUndo: false,
         }),
       },
@@ -509,6 +511,7 @@ suite('Events', function() {
             'x': 0,
             'y': 0,
           },
+          ui: true,
         }),
       },
       {
@@ -529,6 +532,7 @@ suite('Events', function() {
             'x': 0,
             'y': 0,
           },
+          ui: true,
           recordUndo: false,
         }),
       },


### PR DESCRIPTION
Same as PR #5640, except for the addition of a parameter in the JSON to turn this on or off.  While one would normally want animations/sounds on (e.g. undo/redo stack) sometimes they'd be annoying (e.g. events from realtime collaborators).