### PR TITLE
fix: loading messages from script tags.

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -30,12 +30,12 @@ const TEMPLATE_DIR = 'scripts/package/templates';
  * @param {Array<Object>} dependencies An array of dependencies to inject.
  */
 function packageUMD(
-    namespace, dependencies, exportsName = namespace, template = 'umd.template'
+    namespace, dependencies, template = 'umd.template'
 ) {
   return gulp.umd({
     dependencies: function () { return dependencies; },
     namespace: function () { return namespace; },
-    exports: function () { return exportsName; },
+    exports: function () { return namespace; },
     template: path.join(TEMPLATE_DIR, template)
   });
 };
@@ -325,12 +325,7 @@ function packageLocales() {
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
       .pipe(packageUMD(
         'Blockly.Msg',
-        [{
-          name: 'Blockly',
-          amd: '../core',
-          cjs: '../core',
-        }],
-        'messages',
+        [{name: 'Blockly'}],
         'umd-msg.template'))
       .pipe(gulp.dest(`${RELEASE_DIR}/msg`));
 };

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -321,11 +321,8 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
-      // Create a new object so that (for example)
-      // require('blockly/msg/es) != require('blockly/msg/fr')
-      .pipe(gulp.insert.prepend('\nvar Blockly = {};Blockly.Msg={};\n'))
       .pipe(packageUMD(
-        'Blockly.Msg',
+        'messages',
         [{
           name: 'Blockly',
           amd: '../core',

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -29,11 +29,13 @@ const TEMPLATE_DIR = 'scripts/package/templates';
  * @param {string} namespace The export namespace.
  * @param {Array<Object>} dependencies An array of dependencies to inject.
  */
-function packageUMD(namespace, dependencies, template = 'umd.template') {
+function packageUMD(
+    namespace, dependencies, exportsName = namespace, template = 'umd.template'
+) {
   return gulp.umd({
     dependencies: function () { return dependencies; },
     namespace: function () { return namespace; },
-    exports: function () { return namespace; },
+    exports: function () { return exportsName; },
     template: path.join(TEMPLATE_DIR, template)
   });
 };
@@ -322,12 +324,13 @@ function packageLocales() {
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
       .pipe(packageUMD(
-        'messages',
+        'Blockly.Msg',
         [{
           name: 'Blockly',
           amd: '../core',
           cjs: '../core',
         }],
+        'messages',
         'umd-msg.template'))
       .pipe(gulp.dest(`${RELEASE_DIR}/msg`));
 };

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -29,9 +29,7 @@ const TEMPLATE_DIR = 'scripts/package/templates';
  * @param {string} namespace The export namespace.
  * @param {Array<Object>} dependencies An array of dependencies to inject.
  */
-function packageUMD(
-    namespace, dependencies, template = 'umd.template'
-) {
+function packageUMD(namespace, dependencies, template = 'umd.template') {
   return gulp.umd({
     dependencies: function () { return dependencies; },
     namespace: function () { return namespace; },

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -29,12 +29,12 @@ const TEMPLATE_DIR = 'scripts/package/templates';
  * @param {string} namespace The export namespace.
  * @param {Array<Object>} dependencies An array of dependencies to inject.
  */
-function packageUMD(namespace, dependencies) {
+function packageUMD(namespace, dependencies, template = 'umd.template') {
   return gulp.umd({
     dependencies: function () { return dependencies; },
     namespace: function () { return namespace; },
     exports: function () { return namespace; },
-    template: path.join(TEMPLATE_DIR, 'umd.template')
+    template: path.join(TEMPLATE_DIR, template)
   });
 };
 
@@ -321,13 +321,17 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
-      .pipe(gulp.insert.prepend(`
-      var Blockly = {};Blockly.Msg={};`))
-      .pipe(packageUMD('Blockly.Msg', [{
+      // Create a new object so that
+      // require('blockly/msg/es) != require('blockly/msg/fr')
+      .pipe(gulp.insert.prepend('\nvar Blockly = {};Blockly.Msg={};\n'))
+      .pipe(packageUMD(
+        'Blockly.Msg',
+        [{
           name: 'Blockly',
           amd: '../core',
           cjs: '../core',
-        }]))
+        }],
+        'umd-msg.template'))
       .pipe(gulp.dest(`${RELEASE_DIR}/msg`));
 };
 

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -321,7 +321,7 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
-      // Create a new object so that
+      // Create a new object so that (for example)
       // require('blockly/msg/es) != require('blockly/msg/fr')
       .pipe(gulp.insert.prepend('\nvar Blockly = {};Blockly.Msg={};\n'))
       .pipe(packageUMD(

--- a/scripts/i18n/create_messages.py
+++ b/scripts/i18n/create_messages.py
@@ -41,7 +41,7 @@ def load_constants(filename):
   for key in constant_defs:
     value = constant_defs[key]
     value = value.replace('"', '\\"')
-    constants_text += u'\nBlockly.Msg["{0}"] = \"{1}\";'.format(
+    constants_text += u'\nmessages["{0}"] = \"{1}\";'.format(
         key, value)
   return constants_text
 
@@ -88,7 +88,7 @@ def main():
       os.curdir, args.source_synonym_file))
 
   # synonym_defs is also being sorted to ensure the same order is kept
-  synonym_text = '\n'.join([u'Blockly.Msg["{0}"] = Blockly.Msg["{1}"];'
+  synonym_text = '\n'.join([u'messages["{0}"] = messages["{1}"];'
       .format(key, synonym_defs[key]) for key in sorted(synonym_defs)])
 
   # Read in constants file, which must be output in every language.
@@ -123,6 +123,8 @@ def main():
 
 'use strict';
 
+const messages = Object.create(null);
+
 """.format(target_lang.replace('-', '.')))
         # For each key in the source language file, output the target value
         # if present; otherwise, output the source language value with a
@@ -136,7 +138,7 @@ def main():
             value = source_defs[key]
             comment = '  // untranslated'
           value = value.replace('"', '\\"')
-          outfile.write(u'Blockly.Msg["{0}"] = "{1}";{2}\n'
+          outfile.write(u'messages["{0}"] = "{1}";{2}\n'
               .format(key, value, comment))
 
         # Announce any keys defined only for target language.

--- a/scripts/package/templates/umd-msg.template
+++ b/scripts/package/templates/umd-msg.template
@@ -5,9 +5,9 @@
   } else if (typeof exports === 'object') { // Node.js
     module.exports = factory();
   } else { // Browser
-    Object.assign(root.<%= namespace %>, factory());
+    root.Blockly.setLocale(root.<%= namespace %>, factory());
   }
 }(this, function() {
 <%= contents %>
-return <%= exports %>;
+return messages;
 })); 

--- a/scripts/package/templates/umd-msg.template
+++ b/scripts/package/templates/umd-msg.template
@@ -1,0 +1,13 @@
+/* eslint-disable */
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) { // AMD
+    define(<%= amd %>, factory);
+  } else if (typeof exports === 'object') { // Node.js
+    module.exports = factory();
+  } else { // Browser
+    Object.assign(root.<%= namespace %>, factory());
+  }
+}(this, function() {
+<%= contents %>
+return <%= exports %>;
+})); 

--- a/scripts/package/templates/umd-msg.template
+++ b/scripts/package/templates/umd-msg.template
@@ -5,7 +5,10 @@
   } else if (typeof exports === 'object') { // Node.js
     module.exports = factory();
   } else { // Browser
-    root.Blockly.setLocale(root.<%= namespace %>, factory());
+    const messages = factory();
+    for (const key in messages) {
+      root.<%= namespace %>[key] = messages[key];
+    }
   }
 }(this, function() {
 <%= contents %>

--- a/scripts/package/templates/umd-msg.template
+++ b/scripts/package/templates/umd-msg.template
@@ -5,8 +5,8 @@
   } else if (typeof exports === 'object') { // Node.js
     module.exports = factory();
   } else { // Browser
-    const messages = factory();
-    for (const key in messages) {
+    var messages = factory();
+    for (var key in messages) {
       root.<%= namespace %>[key] = messages[key];
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/6123, fixes https://github.com/google/blockly-samples/issues/1066 and fixes https://github.com/google/blockly-samples/issues/1065

Same as #6060, but hopefully this also works for requiring multiple CJS modules.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
See https://github.com/google/blockly/issues/6123#issuecomment-1144197138

Also changed the generated, but unwrapped, msg.js files to write to a new `messages` object, rather than `Blockly.Msg` to be clearer about what we're doing, and hopefully prevent errors in the future.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Message loading from script tags does not work.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Message loading from script tags works.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
See https://github.com/google/blockly/issues/6123#issuecomment-1144197138

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

* Playground
* Playground after changing `prepare.js` to pull the `dist/msg/es.js` file instead of `msg/messages.js`
* Code demo in core as it currently exists.
* continuous-toolbox test page
* continuous-toolbox test  page after changing it to `import Fr from 'blockly/msg/fr'` and `Blockly.setLocale(Fr)`
* Mirror demo in samples
* Plane demo in samples
* React demo in samples
* React demo in samples after importing spanish and french, and setting the locale to spanish then french (so french translations are shown)

I couldn't find anything that actually uses CJS modules to be able to test.

<!-- Tested on: -->
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Will undraft after testing.
