### PR TITLE
feat(build): Support TypeScript in `core/`

### DIFF
--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -15,7 +15,9 @@
  * This method is not specific to Blockly.
  * @namespace Blockly.utils.deprecation
  */
-goog.module('Blockly.utils.deprecation');
+import * as goog from '../../closure/goog/goog.js';
+
+goog.declareModuleId('Blockly.utils.deprecation');
 
 
 /**
@@ -30,7 +32,7 @@ goog.module('Blockly.utils.deprecation');
  * @alias Blockly.utils.deprecation.warn
  * @package
  */
-const warn = function(name, deprecationDate, deletionDate, opt_use) {
+const warn = function(name: string, deprecationDate: string, deletionDate: string, opt_use?: string) {
   let msg = name + ' was deprecated on ' + deprecationDate +
       ' and will be deleted on ' + deletionDate + '.';
   if (opt_use) {
@@ -38,4 +40,4 @@ const warn = function(name, deprecationDate, deletionDate, opt_use) {
   }
   console.warn(msg);
 };
-exports.warn = warn;
+export {warn};

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -31,10 +31,10 @@ goog.declareModuleId('Blockly.utils.deprecation');
  * @alias Blockly.utils.deprecation.warn
  */
 export function warn(
-  name: string, deprecationDate: string, deletionDate: string,
-  opt_use?: string) {
+    name: string, deprecationDate: string, deletionDate: string,
+    opt_use?: string) {
   let msg = name + ' was deprecated on ' + deprecationDate +
-    ' and will be deleted on ' + deletionDate + '.';
+      ' and will be deleted on ' + deletionDate + '.';
   if (opt_use) {
     msg += '\nUse ' + opt_use + ' instead.';
   }

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -22,22 +22,21 @@ goog.declareModuleId('Blockly.utils.deprecation');
 
 /**
  * Warn developers that a function or property is deprecated.
- * @param {string} name The name of the function or property.
- * @param {string} deprecationDate The date of deprecation.
+ * @param name The name of the function or property.
+ * @param deprecationDate The date of deprecation.
  *     Prefer 'month yyyy' or 'quarter yyyy' format.
- * @param {string} deletionDate The date of deletion, in the same format as the
+ * @param deletionDate The date of deletion, in the same format as the
  *     deprecation date.
- * @param {string=} opt_use The name of a function or property to use instead,
- *     if any.
+ * @param opt_use The name of a function or property to use instead, if any.
  * @alias Blockly.utils.deprecation.warn
- * @package
  */
-const warn = function(name: string, deprecationDate: string, deletionDate: string, opt_use?: string) {
+export function warn(
+  name: string, deprecationDate: string, deletionDate: string,
+  opt_use?: string) {
   let msg = name + ' was deprecated on ' + deprecationDate +
-      ' and will be deleted on ' + deletionDate + '.';
+    ' and will be deleted on ' + deletionDate + '.';
   if (opt_use) {
     msg += '\nUse ' + opt_use + ' instead.';
   }
   console.warn(msg);
-};
-export {warn};
+}

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -222,6 +222,9 @@ var JSCOMP_ERROR = [
 /**
  * Closure compiler diagnostic groups we want to be treated as warnings.
  * These are effected when the --debug or --strict flags are passed.
+ *
+ * For most (all?) diagnostic groups this is the default level, so
+ * it's generally sufficient to remove them from JSCOMP_ERROR.
  */
 var JSCOMP_WARNING = [
 ];

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -671,7 +671,10 @@ function cleanBuildDir(done) {
  * Runs clang format on all files in the core directory.
  */
 function format() {
-  return gulp.src(['core/**/*.js', 'blocks/**/*.js'], {base: '.'})
+  return gulp.src([
+    'core/**/*.js', 'core/**/*.ts',
+    'blocks/**/*.js', 'blocks/**/*.ts'
+  ], {base: '.'})
       .pipe(clangFormatter.format('file', clangFormat))
       .pipe(gulp.dest('.'));
 };

--- a/scripts/gulpfiles/chunks.json
+++ b/scripts/gulpfiles/chunks.json
@@ -1,6 +1,6 @@
 {
   "chunk": [
-    "blockly:259",
+    "blockly:260",
     "blocks:10:blockly",
     "all:11:blockly",
     "all1:11:blockly",
@@ -250,6 +250,7 @@
     "./build/src/core/utils/parsing.js",
     "./build/src/core/extensions.js",
     "./build/src/core/block.js",
+    "./build/src/closure/goog/goog.js",
     "./build/src/core/utils/deprecation.js",
     "./build/src/core/utils/string.js",
     "./build/src/core/dialog.js",

--- a/scripts/gulpfiles/chunks.json
+++ b/scripts/gulpfiles/chunks.json
@@ -266,7 +266,7 @@
     "./build/src/core/connection.js",
     "./build/src/core/common.js",
     "./build/src/core/blocks.js",
-    "./closure/goog/base_minimal.js",
+    "./build/src/closure/goog/base_minimal.js",
     "./build/src/core/blockly.js",
     "./blocks/variables_dynamic.js",
     "./blocks/variables.js",

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -134,7 +134,8 @@
     // libary we use, mainly for goog.require / goog.provide /
     // goog.module).
     document.write(
-        '<script src="' + options.root + '/closure/goog/base.js"></script>');
+        '<script src="' + options.root +
+            'build/src/closure/goog/base.js"></script>');
 
     // Prevent spurious transpilation warnings.
     document.write('<script>goog.TRANSPILE = "never";</script>');
@@ -174,7 +175,7 @@
     for (let script, i = 0; script = scripts[i]; i++) {
       const fakeModuleName = 'script.' + script.replace(/[./]/g, "-");
       scriptDeps.push('  goog.addDependency(' +
-          quote('../../' + script) + ', [' + quote(fakeModuleName) +
+          quote('../../../../' + script) + ', [' + quote(fakeModuleName) +
           '], [' + requires.map(quote).join() + "], {'lang': 'es6'});\n");
       requires = [fakeModuleName];
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": [
     "core/**/*",  // N.B.: also pulls in closure/goog/goog.js if needed.
-    "closure/goog/goog.js",  // Just for ouptut directory structure.
+    "closure/**/*",  // Just for ouptut directory structure.
   ],
   "compilerOptions": {
     // Tells TypeScript to read JS files, as


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Closes #5892

### Proposed Changes

- Finish work to support TypeScript in `core/` by making a small tweak to how the Closure Library is presented to Closure Compiler.
- Convert `core/utils/deprecation.js` to TypeScript.
- Enable `clang-format`ting of `.ts` files in `core/` and `blocks/`.

#### Behaviour Before Change

Closure Compiler is fed files in `closure/goog/` as input.  If a `.ts` file `import`s `closure/goog/goog.js`, this causes the compiler to complain because the import will, after compilation by `tsc`, point to `build/src/closure/goog`, and CC won't let you name an input file `goog.js` unless it is in the same directory as `base.js` (or alternatively our `base_minimal.js`).

#### Behaviour After Change

All of `closure/goog/*.js` is passed through `tsc` and ends up in `build/src/closure/goog/`, so CC is reading `goog.js` and `base_minimal.js` from the same directory, making it happy.

### Reason for Changes

See above.

### Test Coverage

- Passes `npm test`.
- Playgrounds load without error and appear properly functional.

No changes to manual test procedures expected.

### Additional Information

There are some issues with MigranTS output which means we cannot blindly copy it over the previous .js files—see individual commit messages for details.
