### PR TITLE
fix!: remove checks for IE and EdgeHTML in core

### DIFF
--- a/core/comment.ts
+++ b/core/comment.ts
@@ -39,7 +39,6 @@ import type {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import type {Size} from './utils/size.js';
 import {Svg} from './utils/svg.js';
-import * as userAgent from './utils/useragent.js';
 
 
 /**

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -256,10 +256,7 @@ export class Comment extends Icon {
 
   /** Show the bubble. Handles deciding if it should be editable or not. */
   private createBubble_() {
-    if (!this.block_.isEditable() || userAgent.IE) {
-      // MSIE does not support foreignobject; textareas are impossible.
-      // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034
-      // Always treat comments in IE as uneditable.
+    if (!this.block_.isEditable()) {
       this.createNonEditableBubble_();
     } else {
       this.createEditableBubble_();

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -30,7 +30,6 @@ import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import {Rect} from './utils/rect.js';
 import * as svgMath from './utils/svg_math.js';
-import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import {WorkspaceCommentSvg} from './workspace_comment_svg.js';
 import type {WorkspaceSvg} from './workspace_svg.js';

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -349,9 +349,7 @@ export function workspaceCommentOption(
   }
 
   const wsCommentOption = {
-    // Foreign objects don't work in IE.  Don't let the user create comments
-    // that they won't be able to edit.
-    enabled: !userAgent.IE,
+    enabled: true,
   } as ContextMenuOption;
   wsCommentOption.text = Msg['ADD_COMMENT'];
   wsCommentOption.callback = function() {

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -24,7 +24,6 @@ import * as eventUtils from './events/utils.js';
 import {inputTypes} from './input_types.js';
 import {Msg} from './msg.js';
 import * as idGenerator from './utils/idgenerator.js';
-import * as userAgent from './utils/useragent.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
 

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -362,8 +362,7 @@ export function registerComment() {
     },
     preconditionFn(scope: Scope) {
       const block = scope.block;
-      // IE doesn't support necessary features for comment editing.
-      if (!userAgent.IE && !block!.isInFlyout &&
+      if (!block!.isInFlyout &&
           block!.workspace.options.comments && !block!.isCollapsed() &&
           block!.isEditable()) {
         return 'enabled';

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -362,9 +362,8 @@ export function registerComment() {
     },
     preconditionFn(scope: Scope) {
       const block = scope.block;
-      if (!block!.isInFlyout &&
-          block!.workspace.options.comments && !block!.isCollapsed() &&
-          block!.isEditable()) {
+      if (!block!.isInFlyout && block!.workspace.options.comments &&
+          !block!.isCollapsed() && block!.isEditable()) {
         return 'enabled';
       }
       return 'hidden';

--- a/core/field.ts
+++ b/core/field.ts
@@ -784,25 +784,19 @@ export abstract class Field implements IASTNodeLocationSvg,
     if (!this.borderRect_) {
       // Browsers are inconsistent in what they return for a bounding box.
       // - Webkit / Blink: fill-box / object bounding box
-      // - Gecko / Triden / EdgeHTML: stroke-box
+      // - Gecko: stroke-box
       const bBox = (this.sourceBlock_ as BlockSvg).getHeightWidth();
       const scale = (this.sourceBlock_.workspace as WorkspaceSvg).scale;
       xy = this.getAbsoluteXY_();
-      scaledWidth = bBox.width * scale;
-      scaledHeight = bBox.height * scale;
+      scaledWidth = (bBox.width + 1) * scale;
+      scaledHeight = (bBox.height +1) * scale;
 
       if (userAgent.GECKO) {
         xy.x += 1.5 * scale;
         xy.y += 1.5 * scale;
-        scaledWidth += 1 * scale;
-        scaledHeight += 1 * scale;
       } else {
-        if (!userAgent.EDGE) {
-          xy.x -= 0.5 * scale;
-          xy.y -= 0.5 * scale;
-        }
-        scaledWidth += 1 * scale;
-        scaledHeight += 1 * scale;
+        xy.x -= 0.5 * scale;
+        xy.y -= 0.5 * scale;
       }
     } else {
       const bBox = this.borderRect_.getBoundingClientRect();

--- a/core/field.ts
+++ b/core/field.ts
@@ -797,7 +797,7 @@ export abstract class Field implements IASTNodeLocationSvg,
         scaledWidth += 1 * scale;
         scaledHeight += 1 * scale;
       } else {
-        if (!userAgent.EDGE && !userAgent.IE) {
+        if (!userAgent.EDGE) {
           xy.x -= 0.5 * scale;
           xy.y -= 0.5 * scale;
         }

--- a/core/field.ts
+++ b/core/field.ts
@@ -789,7 +789,7 @@ export abstract class Field implements IASTNodeLocationSvg,
       const scale = (this.sourceBlock_.workspace as WorkspaceSvg).scale;
       xy = this.getAbsoluteXY_();
       scaledWidth = (bBox.width + 1) * scale;
-      scaledHeight = (bBox.height +1) * scale;
+      scaledHeight = (bBox.height + 1) * scale;
 
       if (userAgent.GECKO) {
         xy.x += 1.5 * scale;

--- a/core/grid.ts
+++ b/core/grid.ts
@@ -148,8 +148,8 @@ export class Grid {
     this.pattern.setAttribute('x', x.toString());
     this.pattern.setAttribute('y', y.toString());
 
-    if (userAgent.IE || userAgent.EDGE) {
-      // IE/Edge doesn't notice that the x/y offsets have changed.
+    if (userAgent.EDGE) {
+      // Edge doesn't notice that the x/y offsets have changed.
       // Force an update.
       this.update(this.scale_);
     }

--- a/core/grid.ts
+++ b/core/grid.ts
@@ -19,7 +19,6 @@ goog.declareModuleId('Blockly.Grid');
 
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
-import * as userAgent from './utils/useragent.js';
 import {GridOptions} from './blockly_options.js';
 
 

--- a/core/grid.ts
+++ b/core/grid.ts
@@ -147,12 +147,6 @@ export class Grid {
   moveTo(x: number, y: number) {
     this.pattern.setAttribute('x', x.toString());
     this.pattern.setAttribute('y', y.toString());
-
-    if (userAgent.EDGE) {
-      // Edge doesn't notice that the x/y offsets have changed.
-      // Force an update.
-      this.update(this.scale_);
-    }
   }
 
   /**

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -462,7 +462,7 @@ export class ConstantProvider {
     this.START_POINT = svgPaths.moveBy(0, 0);
 
     /** A field's text element's dominant baseline. */
-    this.FIELD_TEXT_BASELINE_CENTER = !userAgent.IE && !userAgent.EDGE;
+    this.FIELD_TEXT_BASELINE_CENTER = !userAgent.EDGE;
 
     /** A dropdown field's border rect height. */
     this.FIELD_DROPDOWN_BORDER_RECT_HEIGHT = this.FIELD_BORDER_RECT_HEIGHT;

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -460,7 +460,8 @@ export class ConstantProvider {
 
     this.START_POINT = svgPaths.moveBy(0, 0);
 
-    /** A field's text element's dominant baseline. Pre-2022 this could be false
+    /**
+     * A field's text element's dominant baseline. Pre-2022 this could be false
      * for certain browsers.
      */
     this.FIELD_TEXT_BASELINE_CENTER = true;

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -23,7 +23,6 @@ import * as dom from '../../utils/dom.js';
 import * as parsing from '../../utils/parsing.js';
 import {Svg} from '../../utils/svg.js';
 import * as svgPaths from '../../utils/svg_paths.js';
-import * as userAgent from '../../utils/useragent.js';
 
 
 /** An object containing sizing and path information about outside corners. */

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -461,8 +461,10 @@ export class ConstantProvider {
 
     this.START_POINT = svgPaths.moveBy(0, 0);
 
-    /** A field's text element's dominant baseline. */
-    this.FIELD_TEXT_BASELINE_CENTER = !userAgent.EDGE;
+    /** A field's text element's dominant baseline. Pre-2022 this could be false
+     * for certain browsers.
+     */
+    this.FIELD_TEXT_BASELINE_CENTER = true;
 
     /** A dropdown field's border rect height. */
     this.FIELD_DROPDOWN_BORDER_RECT_HEIGHT = this.FIELD_BORDER_RECT_HEIGHT;

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -89,12 +89,16 @@ let longPid_: AnyDuringMigration = 0;
 export function longStart(e: Event, gesture: Gesture) {
   longStop();
   // Punt on multitouch events.
-  if (e instanceof TouchEvent && e.changedTouches &&
-      e.changedTouches.length !== 1) {
+  // AnyDuringMigration because:  Property 'changedTouches' does not exist on
+  // type 'Event'.
+  if ((e as AnyDuringMigration).changedTouches &&
+      (e as AnyDuringMigration).changedTouches.length !== 1) {
     return;
   }
   longPid_ = setTimeout(function() {
     // TODO(#6097): Make types accurate, possibly by refactoring touch handling.
+    // AnyDuringMigration because:  Property 'changedTouches' does not exist on
+    // type 'Event'.
     const typelessEvent = e as AnyDuringMigration;
     // Additional check to distinguish between touch events and pointer events
     if (typelessEvent.changedTouches) {
@@ -280,11 +284,17 @@ export function isTouchEvent(e: Event|PseudoEvent): boolean {
  */
 export function splitEventByTouches(e: Event): Array<Event|PseudoEvent> {
   const events = [];
-  if (e instanceof TouchEvent) {
-    for (let i = 0; i < e.changedTouches.length; i++) {
+  // AnyDuringMigration because:  Property 'changedTouches' does not exist on
+  // type 'PseudoEvent | Event'.
+  if ((e as AnyDuringMigration).changedTouches) {
+    // AnyDuringMigration because:  Property 'changedTouches' does not exist on
+    // type 'PseudoEvent | Event'.
+    for (let i = 0; i < (e as AnyDuringMigration).changedTouches.length; i++) {
       const newEvent = {
         type: e.type,
-        changedTouches: [e.changedTouches[i]],
+        // AnyDuringMigration because:  Property 'changedTouches' does not exist
+        // on type 'PseudoEvent | Event'.
+        changedTouches: [(e as AnyDuringMigration).changedTouches[i]],
         target: e.target,
         stopPropagation() {
           e.stopPropagation();

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -269,7 +269,7 @@ export function getTextWidth(textElement: SVGTextElement): number {
 
   // Attempt to compute fetch the width of the SVG text element.
   try {
-    if (userAgent.IE || userAgent.EDGE) {
+    if (userAgent.EDGE) {
       width = textElement.getBBox().width;
     } else {
       width = textElement.getComputedTextLength();

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -269,11 +269,7 @@ export function getTextWidth(textElement: SVGTextElement): number {
 
   // Attempt to compute fetch the width of the SVG text element.
   try {
-    if (userAgent.EDGE) {
-      width = textElement.getBBox().width;
-    } else {
-      width = textElement.getComputedTextLength();
-    }
+    width = textElement.getComputedTextLength();
   } catch (e) {
     // In other cases where we fail to get the computed text. Instead, use an
     // approximation and do not cache the result. At some later point in time

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -20,7 +20,6 @@ import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.dom');
 
 import type {Svg} from './svg.js';
-import * as userAgent from './useragent.js';
 
 
 /**

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -196,12 +196,6 @@ export function getViewportBBox(): Rect {
 export function getDocumentScroll(): Coordinate {
   const el = document.documentElement;
   const win = window;
-  if (userAgent.IE && win.pageYOffset !== el.scrollTop) {
-    // The keyboard on IE10 touch devices shifts the page using the pageYOffset
-    // without modifying scrollTop. For this case, we want the body scroll
-    // offsets.
-    return new Coordinate(el.scrollLeft, el.scrollTop);
-  }
   return new Coordinate(
       win.pageXOffset || el.scrollLeft, win.pageYOffset || el.scrollTop);
 }

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -22,7 +22,6 @@ import * as deprecation from './deprecation.js';
 import {Rect} from './rect.js';
 import {Size} from './size.js';
 import * as style from './style.js';
-import * as userAgent from './useragent.js';
 
 
 /**

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -405,16 +405,8 @@ function addAttributes(node: Node, obj: AnyDuringMigration) {
 export function parseToolboxTree(toolboxDef: Element|null|string): Element|
     null {
   if (toolboxDef) {
-    if (typeof toolboxDef !== 'string') {
-      if (userAgent.IE && toolboxDef.outerHTML) {
-        // In this case the tree will not have been properly built by the
-        // browser. The HTML will be contained in the element, but it will
-        // not have the proper DOM structure since the browser doesn't support
-        // XSLTProcessor (XML -> HTML).
-        toolboxDef = toolboxDef.outerHTML;
-      } else if (!(toolboxDef instanceof Element)) {
-        toolboxDef = null;
-      }
+    if (typeof toolboxDef !== 'string' && !(toolboxDef instanceof Element)) {
+      toolboxDef = null;
     }
     if (typeof toolboxDef === 'string') {
       toolboxDef = Xml.textToDom(toolboxDef);

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -26,7 +26,6 @@ import type {ConnectionState} from '../serialization/blocks.js';
 import type {CssConfig as CategoryCssConfig} from '../toolbox/category.js';
 import type {CssConfig as SeparatorCssConfig} from '../toolbox/separator.js';
 import * as Xml from '../xml.js';
-import * as userAgent from './useragent.js';
 
 
 /**

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -97,9 +97,6 @@ isMobile = !isTablet && (isIPod || isIPhone || isAndroid || has('IEMobile'));
 /** @alias Blockly.utils.userAgent.raw */
 export const raw: string = rawUserAgent;
 
-/** @alias Blockly.utils.userAgent.EDGE */
-export const EDGE: boolean = isEdge;
-
 /** @alias Blockly.utils.userAgent.JavaFx */
 export const JavaFx: boolean = isJavaFx;
 

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -97,9 +97,6 @@ isMobile = !isTablet && (isIPod || isIPhone || isAndroid || has('IEMobile'));
 /** @alias Blockly.utils.userAgent.raw */
 export const raw: string = rawUserAgent;
 
-/** @alias Blockly.utils.userAgent.IE */
-export const IE: boolean = isIe;
-
 /** @alias Blockly.utils.userAgent.EDGE */
 export const EDGE: boolean = isEdge;
 
@@ -111,6 +108,7 @@ export const CHROME: boolean = isChrome;
 
 /** @alias Blockly.utils.userAgent.WEBKIT */
 export const WEBKIT: boolean = isWebKit;
+
 /** @alias Blockly.utils.userAgent.GECKO */
 export const GECKO: boolean = isGecko;
 

--- a/core/utils/useragent.ts
+++ b/core/utils/useragent.ts
@@ -23,10 +23,6 @@ goog.declareModuleId('Blockly.utils.userAgent');
 /** The raw useragent string. */
 let rawUserAgent: string;
 
-let isIe: boolean;
-
-let isEdge: boolean;
-
 let isJavaFx: boolean;
 
 let isChrome: boolean;
@@ -63,18 +59,16 @@ function has(name: string): boolean {
 
 // Browsers.  Logic from:
 // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/browser.js
-isIe = has('Trident') || has('MSIE');
-isEdge = has('Edge');
 // Useragent for JavaFX:
 // Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44
 //     (KHTML, like Gecko) JavaFX/8.0 Safari/537.44
 isJavaFx = has('JavaFX');
-isChrome = (has('Chrome') || has('CriOS')) && !isEdge;
+isChrome = (has('Chrome') || has('CriOS'));
 
 // Engines.  Logic from:
 // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/engine.js
-isWebKit = has('WebKit') && !isEdge;
-isGecko = has('Gecko') && !isWebKit && !isIe && !isEdge;
+isWebKit = has('WebKit');
+isGecko = has('Gecko') && !isWebKit;
 
 // Platforms.  Logic from:
 // https://github.com/google/closure-library/blob/master/closure/goog/labs/useragent/platform.js

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -356,16 +356,6 @@ suite('Context Menu Items', function() {
         chai.assert.equal(this.commentOption.preconditionFn(this.scope), 'enabled');
       });
 
-      test.skip('Hidden for IE', function() {
-        const oldState = Blockly.utils.userAgent.IE;
-        try {
-          Blockly.utils.userAgent.IE = true;
-          chai.assert.equal(this.commentOption.preconditionFn(this.scope), 'hidden');
-        } finally {
-          Blockly.utils.userAgent.IE = oldState;
-        }
-      });
-
       test('Hidden for collapsed block', function() {
         // Must render block to collapse it properly.
         this.block.initSvg();


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/6325

### Proposed Changes

- Remove uses of `userAgent.IE`
- Remove export of `userAgent.IE`

Breaking change because of the removed export.

#### Behavior Before Change

Assorted checks for IE in our code.

#### Behavior After Change

No special behaviour for IE--but note that there are still special cases for Edge.

### Reason for Changes

No more IE support.

### Test Coverage

Built and ran tests.

### Additional Information

`isGecko` still uses whether IE has been found inside `useragent.js`

`isGecko = has('Gecko') && !isWebKit && !isIe && !isEdge;`

We should consider removing all exports from `useragent.js` that we aren't already using. User agent sniffing is highly not-recommended, and we can get rid of excess exports. It's technically a breaking change, but I think we want to do it in this release.