### PR TITLE
chore(build): Suppress spurious warnings from closure-make-deps

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -324,13 +324,20 @@ function buildDeps(done) {
   ];
 
   const args = roots.map(root => `--root '${root}' `).join('');
-  execSync(`closure-make-deps ${args} > '${DEPS_FILE}'`,
-           {stdio: 'inherit'});
+  execSync(
+      `set -o pipefail; \
+       (closure-make-deps ${args} >'${DEPS_FILE}') 2>&1 \
+       | (grep -v '^WARNING in' ; true)`,
+      {stdio: 'inherit'});
 
   // Use grep to filter out the entries that are already in deps.js.
   const testArgs = testRoots.map(root => `--root '${root}' `).join('');
-  execSync(`closure-make-deps ${testArgs} | grep 'tests/mocha' ` +
-      `> '${TEST_DEPS_FILE}'`, {stdio: 'inherit'});
+  execSync(
+      `set -o pipefail; \
+       (closure-make-deps ${testArgs} | grep 'tests/mocha' \
+            > '${TEST_DEPS_FILE}') 2>&1 \
+       | (grep -v '^WARNING in' ; true)`,
+      {stdio: 'inherit'});
   done();
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from ts/migration
- [X] My pull request is against ts/migration
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Suppresses spurious error messages from `closure-make-deps`.

### Proposed Changes

A little bit of an ugly hack, but it works: pipe `stderr` through `grep -v` to suppress error output starting with "WARNING in".

#### Behaviour Before Change

`npm run build:deps` generates ~7.7k lines of useless and irrelevant warnings.

#### Behaviour After Change

`npm run build:deps` does not generate any warnings.

### Reason for Changes

The code generated by `tsc` doesn't have Closure type annotations and does have unused variables and other issues that cause the parser in `closure-make-deps` to generate warnings.  Unfortunately that command does not have any (documented) way to suppress these warnings.
