### PR TITLE
fix: remove some IE-specific code in dom and style

### DIFF
--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -78,13 +78,6 @@ export function createSvgElement<T extends SVGElement>(
   for (const key in attrs) {
     e.setAttribute(key, attrs[key]);
   }
-  // IE defines a unique attribute "runtimeStyle", it is NOT applied to
-  // elements created with createElementNS. However, Closure checks for IE
-  // and assumes the presence of the attribute and crashes.
-  if ((document.body as any)
-          .runtimeStyle) {  // Indicates presence of IE-only attr.
-    (e as any).runtimeStyle = (e as any).currentStyle = e.style;
-  }
   if (opt_parent) {
     opt_parent.appendChild(e);
   }

--- a/core/utils/style.ts
+++ b/core/utils/style.ts
@@ -36,7 +36,7 @@ export function getSize(element: Element): Size {
  * Private version of getSize for stubbing in tests.
  */
 function getSizeInternal(element: Element): Size {
-  if (getStyle(element, 'display') !== 'none') {
+  if (getComputedStyle(element, 'display') !== 'none') {
     return getSizeWithDisplay(element);
   }
 
@@ -75,25 +75,6 @@ function getSizeWithDisplay(element: Element): Size {
 }
 
 /**
- * Cross-browser pseudo get computed style. It returns the computed style where
- * available. If not available it tries the inline style value.  It shouldn't be
- * called directly, see http://wiki/Main/ComputedStyleVsCascadedStyle for
- * discussion.
- *
- * Copied from Closure's goog.style.getStyle_
- *
- * @param element Element to get style of.
- * @param style Property to get (must be camelCase, not CSS-style).
- * @returns Style value.
- */
-function getStyle(element: Element, style: string): string {
-  // AnyDuringMigration because:  Property 'style' does not exist on type
-  // 'Element'.
-  return getComputedStyle(element, style) ||
-      (element as AnyDuringMigration).style?.[style];
-}
-
-/**
  * Retrieves a computed style value of a node. It returns empty string
  * if the property requested is an SVG one and it has not been
  * explicitly set (firefox and webkit).
@@ -110,7 +91,7 @@ export function getComputedStyle(element: Element, property: string): string {
   // element.style[..] is undefined for browser specific styles
   // as 'filter'.
   return (styles as AnyDuringMigration)[property] ||
-      styles.getPropertyValue(property) || '';
+      styles.getPropertyValue(property);
 }
 
 /**

--- a/core/utils/style.ts
+++ b/core/utils/style.ts
@@ -14,6 +14,7 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.style');
 
+import * as deprecation from './deprecation.js';
 import {Coordinate} from './coordinate.js';
 import {Rect} from './rect.js';
 import {Size} from './size.js';
@@ -75,8 +76,7 @@ function getSizeWithDisplay(element: Element): Size {
 
 /**
  * Cross-browser pseudo get computed style. It returns the computed style where
- * available. If not available it tries the cascaded style value (IE
- * currentStyle) and in worst case the inline style value.  It shouldn't be
+ * available. If not available it tries the inline style value.  It shouldn't be
  * called directly, see http://wiki/Main/ComputedStyleVsCascadedStyle for
  * discussion.
  *
@@ -88,17 +88,14 @@ function getSizeWithDisplay(element: Element): Size {
  */
 function getStyle(element: Element, style: string): string {
   // AnyDuringMigration because:  Property 'style' does not exist on type
-  // 'Element'. AnyDuringMigration because:  Property 'style' does not exist on
-  // type 'Element'.
-  return getComputedStyle(element, style) || getCascadedStyle(element, style) ||
-      (element as AnyDuringMigration).style &&
-      (element as AnyDuringMigration).style[style];
+  // 'Element'.
+  return getComputedStyle(element, style) ||
+      (element as AnyDuringMigration).style?.[style];
 }
 
 /**
- * Retrieves a computed style value of a node. It returns empty string if the
- * value cannot be computed (which will be the case in Internet Explorer) or
- * "none" if the property requested is an SVG one and it has not been
+ * Retrieves a computed style value of a node. It returns empty string
+ * if the property requested is an SVG one and it has not been
  * explicitly set (firefox and webkit).
  *
  * Copied from Closure's goog.style.getComputedStyle
@@ -109,17 +106,11 @@ function getStyle(element: Element, style: string): string {
  * @alias Blockly.utils.style.getComputedStyle
  */
 export function getComputedStyle(element: Element, property: string): string {
-  if (document.defaultView && document.defaultView.getComputedStyle) {
-    const styles = document.defaultView.getComputedStyle(element, null);
-    if (styles) {
-      // element.style[..] is undefined for browser specific styles
-      // as 'filter'.
-      return (styles as AnyDuringMigration)[property] ||
-          styles.getPropertyValue(property) || '';
-    }
-  }
-
-  return '';
+  const styles = window.getComputedStyle(element);
+  // element.style[..] is undefined for browser specific styles
+  // as 'filter'.
+  return (styles as AnyDuringMigration)[property] ||
+      styles.getPropertyValue(property) || '';
 }
 
 /**
@@ -134,6 +125,9 @@ export function getComputedStyle(element: Element, property: string): string {
  * @alias Blockly.utils.style.getCascadedStyle
  */
 export function getCascadedStyle(element: Element, style: string): string {
+  deprecation.warn(
+      'Blockly.utils.style.getCascadedStyle', 'version 9.0.0',
+      'version 10.0.0');
   // AnyDuringMigration because:  Property 'currentStyle' does not exist on type
   // 'Element'. AnyDuringMigration because:  Property 'currentStyle' does not
   // exist on type 'Element'.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6325 

### Proposed Changes

- Remove some IE-specific code related to setting and reading styles.
- Remove use of `getCascadedStyle` and mark it as deprecated.
- Simplify code in `getComputedStyle` by using `window` instead of `document.defaultView`
  - MDN documentation on [getComputedStyle](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#defaultview) says "In many code samples, getComputedStyle is used from the document.defaultView object. In nearly all cases, this is needless, as getComputedStyle exists on the window object as well. It's likely the defaultView pattern was a combination of folks not wanting to write a testing spec for window and making an API that was also usable in Java."
- Use `?.` to tighten up some style checks. There's future work here to sort out the `AnyDuringMigration`s and figure out whether we need to access `style` in a different way.

#### Behavior Before Change

No change in behaviour.

#### Behavior After Change

No change.

### Reason for Changes

This code ostensibly worked in IE, but that's irrelevant since we no longer transpile to ES5.

### Test Coverage
Opened the playground and clicked around in both Firefox and Chrome. Will need comprehensive testing in all browsers, along with other changes related to #6325.

### Documentation
None

### Additional Information

`getCascadedStyle` was probably not being used externally, but I'm going through the full deprecation process because of its visibility and lack of `@internal` marker.