### PR TITLE
fix: Add missing `import goog` statements

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -13,6 +13,7 @@
  * The class representing one block.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Block');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -13,6 +13,7 @@
  * Methods animating a block on connection and disconnection.
  * @namespace Blockly.blockAnimations
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockAnimations');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -23,6 +23,7 @@
  * while dragging blocks.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockDragSurfaceSvg');
 
 import {Coordinate} from './utils/coordinate.js';

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -13,6 +13,7 @@
  * Methods for dragging a block visually.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockDragger');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a block as SVG.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockSvg');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -13,6 +13,7 @@
  * The top level namespace used to access the Blockly library.
  * @namespace Blockly
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/blockly_options.ts
+++ b/core/blockly_options.ts
@@ -13,6 +13,7 @@
  * Object that defines user-specified options for the workspace.
  * @namespace Blockly.BlocklyOptions
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlocklyOptions');
 
 

--- a/core/blocks.ts
+++ b/core/blocks.ts
@@ -13,6 +13,7 @@
  * A mapping of block type names to block prototype objects.
  * @namespace Blockly.blocks
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blocks');
 
 

--- a/core/browser_events.ts
+++ b/core/browser_events.ts
@@ -13,6 +13,7 @@
  * Browser event handling.
  * @namespace Blockly.browserEvents
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.browserEvents');
 
 import * as Touch from './touch.js';

--- a/core/bubble.ts
+++ b/core/bubble.ts
@@ -13,6 +13,7 @@
  * Object representing a UI bubble.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Bubble');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -13,6 +13,7 @@
  * Methods for dragging a bubble visually.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BubbleDragger');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/bump_objects.ts
+++ b/core/bump_objects.ts
@@ -13,6 +13,7 @@
  * Utilities for bumping objects back into worksapce bounds.
  * @namespace Blockly.bumpObjects
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.bumpObjects');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -13,6 +13,7 @@
  * Blockly's internal clipboard for managing copy-paste.
  * @namespace Blockly.clipboard
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.clipboard');
 
 import {CopyData, ICopyable} from './interfaces/i_copyable.js';

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -13,6 +13,7 @@
  * Object representing a code comment.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Comment');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/common.ts
+++ b/core/common.ts
@@ -15,6 +15,7 @@
  * must not be at the top level to avoid circular dependencies.
  * @namespace Blockly.common
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.common');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/component_manager.ts
+++ b/core/component_manager.ts
@@ -13,6 +13,7 @@
  * Manager for all items registered with the workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ComponentManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/config.ts
