### PR TITLE
fix: json hooks for lists blocks not needing extra state

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -649,10 +649,23 @@ blocks['lists_setIndex'] = {
     this.updateAt_(isAt);
   },
 
-  // This block does not need JSO serialization hooks (saveExtraState and
-  // loadExtraState) because the state of this object is already encoded in the
-  // dropdown values.
-  // XML hooks are kept for backwards compatibility.
+  /**
+   * Returns the state of this block as a JSON serializable object.
+   * This block does not need to serialize any specific state as it is already
+   * encoded in the dropdown values, but must have an implementation to avoid
+   * the backward compatible XML mutations being serialized.
+   * @return {null} The state of this block.
+   */
+  saveExtraState: function() {
+    return null;
+  },
+
+  /**
+   * Applies the given state to this block.
+   * No extra state is needed or expected as it is already encoded in the
+   * dropdown values.
+   */
+  loadExtraState: function() {},
 
   /**
    * Create or delete an input for the numeric index.
@@ -761,10 +774,23 @@ blocks['lists_getSublist'] = {
     this.updateAt_(2, isAt2);
   },
 
-  // This block does not need JSO serialization hooks (saveExtraState and
-  // loadExtraState) because the state of this object is already encoded in the
-  // dropdown values.
-  // XML hooks are kept for backwards compatibility.
+  /**
+   * Returns the state of this block as a JSON serializable object.
+   * This block does not need to serialize any specific state as it is already
+   * encoded in the dropdown values, but must have an implementation to avoid
+   * the backward compatible XML mutations being serialized.
+   * @return {null} The state of this block.
+   */
+  saveExtraState: function() {
+    return null;
+  },
+
+  /**
+   * Applies the given state to this block.
+   * No extra state is needed or expected as it is already encoded in the
+   * dropdown values.
+   */
+  loadExtraState: function() {},
 
   /**
    * Create or delete an input for a numeric index.
@@ -945,10 +971,23 @@ blocks['lists_split'] = {
     this.updateType_(xmlElement.getAttribute('mode'));
   },
 
-  // This block does not need JSO serialization hooks (saveExtraState and
-  // loadExtraState) because the state of this object is already encoded in the
-  // dropdown values.
-  // XML hooks are kept for backwards compatibility.
+  /**
+   * Returns the state of this block as a JSON serializable object.
+   * This block does not need to serialize any specific state as it is already
+   * encoded in the dropdown values, but must have an implementation to avoid
+   * the backward compatible XML mutations being serialized.
+   * @return {null} The state of this block.
+   */
+  saveExtraState: function() {
+    return null;
+  },
+
+  /**
+   * Applies the given state to this block.
+   * No extra state is needed or expected as it is already encoded in the
+   * dropdown values.
+   */
+  loadExtraState: function() {},
 };
 
 // Register provided blocks.

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -106,4 +106,89 @@ suite('Lists', function() {
     ];
     runSerializationTestSuite(testCases);
   });
+
+  /**
+   * Test cases for serialization where JSON hooks should have null
+   * implementation to avoid serializing xml mutations in json.
+   * @param {!Object} serializedJson basic serialized json
+   * @param {!string} xmlMutation xml mutation that should be ignored/not reserialized in round trip
+   * @return {Array<SerializationTestCase>} test cases
+   */
+  function makeTestCasesForBlockNotNeedingExtraState_(serializedJson, xmlMutation) {
+    return [
+      {
+        title: 'JSON not requiring mutations',
+        json: serializedJson,
+        assertBlockStructure: (block) => {
+          chai.assert.equal(block.type, serializedJson.type);
+        },
+      },
+      {
+        title:
+          'JSON with XML extra state',
+        json: {
+          ...serializedJson,
+          "extraState": xmlMutation,
+        },
+        expectedJson: serializedJson,
+        assertBlockStructure: (block) => {},
+      },
+    ];
+  }
+
+  suite('ListsSetIndex', function() {
+    /**
+     * Test cases for serialization tests.
+     * @type {Array<SerializationTestCase>}
+     */
+    const testCases = makeTestCasesForBlockNotNeedingExtraState_(
+      {
+        "type": "lists_setIndex",
+        "id": "1",
+        "fields": {
+          "MODE": "SET",
+          "WHERE": "FROM_START",
+        },
+      },
+      "<mutation at=\"true\"></mutation>"
+    );
+    runSerializationTestSuite(testCases);
+  });
+
+  suite('ListsGetSubList', function() {
+    /**
+     * Test cases for serialization tests.
+     * @type {Array<SerializationTestCase>}
+     */
+     const testCases = makeTestCasesForBlockNotNeedingExtraState_(
+      {
+        "type": "lists_getSublist",
+        "id": "1",
+        "fields": {
+          "WHERE1": "FROM_START",
+          "WHERE2": "FROM_START",
+        },
+      },
+      "<mutation at1=\"true\" at2=\"true\"></mutation>"
+    );
+    runSerializationTestSuite(testCases);
+  });
+
+  suite('ListsSplit', function() {
+    /**
+     * Test cases for serialization tests.
+     * @type {Array<SerializationTestCase>}
+     */
+    const testCases = makeTestCasesForBlockNotNeedingExtraState_(
+      {
+        "type": "lists_split",
+        "id": "1",
+        "fields": {
+          "MODE": "SPLIT",
+        },
+      },
+      "<mutation mode=\"SPLIT\"></mutation>"
+    );
+    runSerializationTestSuite(testCases);
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

https://github.com/google/blockly/issues/6176

### Proposed Changes

Don't serialize xml mutations to extra state in json serialization for

- lists_setIndex
- lists_getSubList
- lists_split

#### Behavior Before Change

xml mutations were serialized in json extra state and deserialized

#### Behavior After Change

xml mutations no longer serialized and are ignored on deserialization

### Reason for Changes

- not needed in JSON serialization
- better (de-)serialization performance

### Test Coverage

Added basic roundtrip (de)serialization tests, including with previous extra state

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
