### PR TITLE
fix: renamed protected parameter properties

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -66,7 +66,6 @@ export class BlockDragger implements IBlockDragger {
    * @param workspace The workspace to drag on.
    */
   constructor(block: BlockSvg, workspace: WorkspaceSvg) {
-
     this.draggingBlock_ = block;
 
     /** Object that keeps track of connections on dragged blocks. */
@@ -222,8 +221,8 @@ export class BlockDragger implements IBlockDragger {
 
     blockAnimation.disconnectUiStop();
 
-    const preventMove =
-        !!this.dragTarget_ && this.dragTarget_.shouldPreventMove(this.draggingBlock_);
+    const preventMove = !!this.dragTarget_ &&
+        this.dragTarget_.shouldPreventMove(this.draggingBlock_);
     let newLoc: Coordinate;
     let delta: Coordinate|null = null;
     if (preventMove) {
@@ -328,7 +327,7 @@ export class BlockDragger implements IBlockDragger {
 
     if (toolbox) {
       const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-                                               'blocklyToolboxGrab';
+                                                        'blocklyToolboxGrab';
 
       // AnyDuringMigration because:  Property 'removeStyle' does not exist on
       // type 'IToolbox'.
@@ -351,8 +350,8 @@ export class BlockDragger implements IBlockDragger {
 
   /** Fire a move event at the end of a block drag. */
   protected fireMoveEvent_() {
-    const event =
-        new (eventUtils.get(eventUtils.BLOCK_MOVE))!(this.draggingBlock_) as BlockMove;
+    const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))!
+        (this.draggingBlock_) as BlockMove;
     event.oldCoordinate = this.startXY_;
     event.recordNew();
     eventUtils.fire(event);

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -50,6 +50,8 @@ export class Connection implements IASTNodeLocationWithBlock {
   static REASON_DRAG_CHECKS_FAILED = 7;
   static REASON_PREVIOUS_AND_OUTPUT = 8;
 
+  protected sourceBlock_: Block;
+
   /** Connection this connection connects to.  Null if not connected. */
   targetConnection: Connection|null = null;
 
@@ -86,7 +88,9 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @param source The block establishing this connection.
    * @param type The type of the connection.
    */
-  constructor(private readonly source: Block, public type: number) {}
+  constructor(source: Block, public type: number) {
+    this.sourceBlock_ = source;
+  }
 
   /**
    * Connect two connections together.  This is the connection on the superior
@@ -171,7 +175,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @return The source block.
    */
   getSourceBlock(): Block {
-    return this.source;
+    return this.sourceBlock_;
   }
 
   /**
@@ -198,7 +202,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @internal
    */
   getConnectionChecker(): IConnectionChecker {
-    return this.source.workspace.connectionChecker;
+    return this.sourceBlock_.workspace.connectionChecker;
   }
 
   /**
@@ -258,13 +262,13 @@ export class Connection implements IASTNodeLocationWithBlock {
     let parentConnection;
     if (this.isSuperior()) {
       // Superior block.
-      parentBlock = this.source;
+      parentBlock = this.sourceBlock_;
       childBlock = otherConnection.getSourceBlock();
       parentConnection = this;
     } else {
       // Inferior block.
       parentBlock = otherConnection.getSourceBlock();
-      childBlock = this.source;
+      childBlock = this.sourceBlock_;
       parentConnection = otherConnection;
     }
 
@@ -333,7 +337,7 @@ export class Connection implements IASTNodeLocationWithBlock {
         (!this.targetConnection ||
          !this.getConnectionChecker().canConnect(
              this, this.targetConnection, false))) {
-      const child = this.isSuperior() ? this.targetBlock() : this.source;
+      const child = this.isSuperior() ? this.targetBlock() : this.sourceBlock_;
       child!.unplug();
     }
   }
@@ -439,7 +443,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    */
   getParentInput(): Input|null {
     let parentInput = null;
-    const inputs = this.source.inputList;
+    const inputs = this.sourceBlock_.inputList;
     for (let i = 0; i < inputs.length; i++) {
       if (inputs[i].connection === this) {
         parentInput = inputs[i];
@@ -455,7 +459,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @return The description.
    */
   toString(): string {
-    const block = this.source;
+    const block = this.sourceBlock_;
     if (!block) {
       return 'Orphan Connection';
     }

--- a/core/flyout_metrics_manager.ts
+++ b/core/flyout_metrics_manager.ts
@@ -28,12 +28,16 @@ import {WorkspaceSvg} from './workspace_svg.js';
  * @alias Blockly.FlyoutMetricsManager
  */
 export class FlyoutMetricsManager extends MetricsManager {
+  /** The flyout that owns the workspace to calculate metrics for. */
+  protected flyout_: IFlyout;
+
   /**
    * @param workspace The flyout's workspace.
    * @param flyout The flyout.
    */
-  constructor(workspace: WorkspaceSvg, private readonly flyout: IFlyout) {
+  constructor(workspace: WorkspaceSvg, flyout: IFlyout) {
     super(workspace);
+    this.flyout_ = flyout;
   }
 
   /**
@@ -45,7 +49,7 @@ export class FlyoutMetricsManager extends MetricsManager {
       {height: number, y: number, width: number, x: number} {
     let blockBoundingBox;
     try {
-      blockBoundingBox = this.workspace.getCanvas().getBBox();
+      blockBoundingBox = this.workspace_.getCanvas().getBBox();
     } catch (e) {
       // Firefox has trouble with hidden elements (Bug 528969).
       // 2021 Update: It looks like this was fixed around Firefox 77 released in
@@ -58,7 +62,7 @@ export class FlyoutMetricsManager extends MetricsManager {
   override getContentMetrics(opt_getWorkspaceCoordinates: boolean) {
     // The bounding box is in workspace coordinates.
     const blockBoundingBox = this.getBoundingBox_();
-    const scale = opt_getWorkspaceCoordinates ? 1 : this.workspace.scale;
+    const scale = opt_getWorkspaceCoordinates ? 1 : this.workspace_.scale;
 
     return {
       height: blockBoundingBox.height * scale,
@@ -74,8 +78,8 @@ export class FlyoutMetricsManager extends MetricsManager {
     // AnyDuringMigration because:  Expected 1 arguments, but got 0.
     const contentMetrics =
         opt_contentMetrics || (this.getContentMetrics as AnyDuringMigration)();
-    const margin = this.flyout.MARGIN * this.workspace.scale;
-    const scale = opt_getWorkspaceCoordinates ? this.workspace.scale : 1;
+    const margin = this.flyout_.MARGIN * this.workspace_.scale;
+    const scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
 
     // The left padding isn't just the margin. Some blocks are also offset by
     // tabWidth so that value and statement blocks line up.

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -181,10 +181,9 @@ export class Gesture {
    *     reference to it.
    */
   constructor(
-      private e: Event,
-      private readonly creatorWorkspace: WorkspaceSvg) {
+      private e: Event, private readonly creatorWorkspace: WorkspaceSvg) {
     this.mostRecentEvent_ = e;
-    
+
     /**
      * How far the mouse has moved during this drag, in pixel units.
      * (0, 0) is at this.mouseDownXY_.
@@ -417,7 +416,8 @@ export class Gesture {
     this.bubbleDragger_ =
         new BubbleDragger((this.startBubble_), (this.startWorkspace_));
     this.bubbleDragger_.startBubbleDrag();
-    this.bubbleDragger_.dragBubble(this.mostRecentEvent_, this.currentDragDeltaXY_);
+    this.bubbleDragger_.dragBubble(
+        this.mostRecentEvent_, this.currentDragDeltaXY_);
   }
 
   /**
@@ -508,7 +508,8 @@ export class Gesture {
     } else if (this.isDraggingBlock_) {
       this.blockDragger_!.drag(this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingBubble_) {
-      this.bubbleDragger_.dragBubble(this.mostRecentEvent_, this.currentDragDeltaXY_);
+      this.bubbleDragger_.dragBubble(
+          this.mostRecentEvent_, this.currentDragDeltaXY_);
     }
     e.preventDefault();
     e.stopPropagation();
@@ -570,9 +571,11 @@ export class Gesture {
     }
     Touch.longStop();
     if (this.isDraggingBubble_) {
-      this.bubbleDragger_.endBubbleDrag(this.mostRecentEvent_, this.currentDragDeltaXY_);
+      this.bubbleDragger_.endBubbleDrag(
+          this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingBlock_) {
-      this.blockDragger_!.endDrag(this.mostRecentEvent_, this.currentDragDeltaXY_);
+      this.blockDragger_!.endDrag(
+          this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingWorkspace_) {
       this.workspaceDragger_.endDrag(this.currentDragDeltaXY_);
     }

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -180,8 +180,7 @@ export class Gesture {
    * @param creatorWorkspace The workspace that created this gesture and has a
    *     reference to it.
    */
-  constructor(
-      private e: Event, private readonly creatorWorkspace: WorkspaceSvg) {
+  constructor(e: Event, private readonly creatorWorkspace: WorkspaceSvg) {
     this.mostRecentEvent_ = e;
 
     /**

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -172,13 +172,19 @@ export class Gesture {
   protected isEnding_ = false;
   private healStack_: boolean;
 
+  /** The event that most recently updated this gesture. */
+  private mostRecentEvent_: Event;
+
   /**
    * @param e The event that kicked off this gesture.
    * @param creatorWorkspace The workspace that created this gesture and has a
    *     reference to it.
    */
   constructor(
-      private e: Event, private readonly creatorWorkspace: WorkspaceSvg) {
+      private e: Event,
+      private readonly creatorWorkspace: WorkspaceSvg) {
+    this.mostRecentEvent_ = e;
+    
     /**
      * How far the mouse has moved during this drag, in pixel units.
      * (0, 0) is at this.mouseDownXY_.
@@ -236,7 +242,7 @@ export class Gesture {
       this.updateIsDragging_();
       Touch.longStop();
     }
-    this.e = e;
+    this.mostRecentEvent_ = e;
   }
 
   /**
@@ -402,7 +408,7 @@ export class Gesture {
     this.blockDragger_ =
         new BlockDraggerClass!((this.targetBlock_), (this.startWorkspace_));
     this.blockDragger_!.startDrag(this.currentDragDeltaXY_, this.healStack_);
-    this.blockDragger_!.drag(this.e, this.currentDragDeltaXY_);
+    this.blockDragger_!.drag(this.mostRecentEvent_, this.currentDragDeltaXY_);
   }
 
   // TODO (fenichel): Possibly combine this and startDraggingBlock_.
@@ -411,7 +417,7 @@ export class Gesture {
     this.bubbleDragger_ =
         new BubbleDragger((this.startBubble_), (this.startWorkspace_));
     this.bubbleDragger_.startBubbleDrag();
-    this.bubbleDragger_.dragBubble(this.e, this.currentDragDeltaXY_);
+    this.bubbleDragger_.dragBubble(this.mostRecentEvent_, this.currentDragDeltaXY_);
   }
 
   /**
@@ -439,7 +445,7 @@ export class Gesture {
     this.startWorkspace_.hideChaff(!!this.flyout_);
 
     this.startWorkspace_.markFocused();
-    this.e = e;
+    this.mostRecentEvent_ = e;
 
     Tooltip.block();
 
@@ -500,9 +506,9 @@ export class Gesture {
     if (this.isDraggingWorkspace_) {
       this.workspaceDragger_.drag(this.currentDragDeltaXY_);
     } else if (this.isDraggingBlock_) {
-      this.blockDragger_!.drag(this.e, this.currentDragDeltaXY_);
+      this.blockDragger_!.drag(this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingBubble_) {
-      this.bubbleDragger_.dragBubble(this.e, this.currentDragDeltaXY_);
+      this.bubbleDragger_.dragBubble(this.mostRecentEvent_, this.currentDragDeltaXY_);
     }
     e.preventDefault();
     e.stopPropagation();
@@ -564,9 +570,9 @@ export class Gesture {
     }
     Touch.longStop();
     if (this.isDraggingBubble_) {
-      this.bubbleDragger_.endBubbleDrag(this.e, this.currentDragDeltaXY_);
+      this.bubbleDragger_.endBubbleDrag(this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingBlock_) {
-      this.blockDragger_!.endDrag(this.e, this.currentDragDeltaXY_);
+      this.blockDragger_!.endDrag(this.mostRecentEvent_, this.currentDragDeltaXY_);
     } else if (this.isDraggingWorkspace_) {
       this.workspaceDragger_.endDrag(this.currentDragDeltaXY_);
     }
@@ -610,7 +616,7 @@ export class Gesture {
           'but the gesture had already been started.');
     }
     this.setStartWorkspace_(ws);
-    this.e = e;
+    this.mostRecentEvent_ = e;
     this.doStart(e);
   }
 
@@ -652,7 +658,7 @@ export class Gesture {
           'but the gesture had already been started.');
     }
     this.setStartBlock(block);
-    this.e = e;
+    this.mostRecentEvent_ = e;
   }
 
   /**
@@ -668,7 +674,7 @@ export class Gesture {
           'but the gesture had already been started.');
     }
     this.setStartBubble(bubble);
-    this.e = e;
+    this.mostRecentEvent_ = e;
   }
 
   /* Begin functions defining what actions to take to execute clicks on each
@@ -686,7 +692,7 @@ export class Gesture {
 
   /** Execute a field click. */
   private doFieldClick_() {
-    this.startField_.showEditor(this.e);
+    this.startField_.showEditor(this.mostRecentEvent_);
     this.bringBlockToFront_();
   }
 

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -35,8 +35,13 @@ import {WorkspaceSvg} from './workspace_svg.js';
  * @alias Blockly.MetricsManager
  */
 export class MetricsManager implements IMetricsManager {
+  /** The workspace to calculate metrics for. */
+  protected readonly workspace_: WorkspaceSvg;
+
   /** @param workspace The workspace to calculate metrics for. */
-  constructor(protected readonly workspace: WorkspaceSvg) {}
+  constructor(workspace: WorkspaceSvg) {
+    this.workspace_ = workspace;
+  }
 
   /**
    * Gets the dimensions of the given workspace component, in pixel coordinates.
@@ -64,11 +69,11 @@ export class MetricsManager implements IMetricsManager {
    */
   getFlyoutMetrics(opt_own?: boolean): ToolboxMetrics {
     const flyoutDimensions =
-        this.getDimensionsPx_(this.workspace.getFlyout(opt_own));
+        this.getDimensionsPx_(this.workspace_.getFlyout(opt_own));
     return {
       width: flyoutDimensions.width,
       height: flyoutDimensions.height,
-      position: this.workspace.toolboxPosition,
+      position: this.workspace_.toolboxPosition,
     };
   }
 
@@ -82,12 +87,12 @@ export class MetricsManager implements IMetricsManager {
    */
   getToolboxMetrics(): ToolboxMetrics {
     const toolboxDimensions =
-        this.getDimensionsPx_(this.workspace.getToolbox());
+        this.getDimensionsPx_(this.workspace_.getToolbox());
 
     return {
       width: toolboxDimensions.width,
       height: toolboxDimensions.height,
-      position: this.workspace.toolboxPosition,
+      position: this.workspace_.toolboxPosition,
     };
   }
 
@@ -97,7 +102,7 @@ export class MetricsManager implements IMetricsManager {
    * @return The width and height of the workspace's parent SVG element.
    */
   getSvgMetrics(): Size {
-    return this.workspace.getCachedParentSvgSize();
+    return this.workspace_.getCachedParentSvgSize();
   }
 
   /**
@@ -110,8 +115,8 @@ export class MetricsManager implements IMetricsManager {
     let absoluteLeft = 0;
     const toolboxMetrics = this.getToolboxMetrics();
     const flyoutMetrics = this.getFlyoutMetrics(true);
-    const doesToolboxExist = !!this.workspace.getToolbox();
-    const doesFlyoutExist = !!this.workspace.getFlyout(true);
+    const doesToolboxExist = !!this.workspace_.getToolbox();
+    const doesFlyoutExist = !!this.workspace_.getFlyout(true);
     const toolboxPosition =
         doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
@@ -144,15 +149,15 @@ export class MetricsManager implements IMetricsManager {
    *     coordinates or pixel coordinates.
    */
   getViewMetrics(opt_getWorkspaceCoordinates?: boolean): ContainerRegion {
-    const scale = opt_getWorkspaceCoordinates ? this.workspace.scale : 1;
+    const scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
     const svgMetrics = this.getSvgMetrics();
     const toolboxMetrics = this.getToolboxMetrics();
     const flyoutMetrics = this.getFlyoutMetrics(true);
-    const doesToolboxExist = !!this.workspace.getToolbox();
+    const doesToolboxExist = !!this.workspace_.getToolbox();
     const toolboxPosition =
         doesToolboxExist ? toolboxMetrics.position : flyoutMetrics.position;
 
-    if (this.workspace.getToolbox()) {
+    if (this.workspace_.getToolbox()) {
       if (toolboxPosition === toolboxUtils.Position.TOP ||
           toolboxPosition === toolboxUtils.Position.BOTTOM) {
         svgMetrics.height -= toolboxMetrics.height;
@@ -161,7 +166,7 @@ export class MetricsManager implements IMetricsManager {
           toolboxPosition === toolboxUtils.Position.RIGHT) {
         svgMetrics.width -= toolboxMetrics.width;
       }
-    } else if (this.workspace.getFlyout(true)) {
+    } else if (this.workspace_.getFlyout(true)) {
       if (toolboxPosition === toolboxUtils.Position.TOP ||
           toolboxPosition === toolboxUtils.Position.BOTTOM) {
         svgMetrics.height -= flyoutMetrics.height;
@@ -174,8 +179,8 @@ export class MetricsManager implements IMetricsManager {
     return {
       height: svgMetrics.height / scale,
       width: svgMetrics.width / scale,
-      top: -this.workspace.scrollY / scale,
-      left: -this.workspace.scrollX / scale,
+      top: -this.workspace_.scrollY / scale,
+      left: -this.workspace_.scrollX / scale,
     };
   }
 
@@ -188,9 +193,9 @@ export class MetricsManager implements IMetricsManager {
    * @return The metrics for the content container.
    */
   getContentMetrics(opt_getWorkspaceCoordinates?: boolean): ContainerRegion {
-    const scale = opt_getWorkspaceCoordinates ? 1 : this.workspace.scale;
+    const scale = opt_getWorkspaceCoordinates ? 1 : this.workspace_.scale;
     // Block bounding box is in workspace coordinates.
-    const blockBox = this.workspace.getBlocksBoundingBox();
+    const blockBox = this.workspace_.getBlocksBoundingBox();
 
     return {
       height: (blockBox.bottom - blockBox.top) * scale,
@@ -207,8 +212,8 @@ export class MetricsManager implements IMetricsManager {
    */
   hasFixedEdges(): boolean {
     // This exists for optimization of bump logic.
-    return !this.workspace.isMovableHorizontally() ||
-        !this.workspace.isMovableVertically();
+    return !this.workspace_.isMovableHorizontally() ||
+        !this.workspace_.isMovableVertically();
   }
 
   /**
@@ -225,8 +230,8 @@ export class MetricsManager implements IMetricsManager {
       return {};
     }
 
-    const hScrollEnabled = this.workspace.isMovableHorizontally();
-    const vScrollEnabled = this.workspace.isMovableVertically();
+    const hScrollEnabled = this.workspace_.isMovableHorizontally();
+    const vScrollEnabled = this.workspace_.isMovableVertically();
 
     const viewMetrics = opt_viewMetrics || this.getViewMetrics(false);
 
@@ -288,7 +293,7 @@ export class MetricsManager implements IMetricsManager {
   getScrollMetrics(
       opt_getWorkspaceCoordinates?: boolean, opt_viewMetrics?: ContainerRegion,
       opt_contentMetrics?: ContainerRegion): ContainerRegion {
-    const scale = opt_getWorkspaceCoordinates ? this.workspace.scale : 1;
+    const scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
     const viewMetrics = opt_viewMetrics || this.getViewMetrics(false);
     const contentMetrics = opt_contentMetrics || this.getContentMetrics();
     const fixedEdges = this.getComputedFixedEdges_(viewMetrics);

--- a/core/renderers/common/info.ts
+++ b/core/renderers/common/info.ts
@@ -67,6 +67,9 @@ export class RenderInfo {
   isInsertionMarker: boolean;
   RTL: boolean;
 
+  /** The block renderer in use. */
+  protected readonly renderer_: Renderer;
+
   /** The height of the rendered block, including child blocks. */
   height = 0;
 
@@ -101,11 +104,13 @@ export class RenderInfo {
    * @param block The block to measure.
    * @internal
    */
-  constructor(protected readonly renderer: Renderer, block: BlockSvg) {
+  constructor(renderer: Renderer, block: BlockSvg) {
+    this.renderer_ = renderer;
+
     this.block_ = block;
 
     /** The renderer's constant provider. */
-    this.constants_ = this.renderer.getConstants();
+    this.constants_ = this.renderer_.getConstants();
 
     /**
      * A measurable representing the output connection if the block has one.
@@ -154,7 +159,7 @@ export class RenderInfo {
    * @internal
    */
   getRenderer(): Renderer {
-    return this.renderer;
+    return this.renderer_;
   }
 
   /**

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -81,6 +81,9 @@ export class MarkerSvg {
 
   protected markerSvgRect_: SVGRectElement|null = null;
 
+  /** The constants necessary to draw the marker. */
+  protected constants_: ConstantProvider;
+
   /**
    * @param workspace The workspace the marker belongs to.
    * @param constants The constants for the renderer.
@@ -88,9 +91,11 @@ export class MarkerSvg {
    */
   constructor(
       private readonly workspace: WorkspaceSvg,
-      private constants: ConstantProvider, private readonly marker: Marker) {
-    const defaultColour = this.isCursor() ? this.constants.CURSOR_COLOUR :
-                                            this.constants.MARKER_COLOUR;
+      constants: ConstantProvider, private readonly marker: Marker) {
+    this.constants_ = constants;
+
+    const defaultColour = this.isCursor() ? this.constants_.CURSOR_COLOUR :
+                                            this.constants_.MARKER_COLOUR;
 
     /** The colour of the marker. */
     this.colour_ = marker.colour || defaultColour;
@@ -168,10 +173,10 @@ export class MarkerSvg {
       return;
     }
 
-    this.constants = this.workspace.getRenderer().getConstants();
+    this.constants_ = this.workspace.getRenderer().getConstants();
 
-    const defaultColour = this.isCursor() ? this.constants.CURSOR_COLOUR :
-                                            this.constants.MARKER_COLOUR;
+    const defaultColour = this.isCursor() ? this.constants_.CURSOR_COLOUR :
+                                            this.constants_.MARKER_COLOUR;
     this.colour_ = this.marker.colour || defaultColour;
     this.applyColour_(curNode);
 
@@ -226,17 +231,17 @@ export class MarkerSvg {
     const width = block.width;
     const height = block.height;
     const markerHeight = height * HEIGHT_MULTIPLIER;
-    const markerOffset = this.constants.CURSOR_BLOCK_PADDING;
+    const markerOffset = this.constants_.CURSOR_BLOCK_PADDING;
 
     if (block.previousConnection) {
       const connectionShape =
-          this.constants.shapeFor(block.previousConnection) as Notch |
+          this.constants_.shapeFor(block.previousConnection) as Notch |
           PuzzleTab;
       this.positionPrevious_(
           width, markerOffset, markerHeight, connectionShape);
     } else if (block.outputConnection) {
       const connectionShape =
-          this.constants.shapeFor(block.outputConnection) as Notch | PuzzleTab;
+          this.constants_.shapeFor(block.outputConnection) as Notch | PuzzleTab;
       this.positionOutput_(width, height, connectionShape);
     } else {
       this.positionBlock_(width, markerOffset, markerHeight);
@@ -280,10 +285,10 @@ export class MarkerSvg {
     const y = wsCoordinate.y;
 
     if (this.workspace.RTL) {
-      x -= this.constants.CURSOR_WS_WIDTH;
+      x -= this.constants_.CURSOR_WS_WIDTH;
     }
 
-    this.positionLine_(x, y, this.constants.CURSOR_WS_WIDTH);
+    this.positionLine_(x, y, this.constants_.CURSOR_WS_WIDTH);
     this.setParent_(this.workspace);
     this.showCurrent_();
   }
@@ -349,13 +354,13 @@ export class MarkerSvg {
 
     // Add padding so that being on a stack looks different than being on a
     // block.
-    const width = heightWidth.width + this.constants.CURSOR_STACK_PADDING;
-    const height = heightWidth.height + this.constants.CURSOR_STACK_PADDING;
+    const width = heightWidth.width + this.constants_.CURSOR_STACK_PADDING;
+    const height = heightWidth.height + this.constants_.CURSOR_STACK_PADDING;
 
     // Shift the rectangle slightly to upper left so padding is equal on all
     // sides.
-    const xPadding = -this.constants.CURSOR_STACK_PADDING / 2;
-    const yPadding = -this.constants.CURSOR_STACK_PADDING / 2;
+    const xPadding = -this.constants_.CURSOR_STACK_PADDING / 2;
+    const yPadding = -this.constants_.CURSOR_STACK_PADDING / 2;
 
     let x = xPadding;
     const y = yPadding;
@@ -412,7 +417,7 @@ export class MarkerSvg {
     const y = connection.getOffsetInBlock().y;
 
     const path = svgPaths.moveTo(0, 0) +
-        (this.constants.shapeFor(connection) as PuzzleTab).pathDown;
+        (this.constants_.shapeFor(connection) as PuzzleTab).pathDown;
 
     this.markerInput_!.setAttribute('d', path);
     this.markerInput_!.setAttribute(
@@ -455,7 +460,7 @@ export class MarkerSvg {
     // 'Notch | PuzzleTab'.
     const markerPath = svgPaths.moveBy(width, 0) +
         svgPaths.lineOnAxis('h', -(width - connectionShape.width)) +
-        svgPaths.lineOnAxis('v', this.constants.TAB_OFFSET_FROM_TOP) +
+        svgPaths.lineOnAxis('v', this.constants_.TAB_OFFSET_FROM_TOP) +
         (connectionShape as AnyDuringMigration).pathDown +
         svgPaths.lineOnAxis('V', height) + svgPaths.lineOnAxis('H', width);
     this.markerBlock_!.setAttribute('d', markerPath);
@@ -483,7 +488,7 @@ export class MarkerSvg {
     // 'Notch | PuzzleTab'.
     const markerPath = svgPaths.moveBy(-markerOffset, markerHeight) +
         svgPaths.lineOnAxis('V', -markerOffset) +
-        svgPaths.lineOnAxis('H', this.constants.NOTCH_OFFSET_LEFT) +
+        svgPaths.lineOnAxis('H', this.constants_.NOTCH_OFFSET_LEFT) +
         (connectionShape as AnyDuringMigration).pathLeft +
         svgPaths.lineOnAxis('H', width + markerOffset * 2) +
         svgPaths.lineOnAxis('V', markerHeight);
@@ -581,8 +586,8 @@ export class MarkerSvg {
     // assignable to parameter of type 'Element | undefined'.
     this.markerSvg_ = dom.createSvgElement(
         Svg.G, {
-          'width': this.constants.CURSOR_WS_WIDTH,
-          'height': this.constants.WS_CURSOR_HEIGHT,
+          'width': this.constants_.CURSOR_WS_WIDTH,
+          'height': this.constants_.WS_CURSOR_HEIGHT,
         },
         this.svgGroup_ as AnyDuringMigration);
 
@@ -592,8 +597,8 @@ export class MarkerSvg {
     // assignable to parameter of type 'Element | undefined'.
     this.markerSvgLine_ = dom.createSvgElement(
         Svg.RECT, {
-          'width': this.constants.CURSOR_WS_WIDTH,
-          'height': this.constants.WS_CURSOR_HEIGHT,
+          'width': this.constants_.CURSOR_WS_WIDTH,
+          'height': this.constants_.WS_CURSOR_HEIGHT,
           'style': 'display: none',
         },
         this.markerSvg_ as AnyDuringMigration);
@@ -626,7 +631,7 @@ export class MarkerSvg {
           'transform': '',
           'style': 'display: none',
           'fill': 'none',
-          'stroke-width': this.constants.CURSOR_STROKE_WIDTH,
+          'stroke-width': this.constants_.CURSOR_STROKE_WIDTH,
         },
         this.markerSvg_ as AnyDuringMigration);
 

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -90,8 +90,8 @@ export class MarkerSvg {
    * @param marker The marker to draw.
    */
   constructor(
-      private readonly workspace: WorkspaceSvg,
-      constants: ConstantProvider, private readonly marker: Marker) {
+      private readonly workspace: WorkspaceSvg, constants: ConstantProvider,
+      private readonly marker: Marker) {
     this.constants_ = constants;
 
     const defaultColour = this.isCursor() ? this.constants_.CURSOR_COLOUR :

--- a/core/renderers/geras/info.ts
+++ b/core/renderers/geras/info.ts
@@ -56,7 +56,7 @@ export class RenderInfo extends BaseRenderInfo {
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   override constants_!: ConstantProvider;
 
-  override renderer: Renderer;
+  protected override readonly renderer_: Renderer;
 
   /**
    * @param renderer The renderer in use.
@@ -65,7 +65,7 @@ export class RenderInfo extends BaseRenderInfo {
    */
   constructor(renderer: Renderer, block: BlockSvg) {
     super(renderer, block);
-    this.renderer = renderer;
+    this.renderer_ = renderer;
   }
 
   /**
@@ -74,7 +74,7 @@ export class RenderInfo extends BaseRenderInfo {
    * @internal
    */
   override getRenderer(): Renderer {
-    return this.renderer;
+    return this.renderer_;
   }
 
   override populateBottomRow_() {

--- a/core/renderers/geras/measurables/inline_input.ts
+++ b/core/renderers/geras/measurables/inline_input.ts
@@ -32,7 +32,7 @@ import {ConstantProvider as GerasConstantProvider} from '../constants.js';
  * @alias Blockly.geras.InlineInput
  */
 export class InlineInput extends BaseInlineInput {
-  override constants: GerasConstantProvider;
+  override constants_: GerasConstantProvider;
 
   /**
    * @param constants The rendering constants provider.
@@ -41,13 +41,13 @@ export class InlineInput extends BaseInlineInput {
    */
   constructor(constants: BaseConstantProvider, input: Input) {
     super(constants, input);
-    this.constants = constants as GerasConstantProvider;
+    this.constants_ = constants as GerasConstantProvider;
 
     if (this.connectedBlock) {
       // We allow the dark path to show on the parent block so that the child
       // block looks embossed.  This takes up an extra pixel in both x and y.
-      this.width += this.constants.DARK_PATH_OFFSET;
-      this.height += this.constants.DARK_PATH_OFFSET;
+      this.width += this.constants_.DARK_PATH_OFFSET;
+      this.height += this.constants_.DARK_PATH_OFFSET;
     }
   }
 }

--- a/core/renderers/geras/measurables/statement_input.ts
+++ b/core/renderers/geras/measurables/statement_input.ts
@@ -32,7 +32,7 @@ import {ConstantProvider as GerasConstantProvider} from '../constants.js';
  * @alias Blockly.geras.StatementInput
  */
 export class StatementInput extends BaseStatementInput {
-  override constants: GerasConstantProvider;
+  override constants_: GerasConstantProvider;
 
   /**
    * @param constants The rendering constants provider.
@@ -41,12 +41,12 @@ export class StatementInput extends BaseStatementInput {
    */
   constructor(constants: BaseConstantProvider, input: Input) {
     super(constants, input);
-    this.constants = constants as GerasConstantProvider;
+    this.constants_ = constants as GerasConstantProvider;
 
     if (this.connectedBlock) {
       // We allow the dark path to show on the parent block so that the child
       // block looks embossed.  This takes up an extra pixel in both x and y.
-      this.height += this.constants.DARK_PATH_OFFSET;
+      this.height += this.constants_.DARK_PATH_OFFSET;
     }
   }
 }

--- a/core/renderers/measurables/base.ts
+++ b/core/renderers/measurables/base.ts
@@ -37,13 +37,18 @@ export class Measurable {
   centerline = 0;
   notchOffset: number;
 
+  /** The renderer's constant provider. */
+  protected readonly constants_: ConstantProvider
+
   /**
    * @param constants The rendering constants provider.
    * @internal
    */
-  constructor(protected readonly constants: ConstantProvider) {
+  constructor(constants: ConstantProvider) {
+    this.constants_ = constants;
+
     this.type = Types.NONE;
 
-    this.notchOffset = this.constants.NOTCH_OFFSET_LEFT;
+    this.notchOffset = this.constants_.NOTCH_OFFSET_LEFT;
   }
 }

--- a/core/renderers/measurables/connection.ts
+++ b/core/renderers/measurables/connection.ts
@@ -45,7 +45,7 @@ export class Connection extends Measurable {
       constants: ConstantProvider, public connectionModel: RenderedConnection) {
     super(constants);
 
-    this.shape = this.constants.shapeFor(connectionModel);
+    this.shape = this.constants_.shapeFor(connectionModel);
 
     this.isDynamicShape = 'isDynamic' in this.shape && this.shape.isDynamic;
     this.type |= Types.CONNECTION;

--- a/core/renderers/measurables/external_value_input.ts
+++ b/core/renderers/measurables/external_value_input.ts
@@ -51,13 +51,13 @@ export class ExternalValueInput extends InputConnection {
       this.height = this.shape.height as number;
     } else {
       this.height = this.connectedBlockHeight -
-          this.constants.TAB_OFFSET_FROM_TOP - this.constants.MEDIUM_PADDING;
+          this.constants_.TAB_OFFSET_FROM_TOP - this.constants_.MEDIUM_PADDING;
     }
 
     this.width = this.shape.width as
-        number + this.constants.EXTERNAL_VALUE_INPUT_PADDING;
+        number + this.constants_.EXTERNAL_VALUE_INPUT_PADDING;
 
-    this.connectionOffsetY = this.constants.TAB_OFFSET_FROM_TOP;
+    this.connectionOffsetY = this.constants_.TAB_OFFSET_FROM_TOP;
 
     this.connectionHeight = this.shape.height as number;
 

--- a/core/renderers/measurables/hat.ts
+++ b/core/renderers/measurables/hat.ts
@@ -41,8 +41,8 @@ export class Hat extends Measurable {
     super(constants);
     this.type |= Types.HAT;
 
-    this.height = this.constants.START_HAT.height;
-    this.width = this.constants.START_HAT.width;
+    this.height = this.constants_.START_HAT.height;
+    this.width = this.constants_.START_HAT.width;
 
     this.ascenderHeight = this.height;
   }

--- a/core/renderers/measurables/in_row_spacer.ts
+++ b/core/renderers/measurables/in_row_spacer.ts
@@ -40,6 +40,6 @@ export class InRowSpacer extends Measurable {
     super(constants);
     this.type |= Types.SPACER | Types.IN_ROW_SPACER;
     this.width = width;
-    this.height = this.constants.SPACER_DEFAULT_HEIGHT;
+    this.height = this.constants_.SPACER_DEFAULT_HEIGHT;
   }
 }

--- a/core/renderers/measurables/inline_input.ts
+++ b/core/renderers/measurables/inline_input.ts
@@ -46,8 +46,8 @@ export class InlineInput extends InputConnection {
     this.type |= Types.INLINE_INPUT;
 
     if (!this.connectedBlock) {
-      this.height = this.constants.EMPTY_INLINE_INPUT_HEIGHT;
-      this.width = this.constants.EMPTY_INLINE_INPUT_PADDING;
+      this.height = this.constants_.EMPTY_INLINE_INPUT_HEIGHT;
+      this.width = this.constants_.EMPTY_INLINE_INPUT_PADDING;
     } else {
       // We allow the dark path to show on the parent block so that the child
       // block looks embossed.  This takes up an extra pixel in both x and y.
@@ -68,7 +68,7 @@ export class InlineInput extends InputConnection {
 
     this.connectionOffsetY = 'connectionOffsetY' in this.shape ?
         this.shape.connectionOffsetY(this.connectionHeight) :
-        this.constants.TAB_OFFSET_FROM_TOP;
+        this.constants_.TAB_OFFSET_FROM_TOP;
 
     this.connectionOffsetX = 'connectionOffsetX' in this.shape ?
         this.shape.connectionOffsetX(this.connectionWidth) :

--- a/core/renderers/measurables/jagged_edge.ts
+++ b/core/renderers/measurables/jagged_edge.ts
@@ -38,7 +38,7 @@ export class JaggedEdge extends Measurable {
   constructor(constants: ConstantProvider) {
     super(constants);
     this.type |= Types.JAGGED_EDGE;
-    this.height = this.constants.JAGGED_TEETH.height;
-    this.width = this.constants.JAGGED_TEETH.width;
+    this.height = this.constants_.JAGGED_TEETH.height;
+    this.width = this.constants_.JAGGED_TEETH.width;
   }
 }

--- a/core/renderers/measurables/output_connection.ts
+++ b/core/renderers/measurables/output_connection.ts
@@ -53,6 +53,6 @@ export class OutputConnection extends Connection {
 
     this.startX = this.width;
 
-    this.connectionOffsetY = this.constants.TAB_OFFSET_FROM_TOP;
+    this.connectionOffsetY = this.constants_.TAB_OFFSET_FROM_TOP;
   }
 }

--- a/core/renderers/measurables/round_corner.ts
+++ b/core/renderers/measurables/round_corner.ts
@@ -42,9 +42,9 @@ export class RoundCorner extends Measurable {
         (!opt_position || opt_position === 'left' ? Types.LEFT_ROUND_CORNER :
                                                     Types.RIGHT_ROUND_CORNER) |
         Types.CORNER;
-    this.width = this.constants.CORNER_RADIUS;
+    this.width = this.constants_.CORNER_RADIUS;
     // The rounded corner extends into the next row by 4 so we only take the
     // height that is aligned with this row.
-    this.height = this.constants.CORNER_RADIUS / 2;
+    this.height = this.constants_.CORNER_RADIUS / 2;
   }
 }

--- a/core/renderers/measurables/row.ts
+++ b/core/renderers/measurables/row.ts
@@ -133,11 +133,16 @@ export class Row {
    */
   align: number|null = null;
 
+  protected readonly constants_: ConstantProvider;
+
   /**
-   * @param constants_ The rendering constants provider.
+   * @param constants The rendering constants provider.
    * @internal
    */
-  constructor(protected readonly constants_: ConstantProvider) {
+  constructor(constants: ConstantProvider) {
+    /** The renderer's constant provider. */
+    this.constants_ = constants;
+
     /** The type of this rendering object. */
     this.type = Types.ROW;
 

--- a/core/renderers/measurables/square_corner.ts
+++ b/core/renderers/measurables/square_corner.ts
@@ -42,7 +42,7 @@ export class SquareCorner extends Measurable {
         (!opt_position || opt_position === 'left' ? Types.LEFT_SQUARE_CORNER :
                                                     Types.RIGHT_SQUARE_CORNER) |
         Types.CORNER;
-    this.height = this.constants.NO_PADDING;
-    this.width = this.constants.NO_PADDING;
+    this.height = this.constants_.NO_PADDING;
+    this.width = this.constants_.NO_PADDING;
   }
 }

--- a/core/renderers/measurables/statement_input.ts
+++ b/core/renderers/measurables/statement_input.ts
@@ -43,14 +43,14 @@ export class StatementInput extends InputConnection {
     this.type |= Types.STATEMENT_INPUT;
 
     if (!this.connectedBlock) {
-      this.height = this.constants.EMPTY_STATEMENT_INPUT_HEIGHT;
+      this.height = this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT;
     } else {
       // We allow the dark path to show on the parent block so that the child
       // block looks embossed.  This takes up an extra pixel in both x and y.
       this.height =
-          this.connectedBlockHeight + this.constants.STATEMENT_BOTTOM_SPACER;
+          this.connectedBlockHeight + this.constants_.STATEMENT_BOTTOM_SPACER;
     }
-    this.width = this.constants.STATEMENT_INPUT_NOTCH_OFFSET +
+    this.width = this.constants_.STATEMENT_INPUT_NOTCH_OFFSET +
         (this.shape.width as number);
   }
 }

--- a/core/renderers/zelos/info.ts
+++ b/core/renderers/zelos/info.ts
@@ -60,7 +60,7 @@ export class RenderInfo extends BaseRenderInfo {
   override topRow: TopRow;
   override bottomRow: BottomRow;
   override constants_: ConstantProvider;
-  override renderer: Renderer;
+  override renderer_: Renderer;
 
   override isInline = true;
   isMultiRow: boolean;
@@ -76,9 +76,9 @@ export class RenderInfo extends BaseRenderInfo {
   constructor(renderer: Renderer, block: BlockSvg) {
     super(renderer, block);
 
-    this.renderer = renderer;
+    this.renderer_ = renderer;
 
-    this.constants_ = this.renderer.getConstants();
+    this.constants_ = this.renderer_.getConstants();
 
     /**
      * An object with rendering information about the top row of the block.
@@ -121,7 +121,7 @@ export class RenderInfo extends BaseRenderInfo {
    * @internal
    */
   override getRenderer(): Renderer {
-    return this.renderer as Renderer;
+    return this.renderer_ as Renderer;
   }
 
   override measure() {

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -270,7 +270,7 @@ export class ToolboxCategory extends ToolboxItem implements
    */
   protected createIconDom_(): Element {
     const toolboxIcon = document.createElement('span');
-    if (!this.parentToolbox.isHorizontal()) {
+    if (!this.parentToolbox_.isHorizontal()) {
       // AnyDuringMigration because:  Argument of type 'string | undefined' is
       // not assignable to parameter of type 'string'.
       dom.addClass(
@@ -450,8 +450,8 @@ export class ToolboxCategory extends ToolboxItem implements
     this.htmlDiv_!.style.display = isVisible ? 'block' : 'none';
     this.isHidden_ = !isVisible;
 
-    if (this.parentToolbox.getSelectedItem() === this) {
-      this.parentToolbox.clearSelection();
+    if (this.parentToolbox_.getSelectedItem() === this) {
+      this.parentToolbox_.clearSelection();
     }
   }
 

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -119,7 +119,7 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
     const ToolboxItemClass =
         registry.getClass(registry.Type.TOOLBOX_ITEM, registryName);
     const toolboxItem =
-        new ToolboxItemClass!(itemDef, this.parentToolbox, this);
+        new ToolboxItemClass!(itemDef, this.parentToolbox_, this);
     this.toolboxItems_.push(toolboxItem);
   }
 
@@ -144,7 +144,7 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
 
   override createIconDom_() {
     const toolboxIcon = document.createElement('span');
-    if (!this.parentToolbox.isHorizontal()) {
+    if (!this.parentToolbox_.isHorizontal()) {
       // AnyDuringMigration because:  Argument of type 'string | undefined' is
       // not assignable to parameter of type 'string'.
       dom.addClass(
@@ -198,7 +198,7 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
     aria.setState(
         this.htmlDiv_ as HTMLDivElement, aria.State.EXPANDED, isExpanded);
 
-    this.parentToolbox.handleToolboxItemResize();
+    this.parentToolbox_.handleToolboxItemResize();
   }
 
   override setVisible_(isVisible: boolean) {
@@ -210,8 +210,8 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
     }
     this.isHidden_ = !isVisible;
 
-    if (this.parentToolbox.getSelectedItem() === this) {
-      this.parentToolbox.clearSelection();
+    if (this.parentToolbox_.getSelectedItem() === this) {
+      this.parentToolbox_.clearSelection();
     }
   }
 

--- a/core/toolbox/toolbox_item.ts
+++ b/core/toolbox/toolbox_item.ts
@@ -48,8 +48,7 @@ export class ToolboxItem implements IToolboxItem {
    *     have a parent.
    */
   constructor(
-      toolboxItemDef: toolbox.ToolboxItemInfo,
-      parentToolbox: IToolbox,
+      toolboxItemDef: toolbox.ToolboxItemInfo, parentToolbox: IToolbox,
       opt_parent?: ICollapsibleToolboxItem) {
     /** The id for the category. */
     this.id_ = (toolboxItemDef as AnyDuringMigration)['toolboxitemid'] ||

--- a/core/toolbox/toolbox_item.ts
+++ b/core/toolbox/toolbox_item.ts
@@ -38,6 +38,8 @@ export class ToolboxItem implements IToolboxItem {
   protected level_: number;
   protected toolboxItemDef_: toolbox.ToolboxItemInfo|null;
   protected workspace_: WorkspaceSvg;
+  /** The toolbox this category belongs to. */
+  protected readonly parentToolbox_: IToolbox;
 
   /**
    * @param toolboxItemDef The JSON defining the toolbox item.
@@ -47,7 +49,7 @@ export class ToolboxItem implements IToolboxItem {
    */
   constructor(
       toolboxItemDef: toolbox.ToolboxItemInfo,
-      protected readonly parentToolbox: IToolbox,
+      parentToolbox: IToolbox,
       opt_parent?: ICollapsibleToolboxItem) {
     /** The id for the category. */
     this.id_ = (toolboxItemDef as AnyDuringMigration)['toolboxitemid'] ||
@@ -62,8 +64,10 @@ export class ToolboxItem implements IToolboxItem {
     /** The JSON definition of the toolbox item. */
     this.toolboxItemDef_ = toolboxItemDef;
 
+    this.parentToolbox_ = parentToolbox;
+
     /** The workspace of the parent toolbox. */
-    this.workspace_ = this.parentToolbox.getWorkspace();
+    this.workspace_ = this.parentToolbox_.getWorkspace();
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The automatic migration script renamed some properties when transforming them into parameter properties. This is fine for private properties, but protected properties are part of our public API, and constitute a breaking change when they are renamed.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Properties were renamed, creating a breaking change.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Property renames are reverted.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Lessen the number of accidental breaking changes we're committing.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
No manual testing needed.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Also going to do a sweep for public properties that might have gotten renamed.
