### PR TITLE
fix: Move @alias onto classes instead of constructors

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -67,6 +67,7 @@ goog.require('Blockly.Events.BlockMove');
  * @implements {IASTNodeLocation}
  * @implements {IDeletable}
  * @unrestricted
+ * @alias Blockly.Block
  */
 class Block {
   /**
@@ -76,7 +77,6 @@ class Block {
    * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
    *     create a new ID.
    * @throws When the prototypeName is not valid or not allowed.
-   * @alias Blockly.Block
    */
   constructor(workspace, prototypeName, opt_id) {
     const {Generator} = goog.module.get('Blockly.Generator');

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -35,11 +35,11 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for a drag surface for the currently dragged block. This is a separate
  * SVG that contains only the currently moving block, or nothing.
+ * @alias Blockly.BlockDragSurfaceSvg
  */
 const BlockDragSurfaceSvg = class {
   /**
    * @param {!Element} container Containing element.
-   * @alias Blockly.BlockDragSurfaceSvg
    */
   constructor(container) {
     /**

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -43,12 +43,12 @@ goog.require('Blockly.Events.BlockMove');
  * Class for a block dragger.  It moves blocks around the workspace when they
  * are being dragged by a mouse or touch.
  * @implements {IBlockDragger}
+ * @alias Blockly.BlockDragger
  */
 const BlockDragger = class {
   /**
    * @param {!BlockSvg} block The block to drag.
    * @param {!WorkspaceSvg} workspace The workspace to drag on.
-   * @alias Blockly.BlockDragger
    */
   constructor(block, workspace) {
     /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -88,6 +88,7 @@ goog.require('Blockly.Touch');
  * @implements {IBoundedElement}
  * @implements {ICopyable}
  * @implements {IDraggable}
+ * @alias Blockly.BlockSvg
  */
 class BlockSvg extends Block {
   /**
@@ -96,7 +97,6 @@ class BlockSvg extends Block {
    *     type-specific functions for this block.
    * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
    *     create a new ID.
-   * @alias Blockly.BlockSvg
    */
   constructor(workspace, prototypeName, opt_id) {
     super(workspace, prototypeName, opt_id);

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -41,6 +41,7 @@ goog.require('Blockly.Workspace');
 /**
  * Class for UI bubble.
  * @implements {IBubble}
+ * @alias Blockly.Bubble
  */
 const Bubble = class {
   /**
@@ -53,7 +54,6 @@ const Bubble = class {
    * @param {?number} bubbleWidth Width of bubble, or null if not resizable.
    * @param {?number} bubbleHeight Height of bubble, or null if not resizable.
    * @struct
-   * @alias Blockly.Bubble
    */
   constructor(workspace, content, shape, anchorXY, bubbleWidth, bubbleHeight) {
     this.workspace_ = workspace;

--- a/core/bubble_dragger.js
+++ b/core/bubble_dragger.js
@@ -45,12 +45,12 @@ goog.require('Blockly.constants');
  * Class for a bubble dragger.  It moves things on the bubble canvas around the
  * workspace when they are being dragged by a mouse or touch.  These can be
  * block comments, mutators, warnings, or workspace comments.
+ * @alias Blockly.BubbleDragger
  */
 const BubbleDragger = class {
   /**
    * @param {!IBubble} bubble The item on the bubble canvas to drag.
    * @param {!WorkspaceSvg} workspace The workspace to drag on.
-   * @alias Blockly.BubbleDragger
    */
   constructor(bubble, workspace) {
     /**

--- a/core/comment.js
+++ b/core/comment.js
@@ -44,11 +44,11 @@ goog.require('Blockly.Warning');
 /**
  * Class for a comment.
  * @extends {Icon}
+ * @alias Blockly.Comment
  */
 class Comment extends Icon {
   /**
    * @param {!BlockSvg} block The block associated with this comment.
-   * @alias Blockly.Comment
    */
   constructor(block) {
     super(block);

--- a/core/component_manager.js
+++ b/core/component_manager.js
@@ -31,11 +31,9 @@ const {IPositionable} = goog.requireType('Blockly.IPositionable');
 
 /**
  * Manager for all items registered with the workspace.
+ * @alias Blockly.ComponentManager
  */
 class ComponentManager {
-  /**
-   * @alias Blockly.ComponentManager
-   */
   constructor() {
     /**
      * A map of the components registered with the workspace, mapped to id.
@@ -219,6 +217,7 @@ ComponentManager.ComponentDatum;
 /**
  * A name with the capability of the element stored in the generic.
  * @template T
+ * @alias Blockly.ComponentManager.Capability
  */
 ComponentManager.Capability = class {
   /**

--- a/core/component_manager.js
+++ b/core/component_manager.js
@@ -34,6 +34,9 @@ const {IPositionable} = goog.requireType('Blockly.IPositionable');
  * @alias Blockly.ComponentManager
  */
 class ComponentManager {
+  /**
+   * Creates a new ComponentManager instance.
+   */
   constructor() {
     /**
      * A map of the components registered with the workspace, mapped to id.

--- a/core/connection.js
+++ b/core/connection.js
@@ -38,12 +38,12 @@ goog.require('Blockly.constants');
 /**
  * Class for a connection between blocks.
  * @implements {IASTNodeLocationWithBlock}
+ * @alias Blockly.Connection
  */
 class Connection {
   /**
    * @param {!Block} source The block establishing this connection.
    * @param {number} type The type of the connection.
-   * @alias Blockly.Connection
    */
   constructor(source, type) {
     /**

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -34,8 +34,6 @@ const {RenderedConnection} = goog.requireType('Blockly.RenderedConnection');
  * @alias Blockly.ConnectionChecker
  */
 class ConnectionChecker {
-  constructor() {}
-
   /**
    * Check whether the current connection can connect with the target
    * connection.

--- a/core/connection_checker.js
+++ b/core/connection_checker.js
@@ -31,11 +31,9 @@ const {RenderedConnection} = goog.requireType('Blockly.RenderedConnection');
 /**
  * Class for connection type checking logic.
  * @implements {IConnectionChecker}
+ * @alias Blockly.ConnectionChecker
  */
 class ConnectionChecker {
-  /**
-   * @alias Blockly.ConnectionChecker
-   */
   constructor() {}
 
   /**

--- a/core/connection_db.js
+++ b/core/connection_db.js
@@ -34,13 +34,13 @@ goog.require('Blockly.constants');
  * Database of connections.
  * Connections are stored in order of their vertical component.  This way
  * connections in an area may be looked up quickly using a binary search.
+ * @alias Blockly.ConnectionDB
  */
 class ConnectionDB {
   /**
    * @param {!IConnectionChecker} checker The workspace's
    *     connection type checker, used to decide if connections are valid during
    * a drag.
-   * @alias Blockly.ConnectionDB
    */
   constructor(checker) {
     /**

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -28,6 +28,9 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  * @alias Blockly.ContextMenuRegistry
  */
 class ContextMenuRegistry {
+  /**
+   * Resets the existing singleton instance of ContextMenuRegistry.
+   */
   constructor() {
     this.reset();
   }

--- a/core/contextmenu_registry.js
+++ b/core/contextmenu_registry.js
@@ -25,11 +25,9 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  * Class for the registry of context menu items. This is intended to be a
  * singleton. You should not create a new instance, and only access this class
  * from ContextMenuRegistry.registry.
+ * @alias Blockly.ContextMenuRegistry
  */
 class ContextMenuRegistry {
-  /**
-   * @alias Blockly.ContextMenuRegistry
-   */
   constructor() {
     this.reset();
   }

--- a/core/delete_area.js
+++ b/core/delete_area.js
@@ -31,11 +31,9 @@ const {IDraggable} = goog.requireType('Blockly.IDraggable');
  * dropped on top of it.
  * @extends {DragTarget}
  * @implements {IDeleteArea}
+ * @alias Blockly.DeleteArea
  */
 class DeleteArea extends DragTarget {
-  /**
-   * @alias Blockly.DeleteArea
-   */
   constructor() {
     super();
 

--- a/core/delete_area.js
+++ b/core/delete_area.js
@@ -34,6 +34,10 @@ const {IDraggable} = goog.requireType('Blockly.IDraggable');
  * @alias Blockly.DeleteArea
  */
 class DeleteArea extends DragTarget {
+  /**
+   * Constructor for DeleteArea. Should not be called directly, only by a
+   * subclass.
+   */
   constructor() {
     super();
 

--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -33,8 +33,6 @@ const {Rect} = goog.requireType('Blockly.utils.Rect');
  * @alias Blockly.DragTarget
  */
 class DragTarget {
-  constructor() {}
-
   /**
    * Handles when a cursor with a block or bubble enters this drag target.
    * @param {!IDraggable} _dragElement The block or bubble currently being

--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -30,11 +30,9 @@ const {Rect} = goog.requireType('Blockly.utils.Rect');
  * Abstract class for a component with custom behaviour when a block or bubble
  * is dragged over or dropped on top of it.
  * @implements {IDragTarget}
+ * @alias Blockly.DragTarget
  */
 class DragTarget {
-  /**
-   * @alias Blockly.DragTarget
-   */
   constructor() {}
 
   /**

--- a/core/events/events_abstract.js
+++ b/core/events/events_abstract.js
@@ -25,6 +25,7 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 /**
  * Abstract class for an event.
  * @abstract
+ * @alias Blockly.Events.Abstract
  */
 class Abstract {
   /**

--- a/core/events/events_block_base.js
+++ b/core/events/events_block_base.js
@@ -23,12 +23,12 @@ const {Block} = goog.requireType('Blockly.Block');
 /**
  * Abstract class for a block event.
  * @extends {AbstractEvent}
+ * @alias Blockly.Events.BlockBase
  */
 class BlockBase extends AbstractEvent {
   /**
    * @param {!Block=} opt_block The block this event corresponds to.
    *     Undefined for a blank event.
-   * @alias Blockly.Events.BlockBase
    */
   constructor(opt_block) {
     super();

--- a/core/events/events_block_change.js
+++ b/core/events/events_block_change.js
@@ -28,6 +28,7 @@ const {Block} = goog.requireType('Blockly.Block');
 /**
  * Class for a block change event.
  * @extends {BlockBase}
+ * @alias Blockly.Events.BlockChange
  */
 class BlockChange extends BlockBase {
   /**
@@ -37,7 +38,6 @@ class BlockChange extends BlockBase {
    * @param {?string=} opt_name Name of input or field affected, or null.
    * @param {*=} opt_oldValue Previous value of element.
    * @param {*=} opt_newValue New value of element.
-   * @alias Blockly.Events.BlockChange
    */
   constructor(opt_block, opt_element, opt_name, opt_oldValue, opt_newValue) {
     super(opt_block);

--- a/core/events/events_block_create.js
+++ b/core/events/events_block_create.js
@@ -27,12 +27,12 @@ const {Block} = goog.requireType('Blockly.Block');
 /**
  * Class for a block creation event.
  * @extends {BlockBase}
+ * @alias Blockly.Events.BlockCreate
  */
 class BlockCreate extends BlockBase {
   /**
    * @param {!Block=} opt_block The created block.  Undefined for a blank
    *     event.
-   * @alias Blockly.Events.BlockCreate
    */
   constructor(opt_block) {
     super(opt_block);

--- a/core/events/events_block_delete.js
+++ b/core/events/events_block_delete.js
@@ -27,12 +27,12 @@ const {Block} = goog.requireType('Blockly.Block');
 /**
  * Class for a block deletion event.
  * @extends {BlockBase}
+ * @alias Blockly.Events.BlockDelete
  */
 class BlockDelete extends BlockBase {
   /**
    * @param {!Block=} opt_block The deleted block.  Undefined for a blank
    *     event.
-   * @alias Blockly.Events.BlockDelete
    */
   constructor(opt_block) {
     super(opt_block);

--- a/core/events/events_block_drag.js
+++ b/core/events/events_block_drag.js
@@ -25,6 +25,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a block drag event.
  * @extends {UiBase}
+ * @alias Blockly.Events.BlockDrag
  */
 class BlockDrag extends UiBase {
   /**
@@ -34,7 +35,6 @@ class BlockDrag extends UiBase {
    *    Undefined for a blank event.
    * @param {!Array<!Block>=} opt_blocks The blocks affected by this
    *    drag. Undefined for a blank event.
-   * @alias Blockly.Events.BlockDrag
    */
   constructor(opt_block, opt_isStart, opt_blocks) {
     const workspaceId = opt_block ? opt_block.workspace.id : undefined;

--- a/core/events/events_block_move.js
+++ b/core/events/events_block_move.js
@@ -27,12 +27,12 @@ const {Coordinate} = goog.require('Blockly.utils.Coordinate');
 /**
  * Class for a block move event.  Created before the move.
  * @extends {BlockBase}
+ * @alias Blockly.Events.BlockMove
  */
 class BlockMove extends BlockBase {
   /**
    * @param {!Block=} opt_block The moved block.  Undefined for a blank
    *     event.
-   * @alias Blockly.Events.BlockMove
    */
   constructor(opt_block) {
     super(opt_block);

--- a/core/events/events_bubble_open.js
+++ b/core/events/events_bubble_open.js
@@ -25,6 +25,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a bubble open event.
  * @extends {UiBase}
+ * @alias Blockly.Events.BubbleOpen
  */
 class BubbleOpen extends UiBase {
   /**
@@ -35,7 +36,6 @@ class BubbleOpen extends UiBase {
    * @param {string=} opt_bubbleType The type of bubble. One of 'mutator',
    *     'comment'
    *    or 'warning'. Undefined for a blank event.
-   * @alias Blockly.Events.BubbleOpen
    */
   constructor(opt_block, opt_isOpen, opt_bubbleType) {
     const workspaceId = opt_block ? opt_block.workspace.id : undefined;

--- a/core/events/events_click.js
+++ b/core/events/events_click.js
@@ -25,6 +25,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a click event.
  * @extends {UiBase}
+ * @alias Blockly.Events.Click
  */
 class Click extends UiBase {
   /**
@@ -35,7 +36,6 @@ class Click extends UiBase {
    *    Not used if block is passed. Undefined for a blank event.
    * @param {string=} opt_targetType The type of element targeted by this click
    *    event. Undefined for a blank event.
-   * @alias Blockly.Events.Click
    */
   constructor(opt_block, opt_workspaceId, opt_targetType) {
     let workspaceId = opt_block ? opt_block.workspace.id : opt_workspaceId;

--- a/core/events/events_comment_base.js
+++ b/core/events/events_comment_base.js
@@ -30,12 +30,12 @@ const {WorkspaceComment} = goog.requireType('Blockly.WorkspaceComment');
 /**
  * Abstract class for a comment event.
  * @extends {AbstractEvent}
+ * @alias Blockly.Events.CommentBase
  */
 class CommentBase extends AbstractEvent {
   /**
    * @param {!WorkspaceComment=} opt_comment The comment this event
    *     corresponds to.  Undefined for a blank event.
-   * @alias Blockly.Events.CommentBase
    */
   constructor(opt_comment) {
     super();

--- a/core/events/events_comment_change.js
+++ b/core/events/events_comment_change.js
@@ -25,6 +25,7 @@ const {WorkspaceComment} = goog.requireType('Blockly.WorkspaceComment');
 /**
  * Class for a comment change event.
  * @extends {CommentBase}
+ * @alias Blockly.Events.CommentChange
  */
 class CommentChange extends CommentBase {
   /**
@@ -32,7 +33,6 @@ class CommentChange extends CommentBase {
    *     changed.  Undefined for a blank event.
    * @param {string=} opt_oldContents Previous contents of the comment.
    * @param {string=} opt_newContents New contents of the comment.
-   * @alias Blockly.Events.CommentChange
    */
   constructor(opt_comment, opt_oldContents, opt_newContents) {
     super(opt_comment);

--- a/core/events/events_comment_create.js
+++ b/core/events/events_comment_create.js
@@ -26,12 +26,12 @@ const {WorkspaceComment} = goog.requireType('Blockly.WorkspaceComment');
 /**
  * Class for a comment creation event.
  * @extends {CommentBase}
+ * @alias Blockly.Events.CommentCreate
  */
 class CommentCreate extends CommentBase {
   /**
    * @param {!WorkspaceComment=} opt_comment The created comment.
    *     Undefined for a blank event.
-   * @alias Blockly.Events.CommentCreate
    */
   constructor(opt_comment) {
     super(opt_comment);

--- a/core/events/events_comment_delete.js
+++ b/core/events/events_comment_delete.js
@@ -25,12 +25,12 @@ const {WorkspaceComment} = goog.requireType('Blockly.WorkspaceComment');
 /**
  * Class for a comment deletion event.
  * @extends {CommentBase}
+ * @alias Blockly.Events.CommentDelete
  */
 class CommentDelete extends CommentBase {
   /**
    * @param {!WorkspaceComment=} opt_comment The deleted comment.
    *     Undefined for a blank event.
-   * @alias Blockly.Events.CommentDelete
    */
   constructor(opt_comment) {
     super(opt_comment);

--- a/core/events/events_comment_move.js
+++ b/core/events/events_comment_move.js
@@ -26,12 +26,12 @@ const {WorkspaceComment} = goog.requireType('Blockly.WorkspaceComment');
 /**
  * Class for a comment move event.  Created before the move.
  * @extends {CommentBase}
+ * @alias Blockly.Events.CommentMove
  */
 class CommentMove extends CommentBase {
   /**
    * @param {!WorkspaceComment=} opt_comment The comment that is being
    *     moved.  Undefined for a blank event.
-   * @alias Blockly.Events.CommentMove
    */
   constructor(opt_comment) {
     super(opt_comment);

--- a/core/events/events_marker_move.js
+++ b/core/events/events_marker_move.js
@@ -28,6 +28,7 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 /**
  * Class for a marker move event.
  * @extends {UiBase}
+ * @alias Blockly.Events.MarkerMove
  */
 class MarkerMove extends UiBase {
   /**
@@ -39,7 +40,6 @@ class MarkerMove extends UiBase {
    *    Undefined for a blank event.
    * @param {!ASTNode=} opt_newNode The new node the marker is now on.
    *    Undefined for a blank event.
-   * @alias Blockly.Events.MarkerMove
    */
   constructor(opt_block, isCursor, opt_oldNode, opt_newNode) {
     let workspaceId = opt_block ? opt_block.workspace.id : undefined;

--- a/core/events/events_selected.js
+++ b/core/events/events_selected.js
@@ -23,6 +23,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a selected event.
  * @extends {UiBase}
+ * @alias Blockly.Events.Selected
  */
 class Selected extends UiBase {
   /**
@@ -32,7 +33,6 @@ class Selected extends UiBase {
    *     no element currently selected (deselect). Undefined for a blank event.
    * @param {string=} opt_workspaceId The workspace identifier for this event.
    *    Null if no element previously selected. Undefined for a blank event.
-   * @alias Blockly.Events.Selected
    */
   constructor(opt_oldElementId, opt_newElementId, opt_workspaceId) {
     super(opt_workspaceId);

--- a/core/events/events_theme_change.js
+++ b/core/events/events_theme_change.js
@@ -23,13 +23,13 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a theme change event.
  * @extends {UiBase}
+ * @alias Blockly.Events.ThemeChange
  */
 class ThemeChange extends UiBase {
   /**
    * @param {string=} opt_themeName The theme name. Undefined for a blank event.
    * @param {string=} opt_workspaceId The workspace identifier for this event.
    *    event. Undefined for a blank event.
-   * @alias Blockly.Events.ThemeChange
    */
   constructor(opt_themeName, opt_workspaceId) {
     super(opt_workspaceId);

--- a/core/events/events_toolbox_item_select.js
+++ b/core/events/events_toolbox_item_select.js
@@ -23,6 +23,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a toolbox item select event.
  * @extends {UiBase}
+ * @alias Blockly.Events.ToolboxItemSelect
  */
 class ToolboxItemSelect extends UiBase {
   /**
@@ -32,7 +33,6 @@ class ToolboxItemSelect extends UiBase {
    *     for a blank event.
    * @param {string=} opt_workspaceId The workspace identifier for this event.
    *    Undefined for a blank event.
-   * @alias Blockly.Events.ToolboxItemSelect
    */
   constructor(opt_oldItem, opt_newItem, opt_workspaceId) {
     super(opt_workspaceId);

--- a/core/events/events_trashcan_open.js
+++ b/core/events/events_trashcan_open.js
@@ -23,6 +23,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a trashcan open event.
  * @extends {UiBase}
+ * @alias Blockly.Events.TrashcanOpen
  */
 class TrashcanOpen extends UiBase {
   /**
@@ -30,7 +31,6 @@ class TrashcanOpen extends UiBase {
    *     if opening). Undefined for a blank event.
    * @param {string=} opt_workspaceId The workspace identifier for this event.
    *    Undefined for a blank event.
-   * @alias Blockly.Events.TrashcanOpen
    */
   constructor(opt_isOpen, opt_workspaceId) {
     super(opt_workspaceId);

--- a/core/events/events_ui.js
+++ b/core/events/events_ui.js
@@ -28,6 +28,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
  * Class for a UI event.
  * @extends {UiBase}
  * @deprecated December 2020. Instead use a more specific UI event.
+ * @alias Blockly.Events.Ui
  */
 class Ui extends UiBase {
   /**
@@ -37,7 +38,6 @@ class Ui extends UiBase {
    *     etc.
    * @param {*=} opt_oldValue Previous value of element.
    * @param {*=} opt_newValue New value of element.
-   * @alias Blockly.Events.Ui
    */
   constructor(opt_block, opt_element, opt_oldValue, opt_newValue) {
     const workspaceId = opt_block ? opt_block.workspace.id : undefined;

--- a/core/events/events_ui_base.js
+++ b/core/events/events_ui_base.js
@@ -27,12 +27,12 @@ const {Abstract: AbstractEvent} = goog.require('Blockly.Events.Abstract');
  * categories).
  * UI events do not undo or redo.
  * @extends {AbstractEvent}
+ * @alias Blockly.Events.UiBase
  */
 class UiBase extends AbstractEvent {
   /**
    * @param {string=} opt_workspaceId The workspace identifier for this event.
    *    Undefined for a blank event.
-   * @alias Blockly.Events.UiBase
    */
   constructor(opt_workspaceId) {
     super();

--- a/core/events/events_var_base.js
+++ b/core/events/events_var_base.js
@@ -23,12 +23,12 @@ const {VariableModel} = goog.requireType('Blockly.VariableModel');
 /**
  * Abstract class for a variable event.
  * @extends {AbstractEvent}
+ * @alias Blockly.Events.VarBase
  */
 class VarBase extends AbstractEvent {
   /**
    * @param {!VariableModel=} opt_variable The variable this event
    *     corresponds to.  Undefined for a blank event.
-   * @alias Blockly.Events.VarBase
    */
   constructor(opt_variable) {
     super();

--- a/core/events/events_var_create.js
+++ b/core/events/events_var_create.js
@@ -25,12 +25,12 @@ const {VariableModel} = goog.requireType('Blockly.VariableModel');
 /**
  * Class for a variable creation event.
  * @extends {VarBase}
+ * @alias Blockly.Events.VarCreate
  */
 class VarCreate extends VarBase {
   /**
    * @param {!VariableModel=} opt_variable The created variable. Undefined
    *     for a blank event.
-   * @alias Blockly.Events.VarCreate
    */
   constructor(opt_variable) {
     super(opt_variable);

--- a/core/events/events_var_delete.js
+++ b/core/events/events_var_delete.js
@@ -25,12 +25,12 @@ const {VariableModel} = goog.requireType('Blockly.VariableModel');
 /**
  * Class for a variable deletion event.
  * @extends {VarBase}
+ * @alias Blockly.Events.VarDelete
  */
 class VarDelete extends VarBase {
   /**
    * @param {!VariableModel=} opt_variable The deleted variable. Undefined
    *     for a blank event.
-   * @alias Blockly.Events.VarDelete
    */
   constructor(opt_variable) {
     super(opt_variable);

--- a/core/events/events_var_rename.js
+++ b/core/events/events_var_rename.js
@@ -25,13 +25,13 @@ const {VariableModel} = goog.requireType('Blockly.VariableModel');
 /**
  * Class for a variable rename event.
  * @extends {VarBase}
+ * @alias Blockly.Events.VarRename
  */
 class VarRename extends VarBase {
   /**
    * @param {!VariableModel=} opt_variable The renamed variable. Undefined
    *     for a blank event.
    * @param {string=} newName The new name the variable will be changed to.
-   * @alias Blockly.Events.VarRename
    */
   constructor(opt_variable, newName) {
     super(opt_variable);

--- a/core/events/events_viewport.js
+++ b/core/events/events_viewport.js
@@ -23,6 +23,7 @@ const {UiBase} = goog.require('Blockly.Events.UiBase');
 /**
  * Class for a viewport change event.
  * @extends {UiBase}
+ * @alias Blockly.Events.ViewportChange
  */
 class ViewportChange extends UiBase {
   /**
@@ -37,7 +38,6 @@ class ViewportChange extends UiBase {
    *    Undefined for a blank event.
    * @param {number=} opt_oldScale The old scale of the workspace. Undefined for
    *     a blank event.
-   * @alias Blockly.Events.ViewportChange
    */
   constructor(opt_top, opt_left, opt_scale, opt_workspaceId, opt_oldScale) {
     super(opt_workspaceId);

--- a/core/events/workspace_events.js
+++ b/core/events/workspace_events.js
@@ -28,12 +28,12 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
  * domToWorkspace).
  * Finished loading events do not record undo or redo.
  * @extends {AbstractEvent}
+ * @alias Blockly.Events.FinishedLoading
  */
 class FinishedLoading extends AbstractEvent {
   /**
    * @param {!Workspace=} opt_workspace The workspace that has finished
    *    loading.  Undefined for a blank event.
-   * @alias Blockly.Events.FinishedLoading
    */
   constructor(opt_workspace) {
     super();

--- a/core/field.js
+++ b/core/field.js
@@ -70,6 +70,7 @@ goog.require('Blockly.Gesture');
  * @implements {IKeyboardAccessible}
  * @implements {IRegistrable}
  * @abstract
+ * @alias Blockly.Field
  */
 class Field {
   /**
@@ -83,7 +84,6 @@ class Field {
    * @param {Object=} opt_config A map of options used to configure the field.
    *    Refer to the individual field's documentation for a list of properties
    *    this parameter supports.
-   * @alias Blockly.Field
    */
   constructor(value, opt_validator, opt_config) {
     /**

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -34,6 +34,7 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for an editable angle field.
  * @extends {FieldTextInput}
+ * @alias Blockly.FieldAngle
  */
 class FieldAngle extends FieldTextInput {
   /**
@@ -49,7 +50,6 @@ class FieldAngle extends FieldTextInput {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/angle#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldAngle
    */
   constructor(opt_value, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_checkbox.js
+++ b/core/field_checkbox.js
@@ -27,6 +27,7 @@ goog.require('Blockly.Events.BlockChange');
 /**
  * Class for a checkbox field.
  * @extends {Field}
+ * @alias Blockly.FieldCheckbox
  */
 class FieldCheckbox extends Field {
   /**
@@ -44,7 +45,6 @@ class FieldCheckbox extends Field {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/checkbox#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldCheckbox
    */
   constructor(opt_value, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_colour.js
+++ b/core/field_colour.js
@@ -35,6 +35,7 @@ goog.require('Blockly.Events.BlockChange');
 /**
  * Class for a colour input field.
  * @extends {Field}
+ * @alias Blockly.FieldColour
  */
 class FieldColour extends Field {
   /**
@@ -52,7 +53,6 @@ class FieldColour extends Field {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/colour}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldColour
    */
   constructor(opt_value, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -38,6 +38,7 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for an editable dropdown field.
  * @extends {Field}
+ * @alias Blockly.FieldDropdown
  */
 class FieldDropdown extends Field {
   /**
@@ -56,7 +57,6 @@ class FieldDropdown extends Field {
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#creation}
    *     for a list of properties this parameter supports.
    * @throws {TypeError} If `menuGenerator` options are incorrectly structured.
-   * @alias Blockly.FieldDropdown
    */
   constructor(menuGenerator, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_image.js
+++ b/core/field_image.js
@@ -28,6 +28,7 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for an image on a block.
  * @extends {Field}
+ * @alias Blockly.FieldImage
  */
 class FieldImage extends Field {
   /**
@@ -46,7 +47,6 @@ class FieldImage extends Field {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/image#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldImage
    */
   constructor(
       src, width, height, opt_alt, opt_onClick, opt_flipRtl, opt_config) {

--- a/core/field_label.js
+++ b/core/field_label.js
@@ -28,6 +28,7 @@ const {Sentinel} = goog.requireType('Blockly.utils.Sentinel');
 /**
  * Class for a non-editable, non-serializable text field.
  * @extends {Field}
+ * @alias Blockly.FieldLabel
  */
 class FieldLabel extends Field {
   /**
@@ -42,7 +43,6 @@ class FieldLabel extends Field {
    *    See the [field creation documentation]{@link
    * https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label#creation}
    *    for a list of properties this parameter supports.
-   * @alias Blockly.FieldLabel
    */
   constructor(opt_value, opt_class, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_label_serializable.js
+++ b/core/field_label_serializable.js
@@ -27,6 +27,7 @@ const {FieldLabel} = goog.require('Blockly.FieldLabel');
 /**
  * Class for a non-editable, serializable text field.
  * @extends {FieldLabel}
+ * @alias Blockly.FieldLabelSerializable
  */
 class FieldLabelSerializable extends FieldLabel {
   /**
@@ -37,7 +38,6 @@ class FieldLabelSerializable extends FieldLabel {
    *    See the [field creation documentation]{@link
    * https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/label-serializable#creation}
    *    for a list of properties this parameter supports.
-   * @alias Blockly.FieldLabelSerializable
    */
   constructor(opt_value, opt_class, opt_config) {
     super(String(opt_value ?? ''), opt_class, opt_config);

--- a/core/field_multilineinput.js
+++ b/core/field_multilineinput.js
@@ -33,6 +33,7 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for an editable text area field.
  * @extends {FieldTextInput}
+ * @alias Blockly.FieldMultilineInput
  */
 class FieldMultilineInput extends FieldTextInput {
   /**
@@ -50,7 +51,6 @@ class FieldMultilineInput extends FieldTextInput {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/multiline-text-input#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldMultilineInput
    */
   constructor(opt_value, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_number.js
+++ b/core/field_number.js
@@ -26,6 +26,7 @@ const {Sentinel} = goog.requireType('Blockly.utils.Sentinel');
 /**
  * Class for an editable number field.
  * @extends {FieldTextInput}
+ * @alias Blockly.FieldNumber
  */
 class FieldNumber extends FieldTextInput {
   /**
@@ -47,7 +48,6 @@ class FieldNumber extends FieldTextInput {
    *     See the [field creation documentation]{@link
    *     https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/number#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldNumber
    */
   constructor(
       opt_value, opt_min, opt_max, opt_precision, opt_validator, opt_config) {

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -41,6 +41,7 @@ goog.require('Blockly.Events.BlockChange');
 
 /**
  * Class for an editable text field.
+ * @alias Blockly.FieldTextInput
  */
 class FieldTextInput extends Field {
   /**
@@ -57,7 +58,6 @@ class FieldTextInput extends Field {
    *     See the [field creation documentation]{@link
    * https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/text-input#creation}
    *     for a list of properties this parameter supports.
-   * @alias Blockly.FieldTextInput
    */
   constructor(opt_value, opt_validator, opt_config) {
     super(Field.SKIP_SETUP);

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -40,6 +40,7 @@ goog.require('Blockly.Events.BlockChange');
 /**
  * Class for a variable's dropdown field.
  * @extends {FieldDropdown}
+ * @alias Blockly.FieldVariable
  */
 class FieldVariable extends FieldDropdown {
   /**
@@ -61,7 +62,6 @@ class FieldVariable extends FieldDropdown {
    *    See the [field creation documentation]{@link
    *    https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/variable#creation}
    *    for a list of properties this parameter supports.
-   * @alias Blockly.FieldVariable
    */
   constructor(
       varName, opt_validator, opt_variableTypes, opt_defaultType, opt_config) {

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -61,12 +61,12 @@ goog.require('Blockly.blockRendering');
  * @abstract
  * @implements {IFlyout}
  * @extends {DeleteArea}
+ * @alias Blockly.Flyout
  */
 class Flyout extends DeleteArea {
   /**
    * @param {!Options} workspaceOptions Dictionary of options for the
    *     workspace.
-   * @alias Blockly.Flyout
    */
   constructor(workspaceOptions) {
     super();

--- a/core/flyout_button.js
+++ b/core/flyout_button.js
@@ -30,6 +30,7 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 
 /**
  * Class for a button or label in the flyout.
+ * @alias Blockly.FlyoutButton
  */
 class FlyoutButton {
   /**
@@ -40,7 +41,6 @@ class FlyoutButton {
    *    The JSON specifying the label/button.
    * @param {boolean} isLabel Whether this button should be styled as a label.
    * @package
-   * @alias Blockly.FlyoutButton
    */
   constructor(workspace, targetWorkspace, json, isLabel) {
     /**

--- a/core/flyout_horizontal.js
+++ b/core/flyout_horizontal.js
@@ -32,12 +32,12 @@ const {Scrollbar} = goog.require('Blockly.Scrollbar');
 /**
  * Class for a flyout.
  * @extends {Flyout}
+ * @alias Blockly.HorizontalFlyout
  */
 class HorizontalFlyout extends Flyout {
   /**
    * @param {!Options} workspaceOptions Dictionary of options for the
    *     workspace.
-   * @alias Blockly.HorizontalFlyout
    */
   constructor(workspaceOptions) {
     super(workspaceOptions);

--- a/core/flyout_metrics_manager.js
+++ b/core/flyout_metrics_manager.js
@@ -26,12 +26,12 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  * Calculates metrics for a flyout's workspace.
  * The metrics are mainly used to size scrollbars for the flyout.
  * @extends {MetricsManager}
+ * @alias Blockly.FlyoutMetricsManager
  */
 class FlyoutMetricsManager extends MetricsManager {
   /**
    * @param {!WorkspaceSvg} workspace The flyout's workspace.
    * @param {!IFlyout} flyout The flyout.
-   * @alias Blockly.FlyoutMetricsManager
    */
   constructor(workspace, flyout) {
     super(workspace);

--- a/core/flyout_vertical.js
+++ b/core/flyout_vertical.js
@@ -36,12 +36,12 @@ goog.require('Blockly.constants');
 /**
  * Class for a flyout.
  * @extends {Flyout}
+ * @alias Blockly.VerticalFlyout
  */
 class VerticalFlyout extends Flyout {
   /**
    * @param {!Options} workspaceOptions Dictionary of options for the
    *     workspace.
-   * @alias Blockly.VerticalFlyout
    */
   constructor(workspaceOptions) {
     super(workspaceOptions);

--- a/core/generator.js
+++ b/core/generator.js
@@ -30,11 +30,11 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 /**
  * Class for a code generator that translates the blocks into a language.
  * @unrestricted
+ * @alias Blockly.Generator
  */
 class Generator {
   /**
    * @param {string} name Language name of this generator.
-   * @alias Blockly.Generator
    */
   constructor(name) {
     this.name_ = name;

--- a/core/gesture.js
+++ b/core/gesture.js
@@ -56,13 +56,13 @@ goog.require('Blockly.Events.Click');
 
 /**
  * Class for one gesture.
+ * @alias Blockly.Gesture
  */
 class Gesture {
   /**
    * @param {!Event} e The event that kicked off this gesture.
    * @param {!WorkspaceSvg} creatorWorkspace The workspace that created
    *     this gesture and has a reference to it.
-   * @alias Blockly.Gesture
    */
   constructor(e, creatorWorkspace) {
     /**

--- a/core/grid.js
+++ b/core/grid.js
@@ -24,6 +24,7 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 
 /**
  * Class for a workspace's grid.
+ * @alias Blockly.Grid
  */
 class Grid {
   /**
@@ -32,7 +33,6 @@ class Grid {
    * @param {!Object} options A dictionary of normalized options for the grid.
    *     See grid documentation:
    *     https://developers.google.com/blockly/guides/configure/web/grid
-   * @alias Blockly.Grid
    */
   constructor(pattern, options) {
     /**

--- a/core/icon.js
+++ b/core/icon.js
@@ -30,11 +30,11 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * Class for an icon.
  * @abstract
+ * @alias Blockly.Icon
  */
 class Icon {
   /**
    * @param {BlockSvg} block The block associated with this icon.
-   * @alias Blockly.Icon
    */
   constructor(block) {
     /**

--- a/core/input.js
+++ b/core/input.js
@@ -45,6 +45,7 @@ exports.Align = Align;
 
 /**
  * Class for an input with an optional field.
+ * @alias Blockly.Input
  */
 class Input {
   /**
@@ -53,7 +54,6 @@ class Input {
    *     this input again.
    * @param {!Block} block The block containing this input.
    * @param {Connection} connection Optional connection for this input.
-   * @alias Blockly.Input
    */
   constructor(type, name, block, connection) {
     if (type !== inputTypes.DUMMY && !name) {

--- a/core/insertion_marker_manager.js
+++ b/core/insertion_marker_manager.js
@@ -52,11 +52,11 @@ const DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
  * Class that controls updates to connections during drags.  It is primarily
  * responsible for finding the closest eligible connection and highlighting or
  * unhighlighting it as needed during a drag.
+ * @alias Blockly.InsertionMarkerManager
  */
 class InsertionMarkerManager {
   /**
    * @param {!BlockSvg} block The top block in the stack being dragged.
-   * @alias Blockly.InsertionMarkerManager
    */
   constructor(block) {
     common.setSelected(block);

--- a/core/keyboard_nav/ast_node.js
+++ b/core/keyboard_nav/ast_node.js
@@ -39,6 +39,7 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
  * Class for an AST node.
  * It is recommended that you use one of the createNode methods instead of
  * creating a node directly.
+ * @alias Blockly.ASTNode
  */
 class ASTNode {
   /**

--- a/core/keyboard_nav/basic_cursor.js
+++ b/core/keyboard_nav/basic_cursor.js
@@ -27,6 +27,7 @@ const {Cursor} = goog.require('Blockly.Cursor');
  * This will allow the user to get to all nodes in the AST by hitting next or
  * previous.
  * @extends {Cursor}
+ * @alias Blockly.BasicCursor
  */
 class BasicCursor extends Cursor {
   /**

--- a/core/keyboard_nav/cursor.js
+++ b/core/keyboard_nav/cursor.js
@@ -25,6 +25,7 @@ const {Marker} = goog.require('Blockly.Marker');
  * Class for a cursor.
  * A cursor controls how a user navigates the Blockly AST.
  * @extends {Marker}
+ * @alias Blockly.Cursor
  */
 class Cursor extends Marker {
   /**

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -29,6 +29,9 @@ const {MarkerSvg} = goog.requireType('Blockly.blockRendering.MarkerSvg');
  * @alias Blockly.Marker
  */
 class Marker {
+  /**
+   * Constructs a new Marker instance.
+   */
   constructor() {
     /**
      * The colour of the marker.

--- a/core/keyboard_nav/marker.js
+++ b/core/keyboard_nav/marker.js
@@ -26,11 +26,9 @@ const {MarkerSvg} = goog.requireType('Blockly.blockRendering.MarkerSvg');
 /**
  * Class for a marker.
  * This is used in keyboard navigation to save a location in the Blockly AST.
+ * @alias Blockly.Marker
  */
 class Marker {
-  /**
-   * @alias Blockly.Marker
-   */
   constructor() {
     /**
      * The colour of the marker.

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -26,11 +26,9 @@ const {Field} = goog.requireType('Blockly.Field');
 /**
  * A cursor for navigating between tab navigable fields.
  * @extends {BasicCursor}
+ * @alias Blockly.TabNavigateCursor
  */
 class TabNavigateCursor extends BasicCursor {
-  /**
-   * @alias Blockly.TabNavigateCursor
-   */
   constructor() {
     super();
   }

--- a/core/keyboard_nav/tab_navigate_cursor.js
+++ b/core/keyboard_nav/tab_navigate_cursor.js
@@ -29,10 +29,6 @@ const {Field} = goog.requireType('Blockly.Field');
  * @alias Blockly.TabNavigateCursor
  */
 class TabNavigateCursor extends BasicCursor {
-  constructor() {
-    super();
-  }
-
   /**
    * Skip all nodes except for tab navigable fields.
    * @param {?ASTNode} node The AST node to check whether it is valid.

--- a/core/marker_manager.js
+++ b/core/marker_manager.js
@@ -25,11 +25,11 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 
 /**
  * Class to manage the multiple markers and the cursor on a workspace.
+ * @alias Blockly.MarkerManager
  */
 class MarkerManager {
   /**
    * @param {!WorkspaceSvg} workspace The workspace for the marker manager.
-   * @alias Blockly.MarkerManager
    * @package
    */
   constructor(workspace) {

--- a/core/menu.js
+++ b/core/menu.js
@@ -29,11 +29,9 @@ const {Size} = goog.requireType('Blockly.utils.Size');
 
 /**
  * A basic menu class.
+ * @alias Blockly.Menu
  */
 const Menu = class {
-  /**
-   * @alias Blockly.Menu
-   */
   constructor() {
     /**
      * Array of menu items.

--- a/core/menu.js
+++ b/core/menu.js
@@ -32,6 +32,9 @@ const {Size} = goog.requireType('Blockly.utils.Size');
  * @alias Blockly.Menu
  */
 const Menu = class {
+  /**
+   * Constructs a new Menu instance.
+   */
   constructor() {
     /**
      * Array of menu items.

--- a/core/menuitem.js
+++ b/core/menuitem.js
@@ -22,13 +22,13 @@ const idGenerator = goog.require('Blockly.utils.idGenerator');
 
 /**
  * Class representing an item in a menu.
+ * @alias Blockly.MenuItem
  */
 const MenuItem = class {
   /**
    * @param {string|!HTMLElement} content Text caption to display as the content
    *     of the item, or a HTML element to display.
    * @param {string=} opt_value Data/model associated with the menu item.
-   * @alias Blockly.MenuItem
    */
   constructor(content, opt_value) {
     /**

--- a/core/metrics_manager.js
+++ b/core/metrics_manager.js
@@ -33,12 +33,12 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 /**
  * The manager for all workspace metrics calculations.
  * @implements {IMetricsManager}
+ * @alias Blockly.MetricsManager
  */
 class MetricsManager {
   /**
    * @param {!WorkspaceSvg} workspace The workspace to calculate metrics
    *     for.
-   * @alias Blockly.MetricsManager
    */
   constructor(workspace) {
     /**

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -47,11 +47,11 @@ goog.require('Blockly.Events.BubbleOpen');
 /**
  * Class for a mutator dialog.
  * @extends {Icon}
+ * @alias Blockly.Mutator
  */
 class Mutator extends Icon {
   /**
    * @param {!Array<string>} quarkNames List of names of sub-blocks for flyout.
-   * @alias Blockly.Mutator
    */
   constructor(quarkNames) {
     super(null);

--- a/core/names.js
+++ b/core/names.js
@@ -27,6 +27,7 @@ goog.requireType('Blockly.Procedures');
 
 /**
  * Class for a database of entity names (variables, procedures, etc).
+ * @alias Blockly.Names
  */
 const Names = class {
   /**
@@ -34,7 +35,6 @@ const Names = class {
    *     illegal for use as names in a language (e.g. 'new,if,this,...').
    * @param {string=} opt_variablePrefix Some languages need a '$' or a
    *     namespace before all variable names (but not procedure names).
-   * @alias Blockly.Names
    */
   constructor(reservedWords, opt_variablePrefix) {
     /**

--- a/core/options.js
+++ b/core/options.js
@@ -31,13 +31,13 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 /**
  * Parse the user-specified options, using reasonable defaults where behaviour
  * is unspecified.
+ * @alias Blockly.Options
  */
 class Options {
   /**
    * @param {!BlocklyOptions} options Dictionary of options.
    *     Specification:
    * https://developers.google.com/blockly/guides/get-started/web#configuration
-   * @alias Blockly.Options
    */
   constructor(options) {
     let toolboxJsonDef = null;

--- a/core/registry.js
+++ b/core/registry.js
@@ -74,11 +74,11 @@ exports.DEFAULT = DEFAULT;
 /**
  * A name with the type of the element stored in the generic.
  * @template T
+ * @alias Blockly.registry.Type
  */
 class Type {
   /**
    * @param {string} name The name of the registry type.
-   * @alias Blockly.registry.Type
    */
   constructor(name) {
     /**

--- a/core/rendered_connection.js
+++ b/core/rendered_connection.js
@@ -43,12 +43,12 @@ const BUMP_RANDOMNESS = 10;
 /**
  * Class for a connection between blocks that may be rendered on screen.
  * @extends {Connection}
+ * @alias Blockly.RenderedConnection
  */
 class RenderedConnection extends Connection {
   /**
    * @param {!BlockSvg} source The block establishing this connection.
    * @param {number} type The type of the connection.
-   * @alias Blockly.RenderedConnection
    */
   constructor(source, type) {
     super(source, type);

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -31,11 +31,11 @@ const {Theme} = goog.requireType('Blockly.Theme');
 
 /**
  * An object that provides constants for rendering blocks.
+ * @alias Blockly.blockRendering.ConstantProvider
  */
 class ConstantProvider {
   /**
    * @package
-   * @alias Blockly.blockRendering.ConstantProvider
    */
   constructor() {
     /**

--- a/core/renderers/common/debugger.js
+++ b/core/renderers/common/debugger.js
@@ -43,13 +43,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
 
 /**
  * An object that renders rectangles and dots for debugging rendering code.
+ * @alias Blockly.blockRendering.Debug
  */
 class Debug {
   /**
    * @param {!ConstantProvider} constants The renderer's
    *     constants.
    * @package
-   * @alias Blockly.blockRendering.Debug
    */
   constructor(constants) {
     /**

--- a/core/renderers/common/drawer.js
+++ b/core/renderers/common/drawer.js
@@ -39,6 +39,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
 
 /**
  * An object that draws a block based on the given rendering information.
+ * @alias Blockly.blockRendering.Drawer
  */
 class Drawer {
   /**
@@ -46,7 +47,6 @@ class Drawer {
    * @param {!RenderInfo} info An object containing all
    *   information needed to render this block.
    * @package
-   * @alias Blockly.blockRendering.Drawer
    */
   constructor(block, info) {
     this.block_ = block;

--- a/core/renderers/common/info.js
+++ b/core/renderers/common/info.js
@@ -57,13 +57,13 @@ const {inputTypes} = goog.require('Blockly.inputTypes');
  * This measure pass does not propagate changes to the block (although fields
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
+ * @alias Blockly.blockRendering.RenderInfo
  */
 class RenderInfo {
   /**
    * @param {!Renderer} renderer The renderer in use.
    * @param {!BlockSvg} block The block to measure.
    * @package
-   * @alias Blockly.blockRendering.RenderInfo
    */
   constructor(renderer, block) {
     this.block_ = block;

--- a/core/renderers/common/marker_svg.js
+++ b/core/renderers/common/marker_svg.js
@@ -63,6 +63,7 @@ const HEIGHT_MULTIPLIER = 3 / 4;
 
 /**
  * Class for a marker.
+ * @alias Blockly.blockRendering.MarkerSvg
  */
 class MarkerSvg {
   /**
@@ -70,7 +71,6 @@ class MarkerSvg {
    * @param {!ConstantProvider} constants The constants for
    *     the renderer.
    * @param {!Marker} marker The marker to draw.
-   * @alias Blockly.blockRendering.MarkerSvg
    */
   constructor(workspace, constants, marker) {
     /**

--- a/core/renderers/common/path_object.js
+++ b/core/renderers/common/path_object.js
@@ -34,6 +34,7 @@ const {Theme} = goog.requireType('Blockly.Theme');
  * An object that handles creating and setting each of the SVG elements
  * used by the renderer.
  * @implements {IPathObject}
+ * @alias Blockly.blockRendering.PathObject
  */
 class PathObject {
   /**
@@ -43,7 +44,6 @@ class PathObject {
    * @param {!ConstantProvider} constants The renderer's
    *     constants.
    * @package
-   * @alias Blockly.blockRendering.PathObject
    */
   constructor(root, style, constants) {
     /**

--- a/core/renderers/common/renderer.js
+++ b/core/renderers/common/renderer.js
@@ -48,12 +48,12 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 /**
  * The base class for a block renderer.
  * @implements {IRegistrable}
+ * @alias Blockly.blockRendering.Renderer
  */
 class Renderer {
   /**
    * @param {string} name The renderer name.
    * @package
-   * @alias Blockly.blockRendering.Renderer
    */
   constructor(name) {
     /**

--- a/core/renderers/geras/constants.js
+++ b/core/renderers/geras/constants.js
@@ -23,11 +23,11 @@ const {ConstantProvider: BaseConstantProvider} = goog.require('Blockly.blockRend
 /**
  * An object that provides constants for rendering blocks in Geras mode.
  * @extends {BaseConstantProvider}
+ * @alias Blockly.geras.ConstantProvider
  */
 class ConstantProvider extends BaseConstantProvider {
   /**
    * @package
-   * @alias Blockly.geras.ConstantProvider
    */
   constructor() {
     super();

--- a/core/renderers/geras/drawer.js
+++ b/core/renderers/geras/drawer.js
@@ -34,6 +34,7 @@ const {RenderInfo} = goog.requireType('Blockly.geras.RenderInfo');
 /**
  * An object that draws a block based on the given rendering information.
  * @extends {BaseDrawer}
+ * @alias Blockly.geras.Drawer
  */
 class Drawer extends BaseDrawer {
   /**
@@ -41,7 +42,6 @@ class Drawer extends BaseDrawer {
    * @param {!RenderInfo} info An object containing all
    *   information needed to render this block.
    * @package
-   * @alias Blockly.geras.Drawer
    */
   constructor(block, info) {
     super(block, info);

--- a/core/renderers/geras/highlight_constants.js
+++ b/core/renderers/geras/highlight_constants.js
@@ -25,13 +25,13 @@ const {ConstantProvider} = goog.requireType('Blockly.blockRendering.ConstantProv
  * Some highlights are simple offsets of the parent paths and can be generated
  * programmatically.  Others, especially on curves, are just made out of piles
  * of constants and are hard to tweak.
+ * @alias Blockly.geras.HighlightConstantProvider
  */
 class HighlightConstantProvider {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.geras.HighlightConstantProvider
    */
   constructor(constants) {
     /**

--- a/core/renderers/geras/highlighter.js
+++ b/core/renderers/geras/highlighter.js
@@ -48,13 +48,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * position of each part of the block.  The resulting paths are not continuous
  * or closed paths.  The highlights for tabs and notches are loosely based on
  * tab and notch shapes, but are not exactly the same.
+ * @alias Blockly.geras.Highlighter
  */
 class Highlighter {
   /**
    * @param {!RenderInfo} info An object containing all
    *     information needed to render this block.
    * @package
-   * @alias Blockly.geras.Highlighter
    */
   constructor(info) {
     this.info_ = info;

--- a/core/renderers/geras/info.js
+++ b/core/renderers/geras/info.js
@@ -47,13 +47,13 @@ const {inputTypes} = goog.require('Blockly.inputTypes');
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
  * @extends {BaseRenderInfo}
+ * @alias Blockly.geras.RenderInfo
  */
 class RenderInfo extends BaseRenderInfo {
   /**
    * @param {!Renderer} renderer The renderer in use.
    * @param {!BlockSvg} block The block to measure.
    * @package
-   * @alias Blockly.geras.RenderInfo
    */
   constructor(renderer, block) {
     super(renderer, block);

--- a/core/renderers/geras/measurables/inline_input.js
+++ b/core/renderers/geras/measurables/inline_input.js
@@ -30,6 +30,7 @@ const {Input} = goog.requireType('Blockly.Input');
  * An object containing information about the space an inline input takes up
  * during rendering.
  * @extends {BaseInlineInput}
+ * @alias Blockly.geras.InlineInput
  */
 class InlineInput extends BaseInlineInput {
   /**
@@ -38,7 +39,6 @@ class InlineInput extends BaseInlineInput {
    * @param {!Input} input The inline input to measure and store
    *     information for.
    * @package
-   * @alias Blockly.geras.InlineInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/geras/measurables/statement_input.js
+++ b/core/renderers/geras/measurables/statement_input.js
@@ -30,6 +30,7 @@ const {StatementInput: BaseStatementInput} = goog.require('Blockly.blockRenderin
  * An object containing information about the space a statement input takes up
  * during rendering.
  * @extends {BaseStatementInput}
+ * @alias Blockly.geras.StatementInput
  */
 class StatementInput extends BaseStatementInput {
   /**
@@ -38,7 +39,6 @@ class StatementInput extends BaseStatementInput {
    * @param {!Input} input The statement input to measure and store
    *     information for.
    * @package
-   * @alias Blockly.geras.StatementInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/geras/path_object.js
+++ b/core/renderers/geras/path_object.js
@@ -29,6 +29,7 @@ const {Theme} = goog.requireType('Blockly.Theme');
 /**
  * An object that handles creating and setting each of the SVG elements
  * used by the renderer.
+ * @alias Blockly.geras.PathObject
  */
 class PathObject extends BasePathObject {
   /**
@@ -36,7 +37,6 @@ class PathObject extends BasePathObject {
    * @param {!Theme.BlockStyle} style The style object to use for
    *     colouring.
    * @param {!ConstantProvider} constants The renderer's constants.
-   * @alias Blockly.geras.PathObject
    * @package
    */
   constructor(root, style, constants) {

--- a/core/renderers/geras/renderer.js
+++ b/core/renderers/geras/renderer.js
@@ -35,12 +35,12 @@ const {Theme} = goog.requireType('Blockly.Theme');
 /**
  * The geras renderer.
  * @extends {BaseRenderer}
+ * @alias Blockly.geras.Renderer
  */
 class Renderer extends BaseRenderer {
   /**
    * @param {string} name The renderer name.
    * @package
-   * @alias Blockly.geras.Renderer
    */
   constructor(name) {
     super(name);

--- a/core/renderers/measurables/base.js
+++ b/core/renderers/measurables/base.js
@@ -25,13 +25,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * The base class to represent a part of a block that takes up space during
  * rendering.  The constructor for each non-spacer Measurable records the size
  * of the block element (e.g. field, statement input).
+ * @alias Blockly.blockRendering.Measurable
  */
 class Measurable {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.Measurable
    */
   constructor(constants) {
     /** @type {number} */

--- a/core/renderers/measurables/bottom_row.js
+++ b/core/renderers/measurables/bottom_row.js
@@ -33,13 +33,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * connections.
  * @extends {Row}
  * @struct
+ * @alias Blockly.blockRendering.BottomRow
  */
 class BottomRow extends Row {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.BottomRow
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/measurables/connection.js
+++ b/core/renderers/measurables/connection.js
@@ -28,6 +28,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * The base class to represent a connection and the space that it takes up on
  * the block.
  * @extends {Measurable}
+ * @alias Blockly.blockRendering.Connection
  */
 class Connection extends Measurable {
   /**
@@ -36,7 +37,6 @@ class Connection extends Measurable {
    * @param {!RenderedConnection} connectionModel The connection object on
    *     the block that this represents.
    * @package
-   * @alias Blockly.blockRendering.Connection
    */
   constructor(constants, connectionModel) {
     super(constants);

--- a/core/renderers/measurables/external_value_input.js
+++ b/core/renderers/measurables/external_value_input.js
@@ -29,6 +29,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * takes up during rendering
  * @struct
  * @extends {InputConnection}
+ * @alias Blockly.blockRendering.ExternalValueInput
  */
 class ExternalValueInput extends InputConnection {
   /**
@@ -37,7 +38,6 @@ class ExternalValueInput extends InputConnection {
    * @param {!Input} input The external value input to measure and store
    *     information for.
    * @package
-   * @alias Blockly.blockRendering.ExternalValueInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/measurables/field.js
+++ b/core/renderers/measurables/field.js
@@ -31,6 +31,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * rendering
  * @struct
  * @extends {Measurable}
+ * @alias Blockly.blockRendering.Field
  */
 class Field extends Measurable {
   /**
@@ -40,7 +41,6 @@ class Field extends Measurable {
    *     for.
    * @param {!Input} parentInput The parent input for the field.
    * @package
-   * @alias Blockly.blockRendering.Field
    */
   constructor(constants, field, parentInput) {
     super(constants);

--- a/core/renderers/measurables/hat.js
+++ b/core/renderers/measurables/hat.js
@@ -27,13 +27,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * rendering.
  * @struct
  * @extends {Measurable}
+ * @alias Blockly.blockRendering.Hat
  */
 class Hat extends Measurable {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.Hat
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/measurables/icon.js
+++ b/core/renderers/measurables/icon.js
@@ -39,7 +39,6 @@ class Icon extends Measurable {
    *   constants provider.
    * @param {!BlocklyIcon} icon The icon to measure and store information for.
    * @package
-   * @alias Blockly.blockRendering.Icon
    */
   constructor(constants, icon) {
     super(constants);

--- a/core/renderers/measurables/in_row_spacer.js
+++ b/core/renderers/measurables/in_row_spacer.js
@@ -27,6 +27,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * row.
  * @extends {Measurable}
  * @struct
+ * @alias Blockly.blockRendering.InRowSpacer
  */
 class InRowSpacer extends Measurable {
   /**
@@ -34,7 +35,6 @@ class InRowSpacer extends Measurable {
    *   constants provider.
    * @param {number} width The width of the spacer.
    * @package
-   * @alias Blockly.blockRendering.InRowSpacer
    */
   constructor(constants, width) {
     super(constants);

--- a/core/renderers/measurables/inline_input.js
+++ b/core/renderers/measurables/inline_input.js
@@ -29,6 +29,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * during rendering
  * @extends {InputConnection}
  * @struct
+ * @alias Blockly.blockRendering.InlineInput
  */
 class InlineInput extends InputConnection {
   /**
@@ -37,7 +38,6 @@ class InlineInput extends InputConnection {
    * @param {!Input} input The inline input to measure and store
    *     information for.
    * @package
-   * @alias Blockly.blockRendering.InlineInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/measurables/input_connection.js
+++ b/core/renderers/measurables/input_connection.js
@@ -31,13 +31,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * during rendering
  * @package
  * @extends {Connection}
+ * @alias Blockly.blockRendering.InputConnection
  */
 class InputConnection extends Connection {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @param {!Input} input The input to measure and store information for.
-   * @alias Blockly.blockRendering.InputConnection
    */
   constructor(constants, input) {
     super(constants, /** @type {!RenderedConnection} */ (input.connection));

--- a/core/renderers/measurables/input_row.js
+++ b/core/renderers/measurables/input_row.js
@@ -29,13 +29,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * An object containing information about a row that holds one or more inputs.
  * @extends {Row}
  * @struct
+ * @alias Blockly.blockRendering.InputRow
  */
 class InputRow extends Row {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.InputRow
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/measurables/jagged_edge.js
+++ b/core/renderers/measurables/jagged_edge.js
@@ -27,13 +27,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * takes up during rendering
  * @extends {Measurable}
  * @struct
+ * @alias Blockly.blockRendering.JaggedEdge
  */
 class JaggedEdge extends Measurable {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.JaggedEdge
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/measurables/next_connection.js
+++ b/core/renderers/measurables/next_connection.js
@@ -29,6 +29,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * up during rendering.
  * @extends {Connection}
  * @struct
+ * @alias Blockly.blockRendering.NextConnection
  */
 class NextConnection extends Connection {
   /**
@@ -37,7 +38,6 @@ class NextConnection extends Connection {
    * @param {!RenderedConnection} connectionModel The connection object on
    *     the block that this represents.
    * @package
-   * @alias Blockly.blockRendering.NextConnection
    */
   constructor(constants, connectionModel) {
     super(constants, connectionModel);

--- a/core/renderers/measurables/output_connection.js
+++ b/core/renderers/measurables/output_connection.js
@@ -30,6 +30,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * up during rendering.
  * @extends {Connection}
  * @struct
+ * @alias Blockly.blockRendering.OutputConnection
  */
 class OutputConnection extends Connection {
   /**
@@ -38,7 +39,6 @@ class OutputConnection extends Connection {
    * @param {!RenderedConnection} connectionModel The connection object on
    *     the block that this represents.
    * @package
-   * @alias Blockly.blockRendering.OutputConnection
    */
   constructor(constants, connectionModel) {
     super(constants, connectionModel);

--- a/core/renderers/measurables/previous_connection.js
+++ b/core/renderers/measurables/previous_connection.js
@@ -29,6 +29,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * up during rendering.
  * @extends {Connection}
  * @struct
+ * @alias Blockly.blockRendering.PreviousConnection
  */
 class PreviousConnection extends Connection {
   /**
@@ -37,7 +38,6 @@ class PreviousConnection extends Connection {
    * @param {!RenderedConnection} connectionModel The connection object on
    *     the block that this represents.
    * @package
-   * @alias Blockly.blockRendering.PreviousConnection
    */
   constructor(constants, connectionModel) {
     super(constants, connectionModel);

--- a/core/renderers/measurables/round_corner.js
+++ b/core/renderers/measurables/round_corner.js
@@ -27,6 +27,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * during rendering.
  * @extends {Measurable}
  * @struct
+ * @alias Blockly.blockRendering.RoundCorner
  */
 class RoundCorner extends Measurable {
   /**
@@ -34,7 +35,6 @@ class RoundCorner extends Measurable {
    *   constants provider.
    * @param {string=} opt_position The position of this corner.
    * @package
-   * @alias Blockly.blockRendering.RoundCorner
    */
   constructor(constants, opt_position) {
     super(constants);

--- a/core/renderers/measurables/row.js
+++ b/core/renderers/measurables/row.js
@@ -28,13 +28,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
 /**
  * An object representing a single row on a rendered block and all of its
  * subcomponents.
+ * @alias Blockly.blockRendering.Row
  */
 class Row {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.Row
    */
   constructor(constants) {
     /**

--- a/core/renderers/measurables/spacer_row.js
+++ b/core/renderers/measurables/spacer_row.js
@@ -25,6 +25,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * An object containing information about a spacer between two rows.
  * @extends {Row}
  * @struct
+ * @alias Blockly.blockRendering.SpacerRow
  */
 class SpacerRow extends Row {
   /**
@@ -33,7 +34,6 @@ class SpacerRow extends Row {
    * @param {number} height The height of the spacer.
    * @param {number} width The width of the spacer.
    * @package
-   * @alias Blockly.blockRendering.SpacerRow
    */
   constructor(constants, height, width) {
     super(constants);

--- a/core/renderers/measurables/square_corner.js
+++ b/core/renderers/measurables/square_corner.js
@@ -27,6 +27,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * during rendering.
  * @extends {Measurable}
  * @struct
+ * @alias Blockly.blockRendering.SquareCorner
  */
 class SquareCorner extends Measurable {
   /**
@@ -34,7 +35,6 @@ class SquareCorner extends Measurable {
    *   constants provider.
    * @param {string=} opt_position The position of this corner.
    * @package
-   * @alias Blockly.blockRendering.SquareCorner
    */
   constructor(constants, opt_position) {
     super(constants);

--- a/core/renderers/measurables/statement_input.js
+++ b/core/renderers/measurables/statement_input.js
@@ -29,6 +29,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * during rendering
  * @struct
  * @extends {InputConnection}
+ * @alias Blockly.blockRendering.StatementInput
  */
 class StatementInput extends InputConnection {
   /**
@@ -37,7 +38,6 @@ class StatementInput extends InputConnection {
    * @param {!Input} input The statement input to measure and store
    *     information for.
    * @package
-   * @alias Blockly.blockRendering.StatementInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/measurables/top_row.js
+++ b/core/renderers/measurables/top_row.js
@@ -34,13 +34,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * elements it needs.
  * @extends {Row}
  * @struct
+ * @alias Blockly.blockRendering.TopRow
  */
 class TopRow extends Row {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.blockRendering.TopRow
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/minimalist/constants.js
+++ b/core/renderers/minimalist/constants.js
@@ -23,11 +23,11 @@ const {ConstantProvider: BaseConstantProvider} = goog.require('Blockly.blockRend
 /**
  * An object that provides constants for rendering blocks in the sample.
  * @extends {BaseConstantProvider}
+ * @alias Blockly.minimalist.ConstantProvider
  */
 class ConstantProvider extends BaseConstantProvider {
   /**
    * @package
-   * @alias Blockly.minimalist.ConstantProvider
    */
   constructor() {
     super();

--- a/core/renderers/minimalist/drawer.js
+++ b/core/renderers/minimalist/drawer.js
@@ -25,6 +25,7 @@ const {RenderInfo} = goog.requireType('Blockly.minimalist.RenderInfo');
 /**
  * An object that draws a block based on the given rendering information.
  * @extends {BaseDrawer}
+ * @alias Blockly.minimalist.Drawer
  */
 class Drawer extends BaseDrawer {
   /**
@@ -32,7 +33,6 @@ class Drawer extends BaseDrawer {
    * @param {!RenderInfo} info An object containing all
    *   information needed to render this block.
    * @package
-   * @alias Blockly.minimalist.Drawer
    */
   constructor(block, info) {
     super(block, info);

--- a/core/renderers/minimalist/info.js
+++ b/core/renderers/minimalist/info.js
@@ -29,13 +29,13 @@ const {Renderer} = goog.requireType('Blockly.minimalist.Renderer');
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
  * @extends {BaseRenderInfo}
+ * @alias Blockly.minimalist.RenderInfo
  */
 class RenderInfo extends BaseRenderInfo {
   /**
    * @param {!Renderer} renderer The renderer in use.
    * @param {!BlockSvg} block The block to measure.
    * @package
-   * @alias Blockly.minimalist.RenderInfo
    */
   constructor(renderer, block) {
     super(renderer, block);

--- a/core/renderers/minimalist/renderer.js
+++ b/core/renderers/minimalist/renderer.js
@@ -29,12 +29,12 @@ const {Renderer: BaseRenderer} = goog.require('Blockly.blockRendering.Renderer')
 /**
  * The minimalist renderer.
  * @extends {BaseRenderer}
+ * @alias Blockly.minimalist.Renderer
  */
 class Renderer extends BaseRenderer {
   /**
    * @param {string} name The renderer name.
    * @package
-   * @alias Blockly.minimalist.Renderer
    */
   constructor(name) {
     super(name);

--- a/core/renderers/thrasos/info.js
+++ b/core/renderers/thrasos/info.js
@@ -39,13 +39,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
  * @extends {BaseRenderInfo}
+ * @alias Blockly.thrasos.RenderInfo
  */
 class RenderInfo extends BaseRenderInfo {
   /**
    * @param {!Renderer} renderer The renderer in use.
    * @param {!BlockSvg} block The block to measure.
    * @package
-   * @alias Blockly.thrasos.RenderInfo
    */
   constructor(renderer, block) {
     super(renderer, block);

--- a/core/renderers/thrasos/renderer.js
+++ b/core/renderers/thrasos/renderer.js
@@ -25,12 +25,12 @@ const {Renderer: BaseRenderer} = goog.require('Blockly.blockRendering.Renderer')
 /**
  * The thrasos renderer.
  * @extends {BaseRenderer}
+ * @alias Blockly.thrasos.Renderer
  */
 class Renderer extends BaseRenderer {
   /**
    * @param {string} name The renderer name.
    * @package
-   * @alias Blockly.thrasos.Renderer
    */
   constructor(name) {
     super(name);

--- a/core/renderers/zelos/constants.js
+++ b/core/renderers/zelos/constants.js
@@ -28,11 +28,11 @@ const {Svg} = goog.require('Blockly.utils.Svg');
 /**
  * An object that provides constants for rendering blocks in Zelos mode.
  * @extends {BaseConstantProvider}
+ * @alias Blockly.zelos.ConstantProvider
  */
 class ConstantProvider extends BaseConstantProvider {
   /**
    * @package
-   * @alias Blockly.zelos.ConstantProvider
    */
   constructor() {
     super();

--- a/core/renderers/zelos/drawer.js
+++ b/core/renderers/zelos/drawer.js
@@ -36,6 +36,7 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
 /**
  * An object that draws a block based on the given rendering information.
  * @extends {BaseDrawer}
+ * @alias Blockly.zelos.Drawer
  */
 class Drawer extends BaseDrawer {
   /**
@@ -43,7 +44,6 @@ class Drawer extends BaseDrawer {
    * @param {!RenderInfo} info An object containing all
    *   information needed to render this block.
    * @package
-   * @alias Blockly.zelos.Drawer
    */
   constructor(block, info) {
     super(block, info);

--- a/core/renderers/zelos/info.js
+++ b/core/renderers/zelos/info.js
@@ -53,13 +53,13 @@ const {inputTypes} = goog.require('Blockly.inputTypes');
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
  * @extends {BaseRenderInfo}
+ * @alias Blockly.zelos.RenderInfo
  */
 class RenderInfo extends BaseRenderInfo {
   /**
    * @param {!Renderer} renderer The renderer in use.
    * @param {!BlockSvg} block The block to measure.
    * @package
-   * @alias Blockly.zelos.RenderInfo
    */
   constructor(renderer, block) {
     super(renderer, block);

--- a/core/renderers/zelos/marker_svg.js
+++ b/core/renderers/zelos/marker_svg.js
@@ -37,6 +37,7 @@ const {ConstantProvider: ZelosConstantProvider} = goog.requireType('Blockly.zelo
 /**
  * Class to draw a marker.
  * @extends {BaseMarkerSvg}
+ * @alias Blockly.zelos.MarkerSvg
  */
 class MarkerSvg extends BaseMarkerSvg {
   /**
@@ -44,7 +45,6 @@ class MarkerSvg extends BaseMarkerSvg {
    * @param {!BaseConstantProvider} constants The constants for
    *     the renderer.
    * @param {!Marker} marker The marker to draw.
-   * @alias Blockly.zelos.MarkerSvg
    */
   constructor(workspace, constants, marker) {
     super(workspace, constants, marker);

--- a/core/renderers/zelos/measurables/bottom_row.js
+++ b/core/renderers/zelos/measurables/bottom_row.js
@@ -26,13 +26,13 @@ const {ConstantProvider} = goog.requireType('Blockly.blockRendering.ConstantProv
  * Elements in a bottom row can consist of corners, spacers and next
  * connections.
  * @extends {BaseBottomRow}
+ * @alias Blockly.zelos.BottomRow
  */
 class BottomRow extends BaseBottomRow {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.zelos.BottomRow
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/zelos/measurables/inputs.js
+++ b/core/renderers/zelos/measurables/inputs.js
@@ -27,6 +27,7 @@ const {StatementInput: BaseStatementInput} = goog.require('Blockly.blockRenderin
  * An object containing information about the space a statement input takes up
  * during rendering.
  * @extends {BaseStatementInput}
+ * @alias Blockly.zelos.StatementInput
  */
 class StatementInput extends BaseStatementInput {
   /**
@@ -34,7 +35,6 @@ class StatementInput extends BaseStatementInput {
    * @param {!Input} input The statement input to measure and store information
    *    for.
    * @package
-   * @alias Blockly.zelos.StatementInput
    */
   constructor(constants, input) {
     super(constants, input);

--- a/core/renderers/zelos/measurables/row_elements.js
+++ b/core/renderers/zelos/measurables/row_elements.js
@@ -26,13 +26,13 @@ const {Types} = goog.require('Blockly.blockRendering.Types');
  * An object containing information about the space a right connection shape
  * takes up during rendering.
  * @extends {Measurable}
+ * @alias Blockly.zelos.RightConnectionShape
  */
 class RightConnectionShape extends Measurable {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.zelos.RightConnectionShape
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/zelos/measurables/top_row.js
+++ b/core/renderers/zelos/measurables/top_row.js
@@ -28,13 +28,13 @@ const {TopRow: BaseTopRow} = goog.require('Blockly.blockRendering.TopRow');
  * After this constructor is called, the row will contain all non-spacer
  * elements it needs.
  * @extends {BaseTopRow}
+ * @alias Blockly.zelos.TopRow
  */
 class TopRow extends BaseTopRow {
   /**
    * @param {!ConstantProvider} constants The rendering
    *   constants provider.
    * @package
-   * @alias Blockly.zelos.TopRow
    */
   constructor(constants) {
     super(constants);

--- a/core/renderers/zelos/path_object.js
+++ b/core/renderers/zelos/path_object.js
@@ -28,6 +28,7 @@ const {Theme} = goog.requireType('Blockly.Theme');
 /**
  * An object that handles creating and setting each of the SVG elements
  * used by the renderer.
+ * @alias Blockly.zelos.PathObject
  */
 class PathObject extends BasePathObject {
   /**
@@ -36,7 +37,6 @@ class PathObject extends BasePathObject {
    *     colouring.
    * @param {!ConstantProvider} constants The renderer's constants.
    * @package
-   * @alias Blockly.zelos.PathObject
    */
   constructor(root, style, constants) {
     super(root, style, constants);

--- a/core/renderers/zelos/renderer.js
+++ b/core/renderers/zelos/renderer.js
@@ -39,12 +39,12 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 /**
  * The zelos renderer.
  * @extends {BaseRenderer}
+ * @alias Blockly.zelos.Renderer
  */
 class Renderer extends BaseRenderer {
   /**
    * @param {string} name The renderer name.
    * @package
-   * @alias Blockly.zelos.Renderer
    */
   constructor(name) {
     super(name);

--- a/core/scrollbar.js
+++ b/core/scrollbar.js
@@ -36,6 +36,7 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
  * Class for a pure SVG scrollbar.
  * This technique offers a scrollbar that is guaranteed to work, but may not
  * look or behave like the system's scrollbars.
+ * @alias Blockly.Scrollbar
  */
 class Scrollbar {
   /**
@@ -44,7 +45,6 @@ class Scrollbar {
    * @param {boolean=} opt_pair True if scrollbar is part of a horiz/vert pair.
    * @param {string=} opt_class A class to be applied to this scrollbar.
    * @param {number=} opt_margin The margin to apply to this scrollbar.
-   * @alias Blockly.Scrollbar
    */
   constructor(workspace, horizontal, opt_pair, opt_class, opt_margin) {
     /**

--- a/core/scrollbar_pair.js
+++ b/core/scrollbar_pair.js
@@ -27,6 +27,7 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 
 /**
  * Class for a pair of scrollbars.  Horizontal and vertical.
+ * @alias Blockly.ScrollbarPair
  */
 const ScrollbarPair = class {
   /**
@@ -37,7 +38,6 @@ const ScrollbarPair = class {
    *    to true.
    * @param {string=} opt_class A class to be applied to these scrollbars.
    * @param {number=} opt_margin The margin to apply to these scrollbars.
-   * @alias Blockly.ScrollbarPair
    */
   constructor(workspace, addHorizontal, addVertical, opt_class, opt_margin) {
     /**

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -30,6 +30,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
  * @alias Blockly.ShortcutRegistry
  */
 class ShortcutRegistry {
+  /**
+   * Resets the existing ShortcutRegistry singleton.
+   */
   constructor() {
     this.reset();
   }

--- a/core/shortcut_registry.js
+++ b/core/shortcut_registry.js
@@ -27,11 +27,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
  * Class for the registry of keyboard shortcuts. This is intended to be a
  * singleton. You should not create a new instance, and only access this class
  * from ShortcutRegistry.registry.
+ * @alias Blockly.ShortcutRegistry
  */
 class ShortcutRegistry {
-  /**
-   * @alias Blockly.ShortcutRegistry
-   */
   constructor() {
     this.reset();
   }

--- a/core/theme_manager.js
+++ b/core/theme_manager.js
@@ -29,13 +29,13 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 
 /**
  * Class for storing and updating a workspace's theme and UI components.
+ * @alias Blockly.ThemeManager
  */
 class ThemeManager {
   /**
    * @param {!WorkspaceSvg} workspace The main workspace.
    * @param {!Theme} theme The workspace theme.
    * @package
-   * @alias Blockly.ThemeManager
    */
   constructor(workspace, theme) {
     /**

--- a/core/toolbox/category.js
+++ b/core/toolbox/category.js
@@ -35,6 +35,7 @@ const {ToolboxItem} = goog.require('Blockly.ToolboxItem');
 /**
  * Class for a category in a toolbox.
  * @implements {ISelectableToolboxItem}
+ * @alias Blockly.ToolboxCategory
  */
 class ToolboxCategory extends ToolboxItem {
   /**
@@ -43,7 +44,6 @@ class ToolboxCategory extends ToolboxItem {
    * @param {!IToolbox} toolbox The parent toolbox for the category.
    * @param {ICollapsibleToolboxItem=} opt_parent The parent category or null if
    *     the category does not have a parent.
-   * @alias Blockly.ToolboxCategory
    */
   constructor(categoryDef, toolbox, opt_parent) {
     super(categoryDef, toolbox, opt_parent);

--- a/core/toolbox/collapsible_category.js
+++ b/core/toolbox/collapsible_category.js
@@ -32,6 +32,7 @@ const {ToolboxSeparator} = goog.require('Blockly.ToolboxSeparator');
 /**
  * Class for a category in a toolbox that can be collapsed.
  * @implements {ICollapsibleToolboxItem}
+ * @alias Blockly.CollapsibleToolboxCategory
  */
 class CollapsibleToolboxCategory extends ToolboxCategory {
   /**
@@ -40,7 +41,6 @@ class CollapsibleToolboxCategory extends ToolboxCategory {
    * @param {!IToolbox} toolbox The parent toolbox for the category.
    * @param {ICollapsibleToolboxItem=} opt_parent The parent category or null if
    *     the category does not have a parent.
-   * @alias Blockly.CollapsibleToolboxCategory
    */
   constructor(categoryDef, toolbox, opt_parent) {
     super(categoryDef, toolbox, opt_parent);

--- a/core/toolbox/separator.js
+++ b/core/toolbox/separator.js
@@ -30,13 +30,13 @@ const {ToolboxItem} = goog.require('Blockly.ToolboxItem');
  * Class for a toolbox separator. This is the thin visual line that appears on
  * the toolbox. This item is not interactable.
  * @extends {ToolboxItem}
+ * @alias Blockly.ToolboxSeparator
  */
 class ToolboxSeparator extends ToolboxItem {
   /**
    * @param {!toolbox.SeparatorInfo} separatorDef The information
    *     needed to create a separator.
    * @param {!IToolbox} toolbox The parent toolbox for the separator.
-   * @alias Blockly.ToolboxSeparator
    */
   constructor(separatorDef, toolbox) {
     super(separatorDef, toolbox);

--- a/core/toolbox/toolbox.js
+++ b/core/toolbox/toolbox.js
@@ -67,12 +67,12 @@ goog.require('Blockly.Events.ToolboxItemSelect');
  * @implements {IStyleable}
  * @implements {IToolbox}
  * @extends {DeleteArea}
+ * @alias Blockly.Toolbox
  */
 class Toolbox extends DeleteArea {
   /**
    * @param {!WorkspaceSvg} workspace The workspace in which to create new
    *     blocks.
-   * @alias Blockly.Toolbox
    */
   constructor(workspace) {
     super();

--- a/core/toolbox/toolbox_item.js
+++ b/core/toolbox/toolbox_item.js
@@ -31,6 +31,7 @@ const {WorkspaceSvg} = goog.requireType('Blockly.WorkspaceSvg');
 /**
  * Class for an item in the toolbox.
  * @implements {IToolboxItem}
+ * @alias Blockly.ToolboxItem
  */
 class ToolboxItem {
   /**
@@ -39,7 +40,6 @@ class ToolboxItem {
    * @param {!IToolbox} toolbox The toolbox that holds the toolbox item.
    * @param {ICollapsibleToolboxItem=} opt_parent The parent toolbox item
    *     or null if the category does not have a parent.
-   * @alias Blockly.ToolboxItem
    */
   constructor(toolboxItemDef, toolbox, opt_parent) {
     /**

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -46,13 +46,13 @@ const ZOOM_OUT_MULTIPLIER = 6;
 /**
  * Class for one gesture.
  * @extends {Gesture}
+ * @alias Blockly.TouchGesture
  */
 class TouchGesture extends Gesture {
   /**
    * @param {!Event} e The event that kicked off this gesture.
    * @param {!WorkspaceSvg} creatorWorkspace The workspace that created
    *     this gesture and has a reference to it.
-   * @alias Blockly.TouchGesture
    */
   constructor(e, creatorWorkspace) {
     super(e, creatorWorkspace);

--- a/core/trashcan.js
+++ b/core/trashcan.js
@@ -57,11 +57,11 @@ goog.require('Blockly.Events.TrashcanOpen');
  * @implements {IAutoHideable}
  * @implements {IPositionable}
  * @extends {DeleteArea}
+ * @alias Blockly.Trashcan
  */
 class Trashcan extends DeleteArea {
   /**
    * @param {!WorkspaceSvg} workspace The workspace to sit in.
-   * @alias Blockly.Trashcan
    */
   constructor(workspace) {
     super();

--- a/core/utils/coordinate.js
+++ b/core/utils/coordinate.js
@@ -21,12 +21,12 @@ goog.module('Blockly.utils.Coordinate');
 
 /**
  * Class for representing coordinates and positions.
+ * @alias Blockly.utils.Coordinate
  */
 const Coordinate = class {
   /**
    * @param {number} x Left.
    * @param {number} y Top.
-   * @alias Blockly.utils.Coordinate
    */
   constructor(x, y) {
     /**

--- a/core/utils/rect.js
+++ b/core/utils/rect.js
@@ -22,6 +22,7 @@ goog.module('Blockly.utils.Rect');
 
 /**
  * Class for representing rectangular regions.
+ * @alias Blockly.utils.Rect
  */
 const Rect = class {
   /**
@@ -30,7 +31,6 @@ const Rect = class {
    * @param {number} left Left.
    * @param {number} right Right.
    * @struct
-   * @alias Blockly.utils.Rect
    */
   constructor(top, bottom, left, right) {
     /** @type {number} */

--- a/core/utils/sentinel.js
+++ b/core/utils/sentinel.js
@@ -18,6 +18,7 @@ goog.module('Blockly.utils.Sentinel');
 
 /**
  * A type used to create flag values.
+ * @alias Blockly.utils.Sentinel
  */
 class Sentinel {}
 

--- a/core/utils/size.js
+++ b/core/utils/size.js
@@ -22,13 +22,13 @@ goog.module('Blockly.utils.Size');
 
 /**
  * Class for representing sizes consisting of a width and height.
+ * @alias Blockly.utils.Size
  */
 const Size = class {
   /**
    * @param {number} width Width.
    * @param {number} height Height.
    * @struct
-   * @alias Blockly.utils.Size
    */
   constructor(width, height) {
     /**

--- a/core/utils/svg.js
+++ b/core/utils/svg.js
@@ -21,12 +21,12 @@ goog.module('Blockly.utils.Svg');
 /**
  * A name with the type of the SVG element stored in the generic.
  * @template T
+ * @alias Blockly.utils.Svg
  */
 class Svg {
   /**
    * @param {string} tagName The SVG element tag name.
    * @package
-   * @alias Blockly.utils.Svg
    */
   constructor(tagName) {
     /**

--- a/core/warning.js
+++ b/core/warning.js
@@ -31,11 +31,11 @@ goog.require('Blockly.Events.BubbleOpen');
 /**
  * Class for a warning.
  * @extends {Icon}
+ * @alias Blockly.Warning
  */
 class Warning extends Icon {
   /**
    * @param {!BlockSvg} block The block associated with this warning.
-   * @alias Blockly.Warning
    */
   constructor(block) {
     super(block);

--- a/core/workspace.js
+++ b/core/workspace.js
@@ -54,11 +54,11 @@ const WorkspaceDB_ = Object.create(null);
  * Class for a workspace.  This is a data structure that contains blocks.
  * There is no UI, and can be created headlessly.
  * @implements {IASTNodeLocation}
+ * @alias Blockly.Workspace
  */
 class Workspace {
   /**
    * @param {!Options=} opt_options Dictionary of options.
-   * @alias Blockly.Workspace
    */
   constructor(opt_options) {
     /** @type {string} */

--- a/core/workspace_comment.js
+++ b/core/workspace_comment.js
@@ -33,6 +33,7 @@ goog.require('Blockly.Events.CommentDelete');
 
 /**
  * Class for a workspace comment.
+ * @alias Blockly.WorkspaceComment
  */
 class WorkspaceComment {
   /**
@@ -42,7 +43,6 @@ class WorkspaceComment {
    * @param {number} width Width of the comment.
    * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
    *     create a new ID.
-   * @alias Blockly.WorkspaceComment
    */
   constructor(workspace, content, height, width, opt_id) {
     /** @type {string} */

--- a/core/workspace_comment_svg.js
+++ b/core/workspace_comment_svg.js
@@ -74,6 +74,7 @@ const TEXTAREA_OFFSET = 2;
  * @implements {IBoundedElement}
  * @implements {IBubble}
  * @implements {ICopyable}
+ * @alias Blockly.WorkspaceCommentSvg
  */
 class WorkspaceCommentSvg extends WorkspaceComment {
   /**
@@ -83,7 +84,6 @@ class WorkspaceCommentSvg extends WorkspaceComment {
    * @param {number} width Width of the comment.
    * @param {string=} opt_id Optional ID.  Use this ID if provided, otherwise
    *     create a new ID.
-   * @alias Blockly.WorkspaceCommentSvg
    */
   constructor(workspace, content, height, width, opt_id) {
     super(workspace, content, height, width, opt_id);

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -121,6 +121,7 @@ goog.require('Blockly.Msg');
  * scrollbars, bubbles, and dragging.
  * @extends {Workspace}
  * @implements {IASTNodeLocationSvg}
+ * @alias Blockly.WorkspaceSvg
  */
 class WorkspaceSvg extends Workspace {
   /**
@@ -129,7 +130,6 @@ class WorkspaceSvg extends Workspace {
    *     blocks.
    * @param {WorkspaceDragSurfaceSvg=} opt_wsDragSurface Drag surface for
    *     the workspace.
-   * @alias Blockly.WorkspaceSvg
    */
   constructor(options, opt_blockDragSurface, opt_wsDragSurface) {
     super(options);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Proposed Changes
This PR moves @alias JSDoc annotations onto the class instead of its constructor, which is needed to maintain consistent output when generating JSDoc.