### PR TITLE
doc: Fix comment for loopTypes

### DIFF
--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -293,8 +293,8 @@ Extensions.register(
  * To add a new loop type add this to your code:
  *
  * // If using the Blockly npm package and es6 import syntax:
- * import {loopTypes} from 'blockly/blocks';
- * loopTypes.add('custom_loop');
+ * import {loops} from 'blockly/blocks';
+ * loops.loopTypes.add('custom_loop');
  *
  * // Else if using Closure Compiler and goog.modules:
  * const {loopTypes} = goog.require('Blockly.libraryBlocks.loops');


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes an error in the instructions about how to access `loopTypes` in the usual case (`import ... from 'blockly/blocks';`).

### Reason for Changes

Instructions were incorrect and misleading.

### Test Coverage

N/A.  But passes `npm test`.
