### PR TITLE
fix: JSON deserialization fails (bug #6091) (collapsed procedure call…

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -721,10 +721,10 @@ const PROCEDURE_CALL_COMMON = {
     if (!mutatorOpen) {
       this.quarkConnections_ = {};
       this.quarkIds_ = null;
-    }
-    if (!paramIds) {
-      // Reset the quarks (a mutator is about to open).
-      return;
+    } else {
+      // fix #6091 - this call could cause an error when outside if-else
+      // expanding block while mutating prevents another error (ancient fix)
+      this.setCollapsed(false);
     }
     // Test arguments (arrays of strings) for changes. '\n' is not a valid
     // argument name character, so it is a valid delimiter here.
@@ -736,7 +736,6 @@ const PROCEDURE_CALL_COMMON = {
     if (paramIds.length !== paramNames.length) {
       throw RangeError('paramNames and paramIds must be the same length.');
     }
-    this.setCollapsed(false);
     if (!this.quarkIds_) {
       // Initialize tracking for this block.
       this.quarkConnections_ = {};

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -390,8 +390,8 @@ const appendPrivate = function(state, workspace, {
   const block = workspace.newBlock(state['type'], state['id']);
   block.setShadow(isShadow);
   loadCoords(block, state);
-  loadExtraState(block, state);
   loadAttributes(block, state);
+  loadExtraState(block, state);
   tryToConnectParent(parentConnection, block, state);
   loadIcons(block, state);
   loadFields(block, state);

--- a/core/serialization/blocks.js
+++ b/core/serialization/blocks.js
@@ -390,8 +390,8 @@ const appendPrivate = function(state, workspace, {
   const block = workspace.newBlock(state['type'], state['id']);
   block.setShadow(isShadow);
   loadCoords(block, state);
-  loadAttributes(block, state);
   loadExtraState(block, state);
+  loadAttributes(block, state);
   tryToConnectParent(parentConnection, block, state);
   loadIcons(block, state);
   loadFields(block, state);

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -1674,12 +1674,52 @@ Serializer.Mutations.Procedure.Caller = new SerializerTestCase(
     '</mutation>' +
     '</block>' +
     '</xml>');
+Serializer.Mutations.Procedure.CollapsedProceduresCallreturn = new SerializerTestCase(
+    'CollapsedProceduresCallreturn',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
+    '<variables>' +
+    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+    '</variables>' +
+    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+    '<mutation>' +
+    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+    '</mutation>' +
+    '<field name="NAME">do something</field>' +
+    '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
+    '</block>' +
+    '<block type="procedures_callreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
+    '<mutation name="do something">' +
+    '<arg name="x"></arg>' +
+    '</mutation>' +
+    '</block>' +
+    '</xml>');
+Serializer.Mutations.Procedure.CollapsedProceduresCallnoreturn = new SerializerTestCase(
+    'CollapsedProceduresCallnoreturn',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
+    '<variables>' +
+    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+    '</variables>' +
+    '<block type="procedures_defnoreturn" id="id******************" x="42" y="42">' +
+    '<mutation>' +
+    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+    '</mutation>' +
+    '<field name="NAME">do something</field>' +
+    '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
+    '</block>' +
+    '<block type="procedures_callnoreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
+    '<mutation name="do something">' +
+    '<arg name="x"></arg>' +
+    '</mutation>' +
+    '</block>' +
+    '</xml>');
 Serializer.Mutations.Procedure.testCases = [
   Serializer.Mutations.Procedure.NoMutation,
   Serializer.Mutations.Procedure.Variables,
   Serializer.Mutations.Procedure.NoStatements,
   Serializer.Mutations.Procedure.IfReturn,
   Serializer.Mutations.Procedure.Caller,
+  Serializer.Mutations.Procedure.CollapsedProceduresCallreturn,
+  Serializer.Mutations.Procedure.CollapsedProceduresCallnoreturn,
 ];
 
 Serializer.Mutations.Procedure.Names = new SerializerTestSuite('Names');


### PR DESCRIPTION
… blocks)

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`
- [x] BONUS: I ran `npm run test`

## The details
### Resolves

#6091

### Proposed Changes

Flipping the call order in core/serialization/blocks.js  of .loadAttributes() and .loadExtraState() does the trick.

#### Behavior Before Change

During deserialization of the call block, a very nasty bug begins here:

https://github.com/google/blockly/blob/d2329f8cba661999cc7f03fcd6c0196770b05cdc/blocks/procedures.js#L739

Because the collapsed attribute was set to true beforehand, this becomes a crime scene:
https://github.com/google/blockly/blob/d2329f8cba661999cc7f03fcd6c0196770b05cdc/core/block_svg.js#L642

this.collapsed_ is true, so the if-cond isn't met and super.setCollapsed(collapsed) is getting executed. This sets collapsed to false, so the condition if (!collapsed) is met and this.updateCollapsed_() gets executed.

updateCollapse_() maintains the logic of setting a dummy with _TEMP_COLLAPSED_INPUT (hence the error "block.js:2022 Uncaught Error: Input not found: _TEMP_COLLAPSED_INPUT")

#### Behavior After Change

For whom is interested in, the "right" call to updateCollapse_() will happen here:
https://github.com/google/blockly/blob/d2329f8cba661999cc7f03fcd6c0196770b05cdc/core/block_svg.js#L1741

As the block must get rendered collapsed.

### Reason for Changes

bug 🐛 

### Test Coverage

Existing tests passed. Manually tested both types "procedures_callnoreturn" and procedures_callreturn" in collapsed state, and observed changed behaviour in debugger.

**Potential Failures:**
As changing the order does change the deserialization of other "attributes":
https://github.com/google/blockly/blob/d2329f8cba661999cc7f03fcd6c0196770b05cdc/core/serialization/blocks.js#L426

I spotted the data-attribute as a potential "let's introduce a regression bug", as it shows up very early in xml deserialization:
https://github.com/google/blockly/blob/d4196c1105d3d7719e967edb0cecd0d7f76508c0/core/xml.js#L882

So it may be better to split up the .loadAttributes() method?


### Documentation

Maybe I should have left a comment in the code 😳 

### Additional Information

Yes, I will add a comment in the code. I will do this, after the code is reviewed.