### PR TITLE
fix: properly export interfaces that were typedefs

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -2102,8 +2102,13 @@ export class Block implements IASTNodeLocation, IDeletable {
     return msg;
   }
 }
-export interface CommentModel {
-  text: string|null;
-  pinned: boolean;
-  size: Size;
+
+export namespace Block {
+  export interface CommentModel {
+    text: string|null;
+    pinned: boolean;
+    size: Size;
+  }
 }
+
+export type CommentModel = Block.CommentModel;

--- a/core/component_manager.ts
+++ b/core/component_manager.ts
@@ -211,8 +211,14 @@ export class ComponentManager {
     return components;
   }
 }
-export interface ComponentDatum {
-  component: IComponent;
-  capabilities: Array<string|Capability<IComponent>>;
-  weight: number;
+
+export namespace ComponentManager {
+  /** An object storing component information. */
+  export interface ComponentDatum {
+    component: IComponent;
+    capabilities: Array<string|Capability<IComponent>>;
+    weight: number;
+  }
 }
+
+export type ComponentDatum = ComponentManager.ComponentDatum;

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -31,8 +31,13 @@ export interface ICopyable extends ISelectable {
    */
   toCopyData: AnyDuringMigration;
 }
-export interface CopyData {
-  saveInfo: AnyDuringMigration|Element;
-  source: WorkspaceSvg;
-  typeCounts: AnyDuringMigration|null;
+
+export namespace ICopyable {
+  export interface CopyData {
+    saveInfo: AnyDuringMigration|Element;
+    source: WorkspaceSvg;
+    typeCounts: AnyDuringMigration|null;
+  }
 }
+
+export type CopyData = ICopyable.CopyData;

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -42,18 +42,6 @@ import {Workspace} from '../workspace.js';
  * @alias Blockly.ASTNode
  */
 export class ASTNode {
-  /** Object holding different types for an AST node. */
-  static types = {
-    FIELD: 'field',
-    BLOCK: 'block',
-    INPUT: 'input',
-    OUTPUT: 'output',
-    NEXT: 'next',
-    PREVIOUS: 'previous',
-    STACK: 'stack',
-    WORKSPACE: 'workspace',
-  };
-
   /**
    * True to navigate to all fields. False to only navigate to clickable fields.
    */
@@ -699,9 +687,24 @@ export namespace ASTNode {
   export interface Params {
     wsCoordinate: Coordinate;
   }
+
+  export enum types {
+    FIELD = 'field',
+    BLOCK = 'block',
+    INPUT = 'input',
+    OUTPUT = 'output',
+    NEXT = 'next',
+    PREVIOUS = 'previous',
+    STACK = 'stack',
+    WORKSPACE = 'workspace',
+  }
 }
 
 export type Params = ASTNode.Params;
+// No need to export ASTNode.types from the module at this time because (1) it
+// wasn't automatically converted by the automatic migration script, (2) the
+// name doesn't follow the styleguide.
+
 
 /**
  * Gets the parent connection on a block.

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -694,9 +694,14 @@ export class ASTNode {
     return astNode;
   }
 }
-export interface Params {
-  wsCoordinate: Coordinate;
+
+export namespace ASTNode {
+  export interface Params {
+    wsCoordinate: Coordinate;
+  }
 }
+
+export type Params = ASTNode.Params;
 
 /**
  * Gets the parent connection on a block.

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -401,32 +401,56 @@ export class MetricsManager implements IMetricsManager {
     };
   }
 }
-export interface ToolboxMetrics {
-  width: number;
-  height: number;
-  position: toolboxUtils.Position;
+
+export namespace MetricsManager {
+  /**
+   * Describes the width, height and location of the toolbox on the main
+   * workspace.
+   */
+  export interface ToolboxMetrics {
+    width: number;
+    height: number;
+    position: toolboxUtils.Position;
+  }
+
+  /** Describes where the viewport starts in relation to the workspace SVG. */
+  export interface AbsoluteMetrics {
+    left: number;
+    top: number;
+  }
+
+  /**
+   * All the measurements needed to describe the size and location of a
+   * container.
+   */
+  export interface ContainerRegion {
+    height: number;
+    width: number;
+    top: number;
+    left: number;
+  }
+
+  /** Describes fixed edges of the workspace. */
+  export interface FixedEdges {
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+  }
+
+  /** Common metrics used for UI elements. */
+  export interface UiMetrics {
+    viewMetrics: ContainerRegion;
+    absoluteMetrics: AbsoluteMetrics;
+    toolboxMetrics: ToolboxMetrics;
+  }
 }
-export interface AbsoluteMetrics {
-  left: number;
-  top: number;
-}
-export interface ContainerRegion {
-  height: number;
-  width: number;
-  top: number;
-  left: number;
-}
-export interface FixedEdges {
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-}
-export interface UiMetrics {
-  viewMetrics: ContainerRegion;
-  absoluteMetrics: AbsoluteMetrics;
-  toolboxMetrics: ToolboxMetrics;
-}
+
+export type ToolboxMetrics = MetricsManager.ToolboxMetrics;
+export type AbsoluteMetrics = MetricsManager.AbsoluteMetrics;
+export type ContainerRegion = MetricsManager.ContainerRegion;
+export type FixedEdges = MetricsManager.FixedEdges;
+export type UiMetrics = MetricsManager.UiMetrics;
 
 registry.register(
     registry.Type.METRICS_MANAGER, registry.DEFAULT, MetricsManager);

--- a/core/options.ts
+++ b/core/options.ts
@@ -427,27 +427,38 @@ export class Options {
         theme.name || 'builtin' + idGenerator.getNextUniqueId(), theme);
   }
 }
