### PR TITLE
chore(demos): redirect some demos to gh-pages

### DIFF
--- a/appengine/redirect.html
+++ b/appengine/redirect.html
@@ -61,6 +61,37 @@ if (loc.match('/apps/puzzle/')) {
   loc = loc.replace('/apps/', '/demos/');
 }
 
+// Demos without saved data were moved to Blockly Samples in 2021.
+if (loc.match('/demos/fixed/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/fixed-demo/';
+} else if (loc.match('/demos/resizable/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/resizable-demo/';
+} else if (loc.match('/demos/toolbox/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/toolbox-demo/';
+} else if (loc.match('/demos/maxBlocks/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/max-blocks-demo/';
+} else if (loc.match('/demos/generator/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/generator-demo/';
+} else if (loc.match('/demos/headless/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/headless-demo/';
+} else if (loc.match('/demos/interpreter/step-execution')) {
+  loc = 'https://google.github.io/blockly-samples/examples/interpreter-demo/step-execution.html';
+} else if (loc.match('/demos/interpreter/async-execution')) {
+  loc = 'https://google.github.io/blockly-samples/examples/interpreter-demo/async-execution.html';
+} else if (loc.match('/demos/graph/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/graph-demo/';
+} else if (loc.match('/demos/rtl/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/rtl-demo/';
+} else if (loc.match('/demos/custom-dialogs/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/custom-dialogs-demo';
+} else if (loc.match('/demos/custom-fields/turtle/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/turtle-field-demo/';
+} else if (loc.match('/demos/custom-fields/pitch/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/pitch-field-demo/';
+} else if (loc.match('/demos/mirror/')) {
+  loc = 'https://google.github.io/blockly-samples/examples/mirror-demo/';
+}
+
 location = loc;
 
     </script>


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/1586

### Proposed Changes

Add redirects to the appengine folder so that some of the demos link to the blockly-samples github pages site instead of appengine.

#### Behavior Before Change

Links went to appengine.

#### Behavior After Change

Links go to github pages.

### Reason for Changes

These demos are duplicated on blockly-samples in the examples folder, and hosted on github pages. We don't need to have them in multiple locations. None of these demos save data, so they don't need to be on appengine.

### Test Coverage

Did not test yet, to avoid overriding the current site during testing. It's fine for this to land in Q2.
Need to check whether the icons for the demos still work on the index page.

### Documentation
None.

### Additional Information

Future work:
- Delete demo folders for the affected demos.
- Decide what to do about the demos that I didn't redirect.
- Move the code demo to blockly games.
- Update the index page to point directly to github pages, instead of through redirects.

To consider:
- We'll lose the ability to locally test some of these configurations by just rebuilding and opening demo pages. I'm okay with that, because the advanced playground lets us test configurations trivially, and the demos are generally part of the end-of-quarter release process rather than normal testing.
- There's no longer a direct link to the demo index page from developers.google.com/blockly. I'm not sure when we deleted it.