### PR TITLE
fix: Fix bug where workspace comments could not be created.

### DIFF
--- a/core/contextmenu.js
+++ b/core/contextmenu.js
@@ -342,7 +342,7 @@ exports.commentDuplicateOption = commentDuplicateOption;
  * @alias Blockly.ContextMenu.workspaceCommentOption
  */
 const workspaceCommentOption = function(ws, e) {
-  const WorkspaceCommentSvg = goog.module.get('Blockly.WorkspaceCommentSvg');
+  const {WorkspaceCommentSvg} = goog.module.get('Blockly.WorkspaceCommentSvg');
   if (!WorkspaceCommentSvg) {
     throw Error('Missing require for Blockly.WorkspaceCommentSvg');
   }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
Fixes a bug that prevented workspace comments from being added via the contextual menu by destructuring WorkspaceCommentSvg when loading its module.