### PR TITLE
fix: update extraState property in serializer typedefs

### DIFF
--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -60,7 +60,7 @@ exports.ConnectionState = ConnectionState;
  *     enabled: (boolean|undefined),
  *     inline: (boolean|undefined),
  *     data: (string|undefined),
- *     extra-state: (*|undefined),
+ *     'extra-state': (*|undefined),
  *     icons: (!Object<string, *>|undefined),
  *     fields: (!Object<string, *>|undefined),
  *     inputs: (!Object<string, !ConnectionState>|undefined),

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -60,7 +60,7 @@ exports.ConnectionState = ConnectionState;
  *     enabled: (boolean|undefined),
  *     inline: (boolean|undefined),
  *     data: (string|undefined),
- *     'extra-state': (*|undefined),
+ *     extraState: (*|undefined),
  *     icons: (!Object<string, *>|undefined),
  *     fields: (!Object<string, *>|undefined),
  *     inputs: (!Object<string, !ConnectionState>|undefined),

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -40,7 +40,7 @@ const {ToolboxSeparator} = goog.requireType('Blockly.ToolboxSeparator');
  *            collapsed: (boolean|undefined),
  *            inline: (boolean|undefined),
  *            data: (string|undefined),
- *            'extra-state': (*|undefined),
+ *            extraState: (*|undefined),
  *            icons: (!Object<string, *>|undefined),
  *            fields: (!Object<string, *>|undefined),
  *            inputs: (!Object<string, !ConnectionState>|undefined),

--- a/core/utils/toolbox.js
+++ b/core/utils/toolbox.js
@@ -40,7 +40,7 @@ const {ToolboxSeparator} = goog.requireType('Blockly.ToolboxSeparator');
  *            collapsed: (boolean|undefined),
  *            inline: (boolean|undefined),
  *            data: (string|undefined),
- *            extra-state: (*|undefined),
+ *            'extra-state': (*|undefined),
  *            icons: (!Object<string, *>|undefined),
  *            fields: (!Object<string, *>|undefined),
  *            inputs: (!Object<string, !ConnectionState>|undefined),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

In the JSON serializer there are two [typedefs](https://github.com/google/blockly/blame/master/core/serialization/blocks.js#L61) with a property called `extra-state`. This breaks the hell out of the typescript definitions because the compiler can't parse the jsdoc. e.g. the early commits here https://github.com/google/blockly/pull/6051 (and also last quarter had to be hand-fixed)

### Proposed Changes

Adds quotations around the property. Properties with dashes can only be accessed with bracket notation and quotes, so adding the quotes helps the TypeScript parser.

I think this property probably should have been called extraState from the beginning. Is it worth changing now? It's probably somewhat annoying for an external developer because they have to use bracket notation. If we were to change it then asap would be better. We could probably handle both values in the serializer to avoid making that a breaking change? Not sure if it's worth it, would like your input Beka.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested this fixes the TypeScript definition generation problems; the output is no longer malformed with this change.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
