### PR TITLE
chore: enable ts for the clang-format workflow

### DIFF
--- a/.github/workflows/check_clang_format.yml
+++ b/.github/workflows/check_clang_format.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: 'core'
-        extensions: 'js'
+        extensions: 'js,ts'
         # This should be as close as possible to the version that the npm
         # package supports. This can be found by running:
         # npx clang-format --version.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Same as https://github.com/google/blockly/pull/6225 but on the correct branch.
