### PR TITLE
fix: make eventUtils throw if event type not registered

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,6 +122,8 @@
                 "argsIgnorePattern": "^_",
                 "varsIgnorePattern": "^_"
             }],
+            "func-call-spacing": ["off"],
+            "@typescript-eslint/func-call-spacing": ["warn"],
             // Temporarily disable. 23 problems.
             "@typescript-eslint/no-explicit-any": ["off"],
             // Temporarily disable. 128 problems.
@@ -132,8 +134,6 @@
             "@typescript-eslint/no-empty-function": ["off"],
             // Temporarily disable. 3 problems.
             "@typescript-eslint/no-empty-interface": ["off"],
-            // Temporarily disable. 34 problems.
-            "func-call-spacing": ["off"],
 
             // TsDoc rules (using JsDoc plugin)
             // Disable built-in jsdoc verifier.

--- a/core/block.ts
+++ b/core/block.ts
@@ -291,7 +291,7 @@ export class Block implements IASTNodeLocation, IDeletable {
 
       // Fire a create event.
       if (eventUtils.isEnabled()) {
-        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))!(this));
+        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(this));
       }
     } finally {
       if (!existingGroup) {
@@ -323,7 +323,7 @@ export class Block implements IASTNodeLocation, IDeletable {
 
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))!(this));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
     }
 
     if (this.onchangeWrapper_) {
@@ -1248,8 +1248,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   setInputsInline(newBoolean: boolean) {
     if (this.inputsInline !== newBoolean) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                      (this, 'inline', null, this.inputsInline, newBoolean));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          this, 'inline', null, this.inputsInline, newBoolean));
       this.inputsInline = newBoolean;
     }
   }
@@ -1318,8 +1318,8 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.isEnabled() !== enabled) {
       const oldValue = this.disabled;
       this.disabled = !enabled;
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                      (this, 'disabled', null, oldValue, !enabled));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          this, 'disabled', null, oldValue, !enabled));
     }
   }
 
@@ -1357,8 +1357,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   setCollapsed(collapsed: boolean) {
     if (this.collapsed_ !== collapsed) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                      (this, 'collapsed', null, this.collapsed_, collapsed));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          this, 'collapsed', null, this.collapsed_, collapsed));
       this.collapsed_ = collapsed;
     }
   }
@@ -2064,8 +2064,8 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.commentModel.text === text) {
       return;
     }
-    eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                    (this, 'comment', null, this.commentModel.text, text));
+    eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        this, 'comment', null, this.commentModel.text, text));
     this.commentModel.text = text;
     // AnyDuringMigration because:  Type 'string | null' is not assignable to
     // type 'string | Comment'.
@@ -2111,7 +2111,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       throw Error('Block has parent.');
     }
     const event =
-        new (eventUtils.get(eventUtils.BLOCK_MOVE))!(this) as BlockMove;
+        new (eventUtils.get(eventUtils.BLOCK_MOVE))(this) as BlockMove;
     this.xy_.translate(dx, dy);
     event.recordNew();
     eventUtils.fire(event);

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -163,8 +163,8 @@ export class BlockDragger implements IBlockDragger {
 
   /** Fire a UI event at the start of a block drag. */
   protected fireDragStartEvent_() {
-    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))!
-        (this.draggingBlock_, true, this.draggingBlock_.getDescendants(false));
+    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))(
+        this.draggingBlock_, true, this.draggingBlock_.getDescendants(false));
     eventUtils.fire(event);
   }
 
@@ -312,8 +312,8 @@ export class BlockDragger implements IBlockDragger {
 
   /** Fire a UI event at the end of a block drag. */
   protected fireDragEndEvent_() {
-    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))!
-        (this.draggingBlock_, false, this.draggingBlock_.getDescendants(false));
+    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))(
+        this.draggingBlock_, false, this.draggingBlock_.getDescendants(false));
     eventUtils.fire(event);
   }
 
@@ -352,8 +352,8 @@ export class BlockDragger implements IBlockDragger {
 
   /** Fire a move event at the end of a block drag. */
   protected fireMoveEvent_() {
-    const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))!
-        (this.draggingBlock_) as BlockMove;
+    const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
+                      this.draggingBlock_) as BlockMove;
     event.oldCoordinate = this.startXY_;
     event.recordNew();
     eventUtils.fire(event);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -284,8 +284,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
         eventUtils.enable();
       }
     }
