### PR TITLE
fix(build): Have `npm run prepare` do nothing when running in CI

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ module.exports = {
   buildCompiled: buildTasks.compiled,
   buildAdvancedCompilationTest: buildTasks.advancedCompilationTest,
   buildJavaScript: buildTasks.javaScript,
-  buildJavaScriptAndDeps: gulp.series(buildTasks.javaScript, buildTasks.deps),
+  buildJavaScriptAndDeps: buildTasks.javaScriptAndDeps,
   // TODO(5621): Re-enable once typings generation is fixed.
   // checkin: gulp.parallel(buildTasks.checkinBuilt, typings.checkinTypings),
   checkin: gulp.parallel(buildTasks.checkinBuilt),
@@ -48,6 +48,7 @@ module.exports = {
   // typings: gulp.series(typings.typings, typings.msgTypings),
   // checkinTypings: typings.checkinTypings,
   package: packageTasks.package,
+  prepare: buildTasks.prepare,
   checkLicenses: licenseTasks.checkLicenses,
   recompile: releaseTasks.recompile,
   prepareDemos: appengineTasks.prepareDemos,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "license": "gulp checkLicenses",
     "lint": "eslint .",
     "package": "gulp package",
-    "prepare": "gulp buildJavaScriptAndDeps",
+    "prepare": "gulp prepare",
     "prepareDemos": "gulp prepareDemos",
     "publish": "gulp publish",
     "publish:beta": "gulp publishBeta",

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -273,6 +273,26 @@ var JSCOMP_OFF = [
 ];
 
 /**
+ * The npm prepare script, run by npm install after installing modules
+ * and as part of the packaging process.
+ *
+ * This does just enough of the build that npm start should work.
+ *
+ * Exception: when running in the CI environment, we don't build
+ * anything.  We don't need to, because npm test will build everything
+ * needed, and we don't want to, because a tsc error would prevent
+ * other workflows (like lint and format) from completing.
+ */
+function prepare() {
+  if (process.env.CI) {
+    return gulp.src('.');  // Do nothing.
+  }
+  return buildJavaScriptAndDeps();
+}
+
+const buildJavaScriptAndDeps = gulp.series(buildJavaScript, buildDeps);
+
+/**
  * Builds Blockly as a JS program, by running tsc on all the files in
  * the core directory.  This must be run before buildDeps or
  * buildCompiled.
@@ -697,7 +717,9 @@ function format() {
 };
 
 module.exports = {
+  prepare: prepare,
   build: build,
+  javaScriptAndDeps: buildJavaScriptAndDeps,
   javaScript: buildJavaScript,
   deps: buildDeps,
   generateLangfiles: generateLangfiles,


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from ts/migration
- [X] My pull request is against ts/migration
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Have `npm run prepare` (which is done automatically by `npm install`) do nothing when running in CI.

We don't need to do any building, because `npm test` will build everything needed in the workflows in which it is run, and we don't want to build anything in other workflows because a `tsc` error would prevent those workflows from completing.

#### Behaviour Before Change

`npm run prepare` (and `npm install`) fail if there are `tsc` errors, causing the clang-formatter and lint workflows to abort unnecessarily.

#### Behaviour After Change

Only the workflows that run `npm test` should fail if there are `tsc` errors.

### Reason for Changes

More useful CI feedback.

### Test Coverage

Have a look at the CI runs for this PR!

