### PR TITLE
chore(generators): Remove unnecessary escapes

### DIFF
--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -250,7 +250,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(myList) {
       // mathMedian([null,null,1,3]) === 2.0.
       const functionName = JavaScript.provideFunction_('mathMedian', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(myList) {
-  var localList = myList.filter(function (x) {return typeof x === \'number\';});
+  var localList = myList.filter(function (x) {return typeof x === 'number';});
   if (!localList.length) return null;
   localList.sort(function(a, b) {return b - a;});
   if (localList.length % 2 === 0) {

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -356,7 +356,7 @@ JavaScript['text_replace'] = function(block) {
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement) {
   needle = needle.replace(/([-()\\[\\]{}+?*.$\\^|,:#<!\\\\])/g, '\\\\$1')
                  .replace(/\\x08/g, '\\\\x08');
-  return haystack.replace(new RegExp(needle, \'g\'), replacement);
+  return haystack.replace(new RegExp(needle, 'g'), replacement);
 }
 `);
   const code = functionName + '(' + text + ', ' + from + ', ' + to + ')';

--- a/generators/python/colour.js
+++ b/generators/python/colour.js
@@ -34,7 +34,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(r, g, b):
   r = round(min(100, max(0, r)) * 2.55)
   g = round(min(100, max(0, g)) * 2.55)
   b = round(min(100, max(0, b)) * 2.55)
-  return \'#%02x%02x%02x\' % (r, g, b)
+  return '#%02x%02x%02x' % (r, g, b)
 `);
   const r = Python.valueToCode(block, 'RED', Python.ORDER_NONE) || 0;
   const g = Python.valueToCode(block, 'GREEN', Python.ORDER_NONE) || 0;
@@ -54,7 +54,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio):
   r = round(r1 * (1 - ratio) + r2 * ratio)
   g = round(g1 * (1 - ratio) + g2 * ratio)
   b = round(b1 * (1 - ratio) + b2 * ratio)
-  return \'#%02x%02x%02x\' % (r, g, b)
+  return '#%02x%02x%02x' % (r, g, b)
 `);
   const colour1 =
       Python.valueToCode(block, 'COLOUR1', Python.ORDER_NONE) || '\'#000000\'';


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Warning message from closure-compiler (and/or closure-make-deps): `Unnecessary escape: "\'" is equivalent to just "'"`.

### Proposed Changes

Remove unnecessary escapes.

### Reason for Changes

Prevent warning message from our tooling by fixing the problem.

### Test Coverage

Passes `npm test`.
