### PR TITLE
chore(build)!: compile to ES2015 instead of ES5

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -607,7 +607,7 @@ function compile(options) {
     compilation_level: 'SIMPLE_OPTIMIZATIONS',
     warning_level: argv.verbose ? 'VERBOSE' : 'DEFAULT',
     language_in: 'ECMASCRIPT_2020',
-    language_out: 'ECMASCRIPT5_STRICT',
+    language_out: 'ECMASCRIPT_2015',
     jscomp_off: [...JSCOMP_OFF],
     rewrite_polyfills: true,
     // N.B.: goog.js refers to lots of properties on goog that are not


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6328 

### Proposed Changes

Set the closure compiler to compile to ES2015 instead of ES5.

#### Behavior Before Change

`blockly_compressed.js` could be used directly in ES5 environments such as Internet Explorer and Firefox < 43.

#### Behavior After Change

`blockly_compressed.js` does not work directly in ES5 environments. It can still be transpiled further if needed.

### Reason for Changes

Part of #6325 

### Test Coverage

Rebuild and started the server, and confirmed that I can open and use the playground.

### Documentation

Any remaining documentation that says that we support ES5 will need to change by the next release.

### Additional Information

The results of `check_metadata.sh` are:

```
Size of build/blockly_compressed.js at 862067 compared to previous 1040413.
Size of build/blocks_compressed.js at 102485 compared to previous 102176.
Size of build/blockly_compressed.js.gz at 172738 compared to previous 185766.
Size of build/blocks_compressed.js.gz at 17107 compared to previous 17016.
```