### PR TITLE
fix: Fix downloading screenshots on the playground.

### DIFF
--- a/tests/playground.html
+++ b/tests/playground.html
@@ -7,6 +7,7 @@
   <!-- This script loads uncompressed when on localhost and loads compressed when it is being hosted.
        Please add any other dependencies to playgrounds/prepare.js.-->
 <script src="playgrounds/prepare.js"></script>
+<script src="playgrounds/screenshot.js"></script>
 <script src="../node_modules/@blockly/dev-tools/dist/index.js"></script>
 <script type=module>
 import Blockly from './playgrounds/blockly.mjs';
@@ -242,7 +243,7 @@ function configureContextMenu(menuOptions, e) {
     text: 'Download Screenshot',
     enabled: workspace.getTopBlocks().length,
     callback: function() {
-      Blockly.downloadScreenshot(workspace);
+      downloadScreenshot(workspace);
     }
   };
   menuOptions.push(screenshotOption);

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -121,7 +121,7 @@ function configureContextMenu(menuOptions, e) {
     text: 'Download Screenshot',
     enabled: workspace.getTopBlocks().length,
     callback: function() {
-      Blockly.downloadScreenshot(workspace);
+      downloadScreenshot(workspace);
     }
   };
   menuOptions.push(screenshotOption);

--- a/tests/playgrounds/screenshot.js
+++ b/tests/playgrounds/screenshot.js
@@ -95,7 +95,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
  * Download a screenshot of the blocks on a Blockly workspace.
  * @param {!Blockly.WorkspaceSvg} workspace The Blockly workspace.
  */
-Blockly.downloadScreenshot = function(workspace) {
+const downloadScreenshot = function(workspace) {
   workspaceToSvg_(workspace, function(datauri) {
     const a = document.createElement('a');
     a.download = 'screenshot.png';

--- a/tests/playgrounds/screenshot.js
+++ b/tests/playgrounds/screenshot.js
@@ -95,7 +95,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
  * Download a screenshot of the blocks on a Blockly workspace.
  * @param {!Blockly.WorkspaceSvg} workspace The Blockly workspace.
  */
-const downloadScreenshot = function(workspace) {
+function downloadScreenshot(workspace) {
   workspaceToSvg_(workspace, function(datauri) {
     const a = document.createElement('a');
     a.download = 'screenshot.png';


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#6023 

### Proposed Changes
This PR fixes the Download Screenshot command in the workspace contextual menu in the playgrounds.

#### Behavior Before Change
The contextual menu item had no visible effect and logged an error to the console.

#### Behavior After Change
A screenshot of the workspace is downloaded.