### PR TITLE
chore: convert mocha tests and test helpers to esmodules

### DIFF
--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -85,13 +85,13 @@
     // List of scripts to load in compressed mode, instead of
     // requires.  Paths relative to root.
     compressedScripts: [
-      'blockly_compressed.js',
-      'blocks_compressed.js',
-      'dart_compressed.js',
-      'javascript_compressed.js',
-      'lua_compressed.js',
-      'php_compressed.js',
-      'python_compressed.js',
+      'build/blockly_compressed.js',
+      'build/blocks_compressed.js',
+      'build/dart_compressed.js',
+      'build/javascript_compressed.js',
+      'build/lua_compressed.js',
+      'build/php_compressed.js',
+      'build/python_compressed.js',
     ],
 
     // Additional scripts to be loaded after Blockly is loaded,

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -85,13 +85,13 @@
     // List of scripts to load in compressed mode, instead of
     // requires.  Paths relative to root.
     compressedScripts: [
-      'build/blockly_compressed.js',
-      'build/blocks_compressed.js',
-      'build/dart_compressed.js',
-      'build/javascript_compressed.js',
-      'build/lua_compressed.js',
-      'build/php_compressed.js',
-      'build/python_compressed.js',
+      'blockly_compressed.js',
+      'blocks_compressed.js',
+      'dart_compressed.js',
+      'javascript_compressed.js',
+      'lua_compressed.js',
+      'php_compressed.js',
+      'python_compressed.js',
     ],
 
     // Additional scripts to be loaded after Blockly is loaded,

--- a/tests/mocha/.eslintrc.json
+++ b/tests/mocha/.eslintrc.json
@@ -11,7 +11,11 @@
         "no-unused-vars": ["off"],
         // Allow uncommented helper functions in tests.
         "require-jsdoc": ["off"],
-        "prefer-rest-params": ["off"]
+        "prefer-rest-params": ["off"],
+        "no-invalid-this": ["off"]
     },
