### PR TITLE
feat(tests): Use official semver.org RegExp

### DIFF
--- a/tests/migration/renamings-schema.json
+++ b/tests/migration/renamings-schema.json
@@ -5,7 +5,7 @@
   "description": "A file containing information about module and module export renamings",
   "type": "object",
   "patternProperties": {
-    "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$": {"$ref": "#/$defs/version"}
+    "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$": {"$ref": "#/$defs/version"}
   },
   "properties": {
     "develop": {"$ref": "#/$defs/version"}


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes

Use [the official semantic versioning regexp from semver.org](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string) rather than [the shorter but sloppier one
we had previously found](https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39).

### Reason for Changes

Avoid any possible problems that could be caused by invalid version numbers in `renamings.json5` when comparing version numbers in the process of running the renamings script.

### Test Coverage

* Passes `npm test`.

