### PR TITLE
chore: remove alt dynamic shape definition

### DIFF
--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -83,9 +83,7 @@ export type BaseShape = {
 
 /** An object containing sizing and type information about a dynamic shape. */
 export type DynamicShape = {
-  type: number;
-  width: (p1: number) => number;
-  height: (p1: number) => number;
+  type: number; width: (p1: number) => number; height: (p1: number) => number;
   isDynamic: true;
   connectionOffsetY: (p1: number) => number;
   connectionOffsetX: (p1: number) => number;

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -81,8 +81,11 @@ export type BaseShape = {
   type: number; width: number; height: number;
 };
 
+/** An object containing sizing and type information about a dynamic shape. */
 export type DynamicShape = {
-  type: number; width: (p1: number) => number; height: (p1: number) => number;
+  type: number;
+  width: (p1: number) => number;
+  height: (p1: number) => number;
   isDynamic: true;
   connectionOffsetY: (p1: number) => number;
   connectionOffsetX: (p1: number) => number;
@@ -94,20 +97,6 @@ export type DynamicShape = {
 
 /** An object containing sizing and type information about a shape. */
 export type Shape = BaseShape|DynamicShape;
-
-/** An object containing sizing and type information about a dynamic shape. */
-// export interface DynamicShape {
-//   type: number;
-//   width: (p1: number) => number;
-//   height: (p1: number) => number;
-//   isDynamic: boolean;
-//   connectionOffsetY: (p1: number) => number;
-//   connectionOffsetX: (p1: number) => number;
-//   pathDown: (p1: number) => string;
-//   pathUp: (p1: number) => string;
-//   pathRightDown: (p1: number) => string;
-//   pathRightUp: (p1: number) => string;
-// }
 
 /**
  * An object that provides constants for rendering blocks.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Removes a commented out definition for a type.

I think the one I chose to leave is the more correct type definition.
