### PR TITLE
fix: advanced playground and playground 

### DIFF
--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -3,29 +3,33 @@
 <head>
 <meta charset="utf-8">
 <title>Advanced Blockly Playground</title>
-<script src="../../blockly_uncompressed.js"></script>
-<script src="../../msg/messages.js"></script>
-<script src="../themes/test_themes.js"></script>
+<script src="prepare.js"></script>
 <script src="./screenshot.js"></script>
+<script src="../themes/test_themes.js"></script>
 <script src="../../node_modules/@blockly/dev-tools/dist/index.js"></script>
 <script src="../../node_modules/@blockly/theme-modern/dist/index.js"></script>
 
 <script>
-// Custom requires for the playground.
-// Rendering.
-goog.require('Blockly.minimalist.Renderer');
-goog.require('Blockly.Themes.Zelos');
+const IS_UNCOMPRESSED = Boolean(window.BlocklyLoader);  // See prepare.js
 
-// Other.
-goog.require('Blockly.WorkspaceCommentSvg');
-goog.require('Blockly.libraryBlocks');
-goog.require('Blockly.Dart.all');
-goog.require('Blockly.JavaScript.all');
-goog.require('Blockly.Lua.all');
-goog.require('Blockly.PHP.all');
-goog.require('Blockly.Python.all');
+if (IS_UNCOMPRESSED) {
+  // Custom requires for the playground.
+  // Rendering.
+  goog.require('Blockly.minimalist.Renderer');
+  goog.require('Blockly.Themes.Zelos');
+
+  // Other.
+  goog.require('Blockly.WorkspaceCommentSvg');
+  goog.require('Blockly.libraryBlocks');
+  goog.require('Blockly.Dart.all');
+  goog.require('Blockly.JavaScript.all');
+  goog.require('Blockly.Lua.all');
+  goog.require('Blockly.PHP.all');
+  goog.require('Blockly.Python.all');
+}
 </script>
