### PR TITLE
feat: add mocha failure messages to console output

### DIFF
--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -18,9 +18,9 @@
     }
   </style>
   <body>
-
     <div id="mocha"></div>
     <div id="failureCount" style="display:none" tests_failed="unset"></div>
+    <div id="failureMessages" style="display:none"></div>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/sinon/pkg/sinon.js"></script>
@@ -173,9 +173,15 @@
     </xml>
 
     <script type="module">
-      mocha.run(function(failures) {
+      let runner = mocha.run(function(failures) {
         var failureDiv = document.getElementById('failureCount');
         failureDiv.setAttribute('tests_failed', failures);
+      });
+      runner.on('fail', function(test, err) {
+        const msg = document.createElement('p');
+        msg.textContent = `"${test.fullTitle()}" failed: ${err.message}`;
+        const div = document.getElementById('failureMessages');
+        div.appendChild(msg);
       });
     </script>
   </body>

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -61,8 +61,18 @@ async function runMochaTestsInBrowser() {
   const elem = await browser.$('#failureCount');
   const numOfFailure = await elem.getAttribute('tests_failed');
 
+  if (numOfFailure > 0) {
+    console.log('==========Blockly Mocha Test Failures================')
+    const failureMessagesEls = await browser.$$('#failureMessages p');
+    if (!failureMessagesEls.length) {
+      console.log('There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.');
+    }
+    for (let el of failureMessagesEls) {
+      console.log(await el.getText());
+    }
+  }
+
   console.log('============Blockly Mocha Test Summary=================');
-  console.log(numOfFailure);
   console.log(numOfFailure + ' tests failed');
   console.log('============Blockly Mocha Test Summary=================');
   if (parseInt(numOfFailure) !== 0) {

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -62,7 +62,7 @@ async function runMochaTestsInBrowser() {
   const numOfFailure = await elem.getAttribute('tests_failed');
 
   if (numOfFailure > 0) {
-    console.log('==========Blockly Mocha Test Failures================')
+    console.log('============Blockly Mocha Test Failures================')
     const failureMessagesEls = await browser.$$('#failureMessages p');
     if (!failureMessagesEls.length) {
       console.log('There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

#5622 

### Proposed Changes

Reports mocha failures in console output when running `npm run test` and `node tests/mocha/run_mocha_tests_in_browser.js` (but not when running `npm run test:mocha:interactive`)

Also removed the extra number that was printed before the line saying `x tests failed`

#### Behavior Before Change

Only logged the number of tests that failed.

#### Behavior After Change

0 failures shows:

```
============Blockly Mocha Test Summary=================
0 tests failed
============Blockly Mocha Test Summary=================
```

1+ failures shows:

```
============Blockly Mocha Test Failures================
"Abstract Fields Serialization Save JSO No implementations" failed: expected 'test value' to not equal 'test value'
"Tooltip Custom Tooltip Custom function is called" failed: Expected custom tooltip function to have been called: expected true to be false
============Blockly Mocha Test Summary=================
2 tests failed
============Blockly Mocha Test Summary=================
```

With the `failZero` flag set to true (like in #5981) then mocha fails but doesn't provide an error message. so in that case we get (I wrote this message so we can change it if desired)

```
============Blockly Mocha Test Failures================
There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.
============Blockly Mocha Test Summary=================
1 tests failed
============Blockly Mocha Test Summary=================
```


It's not the prettiest thing in the world, but it's probably better than not showing any error messages.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I think ultimately the correct thing would be to not use webdriverio at all and just call mocha directly from node. That would require a few changes to our test setup but importantly it's blocked by migrating to es modules (mocha would run each test file directly, and it doesn't understand the `goog.module` syntax. there are probably other ways of working around this but if we're getting off closure modules soon then better just to wait for that). When running from the command line there are lots of build in reporter options that have nicely formatted output.
