### PR TITLE
refactor: Use maps and sets instead of plain objects.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -877,12 +877,10 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     this.rendered = false;
 
     // Clear pending warnings.
-    if (this.warningTextDb.size) {
-      for (const n of this.warningTextDb.values()) {
-        clearTimeout(n);
-      }
-      this.warningTextDb.clear();
+    for (const n of this.warningTextDb.values()) {
+      clearTimeout(n);
     }
+    this.warningTextDb.clear();
 
     const icons = this.getIcons();
     for (let i = 0; i < icons.length; i++) {

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -37,18 +37,17 @@ import type {ConstantProvider} from './constants.js';
 export class PathObject extends BasePathObject {
   /** The selected path of the block. */
   private svgPathSelected_: SVGElement|null = null;
-  private readonly outlines_: {[key: string]: SVGElement};
+
+  /** The outline paths on the block. */
+  private readonly outlines = new Map<string, SVGElement>();
 
   /**
    * A set used to determine which outlines were used during a draw pass.  The
    * set is initialized with a reference to all the outlines in
-   * `this.outlines_`. Every time we use an outline during the draw pass, the
+   * `this.outlines`. Every time we use an outline during the draw pass, the
    * reference is removed from this set.
    */
-  // AnyDuringMigration because:  Type 'null' is not assignable to type '{ [key:
-  // string]: number; }'.
-  private remainingOutlines_: {[key: string]: number} =
-      null as AnyDuringMigration;
+  private remainingOutlines = new Set<string>();
 
   /**
    * The type of block's output connection shape.  This is set when a block
@@ -70,9 +69,6 @@ export class PathObject extends BasePathObject {
     super(root, style, constants);
 
     this.constants = constants;
-
-    /** The outline paths on the block. */
-    this.outlines_ = Object.create(null);
   }
 
   override setPath(pathString: string) {
@@ -91,16 +87,16 @@ export class PathObject extends BasePathObject {
     }
 
     // Apply colour to outlines.
-    for (const key in this.outlines_) {
-      this.outlines_[key].setAttribute('fill', this.style.colourTertiary);
+    for (const outline of this.outlines.values()) {
+      outline.setAttribute('fill', this.style.colourTertiary);
     }
   }
 
   override flipRTL() {
     super.flipRTL();
     // Mirror each input outline path.
-    for (const key in this.outlines_) {
-      this.outlines_[key].setAttribute('transform', 'scale(-1 1)');
+    for (const outline of this.outlines.values()) {
+      outline.setAttribute('transform', 'scale(-1 1)');
     }
   }
 
@@ -151,11 +147,9 @@ export class PathObject extends BasePathObject {
    * @internal
    */
   beginDrawing() {
-    this.remainingOutlines_ = Object.create(null);
-    for (const key in this.outlines_) {
-      // The value set here isn't used anywhere, we are just using the
-      // object as a Set data structure.
-      this.remainingOutlines_[key] = 1;
+    this.remainingOutlines.clear()
+    for (const key of this.outlines.keys()) {
+      this.remainingOutlines.add(key);
     }
   }
 
@@ -166,14 +160,12 @@ export class PathObject extends BasePathObject {
   endDrawing() {
     // Go through all remaining outlines that were not used this draw pass, and
     // remove them.
-    if (this.remainingOutlines_) {
-      for (const key in this.remainingOutlines_) {
+    if (this.remainingOutlines.size) {
+      for (const key of this.remainingOutlines) {
         this.removeOutlinePath_(key);
       }
     }
-    // AnyDuringMigration because:  Type 'null' is not assignable to type '{
-    // [key: string]: number; }'.
-    this.remainingOutlines_ = null as AnyDuringMigration;
+    this.remainingOutlines.clear();
   }
 
   /**
@@ -195,20 +187,21 @@ export class PathObject extends BasePathObject {
    * @return The SVG outline path.
    */
   private getOutlinePath_(name: string): SVGElement {
-    if (!this.outlines_[name]) {
-      this.outlines_[name] = dom.createSvgElement(
-          Svg.PATH, {
-            'class': 'blocklyOutlinePath',  // IE doesn't like paths without the
-            // data definition, set empty
-            // default
-            'd': '',
-          },
-          this.svgRoot);
+    if (!this.outlines.has(name)) {
+      this.outlines.set(
+          name,
+          dom.createSvgElement(
+              Svg.PATH, {
+                'class':
+                    'blocklyOutlinePath',  // IE doesn't like paths without the
+                // data definition, set empty
+                // default
+                'd': '',
+              },
+              this.svgRoot));
     }
-    if (this.remainingOutlines_) {
-      delete this.remainingOutlines_[name];
-    }
-    return this.outlines_[name];
+    this.remainingOutlines.delete(name);
+    return this.outlines.get(name)!;
   }
 
   /**
@@ -216,7 +209,7 @@ export class PathObject extends BasePathObject {
    * @param name The input name.
    */
   private removeOutlinePath_(name: string) {
-    this.outlines_[name].parentNode!.removeChild(this.outlines_[name]);
-    delete this.outlines_[name];
+    this.outlines.get(name)?.parentNode?.removeChild(this.outlines.get(name)!);
+    this.outlines.delete(name);
   }
 }

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -363,11 +363,7 @@ export class VariableMap {
    * @return All of the variable names of all types.
    */
   getAllVariableNames(): string[] {
-    let allNames: string[] = [];
-    for (const variables of this.variableMap.values()) {
-      allNames = allNames.concat(variables.map(variable => variable.name));
-    }
-    return allNames;
+    return Array.from(this.variableMap.values()).flat().map(variable => variable.name);
   }
 
   /**

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -363,7 +363,9 @@ export class VariableMap {
    * @return All of the variable names of all types.
    */
   getAllVariableNames(): string[] {
-    return Array.from(this.variableMap.values()).flat().map(variable => variable.name);
+    return Array.from(this.variableMap.values())
+        .flat()
+        .map(variable => variable.name);
   }
 
   /**

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -46,8 +46,8 @@ export const CATEGORY_NAME = 'VARIABLE';
  */
 export function allUsedVarModels(ws: Workspace): VariableModel[] {
   const blocks = ws.getAllBlocks(false);
-  const variableHash = Object.create(null);
-  // Iterate through every block and add each variable to the hash.
+  const variables = new Set<VariableModel>();
+  // Iterate through every block and add each variable to the set.
   for (let i = 0; i < blocks.length; i++) {
     const blockVariables = blocks[i].getVarModels();
     if (blockVariables) {
@@ -55,17 +55,13 @@ export function allUsedVarModels(ws: Workspace): VariableModel[] {
         const variable = blockVariables[j];
         const id = variable.getId();
         if (id) {
-          variableHash[id] = variable;
+          variables.add(variable);
         }
       }
     }
   }
-  // Flatten the hash into a list.
-  const variableList = [];
-  for (const id in variableHash) {
-    variableList.push(variableHash[id]);
-  }
-  return variableList;
+  // Convert the set into a list.
+  return Array.from(variables.values());
 }
 
 const ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE: {[key: string]: boolean} = {};
@@ -83,7 +79,7 @@ const ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE: {[key: string]: boolean} = {};
  */
 export function allDeveloperVariables(workspace: Workspace): string[] {
   const blocks = workspace.getAllBlocks(false);
-  const variableHash = Object.create(null);
+  const variables = new Set<string>();
   for (let i = 0, block; block = blocks[i]; i++) {
     let getDeveloperVariables = block.getDeveloperVariables;
     if (!getDeveloperVariables &&
@@ -101,12 +97,12 @@ export function allDeveloperVariables(workspace: Workspace): string[] {
     if (getDeveloperVariables) {
       const devVars = getDeveloperVariables();
       for (let j = 0; j < devVars.length; j++) {
-        variableHash[devVars[j]] = true;
+        variables.add(devVars[j]);
       }
     }
   }
-  // Flatten the hash into a list.
-  return Object.keys(variableHash);
+  // Convert the set into a list.
+  return Array.from(variables.values());
 }
 
 /**

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -89,12 +89,12 @@ export class Workspace implements IASTNodeLocation {
 
   private readonly topBlocks_: Block[] = [];
   private readonly topComments_: WorkspaceComment[] = [];
-  private readonly commentDB_: AnyDuringMigration;
+  private readonly commentDB = new Map<string, WorkspaceComment>();
   private readonly listeners_: Function[] = [];
   protected undoStack_: Abstract[] = [];
   protected redoStack_: Abstract[] = [];
-  private readonly blockDB_: AnyDuringMigration;
-  private readonly typedBlocksDB_: AnyDuringMigration;
+  private readonly blockDB = new Map<string, Block>();
+  private readonly typedBlocksDB = new Map<string, Block[]>();
   private variableMap_: VariableMap;
 
   /**
@@ -122,9 +122,6 @@ export class Workspace implements IASTNodeLocation {
      * An object that encapsulates logic for safety, type, and dragging checks.
      */
     this.connectionChecker = new connectionCheckerClass!(this);
-    this.commentDB_ = Object.create(null);
-    this.blockDB_ = Object.create(null);
-    this.typedBlocksDB_ = Object.create(null);
 
     /**
      * A map from variable type to list of variable names.  The lists contain
@@ -222,10 +219,10 @@ export class Workspace implements IASTNodeLocation {
    * @param block Block to add.
    */
   addTypedBlock(block: Block) {
-    if (!this.typedBlocksDB_[block.type]) {
-      this.typedBlocksDB_[block.type] = [];
+    if (!this.typedBlocksDB.has(block.type)) {
+      this.typedBlocksDB.set(block.type, []);
     }
-    this.typedBlocksDB_[block.type].push(block);
+    this.typedBlocksDB.get(block.type)!.push(block);
   }
 
   /**
@@ -233,9 +230,9 @@ export class Workspace implements IASTNodeLocation {
    * @param block Block to remove.
    */
   removeTypedBlock(block: Block) {
-    arrayUtils.removeElem(this.typedBlocksDB_[block.type], block);
-    if (!this.typedBlocksDB_[block.type].length) {
-      delete this.typedBlocksDB_[block.type];
+    arrayUtils.removeElem(this.typedBlocksDB.get(block.type)!, block);
+    if (!this.typedBlocksDB.get(block.type)!.length) {
+      this.typedBlocksDB.delete(block.type);
     }
   }
 
@@ -247,11 +244,11 @@ export class Workspace implements IASTNodeLocation {
    * @return The blocks of the given type.
    */
   getBlocksByType(type: string, ordered: boolean): Block[] {
-    if (!this.typedBlocksDB_[type]) {
+    if (!this.typedBlocksDB.has(type)) {
       return [];
     }
-    const blocks = this.typedBlocksDB_[type].slice(0);
-    if (ordered && blocks.length > 1) {
+    const blocks = this.typedBlocksDB.get(type)!.slice(0);
+    if (ordered && blocks && blocks.length > 1) {
       // AnyDuringMigration because:  Property 'offset' does not exist on type
       // '(a: Block | WorkspaceComment, b: Block | WorkspaceComment) => number'.
       (this.sortObjects_ as AnyDuringMigration).offset =
@@ -280,12 +277,12 @@ export class Workspace implements IASTNodeLocation {
 
     // Note: If the comment database starts to hold block comments, this may
     // need to move to a separate function.
-    if (this.commentDB_[comment.id]) {
+    if (this.commentDB.has(comment.id)) {
       console.warn(
           'Overriding an existing comment on this workspace, with id "' +
           comment.id + '"');
     }
-    this.commentDB_[comment.id] = comment;
+    this.commentDB.set(comment.id, comment);
   }
 
   /**
@@ -301,7 +298,7 @@ export class Workspace implements IASTNodeLocation {
     }
     // Note: If the comment database starts to hold block comments, this may
     // need to move to a separate function.
-    delete this.commentDB_[comment.id];
+    this.commentDB.delete(comment.id);
   }
 
   /**
@@ -687,7 +684,7 @@ export class Workspace implements IASTNodeLocation {
    * @return The sought after block, or null if not found.
    */
   getBlockById(id: string): Block|null {
-    return this.blockDB_[id] || null;
+    return this.blockDB.get(id) || null;
   }
 
   /**
@@ -697,7 +694,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   setBlockById(id: string, block: Block) {
-    this.blockDB_[id] = block;
+    this.blockDB.set(id, block);
   }
 
   /**
@@ -706,7 +703,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   removeBlockById(id: string) {
-    delete this.blockDB_[id];
+    this.blockDB.delete(id);
   }
 
   /**
@@ -716,7 +713,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   getCommentById(id: string): WorkspaceComment|null {
-    return this.commentDB_[id] || null;
+    return this.commentDB.get(id) ?? null;
   }
 
   /**

--- a/core/workspace_audio.ts
+++ b/core/workspace_audio.ts
@@ -32,7 +32,8 @@ const SOUND_LIMIT = 100;
  * @alias Blockly.WorkspaceAudio
  */
 export class WorkspaceAudio {
-  private SOUNDS_: AnyDuringMigration;
+  /** Database of pre-loaded sounds. */
+  private sounds = new Map<string, HTMLAudioElement>();
 
   /** Time that the last sound was played. */
   // AnyDuringMigration because:  Type 'null' is not assignable to type 'Date'.
@@ -42,10 +43,7 @@ export class WorkspaceAudio {
    * @param parentWorkspace The parent of the workspace this audio object
    *     belongs to, or null.
    */
-  constructor(private parentWorkspace: WorkspaceSvg) {
-    /** Database of pre-loaded sounds. */
-    this.SOUNDS_ = Object.create(null);
-  }
+  constructor(private parentWorkspace: WorkspaceSvg) {}
 
   /**
    * Dispose of this audio manager.
@@ -55,7 +53,7 @@ export class WorkspaceAudio {
     // AnyDuringMigration because:  Type 'null' is not assignable to type
     // 'WorkspaceSvg'.
     this.parentWorkspace = null as AnyDuringMigration;
-    this.SOUNDS_ = null;
+    this.sounds.clear();
   }
 
   /**
@@ -88,7 +86,7 @@ export class WorkspaceAudio {
       }
     }
     if (sound) {
-      this.SOUNDS_[name] = sound;
+      this.sounds.set(name, sound);
     }
   }
 
@@ -97,8 +95,7 @@ export class WorkspaceAudio {
    * @internal
    */
   preload() {
-    for (const name in this.SOUNDS_) {
-      const sound = this.SOUNDS_[name];
+    for (const sound of this.sounds.values()) {
       sound.volume = 0.01;
       const playPromise = sound.play();
       // Edge does not return a promise, so we need to check.
@@ -131,7 +128,7 @@ export class WorkspaceAudio {
    * @param opt_volume Volume of sound (0-1).
    */
   play(name: string, opt_volume?: number) {
-    const sound = this.SOUNDS_[name];
+    const sound = this.sounds.get(name);
     if (sound) {
       // Don't play one sound on top of another.
       const now = new Date();
@@ -147,7 +144,7 @@ export class WorkspaceAudio {
         // node which must be deleted and recreated for each new audio tag.
         mySound = sound;
       } else {
-        mySound = sound.cloneNode();
+        mySound = sound.cloneNode() as HTMLAudioElement;
       }
       mySound.volume = opt_volume === undefined ? 1 : opt_volume;
       mySound.play();

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -25,14 +25,14 @@ suite('Keyboard Shortcut Registry Test', function() {
     test('Registering a shortcut', function() {
       const testShortcut = {'name': 'test_shortcut'};
       this.registry.register(testShortcut, true);
-      const shortcut = this.registry.registry_['test_shortcut'];
+      const shortcut = this.registry.registry_.get('test_shortcut');
       chai.assert.equal(shortcut.name, 'test_shortcut');
     });
     test('Registers shortcut with same name', function() {
       const registry = this.registry;
       const testShortcut = {'name': 'test_shortcut'};
 
-      registry.registry_['test_shortcut'] = [testShortcut];
+      registry.registry_.set('test_shortcut', [testShortcut]);
 
       const shouldThrow = function() {
         registry.register(testShortcut);
@@ -51,13 +51,13 @@ suite('Keyboard Shortcut Registry Test', function() {
             'callback': function() {},
           };
 
-          registry.registry_['test_shortcut'] = [testShortcut];
+          registry.registry_.set('test_shortcut', [testShortcut]);
 
           const shouldNotThrow = function() {
             registry.register(otherShortcut, true);
           };
           chai.assert.doesNotThrow(shouldNotThrow);
-          chai.assert.exists(registry.registry_['test_shortcut'].callback);
+          chai.assert.exists(registry.registry_.get('test_shortcut').callback);
         });
     test('Registering a shortcut with keycodes', function() {
       const shiftA = this.registry.createSerializedKey(
@@ -67,9 +67,9 @@ suite('Keyboard Shortcut Registry Test', function() {
         'keyCodes': ['65', 66, shiftA],
       };
       this.registry.register(testShortcut, true);
-      chai.assert.lengthOf(this.registry.keyMap_[shiftA], 1);
-      chai.assert.lengthOf(this.registry.keyMap_['65'], 1);
-      chai.assert.lengthOf(this.registry.keyMap_['66'], 1);
+      chai.assert.lengthOf(this.registry.keyMap.get(shiftA), 1);
+      chai.assert.lengthOf(this.registry.keyMap.get('65'), 1);
+      chai.assert.lengthOf(this.registry.keyMap.get('66'), 1);
     });
     test('Registering a shortcut with allowCollision', function() {
       const testShortcut = {
@@ -93,14 +93,14 @@ suite('Keyboard Shortcut Registry Test', function() {
   suite('Unregistering', function() {
     test('Unregistering a shortcut', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.registry_['test'] = [testShortcut];
-      chai.assert.isOk(this.registry.registry_['test']);
+      this.registry.registry_.set('test', [testShortcut]);
+      chai.assert.isOk(this.registry.registry_.get('test'));
       this.registry.unregister('test', 'test_shortcut');
-      chai.assert.isUndefined(this.registry.registry_['test']);
+      chai.assert.isUndefined(this.registry.registry_.get('test'));
     });
     test('Unregistering a nonexistent shortcut', function() {
       const consoleStub = sinon.stub(console, 'warn');
-      chai.assert.isUndefined(this.registry.registry_['test']);
+      chai.assert.isUndefined(this.registry.registry_.get('test'));
 
       const registry = this.registry;
       chai.assert.isFalse(registry.unregister('test', 'test_shortcut'));
@@ -108,25 +108,25 @@ suite('Keyboard Shortcut Registry Test', function() {
     });
     test('Unregistering a shortcut with key mappings', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut'];
-      this.registry.registry_['test_shortcut'] = testShortcut;
+      this.registry.keyMap.set('keyCode', ['test_shortcut']);
+      this.registry.registry_.set('test_shortcut', testShortcut);
 
       this.registry.unregister('test_shortcut');
 
-      const shortcut = this.registry.registry_['test'];
-      const keyMappings = this.registry.keyMap_['keyCode'];
+      const shortcut = this.registry.registry_.get('test');
+      const keyMappings = this.registry.keyMap.get('keyCode');
       chai.assert.isUndefined(shortcut);
       chai.assert.isUndefined(keyMappings);
     });
     test('Unregistering a shortcut with colliding key mappings', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut', 'other_shortcutt'];
-      this.registry.registry_['test_shortcut'] = testShortcut;
+      this.registry.keyMap.set('keyCode', ['test_shortcut', 'other_shortcutt']);
+      this.registry.registry_.set('test_shortcut', testShortcut);
 
       this.registry.unregister('test_shortcut');
 
-      const shortcut = this.registry.registry_['test'];
-      const keyMappings = this.registry.keyMap_['keyCode'];
+      const shortcut = this.registry.registry_.get('test');
+      const keyMappings = this.registry.keyMap.get('keyCode');
       chai.assert.lengthOf(keyMappings, 1);
       chai.assert.isUndefined(shortcut);
     });
@@ -134,28 +134,28 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('addKeyMapping', function() {
     test('Adds a key mapping', function() {
-      this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
+      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap.get('keyCode');
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
     });
     test('Adds a colliding key mapping - opt_allowCollision=true', function() {
-      this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut_2'];
+      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
+      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut', true);
 
-      const shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap.get('keyCode');
       chai.assert.lengthOf(shortcutNames, 2);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
       chai.assert.equal(shortcutNames[1], 'test_shortcut_2');
     });
     test('Adds a colliding key mapping - opt_allowCollision=false', function() {
       this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut_2'];
+      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
 
       const registry = this.registry;
       const shouldThrow = function() {
@@ -169,29 +169,29 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('removeKeyMapping', function() {
     test('Removes a key mapping', function() {
-      this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut', 'test_shortcut_2'];
+      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
+      this.registry.keyMap.set('keyCode', ['test_shortcut', 'test_shortcut_2']);
 
       const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap.get('keyCode');
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut_2');
       chai.assert.isTrue(isRemoved);
     });
     test('Removes last key mapping for a key', function() {
-      this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
-      this.registry.keyMap_['keyCode'] = ['test_shortcut'];
+      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
+      this.registry.keyMap.set('keyCode', ['test_shortcut']);
 
       this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap_['keyCode'];
+      const shortcutNames = this.registry.keyMap.get('keyCode');
       chai.assert.isUndefined(shortcutNames);
     });
     test('Removes a key map that does not exist opt_quiet=false', function() {
       const consoleStub = sinon.stub(console, 'warn');
-      this.registry.keyMap_['keyCode'] = ['test_shortcut_2'];
+      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
 
       const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
@@ -219,30 +219,30 @@ suite('Keyboard Shortcut Registry Test', function() {
   suite('Setters/Getters', function() {
     test('Sets the key map', function() {
       this.registry.setKeyMap({'keyCode': ['test_shortcut']});
-      chai.assert.lengthOf(Object.keys(this.registry.keyMap_), 1);
-      chai.assert.equal(this.registry.keyMap_['keyCode'][0], 'test_shortcut');
+      chai.assert.equal(this.registry.keyMap.size, 1);
+      chai.assert.equal(this.registry.keyMap.get('keyCode')[0], 'test_shortcut');
     });
     test('Gets a copy of the key map', function() {
-      this.registry.keyMap_['keyCode'] = ['a'];
+      this.registry.keyMap.set('keyCode', ['a']);
       const keyMapCopy = this.registry.getKeyMap();
       keyMapCopy['keyCode'] = ['b'];
-      chai.assert.equal(this.registry.keyMap_['keyCode'][0], 'a');
+      chai.assert.equal(this.registry.keyMap.get('keyCode')[0], 'a');
     });
     test('Gets a copy of the registry', function() {
-      this.registry.registry_['shortcutName'] = {'name': 'shortcutName'};
+      this.registry.registry_.set('shortcutName', {'name': 'shortcutName'});
       const registrycopy = this.registry.getRegistry();
       registrycopy['shortcutName']['name'] = 'shortcutName1';
       chai.assert.equal(
-          this.registry.registry_['shortcutName']['name'], 'shortcutName');
+          this.registry.registry_.get('shortcutName')['name'], 'shortcutName');
     });
     test('Gets keyboard shortcuts from a key code', function() {
-      this.registry.keyMap_['keyCode'] = ['shortcutName'];
+      this.registry.keyMap.set('keyCode', ['shortcutName']);
       const shortcutNames = this.registry.getShortcutNamesByKeyCode('keyCode');
       chai.assert.equal(shortcutNames[0], 'shortcutName');
     });
     test('Gets keycodes by shortcut name', function() {
-      this.registry.keyMap_['keyCode'] = ['shortcutName'];
-      this.registry.keyMap_['keyCode1'] = ['shortcutName'];
+      this.registry.keyMap.set('keyCode', ['shortcutName']);
+      this.registry.keyMap.set('keyCode1', ['shortcutName']);
       const shortcutNames =
           this.registry.getKeyCodesByShortcutName('shortcutName');
       chai.assert.lengthOf(shortcutNames, 2);

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -25,14 +25,14 @@ suite('Keyboard Shortcut Registry Test', function() {
     test('Registering a shortcut', function() {
       const testShortcut = {'name': 'test_shortcut'};
       this.registry.register(testShortcut, true);
-      const shortcut = this.registry.registry_.get('test_shortcut');
+      const shortcut = this.registry.getRegistry()['test_shortcut'];
       chai.assert.equal(shortcut.name, 'test_shortcut');
     });
     test('Registers shortcut with same name', function() {
       const registry = this.registry;
       const testShortcut = {'name': 'test_shortcut'};
 
-      registry.registry_.set('test_shortcut', [testShortcut]);
+      registry.register(testShortcut);
 
       const shouldThrow = function() {
         registry.register(testShortcut);
@@ -51,13 +51,13 @@ suite('Keyboard Shortcut Registry Test', function() {
             'callback': function() {},
           };
 
-          registry.registry_.set('test_shortcut', [testShortcut]);
+          registry.register(testShortcut);
 
           const shouldNotThrow = function() {
             registry.register(otherShortcut, true);
           };
           chai.assert.doesNotThrow(shouldNotThrow);
-          chai.assert.exists(registry.registry_.get('test_shortcut').callback);
+          chai.assert.exists(registry.getRegistry()['test_shortcut'].callback);
         });
     test('Registering a shortcut with keycodes', function() {
       const shiftA = this.registry.createSerializedKey(
@@ -67,9 +67,9 @@ suite('Keyboard Shortcut Registry Test', function() {
         'keyCodes': ['65', 66, shiftA],
       };
       this.registry.register(testShortcut, true);
-      chai.assert.lengthOf(this.registry.keyMap.get(shiftA), 1);
-      chai.assert.lengthOf(this.registry.keyMap.get('65'), 1);
-      chai.assert.lengthOf(this.registry.keyMap.get('66'), 1);
+      chai.assert.lengthOf(this.registry.getKeyMap()[shiftA], 1);
+      chai.assert.lengthOf(this.registry.getKeyMap()['65'], 1);
+      chai.assert.lengthOf(this.registry.getKeyMap()['66'], 1);
     });
     test('Registering a shortcut with allowCollision', function() {
       const testShortcut = {
@@ -93,40 +93,43 @@ suite('Keyboard Shortcut Registry Test', function() {
   suite('Unregistering', function() {
     test('Unregistering a shortcut', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.registry_.set('test', [testShortcut]);
-      chai.assert.isOk(this.registry.registry_.get('test'));
-      this.registry.unregister('test', 'test_shortcut');
-      chai.assert.isUndefined(this.registry.registry_.get('test'));
+      this.registry.register(testShortcut);
+      chai.assert.isOk(this.registry.getRegistry()['test_shortcut']);
+      this.registry.unregister('test_shortcut');
+      chai.assert.isUndefined(this.registry.getRegistry()['test_shortcut']);
     });
     test('Unregistering a nonexistent shortcut', function() {
       const consoleStub = sinon.stub(console, 'warn');
-      chai.assert.isUndefined(this.registry.registry_.get('test'));
+      chai.assert.isUndefined(this.registry.getRegistry['test']);
 
       const registry = this.registry;
-      chai.assert.isFalse(registry.unregister('test', 'test_shortcut'));
+      chai.assert.isFalse(registry.unregister('test'));
       sinon.assert.calledOnceWithExactly(consoleStub, 'Keyboard shortcut with name "test" not found.');
     });
     test('Unregistering a shortcut with key mappings', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.keyMap.set('keyCode', ['test_shortcut']);
-      this.registry.registry_.set('test_shortcut', testShortcut);
+      this.registry.register(testShortcut);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
       this.registry.unregister('test_shortcut');
 
-      const shortcut = this.registry.registry_.get('test');
-      const keyMappings = this.registry.keyMap.get('keyCode');
+      const shortcut = this.registry.getRegistry()['test_shortcut'];
+      const keyMappings = this.registry.getKeyMap()['keyCode'];
       chai.assert.isUndefined(shortcut);
       chai.assert.isUndefined(keyMappings);
     });
     test('Unregistering a shortcut with colliding key mappings', function() {
       const testShortcut = {'name': 'test_shortcut'};
-      this.registry.keyMap.set('keyCode', ['test_shortcut', 'other_shortcutt']);
-      this.registry.registry_.set('test_shortcut', testShortcut);
+      const otherShortcut = {'name': 'other_shortcut'};
+      this.registry.register(testShortcut);
+      this.registry.register(otherShortcut);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut');
+      this.registry.addKeyMapping('keyCode', 'other_shortcut', true);
 
       this.registry.unregister('test_shortcut');
 
-      const shortcut = this.registry.registry_.get('test');
-      const keyMappings = this.registry.keyMap.get('keyCode');
+      const shortcut = this.registry.getRegistry()['test_shortcut'];
+      const keyMappings = this.registry.getKeyMap()['keyCode'];
       chai.assert.lengthOf(keyMappings, 1);
       chai.assert.isUndefined(shortcut);
     });
@@ -134,28 +137,35 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('addKeyMapping', function() {
     test('Adds a key mapping', function() {
-      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
+      const testShortcut = {'name': 'test_shortcut'};
+      this.registry.register(testShortcut);
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap.get('keyCode');
+      const shortcutNames = this.registry.getKeyMap()['keyCode'];
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
     });
     test('Adds a colliding key mapping - opt_allowCollision=true', function() {
-      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
-      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
+      const testShortcut = {'name': 'test_shortcut'};
+      const testShortcut2 = {'name': 'test_shortcut_2'};
+      this.registry.register(testShortcut);
+      this.registry.register(testShortcut2);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut_2');
 
       this.registry.addKeyMapping('keyCode', 'test_shortcut', true);
 
-      const shortcutNames = this.registry.keyMap.get('keyCode');
+      const shortcutNames = this.registry.getKeyMap()['keyCode'];
       chai.assert.lengthOf(shortcutNames, 2);
       chai.assert.equal(shortcutNames[0], 'test_shortcut');
       chai.assert.equal(shortcutNames[1], 'test_shortcut_2');
     });
     test('Adds a colliding key mapping - opt_allowCollision=false', function() {
-      this.registry.registry_['test_shortcut'] = {'name': 'test_shortcut'};
-      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
+      const testShortcut = {'name': 'test_shortcut'};
+      const testShortcut2 = {'name': 'test_shortcut_2'};
+      this.registry.register(testShortcut);
+      this.registry.register(testShortcut2);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut_2');
 
       const registry = this.registry;
       const shouldThrow = function() {
@@ -169,29 +179,36 @@ suite('Keyboard Shortcut Registry Test', function() {
 
   suite('removeKeyMapping', function() {
     test('Removes a key mapping', function() {
-      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
-      this.registry.keyMap.set('keyCode', ['test_shortcut', 'test_shortcut_2']);
+      const testShortcut = {'name': 'test_shortcut'};
+      const testShortcut2 = {'name': 'test_shortcut_2'};
+      this.registry.register(testShortcut);
+      this.registry.register(testShortcut2);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut_2');
+      this.registry.addKeyMapping('keyCode', 'test_shortcut', true);
 
       const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap.get('keyCode');
+      const shortcutNames = this.registry.getKeyMap()['keyCode'];
       chai.assert.lengthOf(shortcutNames, 1);
       chai.assert.equal(shortcutNames[0], 'test_shortcut_2');
       chai.assert.isTrue(isRemoved);
     });
     test('Removes last key mapping for a key', function() {
-      this.registry.registry_.set('test_shortcut', {'name': 'test_shortcut'});
-      this.registry.keyMap.set('keyCode', ['test_shortcut']);
+      const testShortcut = {'name': 'test_shortcut'};
+      this.registry.register(testShortcut);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
       this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
-      const shortcutNames = this.registry.keyMap.get('keyCode');
+      const shortcutNames = this.registry.getKeyMap()['keyCode'];
       chai.assert.isUndefined(shortcutNames);
     });
     test('Removes a key map that does not exist opt_quiet=false', function() {
       const consoleStub = sinon.stub(console, 'warn');
-      this.registry.keyMap.set('keyCode', ['test_shortcut_2']);
+      const testShortcut = {'name': 'test_shortcut_2'};
+      this.registry.register(testShortcut);
+      this.registry.addKeyMapping('keyCode', 'test_shortcut_2');
 
       const isRemoved =
           this.registry.removeKeyMapping('keyCode', 'test_shortcut');
@@ -219,30 +236,30 @@ suite('Keyboard Shortcut Registry Test', function() {
   suite('Setters/Getters', function() {
     test('Sets the key map', function() {
       this.registry.setKeyMap({'keyCode': ['test_shortcut']});
-      chai.assert.equal(this.registry.keyMap.size, 1);
-      chai.assert.equal(this.registry.keyMap.get('keyCode')[0], 'test_shortcut');
+      chai.assert.equal(Object.keys(this.registry.getKeyMap()).length, 1);
+      chai.assert.equal(this.registry.getKeyMap()['keyCode'][0], 'test_shortcut');
     });
     test('Gets a copy of the key map', function() {
-      this.registry.keyMap.set('keyCode', ['a']);
+      this.registry.setKeyMap({'keyCode': ['a']});
       const keyMapCopy = this.registry.getKeyMap();
       keyMapCopy['keyCode'] = ['b'];
-      chai.assert.equal(this.registry.keyMap.get('keyCode')[0], 'a');
+      chai.assert.equal(this.registry.getKeyMap()['keyCode'][0], 'a');
     });
     test('Gets a copy of the registry', function() {
-      this.registry.registry_.set('shortcutName', {'name': 'shortcutName'});
+      const shortcut = {'name': 'shortcutName'};
+      this.registry.register(shortcut);
       const registrycopy = this.registry.getRegistry();
       registrycopy['shortcutName']['name'] = 'shortcutName1';
       chai.assert.equal(
-          this.registry.registry_.get('shortcutName')['name'], 'shortcutName');
+          this.registry.getRegistry()['shortcutName']['name'], 'shortcutName');
     });
     test('Gets keyboard shortcuts from a key code', function() {
-      this.registry.keyMap.set('keyCode', ['shortcutName']);
+      this.registry.setKeyMap({'keyCode': ['shortcutName']});
       const shortcutNames = this.registry.getShortcutNamesByKeyCode('keyCode');
       chai.assert.equal(shortcutNames[0], 'shortcutName');
     });
     test('Gets keycodes by shortcut name', function() {
-      this.registry.keyMap.set('keyCode', ['shortcutName']);
-      this.registry.keyMap.set('keyCode1', ['shortcutName']);
+      this.registry.setKeyMap({'keyCode': ['shortcutName'], 'keyCode1': ['shortcutName']});
       const shortcutNames =
           this.registry.getKeyCodesByShortcutName('shortcutName');
       chai.assert.lengthOf(shortcutNames, 2);

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -840,7 +840,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.nextConnection.connect(child.previousConnection);
         });
       });
@@ -852,7 +852,7 @@ function testAWorkspace() {
             '  <block type="row_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('INPUT').connection.connect(child.outputConnection);
         });
       });
@@ -864,7 +864,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('STATEMENT').connection
               .connect(child.previousConnection);
         });
@@ -881,7 +881,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.nextConnection.connect(child.previousConnection);
         });
       });
@@ -897,7 +897,7 @@ function testAWorkspace() {
             '  <block type="row_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('INPUT').connection.connect(child.outputConnection);
         });
       });
@@ -913,7 +913,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('STATEMENT').connection
               .connect(child.previousConnection);
         });
@@ -930,7 +930,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.nextConnection.connect(child.previousConnection);
         });
       });
@@ -946,7 +946,7 @@ function testAWorkspace() {
             '  <block type="row_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('INPUT').connection.connect(child.outputConnection);
         });
       });
@@ -962,7 +962,7 @@ function testAWorkspace() {
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
-        testUndoConnect.call(this, xml, 1, 2, (parent, child) => {
+        testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
           parent.getInput('STATEMENT').connection
               .connect(child.previousConnection);
         });
@@ -1034,7 +1034,7 @@ function testAWorkspace() {
             '    </next>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Row', function() {
@@ -1046,7 +1046,7 @@ function testAWorkspace() {
             '    </value>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Statement', function() {
@@ -1058,7 +1058,7 @@ function testAWorkspace() {
             '    </statement>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Stack w/ child', function() {
@@ -1074,7 +1074,7 @@ function testAWorkspace() {
             '    </next>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Row w/ child', function() {
@@ -1090,7 +1090,7 @@ function testAWorkspace() {
             '    </value>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Statement w/ child', function() {
@@ -1106,7 +1106,7 @@ function testAWorkspace() {
             '    </statement>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
 
       test('Stack w/ shadow', function() {
@@ -1121,7 +1121,7 @@ function testAWorkspace() {
             '    </next>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
         chai.assert.equal(this.workspace.getAllBlocks().length, 2,
             'expected there to only be 2 blocks on the workspace ' +
             '(check for shadows)');
@@ -1137,7 +1137,7 @@ function testAWorkspace() {
             '    </value>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
         chai.assert.equal(this.workspace.getAllBlocks().length, 2,
             'expected there to only be 2 blocks on the workspace ' +
             '(check for shadows)');
@@ -1153,7 +1153,7 @@ function testAWorkspace() {
             '    </statement>' +
             '  </block>' +
             '</xml>';
-        testUndoDisconnect.call(this, xml, 2);
+        testUndoDisconnect.call(this, xml, '2');
       });
     });
 

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -69,8 +69,7 @@ function testAWorkspace() {
 
       this.workspace.clear();
       chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      const varMapLength =
-          Object.keys(this.workspace.variableMap_.variableMap_).length;
+      const varMapLength = this.workspace.variableMap_.variableMap.size;
       chai.assert.equal(varMapLength, 0);
     });
 
@@ -80,8 +79,7 @@ function testAWorkspace() {
 
       this.workspace.clear();
       chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      const varMapLength =
-          Object.keys(this.workspace.variableMap_.variableMap_).length;
+      const varMapLength = this.workspace.variableMap_.variableMap.size;
       chai.assert.equal(varMapLength, 0);
     });
   });

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -28,21 +28,21 @@ suite('Variable Map', function() {
     });
 
     test('Already exists', function() {
-      // Expect that when the variable already exists, the variableMap_ is unchanged.
+      // Expect that when the variable already exists, the variableMap is unchanged.
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
-      let keys = Object.keys(this.variableMap.variableMap_);
+      let keys = Array.from(this.variableMap.variableMap.keys());
       chai.assert.equal(keys.length, 1);
-      let varMapLength = this.variableMap.variableMap_[keys[0]].length;
+      let varMapLength = this.variableMap.variableMap.get(keys[0]).length;
       chai.assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type1');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
-      // Check that the size of the variableMap_ did not change.
-      keys = Object.keys(this.variableMap.variableMap_);
+      // Check that the size of the variableMap did not change.
+      keys = Array.from(this.variableMap.variableMap.keys());
       chai.assert.equal(keys.length, 1);
-      varMapLength = this.variableMap.variableMap_[keys[0]].length;
+      varMapLength = this.variableMap.variableMap.get(keys[0]).length;
       chai.assert.equal(varMapLength, 1);
     });
 
@@ -52,16 +52,16 @@ suite('Variable Map', function() {
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
-      let keys = Object.keys(this.variableMap.variableMap_);
+      let keys = Array.from(this.variableMap.variableMap.keys());
       chai.assert.equal(keys.length, 1);
-      const varMapLength = this.variableMap.variableMap_[keys[0]].length;
+      const varMapLength = this.variableMap.variableMap.get(keys[0]).length;
       chai.assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type2', 'id2');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
       assertVariableValues(this.variableMap, 'name1', 'type2', 'id2');
-      // Check that the size of the variableMap_ did change.
-      keys = Object.keys(this.variableMap.variableMap_);
+      // Check that the size of the variableMap did change.
+      keys = Array.from(this.variableMap.variableMap.keys());
       chai.assert.equal(keys.length, 2);
     });
 

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -29,7 +29,7 @@ suite('Workspace comment', function() {
       const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       chai.assert.equal(this.workspace.getTopComments(true).length, 1);
-      chai.assert.equal(this.workspace.commentDB_['comment id'], comment);
+      chai.assert.equal(this.workspace.commentDB.get('comment id'), comment);
     });
 
     test('After clear empty workspace', function() {
@@ -42,7 +42,7 @@ suite('Workspace comment', function() {
           this.workspace, 'comment text', 0, 0, 'comment id');
       this.workspace.clear();
       chai.assert.equal(this.workspace.getTopComments(true).length, 0);
-      chai.assert.isFalse('comment id' in this.workspace.commentDB_);
+      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
 
     test('After dispose', function() {
@@ -50,7 +50,7 @@ suite('Workspace comment', function() {
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       chai.assert.equal(this.workspace.getTopComments(true).length, 0);
-      chai.assert.isFalse('comment id' in this.workspace.commentDB_);
+      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
   });
 
@@ -63,7 +63,7 @@ suite('Workspace comment', function() {
       const comment = new Blockly.WorkspaceComment(
           this.workspace, 'comment text', 0, 0, 'comment id');
       chai.assert.equal(this.workspace.getTopComments(false).length, 1);
-      chai.assert.equal(this.workspace.commentDB_['comment id'], comment);
+      chai.assert.equal(this.workspace.commentDB.get('comment id'), comment);
     });
 
     test('After clear empty workspace', function() {
@@ -76,7 +76,7 @@ suite('Workspace comment', function() {
           this.workspace, 'comment text', 0, 0, 'comment id');
       this.workspace.clear();
       chai.assert.equal(this.workspace.getTopComments(false).length, 0);
-      chai.assert.isFalse('comment id' in this.workspace.commentDB_);
+      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
 
     test('After dispose', function() {
@@ -84,7 +84,7 @@ suite('Workspace comment', function() {
           this.workspace, 'comment text', 0, 0, 'comment id');
       comment.dispose();
       chai.assert.equal(this.workspace.getTopComments(false).length, 0);
-      chai.assert.isFalse('comment id' in this.workspace.commentDB_);
+      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
   });
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #5857

### Proposed Changes
This PR uses JS `Map` and `Set` objects in places where plain objects were being used due to the absence of those data structures in older versions of Javascript. Only variables that were private have been converted.

### Reason for Changes
General codehealth and improved typing accuracy.

### Test Coverage
Verified tests pass and manually tried the playground.