### PR TITLE
fix: provide initial values to reduce functions in generated js

### DIFF
--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -222,7 +222,7 @@ JavaScript['math_on_list'] = function(block) {
     case 'SUM':
       list = JavaScript.valueToCode(block, 'LIST',
           JavaScript.ORDER_MEMBER) || '[]';
-      code = list + '.reduce(function(x, y) {return x + y;})';
+      code = list + '.reduce(function(x, y) {return x + y;}, 0)';
       break;
     case 'MIN':
       list = JavaScript.valueToCode(block, 'LIST',
@@ -238,7 +238,7 @@ JavaScript['math_on_list'] = function(block) {
       // mathMean([null,null,1,3]) === 2.0.
       const functionName = JavaScript.provideFunction_('mathMean', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(myList) {
-  return myList.reduce(function(x, y) {return x + y;}) / myList.length;
+  return myList.reduce(function(x, y) {return x + y;}, 0) / myList.length;
 }
 `);
       list = JavaScript.valueToCode(block, 'LIST',

--- a/tests/generators/golden/generated.js
+++ b/tests/generators/golden/generated.js
@@ -476,7 +476,7 @@ function test_change() {
 }
 
 function mathMean(myList) {
-  return myList.reduce(function(x, y) {return x + y;}) / myList.length;
+  return myList.reduce(function(x, y) {return x + y;}, 0) / myList.length;
 }
 
 function mathMedian(myList) {
@@ -538,7 +538,7 @@ function mathRandomList(list) {
 
 // Tests the "list operation" blocks.
 function test_operations_on_list() {
-  assertEquals([3, 4, 5].reduce(function(x, y) {return x + y;}), 12, 'sum');
+  assertEquals([3, 4, 5].reduce(function(x, y) {return x + y;}, 0), 12, 'sum');
   assertEquals(Math.min.apply(null, [3, 4, 5]), 3, 'min');
   assertEquals(Math.max.apply(null, [3, 4, 5]), 5, 'max');
   assertEquals(mathMean([3, 4, 5]), 4, 'average');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

https://github.com/google/blockly/issues/6169

### Proposed Changes

Generated code using reduce (average and sum) has initial value set to 0

#### Behavior Before Change

Runtime error when calling average or sum on an empty list in javascript

#### Behavior After Change

No runtime error

### Reason for Changes

Reduce without an initial value takes the 1st element in the array as the initial value in javascript -> needs an initial value for empty lists.

Note
- mean of an empty list still produces NaN (expected)
- std dev returns null for empty lists already so does not need an initial value passed to reduce

### Test Coverage

Adjusted existing tests to new generated code

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