+++ b/core/config.ts
@@ -17,6 +17,7 @@
  * generally recommended.
  * @namespace Blockly.config
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.config');
 
 /**

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -13,6 +13,7 @@
  * Components for creating connections between blocks.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Connection');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -15,6 +15,7 @@
  * potential connection is safe and valid.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ConnectionChecker');
 
 import * as common from './common.js';

--- a/core/connection_db.ts
+++ b/core/connection_db.ts
@@ -17,6 +17,7 @@
  *    Sorted by y coordinate.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ConnectionDB');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/connection_type.ts
+++ b/core/connection_type.ts
@@ -13,6 +13,7 @@
  * An enum for the possible types of connections.
  * @namespace Blockly.ConnectionType
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ConnectionType');
 
 

--- a/core/constants.ts
+++ b/core/constants.ts
@@ -13,6 +13,7 @@
  * Blockly constants.
  * @namespace Blockly.constants
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.constants');
 
 

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -13,6 +13,7 @@
  * Functionality for the right-click context menus.
  * @namespace Blockly.ContextMenu
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ContextMenu');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -13,6 +13,7 @@
  * Registers default context menu items.
  * @namespace Blockly.ContextMenuItems
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ContextMenuItems');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/contextmenu_registry.ts
+++ b/core/contextmenu_registry.ts
@@ -13,6 +13,7 @@
  * Registry for context menu option items.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ContextMenuRegistry');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/css.ts
+++ b/core/css.ts
@@ -13,6 +13,7 @@
  * Inject Blockly's CSS synchronously.
  * @namespace Blockly.Css
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Css');
 
 import * as deprecation from './utils/deprecation.js';

--- a/core/delete_area.ts
+++ b/core/delete_area.ts
@@ -16,6 +16,7 @@
  * bubble that is dropped on top of it.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.DeleteArea');
 
 import {BlockSvg} from './block_svg.js';

--- a/core/dialog.ts
+++ b/core/dialog.ts
@@ -14,6 +14,7 @@
  * Wrapper functions around JS functions for showing alert/confirmation dialogs.
  * @namespace Blockly.dialog
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.dialog');
 
 let alertImplementation = function(

--- a/core/drag_target.ts
+++ b/core/drag_target.ts
@@ -16,6 +16,7 @@
  * block or bubble is dragged over or dropped on top of it.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.DragTarget');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -15,6 +15,7 @@
  * A div that floats on top of the workspace, for drop-down menus.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.dropDownDiv');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events.ts
+++ b/core/events/events.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of actions in Blockly's editor.
  * @namespace Blockly.Events
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events');
 
 import * as deprecation from '../utils/deprecation.js';

--- a/core/events/events_abstract.ts
+++ b/core/events/events_abstract.ts
@@ -15,6 +15,7 @@
  * Blockly's editor.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.Abstract');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_base.ts
+++ b/core/events/events_block_base.ts
@@ -13,6 +13,7 @@
  * Base class for all types of block events.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockBase');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -13,6 +13,7 @@
  * Class for a block change event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockChange');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_create.ts
+++ b/core/events/events_block_create.ts
@@ -13,6 +13,7 @@
  * Class for a block creation event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockCreate');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_delete.ts
+++ b/core/events/events_block_delete.ts
@@ -13,6 +13,7 @@
  * Class for a block delete event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockDelete');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_drag.ts
+++ b/core/events/events_block_drag.ts
@@ -13,6 +13,7 @@
  * Events fired as a block drag.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockDrag');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_block_move.ts
+++ b/core/events/events_block_move.ts
@@ -13,6 +13,7 @@
  * Class for a block move event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BlockMove');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_bubble_open.ts
+++ b/core/events/events_bubble_open.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of bubble open.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.BubbleOpen');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_click.ts
+++ b/core/events/events_click.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of UI click in Blockly's editor.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.Click');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_comment_base.ts
+++ b/core/events/events_comment_base.ts
@@ -13,6 +13,7 @@
  * Base class for comment events.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.CommentBase');
 
 import * as utilsXml from '../utils/xml.js';

--- a/core/events/events_comment_change.ts
+++ b/core/events/events_comment_change.ts
@@ -13,6 +13,7 @@
  * Class for comment change event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.CommentChange');
 
 import * as registry from '../registry.js';

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -13,6 +13,7 @@
  * Class for comment creation event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.CommentCreate');
 
 import * as registry from '../registry.js';

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -13,6 +13,7 @@
  * Class for comment deletion event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.CommentDelete');
 
 import * as registry from '../registry.js';

--- a/core/events/events_comment_move.ts
+++ b/core/events/events_comment_move.ts
@@ -13,6 +13,7 @@
  * Class for comment move event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.CommentMove');
 
 import * as registry from '../registry.js';

--- a/core/events/events_marker_move.ts
+++ b/core/events/events_marker_move.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of a marker move.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.MarkerMove');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_selected.ts
+++ b/core/events/events_selected.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of element select action.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.Selected');
 
 import * as registry from '../registry.js';

--- a/core/events/events_theme_change.ts
+++ b/core/events/events_theme_change.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of a theme update.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.ThemeChange');
 
 import * as registry from '../registry.js';

--- a/core/events/events_toolbox_item_select.ts
+++ b/core/events/events_toolbox_item_select.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of selecting an item on the toolbox.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.ToolboxItemSelect');
 
 import * as registry from '../registry.js';

--- a/core/events/events_trashcan_open.ts
+++ b/core/events/events_trashcan_open.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of trashcan flyout open and close.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.TrashcanOpen');
 
 import * as registry from '../registry.js';

--- a/core/events/events_ui.ts
+++ b/core/events/events_ui.ts
@@ -15,6 +15,7 @@
  * Blockly's editor.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.Ui');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_ui_base.ts
+++ b/core/events/events_ui_base.ts
@@ -15,6 +15,7 @@
  * Blockly's editor.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.UiBase');
 
 import {Abstract as AbstractEvent} from './events_abstract.js';

--- a/core/events/events_var_base.ts
+++ b/core/events/events_var_base.ts
@@ -13,6 +13,7 @@
  * Abstract class for a variable event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.VarBase');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/events_var_create.ts
+++ b/core/events/events_var_create.ts
@@ -13,6 +13,7 @@
  * Class for a variable creation event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.VarCreate');
 
 import * as registry from '../registry.js';

--- a/core/events/events_var_delete.ts
+++ b/core/events/events_var_delete.ts
@@ -13,6 +13,7 @@
  * Classes for all types of variable events.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.VarDelete');
 
 import * as registry from '../registry.js';

--- a/core/events/events_var_rename.ts
+++ b/core/events/events_var_rename.ts
@@ -13,6 +13,7 @@
  * Class for a variable rename event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.VarRename');
 
 import * as registry from '../registry.js';

--- a/core/events/events_viewport.ts
+++ b/core/events/events_viewport.ts
@@ -13,6 +13,7 @@
  * Events fired as a result of a viewport change.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.ViewportChange');
 
 import * as registry from '../registry.js';

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -15,6 +15,7 @@
  * actions in Blockly's editor.
  * @namespace Blockly.Events.utils
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.utils');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/events/workspace_events.ts
+++ b/core/events/workspace_events.ts
@@ -13,6 +13,7 @@
  * Class for a finished loading workspace event.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events.FinishedLoading');
 
 import * as registry from '../registry.js';

--- a/core/extensions.ts
+++ b/core/extensions.ts
@@ -19,6 +19,7 @@
  *      array attribute.
  * @namespace Blockly.Extensions
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Extensions');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/field.ts
+++ b/core/field.ts
@@ -17,6 +17,7 @@
  * instances would be FieldTextInput, FieldDropdown, etc.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Field');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -13,6 +13,7 @@
  * Angle input field.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldAngle');
 
 import {BlockSvg} from './block_svg.js';

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -13,6 +13,7 @@
  * Checkbox field.  Checked or not checked.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldCheckbox');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -13,6 +13,7 @@
  * Colour input field.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldColour');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -17,6 +17,7 @@
  * properties with the context menu.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldDropdown');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -13,6 +13,7 @@
  * Image field.  Used for pictures, icons, etc.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldImage');
 
 import {Field} from './field.js';

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -15,6 +15,7 @@
  *    labels, etc.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldLabel');
 
 import {Field} from './field.js';

--- a/core/field_label_serializable.ts
+++ b/core/field_label_serializable.ts
@@ -17,6 +17,7 @@
  *    edited programmatically.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldLabelSerializable');
 
 import {FieldLabel} from './field_label.js';

--- a/core/field_multilineinput.ts
+++ b/core/field_multilineinput.ts
@@ -13,6 +13,7 @@
  * Text Area field.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldMultilineInput');
 
 import * as Css from './css.js';

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -13,6 +13,7 @@
  * Number input field
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldNumber');
 
 import {Field} from './field.js';

--- a/core/field_registry.ts
+++ b/core/field_registry.ts
@@ -17,6 +17,7 @@
  *    fields based on JSON.
  * @namespace Blockly.fieldRegistry
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.fieldRegistry');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -13,6 +13,7 @@
  * Text input field.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldTextInput');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -13,6 +13,7 @@
  * Variable input field.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FieldVariable');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -13,6 +13,7 @@
  * Flyout tray containing blocks which may be created.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Flyout');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -13,6 +13,7 @@
  * Class for a button in the flyout.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FlyoutButton');
 
 import * as browserEvents from './browser_events.js';

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -13,6 +13,7 @@
  * Horizontal flyout tray containing blocks which may be created.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.HorizontalFlyout');
 
 import * as browserEvents from './browser_events.js';

--- a/core/flyout_metrics_manager.ts
+++ b/core/flyout_metrics_manager.ts
@@ -13,6 +13,7 @@
  * Calculates and reports flyout workspace metrics.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.FlyoutMetricsManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -13,6 +13,7 @@
  * Layout code for a vertical variant of the flyout.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.VerticalFlyout');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/generator.ts
+++ b/core/generator.ts
@@ -15,6 +15,7 @@
  * Blockly code.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Generator');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -15,6 +15,7 @@
  * or a tap.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Gesture');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/grid.ts
+++ b/core/grid.ts
@@ -15,6 +15,7 @@
  * Blockly.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Grid');
 
 import * as dom from './utils/dom.js';

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -13,6 +13,7 @@
  * Object representing an icon on a block.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Icon');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -13,6 +13,7 @@
  * Functions for injecting Blockly into a web page.
  * @namespace Blockly.inject
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.inject');
 
 import 'angular-mocks';

--- a/core/input.ts
+++ b/core/input.ts
@@ -13,6 +13,7 @@
  * Object representing an input (value, statement, or dummy).
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Input');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/input_types.ts
+++ b/core/input_types.ts
@@ -13,6 +13,7 @@
  * An enum for the possible types of inputs.
  * @namespace Blockly.inputTypes
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.inputTypes');
 
 import {ConnectionType} from './connection_type.js';

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -13,6 +13,7 @@
  * Class that controls updates to connections during drags.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.InsertionMarkerManager');
 
 import * as blockAnimations from './block_animations.js';

--- a/core/interfaces/i_ast_node_location.ts
+++ b/core/interfaces/i_ast_node_location.ts
@@ -13,6 +13,7 @@
  * The interface for an AST node location.
  * @namespace Blockly.IASTNodeLocation
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IASTNodeLocation');
 
 /**

--- a/core/interfaces/i_ast_node_location_svg.ts
+++ b/core/interfaces/i_ast_node_location_svg.ts
@@ -13,6 +13,7 @@
  * The interface for an AST node location SVG.
  * @namespace Blockly.IASTNodeLocationSvg
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IASTNodeLocationSvg');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_ast_node_location_with_block.ts
+++ b/core/interfaces/i_ast_node_location_with_block.ts
@@ -16,6 +16,7 @@
  * block.
  * @namespace Blockly.IASTNodeLocationWithBlock
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IASTNodeLocationWithBlock');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_autohideable.ts
+++ b/core/interfaces/i_autohideable.ts
@@ -16,6 +16,7 @@
  * when WorkspaceSvg.hideChaff is called.
  * @namespace Blockly.IAutoHideable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IAutoHideable');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_block_dragger.ts
+++ b/core/interfaces/i_block_dragger.ts
@@ -13,6 +13,7 @@
  * The interface for a block dragger.
  * @namespace Blockly.IBlockDragger
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IBlockDragger');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_bounded_element.ts
+++ b/core/interfaces/i_bounded_element.ts
@@ -13,6 +13,7 @@
  * The interface for a bounded element.
  * @namespace Blockly.IBoundedElement
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IBoundedElement');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_bubble.ts
+++ b/core/interfaces/i_bubble.ts
@@ -13,6 +13,7 @@
  * The interface for a bubble.
  * @namespace Blockly.IBubble
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IBubble');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_collapsible_toolbox_item.ts
+++ b/core/interfaces/i_collapsible_toolbox_item.ts
@@ -13,6 +13,7 @@
  * The interface for a collapsible toolbox item.
  * @namespace Blockly.ICollapsibleToolboxItem
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ICollapsibleToolboxItem');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_component.ts
+++ b/core/interfaces/i_component.ts
@@ -16,6 +16,7 @@
  * the ComponentManager.
  * @namespace Blockly.IComponent
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IComponent');
 
 

--- a/core/interfaces/i_connection_checker.ts
+++ b/core/interfaces/i_connection_checker.ts
@@ -15,6 +15,7 @@
  * checking whether a potential connection is safe and valid.
  * @namespace Blockly.IConnectionChecker
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IConnectionChecker');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_contextmenu.ts
+++ b/core/interfaces/i_contextmenu.ts
@@ -13,6 +13,7 @@
  * The interface for an object that supports a right-click.
  * @namespace Blockly.IContextMenu
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IContextMenu');
 
 

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that is copyable.
  * @namespace Blockly.ICopyable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ICopyable');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that is deletable.
  * @namespace Blockly.IDeletable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IDeletable');
 
 

--- a/core/interfaces/i_delete_area.ts
+++ b/core/interfaces/i_delete_area.ts
@@ -16,6 +16,7 @@
  * that is dropped on top of it.
  * @namespace Blockly.IDeleteArea
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IDeleteArea');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_drag_target.ts
+++ b/core/interfaces/i_drag_target.ts
@@ -16,6 +16,7 @@
  * block is dropped on top of it.
  * @namespace Blockly.IDragTarget
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IDragTarget');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that is draggable.
  * @namespace Blockly.IDraggable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IDraggable');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_flyout.ts
+++ b/core/interfaces/i_flyout.ts
@@ -13,6 +13,7 @@
  * The interface for a flyout.
  * @namespace Blockly.IFlyout
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IFlyout');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_keyboard_accessible.ts
+++ b/core/interfaces/i_keyboard_accessible.ts
@@ -13,6 +13,7 @@
  * The interface for objects that handle keyboard shortcuts.
  * @namespace Blockly.IKeyboardAccessible
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IKeyboardAccessible');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_metrics_manager.ts
+++ b/core/interfaces/i_metrics_manager.ts
@@ -13,6 +13,7 @@
  * The interface for a metrics manager.
  * @namespace Blockly.IMetricsManager
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IMetricsManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that is movable.
  * @namespace Blockly.IMovable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IMovable');
 
 

--- a/core/interfaces/i_positionable.ts
+++ b/core/interfaces/i_positionable.ts
@@ -13,6 +13,7 @@
  * The interface for a positionable UI element.
  * @namespace Blockly.IPositionable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IPositionable');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_registrable.ts
+++ b/core/interfaces/i_registrable.ts
@@ -16,6 +16,7 @@
  *    (Ex. Toolbox, Fields, Renderers)
  * @namespace Blockly.IRegistrable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IRegistrable');
 
 

--- a/core/interfaces/i_registrable_field.ts
+++ b/core/interfaces/i_registrable_field.ts
@@ -13,6 +13,7 @@
  * The interface for a Blockly field that can be registered.
  * @namespace Blockly.IRegistrableField
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IRegistrableField');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that is selectable.
  * @namespace Blockly.ISelectable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ISelectable');
 
 // eslint-disable-next-line no-unused-vars

--- a/core/interfaces/i_selectable_toolbox_item.ts
+++ b/core/interfaces/i_selectable_toolbox_item.ts
@@ -13,6 +13,7 @@
  * The interface for a selectable toolbox item.
  * @namespace Blockly.ISelectableToolboxItem
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ISelectableToolboxItem');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_serializer.ts
+++ b/core/interfaces/i_serializer.ts
@@ -16,6 +16,7 @@
  *     serializing part of the workspace.
  * @namespace Blockly.serialization.ISerializer
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.ISerializer');
 
 // eslint-disable-next-line no-unused-vars

--- a/core/interfaces/i_styleable.ts
+++ b/core/interfaces/i_styleable.ts
@@ -13,6 +13,7 @@
  * The interface for an object that a style can be added to.
  * @namespace Blockly.IStyleable
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IStyleable');
 
 

--- a/core/interfaces/i_toolbox.ts
+++ b/core/interfaces/i_toolbox.ts
@@ -13,6 +13,7 @@
  * The interface for a toolbox.
  * @namespace Blockly.IToolbox
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IToolbox');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/interfaces/i_toolbox_item.ts
+++ b/core/interfaces/i_toolbox_item.ts
@@ -13,6 +13,7 @@
  * The interface for a toolbox item.
  * @namespace Blockly.IToolboxItem
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IToolboxItem');
 
 

--- a/core/internal_constants.ts
+++ b/core/internal_constants.ts
@@ -15,6 +15,7 @@
  * use these constants outside of the core library.
  * @namespace Blockly.internalConstants
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.internalConstants');
 
 import {ConnectionType} from './connection_type.js';

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -15,6 +15,7 @@
  * Used to traverse the Blockly AST.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ASTNode');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/keyboard_nav/basic_cursor.ts
+++ b/core/keyboard_nav/basic_cursor.ts
@@ -15,6 +15,7 @@
  * Used to demo switching between different cursors.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BasicCursor');
 
 import * as registry from '../registry.js';

--- a/core/keyboard_nav/cursor.ts
+++ b/core/keyboard_nav/cursor.ts
@@ -15,6 +15,7 @@
  * Used primarily for keyboard navigation.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Cursor');
 
 import * as registry from '../registry.js';

--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -15,6 +15,7 @@
  * Used primarily for keyboard navigation to show a marked location.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Marker');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/keyboard_nav/tab_navigate_cursor.ts
+++ b/core/keyboard_nav/tab_navigate_cursor.ts
@@ -15,6 +15,7 @@
  * between tab navigable fields.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.TabNavigateCursor');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/marker_manager.ts
+++ b/core/marker_manager.ts
@@ -13,6 +13,7 @@
  * Object in charge of managing markers and the cursor.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.MarkerManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -13,6 +13,7 @@
  * Blockly menu similar to Closure's goog.ui.Menu
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Menu');
 
 import * as browserEvents from './browser_events.js';

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -13,6 +13,7 @@
  * Blockly menu item similar to Closure's goog.ui.MenuItem
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.MenuItem');
 
 import * as aria from './utils/aria.js';

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -13,6 +13,7 @@
  * Calculates and reports workspace metrics.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.MetricsManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/msg.ts
+++ b/core/msg.ts
@@ -13,6 +13,7 @@
  * Empty name space for the Message singleton.
  * @namespace Blockly.Msg
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Msg');
 
 

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -15,6 +15,7 @@
  * user to change the shape of a block using a nested blocks editor.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Mutator');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/names.ts
+++ b/core/names.ts
@@ -13,6 +13,7 @@
  * Utility functions for handling variable and procedure names.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Names');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/options.ts
+++ b/core/options.ts
@@ -13,6 +13,7 @@
  * Object that controls settings for the workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Options');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/positionable_helpers.ts
+++ b/core/positionable_helpers.ts
@@ -13,6 +13,7 @@
  * Utility functions for positioning UI elements.
  * @namespace Blockly.uiPosition
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.uiPosition');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -13,6 +13,7 @@
  * Utility functions for handling procedures.
  * @namespace Blockly.Procedures
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Procedures');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -15,6 +15,7 @@
  *    for registering and unregistering different types of classes.
  * @namespace Blockly.registry
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.registry');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -13,6 +13,7 @@
  * Components for creating connections between blocks.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.RenderedConnection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -13,6 +13,7 @@
  * Namespace for block rendering functionality.
  * @namespace Blockly.blockRendering
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering');
 
 import * as registry from '../../registry.js';

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -13,6 +13,7 @@
  * An object that provides constants for rendering blocks.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.ConstantProvider');
 
 import {ConnectionType} from '../../connection_type.js';

--- a/core/renderers/common/debug.ts
+++ b/core/renderers/common/debug.ts
@@ -13,6 +13,7 @@
  * Block rendering debugging functionality.
  * @namespace Blockly.blockRendering.debug
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.debug');
 
 import * as deprecation from '../../utils/deprecation.js';

--- a/core/renderers/common/debugger.ts
+++ b/core/renderers/common/debugger.ts
@@ -13,6 +13,7 @@
  * Methods for rendering debug graphics.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Debug');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/drawer.ts
+++ b/core/renderers/common/drawer.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a block as SVG.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Drawer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/i_path_object.ts
+++ b/core/renderers/common/i_path_object.ts
@@ -16,6 +16,7 @@
  * elements.
  * @namespace Blockly.blockRendering.IPathObject
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.IPathObject');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/info.ts
+++ b/core/renderers/common/info.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a block as SVG.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.RenderInfo');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a marker as SVG.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.MarkerSvg');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -13,6 +13,7 @@
  * An object that owns a block's rendering SVG elements.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.PathObject');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/common/renderer.ts
+++ b/core/renderers/common/renderer.ts
@@ -13,6 +13,7 @@
  * Base renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Renderer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/constants.ts
+++ b/core/renderers/geras/constants.ts
@@ -15,6 +15,7 @@
  * mode.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.ConstantProvider');
 
 import {ConstantProvider as BaseConstantProvider} from '../common/constants.js';

--- a/core/renderers/geras/drawer.ts
+++ b/core/renderers/geras/drawer.ts
@@ -13,6 +13,7 @@
  * Renderer that preserves the look and feel of Blockly pre-2019.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.Drawer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/geras.ts
+++ b/core/renderers/geras/geras.ts
@@ -11,6 +11,7 @@
  * Re-exports of Blockly.geras.* modules.
  * @namespace Blockly.geras
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras');
 
 import {ConstantProvider} from './constants.js';

--- a/core/renderers/geras/highlight_constants.ts
+++ b/core/renderers/geras/highlight_constants.ts
@@ -13,6 +13,7 @@
  * Objects for rendering highlights on blocks.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.HighlightConstantProvider');
 
 import * as svgPaths from '../../utils/svg_paths.js';

--- a/core/renderers/geras/highlighter.ts
+++ b/core/renderers/geras/highlighter.ts
@@ -15,6 +15,7 @@
  * compatibility mode.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.Highlighter');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/info.ts
+++ b/core/renderers/geras/info.ts
@@ -15,6 +15,7 @@
  * Geras: spirit of old age.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.RenderInfo');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/measurables/inline_input.ts
+++ b/core/renderers/geras/measurables/inline_input.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.InlineInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/measurables/statement_input.ts
+++ b/core/renderers/geras/measurables/statement_input.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.StatementInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/path_object.ts
+++ b/core/renderers/geras/path_object.ts
@@ -13,6 +13,7 @@
  * An object that owns a block's rendering SVG elements.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.PathObject');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -13,6 +13,7 @@
  * Geras renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.Renderer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/base.ts
+++ b/core/renderers/measurables/base.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a block as SVG.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Measurable');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/bottom_row.ts
+++ b/core/renderers/measurables/bottom_row.ts
@@ -15,6 +15,7 @@
  * of its subcomponents.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.BottomRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/connection.ts
+++ b/core/renderers/measurables/connection.ts
@@ -15,6 +15,7 @@
  * rendering.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Connection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/external_value_input.ts
+++ b/core/renderers/measurables/external_value_input.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.ExternalValueInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/field.ts
+++ b/core/renderers/measurables/field.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Field');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/hat.ts
+++ b/core/renderers/measurables/hat.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Hat');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/icon.ts
+++ b/core/renderers/measurables/icon.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Icon');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/in_row_spacer.ts
+++ b/core/renderers/measurables/in_row_spacer.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.InRowSpacer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/inline_input.ts
+++ b/core/renderers/measurables/inline_input.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.InlineInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/input_connection.ts
+++ b/core/renderers/measurables/input_connection.ts
@@ -13,6 +13,7 @@
  * Class representing inputs with connections on a rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.InputConnection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/input_row.ts
+++ b/core/renderers/measurables/input_row.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.InputRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/jagged_edge.ts
+++ b/core/renderers/measurables/jagged_edge.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.JaggedEdge');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/next_connection.ts
+++ b/core/renderers/measurables/next_connection.ts
@@ -15,6 +15,7 @@
  * rendering.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.NextConnection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/output_connection.ts
+++ b/core/renderers/measurables/output_connection.ts
@@ -15,6 +15,7 @@
  * during rendering.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.OutputConnection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/previous_connection.ts
+++ b/core/renderers/measurables/previous_connection.ts
@@ -15,6 +15,7 @@
  * during rendering.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.PreviousConnection');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/round_corner.ts
+++ b/core/renderers/measurables/round_corner.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.RoundCorner');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/row.ts
+++ b/core/renderers/measurables/row.ts
@@ -13,6 +13,7 @@
  * Object representing a single row on a rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Row');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/spacer_row.ts
+++ b/core/renderers/measurables/spacer_row.ts
@@ -13,6 +13,7 @@
  * Object representing a spacer between two rows.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.SpacerRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/square_corner.ts
+++ b/core/renderers/measurables/square_corner.ts
@@ -15,6 +15,7 @@
  * block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.SquareCorner');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/statement_input.ts
+++ b/core/renderers/measurables/statement_input.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.StatementInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/top_row.ts
+++ b/core/renderers/measurables/top_row.ts
@@ -13,6 +13,7 @@
  * Object representing a top row on a rendered block.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.TopRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/measurables/types.ts
+++ b/core/renderers/measurables/types.ts
@@ -13,6 +13,7 @@
  * Measurable types.
  * @namespace Blockly.blockRendering.Types
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.Types');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/minimalist/constants.ts
+++ b/core/renderers/minimalist/constants.ts
@@ -15,6 +15,7 @@
  * minimalist renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist.ConstantProvider');
 
 import {ConstantProvider as BaseConstantProvider} from '../common/constants.js';

--- a/core/renderers/minimalist/drawer.ts
+++ b/core/renderers/minimalist/drawer.ts
@@ -13,6 +13,7 @@
  * Minimalist rendering drawer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist.Drawer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/minimalist/info.ts
+++ b/core/renderers/minimalist/info.ts
@@ -13,6 +13,7 @@
  * Minimalist render info object.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist.RenderInfo');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/minimalist/minimalist.ts
+++ b/core/renderers/minimalist/minimalist.ts
@@ -11,6 +11,7 @@
  * Re-exports of Blockly.minimalist.* modules.
  * @namespace Blockly.minimalist
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist');
 
 import {ConstantProvider} from './constants.js';

--- a/core/renderers/minimalist/renderer.ts
+++ b/core/renderers/minimalist/renderer.ts
@@ -13,6 +13,7 @@
  * Minimalist renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist.Renderer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/thrasos/info.ts
+++ b/core/renderers/thrasos/info.ts
@@ -15,6 +15,7 @@
  * Thrasos: spirit of boldness.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.thrasos.RenderInfo');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/thrasos/renderer.ts
+++ b/core/renderers/thrasos/renderer.ts
@@ -13,6 +13,7 @@
  * Thrasos renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.thrasos.Renderer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/thrasos/thrasos.ts
+++ b/core/renderers/thrasos/thrasos.ts
@@ -11,6 +11,7 @@
  * Re-exports of Blockly.thrasos.* modules.
  * @namespace Blockly.thrasos
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.thrasos');
 
 import {RenderInfo} from './info.js';

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -15,6 +15,7 @@
  * mode.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.ConstantProvider');
 
 import {ConnectionType} from '../../connection_type.js';

--- a/core/renderers/zelos/drawer.ts
+++ b/core/renderers/zelos/drawer.ts
@@ -13,6 +13,7 @@
  * Zelos renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.Drawer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/info.ts
+++ b/core/renderers/zelos/info.ts
@@ -14,6 +14,7 @@
  * Makecode/scratch-style renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.RenderInfo');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/marker_svg.ts
+++ b/core/renderers/zelos/marker_svg.ts
@@ -13,6 +13,7 @@
  * Methods for graphically rendering a marker as SVG.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.MarkerSvg');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/measurables/bottom_row.ts
+++ b/core/renderers/zelos/measurables/bottom_row.ts
@@ -13,6 +13,7 @@
  * An object representing the bottom row of a rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.BottomRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/measurables/inputs.ts
+++ b/core/renderers/zelos/measurables/inputs.ts
@@ -15,6 +15,7 @@
  * a rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.StatementInput');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/measurables/row_elements.ts
+++ b/core/renderers/zelos/measurables/row_elements.ts
@@ -15,6 +15,7 @@
  * rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.RightConnectionShape');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/measurables/top_row.ts
+++ b/core/renderers/zelos/measurables/top_row.ts
@@ -13,6 +13,7 @@
  * An object representing the top row of a rendered block.
  * @class
  */
