### PR TITLE
fix: undo/redo for auto disabling if-return blocks

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -342,7 +342,7 @@ const CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
   /**
    * Called whenever anything on the workspace changes.
    * Add warning if this flow block is not nested inside a loop.
-   * @param {!AbstractEvent} e Change event.
+   * @param {!AbstractEvent} e Move event.
    * @this {Block}
    */
   onchange: function(e) {

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -1139,7 +1139,7 @@ blocks['procedures_ifreturn'] = {
   /**
    * Called whenever anything on the workspace changes.
    * Add warning if this flow block is not nested inside a loop.
-   * @param {!AbstractEvent} e Change event.
+   * @param {!AbstractEvent} e Move event.
    * @this {Block}
    */
   onchange: function(e) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#6010 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Wrap the enable/disable event for the if-return in the same group as the initial move event, so the events get undone together. This is the same way the break/continue block handles this behavior.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Undoing was not possible because the events were not properly grouped.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Now the events are properly grouped so undo and redo works.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Undo and redo are helpful.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->
1) Drag an if-return from the workspace to a procedure. Undo and redo.
2) Drag an if-return from the workspace to a block inside a procedure. Undo and redo.
3) Drag an if-return from the workspace to a disabled block inside a procedure. Undo and redo. Enable the disabled block. Observe how the if-return is enabled.
1) Drag an if-return from a procedure to the workspace. Undo and redo.
2) Drag an if-return from a procedure to a block on the workspace. Undo and redo.
3) Drag an if-return from a procedure to a disabled block on the workspace. Undo and redo. Enable the disabled block. Observe how the if-return is not enabled.

 Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
N/A
