### PR TITLE
chore!: properly add the removal of utils.global to the renamings file.

### DIFF
--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -215,6 +215,11 @@
       },
     },
     {
+      oldName: 'Blockly.utils.global',
+      newExport: 'globalThis',
+      newPath: 'Blockly.utils.global',
+    }
+    {
       oldName: 'Blockly.utils.IdGenerator',
       newName: 'Blockly.utils.idGenerator',
     },
@@ -1332,5 +1337,10 @@
     },
   ],
 
-  'develop': [ ],
+  'develop': [
+    {
+      'oldName': 'Blockly.utils.global',
+      'newPath': 'globalThis',
+    }
+  ],
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This is clean up from #6120
  * Indicates for conventional commits that this is a breaking change. 
  * Properly adds the renaming to the renaming file.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Before it was possible to access the global-this via `Blockly.utils.global`.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Now the global-this should be accessed via `globalThis`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Providing access to the global this is not Blockly's responsibility. And polyfills will make it accessible to Blockly's internal code.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->

Tested that this renaming works by:
  1) Creating a test renaming file that looks like:
   ```
   {
     '1.0.0': [
       {
         'oldName': 'Blockly.utils.global'
         'newPath': 'globalThis'
       }
     ]
   }
   ```
  2) Created a test file that had `Blockly.utils.global` in it.
  3) Ran the renamings script using those files.
  4) Saw that `Blockly.utils.global` was properly changed to `globalThis`

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### To Migrate

Rename all instances of `Blockly.utils.global` to `globalThis`. You can do this automatically using the [blockly/migrate](https://www.npmjs.com/package/@blockly/migrate) script.