+import * as goog from '../../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.TopRow');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -13,6 +13,7 @@
  * An object that owns a block's rendering SVG elements.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.PathObject');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/renderer.ts
+++ b/core/renderers/zelos/renderer.ts
@@ -13,6 +13,7 @@
  * Zelos renderer.
  * @class
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.Renderer');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/renderers/zelos/zelos.ts
+++ b/core/renderers/zelos/zelos.ts
@@ -11,6 +11,7 @@
  * Re-exports of Blockly.zelos.* modules.
  * @namespace Blockly.zelos
  */
+import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos');
 
 import {ConstantProvider} from './constants.js';

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -13,6 +13,7 @@
  * Object representing a scrollbar.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Scrollbar');
 
 import * as browserEvents from './browser_events.js';

--- a/core/scrollbar_pair.ts
+++ b/core/scrollbar_pair.ts
@@ -13,6 +13,7 @@
  * Object representing a pair of scrollbars.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ScrollbarPair');
 
 import * as eventUtils from './events/utils.js';

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -14,6 +14,7 @@
  * Handles serializing blocks to plain JavaScript objects only containing state.
  * @namespace Blockly.serialization.blocks
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.blocks');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/serialization/exceptions.ts
+++ b/core/serialization/exceptions.ts
@@ -13,6 +13,7 @@
  * Contains custom errors thrown by the serialization system.
  * @namespace Blockly.serialization.exceptions
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.exceptions');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/serialization/priorities.ts
+++ b/core/serialization/priorities.ts
@@ -18,6 +18,7 @@
  * priorities are deserialized first.
  * @namespace Blockly.serialization.priorities
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.priorities');
 
 