-<script>
+<script type="module">
+import Blockly from './blockly.mjs';
 'use strict';
 
 function start() {
@@ -144,7 +148,7 @@ function configureContextMenu(menuOptions, e) {
   // Adds a default-sized workspace comment to the workspace.
   menuOptions.push(Blockly.ContextMenu.workspaceCommentOption(workspace, e));
 }
-
+start();
 </script>
 
 <style>
@@ -169,7 +173,7 @@ function configureContextMenu(menuOptions, e) {
   }
 </style>
 </head>
-<body onload="start()">
+<body>
   <div id="root"></div>
 </body>
 </html>

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -9,25 +9,6 @@
 <script src="../../node_modules/@blockly/dev-tools/dist/index.js"></script>
 <script src="../../node_modules/@blockly/theme-modern/dist/index.js"></script>
 
-<script>
-const IS_UNCOMPRESSED = Boolean(window.BlocklyLoader);  // See prepare.js
-
-if (IS_UNCOMPRESSED) {
-  // Custom requires for the playground.
-  // Rendering.
-  goog.require('Blockly.minimalist.Renderer');
-  goog.require('Blockly.Themes.Zelos');
-
-  // Other.
-  goog.require('Blockly.WorkspaceCommentSvg');
-  goog.require('Blockly.libraryBlocks');
-  goog.require('Blockly.Dart.all');
-  goog.require('Blockly.JavaScript.all');
-  goog.require('Blockly.Lua.all');
-  goog.require('Blockly.PHP.all');
-  goog.require('Blockly.Python.all');
-}
-</script>
 <script type="module">
 import Blockly from './blockly.mjs';
 'use strict';

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -75,7 +75,7 @@
     //   advanced_playground the and regular playground are in different folders.
     // - We need to get the root directory for blockly because it is
     //   different for github.io, appspot and local.
-    const filePaths = [
+    const files = [
       'blockly_compressed.js',
       'msg/messages.js',
       'blocks_compressed.js',
@@ -88,17 +88,12 @@
 
     // We need to load Blockly in compiled mode.
     const hostName = window.location.host.replaceAll('.', '\\.');
-    const re = new RegExp(hostName + '\\/(.*)tests');
-    const matches = re.exec(window.location.href);
-    let root = '';
-    if (matches && matches[1]) {
-      // This should either be 'static/' or 'blockly/'
-      root = matches[1];
-    }
+    const matches = new RegExp(hostName + '\\/(.*)tests').exec(window.location.href);
+    const root = matches && matches[1] ? matches[1] : '';
 
     // Load blockly_compressed.js et al. using <script> tags.
-    for (let i = 0; i < filePaths.length; i++) {
-      document.write('<script src="/' + root + filePaths[i] + '"></script>');
+    for (let i = 0; i < files.length; i++) {
+      document.write('<script src="/' + root + files[i] + '"></script>');
     }
   }
 })();

--- a/tests/playgrounds/prepare.js
+++ b/tests/playgrounds/prepare.js
@@ -70,16 +70,35 @@
           });
         </script>`);
   } else {
+    // The below code is necessary for a few reasons:
+    // - We need an absolute path instead of relative path because the
+    //   advanced_playground the and regular playground are in different folders.
+    // - We need to get the root directory for blockly because it is
+    //   different for github.io, appspot and local.
+    const filePaths = [
+      'blockly_compressed.js',
+      'msg/messages.js',
+      'blocks_compressed.js',
+      'dart_compressed.js',
+      'javascript_compressed.js',
+      'lua_compressed.js',
+      'php_compressed.js',
+      'python_compressed.js',
+    ];
+
     // We need to load Blockly in compiled mode.
+    const hostName = window.location.host.replaceAll('.', '\\.');
+    const re = new RegExp(hostName + '\\/(.*)tests');
+    const matches = re.exec(window.location.href);
+    let root = '';
+    if (matches && matches[1]) {
+      // This should either be 'static/' or 'blockly/'
+      root = matches[1];
+    }
 
     // Load blockly_compressed.js et al. using <script> tags.
-    document.write('<script src="../../blockly_compressed.js"></script>');
-    document.write('<script src="../../msg/messages.js"></script>');
-    document.write('<script src="../../blocks_compressed.js"></script>');
-    document.write('<script src="../../dart_compressed.js"></script>');
-    document.write('<script src="../../javascript_compressed.js"></script>');
-    document.write('<script src="../../lua_compressed.js"></script>');
-    document.write('<script src="../../php_compressed.js"></script>');
-    document.write('<script src="../../python_compressed.js"></script>');
+    for (let i = 0; i < filePaths.length; i++) {
+      document.write('<script src="/' + root + filePaths[i] + '"></script>');
+    }
   }
 })();

--- a/tests/themes/test_themes.js
+++ b/tests/themes/test_themes.js
@@ -5,24 +5,22 @@
  */
 'use strict';
 
-goog.provide('Blockly.TestThemes');
-
 
 /**
  * A theme with classic colours but enables start hats.
  */
-Blockly.Themes.TestHats = Blockly.Theme.defineTheme('testhats', {
+const TestHatsTheme = Blockly.Theme.defineTheme('testhats', {
   'base': Blockly.Themes.Classic
 });
-Blockly.Themes.TestHats.setStartHats(true);
+TestHatsTheme.setStartHats(true);
 
 /**
  * A theme with classic colours but a different font.
  */
-Blockly.Themes.TestFont = Blockly.Theme.defineTheme('testfont', {
+const TestFontTheme = Blockly.Theme.defineTheme('testfont', {
   'base': Blockly.Themes.Classic
 });
-Blockly.Themes.TestFont.setFontStyle({
+TestFontTheme.setFontStyle({
   'family': '"Times New Roman", Times, serif',
   'weight': null, // Use default font-weight
   'size': 16
@@ -33,9 +31,9 @@ Blockly.Themes.TestFont.setFontStyle({
  * @type {!Object<string, Blockly.Theme>}
  * @private
  */
-Blockly.Themes.testThemes_ = {
-  'Test Hats': Blockly.Themes.TestHats,
-  'Test Font': Blockly.Themes.TestFont
+const testThemes_ = {
+  'Test Hats': TestHatsTheme,
+  'Test Font': TestFontTheme
 };
 
 /**
@@ -45,7 +43,7 @@ Blockly.Themes.testThemes_ = {
  * @package
  */
 function getTestTheme(value) {
-  return Blockly.Themes.testThemes_[value];
+  return testThemes_[value];
 }
 
 /**
@@ -54,7 +52,7 @@ function getTestTheme(value) {
  */
 function populateTestThemes() {
   var themeChanger = document.getElementById('themeChanger');
-  var keys = Object.keys(Blockly.Themes.testThemes_);
+  var keys = Object.keys(testThemes_);
   for (var i = 0, key; (key = keys[i]); i++) {
     var option = document.createElement('option');
     option.setAttribute('value', key);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#6019 and the fact that the playground was not working when hosted.

### Proposed Changes
- Changes the prepare.js script to use absolute path instead of relative path. This means that it will work with both the playground and the advanced playground. This makes it possible to fix #6019.
- Moving to the absolute path also fixed a bug that made it impossible to load the scripts from hosted sites. (We were using ../.. instead of just ../)
- Small fix for the test_theme that was not working.
#### Behavior Before Change
- Playground and advanced playground did not work when hosted.

#### Behavior After Change
- Advanced playground and playground now both work when hosted on appspot.
- Regular playground works when hosted on google.github.io. We would still need to upload the dev-tools/index.js file to the gh-pages branch for this to work on `google.github.io`.
### Reason for Changes
- If we are going to keep the advanced playground in core then it might as well work. 
- Hosted playgrounds working is necessary for testing.

### Test Coverage

- Tested on `google.github.io`
- Tested on appspot
- Tested locally
### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
