### PR TITLE
fix(blocks): correct the `callType_` of `procedures_defreturn`

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -443,7 +443,6 @@ const PROCEDURE_DEF_COMMON = {
       }
     }
   },
-  callType_: 'procedures_callnoreturn',
 };
 
 blocks['procedures_defnoreturn'] = {
@@ -486,6 +485,7 @@ blocks['procedures_defnoreturn'] = {
   getProcedureDef: function() {
     return [this.getFieldValue('NAME'), this.arguments_, false];
   },
+  callType_: 'procedures_callnoreturn',
 };
 
 blocks['procedures_defreturn'] = {
@@ -531,6 +531,7 @@ blocks['procedures_defreturn'] = {
   getProcedureDef: function() {
     return [this.getFieldValue('NAME'), this.arguments_, true];
   },
+  callType_: 'procedures_callreturn',
 };
 
 blocks['procedures_mutatorcontainer'] = {


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/5972

### Proposed Changes

The field _callType__ was defined as 'procedures_callnoreturn' in PROCEDURE_DEF_COMMON.
Now it is defined separately in procedures_defnoreturn and in procedures_defreturn so each one defines it's own value for it.

#### Behavior Before Change

As shown in https://github.com/google/blockly/issues/5972, when selecting the option to create a caller of a returning procedure, the result was a procedures_callnoreturn block.

#### Behavior After Change

Now a procedures_callreturn is created.

### Reason for Changes

To fix the problem.

### Test Coverage

Tested on:
Desktop Chrome v98.0.4758.102 (Windows 11)