--- a/core/serialization/registry.ts
+++ b/core/serialization/registry.ts
@@ -15,6 +15,7 @@
  * etc).
  * @namespace Blockly.serialization.registry
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.registry');
 
 // eslint-disable-next-line no-unused-vars

--- a/core/serialization/variables.ts
+++ b/core/serialization/variables.ts
@@ -15,6 +15,7 @@
  * state.
  * @namespace Blockly.serialization.variables
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.variables');
 
 // eslint-disable-next-line no-unused-vars

--- a/core/serialization/workspaces.ts
+++ b/core/serialization/workspaces.ts
@@ -15,6 +15,7 @@
  * objects.
  * @namespace Blockly.serialization.workspaces
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.serialization.workspaces');
 
 import * as eventUtils from '../events/utils.js';

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -13,6 +13,7 @@
  * Registers default keyboard shortcuts.
  * @namespace Blockly.ShortcutItems
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ShortcutItems');
 
 import {BlockSvg} from './block_svg.js';

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -15,6 +15,7 @@
  * key codes used to execute those shortcuts.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ShortcutRegistry');
 
 import {KeyCodes} from './utils/keycodes.js';

--- a/core/sprites.ts
+++ b/core/sprites.ts
@@ -8,6 +8,7 @@
  * @fileoverview Holds constants that have to do with the sprites that create
  * the trashcan and zoom controls.
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.sprite');
 
 

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -13,6 +13,7 @@
  * The class representing a theme.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Theme');
 
 import * as registry from './registry.js';

