### PR TITLE
chore(build): Only suppress expected warnings from closure-make-deps

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -15,7 +15,7 @@ gulp.sourcemaps = require('gulp-sourcemaps');
 
 var path = require('path');
 var fs = require('fs');
-var execSync = require('child_process').execSync;
+const {exec, execSync} = require('child_process');
 var through2 = require('through2');
 
 const clangFormat = require('clang-format');
@@ -336,18 +336,47 @@ function buildDeps(done) {
     'tests/mocha'
   ];
 
-  const args = roots.map(root => `--root '${root}' `).join('');
-  execSync(
-      `closure-make-deps ${args} 2>/dev/null >'${DEPS_FILE}'`,
-      {stdio: 'inherit'});
+  function filterErrors(text) {
+    return text.split('\n')
+        .filter(
+            (line) => !/^WARNING /.test(line) ||
+                !(/Missing type declaration./.test(line) ||
+                  /illegal use of unknown JSDoc tag/.test(line)))
+        .join('\n');
+  }
 
-  // Use grep to filter out the entries that are already in deps.js.
-  const testArgs = testRoots.map(root => `--root '${root}' `).join('');
-  execSync(
-      `closure-make-deps ${testArgs} 2>/dev/null \
-           | grep 'tests/mocha' > '${TEST_DEPS_FILE}'`,
-      {stdio: 'inherit'});
-  done();
+  new Promise((resolve, reject) => {
+    const args = roots.map(root => `--root '${root}' `).join('');
+    exec(
+        `closure-make-deps ${args} >'${DEPS_FILE}'`,
+        {stdio: ['inherit', 'inherit', 'pipe']},
+        (error, stdout, stderr) => {
+          console.warn(filterErrors(stderr));
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+  }).then(() => new Promise((resolve, reject) => {
+    // Use grep to filter out the entries that are already in deps.js.
+    const testArgs =
+        testRoots.map(root => `--root '${root}' `).join('');
+    exec(
+        `closure-make-deps ${testArgs} 2>/dev/null\
+             | grep 'tests/mocha' > '${TEST_DEPS_FILE}'`,
+        {stdio: ['inherit', 'inherit', 'pipe']},
+        (error, stdout, stderr) => {
+          console.warn(filterErrors(stderr));
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+  })).then(() => {
+    done();
+  });
 }
 
 /**


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Modify `buildDeps` gulp target (in `build_tasks.js`) to only suppress expected warnings from `closure-make-deps`.

#### Behaviour Before Change

All `stderr` output from `closure-make-deps` redirected to `/dev/null`

#### Behaviour After Change

`stderr` output from `closure-make-deps` read by the gulp task and logged to console after filtering known-

### Reason for Changes

While preparing PR #6337, @BeksOmega discovered that our block tests (in `tests/mocha/blocks/`) were not being run.  This was due to invalid `import`s, where several of those files attempted to import from `../../build/…` instead of `../../../build/…`.  I was surprised that this did not provoke more complaints from various parts of our build/test infrastructure, and it occurred to me that `closure-make-deps` may have discovered the problem and reported it but we threw the error in the bit-bucket along with all the actually-spurious warnings it generates.

Thus I modified `buildDeps` to be more selective about what is suppresses.

### Additional Information

Alas it turns out that `closure-make-deps` does not in fact care if you attempt to `import` a file that does not actually exist.  Still, it is probably better that we be less heavy-handed in suppressing its warnings generally, so it seems worthwhile keeping the change I made.