### PR TITLE
fix: add compose and decompose to block

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -179,6 +179,20 @@ class Block {
      */
     this.getDeveloperVariables = undefined;
 
+    /**
+     * An optional function that reconfigures the block based on the contents of
+     * the mutator dialog.
+     * @type {undefined|?function(!Block):void}
+     */
+    this.compose = undefined;
+
+    /**
+     * An optional function that populates the mutator's dialog with
+     * this block's components.
+     * @type {undefined|?function(!Workspace):!Block}
+     */
+    this.decompose = undefined;
+
     /** @type {string} */
     this.id = (opt_id && !workspace.getBlockById(opt_id)) ?
         opt_id :

--- a/core/events/utils.js
+++ b/core/events/utils.js
@@ -372,8 +372,8 @@ const filter = function(queueIn, forward) {
     if (!event.isNull()) {
       // Treat all UI events as the same type in hash table.
       const eventType = event.isUiEvent ? UI : event.type;
-      // TODO(#5927): Ceck whether `blockId` exists before accessing it.
-      const blockId = /** @type {*} */ (event).blockId;
+      // TODO(#5927): Check whether `blockId` exists before accessing it.
+      const blockId = /** @type {?} */ (event).blockId;
       const key = [eventType, blockId, event.workspaceId].join(' ');
 
       const lastEntry = hash[key];
@@ -525,7 +525,7 @@ exports.getDescendantIds = getDescendantIds;
  * @alias Blockly.Events.utils.fromJson
  */
 const fromJson = function(json, workspace) {
-  const eventClass = get(json.type);
+  const eventClass = get(json['type']);
   if (!eventClass) {
     throw Error('Unknown event type.');
   }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of migration to typescript.

### Proposed Changes

Add annotations for compose and decompose functions on block.
Change a cast from `*` to `?`.

### Reason for changes

Fixes several type errors blocking typescript conversion.