### PR TITLE
fix: Update typescript definition files for core, blocks, and generators

### DIFF
--- a/typings/blocks.d.ts
+++ b/typings/blocks.d.ts
@@ -11,4 +11,14 @@
 
 /// <reference path="core.d.ts" />
 
-export { Blocks } from './core';
+export const colour: any;
+export const lists: any;
+export const logic: any;
+export const loops: any;
+export const math: any;
+export const procedures: any;
+export const texts: any;
+export const variables: any;
+export const variablesDynamic: any;
+
+export const blocks: any;

--- a/typings/blocks.d.ts
+++ b/typings/blocks.d.ts
@@ -11,5 +11,4 @@
 
 /// <reference path="core.d.ts" />
 
-import * as Blockly from './core';
-export = Blockly.Blocks;
+export { Blocks } from './core';

--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -11,5 +11,4 @@
 
 /// <reference path="blockly.d.ts" />
 
-import * as Blockly from 'blockly';
-export = Blockly;
+export * from 'core/blockly';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,9 +14,7 @@
 /// <reference path="javascript.d.ts" />
 /// <reference path="msg/msg.d.ts" />
 
-import * as Blockly from './core';
-import './blocks';
-import './javascript';
+export * from './core';
+export * from './blocks';
+export * from './javascript';
 import './msg/msg';
-
-export = Blockly;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,6 +16,6 @@
 
 import { Generator } from 'core/blockly';
 export * from './core';
-export * from './blocks';
+export * as libraryBlocks from './blocks';
 export const JavaScript: Generator;
 import './msg/msg';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,7 +14,8 @@
 /// <reference path="javascript.d.ts" />
 /// <reference path="msg/msg.d.ts" />
 
+import { Generator } from 'core/blockly';
 export * from './core';
 export * from './blocks';
-export * from './javascript';
+export const JavaScript: Generator;
 import './msg/msg';

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -12,5 +12,4 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const javascript: Blockly.Generator;
-export = javascript;
+export const JavaScript: Blockly.Generator;

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -12,4 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-export const JavaScript: Blockly.Generator;
+declare const javascript: Blockly.Generator;
+export = javascript;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6079 

### Proposed Changes

Updates TypeScript definition files to properly export Blockly / core and Blocks. I also propose that we cherry pick this change into master and release a patch version of v8.

#### Behavior Before Change

- TypeScript errors when importing Blockly unless you turn off TS checking for libraries (see linked issue)
- No autocomplete when importing Blockly
- No TS definitions available for generators 
- No autocomplete for generators or messages

#### Behavior After Change

- No TS errors when importing Blockly in the way we advise you to
- Autocomplete available for core library
- limited autocomplete (due to incomplete types) of generators, libraryBlocks, and messages

### Reason for Changes

Improve lives of TS developers. Right now Blockly gives TS errors when imported; this used to work so some developers are not updating until this is fixed.

### Test Coverage

Tested in several ways.

I used this test repro from Johnny: https://github.com/johnnyoshika/blockly-typescript-libcheck and removed the "skipLibCheck" from the ts-config.

Then tested that none of this gave errors:

```
import * as Blockly from 'blockly';
import Blocks from 'blockly/blocks';
import * as PHP from 'blockly/php';
import * as Dart from 'blockly/dart';
import * as Lua from 'blockly/lua';
import * as JavaScript from 'blockly/javascript';
import * as libraryBlocks from 'blockly/blocks';
import {loops} from 'blockly/blocks';

JavaScript.addReservedWords('hello');

Blockly.JavaScript.COMMENT_WRAP;

PHP.FUNCTION_NAME_PLACEHOLDER_REGEXP_;
PHP.addReservedWords('testing');
Dart.addReservedWords('hi');
Blockly.Workspace.getAll();
Blockly.JavaScript.addReservedWords('test');

Blockly.Blocks;

PHP.workspaceToCode(Blockly.getMainWorkspace());

Blockly.libraryBlocks.loops.loopTypes;
libraryBlocks.loops.loopTypes;
loops.loopTypes;

console.log(Blockly, Blockly.WorkspaceSvg, Blockly.Msg, Blockly.Blocks, Blocks, PHP, Blockly.JavaScript);
```

Also tested that

`import * as Blockly from 'blockly/core';` works as expected (gives you core blockly, but not JS)

and if you have the `allowSyntheticDefaultModules` flag enabled in your tsconfig file, you can also do `import Blockly from 'blockly';`. The reason you have to have this flag is that we do not provide a default export for the Blockly module. We export quite a lot of different things from the Blockly module and you can only have one default export. We could provide a named export if we did something like `export * as Blockly from 'core/blockly'` but the problem is that consumers would have to then use `import { Blockly } from 'blockly'` which is not what we tell them to do. All of our documentation tells them to use `import * as Blockly from 'blockly';` and this approach is compatible with that guidance. It's just a free bonus that this flag exists and allows consumers to use `import Blockly from 'blockly'`.

I also tested this with the scroll-options plugin in blockly-samples which does not use TypeScript compiler directly. After this change, VS Code properly uses intellisense, and the plugin also compiles and runs correctly still. Checking both of these options is how I am satisfied that the recommended ways of importing modules work with both the actual module (the JavaScript code) and the TypeScript definitions (because otherwise it's possible that the TS compiler is happy yet the actual JavaScript does not exist)


### Why is the JavaScript generator different from the others?

You might have noticed above that I referenced the JS generator with `Blockly.JavaScript` and the PHP generator with a different import statement and reference `PHP` directly. This is because if you `import * as Blockly from 'blockly';` then the JavaScript generator is included in the `*` (import everything from the given module), so the JS generator is available on the name you gave it, Blockly. 

The other generators are also included in the default import in node, but not in the browser :/ however the fact that they are included in the default node package is not documented so I have not added it to the type in this PR. To reference the other language generators you can use `import * as PHP from 'blockly/php';` which will get you proper type checking.

You also have the option of just doing `import 'blockly/php'` which as a side effect will make `Blockly.PHP` available as a module, but TypeScript won't know about it. This is what we currently recommend to people in the README, and we just don't mention TS at all. I believe most people currently use `(Blockly.PHP as any).workspaceToCode()` to avoid this issue. With these updated definitions you can now use the above syntax and get proper type checking.

### What's up with the `export =` syntax?

I originally tried other solutions where I don't use the `export = ` syntax and I use either a named or default export of a constant named e.g. `PHP` so something like `export const PHP: Blockly.Generator` but this adds a layer of indirection to the resulting module imports. It's complicated because for the actual JavaScript code to work you *must* import the module as `import * as PHP from 'blockly/php` (or just `import 'blockly/php'`) but then that fails the TypeScript compiler. The TypeScript compiler is only happy with this definition syntax if you import it like `import { PHP } from 'blockly/php'` but then the actual module loader is unhappy because that's not how the JavaScript module works. So you end up going in circles here. Therefore I just left the `export =` syntax alone.

### What's going on with Blockly.Msg and the locales?

Similar to the above, I tried various strategies but couldn't arrive at a solution that satisfied both the module loader and the TypeScript compiler. So the current status is you have no types for Blockly.Msg still or any of the locales.

### Documentation

We could update the README to instruct TypeScript users to use `import * as PHP from 'blockly/php';` instead of `import 'blockly/php';` but I haven't done that in this PR yet. I wanted to be sure of this solution before updating our documentation.

### Additional Information

<!-- Anything else we should know? -->
