### PR TITLE
fix: improve types in touch code

### DIFF
--- a/core/gesture.js
+++ b/core/gesture.js
@@ -519,10 +519,12 @@ class Gesture {
       return;
     }
 
+    // TODO(#6097): Make types accurate, possibly by refactoring touch handling.
+    const typelessEvent = /** @type {?} */ (e);
     if ((e.type.toLowerCase() === 'touchstart' ||
          e.type.toLowerCase() === 'pointerdown') &&
-        e.pointerType !== 'mouse') {
-      Touch.longStart(e, this);
+        typelessEvent.pointerType !== 'mouse') {
+      Touch.longStart(typelessEvent, this);
     }
 
     this.mouseDownXY_ = new Coordinate(e.clientX, e.clientY);

--- a/core/touch_gesture.js
+++ b/core/touch_gesture.js
@@ -324,9 +324,13 @@ class TouchGesture extends Gesture {
     if (!this.startWorkspace_) {
       return null;
     }
+    // TODO(#6097): Make types accurate, possibly by refactoring touch handling.
+    const typelessEvent = /** @type {?} */ (e);
     return new Coordinate(
-        (e.changedTouches ? e.changedTouches[0].pageX : e.pageX),
-        (e.changedTouches ? e.changedTouches[0].pageY : e.pageY));
+        (typelessEvent.changedTouches ? typelessEvent.changedTouches[0].pageX :
+                                        typelessEvent.pageX),
+        (typelessEvent.changedTouches ? typelessEvent.changedTouches[0].pageY :
+                                        typelessEvent.pageY));
   }
 }
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

### Proposed Changes

Add specificity to types in touch code.

I added more specific types where possible (e.g. with `instanceof`) but left fallbacks to the old code with casts to `?`, to avoid accidentally changing behaviour in the edge cases.

### Reason for Changes

Fix or mask type errors.

### Test Coverage

Tested on desktop chrome and through device emulation in chrome dev tools, acting as a pixel 5.

### Additional Information

https://github.com/google/blockly/issues/6097 tracks future cleanup.

caniuse.com says pointer events are supported in all browsers we support, so we can refactor and simplify this code--but we'll need to do a lot of testing to verify it.