### PR TITLE
fix: message loading from script tags

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -321,8 +321,6 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
-      .pipe(gulp.insert.prepend(`
-      var Blockly = {};Blockly.Msg={};`))
       .pipe(packageUMD('Blockly.Msg', [{
           name: 'Blockly',
           amd: '../core',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Possibly related to https://github.com/google/blockly/issues/4369. Fixes https://github.com/google/blockly-samples/issues/1066 and fixes https://github.com/google/blockly-samples/issues/1065

### Proposed Changes

Removes redundant code from packaged msg files.

#### Behavior Before Change

If you load a message file from `dist/msg` in a script tag, or equivalently if you load a message file from the blockly node module via a script tag (such as we do in samples, or what you would do if you used unpkg) then the message references do not work and you get errors like `No message string for %{BKY_TEXT_APPEND_TOOLTIP} in %{BKY_TEXT_APPEND_TOOLTIP}` and your blocks are broken.

#### Behavior After Change

Message loading works correctly.

### Reason for Changes

Rachel and I investigated this bug after realizing this issue has been present on some of the blockly-samples examples for a while. We are not 100% sure on the cause of this bug but we think this may be the cause based on some evidence:
- this line of code has been here for more than two years, and possibly since Sam wrote the initial wrapper scripts.
- the logic around message loading was changed significantly during the move to closure modules e.g. https://github.com/google/blockly/pull/5768/files but we were not adequately testing the packaged files (#6059)
- this has been broken in blockly-samples since at least v7 (ie this is not a new issue introduced in v8)
- removing this line fixes the problem :)

### Test Coverage

Tested various scenarios. These worked before and continue to work:
- Loading blockly playground in core (`npm run start`)
- Loading the mirror demo in core as it currently is (references the non-packaged file)
- Loading a plugin that uses Blockly and the packaged files via modules and webpack (e.g. continuous-toolbox)

These were broken before this change but now work:
- Loading the mirror demo in core when it uses the packaged message file instead of the non-packaged one 
- Loading the mirror demo in blockly-samples
- Loading the plane demo in blockly-samples

I would like to test with angular or react to see if https://github.com/google/blockly/issues/4369 is resolved but still working on that.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Our current plan is to release a beta version with this change, and ask some folks that seemed affected by this issue to test with the beta. If it works, and if Christopher agrees, then we can release a patch version of Blockly with this change.

We can also use the beta to update the blockly-samples gh-pages site since that is currently blocked by this issue.

We want to wait for Christopher's opinion as the resident expert on module loading.