### PR TITLE
refactor(tests): Use `goog.bootstrap` to allow loading ES modules in playground

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -91,7 +91,14 @@ goog.global.CLOSURE_UNCOMPILED_DEFINES;
  *   var CLOSURE_DEFINES = {'goog.DEBUG': false} ;
  * </pre>
  *
- * @type {Object<string, (string|number|boolean)>|undefined}
+ * Currently the Closure Compiler will only recognize very simple definitions of
+ * this value when looking for values to apply to compiled code and ignore all
+ * other references.  Specifically, it looks the value defined at the variable
+ * declaration, as with the example above.
+ *
+ * TODO(user): Improve the recognized definitions.
+ *
+ * @type {!Object<string, (string|number|boolean)>|null|undefined}
  */
 goog.global.CLOSURE_DEFINES;
 
@@ -3175,23 +3182,10 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
         scriptEl.nonce = nonce;
       }
 
-      if (goog.DebugLoader_.IS_OLD_IE_) {
-        // Execution order is not guaranteed on old IE, halt loading and write
-        // these scripts one at a time, after each loads.
-        controller.pause();
-        scriptEl.onreadystatechange = function() {
-          if (scriptEl.readyState == 'loaded' ||
-              scriptEl.readyState == 'complete') {
-            controller.loaded();
-            controller.resume();
-          }
-        };
-      } else {
-        scriptEl.onload = function() {
-          scriptEl.onload = null;
-          controller.loaded();
-        };
-      }
+      scriptEl.onload = function() {
+        scriptEl.onload = null;
+        controller.loaded();
+      };
 
       scriptEl.src = goog.TRUSTED_TYPES_POLICY_ ?
           goog.TRUSTED_TYPES_POLICY_.createScriptURL(this.path) :
@@ -3502,13 +3496,6 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
     // If one thing is pending it is this.
     var anythingElsePending = controller.pending().length > 1;
 
-    // If anything else is loading we need to lazy load due to bugs in old IE.
-    // Specifically script tags with src and script tags with contents could
-    // execute out of order if document.write is used, so we cannot use
-    // document.write. Do not pause here; it breaks old IE as well.
-    var useOldIeWorkAround =
-        anythingElsePending && goog.DebugLoader_.IS_OLD_IE_;
-
     // Additionally if we are meant to defer scripts but the page is still
     // loading (e.g. an ES6 module is loading) then also defer. Or if we are
     // meant to defer and anything else is pending then defer (those may be
@@ -3517,7 +3504,7 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
     var needsAsyncLoading = goog.Dependency.defer_ &&
         (anythingElsePending || goog.isDocumentLoading_());
 
