### PR TITLE
fix(tests): Enable `--debug` for `test:compile:advanced`; fix some errors (and demote the rest to warnings)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "tests/run_all_tests.sh",
     "test:generators": "tests/scripts/run_generators.sh",
     "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
-    "test:compile:advanced": "gulp buildAdvancedCompilationTest",
+    "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
     "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"
   },

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -209,7 +209,7 @@ var JSCOMP_ERROR = [
   'moduleLoad',
   'msgDescriptions',
   'nonStandardJsDocs',
-  'partialAlias',
+  // 'partialAlias',  // Don't want this to be an error yet; only warning.
   // 'polymer',  // Not applicable.
   // 'reportUnknownTypes',  // VERY verbose.
   // 'strictCheckTypes',  // Use --strict to enable.

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -4,19 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('Main');
+goog.module('Main');
+
 // Core
 // Either require 'Blockly.requires', or just the components you use:
-goog.require('Blockly');
+/* eslint-disable-next-line no-unused-vars */
+const {BlocklyOptions} = goog.requireType('Blockly.BlocklyOptions');
+const {inject} = goog.require('Blockly.inject');
+/** @suppress {extraRequire} */
 goog.require('Blockly.geras.Renderer');
+/** @suppress {extraRequire} */
 goog.require('Blockly.VerticalFlyout');
 // Blocks
-goog.require('Blockly.libraryBlocks');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.logic');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.loops');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.math');
+/** @suppress {extraRequire} */
+goog.require('Blockly.libraryBlocks.texts');
+/** @suppress {extraRequire} */
 goog.require('Blockly.libraryBlocks.testBlocks');
 
-Main.init = function() {
-  Blockly.inject('blocklyDiv', {
-    'toolbox': document.getElementById('toolbox')
-  });
+
+function init() {
+  inject('blocklyDiv', /** @type {BlocklyOptions} */ ({
+           'toolbox': document.getElementById('toolbox')
+         }));
 };
-window.addEventListener('load', Main.init);
+window.addEventListener('load', init);


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

* Pass the `--debug` flag when running the `buildAdvancedCompilationTest` gulp task.
* Migrate `test/compile/main.js` to `goog.module`.
  * Use more selective `goog.requires`.
  * `@suppress` "extra" requires needed for side effects.
* Modify `build_tasks.js` to not promote `JSC_PARTIAL_ALIAS` diagnostics to errors (leave them as warnings).

#### Behaviour Before Change

No (non-fatal) diagnostics would be emitted by the advanced compilation test.

#### Behaviour After Change

Ten `JSC_PARTIAL_ALIAS` warnings are emitted (which ought to be investigated!), and additional warnings and errors will be emitted if there are problems with the code.

### Reason for Changes

* Make advanced compilation test actually test partial compilation.
* Make sure that it picks up any errors that might only be generated when doing `ADVANCED_OPTIMIZATIONS`.

### Test Coverage

* `npm test` completes successfully (for real this time!)
