### PR TITLE
refactor: convert registry files to es6 classes

### DIFF
--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -25,21 +25,101 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  * Class for the registry of context menu items. This is intended to be a
  * singleton. You should not create a new instance, and only access this class
  * from ContextMenuRegistry.registry.
- * @constructor
- * @private
- * @alias Blockly.ContextMenuRegistry
  */
-const ContextMenuRegistry = function() {
-  // Singleton instance should be registered once.
-  ContextMenuRegistry.registry = this;
+class ContextMenuRegistry {
+  /**
+   * @alias Blockly.ContextMenuRegistry
+   */
+  constructor() {
+    this.reset();
+  }
 
   /**
-   * Registry of all registered RegistryItems, keyed by ID.
-   * @type {!Object<string, !ContextMenuRegistry.RegistryItem>}
-   * @private
+   * Clear and recreate the registry.
    */
-  this.registry_ = Object.create(null);
-};
+  reset() {
+    /**
+     * Registry of all registered RegistryItems, keyed by ID.
+     * @type {!Object<string, !ContextMenuRegistry.RegistryItem>}
+     * @private
+     */
+    this.registry_ = Object.create(null);
+  }
+
+  /**
+   * Registers a RegistryItem.
+   * @param {!ContextMenuRegistry.RegistryItem} item Context menu item to
+   *     register.
+   * @throws {Error} if an item with the given ID already exists.
+   */
+  register(item) {
+    if (this.registry_[item.id]) {
+      throw Error('Menu item with ID "' + item.id + '" is already registered.');
+    }
+    this.registry_[item.id] = item;
+  }
+
+  /**
+   * Unregisters a RegistryItem with the given ID.
+   * @param {string} id The ID of the RegistryItem to remove.
+   * @throws {Error} if an item with the given ID does not exist.
+   */
+  unregister(id) {
+    if (!this.registry_[id]) {
+      throw new Error('Menu item with ID "' + id + '" not found.');
+    }
+    delete this.registry_[id];
+  }
+
+  /**
+   * @param {string} id The ID of the RegistryItem to get.
+   * @return {?ContextMenuRegistry.RegistryItem} RegistryItem or null if not found
+   */
+  getItem(id) {
+    return this.registry_[id] || null;
+  }
+
+  /**
+   * Gets the valid context menu options for the given scope type (e.g. block or
+   * workspace) and scope. Blocks are only shown if the preconditionFn shows they
+   * should not be hidden.
+   * @param {!ContextMenuRegistry.ScopeType} scopeType Type of scope where menu
+   *     should be shown (e.g. on a block or on a workspace)
+   * @param {!ContextMenuRegistry.Scope} scope Current scope of context menu
+   *     (i.e., the exact workspace or block being clicked on)
+   * @return {!Array<!ContextMenuRegistry.ContextMenuOption>} the list of
+   *     ContextMenuOptions
+   */
+  getContextMenuOptions(
+      scopeType, scope) {
+    const menuOptions = [];
+    const registry = this.registry_;
+    Object.keys(registry).forEach(function(id) {
+      const item = registry[id];
+      if (scopeType === item.scopeType) {
+        const precondition = item.preconditionFn(scope);
+        if (precondition !== 'hidden') {
+          const displayText = typeof item.displayText === 'function' ?
+              item.displayText(scope) :
+              item.displayText;
+          /** @type {!ContextMenuRegistry.ContextMenuOption} */
+          const menuOption = {
+            text: displayText,
+            enabled: (precondition === 'enabled'),
+            callback: item.callback,
+            scope: scope,
+            weight: item.weight,
+          };
+          menuOptions.push(menuOption);
+        }
+      }
+    });
+    menuOptions.sort(function(a, b) {
+      return a.weight - b.weight;
+    });
+    return menuOptions;
+  }
+}
 
 /**
  * Where this menu item should be rendered. If the menu item should be rendered
@@ -90,85 +170,9 @@ ContextMenuRegistry.ContextMenuOption;
 /**
  * Singleton instance of this class. All interactions with this class should be
  * done on this object.
- * @type {?ContextMenuRegistry}
+ * @type {!ContextMenuRegistry}
  */
-ContextMenuRegistry.registry = null;
+ContextMenuRegistry.registry = new ContextMenuRegistry();
 
