### PR TITLE
chore: remove instances of AnyDuringMigration in icons code

### DIFF
--- a/core/comment.ts
+++ b/core/comment.ts
@@ -76,7 +76,6 @@ export class Comment extends Icon {
 
   /** The top-level node of the comment text, or null if not created. */
   private paragraphElement_: SVGTextElement|null = null;
-  override bubble_: AnyDuringMigration;
 
   /** @param block The block associated with this comment. */
   constructor(block: BlockSvg) {
@@ -187,9 +186,7 @@ export class Comment extends Icon {
 
     setTimeout(textarea.focus.bind(textarea), 0);
 
-    // AnyDuringMigration because:  Type 'SVGForeignObjectElement | null' is not
-    // assignable to type 'SVGElement'.
-    return this.foreignObject_ as AnyDuringMigration;
+    return this.foreignObject_;
   }
 
   /** Add or remove editability of the comment. */
@@ -207,9 +204,7 @@ export class Comment extends Icon {
    * Resize the text area accordingly.
    */
   private onBubbleResize_() {
-    if (!this.isVisible()) {
-      return;
-    }
+    if (!this.bubble_) return;
     this.model_.size = this.bubble_.getBubbleSize();
     this.resizeTextarea_();
   }
@@ -223,14 +218,8 @@ export class Comment extends Icon {
     const doubleBorderWidth = 2 * Bubble.BORDER_WIDTH;
     const widthMinusBorder = size.width - doubleBorderWidth;
     const heightMinusBorder = size.height - doubleBorderWidth;
-    // AnyDuringMigration because:  Argument of type 'number' is not assignable
-    // to parameter of type 'string'.
-    this.foreignObject_!.setAttribute(
-        'width', widthMinusBorder as AnyDuringMigration);
-    // AnyDuringMigration because:  Argument of type 'number' is not assignable
-    // to parameter of type 'string'.
-    this.foreignObject_!.setAttribute(
-        'height', heightMinusBorder as AnyDuringMigration);
+    this.foreignObject_!.setAttribute('width', `${widthMinusBorder}`);
+    this.foreignObject_!.setAttribute('height', `${heightMinusBorder}`);
     this.textarea_!.style.width = widthMinusBorder - 4 + 'px';
     this.textarea_!.style.height = heightMinusBorder - 4 + 'px';
   }
@@ -307,8 +296,10 @@ export class Comment extends Icon {
       browserEvents.unbind(this.onInputWrapper_);
       this.onInputWrapper_ = null;
     }
-    this.bubble_.dispose();
-    this.bubble_ = null;
+    if (this.bubble_) {
+      this.bubble_.dispose();
+      this.bubble_ = null;
+    }
     this.textarea_ = null;
     this.foreignObject_ = null;
     this.paragraphElement_ = null;
@@ -322,7 +313,7 @@ export class Comment extends Icon {
    * @param _e Mouse up event.
    */
   private startEdit_(_e: Event) {
-    if (this.bubble_.promote()) {
+    if (this.bubble_?.promote()) {
       // Since the act of moving this node within the DOM causes a loss of
       // focus, we need to reapply the focus.
       this.textarea_!.focus();

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -71,15 +71,14 @@ export abstract class Icon {
 
     this.block_.getSvgRoot().appendChild(this.iconGroup_);
     browserEvents.conditionalBind(
-        this.iconGroup_, 'mouseup', this,
-        this.iconClick_);
+        this.iconGroup_, 'mouseup', this, this.iconClick_);
     this.updateEditable();
   }
 
   /** Dispose of this icon. */
   dispose() {
     dom.removeNode(this.iconGroup_);  // Dispose of and unlink the icon.
-    this.setVisible(false);  // Dispose of and unlink the bubble.
+    this.setVisible(false);           // Dispose of and unlink the bubble.
   }
 
   /** Add or remove the UI indicating if this icon may be clicked or not. */

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -67,36 +67,25 @@ export abstract class Icon {
     if (this.block_.isInFlyout) {
       dom.addClass(this.iconGroup_ as Element, 'blocklyIconGroupReadonly');
     }
-    // AnyDuringMigration because:  Argument of type 'SVGGElement | null' is not
-    // assignable to parameter of type 'Element'.
-    this.drawIcon_(this.iconGroup_ as AnyDuringMigration);
+    this.drawIcon_(this.iconGroup_);
 
-    // AnyDuringMigration because:  Argument of type 'SVGGElement | null' is not
-    // assignable to parameter of type 'Node'.
-    this.block_.getSvgRoot().appendChild(this.iconGroup_ as AnyDuringMigration);
-    // AnyDuringMigration because:  Argument of type 'SVGGElement | null' is not
-    // assignable to parameter of type 'EventTarget'.
+    this.block_.getSvgRoot().appendChild(this.iconGroup_);
     browserEvents.conditionalBind(
-        this.iconGroup_ as AnyDuringMigration, 'mouseup', this,
+        this.iconGroup_, 'mouseup', this,
         this.iconClick_);
     this.updateEditable();
   }
 
   /** Dispose of this icon. */
   dispose() {
-    // Dispose of and unlink the icon.
-    dom.removeNode(this.iconGroup_);
-    this.iconGroup_ = null;
-    // Dispose of and unlink the bubble.
-    this.setVisible(false);
-    // AnyDuringMigration because:  Type 'null' is not assignable to type
-    // 'BlockSvg'.
-    this.block_ = null as AnyDuringMigration;
+    dom.removeNode(this.iconGroup_);  // Dispose of and unlink the icon.
+    this.setVisible(false);  // Dispose of and unlink the bubble.
   }
 
   /** Add or remove the UI indicating if this icon may be clicked or not. */
-  updateEditable() {}
-  // No-op on the base class.
+  updateEditable() {
+    // No-op on the base class.
+  }
 
   /**
    * Is the associated bubble visible?

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -44,7 +44,7 @@ import type {WorkspaceSvg} from './workspace_svg.js';
  * @alias Blockly.Mutator
  */
 export class Mutator extends Icon {
-  quarkNames_: AnyDuringMigration;
+  private quarkNames_: string[];
 
   /** Workspace in the mutator's bubble. */
   private workspace_: WorkspaceSvg|null = null;
@@ -209,9 +209,7 @@ export class Mutator extends Icon {
     }
     this.svgDialog_!.appendChild(background);
 
-    // AnyDuringMigration because:  Type 'SVGSVGElement | null' is not
-    // assignable to type 'SVGElement'.
-    return this.svgDialog_ as AnyDuringMigration;
+    return this.svgDialog_;
   }
 
   /**
@@ -270,14 +268,8 @@ export class Mutator extends Icon {
       // Resize the bubble.
       this.bubble_!.setBubbleSize(
           width + doubleBorderWidth, height + doubleBorderWidth);
-      // AnyDuringMigration because:  Argument of type 'number' is not
-      // assignable to parameter of type 'string'.
-      this.svgDialog_!.setAttribute(
-          'width', this.workspaceWidth_ as AnyDuringMigration);
-      // AnyDuringMigration because:  Argument of type 'number' is not
-      // assignable to parameter of type 'string'.
-      this.svgDialog_!.setAttribute(
-          'height', this.workspaceHeight_ as AnyDuringMigration);
+      this.svgDialog_!.setAttribute('width', `${this.workspaceWidth_}`);
+      this.svgDialog_!.setAttribute('height', `${this.workspaceHeight_}`);
       this.workspace_!.setCachedParentSvgSize(
           this.workspaceWidth_, this.workspaceHeight_);
     }

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -101,8 +101,7 @@ export class Warning extends Icon {
   private createBubble_() {
     this.paragraphElement_ = Bubble.textToDom(this.getText());
     this.bubble_ = Bubble.createNonEditableBubble(
-        this.paragraphElement_, this.block_,
-        this.iconXY_ as Coordinate);
+        this.paragraphElement_, this.block_, this.iconXY_ as Coordinate);
     this.applyColour();
   }
 

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -32,14 +32,13 @@ import {Svg} from './utils/svg.js';
  * @alias Blockly.Warning
  */
 export class Warning extends Icon {
-  text_: AnyDuringMigration;
+  private text_: {[key: string]: string};
 
   /** The top-level node of the warning text, or null if not created. */
   private paragraphElement_: SVGTextElement|null = null;
 
   /** Does this icon get hidden when the block is collapsed? */
   override collapseHidden = false;
-  override bubble_: AnyDuringMigration;
 
   /** @param block The block associated with this warning. */
   constructor(block: BlockSvg) {
@@ -89,10 +88,8 @@ export class Warning extends Icon {
     if (visible === this.isVisible()) {
       return;
     }
-    // AnyDuringMigration because:  Property 'block_' does not exist on type
-    // 'Warning'.
     eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))!
-                    ((this as AnyDuringMigration).block_, visible, 'warning'));
+                    (this.block_, visible, 'warning'));
     if (visible) {
       this.createBubble_();
     } else {
@@ -103,18 +100,18 @@ export class Warning extends Icon {
   /** Show the bubble. */
   private createBubble_() {
     this.paragraphElement_ = Bubble.textToDom(this.getText());
-    // AnyDuringMigration because:  Property 'block_' does not exist on type
-    // 'Warning'.
     this.bubble_ = Bubble.createNonEditableBubble(
-        this.paragraphElement_, (this as AnyDuringMigration).block_ as BlockSvg,
+        this.paragraphElement_, this.block_,
         this.iconXY_ as Coordinate);
     this.applyColour();
   }
 
   /** Dispose of the bubble and references to it. */
   private disposeBubble_() {
-    this.bubble_.dispose();
-    this.bubble_ = null;
+    if (this.bubble_) {
+      this.bubble_.dispose();
+      this.bubble_ = null;
+    }
     this.paragraphElement_ = null;
   }
 
@@ -153,9 +150,7 @@ export class Warning extends Icon {
 
   /** Dispose of this warning. */
   override dispose() {
-    // AnyDuringMigration because:  Property 'block_' does not exist on type
-    // 'Warning'.
-    (this as AnyDuringMigration).block_.warning = null;
+    this.block_.warning = null;
     super.dispose();
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #5857 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes instances of AnyDuringMigration and replaces them with better types where applicable.

Also makes some private things actually `private`.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
No change in behavior.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No change in bheavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Types are fun!

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I didn't fix the `Pid_` type in mutator because I still don't know how to properly type `setTimeout` return values.