-    const event = new (eventUtils.get(eventUtils.SELECTED))!
-        (oldId, this.id, this.workspace.id);
+    const event = new (eventUtils.get(eventUtils.SELECTED))(
+        oldId, this.id, this.workspace.id);
     eventUtils.fire(event);
     common.setSelected(this);
     this.addSelect();
@@ -299,8 +299,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     if (common.getSelected() !== this) {
       return;
     }
-    const event = new (eventUtils.get(eventUtils.SELECTED))!
-        (this.id, null, this.workspace.id);
+    const event = new (eventUtils.get(eventUtils.SELECTED))(
+        this.id, null, this.workspace.id);
     event.workspaceId = this.workspace.id;
     eventUtils.fire(event);
     common.setSelected(null);

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -197,8 +197,8 @@ export class BubbleDragger {
   /** Fire a move event at the end of a bubble drag. */
   private fireMoveEvent_() {
     if (this.bubble instanceof WorkspaceCommentSvg) {
-      const event = new (eventUtils.get(eventUtils.COMMENT_MOVE))!
-          (this.bubble) as CommentMove;
+      const event = new (eventUtils.get(eventUtils.COMMENT_MOVE))(
+                        this.bubble) as CommentMove;
       event.setOldCoordinate(this.startXY_);
       event.recordNew();
       eventUtils.fire(event);

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -174,9 +174,9 @@ export class Comment extends Icon {
          */
         function(this: Comment, _e: Event) {
           if (this.cachedText_ !== this.model_.text) {
-            eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                            (this.block_, 'comment', null, this.cachedText_,
-                             this.model_.text));
+            eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+                this.block_, 'comment', null, this.cachedText_,
+                this.model_.text));
           }
         });
     this.onInputWrapper_ = browserEvents.conditionalBind(
@@ -240,8 +240,8 @@ export class Comment extends Icon {
     if (visible === this.isVisible()) {
       return;
     }
-    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))!
-                    (this.block_, visible, 'comment'));
+    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+        this.block_, visible, 'comment'));
     this.model_.pinned = visible;
     if (visible) {
       this.createBubble_();

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -119,7 +119,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     let event;
     if (eventUtils.isEnabled()) {
       event =
-          new (eventUtils.get(eventUtils.BLOCK_MOVE))!(childBlock) as BlockMove;
+          new (eventUtils.get(eventUtils.BLOCK_MOVE))(childBlock) as BlockMove;
     }
     connectReciprocally(this, childConnection);
     childBlock.setParent(parentBlock);
@@ -296,7 +296,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     let event;
     if (eventUtils.isEnabled()) {
       event =
-          new (eventUtils.get(eventUtils.BLOCK_MOVE))!(childBlock) as BlockMove;
+          new (eventUtils.get(eventUtils.BLOCK_MOVE))(childBlock) as BlockMove;
     }
     const otherConnection = this.targetConnection;
     if (otherConnection) {

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -249,7 +249,7 @@ export function callbackFactory(block: Block, xml: Element): Function {
       eventUtils.enable();
     }
     if (eventUtils.isEnabled() && !newBlock.isShadow()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))!(newBlock));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(newBlock));
     }
     newBlock.select();
   };

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -328,6 +328,7 @@ export function show(
 const internal = {
   /**
    * Get sizing info about the bounding element.
+   *
    * @return An object containing size information about the bounding element
    *     (bounding box and width/height).
    */
@@ -348,6 +349,7 @@ const internal = {
   /**
    * Helper to position the drop-down and the arrow, maintaining bounds.
    * See explanation of origin points in show.
+   *
    * @param primaryX Desired origin point x, in absolute px.
    * @param primaryY Desired origin point y, in absolute px.
    * @param secondaryX Secondary/alternative origin point x, in absolute px.

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -507,12 +507,16 @@ export function fromJson(
  * Gets the class for a specific event type from the registry.
  *
  * @param eventType The type of the event to get.
- * @returns The event class with the given type or null if none exists.
+ * @returns The event class with the given type.
  * @alias Blockly.Events.utils.get
  */
 export function get(eventType: string):
-    (new (...p1: AnyDuringMigration[]) => Abstract)|null {
-  return registry.getClass(registry.Type.EVENT, eventType);
+    (new (...p1: AnyDuringMigration[]) => Abstract) {
+  const event = registry.getClass(registry.Type.EVENT, eventType);
+  if (!event) {
+    throw new Error(`Event type ${eventType} not found in registry.`);
+  }
+  return event;
 }
 
 /**

--- a/core/field.ts
+++ b/core/field.ts
@@ -972,8 +972,8 @@ export abstract class Field implements IASTNodeLocationSvg,
 
     this.doValueUpdate_(newValue);
     if (source && eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                      (source, 'field', this.name || null, oldValue, newValue));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          source, 'field', this.name || null, oldValue, newValue));
     }
     if (this.isDirty_) {
       this.forceRerender();

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -187,9 +187,9 @@ export class FieldTextInput extends Field {
       // Revert value when the text becomes invalid.
       this.value_ = this.htmlInput_!.getAttribute('data-untyped-default-value');
       if (this.sourceBlock_ && eventUtils.isEnabled()) {
-        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                        (this.sourceBlock_, 'field', this.name || null,
-                         oldValue, this.value_));
+        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+            this.sourceBlock_, 'field', this.name || null, oldValue,
+            this.value_));
       }
     }
   }

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -991,13 +991,13 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       // Fire a VarCreate event for each (if any) new variable created.
       for (let i = 0; i < newVariables.length; i++) {
         const thisVariable = newVariables[i];
-        eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))!
-                        (thisVariable));
+        eventUtils.fire(
+            new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable));
       }
 
       // Block events come after var events, in case they refer to newly created
       // variables.
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))!(newBlock));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(newBlock));
     }
     if (this.autoClose) {
       this.hide();

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -627,8 +627,8 @@ export class Gesture {
    * @param ws The workspace that a user clicks on.
    */
   private fireWorkspaceClick_(ws: WorkspaceSvg) {
-    eventUtils.fire(new (eventUtils.get(eventUtils.CLICK))!
-                    (null, ws.id, 'workspace'));
+    eventUtils.fire(
+        new (eventUtils.get(eventUtils.CLICK))(null, ws.id, 'workspace'));
   }
 
   /**
@@ -714,8 +714,8 @@ export class Gesture {
       }
     } else {
       // Clicks events are on the start block, even if it was a shadow.
-      const event = new (eventUtils.get(eventUtils.CLICK))!
-          (this.startBlock_, this.startWorkspace_.id, 'block');
+      const event = new (eventUtils.get(eventUtils.CLICK))(
+          this.startBlock_, this.startWorkspace_.id, 'block');
       eventUtils.fire(event);
     }
     this.bringBlockToFront_();

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -301,8 +301,8 @@ export class Mutator extends Icon {
       // No change.
       return;
     }
-    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))!
-                    (this.block_, visible, 'mutator'));
+    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+        this.block_, visible, 'mutator'));
     if (visible) {
       // Create the bubble.
       this.bubble_ = new Bubble(
@@ -460,7 +460,7 @@ export class Mutator extends Icon {
 
       const newExtraState = BlockChange.getExtraBlockState_(block);
       if (oldExtraState !== newExtraState) {
-        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!(
+        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
             block, 'mutation', null, oldExtraState, newExtraState));
         // Ensure that any bump is part of this mutation's event group.
         const mutationGroup = eventUtils.getGroup();

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -423,8 +423,8 @@ export function mutateCallers(defBlock: Block) {
       // undo action since it is deterministically tied to the procedure's
       // definition mutation.
       eventUtils.setRecordUndo(false);
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))!
-                      (caller, 'mutation', null, oldMutation, newMutation));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          caller, 'mutation', null, oldMutation, newMutation));
       eventUtils.setRecordUndo(oldRecordUndo);
     }
   }

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -562,8 +562,8 @@ export class MarkerSvg {
    */
   private fireMarkerEvent_(oldNode: ASTNode, curNode: ASTNode) {
     const curBlock = curNode.getSourceBlock();
-    const event = new (eventUtils.get(eventUtils.MARKER_MOVE))!
-        (curBlock, this.isCursor(), oldNode, curNode);
+    const event = new (eventUtils.get(eventUtils.MARKER_MOVE))(
+        curBlock, this.isCursor(), oldNode, curNode);
     eventUtils.fire(event);
   }
 

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -361,7 +361,7 @@ export function appendInternal(
   const block = appendPrivate(state, workspace, {parentConnection, isShadow});
 
   eventUtils.enable();
-  eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))!(block));
+  eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
   eventUtils.setGroup(existingGroup);
   eventUtils.setRecordUndo(prevRecordUndo);
 

--- a/core/serialization/workspaces.ts
+++ b/core/serialization/workspaces.ts
@@ -96,8 +96,7 @@ export function load(
   }
   dom.stopTextWidthCache();
 
-  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))!
-                  (workspace));
+  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))(workspace));
 
   eventUtils.setGroup(existingGroup);
   eventUtils.setRecordUndo(prevRecordUndo);

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -931,8 +931,8 @@ export class Toolbox extends DeleteArea implements IAutoHideable,
     if (oldItem === newItem) {
       newElement = null;
     }
