### PR TITLE
fix: always rename caller to legal name

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -968,11 +968,10 @@ const PROCEDURE_CALL_COMMON = {
         block.appendChild(mutation);
         const field = xmlUtils.createElement('field');
         field.setAttribute('name', 'NAME');
-        let callName = this.getProcedureCall();
-        if (!callName) {
-          // Rename if name is empty string.
-          callName = Procedures.findLegalName('', this);
-          this.renameProcedure('', callName);
+        const callName = this.getProcedureCall();
+        const newName = Procedures.findLegalName(callName, this);
+        if (callName !== newName) {
+          this.renameProcedure(callName, newName);
         }
         field.appendChild(xmlUtils.createTextNode(callName));
         block.appendChild(field);

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -10,7 +10,7 @@ goog.require('Blockly');
 goog.require('Blockly.Msg');
 const {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} = goog.require('Blockly.test.helpers.procedures');
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 
 
 suite('Procedures', function() {
@@ -294,7 +294,12 @@ suite('Procedures', function() {
       });
     });
     suite('caller param mismatch', function() {
-      test.skip('callreturn with missing args', function() {
+      setup(function() {
+        this.TEST_VAR_ID = 'test-id';
+        this.genUidStub = createGenUidStubWithReturns(this.TEST_VAR_ID);
+      });
+
+      test('callreturn with missing args', function() {
         // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
@@ -310,9 +315,9 @@ suite('Procedures', function() {
             '</block>'
         ), this.workspace);
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
-        assertCallBlockStructure(callBlock, ['x'], ['arg']);
+        assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
-      test.skip('callreturn with bad args', function() {
+      test('callreturn with bad args', function() {
         // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
@@ -330,9 +335,10 @@ suite('Procedures', function() {
             </block>
         `), this.workspace);
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
-        assertCallBlockStructure(callBlock, ['x'], ['arg']);
+        assertCallBlockStructure(
+            callBlock, ['y'], [this.TEST_VAR_ID], 'do something2');
       });
-      test.skip('callnoreturn with missing args', function() {
+      test('callnoreturn with missing args', function() {
         // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
@@ -348,9 +354,9 @@ suite('Procedures', function() {
             '</block>'
         ), this.workspace);
         assertDefBlockStructure(defBlock, false, ['x'], ['arg']);
-        assertCallBlockStructure(callBlock, ['x'], ['arg']);
+        assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
-      test.skip('callnoreturn with bad args', function() {
+      test('callnoreturn with bad args', function() {
         // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
@@ -368,7 +374,8 @@ suite('Procedures', function() {
             </block>
         `), this.workspace);
         assertDefBlockStructure(defBlock, false, ['x'], ['arg']);
-        assertCallBlockStructure(callBlock, ['x'], ['arg']);
+        assertCallBlockStructure(
+            callBlock, ['y'], [this.TEST_VAR_ID], 'do something2');
       });
     });
   });

--- a/tests/mocha/procedures_test.js
+++ b/tests/mocha/procedures_test.js
@@ -300,7 +300,6 @@ suite('Procedures', function() {
       });
 
       test('callreturn with missing args', function() {
-        // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
@@ -318,7 +317,6 @@ suite('Procedures', function() {
         assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
       test('callreturn with bad args', function() {
-        // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
@@ -339,7 +337,6 @@ suite('Procedures', function() {
             callBlock, ['y'], [this.TEST_VAR_ID], 'do something2');
       });
       test('callnoreturn with missing args', function() {
-        // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
               <field name="NAME">do something</field>
@@ -357,7 +354,6 @@ suite('Procedures', function() {
         assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
       test('callnoreturn with bad args', function() {
-        // TODO: How do we want it to behave in this situation?
         const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
             <block type="procedures_defnoreturn">
               <field name="NAME">do something</field>

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -85,13 +85,15 @@ function assertDefBlockStructure(defBlock, hasReturn = false,
 exports.assertDefBlockStructure = assertDefBlockStructure;
 
 /**
- * Asserts that the procedure definition block has the expected inputs and
+ * Asserts that the procedure call block has the expected inputs and
  *    fields.
  * @param {!Blockly.Block} callBlock The procedure call block.
  * @param {Array<string>=} args An array of argument names.
  * @param {Array<string>=} varIds An array of variable ids.
+ * @param {string=} name The name we expect the caller to have.
  */
-function assertCallBlockStructure(callBlock, args = [], varIds = []) {
+function assertCallBlockStructure(
+  callBlock, args = [], varIds = [], name = undefined) {
   if (args.length) {
     chai.assert.include(callBlock.toString(), 'with');
   } else {
@@ -100,6 +102,9 @@ function assertCallBlockStructure(callBlock, args = [], varIds = []) {
 
   assertCallBlockArgsStructure(callBlock, args);
   assertBlockVarModels(callBlock, varIds);
+  if (name !== undefined) {
+    chai.assert(callBlock.getFieldValue('NAME'), name);
+  }
 }
 exports.assertCallBlockStructure = assertCallBlockStructure;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#5971 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that when call blocks are created, if their name matches an existing procedure def, but they do not have the args to match that procedure def, a new def is created with a new name, and the callers name is changed to match.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
A new procedure would be created, but the caller would not be renamed to match it, so the program would end up in a broken state.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
The caller is renamed to match the generated definition, so the program is legal.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Letting users accidentally make their programs invalid is bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Love it when my past self writes tests for my future self :D
