### PR TITLE
chore(tests): Use freshly-build files in compressed mode.

### DIFF
--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -85,13 +85,13 @@
     // List of scripts to load in compressed mode, instead of
     // requires.  Paths relative to root.
     compressedScripts: [
-      'blockly_compressed.js',
-      'blocks_compressed.js',
-      'dart_compressed.js',
-      'javascript_compressed.js',
-      'lua_compressed.js',
-      'php_compressed.js',
-      'python_compressed.js',
+      'build/blockly_compressed.js',
+      'build/blocks_compressed.js',
+      'build/dart_compressed.js',
+      'build/javascript_compressed.js',
+      'build/lua_compressed.js',
+      'build/php_compressed.js',
+      'build/python_compressed.js',
     ],
 
     // Additional scripts to be loaded after Blockly is loaded,


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Use the freshly-built `build/*_compresssed.js` files when bootstrapping in compressed mode, rather than using the checked-in files in the repository root.

#### Behaviour Before Change

When running in compressed mode, the code that is run is whatever was last copied to the repository root by `npm run checkin:built`.

#### Behaviour After Change

When running in compressed mode, the code that is run is whatever was most recently built by `npm run build` (possibly via `npm test`).

### Reason for Changes

This helps ensure that compressed and uncompressed mode will be testing (as closely as possible) the same code.

### Test Coverage

Passes `npm test`.  No changes in manual testing are needed.

### Documentation

Instructions for updating hosted playgrounds may need to be updated.

### Additional Information

I'm leaving this as a draft PR until someone (possibly myself) has the chance to investigate [the issue with GitHub Pages](https://github.com/google/blockly/pull/6214#discussion_r898165468) @BeksOmega raised when I previously proposed this change.
