### PR TITLE
fix: deprecate functions in object.ts

### DIFF
--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -299,9 +299,8 @@ export class ShortcutRegistry {
    * @throws {Error} if the modifier is not in the valid modifiers list.
    */
   private checkModifiers_(modifiers: KeyCodes[]) {
-    const validModifiers = object.values(ShortcutRegistry.modifierKeys);
     for (let i = 0, modifier; modifier = modifiers[i]; i++) {
-      if (validModifiers.indexOf(modifier) < 0) {
+      if (!(modifier in ShortcutRegistry.modifierKeys)) {
         throw new Error(modifier + ' is not a valid modifier key.');
       }
     }

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -20,8 +20,8 @@ goog.declareModuleId('Blockly.utils.deprecation');
  * @param name The name of the function or property.
  * @param deprecationDate The date of deprecation.
  *     Prefer 'month yyyy' or 'quarter yyyy' format.
- * @param deletionDate The date of deletion, in the same format as the
- *     deprecation date.
+ * @param deletionDate The date of deletion. Prefer 'version n.0.0'
+ *     format, and fall back to 'month yyyy' or 'quarter yyyy' format.
  * @param opt_use The name of a function or property to use instead, if any.
  * @alias Blockly.utils.deprecation.warn
  * @internal
@@ -30,7 +30,7 @@ export function warn(
     name: string, deprecationDate: string, deletionDate: string,
     opt_use?: string) {
   let msg = name + ' was deprecated on ' + deprecationDate +
-      ' and will be deleted on ' + deletionDate + '.';
+      ' and will be deleted after ' + deletionDate + '.';
   if (opt_use) {
     msg += '\nUse ' + opt_use + ' instead.';
   }

--- a/core/utils/deprecation.ts
+++ b/core/utils/deprecation.ts
@@ -18,8 +18,8 @@ goog.declareModuleId('Blockly.utils.deprecation');
  * Warn developers that a function or property is deprecated.
  *
  * @param name The name of the function or property.
- * @param deprecationDate The date of deprecation.
- *     Prefer 'month yyyy' or 'quarter yyyy' format.
+ * @param deprecationDate The date of deprecation. Prefer 'version n.0.0'
+ *     format, and fall back to 'month yyyy' or 'quarter yyyy' format.
  * @param deletionDate The date of deletion. Prefer 'version n.0.0'
  *     format, and fall back to 'month yyyy' or 'quarter yyyy' format.
  * @param opt_use The name of a function or property to use instead, if any.
@@ -29,8 +29,8 @@ goog.declareModuleId('Blockly.utils.deprecation');
 export function warn(
     name: string, deprecationDate: string, deletionDate: string,
     opt_use?: string) {
-  let msg = name + ' was deprecated on ' + deprecationDate +
-      ' and will be deleted after ' + deletionDate + '.';
+  let msg = name + ' was deprecated in ' + deprecationDate +
+      ' and will be deleted in ' + deletionDate + '.';
   if (opt_use) {
     msg += '\nUse ' + opt_use + ' instead.';
   }

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -25,8 +25,7 @@ import * as deprecation from './deprecation.js';
  */
 export function inherits(childCtor: Function, parentCtor: Function) {
   deprecation.warn(
-      'Blockly.utils.object.inherits', 'September 2022', 'September 2023',
-      'normal inheritance');
+      'Blockly.utils.object.inherits', 'September 2022', 'version 9.0.0');
   // Set a .superClass_ property so that methods can call parent methods
   // without hard-coding the parent class name.
   // Could be replaced by ES6's super().
@@ -90,7 +89,7 @@ export function deepMerge(
  */
 export function values(obj: AnyDuringMigration): AnyDuringMigration[] {
   deprecation.warn(
-      'Blockly.utils.object.values', 'September 2022', 'September 2023',
+      'Blockly.utils.object.values', 'September 2022', 'version 9.0.0',
       'Object.values');
   return Object.values(obj);
 }

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -24,6 +24,9 @@ import * as deprecation from './deprecation.js';
  * @alias Blockly.utils.object.inherits
  */
 export function inherits(childCtor: Function, parentCtor: Function) {
+  deprecation.warn(
+      'Blockly.utils.object.inherits', 'September 2022', 'September 2023',
+      'normal inheritance');
   // Set a .superClass_ property so that methods can call parent methods
   // without hard-coding the parent class name.
   // Could be replaced by ES6's super().
@@ -86,11 +89,8 @@ export function deepMerge(
  * @alias Blockly.utils.object.values
  */
 export function values(obj: AnyDuringMigration): AnyDuringMigration[] {
-  if (Object.values) {
-    return Object.values(obj);
-  }
-  // Fallback for IE.
-  return Object.keys(obj).map(function(e) {
-    return obj[e];
-  });
+  deprecation.warn(
+      'Blockly.utils.object.values', 'September 2022', 'September 2023',
+      'Object.values');
+  return Object.values(obj);
 }

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -25,7 +25,7 @@ import * as deprecation from './deprecation.js';
  */
 export function inherits(childCtor: Function, parentCtor: Function) {
   deprecation.warn(
-      'Blockly.utils.object.inherits', 'September 2022', 'version 9.0.0');
+      'Blockly.utils.object.inherits', 'version 9.0.0', 'version 10.0.0');
   // Set a .superClass_ property so that methods can call parent methods
   // without hard-coding the parent class name.
   // Could be replaced by ES6's super().
@@ -89,7 +89,7 @@ export function deepMerge(
  */
 export function values(obj: AnyDuringMigration): AnyDuringMigration[] {
   deprecation.warn(
-      'Blockly.utils.object.values', 'September 2022', 'version 9.0.0',
+      'Blockly.utils.object.values', 'version 9.0.0', 'version 10.0.0',
       'Object.values');
   return Object.values(obj);
 }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6325.

### Proposed Changes

- Removes special casing for IE in `object.values`.
- Marks `object.values` and `object.inherits` as deprecated, with removal dates.
- Switches to using `Object.values` directly in `shortcut_registry.js`.
- Fixes exposed type errors.
- Changes the deprecation warning function to say things will be deleted after a date or a version.

#### Behavior Before Change

No change.

#### Behavior After Change

No change

### Reason for Changes

Remove workaround and deprecate unused code in preparation for removal.
Improve types!

### Test Coverage

Tested by opening up the playground and trying to register shortcuts with modifiers that do and don't exist:

Functional cases:
```
// Create a serialized key from the primary key and any modifiers.
var ctrlW = Blockly.ShortcutRegistry.registry.createSerializedKey(
    Blockly.utils.KeyCodes.W, [Blockly.ShortcutRegistry.modifierKeys.Control]);
```
Same as above, but not using the enum.
```
// Create a serialized key from the primary key and any modifiers.
var ctrlW = Blockly.ShortcutRegistry.registry.createSerializedKey(
    Blockly.utils.KeyCodes.W, [17]);
```

Broken case:
```
// Create a serialized key from the primary key and any modifiers.
var ctrlW = Blockly.ShortcutRegistry.registry.createSerializedKey(
    Blockly.utils.KeyCodes.W, [6]);
```

### Documentation

None.

### Additional Information

> Should I shorten the deprecation date? I've been using a year by default but we could make it a quarter or two instead.

After discussion we decided to use the next major version instead of a date.

If this deprecation breaks you: you can use `Object.values` instead of `object.values`, but may need to cast the result to `any` or fix any type issues this reveals. You can use standard inheritance in JS or TS instead of our implementation of `object.inherits`.