### PR TITLE
Fix: inject function options dictionary has wrong type definition

### DIFF
--- a/typings/blockly.d.ts
+++ b/typings/blockly.d.ts
@@ -25686,7 +25686,7 @@ declare module "core/inject" {
      * @return {!WorkspaceSvg} Newly created main workspace.
      * @alias Blockly.inject
      */
-    export function inject(container: Element | string, opt_options?: (() => void) | undefined): WorkspaceSvg;
+    export function inject(container: Element | string, opt_options?: Object | undefined): WorkspaceSvg;
     import { WorkspaceSvg } from "core/workspace_svg";
 }
 declare module "core/blockly" {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

The inject function was giving an error while trying to add a JSON toolbox inside an options object. Yet it was working fine after compiling to javascript.

![error1](https://user-images.githubusercontent.com/31995815/174827482-3e1ada42-0e3c-4c0c-8cc0-342fc15f5ff5.jpg)

#### Behavior After Change

Typescript stopped showing any errors after the change. The function runs perfectly fine.

![inject](https://user-images.githubusercontent.com/31995815/174827803-c5d6337d-763c-4f32-9784-14c7641fc866.jpg)

### Reason for Changes

The inject function requires a JSON toolbox to include blocks inside the workspace. Since the function is giving an error when including a toolbox in options, it may be misleading for some.
