### PR TITLE
fix(tests): Enable `--debug` for `test:compile:advanced`; fix some errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "tests/run_all_tests.sh",
     "test:generators": "tests/scripts/run_generators.sh",
     "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
-    "test:compile:advanced": "gulp buildAdvancedCompilationTest",
+    "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
     "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"
   },

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -4,19 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('Main');
+goog.module('Main');
+
 // Core
 // Either require 'Blockly.requires', or just the components you use:
-goog.require('Blockly');
+/* eslint-disable-next-line no-unused-vars */
+const {BlocklyOptions} = goog.requireType('Blockly.BlocklyOptions');
+const {inject} = goog.require('Blockly.inject');
+/** @suppress {extraRequire} */
 goog.require('Blockly.geras.Renderer');
+/** @suppress {extraRequire} */
 goog.require('Blockly.VerticalFlyout');
 // Blocks
-goog.require('Blockly.libraryBlocks');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.logic');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.loops');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.math');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.texts');
+/** @suppress {extraRequire} */
 goog.require('Blockly.libraryBlocks.testBlocks');
 
-Main.init = function() {
-  Blockly.inject('blocklyDiv', {
-    'toolbox': document.getElementById('toolbox')
-  });
+
+function init() {
+  inject('blocklyDiv', /** @type {BlocklyOptions} */ ({
+           'toolbox': document.getElementById('toolbox')
+         }));
 };
-window.addEventListener('load', Main.init);
+window.addEventListener('load', init);


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

* Pass the `--debug` flag when running the `buildAdvancedCompilationTest` gulp task.
* Migrate `test/compile/main.js` to `goog.module`.
  * Use more selective `goog.requires`.
  * `@suppress` "extra" requires needed for side effects.

#### Behaviour Before Change

The compiled output (`tests/compile/main_compressed.js`) was 402441 bytes.

#### Behavior After Change

The compiled output (`tests/compile/main_compressed.js`) is 373888 bytes (a 7% reduction).

### Reason for Changes

* Make advanced compilation test actually test partial compilation.
* Make sure that it picks up any errors that might only be generated when doing `ADVANCED_OPTIMIZATIONS`.

### Test Coverage

* `npm test` completes successfully.