--- a/core/theme/classic.ts
+++ b/core/theme/classic.ts
@@ -15,6 +15,7 @@
  * Contains multi-coloured border to create shadow effect.
  * @namespace Blockly.Themes.Classic
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Themes.Classic');
 
 import {Theme} from '../theme.js';

--- a/core/theme/themes.ts
+++ b/core/theme/themes.ts
@@ -13,6 +13,7 @@
  * Namespace for themes.
  * @namespace Blockly.Themes
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Themes');
 
 import {Classic} from './classic.js';

--- a/core/theme/zelos.ts
+++ b/core/theme/zelos.ts
@@ -13,6 +13,7 @@
  * Zelos theme.
  * @namespace Blockly.Themes.Zelos
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Themes.Zelos');
 
 import {Theme} from '../theme.js';

--- a/core/theme_manager.ts
+++ b/core/theme_manager.ts
@@ -15,6 +15,7 @@
  *     and UI components.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ThemeManager');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -13,6 +13,7 @@
  * A toolbox category used to organize blocks in the toolbox.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ToolboxCategory');
 
 import * as Css from '../css.js';

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -13,6 +13,7 @@
  * A toolbox category used to organize blocks in the toolbox.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.CollapsibleToolboxCategory');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -13,6 +13,7 @@
  * A separator used for separating toolbox categories.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ToolboxSeparator');
 
 import * as Css from '../css.js';

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -13,6 +13,7 @@
  * Toolbox from whence to create blocks.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Toolbox');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/toolbox/toolbox_item.ts
