### PR TITLE
fix: dragging fails for collapsed blocks with Icons, which have been …

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -429,11 +429,7 @@ const BlockDragger = class {
     // Moving icons moves their associated bubbles.
     for (let i = 0; i < this.dragIconData_.length; i++) {
       const data = this.dragIconData_[i];
-      // Don't move hidden Icons as they can have not been initialized.
-      // fixes #6076
-      if (!this.draggingBlock_.isCollapsed() || !data.icon.collapseHidden) {
-        data.icon.setIconLocation(Coordinate.sum(data.location, dxy));
-      }
+      data.icon.setIconLocation(Coordinate.sum(data.location, dxy));
     }
   }
 

--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -429,7 +429,11 @@ const BlockDragger = class {
     // Moving icons moves their associated bubbles.
     for (let i = 0; i < this.dragIconData_.length; i++) {
       const data = this.dragIconData_[i];
-      data.icon.setIconLocation(Coordinate.sum(data.location, dxy));
+      // Don't move hidden Icons as they can have not been initialized.
+      // fixes #6076
+      if (!this.draggingBlock_.isCollapsed() || !data.icon.collapseHidden) {
+        data.icon.setIconLocation(Coordinate.sum(data.location, dxy));
+      }
     }
   }
 

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -398,6 +398,12 @@ const appendPrivate = function(state, workspace, {
   loadInputBlocks(block, state);
   loadNextBlocks(block, state);
   initBlock(block, workspace.rendered);
+  // fixes #6076 JSO deserialization doesn't
+  // set .iconXY_ property so here it will be set
+  const icons = block.getIcons();
+  for (let i = 0; i < icons.length; i++) {
+    icons[i].computeIconLocation();
+  }
 
   return block;
 };
@@ -526,12 +532,6 @@ const loadIcons = function(block, state) {
       const blockSvg = /** @type {!BlockSvg} */ (block);
       setTimeout(() => blockSvg.getCommentIcon().setVisible(true), 1);
     }
-  }
-  // fixes #6076 JSO deserialization doesn't
-  // set .iconXY_ property so here it will be set
-  const icons = block.getIcons();
-  for (let i = 0; i < icons.length; i++) {
-    icons[i].computeIconLocation();
   }
 };
 

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -398,12 +398,6 @@ const appendPrivate = function(state, workspace, {
   loadInputBlocks(block, state);
   loadNextBlocks(block, state);
   initBlock(block, workspace.rendered);
-  // fixes #6076 JSO deserialization doesn't
-  // set .iconXY_ property so here it will be set
-  const icons = block.getIcons();
-  for (let i = 0; i < icons.length; i++) {
-    icons[i].computeIconLocation();
-  }
 
   return block;
 };
@@ -629,6 +623,12 @@ const initBlock = function(block, rendered) {
 
     blockSvg.initSvg();
     blockSvg.render(false);
+    // fixes #6076 JSO deserialization doesn't
+    // set .iconXY_ property so here it will be set
+    const icons = block.getIcons();
+    for (let i = 0; i < icons.length; i++) {
+      icons[i].computeIconLocation();
+    }
   } else {
     block.initModel();
   }

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -527,6 +527,12 @@ const loadIcons = function(block, state) {
       setTimeout(() => blockSvg.getCommentIcon().setVisible(true), 1);
     }
   }
+  // fixes #6076 JSO deserialization doesn't
+  // set .iconXY_ property so here it will be set
+  const icons = block.getIcons();
+  for (let i = 0; i < icons.length; i++) {
+    icons[i].computeIconLocation();
+  }
 };
 
 /**


### PR DESCRIPTION
…deserialized from JSON

## The basics
- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
Fix for "Dragging fails to complete for collapsed procedure blocks that have been deserialised from JSON #6076".
The bug affect every block with icons, not only procedures. So comments in a collapsed block will trigger this bug too.
Precondition is a deserialization from JSON.

### Resolves
[bug #6076](https://github.com/google/blockly/issues/6076)

### Proposed Changes
Provides an appropriate check if the Icon is visible, as this guarantees an initialized state of the Icon Object belonging to the block.
Not moving the not visible Icons should not have side effects, as expanding the block will render the icons so they get a proper state.
An alternative solution would be a simple null check, but this could chew future errors. The specific checks are imho the better way.

#### Behavior Before Change

#### Behavior After Change

### Reason for Changes

### Test Coverage
Manually tested with some blocks on a playground.

Tested on: This bug is not related to the client for obvious reasons.


### Documentation
There is a code comment in the PR explaining the changes and mentions the # of the issue

### Additional Information
