### PR TITLE
fix(build): Don't depend on execSync running bash

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -343,18 +343,14 @@ function buildDeps(done) {
 
   const args = roots.map(root => `--root '${root}' `).join('');
   execSync(
-      `set -o pipefail; \
-       (closure-make-deps ${args} >'${DEPS_FILE}') 2>&1 \
-       | (grep -v '^WARNING in' ; true)`,
+      `closure-make-deps ${args} 2>/dev/null >'${DEPS_FILE}'`,
       {stdio: 'inherit'});
 
   // Use grep to filter out the entries that are already in deps.js.
   const testArgs = testRoots.map(root => `--root '${root}' `).join('');
   execSync(
-      `set -o pipefail; \
-       (closure-make-deps ${testArgs} | grep 'tests/mocha' \
-            > '${TEST_DEPS_FILE}') 2>&1 \
-       | (grep -v '^WARNING in' ; true)`,
+      `closure-make-deps ${testArgs} 2>/dev/null \
+           | grep 'tests/mocha' > '${TEST_DEPS_FILE}'`,
       {stdio: 'inherit'});
   done();
 }


### PR DESCRIPTION
## The basics

- [X] I branched from `ts/migration`
- [X] My pull request is `ts/migration`
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

For some reason on Github CI servers `execSync` uses `/bin/sh`, which is (on Ubuntu) `dash`, which does not understand the `pipefail` option, rather than `bash`.

### Proposed Changes

So remove the `grep` pipe on `stderr` and just discard all error output.

### Additional Information

This is not ideal as errors in test deps will go unreported AND not even cause test failure, but it's not clear that it's worth investing more time to fix this at the moment.