+++ b/core/toolbox/toolbox_item.ts
@@ -13,6 +13,7 @@
  * An item in the toolbox.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ToolboxItem');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -14,6 +14,7 @@
  * tooltip will be used. Third, call bindMouseEvents(e) passing the SVG element.
  * @namespace Blockly.Tooltip
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Tooltip');
 
 import * as browserEvents from './browser_events.js';

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -13,6 +13,7 @@
  * Touch handling for Blockly.
  * @namespace Blockly.Touch
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Touch');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/touch_gesture.ts
+++ b/core/touch_gesture.ts
@@ -15,6 +15,7 @@
  * for both pointer and touch events.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.TouchGesture');
 
 import * as browserEvents from './browser_events.js';

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -13,6 +13,7 @@
  * Object representing a trash can icon.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Trashcan');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -13,6 +13,7 @@
  * Utility methods.
  * @namespace Blockly.utils
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/utils/aria.ts
+++ b/core/utils/aria.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.aria
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.aria');
 
 

--- a/core/utils/array.ts
+++ b/core/utils/array.ts
@@ -19,6 +19,7 @@
  * @return True if an element was removed.
  * @alias Blockly.array.removeElem
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.array');
 
 export function removeElem(

--- a/core/utils/colour.ts
+++ b/core/utils/colour.ts
@@ -13,6 +13,7 @@
  * Utility methods for colour manipulation.
  * @namespace Blockly.utils.colour
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.colour');
 
 /**

--- a/core/utils/coordinate.ts
+++ b/core/utils/coordinate.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Coordinate');
 
 /**

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -15,6 +15,7 @@
  * This method is not specific to Blockly.
  * @namespace Blockly.utils.deprecation
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.deprecation');
 
 

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.dom
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.dom');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/utils/idgenerator.ts
+++ b/core/utils/idgenerator.ts
@@ -13,6 +13,7 @@
  * Generators for unique IDs.
  * @namespace Blockly.utils.idGenerator
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.idGenerator');
 
 

--- a/core/utils/keycodes.ts
+++ b/core/utils/keycodes.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.KeyCodes
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.KeyCodes');
 
 

--- a/core/utils/math.ts
+++ b/core/utils/math.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.math
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.math');
 
 

--- a/core/utils/metrics.ts
+++ b/core/utils/metrics.ts
@@ -13,6 +13,7 @@
  * Workspace metrics definitions.
  * @namespace Blockly.utils.Metrics
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Metrics');
 
 

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -13,6 +13,7 @@
  * Utility methods for objects.
  * @namespace Blockly.utils.object
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.object');
 
 import * as deprecation from './utils/deprecation.js';

--- a/core/utils/parsing.ts
+++ b/core/utils/parsing.ts
@@ -12,6 +12,7 @@
 /**
  * @namespace Blockly.utils.parsing
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.parsing');
 
 import {Msg} from '../msg.js';

--- a/core/utils/rect.ts
+++ b/core/utils/rect.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Rect');
 
 

--- a/core/utils/sentinel.ts
+++ b/core/utils/sentinel.ts
@@ -13,6 +13,7 @@
  * A type used to create flag values.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Sentinel');
 
 

--- a/core/utils/size.ts
+++ b/core/utils/size.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Size');
 
 

--- a/core/utils/string.ts
+++ b/core/utils/string.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.string
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.string');
 
 import * as deprecation from './utils/deprecation.js';

--- a/core/utils/style.ts
+++ b/core/utils/style.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.style
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.style');
 
 import {Coordinate} from './coordinate.js';

--- a/core/utils/svg.ts
+++ b/core/utils/svg.ts
@@ -15,6 +15,7 @@
  * all SVG tag names used by Blockly.
  * @class
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Svg');
 
 

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -13,6 +13,7 @@
  * Utility methods realted to figuring out positions of SVG elements.
  * @namespace Blockly.utils.svgMath
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.svgMath');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/utils/svg_paths.ts
+++ b/core/utils/svg_paths.ts
@@ -14,6 +14,7 @@
  * Methods for creating parts of SVG path strings.  See
  * @namespace Blockly.utils.svgPaths
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.svgPaths');
 
 

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -13,6 +13,7 @@
  * Utility functions for the toolbox and flyout.
  * @namespace Blockly.utils.toolbox
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.toolbox');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.userAgent
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.userAgent');
 
 /** The raw useragent string. */

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -17,6 +17,7 @@
  * a JavaScript framework such as Closure.
  * @namespace Blockly.utils.xml
  */
+import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.xml');
 
 /**

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -13,6 +13,7 @@
  * Object representing a map of variables and their types.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.VariableMap');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/variable_model.ts
+++ b/core/variable_model.ts
@@ -13,6 +13,7 @@
  * Components for the variable model.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.VariableModel');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -13,6 +13,7 @@
  * Utility functions for handling variables.
  * @namespace Blockly.Variables
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Variables');
 
 import {Blocks} from './blocks.js';

--- a/core/variables_dynamic.ts
+++ b/core/variables_dynamic.ts
@@ -14,6 +14,7 @@
  *
  * @namespace Blockly.VariablesDynamic
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.VariablesDynamic');
 
 import {Blocks} from './blocks.js';

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -13,6 +13,7 @@
  * Object representing a warning.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Warning');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -17,6 +17,7 @@
  *     E.g. text input areas, colour pickers, context menus.
  * @namespace Blockly.WidgetDiv
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WidgetDiv');
 
 import * as common from './common.js';

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -13,6 +13,7 @@
  * Object representing a workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Workspace');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/workspace_audio.ts
+++ b/core/workspace_audio.ts
@@ -15,6 +15,7 @@
  *     workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceAudio');
 
 import * as userAgent from './utils/useragent.js';

--- a/core/workspace_comment.ts
+++ b/core/workspace_comment.ts
@@ -13,6 +13,7 @@
  * Object representing a code comment on the workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceComment');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -13,6 +13,7 @@
  * Object representing a code comment on a rendered workspace.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceCommentSvg');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/workspace_drag_surface_svg.ts
+++ b/core/workspace_drag_surface_svg.ts
@@ -20,6 +20,7 @@
  * blocks are never repainted during drag improving performance.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceDragSurfaceSvg');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/workspace_dragger.ts
+++ b/core/workspace_dragger.ts
@@ -13,6 +13,7 @@
  * Methods for dragging a workspace visually.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceDragger');
 
 import * as common from './common.js';

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -13,6 +13,7 @@
  * Object representing a workspace rendered as SVG.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceSvg');
 
 /* eslint-disable-next-line no-unused-vars */

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -13,6 +13,7 @@
  * XML reader and writer.
  * @namespace Blockly.Xml
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Xml');
 
 // Unused import preserved for side-effects. Remove if unneeded.

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -13,6 +13,7 @@
  * Object representing a zoom icons.
  * @class
  */
+import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ZoomControls');
 
 /* eslint-disable-next-line no-unused-vars */


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from ts/migration
- [X] My pull request is against ts/migration
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Resolves tsc "Property 'declareModuleId' does not exist on type 'typeof goog'" errors.

### Proposed Changes

Add `import * as goog from './path/to/closure/goog/goog.js';` statements to each file that uses `goog.declareModuleId()`.

#### Behaviour Before Change

Lots of errors.

#### Behaviour After Change

Fewer errors.

### Reason for Changes

Must not have errors.

### Test Coverage

No: test still failing due to other `tsc` errors.

### Additional Information

I've added each `import` statement immediately before the `goog.declareModuleId` call that depends on it.  This is based on [the advice given for migrating from `goog.module` to ES modules](https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules#migrating-closure-modules-with-named-exports).

There is an argument to be made that we should put the `import` statement in their normal place amongst any other `import`s, and move the `declareModuleId` calls to below the double blank line below the imports, but as these are so tightly coupled, replace the previous `goog.module` calls, and will both be deleted at the same time once the transition to TypeScript is fully complete I think it's fine (and certainly much easier) to do it this way.
