### PR TITLE
Add block's comment from JSON definition

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1113,6 +1113,9 @@ Blockly.Block.prototype.jsonInit = function(json) {
     var localizedValue = Blockly.utils.replaceMessageReferences(rawValue);
     this.setHelpUrl(localizedValue);
   }
+  if (json['commentText'] !== undefined) {
+    this.setCommentText(json['commentText']);
+  }
   if (goog.isString(json['extensions'])) {
     console.warn('JSON attribute \'extensions\' should be an array of ' +
       'strings. Found raw string in JSON for \'' + json['type'] + '\' block.');


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ x] I branched from develop
- [ x] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Resolves issue [#5936](https://github.com/google/blockly/issues/5936)


### Proposed Changes

This pull requests checks the presence of the "commentText" key in a JSON Block definition and if such key exists add the comment to the block.

```
if (json['commentText'] !== undefined) {
    this.setCommentText(json['commentText']);
}
```

#### Behavior Before Change

 Comment is not added 
![image](https://user-images.githubusercontent.com/10393245/153862156-dd9e54f2-618f-4760-9c02-896db577c752.png)
                                                                                                                                       

#### Behavior After Change

![image](https://user-images.githubusercontent.com/10393245/153862225-09b6d710-eb82-4911-a8b6-a60f8b31cb72.png)


### Reason for Changes

Current implementation doesn't check the key "commentText" in the Json definition of a block

### Test Coverage


<!-- Tested on: -->
 * Desktop Chrome 
 * Desktop Firefox 
 * Desktop Safari
 * Desktop Opera



### Documentation

Not needed

### Additional Information

<!-- Anything else we should know? -->
