### PR TITLE
chore(tests): remove unused run of typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "test:generators": "tests/scripts/run_generators.sh",
     "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "typings": "gulp typings",
     "updateGithubPages": "gulp gitUpdateGithubPages"
   },
   "main": "./index.js",

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -58,10 +58,6 @@ fi
 # closure compiler warnings / errors.
 run_test_command "build-debug" "npm run build-debug"
 
-# Generate TypeScript typings and ensure there are no errors.
-# TODO(5621): Re-enable this test once typings generation is fixed.
-# run_test_command "typings" "npm run typings"
-
 # Run renaming validation test.
 run_test_command "renamings" "tests/migration/validate-renamings.js"
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Removes unused code

### Proposed Changes

Removes a commented-out run of typings.

#### Behavior Before Change

No change

#### Behavior After Change

No change

### Reason for Changes

We disabled this during the high-error portion of the rewrite, and now it's redundant because tsc checks types during the normal build.

### Test Coverage

Normal build.

### Documentation


### Additional Information

Typescript is cool!