-export interface GridOptions {
-  colour: string;
-  length: number;
-  snap: boolean;
-  spacing: number;
+
+export namespace Options {
+  export interface GridOptions {
+    colour: string;
+    length: number;
+    snap: boolean;
+    spacing: number;
+  }
+
+  export interface MoveOptions {
+    drag: boolean;
+    scrollbars: boolean|ScrollbarOptions;
+    wheel: boolean;
+  }
+
+  export interface ScrollbarOptions {
+    horizontal: boolean;
+    vertical: boolean;
+  }
+
+  export interface ZoomOptions {
+    controls: boolean;
+    maxScale: number;
+    minScale: number;
+    pinch: boolean;
+    scaleSpeed: number;
+    startScale: number;
+    wheel: boolean;
+  }
 }
-export interface MoveOptions {
-  drag: boolean;
-  scrollbars: boolean|ScrollbarOptions;
-  wheel: boolean;
-}
-export interface ScrollbarOptions {
-  horizontal: boolean;
-  vertical: boolean;
-}
-export interface ZoomOptions {
-  controls: boolean;
-  maxScale: number;
-  minScale: number;
-  pinch: boolean;
-  scaleSpeed: number;
-  startScale: number;
-  wheel: boolean;
-}
+
+export type GridOptions = Options.GridOptions;
+export type MoveOptions = Options.MoveOptions;
+export type ScrollbarOptions = Options.ScrollbarOptions;
+export type ZoomOptions = Options.ZoomOptions;

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -399,8 +399,7 @@ export class ConstantProvider {
    */
   INSERTION_MARKER_OPACITY = 0.2;
 
-  /** Enum for connection shapes. */
-  SHAPES = Shapes;
+  SHAPES: {[key: string]: number} = {PUZZLE: 1, NOTCH: 2};
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   JAGGED_TEETH!: JaggedTeeth;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
@@ -1124,13 +1123,3 @@ export class ConstantProvider {
 }
 /* clang-format on */
 /* eslint-enable indent */
-
-enum Shapes {
-  PUZZLE = 1,
-  NOTCH = 2,
-}
-// No need to use namespace merging to apply Shapes to the ConstantProvider
-// class, because it was originally (and still) provided as an instance
-// property.
-// No need to export Shapes from this module at this time, because all code
-// (internal and external) accesses it as constantProviderInstance.SHAPES.

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -400,7 +400,7 @@ export class ConstantProvider {
   INSERTION_MARKER_OPACITY = 0.2;
 
   /** Enum for connection shapes. */
-  SHAPES = {PUZZLE: 1, NOTCH: 2};
+  SHAPES = Shapes;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   JAGGED_TEETH!: JaggedTeeth;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
@@ -1124,3 +1124,13 @@ export class ConstantProvider {
 }
 /* clang-format on */
 /* eslint-enable indent */
+
+enum Shapes {
+  PUZZLE = 1,
+  NOTCH = 2,
+}
+// No need to use namespace merging to apply Shapes to the ConstantProvider
+// class, because it was originally (and still) provided as an instance
+// property.
+// No need to export Shapes from this module at this time, because all code
+// (internal and external) accesses it as constantProviderInstance.SHAPES.

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -88,7 +88,7 @@ export class ConstantProvider extends BaseConstantProvider {
 
   override START_HAT_WIDTH = 96;
 
-  override SHAPES = Shapes;
+  override SHAPES = {HEXAGONAL: 1, ROUND: 2, SQUARE: 3, PUZZLE: 4, NOTCH: 5};
   SHAPE_IN_SHAPE_PADDING: AnyDuringMigration;
 
   override FULL_BLOCK_FIELDS = true;
@@ -856,16 +856,3 @@ export class ConstantProvider extends BaseConstantProvider {
   }
 }
 /* eslint-enable indent */
-
-enum Shapes {
-  HEXAGONAL = 1,
-  ROUND = 2,
-  SQUARE = 3,
-  PUZZLE = 4,
-  NOTCH = 5
-}
-// No need to use namespace merging to apply Shapes to the ConstantProvider
-// class, because it was originally (and still) provided as an instance
-// property.
-// No need to export Shapes from this module at this time, because all code
-// (internal and external) accesses it as constantProviderInstance.SHAPES.

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -88,7 +88,7 @@ export class ConstantProvider extends BaseConstantProvider {
 
   override START_HAT_WIDTH = 96;
 
-  override SHAPES = {HEXAGONAL: 1, ROUND: 2, SQUARE: 3, PUZZLE: 4, NOTCH: 5};
+  override SHAPES = Shapes;
   SHAPE_IN_SHAPE_PADDING: AnyDuringMigration;
 
   override FULL_BLOCK_FIELDS = true;
@@ -856,3 +856,16 @@ export class ConstantProvider extends BaseConstantProvider {
   }
 }
 /* eslint-enable indent */
+
+enum Shapes {
+  HEXAGONAL = 1,
+  ROUND = 2,
+  SQUARE = 3,
+  PUZZLE = 4,
+  NOTCH = 5
+}
+// No need to use namespace merging to apply Shapes to the ConstantProvider
+// class, because it was originally (and still) provided as an instance
+// property.
+// No need to export Shapes from this module at this time, because all code
+// (internal and external) accesses it as constantProviderInstance.SHAPES.

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -326,14 +326,18 @@ export class ShortcutRegistry {
   }
 }
 
-export interface KeyboardShortcut {
-  callback?: ((p1: Workspace, p2: Event, p3: KeyboardShortcut) => boolean);
-  name: string;
-  preconditionFn?: ((p1: Workspace) => boolean);
-  metadata?: object;
-  keyCodes?: (number|string)[];
-  allowCollision?: boolean;
+export namespace ShortcutRegistry {
+  export interface KeyboardShortcut {
+    callback?: ((p1: Workspace, p2: Event, p3: KeyboardShortcut) => boolean);
+    name: string;
+    preconditionFn?: ((p1: Workspace) => boolean);
+    metadata?: object;
+    keyCodes?: (number|string)[];
+    allowCollsion?: boolean;
+  }
 }
+
+export type KeyboardShortcut = ShortcutRegistry.KeyboardShortcut;
 
 // Creates and assigns the singleton instance.
 const registry = new ShortcutRegistry();

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -30,13 +30,6 @@ import {Workspace} from './workspace.js';
  * @alias Blockly.ShortcutRegistry
  */
 export class ShortcutRegistry {
-  /** Enum of valid modifiers. */
-  static modifierKeys = {
-    'Shift': KeyCodes.SHIFT,
-    'Control': KeyCodes.CTRL,
-    'Alt': KeyCodes.ALT,
-    'Meta': KeyCodes.META,
-  };
   static registry: AnyDuringMigration;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   private registry_!: {[key: string]: KeyboardShortcut};
@@ -335,9 +328,20 @@ export namespace ShortcutRegistry {
     keyCodes?: (number|string)[];
     allowCollision?: boolean;
   }
+
+  /** Supported modifiers. */
+  export enum modifierKeys {
+    Shift = KeyCodes.SHIFT,
+    Control = KeyCodes.CTRL,
+    Alt = KeyCodes.ALT,
+    Meta = KeyCodes.META,
+  }
 }
 
 export type KeyboardShortcut = ShortcutRegistry.KeyboardShortcut;
+// No need to export ShorcutRegistry.modifierKeys from the module at this time
+// because (1) it wasn't automatically converted by the automatic migration
+// script, (2) the name doesn't follow the styleguide.
 
 // Creates and assigns the singleton instance.
 const registry = new ShortcutRegistry();

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -333,7 +333,7 @@ export namespace ShortcutRegistry {
     preconditionFn?: ((p1: Workspace) => boolean);
     metadata?: object;
     keyCodes?: (number|string)[];
-    allowCollsion?: boolean;
+    allowCollision?: boolean;
   }
 }
 

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -165,35 +165,46 @@ export class Theme {
     return theme;
   }
 }
-export interface BlockStyle {
-  colourPrimary: string;
-  colourSecondary: string;
-  colourTertiary: string;
-  hat?: string;
+
+export namespace Theme {
+  export interface BlockStyle {
+    colourPrimary: string;
+    colourSecondary: string;
+    colourTertiary: string;
+    hat?: string;
+  }
+
+  export interface CategoryStyle {
+    colour: string;
+  }
+
+  export interface ComponentStyle {
+    workspaceBackgroundColour: string|null;
+    toolboxBackgroundColour: string|null;
+    toolboxForegroundColour: string|null;
+    flyoutBackgroundColour: string|null;
+    flyoutForegroundColour: string|null;
+    flyoutOpacity: number|null;
+    scrollbarColour: string|null;
+    scrollbarOpacity: number|null;
+    insertionMarkerColour: string|null;
+    insertionMarkerOpacity: number|null;
+    markerColour: string|null;
+    cursorColour: string|null;
+    selectedGlowColour: string|null;
+    selectedGlowOpacity: number|null;
+    replacementGlowColour: string|null;
+    replacementGlowOpacity: number|null;
+  }
+
+  export interface FontStyle {
+    family: string|null;
+    weight: string|null;
+    size: number|null;
+  }
 }
-export interface CategoryStyle {
-  colour: string;
-}
-export interface ComponentStyle {
-  workspaceBackgroundColour: string|null;
-  toolboxBackgroundColour: string|null;
-  toolboxForegroundColour: string|null;
-  flyoutBackgroundColour: string|null;
-  flyoutForegroundColour: string|null;
-  flyoutOpacity: number|null;
-  scrollbarColour: string|null;
-  scrollbarOpacity: number|null;
-  insertionMarkerColour: string|null;
-  insertionMarkerOpacity: number|null;
-  markerColour: string|null;
-  cursorColour: string|null;
-  selectedGlowColour: string|null;
-  selectedGlowOpacity: number|null;
-  replacementGlowColour: string|null;
-  replacementGlowOpacity: number|null;
-}
-export interface FontStyle {
-  family: string|null;
-  weight: string|null;
-  size: number|null;
-}
+
+export type BlockStyle = Theme.BlockStyle;
+export type CategoryStyle = Theme.CategoryStyle;
+export type ComponentStyle = Theme.ComponentStyle;
+export type FontStyle = Theme.FontStyle;

--- a/core/theme_manager.ts
+++ b/core/theme_manager.ts
@@ -185,7 +185,13 @@ export class ThemeManager {
     this.componentDB_ = null as AnyDuringMigration;
   }
 }
-export interface Component {
-  element: Element;
-  propertyName: string;
+
+export namespace ThemeManager {
+  /** The type for a Blockly UI Component. */
+  export interface Component {
+    element: Element;
+    propertyName: string;
+  }
 }
+
+export type Component = ThemeManager.Component;

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -585,16 +585,22 @@ export class ToolboxCategory extends ToolboxItem implements
     dom.removeNode(this.htmlDiv_);
   }
 }
