### PR TITLE
revert: "fix(tests): Enable `--debug` for `test:compile:advanced`; fix some errors"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "tests/run_all_tests.sh",
     "test:generators": "tests/scripts/run_generators.sh",
     "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
-    "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
+    "test:compile:advanced": "gulp buildAdvancedCompilationTest",
     "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"
   },

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -4,33 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Main');
-
+goog.provide('Main');
 // Core
 // Either require 'Blockly.requires', or just the components you use:
-/* eslint-disable-next-line no-unused-vars */
-const {BlocklyOptions} = goog.requireType('Blockly.BlocklyOptions');
-const {inject} = goog.require('Blockly.inject');
-/** @suppress {extraRequire} */
+goog.require('Blockly');
 goog.require('Blockly.geras.Renderer');
-/** @suppress {extraRequire} */
 goog.require('Blockly.VerticalFlyout');
 // Blocks
-/** @suppress {extraRequire} */
-goog.require('Blockly.libraryBlocks.logic');
-/** @suppress {extraRequire} */
-goog.require('Blockly.libraryBlocks.loops');
-/** @suppress {extraRequire} */
-goog.require('Blockly.libraryBlocks.math');
-/** @suppress {extraRequire} */
-goog.require('Blockly.libraryBlocks.texts');
-/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks');
 goog.require('Blockly.libraryBlocks.testBlocks');
 
-
-function init() {
-  inject('blocklyDiv', /** @type {BlocklyOptions} */ ({
-           'toolbox': document.getElementById('toolbox')
-         }));
+Main.init = function() {
+  Blockly.inject('blocklyDiv', {
+    'toolbox': document.getElementById('toolbox')
+  });
 };
-window.addEventListener('load', init);
+window.addEventListener('load', Main.init);


### PR DESCRIPTION
Reverts google/blockly#5959

The above PR caused the advanced compilation CI to break. For some reason the CI on #5959 didn't actually test with the `--debug` flag enabled.