### PR TITLE
fix: incorrect module for event data in renamings database

### DIFF
--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -92,7 +92,7 @@
       oldName: 'Blockly',
       exports: {
         // bind/unbind events functions.  See PR #4642
-        EventData: {newModule: 'Blockly.eventHandling', newExport: 'Data'},
+        EventData: {newModule: 'Blockly.browserEvents', newExport: 'Data'},
         bindEvent_: {newModule: 'Blockly.browserEvents', newExport: 'bind'},
         unbindEvent_: {newModule: 'Blockly.browserEvents', newExport: 'unbind'},
         bindEventWithChecks_: {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details

Data [exists on browserEvents](https://github.com/google/blockly/blob/c9be8d984d6cc459917f2a777e03ba858f2e623d/core/browser_events.js#L31), not eventHandling.
