### PR TITLE
fix: Change the truthy tests of width and height in WorkspaceSvg.setCachedParentSvgSize

### DIFF
--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1244,13 +1244,13 @@ class WorkspaceSvg extends Workspace {
    */
   setCachedParentSvgSize(width, height) {
     const svg = this.getParentSvg();
-    if (width) {
+    if (width != null) {
       this.cachedParentSvgSize_.width = width;
       // This is set to support the public (but deprecated) Blockly.svgSize
       // method.
       svg.cachedWidth_ = width;
     }
-    if (height) {
+    if (height != null) {
       this.cachedParentSvgSize_.height = height;
       // This is set to support the public (but deprecated) Blockly.svgSize
       // method.


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
  fixes #5930 and possibly #5404


### Proposed Changes
Change the truthy tests of width and height in WorkspaceSvg.setCachedParentSvgSize to actual comparisons with null/undefined so that zero value can be saved into the cache


#### Behavior Before Change

If the div containing the Blockly workspace is hidden and Blockly.svgResize is called you end up in a state where the svg is forced to zero size and it will never some back.

The cause is that during the hidden svgResize WorkspaceSvg.setCachedParentSvgSize fails to record the zero size as noted here https://github.com/google/blockly/issues/5404#issuecomment-907989018, but the SVG is still made 0x0. Later when the div is un-hidden svgResize doesn't see that the size is growing since the cached value is bad, so the SVG is not set back to a visible size.

The same as what seemed to be noticed in https://github.com/google/blockly/issues/5404#issuecomment-907989018: change the truthy tests of width and height in WorkspaceSvg.setCachedParentSvgSize to actual comparisons with null so that zero value can be saved into the cache.

#### Behavior After Change

Zero sizes are saved in to the cache so that they can be noticed later in a comparison when non-zero values become active.  Falsey values previously caused entries to not be recorded, but the actual use case is that null/undefined values should not be recorded.  Zero does not appear to have been an intentional "no update" trigger.

### Reason for Changes

To allow  hiding and unhiding of the blockly div to work correctly.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
* Desktop Chrome
I've been using this change in chrome for several weeks

<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

none
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
none
<!-- Anything else we should know? -->