-    const event = new (eventUtils.get(eventUtils.TOOLBOX_ITEM_SELECT))!
-        (oldElement, newElement, this.workspace_.id);
+    const event = new (eventUtils.get(eventUtils.TOOLBOX_ITEM_SELECT))(
+        oldElement, newElement, this.workspace_.id);
     eventUtils.fire(event);
   }
 

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -506,8 +506,8 @@ export class Trashcan extends DeleteArea implements IAutoHideable,
    * @param trashcanOpen Whether the flyout is opening.
    */
   private fireUiEvent_(trashcanOpen: boolean) {
-    const uiEvent = new (eventUtils.get(eventUtils.TRASHCAN_OPEN))!
-        (trashcanOpen, this.workspace.id);
+    const uiEvent = new (eventUtils.get(eventUtils.TRASHCAN_OPEN))(
+        trashcanOpen, this.workspace.id);
     eventUtils.fire(uiEvent);
   }
 

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -103,8 +103,8 @@ export class VariableMap {
    */
   private renameVariableAndUses_(
       variable: VariableModel, newName: string, blocks: Block[]) {
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_RENAME))!
-                    (variable, newName));
+    eventUtils.fire(
+        new (eventUtils.get(eventUtils.VAR_RENAME))(variable, newName));
     variable.name = newName;
     for (let i = 0; i < blocks.length; i++) {
       blocks[i].updateVarName(variable);
@@ -139,7 +139,7 @@ export class VariableMap {
       blocks[i].renameVarById(variable.getId(), conflictVar.getId());
     }
     // Finally delete the original variable, which is now unreferenced.
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))!(variable));
+    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))(variable));
     // And remove it from the list.
     arrayUtils.removeElem(this.variableMap.get(type)!, variable);
   }
