### PR TITLE
fix: Make generator types and BlockDefinition less restrictive

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -522,13 +522,13 @@ declare module "core/blocks" {
      * A block definition.  For now this very lose, but it can potentially
      * be refined e.g. by replacing this typedef with a class definition.
      */
-    export type BlockDefinition = Object;
+    export type BlockDefinition = any;
     /**
      * A block definition.  For now this very lose, but it can potentially
      * be refined e.g. by replacing this typedef with a class definition.
      * @typedef {!Object}
      */
-    export let BlockDefinition: any;
+    // export let BlockDefinition: any;
     /**
      * A mapping of block type names to block prototype objects.
      * @type {!Object<string,!BlockDefinition>}

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const dart: Blockly.Generator;
+declare const dart: any;
 export = dart;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,8 +14,7 @@
 /// <reference path="javascript.d.ts" />
 /// <reference path="msg/msg.d.ts" />
 
-import { Generator } from 'core/blockly';
 export * from './core';
 export * as libraryBlocks from './blocks';
-export const JavaScript: Generator;
+export const JavaScript: any;
 import './msg/msg';

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const javascript: Blockly.Generator;
+declare const javascript: any;
 export = javascript;

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const lua: Blockly.Generator;
+declare const lua: any;
 export = lua;

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const php: Blockly.Generator;
+declare const php: any;
 export = php;

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const python: Blockly.Generator;
+declare const python: any;
 export = python;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

#6079 and problems introduced in #6174 

### Proposed Changes

Types all of the generators as `any` instead of `Blockly.Generator`. They used to be effectively `any` before (because they were broken), and typing them as `Generator` is incomplete because there are additional properties on each generator that aren't captured. So giving them a partial type is worse than `any` because there are additional type errors that would have to be silenced.

Same for the `BlockDefinition` which is used for `Blockly.Blocks` - it was typed as `Object` but even that is too strict as e.g. Objects don't have a property called `jsonInit` which we allow objects in Blockly.Blocks to have.

For more information, see the discussion in #6174 

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested in similar ways to #6174 

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
