### PR TITLE
fix: Theme.name does not match registered name (#6186)

### DIFF
--- a/core/theme.js
+++ b/core/theme.js
@@ -149,6 +149,7 @@ class Theme {
    * @return {!Theme} A new Blockly theme.
    */
   static defineTheme(name, themeObj) {
+    name = name.toLowerCase();
     const theme = new Theme(name);
     let base = themeObj['base'];
     if (base) {

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -274,4 +274,11 @@ suite('Theme', function() {
           this.constants.validatedBlockStyle_(inputStyle), expectedOutput);
     });
   });
+
+  suite('defineTheme', function() {
+    test('Normalizes to lowercase', function() {
+      const theme = Blockly.Theme.defineTheme('TEST', {});
+      chai.assert.equal(theme.name, 'test');
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

#6186

### Proposed Changes

Add a line in defineTheme to convert its name to lower case.

#### Behavior Before Change

`Theme.name` did not match registered name, when it included upper case letters.

#### Behavior After Change

Now it does :tada: 