### PR TITLE
refactor: Be more selective in eslint ignorance

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,10 +1,7 @@
 *_compressed*.js
-blockly_uncompressed.js
-gulpfile.js
 /msg/*
 /build/*
 /dist/*
-/core/utils/global.js
 /tests/blocks/*
 /tests/themes/*
 /tests/compile/*

--- a/blockly_uncompressed.js
+++ b/blockly_uncompressed.js
@@ -10,13 +10,15 @@
 'use strict';
 
 
+/* eslint-disable no-var */
+
 /**
  * Blockly uncompiled-mode startup code.  If running in a browser
  * loads closure/goog/base.js and tests/deps.js, then (in any case)
  * requires Blockly.requires.
  */
 (function(globalThis) {
-  /* eslint-disable no-undef */
+  /* eslint-disable-next-line no-undef */
   var IS_NODE_JS = !!(typeof module !== 'undefined' && module.exports);
 
   if (IS_NODE_JS) {
@@ -52,4 +54,5 @@
     // Load the rest of Blockly.
     document.write('<script>goog.require(\'Blockly\');</script>');
   }
+  /* eslint-disable-next-line no-invalid-this */
 })(this);

--- a/core/utils/global.js
+++ b/core/utils/global.js
@@ -16,6 +16,8 @@
 goog.module('Blockly.utils.global');
 
 
+/* eslint-disable no-undef, no-invalid-this */
+
 /**
  * Reference to the global object.
  *

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,16 +8,17 @@
  * @fileoverview Gulp script to build Blockly for Node & NPM.
  * Run this script by calling "npm install" in this directory.
  */
+/* eslint-env node */
 
-var gulp = require('gulp');
+const gulp = require('gulp');
 
-var buildTasks = require('./scripts/gulpfiles/build_tasks');
-var packageTasks = require('./scripts/gulpfiles/package_tasks');
-var gitTasks = require('./scripts/gulpfiles/git_tasks');
-var licenseTasks = require('./scripts/gulpfiles/license_tasks');
-var appengineTasks = require('./scripts/gulpfiles/appengine_tasks');
-var releaseTasks = require('./scripts/gulpfiles/release_tasks');
-var cleanupTasks = require('./scripts/gulpfiles/cleanup_tasks');
+const buildTasks = require('./scripts/gulpfiles/build_tasks');
+const packageTasks = require('./scripts/gulpfiles/package_tasks');
+const gitTasks = require('./scripts/gulpfiles/git_tasks');
+const licenseTasks = require('./scripts/gulpfiles/license_tasks');
+const appengineTasks = require('./scripts/gulpfiles/appengine_tasks');
+const releaseTasks = require('./scripts/gulpfiles/release_tasks');
+const cleanupTasks = require('./scripts/gulpfiles/cleanup_tasks');
 
 module.exports = {
   deployDemos: appengineTasks.deployDemos,


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Rather than ignoring `blockly_uncompressed.js`, `gulpfile.js` and `core/utils/global.js` entirely, add suitable `eslint-disable` directives to those files so that they lint cleanly (and migrate `gulpfile.js` to use `const` instead of `var`).

#### Behaviour Before Change

Lints cleanly.

#### Behavior After Change

Lints more stuff cleanly.

### Reason for Changes

Catch other (future) lint in these files.

### Test Coverage

`npm run lint` completes successfully.

