### PR TITLE
fix: remove retired "update cursorstyle over toolbox"

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -353,29 +353,6 @@ const BlockDragger = class {
   }
 
   /**
-   * Adds or removes the style of the cursor for the toolbox.
-   * This is what changes the cursor to display an x when a deletable block is
-   * held over the toolbox.
-   * @param {boolean} isEnd True if we are at the end of a drag, false
-   *     otherwise.
-   * @protected
-   */
-  updateToolboxStyle_(isEnd) {
-    const toolbox = this.workspace_.getToolbox();
-
-    if (toolbox) {
-      const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-                                                        'blocklyToolboxGrab';
-
-      if (isEnd && typeof toolbox.removeStyle === 'function') {
-        toolbox.removeStyle(style);
-      } else if (!isEnd && typeof toolbox.addStyle === 'function') {
-        toolbox.addStyle(style);
-      }
-    }
-  }
-
-  /**
    * Fire a move event at the end of a block drag.
    * @protected
    */

--- a/core/interfaces/i_styleable.js
+++ b/core/interfaces/i_styleable.js
@@ -25,13 +25,13 @@ goog.module('Blockly.IStyleable');
 const IStyleable = function() {};
 
 /**
- * Adds a style on the toolbox. Usually used to change the cursor.
+ * Adds a style on an object. Usually used to change the cursor.
  * @param {string} style The name of the class to add.
  */
 IStyleable.prototype.addStyle;
 
 /**
- * Removes a style from the toolbox. Usually used to change the cursor.
+ * Removes a style from an object. Usually used to change the cursor.
  * @param {string} style The name of the class to remove.
  */
 IStyleable.prototype.removeStyle;


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint` 

## The details

The Toolbox has been refactored and extends DeleteArea. As a consequence, the cursor update has been moved to the Toolbox:

https://github.com/google/blockly/blob/24704e0eff63a7e4bb7407d1c16307f3684ee7d2/core/toolbox/toolbox.js#L665

And there is an incorrect comment in IStyleable, as it refers to Toolbox, but it should refer more generally to "an object".

The latter change is somehow tangled to this issue, so it makes sense to bundle it here.

### Resolves

Unused code causes irritation. (I was irritated, so I took action to do this PR)

### Proposed Changes

There was old code which has been removed.

There are [no known references](https://github.com/google/blockly/search?q=updateToolboxStyle_)

#### Behavior Before Change

#### Behavior After Change

No change. The "isDeletable()" check has been implemented in toolbox.js with "wouldDelete()", so no indication of lost functionality.

### Reason for Changes

### Test Coverage

Manually tested. Cursor changes when block is dragged over toolbox.

### Documentation

No doc needed, change is trivial.

### Additional Information

Blockly Team is awesome 🤩 