### PR TITLE
fix: Silence Closure errors when modifying tooltips.

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -248,7 +248,7 @@ class BlockSvg extends Block {
         svgMath.is3dSupported() && !!workspace.getBlockDragSurface();
 
     const svgPath = this.pathObject.svgPath;
-    svgPath.tooltip = this;
+    (/** @type {?} */ (svgPath)).tooltip = this;
     Tooltip.bindMouseEvents(svgPath);
 
     // Expose this block's ID on its top-level SVG group.

--- a/core/field.js
+++ b/core/field.js
@@ -1097,7 +1097,7 @@ class Field {
     }
     const clickTarget = this.getClickTarget_();
     if (clickTarget) {
-      clickTarget.tooltip = newTip;
+      (/** @type {?} */ (clickTarget)).tooltip = newTip;
     } else {
       // Field has not been initialized yet.
       this.tooltip_ = newTip;

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -1045,7 +1045,7 @@ class Flyout extends DeleteArea {
           'width': blockHW.width,
         },
         null);
-    rect.tooltip = block;
+    (/** @type {?} */ (rect)).tooltip = block;
     Tooltip.bindMouseEvents(rect);
     // Add the rectangles under the blocks, so that the blocks' tooltips work.
     this.workspace_.getCanvas().insertBefore(rect, block.getSvgRoot());

--- a/core/tooltip.js
+++ b/core/tooltip.js
@@ -363,7 +363,7 @@ const onMouseOut = function(_e) {
  * @param {!Event} e Mouse event.
  */
 const onMouseMove = function(e) {
-  if (!element || !element.tooltip) {
+  if (!element || !(/** @type {?} */ (element)).tooltip) {
     // No tooltip here to show.
     return;
   } else if (blocked) {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #6097

### Proposed Changes
When modifying a tooltip attribute, the object it is being attached to is cast to ? to silence Closure's complaints.

#### Behavior Before Change
Closure would produce an error in strict mode.

#### Behavior After Change
Closure is silent.

### Reason for Changes
We need to get the codebase compiling cleanly under Closure to migrate to Typescript.

### Test Coverage
Verified that the test suite passes.