### PR TITLE
chore: Removed commented-out side-effect-only imports.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -15,13 +15,8 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BlockSvg');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './theme.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_selected.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './touch.js';
 
 import {Block} from './block.js';
 import * as blockAnimations from './block_animations.js';

--- a/core/bubble.ts
+++ b/core/bubble.ts
@@ -15,12 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Bubble');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './metrics_manager.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './workspace.js';
-
 import type {BlockDragSurfaceSvg} from './block_drag_surface.js';
 import type {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -15,11 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.BubbleDragger');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './bubble.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './constants.js';
-
 import type {BlockDragSurfaceSvg} from './block_drag_surface.js';
 import {ComponentManager} from './component_manager.js';
 import type {CommentMove} from './events/events_comment_move.js';

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -15,18 +15,10 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Comment');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './block.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './workspace_svg.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_block_change.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_bubble_open.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './warning.js';
 
 import type {CommentModel} from './block.js';
 import type {BlockSvg} from './block_svg.js';

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -15,9 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Connection');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './constants.js';
-
 import type {Block} from './block.js';
 import {ConnectionType} from './connection_type.js';
 import type {BlockMove} from './events/events_block_move.js';

--- a/core/connection_db.ts
+++ b/core/connection_db.ts
@@ -19,9 +19,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ConnectionDB');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './constants.js';
-
 import {ConnectionType} from './connection_type.js';
 import type {IConnectionChecker} from './interfaces/i_connection_checker.js';
 import type {RenderedConnection} from './rendered_connection.js';

--- a/core/extensions.ts
+++ b/core/extensions.ts
@@ -21,9 +21,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Extensions');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './mutator.js';
-
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import {FieldDropdown} from './field_dropdown.js';

--- a/core/field.ts
+++ b/core/field.ts
@@ -19,13 +19,8 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Field');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './shortcut_registry.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_block_change.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './gesture.js';
 
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -15,11 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.VerticalFlyout');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './block.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './constants.js';
-
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
 import {Flyout, FlyoutItem} from './flyout_base.js';

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -18,8 +18,6 @@ import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Gesture');
 
 // Unused import preserved for side-effects. Remove if unneeded.
-// import './block_dragger.js';
-// Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_click.js';
 
 import * as blockAnimations from './block_animations.js';

--- a/core/interfaces/i_ast_node_location_with_block.ts
+++ b/core/interfaces/i_ast_node_location_with_block.ts
@@ -17,10 +17,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IASTNodeLocationWithBlock');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../block.js';
-
 import type {IASTNodeLocation} from './i_ast_node_location.js';
 import type {Block} from '../block.js';
 

--- a/core/interfaces/i_block_dragger.ts
+++ b/core/interfaces/i_block_dragger.ts
@@ -17,14 +17,6 @@ import type {Coordinate} from '../utils/coordinate.js';
 import type {BlockSvg} from '../block_svg.js';
 goog.declareModuleId('Blockly.IBlockDragger');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../block_svg.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/coordinate.js';
-
-
 /**
  * A block dragger interface.
  * @alias Blockly.IBlockDragger

--- a/core/interfaces/i_bounded_element.ts
+++ b/core/interfaces/i_bounded_element.ts
@@ -16,11 +16,6 @@ import * as goog from '../../closure/goog/goog.js';
 import type {Rect} from '../utils/rect.js';
 goog.declareModuleId('Blockly.IBoundedElement');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/rect.js';
-
-
 /**
  * A bounded element interface.
  * @alias Blockly.IBoundedElement

--- a/core/interfaces/i_bubble.ts
+++ b/core/interfaces/i_bubble.ts
@@ -17,13 +17,6 @@ import type {Coordinate} from '../utils/coordinate.js';
 import type {BlockDragSurfaceSvg} from '../block_drag_surface.js';
 goog.declareModuleId('Blockly.IBubble');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../block_drag_surface.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/coordinate.js';
-
 import type {IContextMenu} from './i_contextmenu.js';
 import type {IDraggable} from './i_draggable.js';
 

--- a/core/interfaces/i_collapsible_toolbox_item.ts
+++ b/core/interfaces/i_collapsible_toolbox_item.ts
@@ -15,11 +15,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ICollapsibleToolboxItem');
 
-/* eslint-disable-next-line no-unused-vars */
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './i_toolbox_item.js';
-
 import type {ISelectableToolboxItem} from './i_selectable_toolbox_item.js';
 import type {IToolboxItem} from './i_toolbox_item.js';
 

--- a/core/interfaces/i_connection_checker.ts
+++ b/core/interfaces/i_connection_checker.ts
@@ -19,14 +19,6 @@ import type {Connection} from '../connection.js';
 import type {RenderedConnection} from '../rendered_connection.js';
 goog.declareModuleId('Blockly.IConnectionChecker');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../connection.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../rendered_connection.js';
-
-
 /**
  * Class for connection type checking logic.
  * @alias Blockly.IConnectionChecker

--- a/core/interfaces/i_delete_area.ts
+++ b/core/interfaces/i_delete_area.ts
@@ -17,11 +17,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IDeleteArea');
 
-/* eslint-disable-next-line no-unused-vars */
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './i_draggable.js';
-
 import type {IDragTarget} from './i_drag_target.js';
 import type {IDraggable} from './i_draggable.js';
 

--- a/core/interfaces/i_drag_target.ts
+++ b/core/interfaces/i_drag_target.ts
@@ -21,14 +21,6 @@ import {IDraggable} from './i_draggable.js';
 
 goog.declareModuleId('Blockly.IDragTarget');
 
-/* eslint-disable-next-line no-unused-vars */
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './i_draggable.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/rect.js';
-
 import type {IComponent} from './i_component.js';
 
 

--- a/core/interfaces/i_flyout.ts
+++ b/core/interfaces/i_flyout.ts
@@ -15,19 +15,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IFlyout');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/toolbox.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../block_svg.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/coordinate.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/svg.js';
-
 import type {WorkspaceSvg} from '../workspace_svg.js';
 import type {BlockSvg} from '../block_svg.js';
 import type {Coordinate} from '../utils/coordinate.js';

--- a/core/interfaces/i_keyboard_accessible.ts
+++ b/core/interfaces/i_keyboard_accessible.ts
@@ -16,11 +16,6 @@ import * as goog from '../../closure/goog/goog.js';
 import {KeyboardShortcut} from '../shortcut_registry.js';
 goog.declareModuleId('Blockly.IKeyboardAccessible');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../shortcut_registry.js';
-
-
 /**
  * An interface for an object that handles keyboard shortcuts.
  * @alias Blockly.IKeyboardAccessible

--- a/core/interfaces/i_metrics_manager.ts
+++ b/core/interfaces/i_metrics_manager.ts
@@ -18,17 +18,6 @@ import type {Size} from '../utils/size.js';
 import type {Metrics} from '../utils/metrics.js';
 goog.declareModuleId('Blockly.IMetricsManager');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../metrics_manager.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/metrics.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/size.js';
-
-
 /**
  * Interface for a metrics manager.
  * @alias Blockly.IMetricsManager

--- a/core/interfaces/i_positionable.ts
+++ b/core/interfaces/i_positionable.ts
@@ -17,14 +17,6 @@ import type {Rect} from '../utils/rect.js';
 import type {UiMetrics} from '../metrics_manager.js';
 goog.declareModuleId('Blockly.IPositionable');
 
-/* eslint-disable-next-line no-unused-vars */
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../metrics_manager.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/rect.js';
-
 import type {IComponent} from './i_component.js';
 
 

--- a/core/interfaces/i_selectable_toolbox_item.ts
+++ b/core/interfaces/i_selectable_toolbox_item.ts
@@ -16,10 +16,6 @@ import * as goog from '../../closure/goog/goog.js';
 import type {FlyoutItemInfoArray} from '../utils/toolbox';
 goog.declareModuleId('Blockly.ISelectableToolboxItem');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/toolbox.js';
-
 import type {IToolboxItem} from './i_toolbox_item.js';
 
 

--- a/core/interfaces/i_toolbox.ts
+++ b/core/interfaces/i_toolbox.ts
@@ -15,19 +15,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.IToolbox');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../utils/toolbox.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './i_flyout.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './i_toolbox_item.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../workspace_svg.js';
-
 import type {IRegistrable} from './i_registrable.js';
 import type {IToolboxItem} from './i_toolbox_item.js';
 import type {ToolboxInfo} from '../utils/toolbox.js';

--- a/core/names.ts
+++ b/core/names.ts
@@ -15,9 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Names');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './procedures.js';
-
 import {Msg} from './msg.js';
 // import * as Procedures from './procedures.js';
 import type {VariableMap} from './variable_map.js';

--- a/core/positionable_helpers.ts
+++ b/core/positionable_helpers.ts
@@ -15,10 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.uiPosition');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './metrics_manager.js';
-
 import type {UiMetrics} from './metrics_manager.js';
 import {Scrollbar} from './scrollbar.js';
 import {Rect} from './utils/rect.js';

--- a/core/renderers/common/i_path_object.ts
+++ b/core/renderers/common/i_path_object.ts
@@ -17,16 +17,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.IPathObject');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../block_svg.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../connection.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../theme.js';
-
 import type {BlockStyle} from '../../theme.js';
 
 import type {ConstantProvider} from './constants.js';

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -15,10 +15,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.blockRendering.PathObject');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../theme.js';
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import type {BlockStyle} from '../../theme.js';

--- a/core/renderers/geras/highlighter.ts
+++ b/core/renderers/geras/highlighter.ts
@@ -17,10 +17,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.Highlighter');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './renderer.js';
-
 import * as svgPaths from '../../utils/svg_paths.js';
 import type {ConstantProvider} from '../common/constants.js';
 import type {BottomRow} from '../measurables/bottom_row.js';

--- a/core/renderers/geras/path_object.ts
+++ b/core/renderers/geras/path_object.ts
@@ -15,10 +15,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.PathObject');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../theme.js';
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {BlockStyle} from '../../theme.js';
 import * as colour from '../../utils/colour.js';

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -15,10 +15,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.geras.Renderer');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../common/constants.js';
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {BlockStyle, Theme} from '../../theme.js';
 import * as blockRendering from '../common/block_rendering.js';

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -15,10 +15,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.PathObject');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../theme.js';
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import type {BlockStyle} from '../../theme.js';

--- a/core/renderers/zelos/renderer.ts
+++ b/core/renderers/zelos/renderer.ts
@@ -15,10 +15,6 @@
 import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.zelos.Renderer');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../../theme.js';
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import {ConnectionType} from '../../connection_type.js';

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -15,9 +15,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Toolbox');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../shortcut_registry.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import '../events/events_toolbox_item_select.js';
 

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -15,9 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Trashcan');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './metrics_manager.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_trashcan_open.js';
 

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -15,13 +15,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.toolbox');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../toolbox/category.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import '../toolbox/separator.js';
-
 import type {ConnectionState} from '../serialization/blocks.js';
 import type {CssConfig as CategoryCssConfig} from '../toolbox/category.js';
 import type {CssConfig as SeparatorCssConfig} from '../toolbox/separator.js';

--- a/core/workspace_comment.ts
+++ b/core/workspace_comment.ts
@@ -15,13 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceComment');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './events/events_comment_change.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './events/events_comment_create.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './events/events_comment_delete.js';
-
 import type {CommentMove} from './events/events_comment_move.js';
 import * as eventUtils from './events/utils.js';
 import {Coordinate} from './utils/coordinate.js';

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -16,10 +16,6 @@ import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceCommentSvg');
 
 // Unused import preserved for side-effects. Remove if unneeded.
-// import './events/events_comment_create.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './events/events_comment_delete.js';
-// Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_selected.js';
 
 import type {BlockDragSurfaceSvg} from './block_drag_surface.js';

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -15,31 +15,12 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.WorkspaceSvg');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './procedures.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './variables.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './variables_dynamic.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './rendered_connection.js';
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './zoom_controls.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_block_create.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_theme_change.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_viewport.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './metrics_manager.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './msg.js';
 
 import type {Block} from './block.js';
 import type {BlockDragSurfaceSvg} from './block_drag_surface.js';

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -15,15 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Xml');
 
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './comment.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './variables.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './workspace_comment.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './workspace_comment_svg.js';
-
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {Connection} from './connection.js';

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -15,9 +15,6 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ZoomControls');
 
-/* eslint-disable-next-line no-unused-vars */
-// Unused import preserved for side-effects. Remove if unneeded.
-// import './metrics_manager.js';
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_click.js';
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #5857 

### Proposed Changes
Removes commented-out imports that were present for side effects. Since they were commented out, this is a no-op; it's possible some of them might have been needed/are causing bugs we haven't noticed, but we can add them back (uncommented!) should that prove to be the case.