### PR TITLE
chore: Fix no-inferrable-types lint rule violations.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -121,8 +121,6 @@
             "require-jsdoc": ["off"],
             // Temporarily disable. 55 problems.
             "@typescript-eslint/ban-types": ["off"],
-            // Temporarily disable. 18 problems. Autofixable?
-            "@typescript-eslint/no-inferrable-types": ["off"],
             // Temporarily disable. 33 problems.
             "@typescript-eslint/no-empty-function": ["off"],
             // Temporarily disable. 3 problems.

--- a/core/field_multilineinput.ts
+++ b/core/field_multilineinput.ts
@@ -46,7 +46,7 @@ export class FieldMultilineInput extends FieldTextInput {
    * Defines the maximum number of lines of field.
    * If exceeded, scrolling functionality is enabled.
    */
-  protected maxLines_: number = Infinity;
+  protected maxLines_ = Infinity;
 
   /** Whether Y overflow is currently occurring. */
   protected isOverflowedY_ = false;

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -28,10 +28,10 @@ import type {Sentinel} from './utils/sentinel.js';
  */
 export class FieldNumber extends FieldTextInput {
   /** The minimum value this number field can contain. */
-  protected min_: number = -Infinity;
+  protected min_ = -Infinity;
 
   /** The maximum value this number field can contain. */
-  protected max_: number = Infinity;
+  protected max_ = Infinity;
 
   /** The multiple to which this fields value is rounded. */
   protected precision_ = 0;

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -120,7 +120,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
    * Whether the flyout should be laid out horizontally or not.
    * @internal
    */
-  horizontalLayout: boolean = false;
+  horizontalLayout = false;
   protected toolboxPosition_: number;
 
   /**
@@ -173,17 +173,17 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
   /**
    * Does the flyout automatically close when a block is created?
    */
-  autoClose: boolean = true;
+  autoClose = true;
 
   /**
    * Whether the flyout is visible.
    */
-  private isVisible_: boolean = false;
+  private isVisible_ = false;
 
   /**
    * Whether the workspace containing this flyout is visible.
    */
-  private containerVisible_: boolean = true;
+  private containerVisible_ = true;
   protected rectMap_: WeakMap<BlockSvg, SVGElement>;
 
   /**
@@ -202,12 +202,12 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
   /**
    * Width of flyout.
    */
-  protected width_: number = 0;
+  protected width_ = 0;
 
   /**
    * Height of flyout.
    */
-  protected height_: number = 0;
+  protected height_ = 0;
   // clang-format off
   /**
    * Range of a drag angle from a flyout considered "dragging toward
@@ -225,7 +225,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
    * flyout. Setting it to 360 means that all drags create a new block.
    */
   // clang-format on
-  protected dragAngleRange_: number = 70;
+  protected dragAngleRange_ = 70;
 
   /**
    * The path around the background of the flyout, which will be filled with a

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -222,13 +222,13 @@ export class ConstantProvider {
    * ``setFontConstants_`` to be the height of the text based on the font
    * used.
    */
-  FIELD_TEXT_HEIGHT: number = -1;  // Dynamically set.
+  FIELD_TEXT_HEIGHT = -1;  // Dynamically set.
 
   /**
    * Text baseline.  This constant is dynamically set in ``setFontConstants_``
    * to be the baseline of the text based on the font used.
    */
-  FIELD_TEXT_BASELINE: number = -1;  // Dynamically set.
+  FIELD_TEXT_BASELINE = -1;  // Dynamically set.
 
   /** A field's border rect corner radius. */
   FIELD_BORDER_RECT_RADIUS = 4;

--- a/core/renderers/measurables/base.ts
+++ b/core/renderers/measurables/base.ts
@@ -27,9 +27,9 @@ import {Types} from './types.js';
  * @alias Blockly.blockRendering.Measurable
  */
 export class Measurable {
-  width: number = 0;
+  width = 0;
 
-  height: number = 0;
+  height = 0;
   type: number;
   xPos = 0;
 

--- a/core/renderers/measurables/input_connection.ts
+++ b/core/renderers/measurables/input_connection.ts
@@ -34,8 +34,8 @@ export class InputConnection extends Connection {
   connectedBlock: BlockSvg|null;
   connectedBlockWidth: number;
   connectedBlockHeight: number;
-  connectionOffsetX: number = 0;
-  connectionOffsetY: number = 0;
+  connectionOffsetX = 0;
+  connectionOffsetY = 0;
 
   /**
    * @param constants The rendering constants provider.

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -31,14 +31,14 @@ import * as style from './style.js';
  * Note that IE (9,10) returns 'translate(16 8)' instead of 'translate(16, 8)'.
  * Note that IE has been reported to return scientific notation (0.123456e-42).
  */
-const XY_REGEX: RegExp = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
+const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
 
 /**
  * Static regex to pull the x,y values out of a translate() or translate3d()
  * style property.
  * Accounts for same exceptions as XY_REGEX.
  */
-const XY_STYLE_REGEX: RegExp =
+const XY_STYLE_REGEX =
     /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #5857

### Proposed Changes
Removes type annotations that can be inferred from the literal value being assigned.