### PR TITLE
fix!(xml): Make appendDomToWorkspace take only WorkspaceSvg

### DIFF
--- a/core/xml.js
+++ b/core/xml.js
@@ -529,7 +529,7 @@ exports.domToWorkspace = domToWorkspace;
  * Decode an XML DOM and create blocks on the workspace. Position the new
  * blocks immediately below prior blocks, aligned by their starting edge.
  * @param {!Element} xml The XML DOM.
- * @param {!Workspace} workspace The workspace to add to.
+ * @param {!WorkspaceSvg} workspace The workspace to add to.
  * @return {!Array<string>} An array containing new block IDs.
  * @alias Blockly.Xml.appendDomToWorkspace
  */


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Type error in `appendDomToWorkspace` when attempting to call `.getBlocksBoundingBox` on a `Workspace` object.

### Proposed Changes

Have `appendDomToWorkspace` take a `WorkspaceSvg` instead of a `Workspace`.

### Reason for Changes

Turns out if one runs `tsc` on `.js` files in `core/`, the output will be basically identical to the input except for whitespace changes, yet this is sufficient to cause Closure Compiler to detect type errors that were not detected previously.

### Test Coverage

Passes `npm test`.

### Additional Information

BREAKING CHANGE: have appendDomToWorkspace take a WorkspaceSvg instead
of a Workspace as its second parameter.

This function rearranges blocks on the workspace and is only relevant to rendered workspaces.  If you use this function in headless mode, switch to using `domToWorkspace` instead.