-    "extends": "../../.eslintrc.json"
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+      "sourceType": "module"
+    }
 }

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.astNode');
 
 const {ASTNode} = goog.require('Blockly.ASTNode');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('ASTNode', function() {

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.astNode');
+goog.declareModuleId('Blockly.test.astNode');
 
 const {ASTNode} = goog.require('Blockly.ASTNode');
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.astNode');
 
-import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
+import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.astNode');
 
-const {ASTNode} = goog.require('Blockly.ASTNode');
+import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/block_change_event_test.js
+++ b/tests/mocha/block_change_event_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.blockChangeEvent');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {defineMutatorBlocks} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {defineMutatorBlocks} from './test_helpers/block_definitions.js';
 
 
 suite('Block Change Event', function() {

--- a/tests/mocha/block_change_event_test.js
+++ b/tests/mocha/block_change_event_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.blockChangeEvent');
+goog.declareModuleId('Blockly.test.blockChangeEvent');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {defineMutatorBlocks} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/block_create_event_test.js
+++ b/tests/mocha/block_create_event_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.blockCreateEvent');
 
 import {assertEventFired} from './test_helpers/events.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/block_create_event_test.js
+++ b/tests/mocha/block_create_event_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.blockCreateEvent');
 
-const {assertEventFired} = goog.require('Blockly.test.helpers.events');
+import {assertEventFired} from './test_helpers/events.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Block Create Event', function() {

--- a/tests/mocha/block_create_event_test.js
+++ b/tests/mocha/block_create_event_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.blockCreateEvent');
 
 import {assertEventFired} from './test_helpers/events.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/block_create_event_test.js
+++ b/tests/mocha/block_create_event_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.blockCreateEvent');
+goog.declareModuleId('Blockly.test.blockCreateEvent');
 
 const {assertEventFired} = goog.require('Blockly.test.helpers.events');
 const eventUtils = goog.require('Blockly.Events.utils');

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.blockJson');
 
-import {Align} from '../../core/input.js';
+import {Align} from '../../build/src/core/input.js';
 
 
 suite('Block JSON initialization', function() {

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.blockJson');
 
-const {Align} = goog.require('Blockly.Input');
+import {Align} from '../../core/input.js';
 
 
 suite('Block JSON initialization', function() {

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.blockJson');
+goog.declareModuleId('Blockly.test.blockJson');
 
 const {Align} = goog.require('Blockly.Input');
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.blocks');
+goog.declareModuleId('Blockly.test.blocks');
 
 const {Blocks} = goog.require('Blockly.blocks');
 const {ConnectionType} = goog.require('Blockly.ConnectionType');

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -8,10 +8,10 @@ goog.declareModuleId('Blockly.test.blocks');
 
 const {Blocks} = goog.require('Blockly.blocks');
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
-const {createDeprecationWarningStub} = goog.require('Blockly.test.helpers.warnings');
-const {createRenderedBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {createDeprecationWarningStub} from './test_helpers/warnings.js';
+import {createRenderedBlock} from './test_helpers/block_definitions.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Blocks', function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -6,11 +6,11 @@
 
 goog.declareModuleId('Blockly.test.blocks');
 
-const {Blocks} = goog.require('Blockly.blocks');
-const {ConnectionType} = goog.require('Blockly.ConnectionType');
+import {Blocks} from '../../blocks/blocks.js';
+import {ConnectionType} from '../../core/connection_type.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -6,11 +6,10 @@
 
 goog.declareModuleId('Blockly.test.blocks');
 
-import {Blocks} from '../../blocks/blocks.js';
-import {ConnectionType} from '../../core/connection_type.js';
+import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1989,7 +1989,7 @@ suite('Blocks', function() {
       // so we assert init was called to be safe.
       let initCalled = false;
       let recordUndoDuringInit;
-      Blocks['init_test_block'].init = function() {
+      Blockly.Blocks['init_test_block'].init = function() {
         initCalled = true;
         recordUndoDuringInit = eventUtils.getRecordUndo();
         throw new Error();

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.lists');
+goog.declareModuleId('Blockly.test.lists');
 
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -7,9 +7,9 @@
 goog.declareModuleId('Blockly.test.lists');
 
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {sharedTestSetup, sharedTestTeardown} from '../test_helpers/setup_teardown.js';
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
-import {defineStatementBlock} from './test_helpers/block_definitions.js';
+import {defineStatementBlock} from '../test_helpers/block_definitions.js';
 
 
 suite('Lists', function() {

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.lists');
 
-const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
+import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {sharedTestSetup, sharedTestTeardown} from '../test_helpers/setup_teardown.js';
-const {ConnectionType} = goog.require('Blockly.ConnectionType');
+import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {defineStatementBlock} from '../test_helpers/block_definitions.js';
 
 

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -7,9 +7,9 @@
 goog.declareModuleId('Blockly.test.lists');
 
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
-const {defineStatementBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {defineStatementBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Lists', function() {

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.logicTernary');
+goog.declareModuleId('Blockly.test.logicTernary');
 
 const eventUtils = goog.require('Blockly.Events.utils');
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.logicTernary');
 
 const eventUtils = goog.require('Blockly.Events.utils');
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Logic ternary', function() {

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.logicTernary');
 
-const eventUtils = goog.require('Blockly.Events.utils');
-const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
+import * as eventUtils from '../../build/src/core/events/utils.js';
+import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {sharedTestSetup, sharedTestTeardown} from '../test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.logicTernary');
 
 const eventUtils = goog.require('Blockly.Events.utils');
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {sharedTestSetup, sharedTestTeardown} from '../test_helpers/setup_teardown.js';
 
 
 suite('Logic ternary', function() {

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -6,10 +6,9 @@
 
 goog.declareModuleId('Blockly.test.procedures');
 
-goog.require('Blockly');
-goog.require('Blockly.Msg');
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} from '../test_helpers/procedures.js';
-const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
+import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from '../test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -8,9 +8,9 @@ goog.declareModuleId('Blockly.test.procedures');
 
 goog.require('Blockly');
 goog.require('Blockly.Msg');
-import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} from './test_helpers/procedures.js';
+import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} from '../test_helpers/procedures.js';
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from '../test_helpers/setup_teardown.js';
 
 
 suite('Procedures', function() {

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -8,9 +8,9 @@ goog.declareModuleId('Blockly.test.procedures');
 
 goog.require('Blockly');
 goog.require('Blockly.Msg');
-const {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} = goog.require('Blockly.test.helpers.procedures');
+import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} from './test_helpers/procedures.js';
 const {runSerializationTestSuite} = goog.require('Blockly.test.helpers.serialization');
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Procedures', function() {

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.procedures');
+goog.declareModuleId('Blockly.test.procedures');
 
 goog.require('Blockly');
 goog.require('Blockly.Msg');

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.variables');
+goog.declareModuleId('Blockly.test.variables');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.variables');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Variables', function() {

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.variables');
 
-import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {sharedTestSetup, sharedTestTeardown} from '../test_helpers/setup_teardown.js';
 
 
 suite('Variables', function() {

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.commentDeserialization');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {simulateClick} = goog.require('Blockly.test.helpers.userInput');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {simulateClick} from './test_helpers/user_input.js';
 
 
 suite('Comment Deserialization', function() {

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.commentDeserialization');
+goog.declareModuleId('Blockly.test.commentDeserialization');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {simulateClick} = goog.require('Blockly.test.helpers.userInput');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.comments');
 
-const {assertEventFired} = goog.require('Blockly.test.helpers.events');
+import {assertEventFired} from './test_helpers/events.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Comments', function() {

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.comments');
+goog.declareModuleId('Blockly.test.comments');
 
 const {assertEventFired} = goog.require('Blockly.test.helpers.events');
 const eventUtils = goog.require('Blockly.Events.utils');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.comments');
 
 import {assertEventFired} from './test_helpers/events.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.comments');
 
 import {assertEventFired} from './test_helpers/events.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.connectionChecker');
 
-import {ConnectionType} from '../../core/connection_type.js';
+import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.connectionChecker');
 
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Connection checker', function() {

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.connectionChecker');
+goog.declareModuleId('Blockly.test.connectionChecker');
 
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.connectionChecker');
 
-const {ConnectionType} = goog.require('Blockly.ConnectionType');
+import {ConnectionType} from '../../core/connection_type.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.connectionDb');
 
-const {ConnectionType} = goog.require('Blockly.ConnectionType');
+import {ConnectionType} from '../../core/connection_type.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.connectionDb');
+goog.declareModuleId('Blockly.test.connectionDb');
 
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.connectionDb');
 
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Connection Database', function() {

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.connectionDb');
 
-import {ConnectionType} from '../../core/connection_type.js';
+import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.connection');
+goog.declareModuleId('Blockly.test.connection');
 
 const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {defineRowBlock, defineStatementBlock, defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.connection');
 
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {defineRowBlock, defineStatementBlock, defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {defineRowBlock, defineStatementBlock, defineStackBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Connection', function() {

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.contextMenuItem');
+goog.declareModuleId('Blockly.test.contextMenuItem');
 
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.contextMenuItem');
 
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Context Menu Items', function() {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.cursor');
+goog.declareModuleId('Blockly.test.cursor');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {ASTNode} = goog.require('Blockly.ASTNode');

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.cursor');
 
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
-import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
+import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 
 
 suite('Cursor', function() {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.cursor');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 const {ASTNode} = goog.require('Blockly.ASTNode');
 
 

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.cursor');
 
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
-const {ASTNode} = goog.require('Blockly.ASTNode');
+import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
 
 
 suite('Cursor', function() {

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.dropdown');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('DropDownDiv', function() {

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.dropdown');
+goog.declareModuleId('Blockly.test.dropdown');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.event');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} from './test_helpers/events.js';
 import {assertVariableValues} from './test_helpers/variables.js';

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -6,12 +6,12 @@
 
 goog.declareModuleId('Blockly.test.event');
 
-const {ASTNode} = goog.require('Blockly.ASTNode');
+import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
 import {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} from './test_helpers/events.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
-const eventUtils = goog.require('Blockly.Events.utils');
-goog.require('Blockly.WorkspaceComment');
+import * as eventUtils from '../../core/events/utils.js';
+import {WorkspaceComment} from '../../core/workspace_comment.js';
 
 
 suite('Events', function() {

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -7,9 +7,9 @@
 goog.declareModuleId('Blockly.test.event');
 
 const {ASTNode} = goog.require('Blockly.ASTNode');
-const {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} = goog.require('Blockly.test.helpers.events');
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} from './test_helpers/events.js';
+import {assertVariableValues} from './test_helpers/variables.js';
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 const eventUtils = goog.require('Blockly.Events.utils');
 goog.require('Blockly.WorkspaceComment');
 

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.event');
+goog.declareModuleId('Blockly.test.event');
 
 const {ASTNode} = goog.require('Blockly.ASTNode');
 const {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} = goog.require('Blockly.test.helpers.events');

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -6,12 +6,12 @@
 
 goog.declareModuleId('Blockly.test.event');
 
-import {ASTNode} from '../../core/keyboard_nav/ast_node.js';
+import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {assertEventEquals, assertNthCallEventArgEquals, createFireChangeListenerSpy} from './test_helpers/events.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
-import * as eventUtils from '../../core/events/utils.js';
-import {WorkspaceComment} from '../../core/workspace_comment.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
+import {WorkspaceComment} from '../../build/src/core/workspace_comment.js';
 
 
 suite('Events', function() {

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.extensions');
+goog.declareModuleId('Blockly.test.extensions');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.extensions');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Extensions', function() {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldAngle');
+goog.declareModuleId('Blockly.test.fieldAngle');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldAngle');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Angle Fields', function() {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldAngle');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldCheckbox');
+goog.declareModuleId('Blockly.test.fieldCheckbox');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldCheckbox');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldCheckbox');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {defineRowBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Checkbox Fields', function() {

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldColour');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldColour');
+goog.declareModuleId('Blockly.test.fieldColour');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldColour');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Colour Fields', function() {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldDropdown');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Dropdown Fields', function() {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldDropdown');
+goog.declareModuleId('Blockly.test.fieldDropdown');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldDropdown');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldImage');
+goog.declareModuleId('Blockly.test.fieldImage');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldImage');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.fieldImage');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Image Fields', function() {

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldLabelSerialization');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldLabelSerialization');
+goog.declareModuleId('Blockly.test.fieldLabelSerialization');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldLabelSerialization');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Label Serializable Fields', function() {

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldLabel');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {createTestBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {createTestBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Label Fields', function() {

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldLabel');
+goog.declareModuleId('Blockly.test.fieldLabel');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldLabel');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {createTestBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldMultiline');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldMultiline');
+goog.declareModuleId('Blockly.test.fieldMultiline');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -11,6 +11,11 @@ import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSe
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {runCodeGenerationTestSuites} from './test_helpers/code_generation.js';
+const {dartGenerator} = goog.require('Blockly.Dart');
+const {javascriptGenerator} = goog.require('Blockly.JavaScript');
+const {luaGenerator} = goog.require('Blockly.Lua');
+const {phpGenerator} = goog.require('Blockly.PHP');
+const {pythonGenerator} = goog.require('Blockly.Python');
 
 
 suite('Multiline Input Fields', function() {

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -6,10 +6,10 @@
 
 goog.declareModuleId('Blockly.test.fieldMultiline');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {runCodeGenerationTestSuites} = goog.require('Blockly.test.helpers.codeGeneration');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {runCodeGenerationTestSuites} from './test_helpers/code_generation.js';
 
 
 suite('Multiline Input Fields', function() {

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldNumber');
+goog.declareModuleId('Blockly.test.fieldNumber');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -6,10 +6,10 @@
 
 goog.declareModuleId('Blockly.test.fieldNumber');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {runTestCases} = goog.require('Blockly.test.helpers.common');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {runTestCases} from './test_helpers/common.js';
 
 
 suite('Number Fields', function() {

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldNumber');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldRegistry');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.fieldRegistry');
 
-const {createDeprecationWarningStub} = goog.require('Blockly.test.helpers.warnings');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {createDeprecationWarningStub} from './test_helpers/warnings.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Field Registry', function() {

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldRegistry');
+goog.declareModuleId('Blockly.test.fieldRegistry');
 
 const {createDeprecationWarningStub} = goog.require('Blockly.test.helpers.warnings');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldTest');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {addBlockTypeToCleanup, addMessageToCleanup, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.fieldTest');
 
-const {addBlockTypeToCleanup, addMessageToCleanup, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {createDeprecationWarningStub} = goog.require('Blockly.test.helpers.warnings');
+import {addBlockTypeToCleanup, addMessageToCleanup, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 
 
 suite('Abstract Fields', function() {

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldTest');
+goog.declareModuleId('Blockly.test.fieldTest');
 
 const {addBlockTypeToCleanup, addMessageToCleanup, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {createDeprecationWarningStub} = goog.require('Blockly.test.helpers.warnings');

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldTextInput');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldTextInput');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Text Input Fields', function() {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldTextInput');
+goog.declareModuleId('Blockly.test.fieldTextInput');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.fieldVariable');
 
-const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {createTestBlock, defineRowBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';
 
 
 suite('Variable Fields', function() {

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.fieldVariable');
+goog.declareModuleId('Blockly.test.fieldVariable');
 
 const {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} = goog.require('Blockly.test.helpers.fields');
 const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.fieldVariable');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {assertFieldValue, runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests} from './test_helpers/fields.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {createTestBlock, defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -6,7 +6,8 @@
 
 goog.declareModuleId('Blockly.test.flyout');
 
-import {defineStackBlock, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {getBasicToolbox, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getProperSimpleJson, getSeparator, getSimpleJson, getXmlArray} from './test_helpers/toolbox_definitions.js';
 
 

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.flyout');
 
-const {defineStackBlock, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {getBasicToolbox, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getProperSimpleJson, getSeparator, getSimpleJson, getXmlArray} = goog.require('Blockly.test.helpers.toolboxDefinitions');
+import {defineStackBlock, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {getBasicToolbox, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getProperSimpleJson, getSeparator, getSimpleJson, getXmlArray} from './test_helpers/toolbox_definitions.js';
 
 
 suite('Flyout', function() {

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.flyout');
+goog.declareModuleId('Blockly.test.flyout');
 
 const {defineStackBlock, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {getBasicToolbox, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getProperSimpleJson, getSeparator, getSimpleJson, getXmlArray} = goog.require('Blockly.test.helpers.toolboxDefinitions');

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.generator');
 
-// TODO: Not sure hwo to handle this.
+import * as Blockly from '../../build/src/core/blockly.js';
 const {dartGenerator} = goog.require('Blockly.Dart');
 const {javaScriptGenerator} = goog.require('Blockly.JavaScript');
 const {luaGenerator} = goog.require('Blockly.Lua');

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.generator');
 
 import * as Blockly from '../../build/src/core/blockly.js';
 const {dartGenerator} = goog.require('Blockly.Dart');
-const {javaScriptGenerator} = goog.require('Blockly.JavaScript');
+const {javascriptGenerator} = goog.require('Blockly.JavaScript');
 const {luaGenerator} = goog.require('Blockly.Lua');
 const {phpGenerator} = goog.require('Blockly.PHP');
 const {pythonGenerator} = goog.require('Blockly.Python');

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.generator');
+goog.declareModuleId('Blockly.test.generator');
 
 const {dartGenerator} = goog.require('Blockly.Dart');
 const {javaScriptGenerator} = goog.require('Blockly.JavaScript');

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -11,7 +11,7 @@ const {javaScriptGenerator} = goog.require('Blockly.JavaScript');
 const {luaGenerator} = goog.require('Blockly.Lua');
 const {phpGenerator} = goog.require('Blockly.PHP');
 const {pythonGenerator} = goog.require('Blockly.Python');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Generator', function() {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.generator');
 
+// TODO: Not sure hwo to handle this.
 const {dartGenerator} = goog.require('Blockly.Dart');
 const {javaScriptGenerator} = goog.require('Blockly.JavaScript');
 const {luaGenerator} = goog.require('Blockly.Lua');

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.gesture');
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.gesture');
+goog.declareModuleId('Blockly.test.gesture');
 
 const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
 const {defineBasicBlockWithField} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -6,11 +6,11 @@
 
 goog.declareModuleId('Blockly.test.gesture');
 
-const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
-const {defineBasicBlockWithField} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {dispatchPointerEvent} = goog.require('Blockly.test.helpers.userInput');
+import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
+import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
+import {dispatchPointerEvent} from './test_helpers/user_input.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Gesture', function() {

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.gesture');
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.input');
+goog.declareModuleId('Blockly.test.input');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.input');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Inputs', function() {

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.insertionMarker');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('InsertionMarkers', function() {

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.insertionMarker');
+goog.declareModuleId('Blockly.test.insertionMarker');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.jsoDeserialization');
 
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {assertEventFired} = goog.require('Blockly.test.helpers.events');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {assertEventFired} from './test_helpers/events.js';
 const eventUtils = goog.require('Blockly.Events.utils');
 
 

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.jsoDeserialization');
 
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {assertEventFired} from './test_helpers/events.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 
 
 suite('JSO Deserialization', function() {

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.jsoDeserialization');
+goog.declareModuleId('Blockly.test.jsoDeserialization');
 
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {assertEventFired} = goog.require('Blockly.test.helpers.events');

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.jsoDeserialization');
 
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {assertEventFired} from './test_helpers/events.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 
 
 suite('JSO Deserialization', function() {

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.jsoSerialization');
+goog.declareModuleId('Blockly.test.jsoSerialization');
 
 const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {defineRowBlock, defineStackBlock, defineStatementBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.jsoSerialization');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {defineRowBlock, defineStackBlock, defineStatementBlock} from './test_helpers/block_definitions.js';
 

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.jsoSerialization');
 
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {defineRowBlock, defineStackBlock, defineStatementBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {defineRowBlock, defineStackBlock, defineStatementBlock} from './test_helpers/block_definitions.js';
 
 
 suite('JSO Serialization', function() {

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.json');
 
-const {addMessageToCleanup, sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {assertNoWarnings, assertWarnings} = goog.require('Blockly.test.helpers.warnings');
+import {addMessageToCleanup, sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {assertNoWarnings, assertWarnings} from './test_helpers/warnings.js';
 
 
 suite('JSON Block Definitions', function() {

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.json');
+goog.declareModuleId('Blockly.test.json');
 
 const {addMessageToCleanup, sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {assertNoWarnings, assertWarnings} = goog.require('Blockly.test.helpers.warnings');

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.keydown');
+goog.declareModuleId('Blockly.test.keydown');
 
 const {createKeyDownEvent} = goog.require('Blockly.test.helpers.userInput');
 const {defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.keydown');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.keydown');
 
-const {createKeyDownEvent} = goog.require('Blockly.test.helpers.userInput');
-const {defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {createKeyDownEvent} from './test_helpers/user_input.js';
+import {defineStackBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Key Down', function() {

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.metrics');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Metrics', function() {

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.metrics');
+goog.declareModuleId('Blockly.test.metrics');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.mutator');
+goog.declareModuleId('Blockly.test.mutator');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {createRenderedBlock, defineMutatorBlocks} = goog.require('Blockly.test.helpers.blockDefinitions');

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -7,8 +7,8 @@
 
 goog.declareModuleId('Blockly.test.mutator');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {createRenderedBlock, defineMutatorBlocks} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {createRenderedBlock, defineMutatorBlocks} from './test_helpers/block_definitions.js';
 
 
 suite('Mutator', function() {

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.names');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Names', function() {

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.names');
+goog.declareModuleId('Blockly.test.names');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.registry');
+goog.declareModuleId('Blockly.test.registry');
 
 const {assertWarnings} = goog.require('Blockly.test.helpers.warnings');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.registry');
 
-const {assertWarnings} = goog.require('Blockly.test.helpers.warnings');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertWarnings} from './test_helpers/warnings.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Registry', function() {

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.serialization');
 
-const {TestCase, TestSuite, runTestCases, runTestSuites} = goog.require('Blockly.test.helpers.common');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {TestCase, TestSuite, runTestCases, runTestSuites} from './test_helpers/common.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 // TODO: Move this into samples as part of the dev-tools package.

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -6,6 +6,7 @@
 
 goog.declareModuleId('Blockly.test.serialization');
 
+import * as Blockly from '../../build/src/core/blockly.js';
 import {TestCase, TestSuite, runTestCases, runTestSuites} from './test_helpers/common.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.serialization');
+goog.declareModuleId('Blockly.test.serialization');
 
 const {TestCase, TestSuite, runTestCases, runTestSuites} = goog.require('Blockly.test.helpers.common');
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.shortcutRegistry');
 
-const {createKeyDownEvent} = goog.require('Blockly.test.helpers.userInput');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {createKeyDownEvent} from './test_helpers/user_input.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Keyboard Shortcut Registry Test', function() {

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.shortcutRegistry');
+goog.declareModuleId('Blockly.test.shortcutRegistry');
 
 const {createKeyDownEvent} = goog.require('Blockly.test.helpers.userInput');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.helpers.blockDefinitions');
 
 
-function defineStackBlock(name = 'stack_block') {
+export function defineStackBlock(name = 'stack_block') {
   Blockly.defineBlocksWithJsonArray([{
     "type": name,
     "message0": "",
@@ -15,9 +15,8 @@ function defineStackBlock(name = 'stack_block') {
     "nextStatement": null,
   }]);
 }
-exports.defineStackBlock = defineStackBlock;
 
-function defineRowBlock(name = 'row_block') {
+export function defineRowBlock(name = 'row_block') {
   Blockly.defineBlocksWithJsonArray([{
     "type": name,
     "message0": "%1",
@@ -30,9 +29,8 @@ function defineRowBlock(name = 'row_block') {
     "output": null,
   }]);
 }
-exports.defineRowBlock = defineRowBlock;
 
-function defineStatementBlock(name = 'statement_block') {
+export function defineStatementBlock(name = 'statement_block') {
   Blockly.defineBlocksWithJsonArray([{
     "type": name,
     "message0": "%1",
@@ -49,9 +47,8 @@ function defineStatementBlock(name = 'statement_block') {
     "helpUrl": "",
   }]);
 }
-exports.defineStatementBlock = defineStatementBlock;
 
-function defineBasicBlockWithField(name = 'test_field_block') {
+export function defineBasicBlockWithField(name = 'test_field_block') {
   Blockly.defineBlocksWithJsonArray([{
     "type": name,
     "message0": "%1",
@@ -64,9 +61,8 @@ function defineBasicBlockWithField(name = 'test_field_block') {
     "output": null,
   }]);
 }
-exports.defineBasicBlockWithField = defineBasicBlockWithField;
 
-function defineMutatorBlocks() {
+export function defineMutatorBlocks() {
   Blockly.defineBlocksWithJsonArray([
     {
       'type': 'xml_block',
@@ -158,9 +154,8 @@ function defineMutatorBlocks() {
   };
   Blockly.Extensions.registerMutator('jso_mutator', jsoMutator);
 }
-exports.defineMutatorBlocks = defineMutatorBlocks;
 
-function createTestBlock() {
+export function createTestBlock() {
   return {
     'id': 'test',
     'rendered': false,
@@ -174,12 +169,10 @@ function createTestBlock() {
     'updateVarName': Blockly.Block.prototype.updateVarName,
   };
 }
-exports.createTestBlock = createTestBlock;
 
-function createRenderedBlock(workspaceSvg, type) {
+export function createRenderedBlock(workspaceSvg, type) {
   const block = workspaceSvg.newBlock(type);
   block.initSvg();
   block.render();
   return block;
 }
-exports.createRenderedBlock = createRenderedBlock;

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.blockDefinitions');
+goog.declareModuleId('Blockly.test.helpers.blockDefinitions');
 
 
 function defineStackBlock(name = 'stack_block') {

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.codeGeneration');
+goog.declareModuleId('Blockly.test.helpers.codeGeneration');
 
 const {runTestSuites} = goog.require('Blockly.test.helpers.common');
 

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -15,7 +15,7 @@ const {runTestSuites} = goog.require('Blockly.test.helpers.common');
  * @implements {TestCase}
  * @record
  */
-class CodeGenerationTestCase {
+export class CodeGenerationTestCase {
   /**
    * Class for a code generation test case.
    */
@@ -43,14 +43,13 @@ class CodeGenerationTestCase {
    */
   createBlock(workspace) {}
 }
-exports.CodeGenerationTestCase = CodeGenerationTestCase;
 
 /**
  * Code generation test suite.
  * @extends {TestSuite<CodeGenerationTestCase, CodeGenerationTestSuite>}
  * @record
  */
-class CodeGenerationTestSuite {
+export class CodeGenerationTestSuite {
   /**
    * Class for a code generation test suite.
    */
@@ -61,7 +60,6 @@ class CodeGenerationTestSuite {
     this.generator;
   }
 }
-exports.CodeGenerationTestSuite = CodeGenerationTestSuite;
 
 /**
  * Returns mocha test callback for code generation based on provided
@@ -102,7 +100,7 @@ const createCodeGenerationTestFn_ = (generator) => {
  * Runs blockToCode test suites.
  * @param {!Array<!CodeGenerationTestSuite>} testSuites The test suites to run.
  */
-const runCodeGenerationTestSuites = (testSuites) => {
+export const runCodeGenerationTestSuites = (testSuites) => {
   /**
    * Creates function used to generate mocha test callback.
    * @param {!CodeGenerationTestSuite} suiteInfo The test suite information.
@@ -115,4 +113,3 @@ const runCodeGenerationTestSuites = (testSuites) => {
 
   runTestSuites(testSuites, createTestFn);
 };
-exports.runCodeGenerationTestSuites = runCodeGenerationTestSuites;

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -7,7 +7,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.codeGeneration');
 
-const {runTestSuites} = goog.require('Blockly.test.helpers.common');
+import {runTestSuites} from './common.js';
 
 
 /**

--- a/tests/mocha/test_helpers/common.js
+++ b/tests/mocha/test_helpers/common.js
@@ -10,7 +10,7 @@ goog.declareModuleId('Blockly.test.helpers.common');
  * Test case configuration.
  * @record
  */
-class TestCase {
+export class TestCase {
   /**
    * Class for a test case configuration.
    */
@@ -31,7 +31,6 @@ class TestCase {
     this.only;
   }
 }
-exports.TestCase = TestCase;
 
 /**
  * Test suite configuration.
@@ -39,7 +38,7 @@ exports.TestCase = TestCase;
  * @template {TestCase} T
  * @template {TestSuite} U
  */
-class TestSuite {
+export class TestSuite {
   /**
    * Class for a test suite configuration.
    */
@@ -68,7 +67,6 @@ class TestSuite {
     this.only;
   }
 }
-exports.TestSuite = TestSuite;
 
 /**
  * Runs provided test cases.
@@ -77,14 +75,13 @@ exports.TestSuite = TestSuite;
  * @param {function(T):Function} createTestCallback Creates test
  *    callback using given test case.
  */
-function runTestCases(testCases, createTestCallback) {
+export function runTestCases(testCases, createTestCallback) {
   testCases.forEach((testCase) => {
     let testCall = (testCase.skip ? test.skip : test);
     testCall = (testCase.only ? test.only : testCall);
     testCall(testCase.title, createTestCallback(testCase));
   });
 }
-exports.runTestCases = runTestCases;
 
 /**
  * Runs provided test suite.
@@ -95,7 +92,7 @@ exports.runTestCases = runTestCases;
  *    } createTestCaseCallback Creates test case callback using given test
  *    suite.
  */
-function runTestSuites(testSuites, createTestCaseCallback) {
+export function runTestSuites(testSuites, createTestCaseCallback) {
   testSuites.forEach((testSuite) => {
     let suiteCall = (testSuite.skip ? suite.skip : suite);
     suiteCall = (testSuite.only ? suite.only : suiteCall);
@@ -109,4 +106,3 @@ function runTestSuites(testSuites, createTestCaseCallback) {
     });
   });
 }
-exports.runTestSuites = runTestSuites;

--- a/tests/mocha/test_helpers/common.js
+++ b/tests/mocha/test_helpers/common.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.common');
+goog.declareModuleId('Blockly.test.helpers.common');
 
 /**
  * Test case configuration.

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.events');
+goog.declareModuleId('Blockly.test.helpers.events');
 
 
 /**

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -13,10 +13,9 @@ goog.declareModuleId('Blockly.test.helpers.events');
  *    calls on.
  * @return {!SinonSpy} The created spy.
  */
-function createFireChangeListenerSpy(workspace) {
+export function createFireChangeListenerSpy(workspace) {
   return sinon.spy(workspace, 'fireChangeListener');
 }
-exports.createFireChangeListenerSpy = createFireChangeListenerSpy;
 
 /**
  * Asserts whether the given xml property has the expected property.
@@ -75,7 +74,7 @@ function isXmlProperty_(key) {
  * @param {boolean=} [isUiEvent=false] Whether the event is a UI event.
  * @param {string=} message Optional message to prepend assert messages.
  */
-function assertEventEquals(event, expectedType,
+export function assertEventEquals(event, expectedType,
     expectedWorkspaceId, expectedBlockId, expectedProperties, isUiEvent = false, message) {
   let prependMessage = message ? message + ' ' : '';
   prependMessage += 'Event fired ';
@@ -107,7 +106,6 @@ function assertEventEquals(event, expectedType,
     chai.assert.isFalse(event.isUiEvent);
   }
 }
-exports.assertEventEquals = assertEventEquals;
 
 /**
  * Asserts that an event with the given values was fired.
@@ -119,7 +117,7 @@ exports.assertEventEquals = assertEventEquals;
  * @param {string} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-function assertEventFired(spy, instanceType, expectedProperties,
+export function assertEventFired(spy, instanceType, expectedProperties,
     expectedWorkspaceId, expectedBlockId) {
   expectedProperties = Object.assign({
     workspaceId: expectedWorkspaceId,
@@ -129,7 +127,6 @@ function assertEventFired(spy, instanceType, expectedProperties,
       sinon.match.instanceOf(instanceType).and(sinon.match(expectedProperties));
   sinon.assert.calledWith(spy, expectedEvent);
 }
-exports.assertEventFired = assertEventFired;
 
 /**
  * Asserts that an event with the given values was not fired.
@@ -141,7 +138,7 @@ exports.assertEventFired = assertEventFired;
  * @param {string=} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-function assertEventNotFired(spy, instanceType, expectedProperties,
+export function assertEventNotFired(spy, instanceType, expectedProperties,
     expectedWorkspaceId, expectedBlockId) {
   expectedProperties.type = instanceType.prototype.type;
   if (expectedWorkspaceId !== undefined) {
@@ -154,7 +151,6 @@ function assertEventNotFired(spy, instanceType, expectedProperties,
       sinon.match.instanceOf(instanceType).and(sinon.match(expectedProperties));
   sinon.assert.neverCalledWith(spy, expectedEvent);
 }
-exports.assertEventNotFired = assertEventNotFired;
 
 /**
  * Filters out xml properties from given object based on key.
@@ -189,7 +185,7 @@ function splitByXmlProperties_(properties) {
  * @param {string} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
+export function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
     expectedWorkspaceId, expectedBlockId) {
   const nthCall = spy.getCall(n);
   const splitProperties = splitByXmlProperties_(expectedProperties);
@@ -201,4 +197,3 @@ function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
   const eventArg = nthCall.firstArg;
   assertXmlProperties_(eventArg, xmlProperties);
 }
-exports.assertNthCallEventArgEquals = assertNthCallEventArgEquals;

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.fields');
 
-const {runTestCases, TestCase} = goog.require('Blockly.test.helpers.common');
+import {runTestCases, TestCase} from './common.js';
 
 
 /**

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -14,7 +14,7 @@ const {runTestCases, TestCase} = goog.require('Blockly.test.helpers.common');
  * @implements {TestCase}
  * @record
  */
-class FieldValueTestCase {
+export class FieldValueTestCase {
   /**
    * Class for a a field value test case.
    */
@@ -39,14 +39,13 @@ class FieldValueTestCase {
     this.errMsgMatcher;
   }
 }
-exports.FieldValueTestCase = FieldValueTestCase;
 
 /**
  * Field creation test case.
  * @extends {FieldValueTestCase}
  * @record
  */
-class FieldCreationTestCase {
+export class FieldCreationTestCase {
   /**
    * Class for a field creation test case.
    */
@@ -61,7 +60,6 @@ class FieldCreationTestCase {
     this.json;
   }
 }
-exports.FieldCreationTestCase = FieldCreationTestCase;
 
 /**
  * Assert a field's value is the same as the expected value.
@@ -69,7 +67,7 @@ exports.FieldCreationTestCase = FieldCreationTestCase;
  * @param {*} expectedValue The expected value.
  * @param {string=} expectedText The expected text.
  */
-function assertFieldValue(field, expectedValue, expectedText = undefined) {
+export function assertFieldValue(field, expectedValue, expectedText = undefined) {
   const actualValue = field.getValue();
   const actualText = field.getText();
   if (expectedText === undefined) {
@@ -78,7 +76,6 @@ function assertFieldValue(field, expectedValue, expectedText = undefined) {
   chai.assert.equal(actualValue, expectedValue, 'Value');
   chai.assert.equal(actualText, expectedText, 'Text');
 }
-exports.assertFieldValue = assertFieldValue;
 
 /**
  * Runs provided creation test cases.
@@ -145,7 +142,7 @@ function runCreationTestsAssertThrows_(testCases, creation) {
  * @param {function(!FieldCreationTestCase=)=} customCreateWithJs Custom
  *    creation function to use in tests.
  */
-function runConstructorSuiteTests(TestedField, validValueTestCases,
+export function runConstructorSuiteTests(TestedField, validValueTestCases,
     invalidValueTestCases, validRunAssertField, assertFieldDefault,
     customCreateWithJs) {
   suite('Constructor', function() {
@@ -182,7 +179,6 @@ function runConstructorSuiteTests(TestedField, validValueTestCases,
     runCreationTests_(validValueTestCases, validRunAssertField, createWithJs);
   });
 }
-exports.runConstructorSuiteTests = runConstructorSuiteTests;
 
 /**
  * Runs suite of tests for fromJson creation of specified field.
@@ -200,7 +196,7 @@ exports.runConstructorSuiteTests = runConstructorSuiteTests;
  * @param {function(!FieldCreationTestCase=)=} customCreateWithJson Custom
  *    creation function to use in tests.
  */
-function runFromJsonSuiteTests(TestedField, validValueTestCases,
+export function runFromJsonSuiteTests(TestedField, validValueTestCases,
     invalidValueTestCases, validRunAssertField, assertFieldDefault,
     customCreateWithJson) {
   suite('fromJson', function() {
@@ -237,7 +233,6 @@ function runFromJsonSuiteTests(TestedField, validValueTestCases,
     runCreationTests_(validValueTestCases, validRunAssertField, createWithJson);
   });
 }
-exports.runFromJsonSuiteTests = runFromJsonSuiteTests;
 
 /**
  * Runs tests for setValue calls.
@@ -250,7 +245,7 @@ exports.runFromJsonSuiteTests = runFromJsonSuiteTests;
  * @param {string=} invalidRunExpectedText Expected text for field after invalid
  *    call to setValue.
  */
-function runSetValueTests(validValueTestCases, invalidValueTestCases,
+export function runSetValueTests(validValueTestCases, invalidValueTestCases,
     invalidRunExpectedValue, invalidRunExpectedText) {
   /**
    * Creates test callback for invalid setValue test.
@@ -279,4 +274,3 @@ function runSetValueTests(validValueTestCases, invalidValueTestCases,
   runTestCases(invalidValueTestCases, createInvalidSetValueTestCallback);
   runTestCases(validValueTestCases, createValidSetValueTestCallback);
 }
-exports.runSetValueTests = runSetValueTests;

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.fields');
+goog.declareModuleId('Blockly.test.helpers.fields');
 
 const {runTestCases, TestCase} = goog.require('Blockly.test.helpers.common');
 

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -5,7 +5,7 @@
  */
 goog.declareModuleId('Blockly.test.helpers.procedures');
 
-const {ConnectionType} = goog.require('Blockly.ConnectionType');
+import {ConnectionType} from '../../../core/connection_type.js';
 
 
 /**

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -55,7 +55,7 @@ function assertCallBlockArgsStructure(callBlock, args) {
  * @param {boolean=} hasStatements If we expect the procedure def to have a
  *     statement input or not.
  */
-function assertDefBlockStructure(defBlock, hasReturn = false,
+export function assertDefBlockStructure(defBlock, hasReturn = false,
     args = [], varIds = [], hasStatements = true) {
   if (hasStatements) {
     chai.assert.isNotNull(defBlock.getInput('STACK'),
@@ -82,7 +82,6 @@ function assertDefBlockStructure(defBlock, hasReturn = false,
   chai.assert.sameOrderedMembers(defBlock.getVars(), args);
   assertBlockVarModels(defBlock, varIds);
 }
-exports.assertDefBlockStructure = assertDefBlockStructure;
 
 /**
  * Asserts that the procedure call block has the expected inputs and
@@ -92,7 +91,7 @@ exports.assertDefBlockStructure = assertDefBlockStructure;
  * @param {Array<string>=} varIds An array of variable ids.
  * @param {string=} name The name we expect the caller to have.
  */
-function assertCallBlockStructure(
+export function assertCallBlockStructure(
   callBlock, args = [], varIds = [], name = undefined) {
   if (args.length) {
     chai.assert.include(callBlock.toString(), 'with');
@@ -106,7 +105,6 @@ function assertCallBlockStructure(
     chai.assert(callBlock.getFieldValue('NAME'), name);
   }
 }
-exports.assertCallBlockStructure = assertCallBlockStructure;
 
 /**
  * Creates procedure definition block using domToBlock call.
@@ -116,7 +114,7 @@ exports.assertCallBlockStructure = assertCallBlockStructure;
  * @param {Array<string>=} args An array of argument names.
  * @return {Blockly.Block} The created block.
  */
-function createProcDefBlock(
+export function createProcDefBlock(
     workspace, hasReturn = false, args = []) {
   const type = hasReturn ?
       'procedures_defreturn' : 'procedures_defnoreturn';
@@ -130,7 +128,6 @@ function createProcDefBlock(
       '</block>';
   return Blockly.Xml.domToBlock(Blockly.Xml.textToDom(xml), workspace);
 }
-exports.createProcDefBlock = createProcDefBlock;
 
 /**
  * Creates procedure call block using domToBlock call.
@@ -139,7 +136,7 @@ exports.createProcDefBlock = createProcDefBlock;
  *    has return.
  * @return {Blockly.Block} The created block.
  */
-function createProcCallBlock(
+export function createProcCallBlock(
     workspace, hasReturn = false) {
   const type = hasReturn ?
       'procedures_callreturn' : 'procedures_callnoreturn';
@@ -149,4 +146,3 @@ function createProcCallBlock(
       '</block>'
   ), workspace);
 }
-exports.createProcCallBlock = createProcCallBlock;

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -5,7 +5,7 @@
  */
 goog.declareModuleId('Blockly.test.helpers.procedures');
 
-import {ConnectionType} from '../../../core/connection_type.js';
+import {ConnectionType} from '../../../build/src/core/connection_type.js';
 
 
 /**

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -3,7 +3,7 @@
  * Copyright 2020 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-goog.module('Blockly.test.helpers.procedures');
+goog.declareModuleId('Blockly.test.helpers.procedures');
 
 const {ConnectionType} = goog.require('Blockly.ConnectionType');
 

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.serialization');
 
-const {runTestCases} = goog.require('Blockly.test.helpers.common');
+import {runTestCases} from './common.js';
 
 /**
  * Serialization test case.

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.serialization');
+goog.declareModuleId('Blockly.test.helpers.serialization');
 
 const {runTestCases} = goog.require('Blockly.test.helpers.common');
 

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -13,7 +13,7 @@ const {runTestCases} = goog.require('Blockly.test.helpers.common');
  * @implements {TestCase}
  * @record
  */
-class SerializationTestCase {
+export class SerializationTestCase {
   /**
    * Class for a block serialization test case.
    */
@@ -45,13 +45,12 @@ class SerializationTestCase {
    */
   assertBlockStructure(block) {}
 }
-exports.SerializationTestCase = SerializationTestCase;
 
 /**
  * Runs serialization test suite.
  * @param {!Array<!SerializationTestCase>} testCases The test cases to run.
  */
-const runSerializationTestSuite = (testCases) => {
+export const runSerializationTestSuite = (testCases) => {
   /**
    * Creates test callback for xmlToBlock test.
    * @param {!SerializationTestCase} testCase The test case information.
@@ -129,4 +128,3 @@ const runSerializationTestSuite = (testCases) => {
     });
   });
 };
-exports.runSerializationTestSuite = runSerializationTestSuite;

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -6,8 +6,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.setupTeardown');
 
-import * as eventUtils from '../../../core/events/utils.js';
-import {Blocks} from '../../../blocks/blocks.js';
+import * as eventUtils from '../../../build/src/core/events/utils.js';
 
 /**
  * Safely disposes of Blockly workspace, logging any errors.

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -167,7 +167,7 @@ export function sharedTestTeardown() {
 
     const blockTypes = this.sharedCleanup.blockTypesCleanup_;
     for (let i = 0; i < blockTypes.length; i++) {
-      delete Blocks[blockTypes[i]];
+      delete Blockly.Blocks[blockTypes[i]];
     }
     const messages = this.sharedCleanup.messagesCleanup_;
     for (let i = 0; i < messages.length; i++) {

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.setupTeardown');
+goog.declareModuleId('Blockly.test.helpers.setupTeardown');
 
 const eventUtils = goog.require('Blockly.Events.utils');
 const {Blocks} = goog.require('Blockly.blocks');

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -6,9 +6,8 @@
 
 goog.declareModuleId('Blockly.test.helpers.setupTeardown');
 
-const eventUtils = goog.require('Blockly.Events.utils');
-const {Blocks} = goog.require('Blockly.blocks');
-
+import * as eventUtils from '../../../core/events/utils.js';
+import {Blocks} from '../../../blocks/blocks.js';
 
 /**
  * Safely disposes of Blockly workspace, logging any errors.

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -16,7 +16,7 @@ const {Blocks} = goog.require('Blockly.blocks');
  * using workspaceTeardown.call(this).
  * @param {!Blockly.Workspace} workspace The workspace to dispose.
  */
-function workspaceTeardown(workspace) {
+export function workspaceTeardown(workspace) {
   try {
     this.clock.runAll();  // Run all queued setTimeout calls.
     workspace.dispose();
@@ -26,7 +26,6 @@ function workspaceTeardown(workspace) {
     console.error(testRef.fullTitle() + '\n', e);
   }
 }
-exports.workspaceTeardown = workspaceTeardown;
 
 /**
  * Creates stub for Blockly.Events.fire that advances the clock forward after
@@ -53,10 +52,9 @@ function createEventsFireStubFireImmediately_(clock) {
  *    sharedTestSetup.
  * @param {string} message The message to add to shared cleanup object.
  */
-function addMessageToCleanup(sharedCleanupObj, message) {
+export function addMessageToCleanup(sharedCleanupObj, message) {
   sharedCleanupObj.messagesCleanup_.push(message);
 }
-exports.addMessageToCleanup = addMessageToCleanup;
 
 /**
  * Adds block type to shared cleanup object so that it is cleaned from
@@ -65,10 +63,9 @@ exports.addMessageToCleanup = addMessageToCleanup;
  *    sharedTestSetup.
  * @param {string} blockType The block type to add to shared cleanup object.
  */
-function addBlockTypeToCleanup(sharedCleanupObj, blockType) {
+export function addBlockTypeToCleanup(sharedCleanupObj, blockType) {
   sharedCleanupObj.blockTypesCleanup_.push(blockType);
 }
-exports.addBlockTypeToCleanup = addBlockTypeToCleanup;
 
 /**
  * Wraps Blockly.defineBlocksWithJsonArray using stub in order to keep track of
@@ -111,7 +108,7 @@ function wrapDefineBlocksWithJsonArrayWithCleanup_(sharedCleanupObj) {
  * @param {Object<string, boolean>} options Options to enable/disable setup
  *    of certain stubs.
  */
-function sharedTestSetup(options = {}) {
+export function sharedTestSetup(options = {}) {
   this.sharedSetupCalled_ = true;
   // Sandbox created for greater control when certain stubs are cleared.
   this.sharedSetupSandbox_ = sinon.createSandbox();
@@ -128,14 +125,13 @@ function sharedTestSetup(options = {}) {
   this.messagesCleanup_ = this.sharedCleanup.messagesCleanup_;
   wrapDefineBlocksWithJsonArrayWithCleanup_(this.sharedCleanup);
 }
-exports.sharedTestSetup = sharedTestSetup;
 
 /**
  * Shared cleanup method that clears up pending setTimeout calls, disposes of
  * workspace, and resets global variables. Should be called in setup of
  * outermost suite using sharedTestTeardown.call(this).
  */
-function sharedTestTeardown() {
+export function sharedTestTeardown() {
   const testRef = this.currentTest || this.test;
   if (!this.sharedSetupCalled_) {
     console.error('"' + testRef.fullTitle() + '" did not call sharedTestSetup');
@@ -183,7 +179,6 @@ function sharedTestTeardown() {
     Blockly.WidgetDiv.testOnly_setDiv(null);
   }
 }
-exports.sharedTestTeardown = sharedTestTeardown;
 
 /**
  * Creates stub for Blockly.utils.genUid that returns the provided id or ids.
@@ -194,7 +189,7 @@ exports.sharedTestTeardown = sharedTestTeardown;
  *    that value.
  * @return {!SinonStub} The created stub.
  */
-function createGenUidStubWithReturns(returnIds) {
+export function createGenUidStubWithReturns(returnIds) {
   const stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, "genUid");
   if (Array.isArray(returnIds)) {
     for (let i = 0; i < returnIds.length; i++) {
@@ -205,4 +200,3 @@ function createGenUidStubWithReturns(returnIds) {
   }
   return stub;
 }
-exports.createGenUidStubWithReturns = createGenUidStubWithReturns;

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.toolboxDefinitions');
+goog.declareModuleId('Blockly.test.helpers.toolboxDefinitions');
 
 
 /**

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -175,7 +175,7 @@ export function getDeeplyNestedJSON() {
  * Get an array filled with xml elements.
  * @return {Array<Node>} Array holding xml elements for a toolbox.
  */
-function getXmlArray() {
+export function getXmlArray() {
   const block = Blockly.Xml.textToDom(
       `<block type="logic_compare">
         <field name="OP">NEQ</field>
@@ -195,7 +195,6 @@ function getXmlArray() {
   const label = Blockly.Xml.textToDom('<label text="tooltips"></label>');
   return [block, separator, button, label];
 }
-exports.getXmlArray = getXmlArray;
 
 export function getInjectedToolbox() {
   /**

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -12,7 +12,7 @@ goog.declareModuleId('Blockly.test.helpers.toolboxDefinitions');
  * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
  *    for a toolbox.
  */
-function getCategoryJSON() {
+export function getCategoryJSON() {
   return {"contents": [
     {
       "kind": "CATEGORY",
@@ -42,14 +42,13 @@ function getCategoryJSON() {
       "name": "Second",
     }]};
 }
-exports.getCategoryJSON = getCategoryJSON;
 
 /**
  * Get JSON for a simple toolbox.
  * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
  *    for a simple toolbox.
  */
-function getSimpleJson() {
+export function getSimpleJson() {
   return {"contents": [
     {
       "kind": "BLOCK",
@@ -83,9 +82,8 @@ function getSimpleJson() {
     },
   ]};
 }
-exports.getSimpleJson = getSimpleJson;
 
-function getProperSimpleJson() {
+export function getProperSimpleJson() {
   return {
     "contents": [
       {
@@ -128,14 +126,13 @@ function getProperSimpleJson() {
       },
     ]};
 }
-exports.getProperSimpleJson = getProperSimpleJson;
 
 /**
  * Get JSON for a toolbox that contains categories that contain categories.
  * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
  *    for a toolbox.
  */
-function getDeeplyNestedJSON() {
+export function getDeeplyNestedJSON() {
   return {"contents": [
     {
       "kind": "CATEGORY",
@@ -173,7 +170,6 @@ function getDeeplyNestedJSON() {
       "name": "Second",
     }]};
 }
-exports.getDeeplyNestedJSON = getDeeplyNestedJSON;
 
 /**
  * Get an array filled with xml elements.
@@ -201,7 +197,7 @@ function getXmlArray() {
 }
 exports.getXmlArray = getXmlArray;
 
-function getInjectedToolbox() {
+export function getInjectedToolbox() {
   /**
    * Category: First
    *   sep
@@ -221,18 +217,16 @@ function getInjectedToolbox() {
       });
   return workspace.getToolbox();
 }
-exports.getInjectedToolbox = getInjectedToolbox;
 
-function getBasicToolbox() {
+export function getBasicToolbox() {
   const workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
   const toolbox = new Blockly.Toolbox(workspace);
   toolbox.HtmlDiv = document.createElement('div');
   toolbox.flyout_ = sinon.createStubInstance(Blockly.VerticalFlyout);
   return toolbox;
 }
-exports.getBasicToolbox = getBasicToolbox;
 
-function getCollapsibleItem(toolbox) {
+export function getCollapsibleItem(toolbox) {
   const contents = toolbox.contents_;
   for (let i = 0; i < contents.length; i++) {
     const item = contents[i];
@@ -241,9 +235,8 @@ function getCollapsibleItem(toolbox) {
     }
   }
 }
-exports.getCollapsibleItem = getCollapsibleItem;
 
-function getNonCollapsibleItem(toolbox) {
+export function getNonCollapsibleItem(toolbox) {
   const contents = toolbox.contents_;
   for (let i = 0; i < contents.length; i++) {
     const item = contents[i];
@@ -252,14 +245,11 @@ function getNonCollapsibleItem(toolbox) {
     }
   }
 }
-exports.getNonCollapsibleItem = getNonCollapsibleItem;
 
-function getChildItem(toolbox) {
+export function getChildItem(toolbox) {
   return toolbox.getToolboxItemById('nestedCategory');
 }
-exports.getChildItem = getChildItem;
 
-function getSeparator(toolbox) {
+export function getSeparator(toolbox) {
   return toolbox.getToolboxItemById('separator');
 }
-exports.getSeparator = getSeparator;

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.userInput');
 
-const {KeyCodes} = goog.require('Blockly.utils.KeyCodes');
+import {KeyCodes} from '../../../core/utils/keycodes.js';
 
 
 /**

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.helpers.userInput');
 
-import {KeyCodes} from '../../../core/utils/keycodes.js';
+import {KeyCodes} from '../../../build/src/core/utils/keycodes.js';
 
 
 /**

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -17,7 +17,7 @@ const {KeyCodes} = goog.require('Blockly.utils.KeyCodes');
  * @param {Object<string, string>=} properties Properties to pass into event
  *    constructor.
  */
-function dispatchPointerEvent(target, type, properties) {
+export function dispatchPointerEvent(target, type, properties) {
   const eventInitDict = {
     cancelable: true,
     bubbles: true,
@@ -32,7 +32,6 @@ function dispatchPointerEvent(target, type, properties) {
   const event = new PointerEvent(type, eventInitDict);
   target.dispatchEvent(event);
 }
-exports.dispatchPointerEvent = dispatchPointerEvent;
 
 /**
  * Creates a key down event used for testing.
@@ -40,7 +39,7 @@ exports.dispatchPointerEvent = dispatchPointerEvent;
  * @param {!Array<number>=} modifiers A list of modifiers. Use Blockly.utils.KeyCodes enum.
  * @return {!KeyboardEvent} The mocked keydown event.
  */
-function createKeyDownEvent(keyCode, modifiers) {
+export function createKeyDownEvent(keyCode, modifiers) {
   const event = {
     keyCode: keyCode,
   };
@@ -52,7 +51,6 @@ function createKeyDownEvent(keyCode, modifiers) {
   }
   return new KeyboardEvent('keydown', event);
 }
-exports.createKeyDownEvent = createKeyDownEvent;
 
 /**
  * Simulates mouse click by triggering relevant mouse events.
@@ -60,9 +58,8 @@ exports.createKeyDownEvent = createKeyDownEvent;
  * @param {Object<string, string>=} properties Properties to pass into event
  *    constructor.
  */
-function simulateClick(target, properties) {
+export function simulateClick(target, properties) {
   dispatchPointerEvent(target, 'pointerdown', properties);
   dispatchPointerEvent(target, 'pointerup', properties);
   dispatchPointerEvent(target, 'click', properties);
 }
-exports.simulateClick = simulateClick;

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.userInput');
+goog.declareModuleId('Blockly.test.helpers.userInput');
 
 const {KeyCodes} = goog.require('Blockly.utils.KeyCodes');
 

--- a/tests/mocha/test_helpers/variables.js
+++ b/tests/mocha/test_helpers/variables.js
@@ -15,11 +15,10 @@ goog.declareModuleId('Blockly.test.helpers.variables');
  * @param {!string} type The expected type of the variable.
  * @param {!string} id The expected id of the variable.
  */
-function assertVariableValues(container, name, type, id) {
+export function assertVariableValues(container, name, type, id) {
   const variable = container.getVariableById(id);
   chai.assert.isDefined(variable);
   chai.assert.equal(variable.name, name);
   chai.assert.equal(variable.type, type);
   chai.assert.equal(variable.getId(), id);
 }
-exports.assertVariableValues = assertVariableValues;

--- a/tests/mocha/test_helpers/variables.js
+++ b/tests/mocha/test_helpers/variables.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.variables');
+goog.declareModuleId('Blockly.test.helpers.variables');
 
 
 /**

--- a/tests/mocha/test_helpers/warnings.js
+++ b/tests/mocha/test_helpers/warnings.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.warnings');
+goog.declareModuleId('Blockly.test.helpers.warnings');
 
 
 /**

--- a/tests/mocha/test_helpers/warnings.js
+++ b/tests/mocha/test_helpers/warnings.js
@@ -13,7 +13,7 @@ goog.declareModuleId('Blockly.test.helpers.warnings');
  * @param {Function} innerFunc The function where warnings may called.
  * @return {Array<string>} The warning messages (only the first arguments).
  */
-function captureWarnings(innerFunc) {
+export function captureWarnings(innerFunc) {
   const msgs = [];
   const nativeConsoleWarn = console.warn;
   try {
@@ -26,7 +26,6 @@ function captureWarnings(innerFunc) {
   }
   return msgs;
 }
-exports.captureWarnings = captureWarnings;
 
 /**
  * Asserts that the given function logs the provided warning messages.
@@ -34,7 +33,7 @@ exports.captureWarnings = captureWarnings;
  * @param {Array<!RegExp>|!RegExp} messages A list of regex for the expected
  *    messages (in the expected order).
  */
-function assertWarnings(innerFunc, messages) {
+export function assertWarnings(innerFunc, messages) {
   if (!Array.isArray(messages)) {
     messages = [messages];
   }
@@ -44,25 +43,22 @@ function assertWarnings(innerFunc, messages) {
     chai.assert.match(warnings[i], message);
   });
 }
-exports.assertWarnings = assertWarnings;
 
 /**
  * Asserts that the given function logs no warning messages.
  * @param {function()} innerFunc The function to call.
  */
-function assertNoWarnings(innerFunc) {
+export function assertNoWarnings(innerFunc) {
   assertWarnings(innerFunc, []);
 }
-exports.assertNoWarnings = assertNoWarnings;
 
 /**
  * Stubs Blockly.utils.deprecation.warn call.
  * @return {!SinonStub} The created stub.
  */
-function createDeprecationWarningStub() {
+export function createDeprecationWarningStub() {
   return sinon.stub(Blockly.utils.deprecation, 'warn');
 }
-exports.createDeprecationWarningStub = createDeprecationWarningStub;
 
 /**
  * Asserts whether the given deprecation warning stub or call was called with
@@ -71,10 +67,9 @@ exports.createDeprecationWarningStub = createDeprecationWarningStub;
  * @param {string} functionName The function name to check that the given spy or
  *    spy call was called with.
  */
-function assertDeprecationWarningCall(spyOrSpyCall, functionName) {
+export function assertDeprecationWarningCall(spyOrSpyCall, functionName) {
   sinon.assert.calledWith(spyOrSpyCall, functionName);
 }
-exports.assertDeprecationWarningCall = assertDeprecationWarningCall;
 
 /**
  * Asserts that there was a single deprecation warning call with the given
@@ -83,8 +78,7 @@ exports.assertDeprecationWarningCall = assertDeprecationWarningCall;
  * @param {string} functionName The function name to check that the given spy
  *    was called with.
  */
-function assertSingleDeprecationWarningCall(spy, functionName) {
+export function assertSingleDeprecationWarningCall(spy, functionName) {
   sinon.assert.calledOnce(spy);
   assertDeprecationWarningCall(spy.getCall(0), functionName);
 }
-exports.assertSingleDeprecationWarningCall = assertSingleDeprecationWarningCall;

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.helpers.workspace');
+goog.declareModuleId('Blockly.test.helpers.workspace');
 
 const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
 const {assertWarnings} = goog.require('Blockly.test.helpers.warnings');

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -12,7 +12,7 @@ const eventUtils = goog.require('Blockly.Events.utils');
 const {workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 
 
-function testAWorkspace() {
+export function testAWorkspace() {
   setup(function() {
     Blockly.defineBlocksWithJsonArray([{
       "type": "get_var_block",
@@ -1528,4 +1528,3 @@ function testAWorkspace() {
     });
   });
 }
-exports.testAWorkspace = testAWorkspace;

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -6,10 +6,10 @@
 
 goog.declareModuleId('Blockly.test.helpers.workspace');
 
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
-const {assertWarnings} = goog.require('Blockly.test.helpers.warnings');
-const eventUtils = goog.require('Blockly.Events.utils');
-const {workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertVariableValues} from './variables.js';
+import {assertWarnings} from './warnings.js';
+import * as eventUtils from '../../../core/events/utils.js';
+import {workspaceTeardown} from './setup_teardown.js';
 
 
 export function testAWorkspace() {

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -8,7 +8,7 @@ goog.declareModuleId('Blockly.test.helpers.workspace');
 
 import {assertVariableValues} from './variables.js';
 import {assertWarnings} from './warnings.js';
-import * as eventUtils from '../../../core/events/utils.js';
+import * as eventUtils from '../../../build/src/core/events/utils.js';
 import {workspaceTeardown} from './setup_teardown.js';
 
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.theme');
+goog.declareModuleId('Blockly.test.theme');
 
 const {assertEventFired} = goog.require('Blockly.test.helpers.events');
 const eventUtils = goog.require('Blockly.Events.utils');

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.theme');
 
 import {assertEventFired} from './test_helpers/events.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.theme');
 
-const {assertEventFired} = goog.require('Blockly.test.helpers.events');
+import {assertEventFired} from './test_helpers/events.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Theme', function() {

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.theme');
 
 import {assertEventFired} from './test_helpers/events.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.toolbox');
 
-const {defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {getBasicToolbox, getCategoryJSON, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getSeparator, getSimpleJson, getXmlArray} = goog.require('Blockly.test.helpers.toolboxDefinitions');
+import {defineStackBlock} from './test_helpers/block_definitions.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {getBasicToolbox, getCategoryJSON, getChildItem, getCollapsibleItem, getDeeplyNestedJSON, getInjectedToolbox, getNonCollapsibleItem, getSeparator, getSimpleJson, getXmlArray} from './test_helpers/toolbox_definitions.js';
 
 
 suite('Toolbox', function() {

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.toolbox');
+goog.declareModuleId('Blockly.test.toolbox');
 
 const {defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.tooltip');
 
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Tooltip', function() {

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.tooltip');
+goog.declareModuleId('Blockly.test.tooltip');
 
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -6,11 +6,11 @@
 
 goog.declareModuleId('Blockly.test.trashcan');
 
-const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {defineBasicBlockWithField, defineMutatorBlocks, defineRowBlock, defineStackBlock, defineStatementBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {defineBasicBlockWithField, defineMutatorBlocks, defineRowBlock, defineStackBlock, defineStatementBlock} from './test_helpers/block_definitions.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {simulateClick} = goog.require('Blockly.test.helpers.userInput');
+import {simulateClick} from './test_helpers/user_input.js';
 
 
 suite("Trashcan", function() {

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.trashcan');
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {defineBasicBlockWithField, defineMutatorBlocks, defineRowBlock, defineStackBlock, defineStatementBlock} from './test_helpers/block_definitions.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.trashcan');
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {defineBasicBlockWithField, defineMutatorBlocks, defineRowBlock, defineStackBlock, defineStatementBlock} from './test_helpers/block_definitions.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.trashcan');
+goog.declareModuleId('Blockly.test.trashcan');
 
 const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.utils');
+goog.declareModuleId('Blockly.test.utils');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.utils');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Utils', function() {

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.variableMap');
+goog.declareModuleId('Blockly.test.variableMap');
 
 const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
 const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.variableMap');
 
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
-const {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {assertVariableValues} from './test_helpers/variables.js';
+import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Variable Map', function() {

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.variableModel');
+goog.declareModuleId('Blockly.test.variableModel');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.variableModel');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Variable Model', function() {

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.widgetDiv');
+goog.declareModuleId('Blockly.test.widgetDiv');
 
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.widgetDiv');
 
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('WidgetDiv', function() {

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.workspaceComment');
+goog.declareModuleId('Blockly.test.workspaceComment');
 
 goog.require('Blockly.WorkspaceComment');
 const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.workspaceComment');
 
-import {WorkspaceComment} from '../../core/workspace_comment.js';
+import {WorkspaceComment} from '../../build/src/core/workspace_comment.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -6,7 +6,7 @@
 
 goog.declareModuleId('Blockly.test.workspaceComment');
 
-goog.require('Blockly.WorkspaceComment');
+import {WorkspaceComment} from '../../core/workspace_comment.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.workspaceComment');
 
 goog.require('Blockly.WorkspaceComment');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 
 suite('Workspace comment', function() {

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.workspaceSvg');
+goog.declareModuleId('Blockly.test.workspaceSvg');
 
 const {assertEventFired, assertEventNotFired, createFireChangeListenerSpy} = goog.require('Blockly.test.helpers.events');
 const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.workspaceSvg');
 import {assertEventFired, assertEventNotFired, createFireChangeListenerSpy} from './test_helpers/events.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {testAWorkspace} from './test_helpers/workspace.js';
 

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -6,12 +6,12 @@
 
 goog.declareModuleId('Blockly.test.workspaceSvg');
 
-const {assertEventFired, assertEventNotFired, createFireChangeListenerSpy} = goog.require('Blockly.test.helpers.events');
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
-const {defineStackBlock} = goog.require('Blockly.test.helpers.blockDefinitions');
+import {assertEventFired, assertEventNotFired, createFireChangeListenerSpy} from './test_helpers/events.js';
+import {assertVariableValues} from './test_helpers/variables.js';
+import {defineStackBlock} from './test_helpers/block_definitions.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {testAWorkspace} = goog.require('Blockly.test.helpers.workspace');
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {testAWorkspace} from './test_helpers/workspace.js';
 
 
 suite('WorkspaceSvg', function() {

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -9,7 +9,7 @@ goog.declareModuleId('Blockly.test.workspaceSvg');
 import {assertEventFired, assertEventNotFired, createFireChangeListenerSpy} from './test_helpers/events.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
 import {testAWorkspace} from './test_helpers/workspace.js';
 

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.workspace');
+goog.declareModuleId('Blockly.test.workspace');
 
 const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
 const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -6,9 +6,9 @@
 
 goog.declareModuleId('Blockly.test.workspace');
 
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
-const {sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {testAWorkspace} = goog.require('Blockly.test.helpers.workspace');
+import {assertVariableValues} from './test_helpers/variables.js';
+import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {testAWorkspace} from './test_helpers/workspace.js';
 
 
 suite('Workspace', function() {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -6,8 +6,8 @@
 
 goog.declareModuleId('Blockly.test.xml');
 
-const {addBlockTypeToCleanup, createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');
+import {addBlockTypeToCleanup, createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_helpers/setup_teardown.js';
+import {assertVariableValues} from './test_helpers/variables.js';
 
 
 suite('XML', function() {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.xml');
+goog.declareModuleId('Blockly.test.xml');
 
 const {addBlockTypeToCleanup, createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
 const {assertVariableValues} = goog.require('Blockly.test.helpers.variables');

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.zoomControls');
 
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
-import * as eventUtils from '../../core/events/utils.js';
+import * as eventUtils from '../../build/src/core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -6,10 +6,10 @@
 
 goog.declareModuleId('Blockly.test.zoomControls');
 
-const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
+import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 const eventUtils = goog.require('Blockly.Events.utils');
-const {sharedTestSetup, sharedTestTeardown} = goog.require('Blockly.test.helpers.setupTeardown');
-const {simulateClick} = goog.require('Blockly.test.helpers.userInput');
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {simulateClick} from './test_helpers/user_input.js';
 
 
 suite("Zoom Controls", function() {

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.zoomControls');
 
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
-const eventUtils = goog.require('Blockly.Events.utils');
+import * as eventUtils from '../../core/events/utils.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.module('Blockly.test.zoomControls');
+goog.declareModuleId('Blockly.test.zoomControls');
 
 const {assertEventFired, assertEventNotFired} = goog.require('Blockly.test.helpers.events');
 const eventUtils = goog.require('Blockly.Events.utils');

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -8,6 +8,7 @@
      compressed when it is being hosted or on Internet Explorer.  -->
 <script>
   var BLOCKLY_BOOTSTRAP_OPTIONS = {
+    loadCompressed: true,
     additionalScripts: [
       'msg/messages.js',
       'tests/playgrounds/screenshot.js',

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -8,7 +8,6 @@
      compressed when it is being hosted or on Internet Explorer.  -->
 <script>
   var BLOCKLY_BOOTSTRAP_OPTIONS = {
-    loadCompressed: true,
     additionalScripts: [
       'msg/messages.js',
       'tests/playgrounds/screenshot.js',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Converts the mcoah tests to esmodules.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
No change in behavior.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No change in behavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
If we want to move to webpack, it is a good idea to convert the tests to esmodules. If we want to run the tests in node rather than webdriver, it is also a good idea to convert the tests to esmodules.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
This is tests silly!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
There are still some `goog.declareModuleId` statements so that the `index.html` file can properly import these. And there are still `goog.require` statements because the blocks and generators have not yet been converted.
