### PR TITLE
fix: Increases the  speed of deleting blocks

### DIFF
--- a/core/block_animations.js
+++ b/core/block_animations.js
@@ -59,9 +59,8 @@ const disposeUiEffect = function(block) {
   const clone = svgGroup.cloneNode(true);
   clone.setAttribute('transform', 'translate(' + xy.x + ',' + xy.y + ')');
   workspace.getParentSvg().appendChild(clone);
-  const bBox = clone.getBBox();
   const cloneRect =
-      {'x': xy.x, 'y': xy.y, 'width': bBox.width, 'height': bBox.height};
+      {'x': xy.x, 'y': xy.y, 'width': block.width, 'height': block.height};
   // Start the animation.
   disposeUiStep(clone, cloneRect, workspace.RTL, new Date, workspace.scale);
 };

--- a/core/block_drag_surface.js
+++ b/core/block_drag_surface.js
@@ -137,17 +137,14 @@ const BlockDragSurfaceSvg = class {
    */
   translateAndScaleGroup(x, y, scale) {
     this.scale_ = scale;
-    // This is a work-around to prevent a the blocks from rendering
-    // fuzzy while they are being dragged on the drag surface.
-    const fixedX = x.toFixed(0);
-    const fixedY = y.toFixed(0);
-
-    this.childSurfaceXY_.x = parseInt(fixedX, 10);
-    this.childSurfaceXY_.y = parseInt(fixedY, 10);
-
+    // Make sure the svg exists on a pixel boundary so that it is not fuzzy.
+    const roundX = Math.round(x);
+    const roundY = Math.round(y);
+    this.childSurfaceXY_.x = roundX;
+    this.childSurfaceXY_.y = roundY;
     this.dragGroup_.setAttribute(
         'transform',
-        'translate(' + fixedX + ',' + fixedY + ') scale(' + scale + ')');
+        'translate(' + roundX + ',' + roundY + ') scale(' + scale + ')');
   }
 
   /**
@@ -157,10 +154,9 @@ const BlockDragSurfaceSvg = class {
   translateSurfaceInternal_() {
     let x = this.surfaceXY_.x;
     let y = this.surfaceXY_.y;
-    // This is a work-around to prevent a the blocks from rendering
-    // fuzzy while they are being dragged on the drag surface.
-    x = x.toFixed(0);
-    y = y.toFixed(0);
+    // Make sure the svg exists on a pixel boundary so that it is not fuzzy.
+    x = Math.round(x);
+    y = Math.round(y);
     this.SVG_.style.display = 'block';
 
     dom.setCssTransform(this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -293,10 +293,9 @@ exports.showPositionedByField = showPositionedByField;
  */
 const getScaledBboxOfBlock = function(block) {
   const blockSvg = block.getSvgRoot();
-  const bBox = blockSvg.getBBox();
   const scale = block.workspace.scale;
-  const scaledHeight = bBox.height * scale;
-  const scaledWidth = bBox.width * scale;
+  const scaledHeight = block.height * scale;
+  const scaledWidth = block.width * scale;
   const xy = style.getPageOffset(blockSvg);
   return new Rect(xy.y, xy.y + scaledHeight, xy.x, xy.x + scaledWidth);
 };

--- a/core/workspace_drag_surface_svg.js
+++ b/core/workspace_drag_surface_svg.js
@@ -101,11 +101,9 @@ class WorkspaceDragSurfaceSvg {
    * @package
    */
   translateSurface(x, y) {
-    // This is a work-around to prevent a the blocks from rendering
-    // fuzzy while they are being moved on the drag surface.
-    const fixedX = x.toFixed(0);
-    const fixedY = y.toFixed(0);
-
+    // Make sure the svg exists on a pixel boundary so that it is not fuzzy.
+    const fixedX = Math.round(x);
+    const fixedY = Math.round(y);
     this.SVG_.style.display = 'block';
     dom.setCssTransform(
         this.SVG_, 'translate3d(' + fixedX + 'px, ' + fixedY + 'px, 0)');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #6124

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Removes the forced style calculation and layout by removing the call to `getBBox`
* Uses `Math.round` instead of `.toFixed(0)`

Average time to run onKeyDown decreased from ~27ms to ~15ms. Doesn't quite meet the goal of 10ms, but does almost double speeds.

![image](https://user-images.githubusercontent.com/25440652/165850638-16bcea0a-c5ec-4927-96f4-aec6fb86590d.png)
[deleting-2.txt](https://github.com/google/blockly/files/8586810/deleting-2.txt)


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Performance is good!

### Test Coverage

Deletion:
  1) Drag a block onto the workspace.
  2) Delete it.
  3) Observe how the animation  plays correctly.
  4) Repeat with:
      * Workspace zoomed in
      * Workspace zoomed out
      * Page zoomed in
      * Page zoomed out
      * Combinations of the above four.

Block dragging:
  1) Drag a block onto the workspace.
  2) Drag the block around the workspace.
  3) Observe how the block is not fuzzy.

Workspace dragging:
  1) Drag a block onto the workspace.
  2) Drag the workspace.
  3) Observe how the block is not fuzzy

DropDownDiv Positioning:
  1) Modify the FieldDropdown to call `showPositionedByBlock`.
  2) Drag out a block with a dropdown.
  3) Click on the dropdown.
  3) Observe how the dropdown div is positioned correctly.
  4) Repeat with different workspace/page zoom levels.

With `getBBox`:
![image](https://user-images.githubusercontent.com/25440652/165982084-4e684594-bfb4-4d03-a061-cae238492b2f.png)

With `block.width` and `block.height`:
![image](https://user-images.githubusercontent.com/25440652/165982190-206843e4-065a-428b-9ced-fb003446e21d.png)


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
