### PR TITLE
fix: options parser should add trailing slash to 'media' if not present. (#6263)

### DIFF
--- a/core/options.js
+++ b/core/options.js
@@ -15,6 +15,7 @@
  */
 goog.module('Blockly.Options');
 
+const deprecation = goog.require('Blockly.utils.deprecation');
 const idGenerator = goog.require('Blockly.utils.idGenerator');
 const registry = goog.require('Blockly.registry');
 const toolbox = goog.require('Blockly.utils.toolbox');
@@ -109,6 +110,7 @@ class Options {
                                                      options['media'] + '/';
     } else if (options['path']) {
       // 'path' is a deprecated option which has been replaced by 'media'.
+      deprecation.warn('path', 'Nov 2014', 'Jul 2023', 'media');
       pathToMedia = options['path'] + 'media/';
     }
     let oneBasedIndex;

--- a/core/options.js
+++ b/core/options.js
@@ -105,7 +105,8 @@ class Options {
     }
     let pathToMedia = 'https://blockly-demo.appspot.com/static/media/';
     if (options['media']) {
-      pathToMedia = options['media'];
+      pathToMedia = options['media'].endsWith('/') ? options['media'] :
+                                                     options['media'] + '/';
     } else if (options['path']) {
       // 'path' is a deprecated option which has been replaced by 'media'.
       pathToMedia = options['path'] + 'media/';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#6263 

### Proposed Changes
Add a trailing slash to `media` option, if not present.
Add deprecated warning to `path` option

### Additional Information
I was unsure about the deletion date on the deprecation warning, so I just set it to 1 year from now.