### PR TITLE
chore: Fix or individually disable no-this-alias lint rule violations.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -125,8 +125,6 @@
             "@typescript-eslint/no-inferrable-types": ["off"],
             // Temporarily disable. 33 problems.
             "@typescript-eslint/no-empty-function": ["off"],
-            // Temporarily disable. 17 problems.
-            "@typescript-eslint/no-this-alias": ["off"],
             // Temporarily disable. 3 problems.
             "@typescript-eslint/no-empty-interface": ["off"],
             // Temporarily disable. 34 problems.

--- a/core/block.ts
+++ b/core/block.ts
@@ -570,6 +570,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @return The block (if any) that surrounds the current block.
    */
   getSurroundParent(): this|null {
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block = this;
     let prevBlock;
     do {
@@ -625,6 +626,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   getRootBlock(): this {
     let rootBlock: this;
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this|null = this;
     do {
       rootBlock = block;
@@ -641,6 +643,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @internal
    */
   getTopStackBlock(): this {
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block = this;
     let previous;
     do {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1242,6 +1242,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @internal
    */
   bringToFront() {
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block = this;
     do {
       const root = block.getSvgRoot();
@@ -1550,19 +1551,18 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @internal
    */
   scheduleSnapAndBump() {
-    const block = this;
     // Ensure that any snap and bump are part of this move's event group.
     const group = eventUtils.getGroup();
 
-    setTimeout(function() {
+    setTimeout(() => {
       eventUtils.setGroup(group);
-      block.snapToGrid();
+      this.snapToGrid();
       eventUtils.setGroup(false);
     }, config.bumpDelay / 2);
 
-    setTimeout(function() {
+    setTimeout(() => {
       eventUtils.setGroup(group);
-      block.bumpNeighbours();
+      this.bumpNeighbours();
       eventUtils.setGroup(false);
     }, config.bumpDelay);
   }

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -566,13 +566,11 @@ WorkspaceCommentSvg.prototype.showContextMenu =
       if (this.workspace.options.readOnly) {
         return;
       }
-      // Save the current workspace comment in a variable for use in closures.
-      const comment = this;
       const menuOptions = [];
     
       if (this.isDeletable() && this.isMovable()) {
-        menuOptions.push(ContextMenu.commentDuplicateOption(comment));
-        menuOptions.push(ContextMenu.commentDeleteOption(comment));
+        menuOptions.push(ContextMenu.commentDuplicateOption(this));
+        menuOptions.push(ContextMenu.commentDeleteOption(this));
       }
     
       ContextMenu.show(e, menuOptions, this.RTL);

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -897,12 +897,11 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
    * @return Function to call when block is clicked.
    */
   private blockMouseDown_(block: BlockSvg): Function {
-    const flyout = this;
     return (e: MouseEvent) => {
-      const gesture = flyout.targetWorkspace.getGesture(e);
+      const gesture = this.targetWorkspace.getGesture(e);
       if (gesture) {
         gesture.setStartBlock(block);
-        gesture.handleFlyoutStart(e, flyout);
+        gesture.handleFlyoutStart(e, this);
       }
     };
   }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -153,6 +153,7 @@ export class RenderedConnection extends Connection {
         return;
       }
       // Swap the connections and move the 'static' connection instead.
+      /* eslint-disable-next-line @typescript-eslint/no-this-alias */
       staticConnection = this;
       reverse = true;
     }
@@ -495,8 +496,7 @@ export class RenderedConnection extends Connection {
 
     const renderedChildConnection = childConnection as RenderedConnection;
 
-    const parentConnection = this;
-    const parentBlock = parentConnection.getSourceBlock();
+    const parentBlock = this.getSourceBlock();
     const childBlock = renderedChildConnection.getSourceBlock();
     const parentRendered = parentBlock.rendered;
     const childRendered = childBlock.rendered;
@@ -508,8 +508,8 @@ export class RenderedConnection extends Connection {
       childBlock.updateDisabled();
     }
     if (parentRendered && childRendered) {
-      if (parentConnection.type === ConnectionType.NEXT_STATEMENT ||
-          parentConnection.type === ConnectionType.PREVIOUS_STATEMENT) {
+      if (this.type === ConnectionType.NEXT_STATEMENT ||
+          this.type === ConnectionType.PREVIOUS_STATEMENT) {
         // Child block may need to square off its corners if it is in a stack.
         // Rendering a child will render its parent.
         childBlock.render();

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -164,12 +164,10 @@ export class Scrollbar {
       this.lengthAttribute_ = 'height';
       this.positionAttribute_ = 'y';
     }
-    const scrollbar = this;
     this.onMouseDownBarWrapper_ = browserEvents.conditionalBind(
-        this.svgBackground_!, 'mousedown', scrollbar,
-        scrollbar.onMouseDownBar_);
+        this.svgBackground_!, 'mousedown', this, this.onMouseDownBar_);
     this.onMouseDownHandleWrapper_ = browserEvents.conditionalBind(
-        this.svgHandle_!, 'mousedown', scrollbar, scrollbar.onMouseDownHandle_);
+        this.svgHandle_!, 'mousedown', this, this.onMouseDownHandle_);
   }
 
   /**

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -481,6 +481,7 @@ export class ToolboxCategory extends ToolboxItem implements
    * @return True only if every ancestor is expanded
    */
   protected allAncestorsExpanded_(): boolean {
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let category: IToolboxItem = this;
     while (category.getParent()) {
       category = category.getParent()!;

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -227,20 +227,19 @@ export class VariableMap {
         }
       }
 
-      const map = this;
       if (uses.length > 1) {
         // Confirm before deleting multiple blocks.
         const confirmText = Msg['DELETE_VARIABLE_CONFIRMATION']
                                 .replace('%1', String(uses.length))
                                 .replace('%2', variableName);
-        dialog.confirm(confirmText, function(ok) {
+        dialog.confirm(confirmText, (ok) => {
           if (ok && variable) {
-            map.deleteVariableInternal(variable, uses);
+            this.deleteVariableInternal(variable, uses);
           }
         });
       } else {
         // No confirmation necessary for a single block.
-        map.deleteVariableInternal(variable, uses);
+        this.deleteVariableInternal(variable, uses);
       }
     } else {
       console.warn('Can\'t delete non-existent variable: ' + id);

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -978,20 +978,18 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
    * @internal
    */
   setFocus() {
-    const comment = this;
     this.focused_ = true;
     // Defer CSS changes.
-    setTimeout(function() {
-      if (comment.disposed_) {
+    setTimeout(() => {
+      if (this.disposed_) {
         return;
       }
-      comment.textarea_!.focus();
-      comment.addFocus();
+      this.textarea_!.focus();
+      this.addFocus();
       dom.addClass(
-          comment.svgRectTarget_ as SVGRectElement,
-          'blocklyCommentTargetFocused');
+          this.svgRectTarget_ as SVGRectElement, 'blocklyCommentTargetFocused');
       dom.addClass(
-          comment.svgHandleTarget_ as SVGRectElement,
+          this.svgHandleTarget_ as SVGRectElement,
           'blocklyCommentHandleTargetFocused');
     }, 0);
   }
@@ -1001,21 +999,19 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
    * @internal
    */
   blurFocus() {
-    const comment = this;
     this.focused_ = false;
     // Defer CSS changes.
-    setTimeout(function() {
-      if (comment.disposed_) {
+    setTimeout(() => {
+      if (this.disposed_) {
         return;
       }
 
-      comment.textarea_!.blur();
-      comment.removeFocus();
+      this.textarea_!.blur();
+      this.removeFocus();
       dom.removeClass(
-          comment.svgRectTarget_ as SVGRectElement,
-          'blocklyCommentTargetFocused');
+          this.svgRectTarget_ as SVGRectElement, 'blocklyCommentTargetFocused');
       dom.removeClass(
-          comment.svgHandleTarget_ as SVGRectElement,
+          this.svgHandleTarget_ as SVGRectElement,
           'blocklyCommentHandleTargetFocused');
     }, 0);
   }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #5857

### Proposed Changes
Fixes or individually disables violations of the no-this-alias lint rule. Where the violation was in the spirit of the rule (shenanigans with `this`) I fixed it by generally converting to arrow functions; in cases where the assignment was intentional (generally recursive traversals starting with `this`), I disabled the warning.

#### Behavior Before Change
Lint warnings for assigning `this` to a variable were always suppressed.

#### Behavior After Change
Lint warnings for assigning `this` to a variable are selectively suppressed but generally enabled.