### PR TITLE
chore(build): use inline sources in sourcemaps; don't package sources separately

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -674,8 +674,7 @@ function buildCompiled() {
       .pipe(gulp.sourcemaps.init())
       .pipe(compile(options))
       .pipe(gulp.rename({suffix: COMPILED_SUFFIX}))
-      .pipe(
-          gulp.sourcemaps.write('.', {includeContent: false, sourceRoot: './'}))
+      .pipe(gulp.sourcemaps.write('.'))
       .pipe(gulp.dest(BUILD_DIR));
 }
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -659,15 +659,6 @@ function buildCompiled() {
     // option to Closure Compiler; instead feed them as input via gulp.src.
   };
 
-  // Symlink source dirs from build dir so that sourcemaps work in
-  // compiled-mode testing.
-  for (const src of ['core', 'blocks', 'generators']) {
-    const target = `${BUILD_DIR}/${src}`
-    if (!fs.existsSync(target)) {
-      fs.symlinkSync(`../${src}`, target);
-    }
-  }
-
   // Fire up compilation pipline.
   return gulp.src(chunkOptions.js, {base: './'})
       .pipe(stripApacheLicense())

--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -80,15 +80,6 @@ function checkBuildDir(done) {
 }
 
 /**
- * This task copies source files into the release directory.
- */
-function packageSources() {
-  return gulp.src(['core/**/**', 'blocks/**', 'generators/**/**'],
-      {base: '.'})
-    .pipe(gulp.dest(RELEASE_DIR));
-};
-
-/**
  * This task copies the compressed files and their source maps into
  * the release directory.
  */
@@ -414,7 +405,6 @@ const package = gulp.series(
     cleanReleaseDir,
     gulp.parallel(
         packageIndex,
-        packageSources,
         packageCompressed,
         packageBrowser,
         packageNode,


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

`tsc` compile failures for developers whose build pipeline is misconfigured in a way that causes it to ingest `.ts` source files from `node_modules/blockly/core/`—somehow without also ingesting `core/any_aliases.ts`—resulting in compile errors due to `AnyDuringMigration`.  (See e.g. item #2 of #6358.)

### Proposed Changes

Don't package the source `.ts` files; instead, include sources inline in the `.js.map` sourcemaps.

#### Behaviour Before Change

`.ts` files are copied from `core/`, `blocks/` and `generators/` to `dist/`.

Sourcemap (`.js.map`) files contain a two-byte `sourceRoot` property.

#### Behaviour After Change

`.ts` files are not packaged.

Sourcemap files contain a large `sourcesContent` property (~2MB for `blockly_compressed.js.map), containing all of the original source.

### Reason for Changes

@btw17 points out that it is [generally not advised to package `.ts` sources along with compiled code in NPM packages]https://stackoverflow.com/a/57534667/4969945), and empirically it does appear to be causing problem for some of our developers.

### Test Coverage

Manually verified that sourcemaps with inline sources work correctly in compiled and uncompiled mode.

### Additional Information

I sent email to @samelhusseini to get clarity about why sources were originally included in the Blockly NPM package.  I think it worth waiting for a response before merging this PR.
