### PR TITLE
fix: playground test blocks, text area listeners, and show/hide buttons

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -7,6 +7,7 @@
   <!-- This script loads uncompressed when on localhost and loads compressed when it is being hosted.
        Please add any other dependencies to playgrounds/prepare.js.-->
 <script src="playgrounds/prepare.js"></script>
+<script src="../node_modules/@blockly/dev-tools/dist/index.js"></script>
 <script type=module>
 import Blockly from './playgrounds/blockly.mjs';
 
@@ -85,7 +86,7 @@ function start() {
     load();
   }
 
-  addClickHandlers();
+  addEventHandlers();
 }
 
 function setBackgroundColour() {
@@ -387,7 +388,7 @@ var spaghettiXml = [
 // automatically deferred, so it will not be run until after the
 // document has been parsed, but before firing DOMContentLoaded.
 
-function addClickHandlers() {
+function addEventHandlers() {
   document.getElementById('save-json').addEventListener('click', saveJson);
   document.getElementById('save-xml').addEventListener('click', saveXml);
   document.getElementById('import').addEventListener('click', load);
@@ -414,6 +415,14 @@ function addClickHandlers() {
       .addEventListener('click', function() { logEvents(this.checked) });
   document.getElementById('logFlyoutCheck')
       .addEventListener('click', function() { logFlyoutEvents(this.checked) });
+
+  document.getElementById('importExport').addEventListener('change', taChange);
+  document.getElementById('importExport').addEventListener('keyup', taChange);
+
+  document.getElementById('show')
+      .addEventListener('click', function() { workspace.setVisible(true); });
+  document.getElementById('hide')
+      .addEventListener('click', function() { workspace.setVisible(false); });
 }
   
 start();
@@ -469,9 +478,11 @@ start();
 
   <h1>Blockly Playground</h1>
 
-  <p><a href="javascript:void(workspace.setVisible(true))">Show</a>
-   - <a href="javascript:void(workspace.setVisible(false))">Hide</a>
-   - <a href="playgrounds/advanced_playground.html">Advanced</a></p>
+  <p>
+    <input id="show" type="button" value="Show"></input> -
+    <input id="hide" type="button" value="Hide"></input> -
+    <a href="playgrounds/advanced_playground.html">Advanced</a>
+  </p>
 
   <form id="options">
     <select name="dir" onchange="document.forms.options.submit()">
@@ -496,8 +507,7 @@ start();
     <input id="to-code-lua" type="button" value="To Lua">
     <input id="to-code-dart" type="button" value="To Dart">
     <br>
-    <textarea id="importExport" style="width: 26%; height: 12em"
-      onchange="taChange();" onkeyup="taChange()"></textarea>
+    <textarea id="importExport" style="width: 26%; height: 12em"></textarea>
   </p>
 
   <p>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that:
1) Test blocks are accessible.
2) The text area properly triggers updates.
3) The show and hide buttons work.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
None of those things worked.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Now they work!

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Need to be able to use the playground for testing.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Abby figured out how to get the test blocks to import! They need to be added as a plain script instead of a module script (I think b/c we're using the dist version). I didn't think that would work b/c Blockly wouldn't be defined. But it turns out prepare.js defines Blockly in the global scope. So as long as we load the test blocks after we load prepare.js everything is happy :D
