### PR TITLE
fix: packaging .d.ts files

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -389,7 +389,7 @@ function packageDTS() {
     'typings/msg/msg.d.ts',
   ];
   return gulp.src(handwrittenSrcs, {base: 'typings'})
-      .pipe(gulp.src(`${BUILD_DIR}/${TYPINGS_BUILD_DIR}/**/*.d.ts`))
+      .pipe(gulp.src(`${TYPINGS_BUILD_DIR}/**/*.d.ts`))
       .pipe(gulp.replace('AnyDuringMigration', 'any'))
       .pipe(gulp.dest(RELEASE_DIR));
 };

--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -9,4 +9,4 @@
  * @author samelh@google.com (Sam El-Husseini)
  */
 
-export * from './declarations/core/blockly';
+export * from './core/blockly';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,6 @@
  * @author samelh@google.com (Sam El-Husseini)
  */
 
-export * from './declarations/core/blockly';
+export * from './core/blockly';
 export * as libraryBlocks from './blocks';  // Handcrafted file.
 export const JavaScript: any;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Messed up on one of the final commits to https://github.com/google/blockly/pull/6257 where I changed it to use the `config.js` values instead of the `tsconfig.json` values, so the type definitions weren't actually getting included. This fixes that.


### Testing

Tested against the `blockly-typescript-libcheck` repo and it works.