### PR TITLE
refactor: remove AnyDuringMigration from the block drag surface

### DIFF
--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -25,7 +25,8 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockDragSurfaceSvg');
 
-import {Coordinate} from './utils/coordinate.js';
+import { Coordinate } from './utils/coordinate.js';
+import * as deprecation from './utils/deprecation.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
 import * as svgMath from './utils/svg_math.js';
@@ -85,7 +86,10 @@ export class BlockDragSurfaceSvg {
 
   /** Create the drag surface and inject it into the container. */
   createDom() {
-    // TODO: Add deprecation warning.
+    // No alternative provided, because now the dom is just automatically
+    // created in the constructor now.
+    deprecation.warn(
+        'BlockDragSurfaceSvg createDom', 'June 2022', 'June 2023');
   }
 
   /**

--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -38,7 +38,7 @@ import * as svgMath from './utils/svg_math.js';
  */
 export class BlockDragSurfaceSvg {
   /** The SVG drag surface. Set once by BlockDragSurfaceSvg.createDom. */
-  private SVG_: SVGElement;
+  private svg_: SVGElement;
 
   /**
    * This is where blocks live while they are being dragged if the drag
@@ -69,7 +69,7 @@ export class BlockDragSurfaceSvg {
      */
     this.childSurfaceXY_ = new Coordinate(0, 0);
 
-    this.SVG_ = dom.createSvgElement(
+    this.svg_ = dom.createSvgElement(
       Svg.SVG,
       {
         'xmlns': dom.SVG_NS,
@@ -80,7 +80,7 @@ export class BlockDragSurfaceSvg {
       },
       this.container);
     this.dragGroup_ =
-      dom.createSvgElement(Svg.G, {}, this.SVG_ as SVGElement);
+      dom.createSvgElement(Svg.G, {}, this.svg_ as SVGElement);
   }
 
   /** Create the drag surface and inject it into the container. */
@@ -99,7 +99,7 @@ export class BlockDragSurfaceSvg {
     }
     // appendChild removes the blocks from the previous parent
     this.dragGroup_.appendChild(blocks);
-    this.SVG_.style.display = 'block';
+    this.svg_.style.display = 'block';
     this.surfaceXY_ = new Coordinate(0, 0);
   }
 
@@ -132,8 +132,8 @@ export class BlockDragSurfaceSvg {
     // Make sure the svg exists on a pixel boundary so that it is not fuzzy.
     x = Math.round(x);
     y = Math.round(y);
-    this.SVG_.style.display = 'block';
-    dom.setCssTransform(this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
+    this.svg_.style.display = 'block';
+    dom.setCssTransform(this.svg_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
   }
 
   /**
@@ -167,7 +167,7 @@ export class BlockDragSurfaceSvg {
    * @return Current translation of the surface.
    */
   getSurfaceTranslation(): Coordinate {
-    const xy = svgMath.getRelativeXY(this.SVG_ as SVGElement);
+    const xy = svgMath.getRelativeXY(this.svg_ as SVGElement);
     return new Coordinate(xy.x / this.scale_, xy.y / this.scale_);
   }
 
@@ -184,8 +184,8 @@ export class BlockDragSurfaceSvg {
    * Returns the SVG drag surface.
    * @returns The SVG drag surface.
    */
-  getSvgRoot(): SVGElement|null {
-    return this.SVG_;
+  getSvgRoot(): SVGElement | null {
+    return this.svg_;
   }
 
   /**
@@ -227,7 +227,7 @@ export class BlockDragSurfaceSvg {
         this.dragGroup_.removeChild(currentBlockElement);
       }
     }
-    this.SVG_.style.display = 'none';
+    this.svg_.style.display = 'none';
     if (this.dragGroup_.childNodes.length) {
       throw Error('Drag group was not cleared.');
     }

--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -38,13 +38,13 @@ import * as svgMath from './utils/svg_math.js';
  */
 export class BlockDragSurfaceSvg {
   /** The SVG drag surface. Set once by BlockDragSurfaceSvg.createDom. */
-  private SVG_: SVGElement|null = null;
+  private SVG_: SVGElement;
 
   /**
    * This is where blocks live while they are being dragged if the drag
    * surface is enabled.
    */
-  private dragGroup_: SVGElement|null = null;
+  private dragGroup_: SVGElement;
 
   /**
    * Cached value for the scale of the drag surface.
@@ -57,7 +57,7 @@ export class BlockDragSurfaceSvg {
    * This translation is in pixel units, because the scale is applied to the
    * drag group rather than the top-level SVG.
    */
-  private surfaceXY_: Coordinate|null = null;
+  private surfaceXY_: Coordinate = new Coordinate(0, 0);
   private readonly childSurfaceXY_: Coordinate;
 
   /** @param container Containing element. */
@@ -69,28 +69,23 @@ export class BlockDragSurfaceSvg {
      */
     this.childSurfaceXY_ = new Coordinate(0, 0);
 
-    this.createDom();
+    this.SVG_ = dom.createSvgElement(
+      Svg.SVG,
+      {
+        'xmlns': dom.SVG_NS,
+        'xmlns:html': dom.HTML_NS,
+        'xmlns:xlink': dom.XLINK_NS,
+        'version': '1.1',
+        'class': 'blocklyBlockDragSurface',
+      },
+      this.container);
+    this.dragGroup_ =
+      dom.createSvgElement(Svg.G, {}, this.SVG_ as SVGElement);
   }
 
   /** Create the drag surface and inject it into the container. */
   createDom() {
-    if (this.SVG_) {
-      return;
-    }
-    // Already created.
-    this.SVG_ = dom.createSvgElement(
-        Svg.SVG, {
-          'xmlns': dom.SVG_NS,
-          'xmlns:html': dom.HTML_NS,
-          'xmlns:xlink': dom.XLINK_NS,
-          'version': '1.1',
-          'class': 'blocklyBlockDragSurface',
-        },
-        this.container);
-    // AnyDuringMigration because:  Argument of type 'SVGElement | null' is not
-    // assignable to parameter of type 'Element | undefined'.
-    this.dragGroup_ =
-        dom.createSvgElement(Svg.G, {}, this.SVG_ as AnyDuringMigration);
+    // TODO: Add deprecation warning.
   }
 
   /**
@@ -99,12 +94,12 @@ export class BlockDragSurfaceSvg {
    * @param blocks Block or group of blocks to place on the drag surface.
    */
   setBlocksAndShow(blocks: SVGElement) {
-    if (this.dragGroup_!.childNodes.length) {
+    if (this.dragGroup_.childNodes.length) {
       throw Error('Already dragging a block.');
     }
     // appendChild removes the blocks from the previous parent
-    this.dragGroup_!.appendChild(blocks);
-    this.SVG_!.style.display = 'block';
+    this.dragGroup_.appendChild(blocks);
+    this.SVG_.style.display = 'block';
     this.surfaceXY_ = new Coordinate(0, 0);
   }
 
@@ -137,13 +132,8 @@ export class BlockDragSurfaceSvg {
     // Make sure the svg exists on a pixel boundary so that it is not fuzzy.
     x = Math.round(x);
     y = Math.round(y);
-    this.SVG_!.style.display = 'block';
-
-    // AnyDuringMigration because:  Argument of type 'SVGElement | null' is not
-    // assignable to parameter of type 'Element'.
-    dom.setCssTransform(
-        this.SVG_ as AnyDuringMigration,
-        'translate3d(' + x + 'px, ' + y + 'px, 0)');
+    this.SVG_.style.display = 'block';
+    dom.setCssTransform(this.SVG_, 'translate3d(' + x + 'px, ' + y + 'px, 0)');
   }
 
   /**
@@ -152,8 +142,8 @@ export class BlockDragSurfaceSvg {
    * @param deltaY Vertical offset in pixel units.
    */
   translateBy(deltaX: number, deltaY: number) {
-    const x = this.surfaceXY_!.x + deltaX;
-    const y = this.surfaceXY_!.y + deltaY;
+    const x = this.surfaceXY_.x + deltaX;
+    const y = this.surfaceXY_.y + deltaY;
     this.surfaceXY_ = new Coordinate(x, y);
     this.translateSurfaceInternal_();
   }
@@ -203,8 +193,8 @@ export class BlockDragSurfaceSvg {
    * for BlockSvg.getRelativeToSurfaceXY).
    * @return Drag surface block DOM element, or null if no blocks exist.
    */
-  getCurrentBlock(): Element|null {
-    return this.dragGroup_!.firstChild as Element;
+  getCurrentBlock(): Element | null {
+    return this.dragGroup_.firstChild as Element;
   }
 
   /**
@@ -234,13 +224,13 @@ export class BlockDragSurfaceSvg {
         // appendChild removes the node from this.dragGroup_
         opt_newSurface.appendChild(currentBlockElement);
       } else {
-        this.dragGroup_!.removeChild(currentBlockElement);
+        this.dragGroup_.removeChild(currentBlockElement);
       }
     }
-    this.SVG_!.style.display = 'none';
-    if (this.dragGroup_!.childNodes.length) {
+    this.SVG_.style.display = 'none';
+    if (this.dragGroup_.childNodes.length) {
       throw Error('Drag group was not cleared.');
     }
-    this.surfaceXY_ = null;
+    this.surfaceXY_ = new Coordinate(0, 0);
   }
 }

--- a/core/block_drag_surface.ts
+++ b/core/block_drag_surface.ts
@@ -25,7 +25,7 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockDragSurfaceSvg');
 
-import { Coordinate } from './utils/coordinate.js';
+import {Coordinate} from './utils/coordinate.js';
 import * as deprecation from './utils/deprecation.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
@@ -71,25 +71,22 @@ export class BlockDragSurfaceSvg {
     this.childSurfaceXY_ = new Coordinate(0, 0);
 
     this.svg_ = dom.createSvgElement(
-      Svg.SVG,
-      {
-        'xmlns': dom.SVG_NS,
-        'xmlns:html': dom.HTML_NS,
-        'xmlns:xlink': dom.XLINK_NS,
-        'version': '1.1',
-        'class': 'blocklyBlockDragSurface',
-      },
-      this.container);
-    this.dragGroup_ =
-      dom.createSvgElement(Svg.G, {}, this.svg_ as SVGElement);
+        Svg.SVG, {
+          'xmlns': dom.SVG_NS,
+          'xmlns:html': dom.HTML_NS,
+          'xmlns:xlink': dom.XLINK_NS,
+          'version': '1.1',
+          'class': 'blocklyBlockDragSurface',
+        },
+        this.container);
+    this.dragGroup_ = dom.createSvgElement(Svg.G, {}, this.svg_ as SVGElement);
   }
 
   /** Create the drag surface and inject it into the container. */
   createDom() {
     // No alternative provided, because now the dom is just automatically
     // created in the constructor now.
-    deprecation.warn(
-        'BlockDragSurfaceSvg createDom', 'June 2022', 'June 2023');
+    deprecation.warn('BlockDragSurfaceSvg createDom', 'June 2022', 'June 2023');
   }
 
   /**
@@ -188,7 +185,7 @@ export class BlockDragSurfaceSvg {
    * Returns the SVG drag surface.
    * @returns The SVG drag surface.
    */
-  getSvgRoot(): SVGElement | null {
+  getSvgRoot(): SVGElement|null {
     return this.svg_;
   }
 
@@ -197,7 +194,7 @@ export class BlockDragSurfaceSvg {
    * for BlockSvg.getRelativeToSurfaceXY).
    * @return Drag surface block DOM element, or null if no blocks exist.
    */
-  getCurrentBlock(): Element | null {
+  getCurrentBlock(): Element|null {
     return this.dragGroup_.firstChild as Element;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Remove AnyDuringMigration from block drag surface.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
No behavior change.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No behavior change.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Types are better than AnyDuringMigration.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

## Migration

Calls to `BlockDragSurface().createDom()` should be removed because the dom is now automatically created by the constructor, and `createDom()` is no-op.