### PR TITLE
fix: Fix errors in TS declarations with blocks and generators

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -531,13 +531,13 @@ declare module "core/blocks" {
      * A block definition.  For now this very lose, but it can potentially
      * be refined e.g. by replacing this typedef with a class definition.
      */
-    export type BlockDefinition = Object;
+    export type BlockDefinition = any;
     /**
      * A block definition.  For now this very lose, but it can potentially
      * be refined e.g. by replacing this typedef with a class definition.
      * @typedef {!Object}
      */
-    export let BlockDefinition: any;
+    // export let BlockDefinition: any;
     /**
      * A mapping of block type names to block prototype objects.
      * @type {!Object<string,!BlockDefinition>}

--- a/typings/blocks.d.ts
+++ b/typings/blocks.d.ts
@@ -11,5 +11,14 @@
 
 /// <reference path="core.d.ts" />
 
-import * as Blockly from './core';
-export = Blockly.Blocks;
+export const colour: any;
+export const lists: any;
+export const logic: any;
+export const loops: any;
+export const math: any;
+export const procedures: any;
+export const texts: any;
+export const variables: any;
+export const variablesDynamic: any;
+
+export const blocks: any;

--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -11,5 +11,4 @@
 
 /// <reference path="blockly.d.ts" />
 
-import * as Blockly from 'blockly';
-export = Blockly;
+export * from 'core/blockly';

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const dart: Blockly.Generator;
+declare const dart: any;
 export = dart;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,9 +14,7 @@
 /// <reference path="javascript.d.ts" />
 /// <reference path="msg/msg.d.ts" />
 
-import * as Blockly from './core';
-import './blocks';
-import './javascript';
+export * from './core';
+export * as libraryBlocks from './blocks';
+export const JavaScript: any;
 import './msg/msg';
-
-export = Blockly;

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const javascript: Blockly.Generator;
+declare const javascript: any;
 export = javascript;

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const lua: Blockly.Generator;
+declare const lua: any;
 export = lua;

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const php: Blockly.Generator;
+declare const php: any;
 export = php;

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -12,5 +12,5 @@
 /// <reference path="core.d.ts" />
 
 import * as Blockly from './core';
-declare const python: Blockly.Generator;
+declare const python: any;
 export = python;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6079. 

### Proposed Changes

This is a cherry-pick of #6174 and #6185 

#### Behavior Before Change

Errors when using Blockly v8 with TypeScript (see issue)

#### Behavior After Change

There are still problems with the TypeScript declarations, but they can be worked around by casting to `any`. For example, you may see a TypeError related to the injection of BlocklyOptions in `Blockly.inject`. If so, you can avoid that by casting that parameter to `any` to bypass the type error.

This is in contrast with the current behavior which throws an error that cannot be avoided by casting.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

See original PRs for more information about testing and background.
