### PR TITLE
fix(variables): Revert inadvertent change to `allDeveloperVariables`

### DIFF
--- a/core/variables.ts
+++ b/core/variables.ts
@@ -99,7 +99,7 @@ export function allDeveloperVariables(workspace: Workspace): string[] {
       }
     }
     if (getDeveloperVariables) {
-      const devVars = block.getDeveloperVariables!();
+      const devVars = getDeveloperVariables();
       for (let j = 0; j < devVars.length; j++) {
         variableHash[devVars[j]] = true;
       }


### PR DESCRIPTION
## The basics

- [X] I branched from `ts/migration`
- [X] My pull request is against `ts/migration`
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`
  - You didn't ask if they passed!

## The details
### Resolves

Generator test failures

### Proposed Changes

It appears that a function call got modified incorrectly (possibly in an effort to fix a typing issue).  This fix trivially reverts
the line in question to match the original JS version from `develop`.
