### PR TITLE
fix(build): Have prepare task signal async completion

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -295,11 +295,12 @@ var JSCOMP_OFF = [
  * needed, and we don't want to, because a tsc error would prevent
  * other workflows (like lint and format) from completing.
  */
-function prepare() {
+function prepare(done) {
   if (process.env.CI) {
-    return gulp.src('.');  // Do nothing.
+    done();
+    return;
   }
-  return buildJavaScriptAndDeps();
+  return buildJavaScriptAndDeps(done);
 }
 
 const buildJavaScriptAndDeps = gulp.series(buildJavaScript, buildDeps);


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

"Did you forget to signal async completion?" error from gulp when running the `prepare` task (as invoked by `npm run prepare` or `npm install`).

### Proposed Changes

Add a `done` parameter and pass the provided callback to `buildJavaScriptAndDeps`.  This also allows a simplification of the the don't-run case by simply calling `done()` and then `return`ing.

#### Behaviour Before Change

When not run by a GitHub action, `npm run prepare` and `npm install` generate the aforementioned error.

#### Behaviour After Change

`prepare` script successfully signals async completion, avoiding error.

### Reason for Changes

PR #6244 made a change to have the `npm run prepare` script (automatically invoked by `npm install` after package installation) not bother running the `buildJavaScriptAndDeps` gulp task when run from a GitHub action (since our build action will do npm test straight afterwards, which runs this task).

Unfortunately, due my misunderstanding of how gulp tasks work the "fix" was not correct, and somehow I overlooked the error while testing locally (and of course it was not generated in CI because the other branch of the conditional was taken).

### Test Coverage

* [X] Tested locally to verify that `buildJavaScriptAndDeps` is run and no error generated.
* [x] Tested in CI to verify that  `buildJavaScriptAndDeps` is **not** run and no error generated.

No manual testing changes envisioned.

