### PR TITLE
chore: remove AnyDuringMigration from dropdown and widget divs

### DIFF
--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -22,12 +22,10 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 
 
 /** The object currently using this container. */
-let owner: AnyDuringMigration = null;
+let owner: unknown = null;
 
 /** Optional cleanup function set by whichever object uses the widget. */
-// AnyDuringMigration because:  Type 'null' is not assignable to type
-// 'Function'.
-let dispose: Function = null as AnyDuringMigration;
+let dispose: (() => void)|null = null;
 
 /** A class name representing the current owner's workspace renderer. */
 let rendererClassName = '';
@@ -85,22 +83,19 @@ export function createDom() {
  * @alias Blockly.WidgetDiv.show
  */
 export function show(
-    newOwner: AnyDuringMigration, rtl: boolean, newDispose: Function) {
+    newOwner: unknown, rtl: boolean, newDispose: () => void) {
   hide();
   owner = newOwner;
   dispose = newDispose;
   const div = containerDiv;
-  div!.style.direction = rtl ? 'rtl' : 'ltr';
-  div!.style.display = 'block';
+  if (!div) return;
+  div.style.direction = rtl ? 'rtl' : 'ltr';
+  div.style.display = 'block';
   const mainWorkspace = common.getMainWorkspace() as WorkspaceSvg;
   rendererClassName = mainWorkspace.getRenderer().getClassName();
   themeClassName = mainWorkspace.getTheme().getClassName();
-  // AnyDuringMigration because:  Argument of type 'HTMLDivElement | null' is
-  // not assignable to parameter of type 'Element'.
-  dom.addClass(div as AnyDuringMigration, rendererClassName);
-  // AnyDuringMigration because:  Argument of type 'HTMLDivElement | null' is
-  // not assignable to parameter of type 'Element'.
-  dom.addClass(div as AnyDuringMigration, themeClassName);
+  dom.addClass(div, rendererClassName);
+  dom.addClass(div, themeClassName);
 }
 
 /**
@@ -115,25 +110,20 @@ export function hide() {
   owner = null;
 
   const div = containerDiv;
-  div!.style.display = 'none';
-  div!.style.left = '';
-  div!.style.top = '';
+  if (!div) return;
+  div.style.display = 'none';
+  div.style.left = '';
+  div.style.top = '';
   dispose && dispose();
-  // AnyDuringMigration because:  Type 'null' is not assignable to type
-  // 'Function'.
-  dispose = null as AnyDuringMigration;
-  div!.textContent = '';
+  dispose = null;
+  div.textContent = '';
 
   if (rendererClassName) {
-    // AnyDuringMigration because:  Argument of type 'HTMLDivElement | null' is
-    // not assignable to parameter of type 'Element'.
-    dom.removeClass(div as AnyDuringMigration, rendererClassName);
+    dom.removeClass(div, rendererClassName);
     rendererClassName = '';
   }
   if (themeClassName) {
-    // AnyDuringMigration because:  Argument of type 'HTMLDivElement | null' is
-    // not assignable to parameter of type 'Element'.
-    dom.removeClass(div as AnyDuringMigration, themeClassName);
+    dom.removeClass(div, themeClassName);
     themeClassName = '';
   }
   (common.getMainWorkspace() as WorkspaceSvg).markFocused();
@@ -156,7 +146,7 @@ export function isVisible(): boolean {
  * @param oldOwner The object that was using this container.
  * @alias Blockly.WidgetDiv.hideIfOwner
  */
-export function hideIfOwner(oldOwner: AnyDuringMigration) {
+export function hideIfOwner(oldOwner: unknown) {
   if (owner === oldOwner) {
     hide();
   }

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -82,8 +82,7 @@ export function createDom() {
  *     closed.
  * @alias Blockly.WidgetDiv.show
  */
-export function show(
-    newOwner: unknown, rtl: boolean, newDispose: () => void) {
+export function show(newOwner: unknown, rtl: boolean, newDispose: () => void) {
   hide();
   owner = newOwner;
   dispose = newDispose;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #5857 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes instances of `AnyDuringMigration` from the `DropDownDiv` and the `WidgetDiv`

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
No change in behavior.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No change in behavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Types are fun :D

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
