### PR TITLE
fix: component id should be on the prototype

### DIFF
--- a/core/delete_area.js
+++ b/core/delete_area.js
@@ -49,6 +49,13 @@ class DeleteArea extends DragTarget {
      * @protected
      */
     this.wouldDelete_ = false;
+
+    /**
+     * The unique id for this component that is used to register with the
+     * ComponentManager.
+     * @type {string}
+     */
+    this.id;
   }
 
   /**

--- a/core/drag_target.js
+++ b/core/drag_target.js
@@ -34,6 +34,19 @@ const {Rect} = goog.requireType('Blockly.utils.Rect');
  */
 class DragTarget {
   /**
+   * Constructor for DragTarget. It exists to add the id property and should not
+   * be called directly, only by a subclass.
+   */
+  constructor() {
+    /**
+     * The unique id for this component that is used to register with the
+     * ComponentManager.
+     * @type {string}
+     */
+    this.id;
+  }
+
+  /**
    * Handles when a cursor with a block or bubble enters this drag target.
    * @param {!IDraggable} _dragElement The block or bubble currently being
    *   dragged.

--- a/core/interfaces/i_block_dragger.js
+++ b/core/interfaces/i_block_dragger.js
@@ -63,4 +63,9 @@ IBlockDragger.prototype.endDrag;
  */
 IBlockDragger.prototype.getInsertionMarkers;
 
+/**
+ * Sever all links from this object and do any necessary cleanup.
+ */
+IBlockDragger.prototype.dispose;
+
 exports.IBlockDragger = IBlockDragger;

--- a/core/interfaces/i_component.js
+++ b/core/interfaces/i_component.js
@@ -32,6 +32,6 @@ const IComponent = function() {};
  * ComponentManager.
  * @type {string}
  */
-IComponent.id;
+IComponent.prototype.id;
 
 exports.IComponent = IComponent;


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/5857

### Proposed Changes

Changes the `id` property on `i_component` to be on the prototype, and then updates things that implement `IComponent` accordingly.

The IDs were already there--created in the constructors for things that implement `IComponent`. `id` was not supposed to be at the top level, since it's not shared between instances of a class.

Also added `dispose` to `IBlockDragger`.


### Reason for Changes

Fix type errors to convert to typescript