-    if (useOldIeWorkAround || needsAsyncLoading) {
+    if (needsAsyncLoading) {
       // Note that we only defer when we have to rather than 100% of the time.
       // Always defering would work, but then in theory the order of
       // goog.require calls would then matter. We want to enforce that most of
@@ -3561,8 +3548,7 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
       };
     } else {
       // Always eval on old IE.
-      if (goog.DebugLoader_.IS_OLD_IE_ || !goog.inHtmlDocument_() ||
-          !goog.isDocumentLoading_()) {
+      if (!goog.inHtmlDocument_() || !goog.isDocumentLoading_()) {
         load();
       } else {
         fetchInOwnScriptThenLoad();
@@ -3704,15 +3690,6 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
           ');';
     }
   };
-
-
-  /**
-   * Whether the browser is IE9 or earlier, which needs special handling
-   * for deferred modules.
-   * @const @private {boolean}
-   */
-  goog.DebugLoader_.IS_OLD_IE_ = !!(
-      !goog.global.atob && goog.global.document && goog.global.document['all']);
 
 
   /**

--- a/closure/goog/goog.js
+++ b/closure/goog/goog.js
@@ -1,0 +1,99 @@
+// Copyright 2018 The Closure Library Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview ES6 module that exports symbols from base.js so that ES6
+ * modules do not need to use globals and so that is clear if a project is using
+ * Closure's base.js file. It is also a subset of properties in base.js, meaning
+ * it should be clearer what should not be used in ES6 modules
+ * (goog.module/provide are not exported here, for example). Though that is not
+ * to say that everything in this file should be used in an ES6 module; some
+ * depreciated functions are exported to make migration easier (e.g.
+ * goog.scope).
+ *
+ * Note that this does not load Closure's base.js file, it is still up to the
+ * programmer to include it. Nor does the fact that this is an ES6 module mean
+ * that projects no longer require deps.js files for debug loading - they do.
+ * Closure will need to load your ES6 modules for you if you have any Closure
+ * file (goog.provide/goog.module) dependencies, as they need to be available
+ * before the ES6 module evaluates.
+ *
+ * Also note that this file has special compiler handling! It is okay to export
+ * anything from this file, but the name also needs to exist on the global goog.
+ * This special compiler pass enforces that you always import this file as
+ * `import * as goog`, as many tools use regex based parsing to find
+ * goog.require calls.
+ */
+
+export const global = goog.global;
+export const require = goog.require;
+export const define = goog.define;
+export const DEBUG = goog.DEBUG;
+export const LOCALE = goog.LOCALE;
+export const TRUSTED_SITE = goog.TRUSTED_SITE;
+export const DISALLOW_TEST_ONLY_CODE = goog.DISALLOW_TEST_ONLY_CODE;
+export const getGoogModule = goog.module.get;
+export const setTestOnly = goog.setTestOnly;
+export const forwardDeclare = goog.forwardDeclare;
+export const getObjectByName = goog.getObjectByName;
+export const basePath = goog.basePath;
+export const addSingletonGetter = goog.addSingletonGetter;
+export const typeOf = goog.typeOf;
+export const isArrayLike = goog.isArrayLike;
+export const isDateLike = goog.isDateLike;
+export const isObject = goog.isObject;
+export const getUid = goog.getUid;
+export const hasUid = goog.hasUid;
+export const removeUid = goog.removeUid;
+export const mixin = goog.mixin;
+export const now = Date.now;
+export const globalEval = goog.globalEval;
+export const getCssName = goog.getCssName;
+export const setCssNameMapping = goog.setCssNameMapping;
+export const getMsg = goog.getMsg;
+export const getMsgWithFallback = goog.getMsgWithFallback;
+export const exportSymbol = goog.exportSymbol;
+export const exportProperty = goog.exportProperty;
+export const nullFunction = goog.nullFunction;
+export const abstractMethod = goog.abstractMethod;
+export const cloneObject = goog.cloneObject;
+export const bind = goog.bind;
+export const partial = goog.partial;
+export const inherits = goog.inherits;
+export const scope = goog.scope;
+export const defineClass = goog.defineClass;
+export const declareModuleId = goog.declareModuleId;
+
+// Export select properties of module. Do not export the function itself or
+// goog.module.declareLegacyNamespace.
+export const module = {
+  get: goog.module.get,
+};
+
+// Omissions include:
+// goog.ENABLE_DEBUG_LOADER - define only used in base.
+// goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING - define only used in base.
+// goog.provide - ES6 modules do not provide anything.
+// goog.module - ES6 modules cannot be goog.modules.
+// goog.module.declareLegacyNamespace - ES6 modules cannot declare namespaces.
+// goog.addDependency - meant to only be used by dependency files.
+// goog.DEPENDENCIES_ENABLED - constant only used in base.
+// goog.TRANSPILE - define only used in base.
+// goog.TRANSPILER - define only used in base.
+// goog.loadModule - should not be called by any ES6 module; exists for
+//   generated bundles.
+// goog.LOAD_MODULE_USING_EVAL - define only used in base.
+// goog.SEAL_MODULE_EXPORTS - define only used in base.
+// goog.DebugLoader - used rarely, only outside of compiled code.
+// goog.Transpiler - used rarely, only outside of compiled code.

--- a/tests/deps.js
+++ b/tests/deps.js
@@ -323,4 +323,5 @@ goog.addDependency('../../generators/python/variables.js', ['Blockly.Python.vari
 goog.addDependency('../../generators/python/variables_dynamic.js', ['Blockly.Python.variablesDynamic'], ['Blockly.Python', 'Blockly.Python.variables'], {'lang': 'es6', 'module': 'goog'});
 goog.addDependency('base.js', [], []);
 goog.addDependency('base_minimal.js', [], []);
+goog.addDependency('goog.js', [], [], {'lang': 'es6', 'module': 'es6'});
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -5,7 +5,7 @@
 <title>Blockly Playground</title>
 
   <!-- This script loads uncompressed when on localhost and loads compressed when it is being hosted.
-       Please add any other dependencies to playgrounds/load_all.js.-->
+       Please add any other dependencies to playgrounds/prepare.js.-->
 <script src="playgrounds/prepare.js"></script>
 <script type=module>
 import Blockly from './playgrounds/blockly.mjs';

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -6,10 +6,11 @@
 
   <!-- This script loads uncompressed when on localhost and loads compressed when it is being hosted.
        Please add any other dependencies to playgrounds/load_all.js.-->
-<script src="playgrounds/load_all.js"></script>
-<script>
-'use strict';
+<script src="playgrounds/prepare.js"></script>
+<script type=module>
+import Blockly from './playgrounds/blockly.mjs';
 
+console.log("MAIN SCRIPT START");
 const IS_UNCOMPRESSED = !!document.getElementById('blockly-uncompressed-script');
 var workspace = null;
 
@@ -381,6 +382,13 @@ var spaghettiXml = [
     'next': { }
   });
 
+// Call start().  Because this <script> has type=module, it is
+// automatically deferred, so it will not be run until after the
+// document has been parsed, but before firing DOMContentLoaded.
+  
+start();
+
+console.log("MAIN SCRIPT END");
 </script>
 
 <style>
@@ -430,7 +438,7 @@ var spaghettiXml = [
   }
 </style>
 </head>
-<body onload="start()">
+<body>
 
   <div id="blocklyDiv"></div>
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -10,8 +10,7 @@
 <script type=module>
 import Blockly from './playgrounds/blockly.mjs';
 
-console.log("MAIN SCRIPT START");
-const IS_UNCOMPRESSED = !!document.getElementById('blockly-uncompressed-script');
+const IS_UNCOMPRESSED = Boolean(window.BlocklyLoader);  // See prepare.js
 var workspace = null;
 
 function start() {
@@ -388,7 +387,6 @@ var spaghettiXml = [
   
 start();
 
-console.log("MAIN SCRIPT END");
 </script>
 
 <style>

--- a/tests/playgrounds/blockly.mjs
+++ b/tests/playgrounds/blockly.mjs
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,6 +17,8 @@
  *     You must use a <script> tag to load prepare.js first, before
  *     importing this module in a <script type=module> to obtain the
  *     loaded value.
+ *
+ *     See tests/playground.html for example usage.
  */
 
 let Blockly;

--- a/tests/playgrounds/blockly.mjs
+++ b/tests/playgrounds/blockly.mjs
@@ -32,11 +32,25 @@ if ('goog' in globalThis) {
   // (https://v8.dev/features/top-level-await) to block loading of
   // this module until goog.bootstrap()ping of Blockly is finished.
   await new Promise((resolve, reject) => {
+    goog.bootstrap(['Blockly'], resolve);
+  });
+  
+  // Retrieve loaded module.
+  Blockly = goog.module.get('Blockly');
+
+  // Copy Messages from temporary Blockly.Msg object to the real one:
+  Object.assign(Blockly.Msg, window.BlocklyMsg);
+
+  await new Promise((resolve, reject) => {
     goog.bootstrap(
-        ['Blockly', 'Blockly.blocks.all', 'Blockly.JavaScript.all'], () => {
-          Blockly = goog.module.get('Blockly');
-          resolve();
-        });
+        [
+          'Blockly.blocks.all',
+          'Blockly.Dart.all',
+          'Blockly.JavaScript.all',
+          'Blockly.Lua.all',
+          'Blockly.PHP.all',
+          'Blockly.Python.all',
+        ], resolve);
   });
 } else {
   // Compiled mode.  Retrieve the pre-installed Blockly global.

--- a/tests/playgrounds/blockly.mjs
+++ b/tests/playgrounds/blockly.mjs
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Finishes loading Blockly and exports it as this
+ *     module's default export.
+ *
+ *     It is exported as the default export to avoid having to
+ *     re-export each property on Blockly individually, because you
+ *     can't do:
+ *
+ *         export * from <dynamically computed source>;  // SYNTAX ERROR
+ */
+
+// We don't
+//
+//   import * as goog from '../../closure/goog/goog.js';
+//
+// here as that will fail if we're in compiled mode and prepare.js did
+// not load base.js.  Just access goog directly from the global scope;
+// this is fine because this file is never run through Closure
+// Compiler, and only it cares about using the goog.js module instead
+// of the goog global.
+
+let Blockly;
+
+if ('goog' in globalThis) {
+  // Uncompiled mode.  Use top-level await
+  // (https://v8.dev/features/top-level-await) to block loading of
+  // this module until goog.bootstrap()ping of Blockly is finished.
+  await new Promise((resolve, reject) => {
+    goog.bootstrap(
+        ['Blockly', 'Blockly.blocks.all', 'Blockly.JavaScript.all'], () => {
+          Blockly = goog.module.get('Blockly');
+          resolve();
+        });
+  });
+} else {
+  // Compiled mode.  Retrieve the pre-installed Blockly global.
+  if (!('Blockly' in globalThis)) {
+    throw new Error('blockly_compressed.js not loaded');
+  }
+  Blockly = globalThis.Blockly;
+}
+
+export default Blockly;

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -7,6 +7,10 @@
 /**
  * @fileoverview Load this file in a <script> tag to prepare for
  *     importing Blockly into a web page.
+ *
+ *     You must use a <script> tag to load this script first, then
+ *     import blockly.mjs in a <script type=module> to obtain the
+ *     loaded value.
  */
 'use strict';
 
@@ -30,7 +34,7 @@
     // deps.js, run `npm run build:deps`.
     document.write('<script src="../../tests/deps.js"></script>');
 
-    // Msg loading hack.  This should go away once #5409 and/or
+    // Msg loading kludge.  This should go away once #5409 and/or
     // #1895 are fixed.
 
     // Load messages into a temporary Blockly.Msg object, deleting it
@@ -41,6 +45,27 @@
         <script>
           window.BlocklyMsg = window.Blockly.Msg;
           delete window.Blockly;
+        </script>`);
+
+    document.write(`
+        <script>
+          window.BlocklyLoader = new Promise((resolve, reject) => {
+            goog.bootstrap(
+                [
+                  'Blockly',
+                  'Blockly.blocks.all',
+                  'Blockly.Dart.all',
+                  'Blockly.JavaScript.all',
+                  'Blockly.Lua.all',
+                  'Blockly.PHP.all',
+                  'Blockly.Python.all',
+                ], resolve);
+          }).then(() => {
+            // Copy Messages from temporary Blockly.Msg object to the real one:
+            Object.assign(goog.module.get('Blockly').Msg, window.BlocklyMsg);
+          }).then(() => {
+            return goog.module.get('Blockly');
+          });
         </script>`);
   } else {
     // We need to load Blockly in compiled mode.

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -21,7 +21,7 @@
     // We can load Blockly in uncompiled mode.
 
     // Disable loading of closure/goog/deps.js (which doesn't exist).
-    globalThis.CLOSURE_NO_DEPS = true;
+    window.CLOSURE_NO_DEPS = true;
     // Load the Closure Library's base.js (the only part of the
     // libary we use, mainly for goog.require / goog.provide /
     // goog.module).
@@ -29,6 +29,19 @@
     // Load dependency graph info from test/deps.js.  To update
     // deps.js, run `npm run build:deps`.
     document.write('<script src="../../tests/deps.js"></script>');
+
+    // Msg loading hack.  This should go away once #5409 and/or
+    // #1895 are fixed.
+
+    // Load messages into a temporary Blockly.Msg object, deleting it
+    // afterwards (after saving the messages!)
+    window.Blockly = {Msg: Object.create(null)};
+    document.write('<script src="../../msg/messages.js"></script>');
+    document.write(`
+        <script>
+          window.BlocklyMsg = window.Blockly.Msg;
+          delete window.Blockly;
+        </script>`);
   } else {
     // We need to load Blockly in compiled mode.
 

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -11,6 +11,8 @@
  *     You must use a <script> tag to load this script first, then
  *     import blockly.mjs in a <script type=module> to obtain the
  *     loaded value.
+ *
+ *     See tests/playground.html for example usage.
  */
 'use strict';
 

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Load this file in a <script> tag to prepare for
+ *     importing Blockly into a web page.
+ */
+'use strict';
+
+(function() {
+  // Decide whether we can load Blockly uncompiled, or must load the
+  // compiled version.  Please see issue #5557 for more information.
+  const isIe = navigator.userAgent.indexOf('MSIE') !== -1 ||
+      navigator.appVersion.indexOf('Trident/') > -1;
+  const localhosts = ['localhost', '127.0.0.1', '[::1]'];
+
+  if (localhosts.includes(location.hostname) && !isIe) {
+    // We can load Blockly in uncompiled mode.
+
+    // Disable loading of closure/goog/deps.js (which doesn't exist).
+    globalThis.CLOSURE_NO_DEPS = true;
+    // Load the Closure Library's base.js (the only part of the
+    // libary we use, mainly for goog.require / goog.provide /
+    // goog.module).
+    document.write('<script src="../../closure/goog/base.js"></script>');
+    // Load dependency graph info from test/deps.js.  To update
+    // deps.js, run `npm run build:deps`.
+    document.write('<script src="../../tests/deps.js"></script>');
+  } else {
+    // We need to load Blockly in compiled mode.
+
+    // Load blockly_compressed.js et al. using <script> tags.
+    document.write('<script src="../../blockly_compressed.js"></script>');
+    document.write('<script src="../../dart_compressed.js"></script>');
+    document.write('<script src="../../javascript_compressed.js"></script>');
+    document.write('<script src="../../lua_compressed.js"></script>');
+    document.write('<script src="../../php_compressed.js"></script>');
+    document.write('<script src="../../python_compressed.js"></script>');
+    document.write('<script src="../../blocks_compressed.js"></script>');
+    document.write('<script src="../../msg/messages.js"></script>');
+  }
+})();


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5904.

### Proposed Changes

Change how `tests/playground.html` loads Blockly.

#### Behaviour Before Change

* `playground.html` would use a `<script>` tag to load `tests/playgrounds/load_all.js`
  * which in turn would (in uncompiled mode) use a `<script>` tag to load `blockly_uncompressed.js` from the project root
    * which in turn used further `<script>` tags to load `base.js` and `deps.js` and then finally do a `goog.require('Blockly')` call to get the debug module loader to load `core/*`.
  * After this, `load_all.js` would use further `<script>` tags to load `msg/messages.js`, `tests/themes/test_themes.js` and `@blockly/block-test`.
* Finally, a `<body onload="...">` would call the `start` function in `playground.html`.

#### Behaviour After Change

* `playground.html` will use a `<script>` tag to load `tests/playgrounds/prepare.js`
  * which in turn will (in uncompiled mode) use `<script>` tags to load `base.js`, `deps.js`, and `msg/messages.js`.
  * It will then create a Promise, stored on `window.BlocklyLoader`, that will:
    *  Call `goog.bootstrap()`, passing in a list of the top-level entrypoints (`Blockly`, `Blockly.blocks.all`, `Blockly.Javascript.all`, etc.)
    * Copy messages loaded from `msg/messages.js` from where they were temporarily stored into `Blockly.Msg`.
    * Resolve to a value that is the `Blockly` module exports object.
* `playground.html` will then use an inline `<script type=module>` to `import` `tests/playgrounds/blockly.mjs`,
  * which will `await` the resolution of the loader Promise, and `export` the returned value.
* The inline module will then call `start()` directly, which is safe because the page will have been loaded by this point.

(In compiled mode, `prepare.js` will load `blockly_compressed.js` et al. using the same implementation as `load_all.js` did previously.)

### Reason for Changes

Because the debug loader loads ES modules using `<script type=module>` tags, their loading is deferred until after all the top level (non-`module`) `<script>` tags have been run.  This means that any ES modules (and any `goog.module`s that depend on them, including the root `Blockly` module) will not be loaded in time to call `Blockly.inject` from the start script.

### Test Coverage

Tested on:
* Desktop Chrome

Also passes `npm test`.

### Documentation

Once the dust has settled, we probably ought to update any documentation that we have that discusses loading Blockly in uncompiled mode since any previous sample code snippets will not work.

### Additional Information & questions

* This only addresses `tests/playground.html`, not any of the other playgrounds, tests, samples, etc.
* Earlier I was encountering difficulty with blocks modules' initialisation code being run before `Blockly.Msg` had been populated, but moving the `goog.bootstrap` call from `blockly.mjs` (executed after page has loaded) to `prepare.js` seems to fixed this problem as well.
  * It may however reoccur when blocks modules's dependencies are migrated to ES module, causing both the dependency and the dependent block module evaluation to be delayed until after the page has been loaded.
* **I have omitted loading `tests/themes/test_themes.js` and `@blockly/block-test`** as these were not being loaded in compiled mode.
  * Do we want to load them in uncompiled mode?
  * Ought they also to be loaded in compiled mode?
