### PR TITLE
chore: Fix whitespace

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -8,7 +8,6 @@
  * @fileoverview The class representing one block.
  */
 
-
 /**
  * The class representing one block.
  * @class
@@ -707,7 +706,6 @@ export class Block implements IASTNodeLocation, IDeletable {
           'Cannot set parent to null while block is still connected to' +
           ' superior block.');
     }
-
 
     // This block hasn't actually moved on-screen, so there's no need to
     // update

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods animating a block on connection and disconnection.
  */
 
-
 /**
  * Methods animating a block on connection and disconnection.
  * @namespace Blockly.blockAnimations

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -20,6 +20,7 @@ import {BlockSvg} from './block_svg.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
 
+
 /** A bounding box for a cloned block. */
 interface CloneRect {
   x: number;

--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -13,7 +13,6 @@
  * while dragging blocks.
  */
 
-
 /**
  * A class that manages a surface for dragging blocks.  When a
  * block drag is started, we move the block (and children) to a separate DOM

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for dragging a block visually.
  */
 
-
 /**
  * Methods for dragging a block visually.
  * @class

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a block as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a block as SVG.
  * @class

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -8,7 +8,6 @@
  * @fileoverview The top level namespace used to access the Blockly library.
  */
 
-
 /**
  * The top level namespace used to access the Blockly library.
  * @namespace Blockly
@@ -348,7 +347,6 @@ export const defineBlocksWithJsonArray =
 // type 'void'.
 export const setParentContainer =
     (common as AnyDuringMigration).setParentContainer;
-
 
 /**
  * Returns the dimensions of the specified SVG image.

--- a/core/blockly_options.ts
+++ b/core/blockly_options.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object that defines user-specified options for the workspace.
  */
 
-
 /**
  * Object that defines user-specified options for the workspace.
  * @namespace Blockly.BlocklyOptions

--- a/core/blocks.ts
+++ b/core/blocks.ts
@@ -8,7 +8,6 @@
  * @fileoverview A mapping of block type names to block prototype objects.
  */
 
-
 /**
  * A mapping of block type names to block prototype objects.
  * @namespace Blockly.blocks

--- a/core/browser_events.ts
+++ b/core/browser_events.ts
@@ -8,7 +8,6 @@
  * @fileoverview Browser event handling.
  */
 
-
 /**
  * Browser event handling.
  * @namespace Blockly.browserEvents
@@ -115,7 +114,6 @@ export function conditionalBind(
   }
   return bindData;
 }
-
 
 /**
  * Bind an event handler that should be called regardless of whether it is part

--- a/core/bubble.ts
+++ b/core/bubble.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a UI bubble.
  */
 
-
 /**
  * Object representing a UI bubble.
  * @class

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for dragging a bubble visually.
  */
 
-
 /**
  * Methods for dragging a bubble visually.
  * @class

--- a/core/bump_objects.ts
+++ b/core/bump_objects.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utilities for bumping objects back into worksapce bounds.
  */
 
-
 /**
  * Utilities for bumping objects back into worksapce bounds.
  * @namespace Blockly.bumpObjects

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -8,7 +8,6 @@
  * @fileoverview Blockly's internal clipboard for managing copy-paste.
  */
 
-
 /**
  * Blockly's internal clipboard for managing copy-paste.
  * @namespace Blockly.clipboard

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a code comment.
  */
 
-
 /**
  * Object representing a code comment.
  * @class

--- a/core/common.ts
+++ b/core/common.ts
@@ -9,7 +9,6 @@
  * must not be at the top level to avoid circular dependencies.
  */
 
-
 /**
  * Common functions used both internally and externally, but which
  * must not be at the top level to avoid circular dependencies.

--- a/core/component_manager.ts
+++ b/core/component_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview Manager for all items registered with the workspace.
  */
 
-
 /**
  * Manager for all items registered with the workspace.
  * @class

--- a/core/config.ts
+++ b/core/config.ts
@@ -19,6 +19,7 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.config');
 
+
 /**
  * All the values that we expect developers to be able to change
  * before injecting Blockly.

--- a/core/config.ts
+++ b/core/config.ts
@@ -10,7 +10,6 @@
  * generally recommended.
  */
 
-
 /**
  * All the values that we expect developers to be able to change
  * before injecting Blockly. Changing these values during run time is not

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -8,7 +8,6 @@
  * @fileoverview Components for creating connections between blocks.
  */
 
-
 /**
  * Components for creating connections between blocks.
  * @class

--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -9,7 +9,6 @@
  * potential connection is safe and valid.
  */
 
-
 /**
  * An object that encapsulates logic for checking whether a
  * potential connection is safe and valid.

--- a/core/connection_db.ts
+++ b/core/connection_db.ts
@@ -10,7 +10,6 @@
  *    Sorted by y coordinate.
  */
 
-
 /**
  * A database of all the rendered connections that could
  *    possibly be connected to (i.e. not collapsed, etc).

--- a/core/connection_type.ts
+++ b/core/connection_type.ts
@@ -8,7 +8,6 @@
  * @fileoverview An enum for the possible types of connections.
  */
 
-
 /**
  * An enum for the possible types of connections.
  * @namespace Blockly.ConnectionType

--- a/core/constants.ts
+++ b/core/constants.ts
@@ -8,7 +8,6 @@
  * @fileoverview Blockly constants.
  */
 
-
 /**
  * Blockly constants.
  * @namespace Blockly.constants

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -8,7 +8,6 @@
  * @fileoverview Functionality for the right-click context menus.
  */
 
-
 /**
  * Functionality for the right-click context menus.
  * @namespace Blockly.ContextMenu

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -8,7 +8,6 @@
  * @fileoverview Registers default context menu items.
  */
 
-
 /**
  * Registers default context menu items.
  * @namespace Blockly.ContextMenuItems

--- a/core/contextmenu_registry.ts
+++ b/core/contextmenu_registry.ts
@@ -8,7 +8,6 @@
  * @fileoverview Registry for context menu option items.
  */
 
-
 /**
  * Registry for context menu option items.
  * @class

--- a/core/css.ts
+++ b/core/css.ts
@@ -8,7 +8,6 @@
  * @fileoverview Inject Blockly's CSS synchronously.
  */
 
-
 /**
  * Inject Blockly's CSS synchronously.
  * @namespace Blockly.Css

--- a/core/delete_area.ts
+++ b/core/delete_area.ts
@@ -9,8 +9,6 @@
  * bubble that is dropped on top of it.
  */
 
-
-
 /**
  * The abstract class for a component that can delete a block or
  * bubble that is dropped on top of it.

--- a/core/dialog.ts
+++ b/core/dialog.ts
@@ -16,6 +16,7 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.dialog');
 
+
 let alertImplementation = function(
     message: AnyDuringMigration, opt_callback: AnyDuringMigration) {
   window.alert(message);

--- a/core/dialog.ts
+++ b/core/dialog.ts
@@ -9,7 +9,6 @@
  * alert/confirmation dialogs.
  */
 
-
 /**
  * Wrapper functions around JS functions for showing alert/confirmation dialogs.
  * @namespace Blockly.dialog

--- a/core/drag_target.ts
+++ b/core/drag_target.ts
@@ -9,8 +9,6 @@
  * block or bubble is dragged over or dropped on top of it.
  */
 
-
-
 /**
  * The abstract class for a component with custom behaviour when a
  * block or bubble is dragged over or dropped on top of it.

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -10,7 +10,6 @@
  * The drop-down can be kept inside the workspace, animate in/out, etc.
  */
 
-
 /**
  * A div that floats on top of the workspace, for drop-down menus.
  * @class

--- a/core/events/events.ts
+++ b/core/events/events.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of actions in Blockly's editor.
  */
 
-
 /**
  * Events fired as a result of actions in Blockly's editor.
  * @namespace Blockly.Events

--- a/core/events/events_abstract.ts
+++ b/core/events/events_abstract.ts
@@ -9,7 +9,6 @@
  * Blockly's editor.
  */
 
-
 /**
  * Abstract class for events fired as a result of actions in
  * Blockly's editor.

--- a/core/events/events_block_base.ts
+++ b/core/events/events_block_base.ts
@@ -8,7 +8,6 @@
  * @fileoverview Base class for all types of block events.
  */
 
-
 /**
  * Base class for all types of block events.
  * @class

--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a block change event.
  */
 
-
 /**
  * Class for a block change event.
  * @class

--- a/core/events/events_block_create.ts
+++ b/core/events/events_block_create.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a block creation event.
  */
 
-
 /**
  * Class for a block creation event.
  * @class

--- a/core/events/events_block_delete.ts
+++ b/core/events/events_block_delete.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a block delete event.
  */
 
-
 /**
  * Class for a block delete event.
  * @class

--- a/core/events/events_block_drag.ts
+++ b/core/events/events_block_drag.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a block drag.
  */
 
-
 /**
  * Events fired as a block drag.
  * @class

--- a/core/events/events_block_move.ts
+++ b/core/events/events_block_move.ts
@@ -24,6 +24,7 @@ import {Coordinate} from '../utils/coordinate.js';
 import {BlockBase} from './events_block_base.js';
 import * as eventUtils from './utils.js';
 
+
 interface BlockLocation {
   parentId: string;
   inputName: string;

--- a/core/events/events_block_move.ts
+++ b/core/events/events_block_move.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a block move event.
  */
 
-
 /**
  * Class for a block move event.
  * @class

--- a/core/events/events_bubble_open.ts
+++ b/core/events/events_bubble_open.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of bubble open.
  */
 
-
 /**
  * Events fired as a result of bubble open.
  * @class

--- a/core/events/events_click.ts
+++ b/core/events/events_click.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of UI click in Blockly's editor.
  */
 
-
 /**
  * Events fired as a result of UI click in Blockly's editor.
  * @class

--- a/core/events/events_comment_base.ts
+++ b/core/events/events_comment_base.ts
@@ -8,7 +8,6 @@
  * @fileoverview Base class for comment events.
  */
 
-
 /**
  * Base class for comment events.
  * @class

--- a/core/events/events_comment_change.ts
+++ b/core/events/events_comment_change.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for comment change event.
  */
 
-
 /**
  * Class for comment change event.
  * @class

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for comment creation event.
  */
 
-
 /**
  * Class for comment creation event.
  * @class

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for comment deletion event.
  */
 
-
 /**
  * Class for comment deletion event.
  * @class

--- a/core/events/events_comment_move.ts
+++ b/core/events/events_comment_move.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for comment move event.
  */
 
-
 /**
  * Class for comment move event.
  * @class

--- a/core/events/events_marker_move.ts
+++ b/core/events/events_marker_move.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of a marker move.
  */
 
-
 /**
  * Events fired as a result of a marker move.
  * @class

--- a/core/events/events_selected.ts
+++ b/core/events/events_selected.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of element select action.
  */
 
-
 /**
  * Events fired as a result of element select action.
  * @class

--- a/core/events/events_theme_change.ts
+++ b/core/events/events_theme_change.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of a theme update.
  */
 
-
 /**
  * Events fired as a result of a theme update.
  * @class

--- a/core/events/events_toolbox_item_select.ts
+++ b/core/events/events_toolbox_item_select.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of selecting an item on the toolbox.
  */
 
-
 /**
  * Events fired as a result of selecting an item on the toolbox.
  * @class

--- a/core/events/events_trashcan_open.ts
+++ b/core/events/events_trashcan_open.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of trashcan flyout open and close.
  */
 
-
 /**
  * Events fired as a result of trashcan flyout open and close.
  * @class

--- a/core/events/events_ui.ts
+++ b/core/events/events_ui.ts
@@ -9,7 +9,6 @@
  * Blockly's editor.
  */
 
-
 /**
  * (Deprecated) Events fired as a result of UI actions in
  * Blockly's editor.

--- a/core/events/events_ui_base.ts
+++ b/core/events/events_ui_base.ts
@@ -9,7 +9,6 @@
  * Blockly's editor.
  */
 
-
 /**
  * Base class for events fired as a result of UI actions in
  * Blockly's editor.

--- a/core/events/events_var_base.ts
+++ b/core/events/events_var_base.ts
@@ -8,7 +8,6 @@
  * @fileoverview Abstract class for a variable event.
  */
 
-
 /**
  * Abstract class for a variable event.
  * @class

--- a/core/events/events_var_create.ts
+++ b/core/events/events_var_create.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a variable creation event.
  */
 
-
 /**
  * Class for a variable creation event.
  * @class

--- a/core/events/events_var_delete.ts
+++ b/core/events/events_var_delete.ts
@@ -8,7 +8,6 @@
  * @fileoverview Classes for all types of variable events.
  */
 
-
 /**
  * Classes for all types of variable events.
  * @class

--- a/core/events/events_var_rename.ts
+++ b/core/events/events_var_rename.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a variable rename event.
  */
 
-
 /**
  * Class for a variable rename event.
  * @class

--- a/core/events/events_viewport.ts
+++ b/core/events/events_viewport.ts
@@ -8,7 +8,6 @@
  * @fileoverview Events fired as a result of a viewport change.
  */
 
-
 /**
  * Events fired as a result of a viewport change.
  * @class

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -9,7 +9,6 @@
  * actions in Blockly's editor.
  */
 
-
 /**
  * Helper methods for events that are fired as a result of
  * actions in Blockly's editor.

--- a/core/events/workspace_events.ts
+++ b/core/events/workspace_events.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a finished loading workspace event.
  */
 
-
 /**
  * Class for a finished loading workspace event.
  * @class

--- a/core/extensions.ts
+++ b/core/extensions.ts
@@ -11,7 +11,6 @@
  *      array attribute.
  */
 
-
 /**
  * Extensions are functions that help initialize blocks, usually
  *      adding dynamic behavior such as onchange handlers and mutators. These

--- a/core/field.ts
+++ b/core/field.ts
@@ -10,7 +10,6 @@
  * instances would be FieldTextInput, FieldDropdown, etc.
  */
 
-
 /**
  * Field.  Used for editable titles, variables, etc.
  * This is an abstract class that defines the UI on the block.  Actual

--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -8,7 +8,6 @@
  * @fileoverview Angle input field.
  */
 
-
 /**
  * Angle input field.
  * @class

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -8,7 +8,6 @@
  * @fileoverview Checkbox field.  Checked or not checked.
  */
 
-
 /**
  * Checkbox field.  Checked or not checked.
  * @class

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -8,7 +8,6 @@
  * @fileoverview Colour input field.
  */
 
-
 /**
  * Colour input field.
  * @class

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -10,7 +10,6 @@
  * properties with the context menu.
  */
 
-
 /**
  * Dropdown input field.  Used for editable titles and variables.
  * In the interests of a consistent UI, the toolbox shares some functions and
@@ -120,7 +119,6 @@ export class FieldDropdown extends Field {
       menuGenerator: AnyDuringMigration[][]|Function|Sentinel,
       opt_validator?: Function, opt_config?: AnyDuringMigration) {
     super(Field.SKIP_SETUP);
-
 
     // If we pass SKIP_SETUP, don't do *anything* with the menu generator.
     if (menuGenerator === Field.SKIP_SETUP) {

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -8,7 +8,6 @@
  * @fileoverview Image field.  Used for pictures, icons, etc.
  */
 
-
 /**
  * Image field.  Used for pictures, icons, etc.
  * @class

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -9,7 +9,6 @@
  *    labels, etc.
  */
 
-
 /**
  * Non-editable, non-serializable text field.  Used for titles,
  *    labels, etc.

--- a/core/field_label_serializable.ts
+++ b/core/field_label_serializable.ts
@@ -10,7 +10,6 @@
  *    edited programmatically.
  */
 
-
 /**
  * Non-editable, serializable text field. Behaves like a
  *    normal label but is serialized to XML. It may only be

--- a/core/field_multilineinput.ts
+++ b/core/field_multilineinput.ts
@@ -8,7 +8,6 @@
  * @fileoverview Text Area field.
  */
 
-
 /**
  * Text Area field.
  * @class

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -8,7 +8,6 @@
  * @fileoverview Number input field
  */
 
-
 /**
  * Number input field
  * @class

--- a/core/field_registry.ts
+++ b/core/field_registry.ts
@@ -10,7 +10,6 @@
  *    fields based on JSON.
  */
 
-
 /**
  * Fields can be created based on a JSON definition. This file
  *    contains methods for registering those JSON definitions, and building the

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -8,7 +8,6 @@
  * @fileoverview Text input field.
  */
 
-
 /**
  * Text input field.
  * @class

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -8,7 +8,6 @@
  * @fileoverview Variable input field.
  */
 
-
 /**
  * Variable input field.
  * @class

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -8,7 +8,6 @@
  * @fileoverview Flyout tray containing blocks which may be created.
  */
 
-
 /**
  * Flyout tray containing blocks which may be created.
  * @class

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class for a button in the flyout.
  */
 
-
 /**
  * Class for a button in the flyout.
  * @class

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -8,7 +8,6 @@
  * @fileoverview Horizontal flyout tray containing blocks which may be created.
  */
 
-
 /**
  * Horizontal flyout tray containing blocks which may be created.
  * @class

--- a/core/flyout_metrics_manager.ts
+++ b/core/flyout_metrics_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview Calculates and reports flyout workspace metrics.
  */
 
-
 /**
  * Calculates and reports flyout workspace metrics.
  * @class

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -8,7 +8,6 @@
  * @fileoverview Layout code for a vertical variant of the flyout.
  */
 
-
 /**
  * Layout code for a vertical variant of the flyout.
  * @class

--- a/core/generator.ts
+++ b/core/generator.ts
@@ -9,7 +9,6 @@
  * Blockly code.
  */
 
-
 /**
  * Utility functions for generating executable code from
  * Blockly code.

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -9,7 +9,6 @@
  * or a tap.
  */
 
-
 /**
  * The class representing an in-progress gesture, usually a drag
  * or a tap.
@@ -50,7 +49,6 @@ import {WorkspaceCommentSvg} from './workspace_comment_svg.js';
 import {WorkspaceDragger} from './workspace_dragger.js';
 /* eslint-disable-next-line no-unused-vars */
 import {WorkspaceSvg} from './workspace_svg.js';
-
 
 
 /**

--- a/core/grid.ts
+++ b/core/grid.ts
@@ -9,7 +9,6 @@
  * Blockly.
  */
 
-
 /**
  * Object for configuring and updating a workspace grid in
  * Blockly.

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing an icon on a block.
  */
 
-
 /**
  * Object representing an icon on a block.
  * @class

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -8,7 +8,6 @@
  * @fileoverview Functions for injecting Blockly into a web page.
  */
 
-
 /**
  * Functions for injecting Blockly into a web page.
  * @namespace Blockly.inject

--- a/core/input.ts
+++ b/core/input.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing an input (value, statement, or dummy).
  */
 
-
 /**
  * Object representing an input (value, statement, or dummy).
  * @class

--- a/core/input_types.ts
+++ b/core/input_types.ts
@@ -8,7 +8,6 @@
  * @fileoverview An enum for the possible types of inputs.
  */
 
-
 /**
  * An enum for the possible types of inputs.
  * @namespace Blockly.inputTypes

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class that controls updates to connections during drags.
  */
 
-
 /**
  * Class that controls updates to connections during drags.
  * @class
@@ -52,7 +51,6 @@ const DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
     'manager tried to create a marker but the result is missing %1. If ' +
     'you are using a mutator, make sure your domToMutation method is ' +
     'properly defined.';
-
 
 export enum PreviewType {
   INSERTION_MARKER = 0,

--- a/core/interfaces/i_ast_node_location.ts
+++ b/core/interfaces/i_ast_node_location.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an AST node location.
  */
 
-
 /**
  * The interface for an AST node location.
  * @namespace Blockly.IASTNodeLocation

--- a/core/interfaces/i_ast_node_location.ts
+++ b/core/interfaces/i_ast_node_location.ts
@@ -15,6 +15,7 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IASTNodeLocation');
 
+
 /**
  * An AST node location interface.
  * @alias Blockly.IASTNodeLocation

--- a/core/interfaces/i_ast_node_location_svg.ts
+++ b/core/interfaces/i_ast_node_location_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an AST node location SVG.
  */
 
-
 /**
  * The interface for an AST node location SVG.
  * @namespace Blockly.IASTNodeLocationSvg

--- a/core/interfaces/i_ast_node_location_with_block.ts
+++ b/core/interfaces/i_ast_node_location_with_block.ts
@@ -9,8 +9,6 @@
  * block.
  */
 
-
-
 /**
  * The interface for an AST node location that has an associated
  * block.

--- a/core/interfaces/i_autohideable.ts
+++ b/core/interfaces/i_autohideable.ts
@@ -9,8 +9,6 @@
  * when WorkspaceSvg.hideChaff is called.
  */
 
-
-
 /**
  * The interface for a component that is automatically hidden
  * when WorkspaceSvg.hideChaff is called.

--- a/core/interfaces/i_block_dragger.ts
+++ b/core/interfaces/i_block_dragger.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a block dragger.
  */
 
-
 /**
  * The interface for a block dragger.
  * @namespace Blockly.IBlockDragger

--- a/core/interfaces/i_bounded_element.ts
+++ b/core/interfaces/i_bounded_element.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a bounded element.
  */
 
-
 /**
  * The interface for a bounded element.
  * @namespace Blockly.IBoundedElement

--- a/core/interfaces/i_bubble.ts
+++ b/core/interfaces/i_bubble.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a bubble.
  */
 
-
 /**
  * The interface for a bubble.
  * @namespace Blockly.IBubble

--- a/core/interfaces/i_collapsible_toolbox_item.ts
+++ b/core/interfaces/i_collapsible_toolbox_item.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a collapsible toolbox item.
  */
 
-
 /**
  * The interface for a collapsible toolbox item.
  * @namespace Blockly.ICollapsibleToolboxItem

--- a/core/interfaces/i_component.ts
+++ b/core/interfaces/i_component.ts
@@ -9,8 +9,6 @@
  * the ComponentManager.
  */
 
-
-
 /**
  * Interface for a workspace component that can be registered with
  * the ComponentManager.

--- a/core/interfaces/i_connection_checker.ts
+++ b/core/interfaces/i_connection_checker.ts
@@ -9,7 +9,6 @@
  * checking whether a potential connection is safe and valid.
  */
 
-
 /**
  * The interface for an object that encapsulates logic for
  * checking whether a potential connection is safe and valid.

--- a/core/interfaces/i_contextmenu.ts
+++ b/core/interfaces/i_contextmenu.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that supports a right-click.
  */
 
-
 /**
  * The interface for an object that supports a right-click.
  * @namespace Blockly.IContextMenu

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that is copyable.
  */
 
-
 /**
  * The interface for an object that is copyable.
  * @namespace Blockly.ICopyable

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that is deletable.
  */
 
-
 /**
  * The interface for an object that is deletable.
  * @namespace Blockly.IDeletable

--- a/core/interfaces/i_delete_area.ts
+++ b/core/interfaces/i_delete_area.ts
@@ -9,8 +9,6 @@
  * that is dropped on top of it.
  */
 
-
-
 /**
  * The interface for a component that can delete a block or bubble
  * that is dropped on top of it.

--- a/core/interfaces/i_drag_target.ts
+++ b/core/interfaces/i_drag_target.ts
@@ -9,8 +9,6 @@
  * block is dropped on top of it.
  */
 
-
-
 /**
  * The interface for a component that has a handler for when a
  * block is dropped on top of it.

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that is draggable.
  */
 
-
 /**
  * The interface for an object that is draggable.
  * @namespace Blockly.IDraggable

--- a/core/interfaces/i_flyout.ts
+++ b/core/interfaces/i_flyout.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a flyout.
  */
 
-
 /**
  * The interface for a flyout.
  * @namespace Blockly.IFlyout

--- a/core/interfaces/i_keyboard_accessible.ts
+++ b/core/interfaces/i_keyboard_accessible.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for objects that handle keyboard shortcuts.
  */
 
-
 /**
  * The interface for objects that handle keyboard shortcuts.
  * @namespace Blockly.IKeyboardAccessible

--- a/core/interfaces/i_metrics_manager.ts
+++ b/core/interfaces/i_metrics_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a metrics manager.
  */
 
-
 /**
  * The interface for a metrics manager.
  * @namespace Blockly.IMetricsManager

--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that is movable.
  */
 
-
 /**
  * The interface for an object that is movable.
  * @namespace Blockly.IMovable

--- a/core/interfaces/i_positionable.ts
+++ b/core/interfaces/i_positionable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a positionable UI element.
  */
 
-
 /**
  * The interface for a positionable UI element.
  * @namespace Blockly.IPositionable

--- a/core/interfaces/i_registrable.ts
+++ b/core/interfaces/i_registrable.ts
@@ -9,8 +9,6 @@
  *    (Ex. Toolbox, Fields, Renderers)
  */
 
-
-
 /**
  * The interface for a Blockly component that can be registered.
  *    (Ex. Toolbox, Fields, Renderers)

--- a/core/interfaces/i_registrable_field.ts
+++ b/core/interfaces/i_registrable_field.ts
@@ -18,6 +18,7 @@ goog.declareModuleId('Blockly.IRegistrableField');
 /* eslint-disable-next-line no-unused-vars */
 import {Field} from '../field.js';
 
+
 type fromJson = (p1: object) => Field;
 
 /**

--- a/core/interfaces/i_registrable_field.ts
+++ b/core/interfaces/i_registrable_field.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a Blockly field that can be registered.
  */
 
-
 /**
  * The interface for a Blockly field that can be registered.
  * @namespace Blockly.IRegistrableField

--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that is selectable.
  */
 
-
 /**
  * The interface for an object that is selectable.
  * @namespace Blockly.ISelectable

--- a/core/interfaces/i_selectable_toolbox_item.ts
+++ b/core/interfaces/i_selectable_toolbox_item.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a selectable toolbox item.
  */
 
-
 /**
  * The interface for a selectable toolbox item.
  * @namespace Blockly.ISelectableToolboxItem

--- a/core/interfaces/i_serializer.ts
+++ b/core/interfaces/i_serializer.ts
@@ -9,8 +9,6 @@
  * serializing part of the workspace.
  */
 
-
-
 /**
  * The record type for an object containing functions for
  *     serializing part of the workspace.

--- a/core/interfaces/i_styleable.ts
+++ b/core/interfaces/i_styleable.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for an object that a style can be added to.
  */
 
-
 /**
  * The interface for an object that a style can be added to.
  * @namespace Blockly.IStyleable

--- a/core/interfaces/i_toolbox.ts
+++ b/core/interfaces/i_toolbox.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a toolbox.
  */
 
-
 /**
  * The interface for a toolbox.
  * @namespace Blockly.IToolbox

--- a/core/interfaces/i_toolbox_item.ts
+++ b/core/interfaces/i_toolbox_item.ts
@@ -8,7 +8,6 @@
  * @fileoverview The interface for a toolbox item.
  */
 
-
 /**
  * The interface for a toolbox item.
  * @namespace Blockly.IToolboxItem

--- a/core/internal_constants.ts
+++ b/core/internal_constants.ts
@@ -9,7 +9,6 @@
  * use these constants outside of the core library.
  */
 
-
 /**
  * Module that provides constants for use inside Blockly. Do not
  * use these constants outside of the core library.

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -9,7 +9,6 @@
  * Used to traverse the Blockly AST.
  */
 
-
 /**
  * The class representing an AST node.
  * Used to traverse the Blockly AST.

--- a/core/keyboard_nav/basic_cursor.ts
+++ b/core/keyboard_nav/basic_cursor.ts
@@ -9,7 +9,6 @@
  * Used to demo switching between different cursors.
  */
 
-
 /**
  * The class representing a basic cursor.
  * Used to demo switching between different cursors.

--- a/core/keyboard_nav/cursor.ts
+++ b/core/keyboard_nav/cursor.ts
@@ -22,6 +22,7 @@ import * as registry from '../registry.js';
 import {ASTNode} from './ast_node.js';
 import {Marker} from './marker.js';
 
+
 /**
  * Class for a cursor.
  * A cursor controls how a user navigates the Blockly AST.

--- a/core/keyboard_nav/cursor.ts
+++ b/core/keyboard_nav/cursor.ts
@@ -9,7 +9,6 @@
  * Used primarily for keyboard navigation.
  */
 
-
 /**
  * The class representing a cursor.
  * Used primarily for keyboard navigation.

--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -9,7 +9,6 @@
  * Used primarily for keyboard navigation to show a marked location.
  */
 
-
 /**
  * The class representing a marker.
  * Used primarily for keyboard navigation to show a marked location.

--- a/core/keyboard_nav/tab_navigate_cursor.ts
+++ b/core/keyboard_nav/tab_navigate_cursor.ts
@@ -9,7 +9,6 @@
  * between tab navigable fields.
  */
 
-
 /**
  * The class representing a cursor that is used to navigate
  * between tab navigable fields.

--- a/core/marker_manager.ts
+++ b/core/marker_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object in charge of managing markers and the cursor.
  */
 
-
 /**
  * Object in charge of managing markers and the cursor.
  * @class

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -8,7 +8,6 @@
  * @fileoverview Blockly menu similar to Closure's goog.ui.Menu
  */
 
-
 /**
  * Blockly menu similar to Closure's goog.ui.Menu
  * @class

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -8,7 +8,6 @@
  * @fileoverview Blockly menu item similar to Closure's goog.ui.MenuItem
  */
 
-
 /**
  * Blockly menu item similar to Closure's goog.ui.MenuItem
  * @class

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -8,7 +8,6 @@
  * @fileoverview Calculates and reports workspace metrics.
  */
 
-
 /**
  * Calculates and reports workspace metrics.
  * @class

--- a/core/msg.ts
+++ b/core/msg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Empty name space for the Message singleton.
  */
 
-
 /**
  * Empty name space for the Message singleton.
  * @namespace Blockly.Msg

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -9,7 +9,6 @@
  * user to change the shape of a block using a nested blocks editor.
  */
 
-
 /**
  * Object representing a mutator dialog.  A mutator allows the
  * user to change the shape of a block using a nested blocks editor.

--- a/core/names.ts
+++ b/core/names.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for handling variable and procedure names.
  */
 
-
 /**
  * Utility functions for handling variable and procedure names.
  * @class

--- a/core/options.ts
+++ b/core/options.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object that controls settings for the workspace.
  */
 
-
 /**
  * Object that controls settings for the workspace.
  * @class

--- a/core/positionable_helpers.ts
+++ b/core/positionable_helpers.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for positioning UI elements.
  */
 
-
 /**
  * Utility functions for positioning UI elements.
  * @namespace Blockly.uiPosition

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for handling procedures.
  */
 
-
 /**
  * Utility functions for handling procedures.
  * @namespace Blockly.Procedures

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -9,7 +9,6 @@
  *    for registering and unregistering different types of classes.
  */
 
-
 /**
  * This file is a universal registry that provides generic methods
  *    for registering and unregistering different types of classes.
@@ -101,7 +100,6 @@ export class Type<T> {
     return this.name;
   }
 }
-
 
 // Type.CONNECTION_CHECKER = new Type('connectionChecker');
 

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -33,6 +33,7 @@ import {Svg} from './utils/svg.js';
 import * as svgMath from './utils/svg_math.js';
 import * as svgPaths from './utils/svg_paths.js';
 
+
 /** A shape that has a pathDown property. */
 interface PathDownShape {
   pathDown: string;

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -8,7 +8,6 @@
  * @fileoverview Components for creating connections between blocks.
  */
 
-
 /**
  * Components for creating connections between blocks.
  * @class

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -52,6 +52,7 @@ import {MarkerSvg} from './marker_svg.js';
 import {PathObject} from './path_object.js';
 import {Renderer} from './renderer.js';
 
+
 /**
  * Returns whether the debugger is turned on.
  * @return Whether the debugger is turned on.

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -8,7 +8,6 @@
  * @fileoverview Namespace for block rendering functionality.
  */
 
-
 /**
  * Namespace for block rendering functionality.
  * @namespace Blockly.blockRendering

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -26,6 +26,7 @@ import {Svg} from '../../utils/svg.js';
 import * as svgPaths from '../../utils/svg_paths.js';
 import * as userAgent from '../../utils/useragent.js';
 
+
 /** An object containing sizing and path information about outside corners. */
 export interface OutsideCorners {
   topLeft: string;

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object that provides constants for rendering blocks.
  */
 
-
 /**
  * An object that provides constants for rendering blocks.
  * @class

--- a/core/renderers/common/debug.ts
+++ b/core/renderers/common/debug.ts
@@ -8,7 +8,6 @@
  * @fileoverview Block rendering debugging functionality.
  */
 
-
 /**
  * Block rendering debugging functionality.
  * @namespace Blockly.blockRendering.debug

--- a/core/renderers/common/debugger.ts
+++ b/core/renderers/common/debugger.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for rendering debug graphics.
  */
 
-
 /**
  * Methods for rendering debug graphics.
  * @class
@@ -196,7 +195,6 @@ export class Debug {
             this.svgRoot_));
       }
     }
-
 
     if (Types.isInput(elem) && elem instanceof InputConnection &&
         Debug.config.connections) {

--- a/core/renderers/common/drawer.ts
+++ b/core/renderers/common/drawer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a block as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a block as SVG.
  * @class

--- a/core/renderers/common/i_path_object.ts
+++ b/core/renderers/common/i_path_object.ts
@@ -9,8 +9,6 @@
  * elements.
  */
 
-
-
 /**
  * The interface for an object that owns a block's rendering SVG
  * elements.

--- a/core/renderers/common/info.ts
+++ b/core/renderers/common/info.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a block as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a block as SVG.
  * @class

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a marker as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a marker as SVG.
  * @class

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object that owns a block's rendering SVG elements.
  */
 
-
 /**
  * An object that owns a block's rendering SVG elements.
  * @class

--- a/core/renderers/common/renderer.ts
+++ b/core/renderers/common/renderer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Base renderer.
  */
 
-
 /**
  * Base renderer.
  * @class

--- a/core/renderers/geras/constants.ts
+++ b/core/renderers/geras/constants.ts
@@ -9,7 +9,6 @@
  * mode.
  */
 
-
 /**
  * An object that provides constants for rendering blocks in Geras
  * mode.

--- a/core/renderers/geras/drawer.ts
+++ b/core/renderers/geras/drawer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Renderer that preserves the look and feel of Blockly pre-2019.
  */
 
-
 /**
  * Renderer that preserves the look and feel of Blockly pre-2019.
  * @class

--- a/core/renderers/geras/geras.ts
+++ b/core/renderers/geras/geras.ts
@@ -23,6 +23,7 @@ import {StatementInput} from './measurables/statement_input.js';
 import {PathObject} from './path_object.js';
 import {Renderer} from './renderer.js';
 
+
 export {
   ConstantProvider,
   Drawer,

--- a/core/renderers/geras/geras.ts
+++ b/core/renderers/geras/geras.ts
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Re-exports of Blockly.geras.* modules.
  * @namespace Blockly.geras

--- a/core/renderers/geras/highlight_constants.ts
+++ b/core/renderers/geras/highlight_constants.ts
@@ -19,6 +19,7 @@ import * as svgPaths from '../../utils/svg_paths.js';
 /* eslint-disable-next-line no-unused-vars */
 import {ConstantProvider} from '../common/constants.js';
 
+
 /** An object containing sizing and path information about an outside corner. */
 export interface OutsideCorner {
   height: number;

--- a/core/renderers/geras/highlight_constants.ts
+++ b/core/renderers/geras/highlight_constants.ts
@@ -8,7 +8,6 @@
  * @fileoverview Objects for rendering highlights on blocks.
  */
 
-
 /**
  * Objects for rendering highlights on blocks.
  * @class

--- a/core/renderers/geras/highlighter.ts
+++ b/core/renderers/geras/highlighter.ts
@@ -9,7 +9,6 @@
  * compatibility mode.
  */
 
-
 /**
  * Methods for adding highlights on block, for rendering in
  * compatibility mode.

--- a/core/renderers/geras/info.ts
+++ b/core/renderers/geras/info.ts
@@ -9,7 +9,6 @@
  * Geras: spirit of old age.
  */
 
-
 /**
  * Old (compatibility) renderer.
  * Geras: spirit of old age.

--- a/core/renderers/geras/measurables/inline_input.ts
+++ b/core/renderers/geras/measurables/inline_input.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Objects representing inline inputs with connections on a
  * rendered block.

--- a/core/renderers/geras/measurables/statement_input.ts
+++ b/core/renderers/geras/measurables/statement_input.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Objects representing statement inputs with connections on a
  * rendered block.

--- a/core/renderers/geras/path_object.ts
+++ b/core/renderers/geras/path_object.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object that owns a block's rendering SVG elements.
  */
 
-
 /**
  * An object that owns a block's rendering SVG elements.
  * @class

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Geras renderer.
  */
 
-
 /**
  * Geras renderer.
  * @class

--- a/core/renderers/measurables/base.ts
+++ b/core/renderers/measurables/base.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a block as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a block as SVG.
  * @class

--- a/core/renderers/measurables/bottom_row.ts
+++ b/core/renderers/measurables/bottom_row.ts
@@ -9,7 +9,6 @@
  * of its subcomponents.
  */
 
-
 /**
  * Object representing a bottom row on a rendered block.
  * of its subcomponents.

--- a/core/renderers/measurables/connection.ts
+++ b/core/renderers/measurables/connection.ts
@@ -9,7 +9,6 @@
  * rendering.
  */
 
-
 /**
  * Base class representing the space a connection takes up during
  * rendering.

--- a/core/renderers/measurables/connection.ts
+++ b/core/renderers/measurables/connection.ts
@@ -25,6 +25,7 @@ import {ConstantProvider, Shape} from '../common/constants.js';
 import {Measurable} from './base.js';
 import {Types} from './types.js';
 
+
 /**
  * The base class to represent a connection and the space that it takes up on
  * the block.

--- a/core/renderers/measurables/external_value_input.ts
+++ b/core/renderers/measurables/external_value_input.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Class representing external value inputs with connections on a
  * rendered block.

--- a/core/renderers/measurables/field.ts
+++ b/core/renderers/measurables/field.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a field in a row of a rendered
  * block.

--- a/core/renderers/measurables/hat.ts
+++ b/core/renderers/measurables/hat.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a hat in a row of a rendered
  * block.

--- a/core/renderers/measurables/icon.ts
+++ b/core/renderers/measurables/icon.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing an icon in a row of a rendered
  * block.

--- a/core/renderers/measurables/in_row_spacer.ts
+++ b/core/renderers/measurables/in_row_spacer.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a spacer in a row of a rendered
  * block.

--- a/core/renderers/measurables/inline_input.ts
+++ b/core/renderers/measurables/inline_input.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Class representing inline inputs with connections on a rendered
  * block.

--- a/core/renderers/measurables/input_connection.ts
+++ b/core/renderers/measurables/input_connection.ts
@@ -8,7 +8,6 @@
  * @fileoverview Class representing inputs with connections on a rendered block.
  */
 
-
 /**
  * Class representing inputs with connections on a rendered block.
  * @class

--- a/core/renderers/measurables/input_row.ts
+++ b/core/renderers/measurables/input_row.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Object representing a row that holds one or more inputs on a
  * rendered block.

--- a/core/renderers/measurables/jagged_edge.ts
+++ b/core/renderers/measurables/jagged_edge.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a jagged edge in a row of a rendered
  * block.

--- a/core/renderers/measurables/next_connection.ts
+++ b/core/renderers/measurables/next_connection.ts
@@ -9,7 +9,6 @@
  * rendering.
  */
 
-
 /**
  * Class representing the space a next connection takes up during
  * rendering.

--- a/core/renderers/measurables/output_connection.ts
+++ b/core/renderers/measurables/output_connection.ts
@@ -9,7 +9,6 @@
  * during rendering.
  */
 
-
 /**
  * Class representing the space a output connection takes up
  * during rendering.

--- a/core/renderers/measurables/previous_connection.ts
+++ b/core/renderers/measurables/previous_connection.ts
@@ -9,7 +9,6 @@
  * during rendering.
  */
 
-
 /**
  * Class representing the space a previous connection takes up
  * during rendering.

--- a/core/renderers/measurables/round_corner.ts
+++ b/core/renderers/measurables/round_corner.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a round corner in a row of a rendered
  * block.

--- a/core/renderers/measurables/row.ts
+++ b/core/renderers/measurables/row.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a single row on a rendered block.
  */
 
-
 /**
  * Object representing a single row on a rendered block.
  * @class

--- a/core/renderers/measurables/spacer_row.ts
+++ b/core/renderers/measurables/spacer_row.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a spacer between two rows.
  */
 
-
 /**
  * Object representing a spacer between two rows.
  * @class

--- a/core/renderers/measurables/square_corner.ts
+++ b/core/renderers/measurables/square_corner.ts
@@ -9,7 +9,6 @@
  * block.
  */
 
-
 /**
  * Objects representing a square corner in a row of a rendered
  * block.

--- a/core/renderers/measurables/statement_input.ts
+++ b/core/renderers/measurables/statement_input.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Class representing statement inputs with connections on a
  * rendered block.

--- a/core/renderers/measurables/top_row.ts
+++ b/core/renderers/measurables/top_row.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a top row on a rendered block.
  */
 
-
 /**
  * Object representing a top row on a rendered block.
  * @class

--- a/core/renderers/measurables/types.ts
+++ b/core/renderers/measurables/types.ts
@@ -8,7 +8,6 @@
  * @fileoverview Measurable types.
  */
 
-
 /**
  * Measurable types.
  * @namespace Blockly.blockRendering.Types

--- a/core/renderers/minimalist/constants.ts
+++ b/core/renderers/minimalist/constants.ts
@@ -9,7 +9,6 @@
  * minimalist renderer.
  */
 
-
 /**
  * An object that provides constants for rendering blocks in the
  * minimalist renderer.

--- a/core/renderers/minimalist/drawer.ts
+++ b/core/renderers/minimalist/drawer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Minimalist rendering drawer.
  */
 
-
 /**
  * Minimalist rendering drawer.
  * @class

--- a/core/renderers/minimalist/info.ts
+++ b/core/renderers/minimalist/info.ts
@@ -8,7 +8,6 @@
  * @fileoverview Minimalist render info object.
  */
 
-
 /**
  * Minimalist render info object.
  * @class

--- a/core/renderers/minimalist/minimalist.ts
+++ b/core/renderers/minimalist/minimalist.ts
@@ -18,4 +18,5 @@ import {Drawer} from './drawer.js';
 import {RenderInfo} from './info.js';
 import {Renderer} from './renderer.js';
 
+
 export {ConstantProvider, Drawer, Renderer, RenderInfo};

--- a/core/renderers/minimalist/minimalist.ts
+++ b/core/renderers/minimalist/minimalist.ts
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Re-exports of Blockly.minimalist.* modules.
  * @namespace Blockly.minimalist

--- a/core/renderers/minimalist/renderer.ts
+++ b/core/renderers/minimalist/renderer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Minimalist renderer.
  */
 
-
 /**
  * Minimalist renderer.
  * @class

--- a/core/renderers/thrasos/info.ts
+++ b/core/renderers/thrasos/info.ts
@@ -9,7 +9,6 @@
  * Thrasos: spirit of boldness.
  */
 
-
 /**
  * New (evolving) renderer.
  * Thrasos: spirit of boldness.

--- a/core/renderers/thrasos/renderer.ts
+++ b/core/renderers/thrasos/renderer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Thrasos renderer.
  */
 
-
 /**
  * Thrasos renderer.
  * @class

--- a/core/renderers/thrasos/thrasos.ts
+++ b/core/renderers/thrasos/thrasos.ts
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Re-exports of Blockly.thrasos.* modules.
  * @namespace Blockly.thrasos

--- a/core/renderers/thrasos/thrasos.ts
+++ b/core/renderers/thrasos/thrasos.ts
@@ -16,4 +16,5 @@ goog.declareModuleId('Blockly.thrasos');
 import {RenderInfo} from './info.js';
 import {Renderer} from './renderer.js';
 
+
 export {Renderer, RenderInfo};

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -27,6 +27,7 @@ import * as svgPaths from '../../utils/svg_paths.js';
 /* eslint-disable-next-line no-unused-vars */
 import {ConstantProvider as BaseConstantProvider, Shape} from '../common/constants.js';
 
+
 /** An object containing sizing and path information about inside corners. */
 export interface InsideCorners {
   width: number;
@@ -38,7 +39,6 @@ export interface InsideCorners {
   pathTopRight: string;
   pathBottomRight: string;
 }
-
 
 /**
  * An object that provides constants for rendering blocks in Zelos mode.

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -9,7 +9,6 @@
  * mode.
  */
 
-
 /**
  * An object that provides constants for rendering blocks in Zelos
  * mode.

--- a/core/renderers/zelos/drawer.ts
+++ b/core/renderers/zelos/drawer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Zelos renderer.
  */
 
-
 /**
  * Zelos renderer.
  * @class

--- a/core/renderers/zelos/info.ts
+++ b/core/renderers/zelos/info.ts
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Makecode/scratch-style renderer.
  * @class

--- a/core/renderers/zelos/marker_svg.ts
+++ b/core/renderers/zelos/marker_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for graphically rendering a marker as SVG.
  */
 
-
 /**
  * Methods for graphically rendering a marker as SVG.
  * @class

--- a/core/renderers/zelos/measurables/bottom_row.ts
+++ b/core/renderers/zelos/measurables/bottom_row.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object representing the bottom row of a rendered block.
  */
 
-
 /**
  * An object representing the bottom row of a rendered block.
  * @class

--- a/core/renderers/zelos/measurables/inputs.ts
+++ b/core/renderers/zelos/measurables/inputs.ts
@@ -9,7 +9,6 @@
  * a rendered block.
  */
 
-
 /**
  * Zelos specific objects representing inputs with connections on
  * a rendered block.

--- a/core/renderers/zelos/measurables/row_elements.ts
+++ b/core/renderers/zelos/measurables/row_elements.ts
@@ -9,7 +9,6 @@
  * rendered block.
  */
 
-
 /**
  * Zelos specific objects representing elements in a row of a
  * rendered block.

--- a/core/renderers/zelos/measurables/top_row.ts
+++ b/core/renderers/zelos/measurables/top_row.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object representing the top row of a rendered block.
  */
 
-
 /**
  * An object representing the top row of a rendered block.
  * @class

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -8,7 +8,6 @@
  * @fileoverview An object that owns a block's rendering SVG elements.
  */
 
-
 /**
  * An object that owns a block's rendering SVG elements.
  * @class

--- a/core/renderers/zelos/renderer.ts
+++ b/core/renderers/zelos/renderer.ts
@@ -8,7 +8,6 @@
  * @fileoverview Zelos renderer.
  */
 
-
 /**
  * Zelos renderer.
  * @class

--- a/core/renderers/zelos/zelos.ts
+++ b/core/renderers/zelos/zelos.ts
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Re-exports of Blockly.zelos.* modules.
  * @namespace Blockly.zelos

--- a/core/renderers/zelos/zelos.ts
+++ b/core/renderers/zelos/zelos.ts
@@ -24,6 +24,7 @@ import {TopRow} from './measurables/top_row.js';
 import {PathObject} from './path_object.js';
 import {Renderer} from './renderer.js';
 
+
 export {
   BottomRow,
   ConstantProvider,

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a scrollbar.
  */
 
-
 /**
  * Object representing a scrollbar.
  * @class

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -25,6 +25,8 @@ import {Svg} from './utils/svg.js';
 import * as svgMath from './utils/svg_math.js';
 /* eslint-disable-next-line no-unused-vars */
 import {WorkspaceSvg} from './workspace_svg.js';
+
+
 /**
  * A note on units: most of the numbers that are in CSS pixels are scaled if the
  * scrollbar is in a mutator.

--- a/core/scrollbar_pair.ts
+++ b/core/scrollbar_pair.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a pair of scrollbars.
  */
 
-
 /**
  * Object representing a pair of scrollbars.
  * @class

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -9,7 +9,6 @@
  * containing state.
  */
 
-
 /**
  * Handles serializing blocks to plain JavaScript objects only containing state.
  * @namespace Blockly.serialization.blocks

--- a/core/serialization/exceptions.ts
+++ b/core/serialization/exceptions.ts
@@ -8,7 +8,6 @@
  * @fileoverview Contains custom errors thrown by the serialization system.
  */
 
-
 /**
  * Contains custom errors thrown by the serialization system.
  * @namespace Blockly.serialization.exceptions

--- a/core/serialization/priorities.ts
+++ b/core/serialization/priorities.ts
@@ -10,8 +10,6 @@
  * serializers. Higher priorities are deserialized first.
  */
 
-
-
 /**
  * The top level namespace for priorities of plugin serializers.
  * Includes constants for the priorities of different plugin serializers. Higher

--- a/core/serialization/registry.ts
+++ b/core/serialization/registry.ts
@@ -9,7 +9,6 @@
  * variables, plugins, etc).
  */
 
-
 /**
  * Contains functions registering serializers (eg blocks, variables, plugins,
  * etc).

--- a/core/serialization/variables.ts
+++ b/core/serialization/variables.ts
@@ -9,7 +9,6 @@
  * containing state.
  */
 
-
 /**
  * Handles serializing variables to plain JavaScript objects, only containing
  * state.

--- a/core/serialization/workspaces.ts
+++ b/core/serialization/workspaces.ts
@@ -9,7 +9,6 @@
  * plain JavaScript objects.
  */
 
-
 /**
  * Contains top-level functions for serializing workspaces to plain JavaScript
  * objects.

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -8,7 +8,6 @@
  * @fileoverview Registers default keyboard shortcuts.
  */
 
-
 /**
  * Registers default keyboard shortcuts.
  * @namespace Blockly.ShortcutItems

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -9,7 +9,6 @@
  * key codes used to execute those shortcuts.
  */
 
-
 /**
  * The namespace used to keep track of keyboard shortcuts and the
  * key codes used to execute those shortcuts.

--- a/core/sprites.ts
+++ b/core/sprites.ts
@@ -17,7 +17,6 @@ goog.declareModuleId('Blockly.sprite');
  * and zoom controls.
  */
 
-
 /**
  * Contains the path to a single png tat holds the images for the trashcan
  * as well as the zoom controls.

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -8,7 +8,6 @@
  * @fileoverview The class representing a theme.
  */
 
-
 /**
  * The class representing a theme.
  * @class

--- a/core/theme/classic.ts
+++ b/core/theme/classic.ts
@@ -9,7 +9,6 @@
  * Contains multi-coloured border to create shadow effect.
  */
 
-
 /**
  * Classic theme.
  * Contains multi-coloured border to create shadow effect.

--- a/core/theme/themes.ts
+++ b/core/theme/themes.ts
@@ -18,4 +18,5 @@ goog.declareModuleId('Blockly.Themes');
 import {Classic} from './classic.js';
 import {Zelos} from './zelos.js';
 
+
 export {Classic, Zelos};

--- a/core/theme/themes.ts
+++ b/core/theme/themes.ts
@@ -8,7 +8,6 @@
  * @fileoverview Namespace for themes.
  */
 
-
 /**
  * Namespace for themes.
  * @namespace Blockly.Themes

--- a/core/theme/zelos.ts
+++ b/core/theme/zelos.ts
@@ -8,7 +8,6 @@
  * @fileoverview Zelos theme.
  */
 
-
 /**
  * Zelos theme.
  * @namespace Blockly.Themes.Zelos

--- a/core/theme_manager.ts
+++ b/core/theme_manager.ts
@@ -9,7 +9,6 @@
  *     and UI components.
  */
 
-
 /**
  * Object in charge of storing and updating a workspace theme
  *     and UI components.

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -8,7 +8,6 @@
  * @fileoverview A toolbox category used to organize blocks in the toolbox.
  */
 
-
 /**
  * A toolbox category used to organize blocks in the toolbox.
  * @class

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -8,7 +8,6 @@
  * @fileoverview A toolbox category used to organize blocks in the toolbox.
  */
 
-
 /**
  * A toolbox category used to organize blocks in the toolbox.
  * @class
@@ -261,7 +260,6 @@ export interface CssConfig {
   closedicon: string|null;
   contents: string|null;
 }
-
 
 registry.register(
     registry.Type.TOOLBOX_ITEM, CollapsibleToolboxCategory.registrationName,

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -8,7 +8,6 @@
  * @fileoverview A separator used for separating toolbox categories.
  */
 
-
 /**
  * A separator used for separating toolbox categories.
  * @class

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -8,7 +8,6 @@
  * @fileoverview Toolbox from whence to create blocks.
  */
 
-
 /**
  * Toolbox from whence to create blocks.
  * @class

--- a/core/toolbox/toolbox_item.ts
+++ b/core/toolbox/toolbox_item.ts
@@ -8,7 +8,6 @@
  * @fileoverview An item in the toolbox.
  */
 
-
 /**
  * An item in the toolbox.
  * @class

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Library to create tooltips for Blockly.
  * First, call createDom() after onload.

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -8,7 +8,6 @@
  * @fileoverview Touch handling for Blockly.
  */
 
-
 /**
  * Touch handling for Blockly.
  * @namespace Blockly.Touch
@@ -269,7 +268,6 @@ export function isMouseOrTouchEvent(e: Event|PseudoEvent): boolean {
 export function isTouchEvent(e: Event|PseudoEvent): boolean {
   return e.type.startsWith('touch') || e.type.startsWith('pointer');
 }
-
 
 /**
  * Split an event into an array of events, one per changed touch or mouse

--- a/core/touch_gesture.ts
+++ b/core/touch_gesture.ts
@@ -9,7 +9,6 @@
  * for both pointer and touch events.
  */
 
-
 /**
  * The class extends Gesture to support pinch to zoom
  * for both pointer and touch events.
@@ -30,7 +29,6 @@ import {WorkspaceSvg} from './workspace_svg.js';
  * Note: In this file "start" refers to touchstart, mousedown, and pointerstart
  * events.  "End" refers to touchend, mouseup, and pointerend events.
  */
-
 
 /** A multiplier used to convert the gesture scale to a zoom in delta. */
 const ZOOM_IN_MULTIPLIER = 5;

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a trash can icon.
  */
 
-
 /**
  * Object representing a trash can icon.
  * @class

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -45,6 +45,7 @@ import * as xml from './utils/xml.js';
 /* eslint-disable-next-line no-unused-vars */
 import {WorkspaceSvg} from './workspace_svg.js';
 
+
 export {
   aria,
   arrayUtils as array,

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods.
  */
 
-
 /**
  * Utility methods.
  * @namespace Blockly.utils

--- a/core/utils/aria.ts
+++ b/core/utils/aria.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * ARIA-related constants and utilities.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/array.ts
+++ b/core/utils/array.ts
@@ -8,8 +8,9 @@
  * @fileoverview Utility methods related to arrays.
  */
 
-
 /** @namespace Blockly.utils.array */
+import * as goog from '../../closure/goog/goog.js';
+goog.declareModuleId('Blockly.utils.array');
 
 
 /**
@@ -19,9 +20,6 @@
  * @return True if an element was removed.
  * @alias Blockly.array.removeElem
  */
-import * as goog from '../../closure/goog/goog.js';
-goog.declareModuleId('Blockly.utils.array');
-
 export function removeElem(
     arr: AnyDuringMigration[], value: AnyDuringMigration): boolean {
   const i = arr.indexOf(value);

--- a/core/utils/colour.ts
+++ b/core/utils/colour.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for colour manipulation.
  */
 
-
 /**
  * Utility methods for colour manipulation.
  * @namespace Blockly.utils.colour

--- a/core/utils/colour.ts
+++ b/core/utils/colour.ts
@@ -1,4 +1,4 @@
-	/**
+/**
  * @license
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: Apache-2.0

--- a/core/utils/colour.ts
+++ b/core/utils/colour.ts
@@ -1,4 +1,4 @@
-/**
+	/**
  * @license
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -14,6 +14,7 @@
  */
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.colour');
+
 
 /**
  * The richness of block colours, regardless of the hue.

--- a/core/utils/coordinate.ts
+++ b/core/utils/coordinate.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for coordinate manipulation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/coordinate.ts
+++ b/core/utils/coordinate.ts
@@ -19,6 +19,7 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.Coordinate');
 
+
 /**
  * Class for representing coordinates and positions.
  * @alias Blockly.utils.Coordinate

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -9,7 +9,6 @@
  * This method is not specific to Blockly.
  */
 
-
 /**
  * Helper function for warning developers about deprecations.
  * This method is not specific to Blockly.

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for DOM manipulation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/idgenerator.ts
+++ b/core/utils/idgenerator.ts
@@ -8,7 +8,6 @@
  * @fileoverview Generators for unique IDs.
  */
 
-
 /**
  * Generators for unique IDs.
  * @namespace Blockly.utils.idGenerator

--- a/core/utils/keycodes.ts
+++ b/core/utils/keycodes.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Constant declarations for common key codes.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/math.ts
+++ b/core/utils/math.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for math.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/metrics.ts
+++ b/core/utils/metrics.ts
@@ -8,7 +8,6 @@
  * @fileoverview Workspace metrics definitions.
  */
 
-
 /**
  * Workspace metrics definitions.
  * @namespace Blockly.utils.Metrics

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -17,6 +17,7 @@ goog.declareModuleId('Blockly.utils.object');
 
 import * as deprecation from './utils/deprecation.js';
 
+
 /**
  * Inherit the prototype methods from one constructor into another.
  * @param childCtor Child class.

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for objects.
  */
 
-
 /**
  * Utility methods for objects.
  * @namespace Blockly.utils.object

--- a/core/utils/parsing.ts
+++ b/core/utils/parsing.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods related to block and message parsing.
  */
 
-
 /**
  * @namespace Blockly.utils.parsing
  */

--- a/core/utils/rect.ts
+++ b/core/utils/rect.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for rectangle manipulation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/sentinel.ts
+++ b/core/utils/sentinel.ts
@@ -8,7 +8,6 @@
  * @fileoverview A type used to create flag values (e.g. SKIP_SETUP).
  */
 
-
 /**
  * A type used to create flag values.
  * @class

--- a/core/utils/size.ts
+++ b/core/utils/size.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for size calculation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/string.ts
+++ b/core/utils/string.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utility methods for string manipulation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/style.ts
+++ b/core/utils/style.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Utilities for element styles.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/svg.ts
+++ b/core/utils/svg.ts
@@ -9,7 +9,6 @@
  * all SVG tag names used by Blockly.
  */
 
-
 /**
  * Defines the Svg class. Its constants enumerate
  * all SVG tag names used by Blockly.

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility methods for SVG math.
  */
 
-
 /**
  * Utility methods realted to figuring out positions of SVG elements.
  * @namespace Blockly.utils.svgMath
@@ -43,7 +42,6 @@ const XY_REGEX: RegExp = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
  */
 const XY_STYLE_REGEX: RegExp =
     /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
-
 
 /**
  * Return the coordinates of the top-left corner of this element relative to
@@ -264,7 +262,6 @@ export function svgSize(svg: SVGElement): Size {
       Number(svg.getAttribute('data-cached-width')),
       Number(svg.getAttribute('data-cached-height')));
 }
-
 
 export const TEST_ONLY = {
   XY_REGEX,

--- a/core/utils/svg_paths.ts
+++ b/core/utils/svg_paths.ts
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * Methods for creating parts of SVG path strings.  See
  * @namespace Blockly.utils.svgPaths

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for the toolbox and flyout.
  */
 
-
 /**
  * Utility functions for the toolbox and flyout.
  * @namespace Blockly.utils.toolbox

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -27,8 +27,8 @@ import {ConnectionState} from '../serialization/blocks.js';
 import {CssConfig as CategoryCssConfig} from '../toolbox/category.js';
 import {CssConfig as SeparatorCssConfig} from '../toolbox/separator.js';
 import * as Xml from '../xml.js';
-
 import * as userAgent from './useragent.js';
+
 
 /**
  * The information needed to create a block in the toolbox.

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * Useragent detection.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -19,6 +19,7 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.userAgent');
 
+
 /** The raw useragent string. */
 let rawUserAgent: string;
 

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -10,7 +10,6 @@
  * a JavaScript framework such as Closure.
  */
 
-
 /**
  * XML element manipulation.
  * These methods are not specific to Blockly, and could be factored out into

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -19,6 +19,7 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.xml');
 
+
 /**
  * Namespace for Blockly's XML.
  * @alias Blockly.utils.xml.NAME_SPACE

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a map of variables and their types.
  */
 
-
 /**
  * Object representing a map of variables and their types.
  * @class

--- a/core/variable_model.ts
+++ b/core/variable_model.ts
@@ -8,7 +8,6 @@
  * @fileoverview Components for the variable model.
  */
 
-
 /**
  * Components for the variable model.
  * @class

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -26,6 +26,7 @@ import {Workspace} from './workspace.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 import * as Xml from './xml.js';
 
+
 /**
  * String for use in the "custom" attribute of a category in toolbox XML.
  * This string indicates that the category should be dynamically populated with

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for handling variables.
  */
 
-
 /**
  * Utility functions for handling variables.
  * @namespace Blockly.Variables

--- a/core/variables_dynamic.ts
+++ b/core/variables_dynamic.ts
@@ -8,7 +8,6 @@
  * @fileoverview Utility functions for handling typed variables.
  */
 
-
 /**
  * Utility functions for handling typed variables.
  *
@@ -83,7 +82,6 @@ export function flyoutCategory(workspace: WorkspaceSvg): Element[] {
       'CREATE_VARIABLE_NUMBER', numberButtonClickHandler);
   workspace.registerButtonCallback(
       'CREATE_VARIABLE_COLOUR', colourButtonClickHandler);
-
 
   // AnyDuringMigration because:  Argument of type 'WorkspaceSvg' is not
   // assignable to parameter of type 'Workspace'.

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a warning.
  */
 
-
 /**
  * Object representing a warning.
  * @class

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -10,7 +10,6 @@
  *     E.g. text input areas, colour pickers, context menus.
  */
 
-
 /**
  * A div that floats on top of Blockly.  This singleton contains
  *     temporary HTML UI widgets that the user is currently interacting with.

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a workspace.
  */
 
-
 /**
  * Object representing a workspace.
  * @class

--- a/core/workspace_audio.ts
+++ b/core/workspace_audio.ts
@@ -9,7 +9,6 @@
  *     workspace.
  */
 
-
 /**
  * Object in charge of loading, storing, and playing audio for a
  *     workspace.

--- a/core/workspace_comment.ts
+++ b/core/workspace_comment.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a code comment on the workspace.
  */
 
-
 /**
  * Object representing a code comment on the workspace.
  * @class

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a code comment on a rendered workspace.
  */
 
-
 /**
  * Object representing a code comment on a rendered workspace.
  * @class

--- a/core/workspace_drag_surface_svg.ts
+++ b/core/workspace_drag_surface_svg.ts
@@ -11,8 +11,6 @@
  * blocks are never repainted during drag improving performance.
  */
 
-
-
 /**
  * An SVG that floats on top of the workspace.
  * Blocks are moved into this SVG during a drag, improving performance.

--- a/core/workspace_dragger.ts
+++ b/core/workspace_dragger.ts
@@ -8,7 +8,6 @@
  * @fileoverview Methods for dragging a workspace visually.
  */
 
-
 /**
  * Methods for dragging a workspace visually.
  * @class

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a workspace rendered as SVG.
  */
 
-
 /**
  * Object representing a workspace rendered as SVG.
  * @class

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -8,7 +8,6 @@
  * @fileoverview XML reader and writer.
  */
 
-
 /**
  * XML reader and writer.
  * @namespace Blockly.Xml
@@ -905,7 +904,6 @@ function applyNextTagNodes(
     }
   }
 }
-
 
 /**
  * Decode an XML block tag and create a block (and possibly sub blocks) on the

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -8,7 +8,6 @@
  * @fileoverview Object representing a zoom icons.
  */
 
-
 /**
  * Object representing a zoom icons.
  * @class


### PR DESCRIPTION
## The basics

- [X] I branched from ts/migration
- [X] My pull request is against ts/migration
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Fix whitespace so that each file has exactly one pair of blank lines, between the imports (or module declaration) and the beginning of the main body of the module.

### Reason for Changes

Conform to style guide / established precedent.

### Test Coverage

No.
