### PR TITLE
refactor: Mark optional parameters as optional.

### DIFF
--- a/core/events/events_bubble_open.ts
+++ b/core/events/events_bubble_open.ts
@@ -38,7 +38,7 @@ export class BubbleOpen extends UiBase {
    *     'warning'. Undefined for a blank event.
    */
   constructor(
-      opt_block: BlockSvg, opt_isOpen?: boolean, opt_bubbleType?: string) {
+      opt_block?: BlockSvg, opt_isOpen?: boolean, opt_bubbleType?: string) {
     const workspaceId = opt_block ? opt_block.workspace.id : undefined;
     super(workspaceId);
     this.blockId = opt_block ? opt_block.id : null;

--- a/core/flyout_metrics_manager.ts
+++ b/core/flyout_metrics_manager.ts
@@ -56,7 +56,7 @@ export class FlyoutMetricsManager extends MetricsManager {
     return blockBoundingBox;
   }
 
-  override getContentMetrics(opt_getWorkspaceCoordinates: boolean) {
+  override getContentMetrics(opt_getWorkspaceCoordinates?: boolean) {
     // The bounding box is in workspace coordinates.
     const blockBoundingBox = this.getBoundingBox_();
     const scale = opt_getWorkspaceCoordinates ? 1 : this.workspace_.scale;
@@ -70,8 +70,8 @@ export class FlyoutMetricsManager extends MetricsManager {
   }
 
   override getScrollMetrics(
-      opt_getWorkspaceCoordinates: boolean, opt_viewMetrics: ContainerRegion,
-      opt_contentMetrics: ContainerRegion) {
+      opt_getWorkspaceCoordinates?: boolean, opt_viewMetrics?: ContainerRegion,
+      opt_contentMetrics?: ContainerRegion) {
     // AnyDuringMigration because:  Expected 1 arguments, but got 0.
     const contentMetrics =
         opt_contentMetrics || (this.getContentMetrics as AnyDuringMigration)();

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -296,7 +296,7 @@ export function getObject<T>(
  * @alias Blockly.registry.getAllItems
  */
 export function getAllItems<T>(
-    type: string|Type<T>, opt_cased: boolean, opt_throwIfMissing?: boolean):
+    type: string|Type<T>, opt_cased?: boolean, opt_throwIfMissing?: boolean):
     {[key: string]: T|null|(new (...p1: AnyDuringMigration[]) => T)}|null {
   type = String(type).toLowerCase();
   const typeRegistry = typeMap[type];

--- a/core/renderers/common/renderer.ts
+++ b/core/renderers/common/renderer.ts
@@ -77,7 +77,8 @@ export class Renderer implements IRegistrable {
    * @param opt_rendererOverrides Rendering constant overrides.
    * @internal
    */
-  init(theme: Theme, opt_rendererOverrides?: object) {
+  init(
+      theme: Theme, opt_rendererOverrides?: {[rendererConstant: string]: any}) {
     this.constants_ = this.makeConstants_();
     if (opt_rendererOverrides) {
       this.overrides = opt_rendererOverrides;

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -51,7 +51,8 @@ export class Renderer extends BaseRenderer {
    *
    * @internal
    */
-  override init(theme: Theme, opt_rendererOverrides?: object) {
+  override init(
+      theme: Theme, opt_rendererOverrides?: {[rendererConstant: string]: any}) {
     super.init(theme, opt_rendererOverrides);
     this.highlightConstants_ = this.makeHighlightConstants_();
     this.highlightConstants_.init();

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -51,7 +51,7 @@ export class Renderer extends BaseRenderer {
    *
    * @internal
    */
-  override init(theme: Theme, opt_rendererOverrides: AnyDuringMigration) {
+  override init(theme: Theme, opt_rendererOverrides?: object) {
     super.init(theme, opt_rendererOverrides);
     this.highlightConstants_ = this.makeHighlightConstants_();
     this.highlightConstants_.init();


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Part of #5857

### Proposed Changes
Makes optional arguments to some methods actually optional; before they had an opt_ prefix and were treated as optional, but were actually required arguments from TS' perspective.