@@ -200,8 +200,8 @@ export class VariableMap {
         const tempVar = variableList[i];
         if (tempVar.getId() === variableId) {
           variableList.splice(i, 1);
-          eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))!
-                          (variable));
+          eventUtils.fire(
+              new (eventUtils.get(eventUtils.VAR_DELETE))(variable));
           return;
         }
       }

--- a/core/variable_model.ts
+++ b/core/variable_model.ts
@@ -59,7 +59,7 @@ export class VariableModel {
      */
     this.id_ = opt_id || idGenerator.genUid();
 
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))!(this));
+    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))(this));
   }
 
   /** @returns The ID for the variable. */

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -88,8 +88,8 @@ export class Warning extends Icon {
     if (visible === this.isVisible()) {
       return;
     }
-    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))!
-                    (this.block_, visible, 'warning'));
+    eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+        this.block_, visible, 'warning'));
     if (visible) {
       this.createBubble_();
     } else {

--- a/core/workspace_comment.ts
+++ b/core/workspace_comment.ts
@@ -104,7 +104,7 @@ export class WorkspaceComment {
     }
 
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))!(this));
+      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))(this));
     }
     // Remove from the list of top comments and the comment database.
     this.workspace.removeTopComment(this);
@@ -174,7 +174,7 @@ export class WorkspaceComment {
    */
   moveBy(dx: number, dy: number) {
     const event =
-        new (eventUtils.get(eventUtils.COMMENT_MOVE))!(this) as CommentMove;
+        new (eventUtils.get(eventUtils.COMMENT_MOVE))(this) as CommentMove;
     this.xy_.translate(dx, dy);
     event.recordNew();
     eventUtils.fire(event);
@@ -259,8 +259,8 @@ export class WorkspaceComment {
    */
   setContent(content: string) {
     if (this.content_ !== content) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CHANGE))!
-                      (this, this.content_, content));
+      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CHANGE))(
+          this, this.content_, content));
       this.content_ = content;
     }
   }
@@ -321,8 +321,8 @@ export class WorkspaceComment {
         eventUtils.setGroup(true);
       }
       try {
-        eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CREATE))!
-                        (comment));
+        eventUtils.fire(
+            new (eventUtils.get(eventUtils.COMMENT_CREATE))(comment));
       } finally {
         if (!existingGroup) {
           eventUtils.setGroup(false);

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -150,7 +150,7 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
     }
 
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))!(this));
+      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))(this));
     }
 
     dom.removeNode(this.svgGroup_);
@@ -238,8 +238,8 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
         eventUtils.enable();
       }
     }
