### PR TITLE
fix(tests): Fix race condition causing flakiness in PHP generator test

### DIFF
--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -24,7 +24,7 @@ async function runLangGeneratorInBrowser(browser, filename, codegenFn) {
   await browser.execute(codegenFn);
   var elem = await browser.$("#importExport");
   var result = await elem.getValue();
-  fs.writeFile(filename, result, function(err) {
+  fs.writeFileSync(filename, result, function(err) {
     if (err) {
       return console.log(err);
     }


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Turns out `process.exit()` was sometimes getting called before the (async) `fs.writeFile` had finished writing the last of the generator output files.  This was causing occasional failures where the last (or last several) generator tests would fail because they ended up writing 0 byte files.

### Proposed Changes

Use `fs.writeFileSync` instead of `fs.writeFile`

#### Behaviour Before Change

Generator tests could fail due to a race condition.

#### Behaviour After Change

Generator tests no longer fail because of this particular race condition.

### Reason for Changes

Changes made in one of my TS-related branches were causing this failure to happen almost every time.
