### PR TITLE
refactor(build): Prepare UMD wrapper generation for transition to ES modules

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -129,7 +129,7 @@ const chunks = [
   {
     name: 'dart',
     entry: 'generators/dart/all.js',
-    reexports: 'Blockly.Dart',
+    reexport: 'Blockly.Dart',
   }
 ];
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -92,8 +92,6 @@ const NAMESPACE_PROPERTY = '__namespace__';
  *   "Blockly.libraryBlocks" is not a valid variable name.)
  * - .factoryPreamble: code to override the default wrapper factory
  *   function preamble.
- * - .factoryPostamble: code to override the default wrapper factory
- *   function postabmle.
  *
  * The function getChunkOptions will, after running
  * closure-calculate-chunks, update each chunk to add the following
@@ -111,8 +109,6 @@ const chunks = [
     exports: 'Blockly',
     importAs: 'Blockly',
     factoryPreamble: `const ${NAMESPACE_VARIABLE}={};`,
-    factoryPostamble: `${NAMESPACE_VARIABLE}.Blockly.${NAMESPACE_PROPERTY}=` +
-        `${NAMESPACE_VARIABLE};`,
   },
   {
     name: 'blocks',
@@ -152,11 +148,6 @@ const chunks = [
  */
 const FACTORY_PREAMBLE =
     `const ${NAMESPACE_VARIABLE}=Blockly.${NAMESPACE_PROPERTY};`;
-
-/**
- * The default factory function postamble.
- */
-const FACTORY_POSTAMBLE = '';
 
 const licenseRegex = `\\/\\*\\*
  \\* @license
@@ -373,6 +364,9 @@ function chunkWrapper(chunk) {
   const browserDeps =
       chunk.dependencies.map(d => `root.${d.exports}`).join(', ');
   const factoryParams = chunk.dependencies.map(d => d.importAs).join(', ');
+  // Expression that evaluates the the value of the exports object
+  // for the specified chunk.
+  const exportsExpression = `${NAMESPACE_VARIABLE}.${chunk.exports}`;
 
   // Note that when loading in a browser the base of the exported path
   // (e.g. Blockly.blocks.all - see issue #5932) might not exist
@@ -394,8 +388,8 @@ function chunkWrapper(chunk) {
 }(this, function(${factoryParams}) {
 ${chunk.factoryPreamble || FACTORY_PREAMBLE}
 %output%
-${chunk.factoryPostamble || FACTORY_POSTAMBLE}
-return ${NAMESPACE_VARIABLE}.${chunk.exports};
+${exportsExpression}.${NAMESPACE_PROPERTY}=${NAMESPACE_VARIABLE};
+return ${exportsExpression};
 }));
 `;
 };


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

Part of #5904.

### Proposed Changes

Makes various changes to the way UMD chunk wrappers are generated.  Specifically:

* Corrects erroneous assumption that `closure-calculate-chunks` outputs chunks in the same order as the `--entrypoint`s were specified on the command line.
* Introduces the configuration constant `NAMESPACE_PROPERTY` to control where the namespace object is saved on the exports object.
* Save the namespace object on every chunk exports object.
* Corrects erroneous assumption that chunks could have multiple dependencies; instead, they have a single parent chunk.
* Miscellaneous other updates to chunk wrapper generation.

#### Behaviour Before Change

The namespace object is saved only on the `.internal_` property of the first (`blockly`) chunk's exports object.

#### Behaviour After Change

The namespace object is saved on the `.__namespace__` property of every chunk's exports object.

### Reason for Changes

* Correction of erroneous code so as to avoid generating incorrect output if erroneous assumptions are violated in future.
* Refactor chunk wrapper generation to make it easier to modify to support ES modules, which will not have `goog.module.declareLegacyNamespace` calls.

### Test Coverage

* Passes `npm test`.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