-export interface CssConfig {
-  container: string|undefined;
-  row: string|undefined;
-  rowcontentcontainer: string|undefined;
-  icon: string|undefined;
-  label: string|undefined;
-  selected: string|undefined;
-  openicon: string|undefined;
-  closedicon: string|undefined;
+
+export namespace ToolboxCategory {
+  /** All the CSS class names that are used to create a category. */
+  export interface CssConfig {
+    container: string|undefined;
+    row: string|undefined;
+    rowcontentcontainer: string|undefined;
+    icon: string|undefined;
+    label: string|undefined;
+    selected: string|undefined;
+    openicon: string|undefined;
+    closedicon: string|undefined;
+  }
 }
+
+export type CssConfig = ToolboxCategory.CssConfig;
 
 /** CSS for Toolbox.  See css.js for use. */
 Css.register(`

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -249,17 +249,27 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
     return this.toolboxItems_;
   }
 }
-export interface CssConfig {
-  container: string|null;
-  row: string|null;
-  rowcontentcontainer: string|null;
-  icon: string|null;
-  label: string|null;
-  selected: string|null;
-  openicon: string|null;
-  closedicon: string|null;
-  contents: string|null;
+
+export namespace CollapsibleToolboxCategory {
+  /**
+   * All the CSS class names that are used to create a collapsible
+   * category. This is all the properties from the regular category plus
+   * contents.
+   */
+  export interface CssConfig {
+    container: string|null;
+    row: string|null;
+    rowcontentcontainer: string|null;
+    icon: string|null;
+    label: string|null;
+    selected: string|null;
+    openicon: string|null;
+    closedicon: string|null;
+    contents: string|null;
+  }
 }
+
+export type CssConfig = CollapsibleToolboxCategory.CssConfig;
 
 registry.register(
     registry.Type.TOOLBOX_ITEM, CollapsibleToolboxCategory.registrationName,

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -75,9 +75,14 @@ export class ToolboxSeparator extends ToolboxItem {
     dom.removeNode(this.htmlDiv_ as HTMLDivElement);
   }
 }
-export interface CssConfig {
-  container: string|undefined;
+
+export namespace ToolboxSeparator {
+  export interface CssConfig {
+    container: string|undefined;
+  }
 }
+
+export type CssConfig = ToolboxSeparator.CssConfig;
 
 /** CSS for Toolbox.  See css.js for use. */
 Css.register(`


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A
Follows the same strategy as #6246 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Typedefs that were on classes were transformed into interfaces, but they were not properly appended to the classes they used to exist on. This fixes that, and also exports the type to match the other places where the auto-migration script changed things.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Should be no change in behavior (besides whether these types exist or not).

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Should be no change in behavior (besides whether these types exist or not).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Backwards compatibility.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
No manual testing necessary.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I didn't include the `export const E = C.E;` line, because I don't believe we actually want these to be declared (at the module level) in the exported JavaScript.
