### PR TITLE
fix: remove vestigial dependency

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -321,10 +321,7 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
-      .pipe(packageUMD(
-        'Blockly.Msg',
-        [{name: 'Blockly'}],
-        'umd-msg.template'))
+      .pipe(packageUMD('Blockly.Msg', [], 'umd-msg.template'))
       .pipe(gulp.dest(`${RELEASE_DIR}/msg`));
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Hopefully fixes problems with message dependencies we ran into in samples.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the vestigially Blockly dependency from the message wrappers.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
The Blockly module could not be resolved.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No need to resolve any modules hopefully.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Getting the messages to actually work.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->

I tested manually removing the dependencies in the node_modules of some plugins in samples, and that seemed to fix things.

I also tried linking to `field-bitmap` and running `npm run predeploy` before and after this change, and the changes in this PR seemed to fix the problem.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