-/**
- * Registers a RegistryItem.
- * @param {!ContextMenuRegistry.RegistryItem} item Context menu item to
- *     register.
- * @throws {Error} if an item with the given ID already exists.
- */
-ContextMenuRegistry.prototype.register = function(item) {
-  if (this.registry_[item.id]) {
-    throw Error('Menu item with ID "' + item.id + '" is already registered.');
-  }
-  this.registry_[item.id] = item;
-};
-
-/**
- * Unregisters a RegistryItem with the given ID.
- * @param {string} id The ID of the RegistryItem to remove.
- * @throws {Error} if an item with the given ID does not exist.
- */
-ContextMenuRegistry.prototype.unregister = function(id) {
-  if (!this.registry_[id]) {
-    throw new Error('Menu item with ID "' + id + '" not found.');
-  }
-  delete this.registry_[id];
-};
-
-/**
- * @param {string} id The ID of the RegistryItem to get.
- * @return {?ContextMenuRegistry.RegistryItem} RegistryItem or null if not found
- */
-ContextMenuRegistry.prototype.getItem = function(id) {
-  return this.registry_[id] || null;
-};
-
-/**
- * Gets the valid context menu options for the given scope type (e.g. block or
- * workspace) and scope. Blocks are only shown if the preconditionFn shows they
- * should not be hidden.
- * @param {!ContextMenuRegistry.ScopeType} scopeType Type of scope where menu
- *     should be shown (e.g. on a block or on a workspace)
- * @param {!ContextMenuRegistry.Scope} scope Current scope of context menu
- *     (i.e., the exact workspace or block being clicked on)
- * @return {!Array<!ContextMenuRegistry.ContextMenuOption>} the list of
- *     ContextMenuOptions
- */
-ContextMenuRegistry.prototype.getContextMenuOptions = function(
-    scopeType, scope) {
-  const menuOptions = [];
-  const registry = this.registry_;
-  Object.keys(registry).forEach(function(id) {
-    const item = registry[id];
-    if (scopeType === item.scopeType) {
-      const precondition = item.preconditionFn(scope);
-      if (precondition !== 'hidden') {
-        const displayText = typeof item.displayText === 'function' ?
-            item.displayText(scope) :
-            item.displayText;
-        /** @type {!ContextMenuRegistry.ContextMenuOption} */
-        const menuOption = {
-          text: displayText,
-          enabled: (precondition === 'enabled'),
-          callback: item.callback,
-          scope: scope,
-          weight: item.weight,
-        };
-        menuOptions.push(menuOption);
-      }
-    }
-  });
-  menuOptions.sort(function(a, b) {
-    return a.weight - b.weight;
-  });
-  return menuOptions;
-};
-
-// Creates and assigns the singleton instance.
-new ContextMenuRegistry();
-
+exports.contextMenuRegistry = ContextMenuRegistry.registry;
 exports.ContextMenuRegistry = ContextMenuRegistry;

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -73,7 +73,8 @@ class ContextMenuRegistry {
 
   /**
    * @param {string} id The ID of the RegistryItem to get.
-   * @return {?ContextMenuRegistry.RegistryItem} RegistryItem or null if not found
+   * @return {?ContextMenuRegistry.RegistryItem} RegistryItem or null if not
+   *     found
    */
   getItem(id) {
     return this.registry_[id] || null;
@@ -81,8 +82,8 @@ class ContextMenuRegistry {
 
   /**
    * Gets the valid context menu options for the given scope type (e.g. block or
-   * workspace) and scope. Blocks are only shown if the preconditionFn shows they
-   * should not be hidden.
+   * workspace) and scope. Blocks are only shown if the preconditionFn shows
+   * they should not be hidden.
    * @param {!ContextMenuRegistry.ScopeType} scopeType Type of scope where menu
    *     should be shown (e.g. on a block or on a workspace)
    * @param {!ContextMenuRegistry.Scope} scope Current scope of context menu
@@ -90,8 +91,7 @@ class ContextMenuRegistry {
    * @return {!Array<!ContextMenuRegistry.ContextMenuOption>} the list of
    *     ContextMenuOptions
    */
-  getContextMenuOptions(
-      scopeType, scope) {
+  getContextMenuOptions(scopeType, scope) {
     const menuOptions = [];
     const registry = this.registry_;
     Object.keys(registry).forEach(function(id) {

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -174,5 +174,4 @@ ContextMenuRegistry.ContextMenuOption;
  */
 ContextMenuRegistry.registry = new ContextMenuRegistry();
 
-exports.contextMenuRegistry = ContextMenuRegistry.registry;
 exports.ContextMenuRegistry = ContextMenuRegistry;

--- a/core/registry.js
+++ b/core/registry.js
@@ -73,28 +73,31 @@ exports.DEFAULT = DEFAULT;
 
 /**
  * A name with the type of the element stored in the generic.
- * @param {string} name The name of the registry type.
- * @constructor
  * @template T
  * @alias Blockly.registry.Type
  */
-const Type = function(name) {
+class Type {
   /**
-   * @type {string}
-   * @private
+   * @param {string} name The name of the registry type.
    */
-  this.name_ = name;
-};
+  constructor(name) {
+    /**
+     * @type {string}
+     * @private
+     */
+    this.name_ = name;
+  }
+
+  /**
+   * Returns the name of the type.
+   * @return {string} The name.
+   */
+  toString() {
+    return this.name_;
+  }
+}
 exports.Type = Type;
 
-/**
- * Returns the name of the type.
- * @return {string} The name.
- * @override
- */
-Type.prototype.toString = function() {
-  return this.name_;
-};
 
 /** @type {!Type<IConnectionChecker>} */
 Type.CONNECTION_CHECKER = new Type('connectionChecker');

--- a/core/registry.js
+++ b/core/registry.js
@@ -74,11 +74,11 @@ exports.DEFAULT = DEFAULT;
 /**
  * A name with the type of the element stored in the generic.
  * @template T
- * @alias Blockly.registry.Type
  */
 class Type {
   /**
    * @param {string} name The name of the registry type.
+   * @alias Blockly.registry.Type
    */
   constructor(name) {
     /**

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -33,8 +33,6 @@ class ShortcutRegistry {
    * @alias Blockly.ShortcutRegistry
    */
   constructor() {
-    // Singleton instance should be registered once.
-    // ShortcutRegistry.registry = this;
     this.reset();
   }
 

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -74,8 +74,8 @@ class ShortcutRegistry {
   }
 
   /**
-   * Unregisters a keyboard shortcut registered with the given key code. This will
-   * also remove any key mappings that reference this shortcut.
+   * Unregisters a keyboard shortcut registered with the given key code. This
+   * will also remove any key mappings that reference this shortcut.
    * @param {string} shortcutName The name of the shortcut to unregister.
    * @return {boolean} True if an item was unregistered, false otherwise.
    * @public
@@ -107,8 +107,7 @@ class ShortcutRegistry {
    * @throws {Error} if the given key code is already mapped to a shortcut.
    * @public
    */
-  addKeyMapping(
-      keyCode, shortcutName, opt_allowCollision) {
+  addKeyMapping(keyCode, shortcutName, opt_allowCollision) {
     keyCode = String(keyCode);
     const shortcutNames = this.keyMap_[keyCode];
     if (shortcutNames && !opt_allowCollision) {
@@ -134,8 +133,7 @@ class ShortcutRegistry {
    * @return {boolean} True if a key mapping was removed, false otherwise.
    * @public
    */
-  removeKeyMapping(
-      keyCode, shortcutName, opt_quiet) {
+  removeKeyMapping(keyCode, shortcutName, opt_quiet) {
     const shortcutNames = this.keyMap_[keyCode];
 
     if (!shortcutNames && !opt_quiet) {
@@ -163,10 +161,10 @@ class ShortcutRegistry {
 
   /**
    * Removes all the key mappings for a shortcut with the given name.
-   * Useful when changing the default key mappings and the key codes registered to
-   * the shortcut are unknown.
-   * @param {string} shortcutName The name of the shortcut to remove from the key
-   *     map.
+   * Useful when changing the default key mappings and the key codes registered
+   * to the shortcut are unknown.
+   * @param {string} shortcutName The name of the shortcut to remove from the
+   *     key map.
    * @public
    */
   removeAllKeyMappings(shortcutName) {
@@ -176,7 +174,8 @@ class ShortcutRegistry {
   }
 
   /**
-   * Sets the key map. Setting the key map will override any default key mappings.
+   * Sets the key map. Setting the key map will override any default key
+   * mappings.
    * @param {!Object<string, !Array<string>>} keyMap The object with key code to
    *     shortcut names.
    * @public
@@ -288,7 +287,8 @@ class ShortcutRegistry {
 
   /**
    * Checks whether any of the given modifiers are not valid.
-   * @param {!Array<string>} modifiers List of modifiers to be used with the key.
+   * @param {!Array<string>} modifiers List of modifiers to be used with the
+   *     key.
    * @throws {Error} if the modifier is not in the valid modifiers list.
    * @private
    */
@@ -304,8 +304,8 @@ class ShortcutRegistry {
   /**
    * Creates the serialized key code that will be used in the key map.
    * @param {number} keyCode Number code representing the key.
-   * @param {?Array<string>} modifiers List of modifier key codes to be used with
-   *     the key. All valid modifiers can be found in the
+   * @param {?Array<string>} modifiers List of modifier key codes to be used
+   *     with the key. All valid modifiers can be found in the
    *     ShortcutRegistry.modifierKeys.
    * @return {string} The serialized key code for the given modifiers and key.
    * @public

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -27,27 +27,315 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
  * Class for the registry of keyboard shortcuts. This is intended to be a
  * singleton. You should not create a new instance, and only access this class
  * from ShortcutRegistry.registry.
- * @constructor
- * @alias Blockly.ShortcutRegistry
  */
-const ShortcutRegistry = function() {
-  // Singleton instance should be registered once.
-  ShortcutRegistry.registry = this;
+class ShortcutRegistry {
+  /**
+   * @alias Blockly.ShortcutRegistry
+   */
+  constructor() {
+    // Singleton instance should be registered once.
+    // ShortcutRegistry.registry = this;
+    this.reset();
+  }
 
   /**
-   * Registry of all keyboard shortcuts, keyed by name of shortcut.
-   * @type {!Object<string, !ShortcutRegistry.KeyboardShortcut>}
-   * @private
+   * Clear and recreate the registry and keyMap.
    */
-  this.registry_ = Object.create(null);
+  reset() {
+    /**
+     * Registry of all keyboard shortcuts, keyed by name of shortcut.
+     * @type {!Object<string, !ShortcutRegistry.KeyboardShortcut>}
+     * @private
+     */
+    this.registry_ = Object.create(null);
+
+    /**
+     * Map of key codes to an array of shortcut names.
+     * @type {!Object<string, !Array<string>>}
+     * @private
+     */
+    this.keyMap_ = Object.create(null);
+  }
 
   /**
-   * Map of key codes to an array of shortcut names.
-   * @type {!Object<string, !Array<string>>}
+   * Registers a keyboard shortcut.
+   * @param {!ShortcutRegistry.KeyboardShortcut} shortcut The
+   *     shortcut for this key code.
+   * @param {boolean=} opt_allowOverrides True to prevent a warning when
+   *     overriding an already registered item.
+   * @throws {Error} if a shortcut with the same name already exists.
+   * @public
+   */
+  register(shortcut, opt_allowOverrides) {
+    const registeredShortcut = this.registry_[shortcut.name];
+    if (registeredShortcut && !opt_allowOverrides) {
+      throw new Error(
+          'Shortcut with name "' + shortcut.name + '" already exists.');
+    }
+    this.registry_[shortcut.name] = shortcut;
+  }
+
+  /**
+   * Unregisters a keyboard shortcut registered with the given key code. This will
+   * also remove any key mappings that reference this shortcut.
+   * @param {string} shortcutName The name of the shortcut to unregister.
+   * @return {boolean} True if an item was unregistered, false otherwise.
+   * @public
+   */
+  unregister(shortcutName) {
+    const shortcut = this.registry_[shortcutName];
+
+    if (!shortcut) {
+      console.warn(
+          'Keyboard shortcut with name "' + shortcutName + '" not found.');
+      return false;
+    }
+
+    this.removeAllKeyMappings(shortcutName);
+
+    delete this.registry_[shortcutName];
+    return true;
+  }
+
+  /**
+   * Adds a mapping between a keycode and a keyboard shortcut.
+   * @param {string|KeyCodes} keyCode The key code for the keyboard
+   *     shortcut. If registering a key code with a modifier (ex: ctrl+c) use
+   *     ShortcutRegistry.registry.createSerializedKey;
+   * @param {string} shortcutName The name of the shortcut to execute when the
+   *     given keycode is pressed.
+   * @param {boolean=} opt_allowCollision True to prevent an error when adding a
+   *     shortcut to a key that is already mapped to a shortcut.
+   * @throws {Error} if the given key code is already mapped to a shortcut.
+   * @public
+   */
+  addKeyMapping(
+      keyCode, shortcutName, opt_allowCollision) {
+    keyCode = String(keyCode);
+    const shortcutNames = this.keyMap_[keyCode];
+    if (shortcutNames && !opt_allowCollision) {
+      throw new Error(
+          'Shortcut with name "' + shortcutName + '" collides with shortcuts ' +
+          shortcutNames.toString());
+    } else if (shortcutNames && opt_allowCollision) {
+      shortcutNames.unshift(shortcutName);
+    } else {
+      this.keyMap_[keyCode] = [shortcutName];
+    }
+  }
+
+  /**
+   * Removes a mapping between a keycode and a keyboard shortcut.
+   * @param {string} keyCode The key code for the keyboard shortcut. If
+   *     registering a key code with a modifier (ex: ctrl+c) use
+   *     ShortcutRegistry.registry.createSerializedKey;
+   * @param {string} shortcutName The name of the shortcut to execute when the
+   *     given keycode is pressed.
+   * @param {boolean=} opt_quiet True to not console warn when there is no
+   *     shortcut to remove.
+   * @return {boolean} True if a key mapping was removed, false otherwise.
+   * @public
+   */
+  removeKeyMapping(
+      keyCode, shortcutName, opt_quiet) {
+    const shortcutNames = this.keyMap_[keyCode];
+
+    if (!shortcutNames && !opt_quiet) {
+      console.warn(
+          'No keyboard shortcut with name "' + shortcutName +
+          '" registered with key code "' + keyCode + '"');
+      return false;
+    }
+
+    const shortcutIdx = shortcutNames.indexOf(shortcutName);
+    if (shortcutIdx > -1) {
+      shortcutNames.splice(shortcutIdx, 1);
+      if (shortcutNames.length === 0) {
+        delete this.keyMap_[keyCode];
+      }
+      return true;
+    }
+    if (!opt_quiet) {
+      console.warn(
+          'No keyboard shortcut with name "' + shortcutName +
+          '" registered with key code "' + keyCode + '"');
+    }
+    return false;
+  }
+
+  /**
+   * Removes all the key mappings for a shortcut with the given name.
+   * Useful when changing the default key mappings and the key codes registered to
+   * the shortcut are unknown.
+   * @param {string} shortcutName The name of the shortcut to remove from the key
+   *     map.
+   * @public
+   */
+  removeAllKeyMappings(shortcutName) {
+    for (const keyCode in this.keyMap_) {
+      this.removeKeyMapping(keyCode, shortcutName, true);
+    }
+  }
+
+  /**
+   * Sets the key map. Setting the key map will override any default key mappings.
+   * @param {!Object<string, !Array<string>>} keyMap The object with key code to
+   *     shortcut names.
+   * @public
+   */
+  setKeyMap(keyMap) {
+    this.keyMap_ = keyMap;
+  }
+
+  /**
+   * Gets the current key map.
+   * @return {!Object<string,!Array<!ShortcutRegistry.KeyboardShortcut>>}
+   *     The object holding key codes to ShortcutRegistry.KeyboardShortcut.
+   * @public
+   */
+  getKeyMap() {
+    return object.deepMerge(Object.create(null), this.keyMap_);
+  }
+
+  /**
+   * Gets the registry of keyboard shortcuts.
+   * @return {!Object<string, !ShortcutRegistry.KeyboardShortcut>}
+   *     The registry of keyboard shortcuts.
+   * @public
+   */
+  getRegistry() {
+    return object.deepMerge(Object.create(null), this.registry_);
+  }
+
+  /**
+   * Handles key down events.
+   * @param {!Workspace} workspace The main workspace where the event was
+   *     captured.
+   * @param {!Event} e The key down event.
+   * @return {boolean} True if the event was handled, false otherwise.
+   * @public
+   */
+  onKeyDown(workspace, e) {
+    const key = this.serializeKeyEvent_(e);
+    const shortcutNames = this.getShortcutNamesByKeyCode(key);
+    if (!shortcutNames) {
+      return false;
+    }
+    for (let i = 0, shortcutName; (shortcutName = shortcutNames[i]); i++) {
+      const shortcut = this.registry_[shortcutName];
+      if (!shortcut.preconditionFn || shortcut.preconditionFn(workspace)) {
+        // If the key has been handled, stop processing shortcuts.
+        if (shortcut.callback && shortcut.callback(workspace, e, shortcut)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gets the shortcuts registered to the given key code.
+   * @param {string} keyCode The serialized key code.
+   * @return {!Array<string>|undefined} The list of shortcuts to call when the
+   *     given keyCode is used. Undefined if no shortcuts exist.
+   * @public
+   */
+  getShortcutNamesByKeyCode(keyCode) {
+    return this.keyMap_[keyCode] || [];
+  }
+
+  /**
+   * Gets the serialized key codes that the shortcut with the given name is
+   * registered under.
+   * @param {string} shortcutName The name of the shortcut.
+   * @return {!Array<string>} An array with all the key codes the shortcut is
+   *     registered under.
+   * @public
+   */
+  getKeyCodesByShortcutName(shortcutName) {
+    const keys = [];
+    for (const keyCode in this.keyMap_) {
+      const shortcuts = this.keyMap_[keyCode];
+      const shortcutIdx = shortcuts.indexOf(shortcutName);
+      if (shortcutIdx > -1) {
+        keys.push(keyCode);
+      }
+    }
+    return keys;
+  }
+
+  /**
+   * Serializes a key event.
+   * @param {!Event} e A key down event.
+   * @return {string} The serialized key code for the given event.
    * @private
    */
-  this.keyMap_ = Object.create(null);
-};
+  serializeKeyEvent_(e) {
+    let serializedKey = '';
+    for (const modifier in ShortcutRegistry.modifierKeys) {
+      if (e.getModifierState(modifier)) {
+        if (serializedKey !== '') {
+          serializedKey += '+';
+        }
+        serializedKey += modifier;
+      }
+    }
+    if (serializedKey !== '' && e.keyCode) {
+      serializedKey = serializedKey + '+' + e.keyCode;
+    } else if (e.keyCode) {
+      serializedKey = e.keyCode.toString();
+    }
+    return serializedKey;
+  }
+
+  /**
+   * Checks whether any of the given modifiers are not valid.
+   * @param {!Array<string>} modifiers List of modifiers to be used with the key.
+   * @throws {Error} if the modifier is not in the valid modifiers list.
+   * @private
+   */
+  checkModifiers_(modifiers) {
+    const validModifiers = object.values(ShortcutRegistry.modifierKeys);
+    for (let i = 0, modifier; (modifier = modifiers[i]); i++) {
+      if (validModifiers.indexOf(modifier) < 0) {
+        throw new Error(modifier + ' is not a valid modifier key.');
+      }
+    }
+  }
+
+  /**
+   * Creates the serialized key code that will be used in the key map.
+   * @param {number} keyCode Number code representing the key.
+   * @param {?Array<string>} modifiers List of modifier key codes to be used with
+   *     the key. All valid modifiers can be found in the
+   *     ShortcutRegistry.modifierKeys.
+   * @return {string} The serialized key code for the given modifiers and key.
+   * @public
+   */
+  createSerializedKey(keyCode, modifiers) {
+    let serializedKey = '';
+
+    if (modifiers) {
+      this.checkModifiers_(modifiers);
+      for (const modifier in ShortcutRegistry.modifierKeys) {
+        const modifierKeyCode = ShortcutRegistry.modifierKeys[modifier];
+        if (modifiers.indexOf(modifierKeyCode) > -1) {
+          if (serializedKey !== '') {
+            serializedKey += '+';
+          }
+          serializedKey += modifier;
+        }
+      }
+    }
+
+    if (serializedKey !== '' && keyCode) {
+      serializedKey = serializedKey + '+' + keyCode;
+    } else if (keyCode) {
+      serializedKey = keyCode.toString();
+    }
+    return serializedKey;
+  }
+}
 
 /**
  * Enum of valid modifiers.
@@ -72,286 +360,9 @@ ShortcutRegistry.modifierKeys = {
  */
 ShortcutRegistry.KeyboardShortcut;
 
-/**
- * Registers a keyboard shortcut.
- * @param {!ShortcutRegistry.KeyboardShortcut} shortcut The
- *     shortcut for this key code.
- * @param {boolean=} opt_allowOverrides True to prevent a warning when
- *     overriding an already registered item.
- * @throws {Error} if a shortcut with the same name already exists.
- * @public
- */
-ShortcutRegistry.prototype.register = function(shortcut, opt_allowOverrides) {
-  const registeredShortcut = this.registry_[shortcut.name];
-  if (registeredShortcut && !opt_allowOverrides) {
-    throw new Error(
-        'Shortcut with name "' + shortcut.name + '" already exists.');
-  }
-  this.registry_[shortcut.name] = shortcut;
-};
-
-/**
- * Unregisters a keyboard shortcut registered with the given key code. This will
- * also remove any key mappings that reference this shortcut.
- * @param {string} shortcutName The name of the shortcut to unregister.
- * @return {boolean} True if an item was unregistered, false otherwise.
- * @public
- */
-ShortcutRegistry.prototype.unregister = function(shortcutName) {
-  const shortcut = this.registry_[shortcutName];
-
-  if (!shortcut) {
-    console.warn(
-        'Keyboard shortcut with name "' + shortcutName + '" not found.');
-    return false;
-  }
-
-  this.removeAllKeyMappings(shortcutName);
-
-  delete this.registry_[shortcutName];
-  return true;
-};
-
-/**
- * Adds a mapping between a keycode and a keyboard shortcut.
- * @param {string|KeyCodes} keyCode The key code for the keyboard
- *     shortcut. If registering a key code with a modifier (ex: ctrl+c) use
- *     ShortcutRegistry.registry.createSerializedKey;
- * @param {string} shortcutName The name of the shortcut to execute when the
- *     given keycode is pressed.
- * @param {boolean=} opt_allowCollision True to prevent an error when adding a
- *     shortcut to a key that is already mapped to a shortcut.
- * @throws {Error} if the given key code is already mapped to a shortcut.
- * @public
- */
-ShortcutRegistry.prototype.addKeyMapping = function(
-    keyCode, shortcutName, opt_allowCollision) {
-  keyCode = String(keyCode);
-  const shortcutNames = this.keyMap_[keyCode];
-  if (shortcutNames && !opt_allowCollision) {
-    throw new Error(
-        'Shortcut with name "' + shortcutName + '" collides with shortcuts ' +
-        shortcutNames.toString());
-  } else if (shortcutNames && opt_allowCollision) {
-    shortcutNames.unshift(shortcutName);
-  } else {
-    this.keyMap_[keyCode] = [shortcutName];
-  }
-};
-
-/**
- * Removes a mapping between a keycode and a keyboard shortcut.
- * @param {string} keyCode The key code for the keyboard shortcut. If
- *     registering a key code with a modifier (ex: ctrl+c) use
- *     ShortcutRegistry.registry.createSerializedKey;
- * @param {string} shortcutName The name of the shortcut to execute when the
- *     given keycode is pressed.
- * @param {boolean=} opt_quiet True to not console warn when there is no
- *     shortcut to remove.
- * @return {boolean} True if a key mapping was removed, false otherwise.
- * @public
- */
-ShortcutRegistry.prototype.removeKeyMapping = function(
-    keyCode, shortcutName, opt_quiet) {
-  const shortcutNames = this.keyMap_[keyCode];
-
-  if (!shortcutNames && !opt_quiet) {
-    console.warn(
-        'No keyboard shortcut with name "' + shortcutName +
-        '" registered with key code "' + keyCode + '"');
-    return false;
-  }
-
-  const shortcutIdx = shortcutNames.indexOf(shortcutName);
-  if (shortcutIdx > -1) {
-    shortcutNames.splice(shortcutIdx, 1);
-    if (shortcutNames.length === 0) {
-      delete this.keyMap_[keyCode];
-    }
-    return true;
-  }
-  if (!opt_quiet) {
-    console.warn(
-        'No keyboard shortcut with name "' + shortcutName +
-        '" registered with key code "' + keyCode + '"');
-  }
-  return false;
-};
-
-/**
- * Removes all the key mappings for a shortcut with the given name.
- * Useful when changing the default key mappings and the key codes registered to
- * the shortcut are unknown.
- * @param {string} shortcutName The name of the shortcut to remove from the key
- *     map.
- * @public
- */
-ShortcutRegistry.prototype.removeAllKeyMappings = function(shortcutName) {
-  for (const keyCode in this.keyMap_) {
-    this.removeKeyMapping(keyCode, shortcutName, true);
-  }
-};
-
-/**
- * Sets the key map. Setting the key map will override any default key mappings.
- * @param {!Object<string, !Array<string>>} keyMap The object with key code to
- *     shortcut names.
- * @public
- */
-ShortcutRegistry.prototype.setKeyMap = function(keyMap) {
-  this.keyMap_ = keyMap;
-};
-
-/**
- * Gets the current key map.
- * @return {!Object<string,!Array<!ShortcutRegistry.KeyboardShortcut>>}
- *     The object holding key codes to ShortcutRegistry.KeyboardShortcut.
- * @public
- */
-ShortcutRegistry.prototype.getKeyMap = function() {
-  return object.deepMerge(Object.create(null), this.keyMap_);
-};
-
-/**
- * Gets the registry of keyboard shortcuts.
- * @return {!Object<string, !ShortcutRegistry.KeyboardShortcut>}
- *     The registry of keyboard shortcuts.
- * @public
- */
-ShortcutRegistry.prototype.getRegistry = function() {
-  return object.deepMerge(Object.create(null), this.registry_);
-};
-
-/**
- * Handles key down events.
- * @param {!Workspace} workspace The main workspace where the event was
- *     captured.
- * @param {!Event} e The key down event.
- * @return {boolean} True if the event was handled, false otherwise.
- * @public
- */
-ShortcutRegistry.prototype.onKeyDown = function(workspace, e) {
-  const key = this.serializeKeyEvent_(e);
-  const shortcutNames = this.getShortcutNamesByKeyCode(key);
-  if (!shortcutNames) {
-    return false;
-  }
-  for (let i = 0, shortcutName; (shortcutName = shortcutNames[i]); i++) {
-    const shortcut = this.registry_[shortcutName];
-    if (!shortcut.preconditionFn || shortcut.preconditionFn(workspace)) {
-      // If the key has been handled, stop processing shortcuts.
-      if (shortcut.callback && shortcut.callback(workspace, e, shortcut)) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
-/**
- * Gets the shortcuts registered to the given key code.
- * @param {string} keyCode The serialized key code.
- * @return {!Array<string>|undefined} The list of shortcuts to call when the
- *     given keyCode is used. Undefined if no shortcuts exist.
- * @public
- */
-ShortcutRegistry.prototype.getShortcutNamesByKeyCode = function(keyCode) {
-  return this.keyMap_[keyCode] || [];
-};
-
-/**
- * Gets the serialized key codes that the shortcut with the given name is
- * registered under.
- * @param {string} shortcutName The name of the shortcut.
- * @return {!Array<string>} An array with all the key codes the shortcut is
- *     registered under.
- * @public
- */
-ShortcutRegistry.prototype.getKeyCodesByShortcutName = function(shortcutName) {
-  const keys = [];
-  for (const keyCode in this.keyMap_) {
-    const shortcuts = this.keyMap_[keyCode];
-    const shortcutIdx = shortcuts.indexOf(shortcutName);
-    if (shortcutIdx > -1) {
-      keys.push(keyCode);
-    }
-  }
-  return keys;
-};
-
-/**
- * Serializes a key event.
- * @param {!Event} e A key down event.
- * @return {string} The serialized key code for the given event.
- * @private
- */
-ShortcutRegistry.prototype.serializeKeyEvent_ = function(e) {
-  let serializedKey = '';
-  for (const modifier in ShortcutRegistry.modifierKeys) {
-    if (e.getModifierState(modifier)) {
-      if (serializedKey !== '') {
-        serializedKey += '+';
-      }
-      serializedKey += modifier;
-    }
-  }
-  if (serializedKey !== '' && e.keyCode) {
-    serializedKey = serializedKey + '+' + e.keyCode;
-  } else if (e.keyCode) {
-    serializedKey = e.keyCode.toString();
-  }
-  return serializedKey;
-};
-
-/**
- * Checks whether any of the given modifiers are not valid.
- * @param {!Array<string>} modifiers List of modifiers to be used with the key.
- * @throws {Error} if the modifier is not in the valid modifiers list.
- * @private
- */
-ShortcutRegistry.prototype.checkModifiers_ = function(modifiers) {
-  const validModifiers = object.values(ShortcutRegistry.modifierKeys);
-  for (let i = 0, modifier; (modifier = modifiers[i]); i++) {
-    if (validModifiers.indexOf(modifier) < 0) {
-      throw new Error(modifier + ' is not a valid modifier key.');
-    }
-  }
-};
-
-/**
- * Creates the serialized key code that will be used in the key map.
- * @param {number} keyCode Number code representing the key.
- * @param {?Array<string>} modifiers List of modifier key codes to be used with
- *     the key. All valid modifiers can be found in the
- *     ShortcutRegistry.modifierKeys.
- * @return {string} The serialized key code for the given modifiers and key.
- * @public
- */
-ShortcutRegistry.prototype.createSerializedKey = function(keyCode, modifiers) {
-  let serializedKey = '';
-
-  if (modifiers) {
-    this.checkModifiers_(modifiers);
-    for (const modifier in ShortcutRegistry.modifierKeys) {
-      const modifierKeyCode = ShortcutRegistry.modifierKeys[modifier];
-      if (modifiers.indexOf(modifierKeyCode) > -1) {
-        if (serializedKey !== '') {
-          serializedKey += '+';
-        }
-        serializedKey += modifier;
-      }
-    }
-  }
-
-  if (serializedKey !== '' && keyCode) {
-    serializedKey = serializedKey + '+' + keyCode;
-  } else if (keyCode) {
-    serializedKey = keyCode.toString();
-  }
-  return serializedKey;
-};
-
 // Creates and assigns the singleton instance.
-new ShortcutRegistry();
+const registry = new ShortcutRegistry();
+ShortcutRegistry.registry = registry;
 
+exports.shortcutRegistry = registry;
 exports.ShortcutRegistry = ShortcutRegistry;

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -362,5 +362,4 @@ ShortcutRegistry.KeyboardShortcut;
 const registry = new ShortcutRegistry();
 ShortcutRegistry.registry = registry;
 
-exports.shortcutRegistry = registry;
 exports.ShortcutRegistry = ShortcutRegistry;

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -17,10 +17,9 @@ suite('Context Menu Items', function() {
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
 
-    // Declare a new registry to ensure default options are called.
-    new Blockly.ContextMenuRegistry();
-    Blockly.ContextMenuItems.registerDefaultOptions();
     this.registry = Blockly.ContextMenuRegistry.registry;
+    this.registry.reset();
+    Blockly.ContextMenuItems.registerDefaultOptions();
   });
 
   teardown(function() {

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -12,7 +12,8 @@ const {createKeyDownEvent, sharedTestSetup, sharedTestTeardown} = goog.require('
 suite('Keyboard Shortcut Registry Test', function() {
   setup(function() {
     sharedTestSetup.call(this);
-    this.registry = new Blockly.ShortcutRegistry();
+    this.registry = Blockly.ShortcutRegistry.registry;
+    this.registry.reset();
     Blockly.ShortcutItems.registerDefaultShortcuts();
   });
   teardown(function() {


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5860

### Proposed Changes

- Change the shortcut registry and context menu registry to have internal `registry` variables that are exported under appropriate names.
- Add `reset` functions to the shortcut registry and context menu registry.
- Update tests as needed.
- Change the `Type` object in `registry.js` to an es6 class.

#### Behavior Before Change

Clearing the shortcut registry or context menu registry in tests was done by calling the constructor. 

#### Behavior After Change

Now clearing those registries is done by calling `reset`.

### Reason for Changes

Movement toward Typescript.

### Test Coverage


### Documentation
### Additional Information

Typescript warns that `keyMap_` and `registry_` and so on can be undefined, because I'm setting them in the `reset` function instead of directly in the constructor. Typescript has the [definite assignment assertion operator](https://www.typescriptlang.org/docs/handbook/2/classes.html#--strictpropertyinitialization) to deal with this.