### PR TITLE
fix: TS errors on dependent projects with certain tsconfig settings (#6360)

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1371,7 +1371,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns Text of block.
    */
   toString(opt_maxLength?: number, opt_emptyToken?: string): string {
-    const text = [];
+    const tokens = [];
     const emptyFieldPlaceholder = opt_emptyToken || '?';
 
     // Temporarily set flag to navigate to all fields.
@@ -1410,16 +1410,16 @@ export class Block implements IASTNodeLocation, IDeletable {
         case ASTNode.types.INPUT: {
           const connection = node.getLocation() as Connection;
           if (!node.in()) {
-            text.push(emptyFieldPlaceholder);
+            tokens.push(emptyFieldPlaceholder);
           } else if (shouldAddParentheses(connection)) {
-            text.push('(');
+            tokens.push('(');
           }
           break;
         }
         case ASTNode.types.FIELD: {
           const field = node.getLocation() as Field;
           if (field.name !== constants.COLLAPSED_FIELD_NAME) {
-            text.push(field.getText());
+            tokens.push(field.getText());
           }
           break;
         }
@@ -1437,7 +1437,7 @@ export class Block implements IASTNodeLocation, IDeletable {
           // If we hit an input on the way up, possibly close out parentheses.
           if (node && node.getType() === ASTNode.types.INPUT &&
               shouldAddParentheses(node.getLocation() as Connection)) {
-            text.push(')');
+            tokens.push(')');
           }
         }
         if (node) {
@@ -1452,28 +1452,28 @@ export class Block implements IASTNodeLocation, IDeletable {
     // Run through our text array and simplify expression to remove parentheses
     // around single field blocks.
     // E.g. ['repeat', '(', '10', ')', 'times', 'do', '?']
-    for (let i = 2; i < text.length; i++) {
-      if (text[i - 2] === '(' && text[i] === ')') {
-        text[i - 2] = text[i - 1];
-        text.splice(i - 1, 2);
+    for (let i = 2; i < tokens.length; i++) {
+      if (tokens[i - 2] === '(' && tokens[i] === ')') {
+        tokens[i - 2] = tokens[i - 1];
+        tokens.splice(i - 1, 2);
       }
     }
 
     // Join the text array, removing spaces around added parentheses.
-    let combinedText: string = text.reduce(function(acc, value) {
+    let text: string = tokens.reduce(function(acc, value) {
       return acc + (acc.substr(-1) === '(' || value === ')' ? '' : ' ') + value;
     }, '');
 
-    combinedText = combinedText.trim() || '???';
+    text = text.trim() || '???';
     if (opt_maxLength) {
       // TODO: Improve truncation so that text from this block is given
       // priority. E.g. "1+2+3+4+5+6+7+8+9=0" should be "...6+7+8+9=0", not
       // "1+2+3+4+5...". E.g. "1+2+3+4+5=6+7+8+9+0" should be "...4+5=6+7...".
-      if (combinedText.length > opt_maxLength) {
-        combinedText = combinedText.substring(0, opt_maxLength - 3) + '...';
+      if (text.length > opt_maxLength) {
+        text = text.substring(0, opt_maxLength - 3) + '...';
       }
     }
-    return combinedText;
+    return text;
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -1371,7 +1371,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns Text of block.
    */
   toString(opt_maxLength?: number, opt_emptyToken?: string): string {
-    let text = [];
+    const text = [];
     const emptyFieldPlaceholder = opt_emptyToken || '?';
 
     // Temporarily set flag to navigate to all fields.
@@ -1460,26 +1460,20 @@ export class Block implements IASTNodeLocation, IDeletable {
     }
 
     // Join the text array, removing spaces around added parentheses.
-    // AnyDuringMigration because:  Type 'string' is not assignable to type
-    // 'any[]'.
-    text = text.reduce(function(acc, value) {
+    let combinedText: string = text.reduce(function(acc, value) {
       return acc + (acc.substr(-1) === '(' || value === ')' ? '' : ' ') + value;
-    }, '') as AnyDuringMigration;
-    // AnyDuringMigration because:  Property 'trim' does not exist on type
-    // 'any[]'.
-    text = (text as AnyDuringMigration).trim() || '???';
+    }, '');
+
+    combinedText = combinedText.trim() || '???';
     if (opt_maxLength) {
       // TODO: Improve truncation so that text from this block is given
       // priority. E.g. "1+2+3+4+5+6+7+8+9=0" should be "...6+7+8+9=0", not
       // "1+2+3+4+5...". E.g. "1+2+3+4+5=6+7+8+9+0" should be "...4+5=6+7...".
-      if (text.length > opt_maxLength) {
-        // AnyDuringMigration because:  Type 'string' is not assignable to type
-        // 'any[]'.
-        text = (text.substring(0, opt_maxLength - 3) + '...') as
-            AnyDuringMigration;
+      if (combinedText.length > opt_maxLength) {
+        combinedText = combinedText.substring(0, opt_maxLength - 3) + '...';
       }
     }
-    return text;
+    return combinedText;
   }
 
   /**

--- a/core/field_registry.ts
+++ b/core/field_registry.ts
@@ -67,10 +67,7 @@ export function fromJson(options: AnyDuringMigration): Field|null {
  * @param options
  */
 function fromJsonInternal(options: AnyDuringMigration): Field|null {
-  const fieldObject =
-      registry.getObject(registry.Type.FIELD, options['type']) as unknown as
-          IRegistrableField |
-      null;
+  const fieldObject = registry.getObject(registry.Type.FIELD, options['type']);
   if (!fieldObject) {
     console.warn(
         'Blockly could not create a field of type ' + options['type'] +
@@ -78,8 +75,11 @@ function fromJsonInternal(options: AnyDuringMigration): Field|null {
         ' the file is not loaded, the field does not register itself (Issue' +
         ' #1584), or the registration is not being reached.');
     return null;
+  } else if (typeof (fieldObject as any)['fromJson'] !== 'function') {
+    throw new TypeError('returned Field was not a IRegistrableField');
+  } else {
+    return (fieldObject as unknown as IRegistrableField).fromJson(options);
   }
-  return fieldObject.fromJson(options);
 }
 
 export const TEST_ONLY = {

--- a/core/field_registry.ts
+++ b/core/field_registry.ts
@@ -68,7 +68,7 @@ export function fromJson(options: AnyDuringMigration): Field|null {
  */
 function fromJsonInternal(options: AnyDuringMigration): Field|null {
   const fieldObject =
-      registry.getObject(registry.Type.FIELD, options['type']) as
+      registry.getObject(registry.Type.FIELD, options['type']) as unknown as
           IRegistrableField |
       null;
   if (!fieldObject) {

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -417,20 +417,18 @@ function addAttributes(node: Node, obj: AnyDuringMigration) {
  */
 export function parseToolboxTree(toolboxDef: Element|null|string): Element|
     null {
+  let parsedToolboxDef: Element|null = null;
   if (toolboxDef) {
-    if (typeof toolboxDef !== 'string' && !(toolboxDef instanceof Element)) {
-      toolboxDef = null;
-    }
     if (typeof toolboxDef === 'string') {
-      toolboxDef = Xml.textToDom(toolboxDef);
-      if (toolboxDef.nodeName.toLowerCase() !== 'xml') {
+      parsedToolboxDef = Xml.textToDom(toolboxDef);
+      if (parsedToolboxDef.nodeName.toLowerCase() !== 'xml') {
         throw TypeError('Toolbox should be an <xml> document.');
       }
+    } else if (toolboxDef instanceof Element) {
+      parsedToolboxDef = toolboxDef;
     }
-  } else {
-    toolboxDef = null;
   }
-  return toolboxDef;
+  return parsedToolboxDef;
 }
 
 export const TEST_ONLY = {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

resolves #6360

### Proposed Changes

Fairly minor refactoring to bypass some typescript errors appearing on dependent projects with certain tsconfig settings.

#### Behavior Before Change

N/A. No behavioral changes. 

#### Behavior After Change

N/A. No behavioral changes. 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Existing tests should cover my changes:
- run_node_test.js covers `Generator#workspaceToCode`
- toolbox_test.js has "parseToolbox" suite covers `parseToolboxTree`
- block_test.js has "toString" suite to test `Block#tostring`

Ran `npm run test` and all existing tests passed. 

