### PR TITLE
fix: Check for undefined value in InputRow.measure

### DIFF
--- a/core/renderers/measurables/input_row.js
+++ b/core/renderers/measurables/input_row.js
@@ -59,6 +59,9 @@ class InputRow extends Row {
     let connectedBlockWidths = 0;
     for (let i = 0; i < this.elements.length; i++) {
       const elem = this.elements[i];
+      if (elem === undefined) {
+        continue;
+      }
       this.width += elem.width;
       if (Types.isInput(elem) && elem instanceof InputConnection) {
         if (Types.isStatementInput(elem) && elem instanceof StatementInput) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A (no GitHub issue was opened)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

- Check for possible `undefined` value in `measure` method of `Blockly.blockRendering.InputRow` class.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
- There is no check for `undefined` value in `measure` method of `Blockly.blockRendering.InputRow` class.
- Execution is interrupted with error if there is `undefined` value in `this.elements` array (because of attempt to access a non-existent property): `Uncaught TypeError: elem is undefined`.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
- `measure` method of `InputRow` will continue loop on `undefined` value instead of throwing error.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

This issue was discovered in process of development of custom Blockly-based application with integrated [block-plus-minus plugin](https://github.com/google/blockly-samples/tree/master/plugins/block-plus-minus).

In some cases, it causes endless freeze of entire Blockly workspace after clicking "plus" button (attempt to add user-defined argument) on "Procedure" block (with active "block-plus-minus" plugin).

![Screenshot of "plus" button on block](https://user-images.githubusercontent.com/50130486/173517048-0188a1cb-6618-4cc3-a757-dee1c0a3b751.png)

![Screenshot of JS console with error log](https://user-images.githubusercontent.com/50130486/173517072-0bb83a8b-cdae-4942-8d93-69fe57053df4.png)

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->

- Probably no new tests required.
- Built-in tests are successfully passed.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

This error can break the entire rendering process of workspace, it will infinitely throw `Uncaught TypeError: this.blockDragger_ is null` in console on any gesture or mouse move. The Blockly workspace becomes unusable after triggering this error.

![Screenshot of console with bunch of errors](https://user-images.githubusercontent.com/50130486/173517115-0811c1e7-bb28-4ca8-89bb-385c1e625680.png)