-    const event = new (eventUtils.get(eventUtils.SELECTED))!
-        (oldId, this.id, this.workspace.id);
+    const event = new (eventUtils.get(eventUtils.SELECTED))(
+        oldId, this.id, this.workspace.id);
     eventUtils.fire(event);
     common.setSelected(this);
     this.addSelect();
@@ -254,8 +254,8 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
     if (common.getSelected() !== this) {
       return;
     }
-    const event = new (eventUtils.get(eventUtils.SELECTED))!
-        (this.id, null, this.workspace.id);
+    const event = new (eventUtils.get(eventUtils.SELECTED))(
+        this.id, null, this.workspace.id);
     eventUtils.fire(event);
     common.setSelected(null);
     this.removeSelect();
@@ -354,7 +354,7 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
    */
   override moveBy(dx: number, dy: number) {
     const event =
-        new (eventUtils.get(eventUtils.COMMENT_MOVE))!(this) as CommentMove;
+        new (eventUtils.get(eventUtils.COMMENT_MOVE))(this) as CommentMove;
     // TODO: Do I need to look up the relative to surface XY position here?
     const xy = this.getRelativeToSurfaceXY();
     this.translate(xy.x + dx, xy.y + dy);

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -596,8 +596,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       this.setVisible(true);
     }
 
-    const event = new (eventUtils.get(eventUtils.THEME_CHANGE))!
-        (this.getTheme().name, this.id);
+    const event = new (eventUtils.get(eventUtils.THEME_CHANGE))(
+        this.getTheme().name, this.id);
     eventUtils.fire(event);
   }
 
@@ -1160,8 +1160,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       // of negligible changes in viewport top/left.
       return;
     }
-    const event = new (eventUtils.get(eventUtils.VIEWPORT_CHANGE))!
-        (top, left, scale, this.id, this.oldScale_);
+    const event = new (eventUtils.get(eventUtils.VIEWPORT_CHANGE))(
+        top, left, scale, this.id, this.oldScale_);
     this.oldScale_ = scale;
     this.oldTop_ = top;
     this.oldLeft_ = left;
@@ -1488,7 +1488,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       eventUtils.enable();
     }
     if (eventUtils.isEnabled() && !block!.isShadow()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))!(block!));
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block!));
     }
     block!.select();
     return block!;

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -512,8 +512,7 @@ export function domToWorkspace(xml: Element, workspace: Workspace): string[] {
   if ((workspace as WorkspaceSvg).setResizesEnabled) {
     (workspace as WorkspaceSvg).setResizesEnabled(true);
   }
-  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))!
-                  (workspace));
+  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))(workspace));
   return newBlockIds;
 }
 
@@ -627,12 +626,12 @@ export function domToBlock(xmlBlock: Element, workspace: Workspace): Block {
     // Fire a VarCreate event for each (if any) new variable created.
     for (let i = 0; i < newVariables.length; i++) {
       const thisVariable = newVariables[i];
-      eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))!
-                      (thisVariable));
+      eventUtils.fire(
+          new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable));
     }
     // Block events come after var events, in case they refer to newly created
     // variables.
-    eventUtils.fire(new (eventUtils.get(eventUtils.CREATE))!(topBlock));
+    eventUtils.fire(new (eventUtils.get(eventUtils.CREATE))(topBlock));
   }
   return topBlock;
 }

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -417,8 +417,8 @@ export class ZoomControls implements IPositionable {
 
   /** Fires a zoom control UI event. */
   private fireZoomEvent_() {
-    const uiEvent = new (eventUtils.get(eventUtils.CLICK))!
-        (null, this.workspace.id, 'zoom_controls');
+    const uiEvent = new (eventUtils.get(eventUtils.CLICK))(
+        null, this.workspace.id, 'zoom_controls');
     eventUtils.fire(uiEvent);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Removes lint exception for "func-call-spacing"

### Proposed Changes

1. Makes eventUtils.get() throw an error if the event type is not in the registry. In practice, this would have happened anyway since everywhere we call this method we assert is non-null and then try to call it. So now there is a helpful error message instead of "undefined is not a function"
2. Remove the non-null assertion operator from where we call this function as it can no longer return null
3. Remove the exception for "func-call-spacing" from eslint, which were all a problem because of 2. But using the TS-specific rule for it now.

#### Behavior Before Change

Lint errors (commented out), and bad error message for missing events

#### Behavior After Change

No lint errors, better error message for missing events

### Reason for Changes

Linting

### Test Coverage

Manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
