### PR TITLE
fix(build): Fix sourcemaps

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -635,7 +635,7 @@ function buildCompiled() {
   for (const src of ['core', 'blocks', 'generators']) {
     const target = `${BUILD_DIR}/${src}`
     if (!fs.existsSync(target)) {
-      fs.symlinkSync(`../${dir}`, target);
+      fs.symlinkSync(`../${src}`, target);
     }
   }
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -630,6 +630,15 @@ function buildCompiled() {
     // option to Closure Compiler; instead feed them as input via gulp.src.
   };
 
+  // Symlink source dirs from build dir so that sourcemaps work in
+  // compiled-mode testing.
+  for (const src of ['core', 'blocks', 'generators']) {
+    const target = `${BUILD_DIR}/${src}`
+    if (!fs.existsSync(target)) {
+      fs.symlinkSync(`../${dir}`, target);
+    }
+  }
+
   // Fire up compilation pipline.
   return gulp.src(chunkOptions.js, {base: './'})
       .pipe(stripApacheLicense())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,9 @@
     // normally they are ignored as source files
     "allowJs": true,
 
-    // Generate d.ts files
+    // Generate d.ts files and sourcemaps.
     "declaration": true,
+    "sourceMap": true,
 
     "module": "ES2015",
     "moduleResolution": "node",


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #5857.

### Proposed Changes

* Enable `sourceMap` in `tsconfig.json`.  This alone is suffiicient to get functional,  per-`.ts`-file sourcemaps in `build/src/**` that work in uncompiled mode (i.e. in the playground / tests).  Moreover, no further changes are required for these to be ingested by gulp + Closure Compiler; the resulting sourcemaps—`build/*_compressed.js.map`—now correctly point at files in core/, blocks/, etc.  This works when packaged and also when doing local testing in compiled mode of the checked-in build products (i.e., after they are copied to the repository root by `checkinBuilt`).

* In order to get sourcemaps to work for local testing in compiled mode of the build products directly from `build/`, modify `buildCompiled` so that it creates symlinks in `build/` to `core/`, `blocks/` and `generators/`.

#### Behaviour Before Change

* No sourcemaps in uncompiled mode.
* In compiled mode (when packaged or checked in), sourcemaps point at `.js` files in `build/src/`.

#### Behaviour After Change

* Sourcemaps point at `.ts` files in `core/`, `blocks/` and `generators/`.

### Reason for Changes

Sourcemaps are more useful if they point at the original sources.

### Test Coverage

No manual testing changes anticipated.

### Documentation

No documentation changes expected.
