### PR TITLE
refactor!: Removed backwards compatibility for getDeveloperVars().

### DIFF
--- a/core/variables.ts
+++ b/core/variables.ts
@@ -63,8 +63,6 @@ export function allUsedVarModels(ws: Workspace): VariableModel[] {
   return Array.from(variables.values());
 }
 
-const ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE: {[key: string]: boolean} = {};
-
 /**
  * Find all developer variables used by blocks in the workspace.
  * Developer variables are never shown to the user, but are declared as global
@@ -81,18 +79,7 @@ export function allDeveloperVariables(workspace: Workspace): string[] {
   const blocks = workspace.getAllBlocks(false);
   const variables = new Set<string>();
   for (let i = 0, block; block = blocks[i]; i++) {
-    let getDeveloperVariables = block.getDeveloperVariables;
-    if (!getDeveloperVariables && (block as any).getDeveloperVars) {
-      // August 2018: getDeveloperVars() was deprecated and renamed
-      // getDeveloperVariables().
-      getDeveloperVariables = (block as any).getDeveloperVars;
-      if (!ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[block.type]) {
-        console.warn(
-            'Function getDeveloperVars() deprecated. Use ' +
-            'getDeveloperVariables() (block type \'' + block.type + '\')');
-        ALL_DEVELOPER_VARS_WARNINGS_BY_BLOCK_TYPE[block.type] = true;
-      }
-    }
+    const getDeveloperVariables = block.getDeveloperVariables;
     if (getDeveloperVariables) {
       const devVars = getDeveloperVariables();
       for (let j = 0; j < devVars.length; j++) {

--- a/tests/generators/unittest.js
+++ b/tests/generators/unittest.js
@@ -20,7 +20,7 @@ Blockly.Blocks['unittest_main'] = {
     this.setTooltip('Executes the enclosed unit tests,\n' +
                     'then prints a summary.');
   },
-  getDeveloperVars: function() {
+  getDeveloperVariables: function() {
     return ['unittestResults'];
   }
 };
@@ -40,7 +40,7 @@ Blockly.Blocks['unittest_assertequals'] = {
         .appendField('expected');
     this.setTooltip('Tests that "actual == expected".');
   },
-  getDeveloperVars: function() {
+  getDeveloperVariables: function() {
     return ['unittestResults'];
   }
 };
@@ -60,7 +60,7 @@ Blockly.Blocks['unittest_assertvalue'] = {
         [['true', 'TRUE'], ['false', 'FALSE'], ['null', 'NULL']]), 'EXPECTED');
     this.setTooltip('Tests that the value is true, false, or null.');
   },
-  getDeveloperVars: function() {
+  getDeveloperVariables: function() {
     return ['unittestResults'];
   }
 };
@@ -76,7 +76,7 @@ Blockly.Blocks['unittest_fail'] = {
         .appendField('fail');
     this.setTooltip('Records an error.');
   },
-  getDeveloperVars: function() {
+  getDeveloperVariables: function() {
     return ['unittestResults'];
   }
 };


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes
Removes checks for getDeveloperVars(), which was deprecated and replaced by getDeveloperVariables() 4 years ago.

#### Behavior Before Change
getDeveloperVars() method would be called if present.

#### Behavior After Change
Only getDeveloperVariables() will be invoked.