### PR TITLE
fix: type error in uneditable bubbles

### DIFF
--- a/core/browser_events.js
+++ b/core/browser_events.js
@@ -219,10 +219,14 @@ const isTargetInput = function(e) {
 
     if (e.target instanceof HTMLInputElement) {
       const target = e.target;
-      return target.type === 'textarea' || target.type === 'text' ||
-          target.type === 'number' || target.type === 'email' ||
-          target.type === 'password' || target.type === 'search' ||
-          target.type === 'tel' || target.type === 'url';
+      return target.type === 'text' || target.type === 'number' ||
+          target.type === 'email' || target.type === 'password' ||
+          target.type === 'search' || target.type === 'tel' ||
+          target.type === 'url';
+    }
+
+    if (e.target instanceof HTMLTextAreaElement) {
+      return true;
     }
   }
 

--- a/core/bubble.js
+++ b/core/bubble.js
@@ -931,7 +931,9 @@ const Bubble = class {
       // This cannot be done until the bubble is rendered on screen.
       const maxWidth = paragraphElement.getBBox().width;
       for (let i = 0, textElement;
-           (textElement = paragraphElement.childNodes[i]); i++) {
+           (textElement = /** @type {!SVGTSpanElement} */ (
+                paragraphElement.childNodes[i]));
+           i++) {
         textElement.setAttribute('text-anchor', 'end');
         textElement.setAttribute('x', maxWidth + Bubble.BORDER_WIDTH);
       }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes a type error in bubble code.
Fixes a runtime error in `isTargetInput`

### Proposed Changes

In bubble code, cast child nodes appropriately.

In `isTargetInput`, separate the check for a textarea from the check for other input types.

#### Behavior Before Change

Clicking on comments didn't work; backspace when editing a new comment deleted the comment.

#### Behavior After Change

Input on textareas works again; two type errors resolved.

### Reason for Changes

Fix type problems, and I found the textarea issue while testing.

### Test Coverage

Test case 1: textarea input
- Add a block to the workspace
- Right-click and add a comment
- Type some text, then hit backspace

**Comment should not disappear**

Test case 2: textarea input
- Add a block to the workspace
- Right-click and add a comment
- Click away
- Click on the comment

**Comment should be editable**

Test case 3: non-editable bubbles
- Load the following XML into the workspace:
```
<xml xmlns="https://developers.google.com/blockly/xml">
  <block type="text_multiline" id="Rdl!b(/pG$`rZ|c*uH4c" x="638" y="163" editable="false">
    <field name="TEXT"></field>
    <comment pinned="true" h="80" w="160">multiline


comment text
    </comment>
  </block>
  <block type="text_multiline" id="g%J@yV~;M=k_Y$DKaVKh" editable="false" x="213" y="363">
    <field name="TEXT"></field>
    <comment pinned="true" h="80" w="160">comment text</comment>
  </block>
</xml>
```

**Comments should render as non-editable bubbles**

Test case 4: compile
- Run `npm run build-debug > debug_output_original.txt`
- Enable `strictCheckTypes` and `strictMissingProperties` in `build_tasks.js`
- Run `npm run build-debug > debug_output_new.txt`
- Diff the outputs to confirm that two errors have disappeared.

### Documentation
None

### Additional Information

