### PR TITLE
fix: reuse the 'bumpObjects' module in inject.js

### DIFF
--- a/core/inject.js
+++ b/core/inject.js
@@ -219,8 +219,7 @@ const init = function(mainWorkspace) {
       browserEvents.conditionalBind(window, 'resize', null, function() {
         mainWorkspace.hideChaff(true);
         common.svgResize(mainWorkspace);
-        goog.module.get('Blockly.bumpObjects')
-            .bumpTopObjectsIntoBounds(mainWorkspace);
+        bumpObjects.bumpTopObjectsIntoBounds(mainWorkspace);
       });
   mainWorkspace.setResizeHandlerWrapper(workspaceResizeHandler);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes

The changes include a small improvement that reuses the imported module `bumpObjects` instead of loading it again with `goog.module.get`.

### Reason for Changes

`bumpObjects` is imported here:

https://github.com/google/blockly/blob/63ca83b545d9f00ed8a7e0be6ff8c54dc909e1a7/core/inject.js#L24

then used here:

https://github.com/google/blockly/blob/63ca83b545d9f00ed8a7e0be6ff8c54dc909e1a7/core/inject.js#L190-L191

and loaded again here:

https://github.com/google/blockly/blob/63ca83b545d9f00ed8a7e0be6ff8c54dc909e1a7/core/inject.js#L222-L223

`goog.module.get` is unnecessary.

### Test Coverage

No tests have been modified.

### Documentation

The API has not changed.