### PR TITLE
fix: mutators disconnecting from children instead of moving them

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -198,10 +198,13 @@ blocks['lists_create_with'] = {
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     const connections = [];
-    while (itemBlock && !itemBlock.isInsertionMarker()) {
+    while (itemBlock) {
+      if (itemBlock.isInsertionMarker()) {
+        itemBlock = itemBlock.getNextBlock();
+        continue;
+      }
       connections.push(itemBlock.valueConnection_);
-      itemBlock =
-          itemBlock.nextConnection && itemBlock.nextConnection.targetBlock();
+      itemBlock = itemBlock.getNextBlock();
     }
     // Disconnect any children that don't belong.
     for (let i = 0; i < this.itemCount_; i++) {
@@ -226,10 +229,13 @@ blocks['lists_create_with'] = {
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     let i = 0;
     while (itemBlock) {
+      if (itemBlock.isInsertionMarker()) {
+        itemBlock = itemBlock.getNextBlock();
+        continue;
+      }
       const input = this.getInput('ADD' + i);
       itemBlock.valueConnection_ = input && input.connection.targetConnection;
-      itemBlock =
-          itemBlock.nextConnection && itemBlock.nextConnection.targetBlock();
+      itemBlock = itemBlock.getNextBlock();
       i++;
     }
   },

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -394,7 +394,11 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
     const valueConnections = [null];
     const statementConnections = [null];
     let elseStatementConnection = null;
-    while (clauseBlock && !clauseBlock.isInsertionMarker()) {
+    while (clauseBlock) {
+      if (clauseBlock.isInsertionMarker()) {
+        clauseBlock = clauseBlock.getNextBlock();
+        continue;
+      }
       switch (clauseBlock.type) {
         case 'controls_if_elseif':
           this.elseifCount_++;
@@ -408,8 +412,7 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
         default:
           throw TypeError('Unknown block type: ' + clauseBlock.type);
       }
-      clauseBlock = clauseBlock.nextConnection &&
-          clauseBlock.nextConnection.targetBlock();
+      clauseBlock = clauseBlock.getNextBlock();
     }
     this.updateShape_();
     // Reconnect any child blocks.
@@ -425,6 +428,10 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
     let clauseBlock = containerBlock.nextConnection.targetBlock();
     let i = 1;
     while (clauseBlock) {
+      if (clauseBlock.isInsertionMarker()) {
+        clauseBlock = clauseBlock.getNextBlock();
+        continue;
+      }
       switch (clauseBlock.type) {
         case 'controls_if_elseif': {
           const inputIf = this.getInput('IF' + i);
@@ -445,8 +452,7 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
         default:
           throw TypeError('Unknown block type: ' + clauseBlock.type);
       }
-      clauseBlock = clauseBlock.nextConnection &&
-          clauseBlock.nextConnection.targetBlock();
+      clauseBlock = clauseBlock.getNextBlock();
     }
   },
   /**

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -781,10 +781,13 @@ const TEXT_JOIN_MUTATOR_MIXIN = {
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     const connections = [];
-    while (itemBlock && !itemBlock.isInsertionMarker()) {
+    while (itemBlock) {
+      if (itemBlock.isInsertionMarker()) {
+        itemBlock = itemBlock.getNextBlock();
+        continue;
+      }
       connections.push(itemBlock.valueConnection_);
-      itemBlock =
-          itemBlock.nextConnection && itemBlock.nextConnection.targetBlock();
+      itemBlock = itemBlock.getNextBlock();
     }
     // Disconnect any children that don't belong.
     for (let i = 0; i < this.itemCount_; i++) {
@@ -809,10 +812,13 @@ const TEXT_JOIN_MUTATOR_MIXIN = {
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     let i = 0;
     while (itemBlock) {
+      if (itemBlock.isInsertionMarker()) {
+        itemBlock = itemBlock.getNextBlock();
+        continue;
+      }
       const input = this.getInput('ADD' + i);
       itemBlock.valueConnection_ = input && input.connection.targetConnection;
-      itemBlock =
-          itemBlock.nextConnection && itemBlock.nextConnection.targetBlock();
+      itemBlock = itemBlock.getNextBlock();
       i++;
     }
   },

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -364,10 +364,11 @@ class Mutator extends Icon {
       this.rootBlock_.moveBy(x, margin);
       // Save the initial connections, then listen for further changes.
       if (this.block_.saveConnections) {
-        this.block_.saveConnections(this.rootBlock_);
+        const thisRootBlock = this.rootBlock_;
+        this.block_.saveConnections(thisRootBlock);
         this.sourceListener_ = () => {
           if (this.block_) {
-            this.block_.saveConnections(this.rootBlock_);
+            this.block_.saveConnections(thisRootBlock);
           }
         };
         this.block_.workspace.addChangeListener(this.sourceListener_);

--- a/core/mutator.js
+++ b/core/mutator.js
@@ -364,11 +364,10 @@ class Mutator extends Icon {
       this.rootBlock_.moveBy(x, margin);
       // Save the initial connections, then listen for further changes.
       if (this.block_.saveConnections) {
-        const thisRootBlock = this.rootBlock_;
-        this.block_.saveConnections(thisRootBlock);
+        this.block_.saveConnections(this.rootBlock_);
         this.sourceListener_ = () => {
           if (this.block_) {
-            this.block_.saveConnections(thisRootBlock);
+            this.block_.saveConnections(this.rootBlock_);
           }
         };
         this.block_.workspace.addChangeListener(this.sourceListener_);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #6033 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that saveConnections skips insertion markers.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Child blocks would sometimes get disconnected when they should not.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No more badly disconnected child blocks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs be bad.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

1. Created a 6 input block as in #6033 
2. Moved the bottom input to the top.
3. Moved the bottom input to the top again.
4. Disconnected the bottom input.
5. Attached the disconnected child to the open input. -> Tests that saved connections are updated when the main workspace is modified.
6. Reattached the disconnected bottom input at the top.
7. Observed how the top input was now empty.
8. Observed how at no point where children erroneously disconnected.

I would include a screen recording, but I can't figure out how to do that with my current linux setup.

Tested on:
 * Desktop Chrome 


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
We should probably update the mutator pages with info about how to ignore insertion markers, as noted originally in #4449. @maribethb

### Additional Information

<!-- Anything else we should know? -->
Linked #6033 to the ongoing issue about refactoring insertion markers.
