### PR TITLE
fix: add timeouts to delay expensive mutation operations

### DIFF
--- a/core/mutator.js
+++ b/core/mutator.js
@@ -424,10 +424,9 @@ class Mutator extends Icon {
    * @return {boolean} Whether to ignore the event or not.
    */
   shouldIgnoreMutatorEvent_(e) {
-    return e.isUiEvent ||
-        e.type === eventUtils.CREATE ||
+    return e.isUiEvent || e.type === eventUtils.CREATE ||
         e.type === eventUtils.CHANGE &&
-            /** @type {!BlockChange} */ (e).element === 'disabled';
+        /** @type {!BlockChange} */ (e).element === 'disabled';
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #6131 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Delays expensive operations using setTimeout so that:
  1) We aren't calling `compose()` multiple times for things that won't be rendered.
  2) We can render the mutated block without waiting for the mutator bubble to resize (which is expensive). This makes the UI feel more responsive.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
~188ms for `updateWorkspace` to run, which was required to complete before the first frame could be drawn.


#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
~35ms for `updateWorkspace` to run, after which the mutated block is drawn
Then ~20ms for `resizeBubble_` to run, after which the newly positioned/sized bubble is drawn

![image](https://user-images.githubusercontent.com/25440652/167176727-11debe82-cc89-4554-a00b-db438096fa08.png)
[mutating-2.txt](https://github.com/google/blockly/files/8642273/mutating-2.txt)


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Make the UI feel more responsive.

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

I button mashed mutating the block + undo and redo. This didn't seem to cause any problems because the events should always be undone and redone in a deterministic order, which is great!

Tested on:
 * Desktop Chrome
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

N/A

### Additional Information

<!-- Anything else we should know? -->
I tried to speed up `resizeBubble_` but I couldn't figure out a way to remove the layout thrashing. The issue is our operations look like:
1) Get the size of the mutator workspace (and its blocks) <- requires a forced layout 
2) Get the size of the block the mutator is attached to, so that the bubble doesn't obfuscate it <- requires a forced layout
3) Resize and reposition the bubble based on 1 & 2
4) Resize the workpace to match the new size of the bubble (updates the flyout height) <- requires a forced layout

Afaict 1 and 4 are unavoidable, unless we *really* want to refactor how the metrics manager works (eg having it calculate based on the `width` and `height` properties of blockSvgs, rather than using the browser's measurement).

We could get rid of 2 (which is triggered by [this call](https://github.com/google/blockly/blob/6c5197f69bd15ac35642998c6a256c0a1ab83327/core/bubble.js#L444)) by changing `this.shape_` to be a `Blockly.Rect` instead of an `SVGElement`. But this would be a breaking change.

---

We could also probably speed up `compose` and therefore `updateWorkspace_` by *not* [completely tearing down the block](https://github.com/google/blockly/blob/6c5197f69bd15ac35642998c6a256c0a1ab83327/blocks/logic.js#L487), which requires disposing and then re-creating all of the DOM elements associated with a block. But that's a much bigger refactor than I was looking to do.