### PR TITLE
fix: stop using `is3dSupported`

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -196,8 +196,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
      * Whether to move the block to the drag surface when it is dragged.
      * True if it should move, false if it should be translated directly.
      */
-    this.useDragSurface_ =
-        svgMath.is3dSupported() && !!workspace.getBlockDragSurface();
+    this.useDragSurface_ = !!workspace.getBlockDragSurface();
 
     const svgPath = this.pathObject.svgPath;
     (svgPath as AnyDuringMigration).tooltip = this;

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -20,7 +20,6 @@ import type {IBubble} from './interfaces/i_bubble.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import {Coordinate} from './utils/coordinate.js';
-import * as svgMath from './utils/svg_math.js';
 import {WorkspaceCommentSvg} from './workspace_comment_svg.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -56,9 +55,7 @@ export class BubbleDragger {
      * The drag surface to move bubbles to during a drag, or null if none should
      * be used.  Block dragging and bubble dragging use the same surface.
      */
-    this.dragSurface_ = !!workspace.getBlockDragSurface() ?
-        workspace.getBlockDragSurface() :
-        null;
+    this.dragSurface_ = workspace.getBlockDragSurface();
   }
 
   /**

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -56,8 +56,7 @@ export class BubbleDragger {
      * The drag surface to move bubbles to during a drag, or null if none should
      * be used.  Block dragging and bubble dragging use the same surface.
      */
-    this.dragSurface_ =
-        svgMath.is3dSupported() && !!workspace.getBlockDragSurface() ?
+    this.dragSurface_ = !!workspace.getBlockDragSurface() ?
         workspace.getBlockDragSurface() :
         null;
   }

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -38,9 +38,6 @@ const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
 const XY_STYLE_REGEX =
     /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
 
-/** Cached return value of isSupported3d. */
-let is3dSupportedCached: boolean|undefined;
-
 /**
  * Return the coordinates of the top-left corner of this element relative to
  * its parent.  Only for SVG elements and children (e.g. rect, g, path).
@@ -120,38 +117,10 @@ export function getInjectionDivXY(element: Element): Coordinate {
  * @alias Blockly.utils.svgMath.is3dSupported
  */
 export function is3dSupported(): boolean {
-  if (is3dSupportedCached !== undefined) {
-    return is3dSupportedCached;
-  }
-  // CC-BY-SA Lorenzo Polidori
-  // Based on
-  // stackoverflow.com/questions/5661671/detecting-transform-translate3d-support
-
-  const el = document.createElement('p');
-  let has3d = 'none';
-  const transform = 'transform';
-
-  // Add it to the body to get the computed style.
-  document.body.insertBefore(el, null);
-
-  if ((el.style as AnyDuringMigration)[transform] !== undefined) {
-    (el.style as AnyDuringMigration)[transform] = 'translate3d(1px,1px,1px)';
-    const computedStyle = window.getComputedStyle(el);
-    if (!computedStyle) {
-      // getComputedStyle in Firefox returns null when Blockly is loaded
-      // inside an iframe with display: none.  Returning false and not
-      // caching is3dSupported means we try again later.  This is most likely
-      // when users are interacting with blocks which should mean Blockly is
-      // visible again.
-      // See https://bugzilla.mozilla.org/show_bug.cgi?id=548397
-      document.body.removeChild(el);
-      return false;
-    }
-    has3d = computedStyle.getPropertyValue(transform);
-  }
-  document.body.removeChild(el);
-  is3dSupportedCached = (has3d !== 'none');
-  return is3dSupportedCached;
+  // All browsers support translate3d in 2022.
+  deprecation.warn(
+      'Blockly.utils.svgMath.is3dSupported', 'version 9.0.0', 'version 10.0.0');
+  return true;
 }
 
 /**

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -38,6 +38,9 @@ const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
 const XY_STYLE_REGEX =
     /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
 
+/** Cached return value of isSupported3d. */
+let is3dSupportedCached: boolean|undefined;
+
 /**
  * Return the coordinates of the top-left corner of this element relative to
  * its parent.  Only for SVG elements and children (e.g. rect, g, path).
@@ -117,57 +120,38 @@ export function getInjectionDivXY(element: Element): Coordinate {
  * @alias Blockly.utils.svgMath.is3dSupported
  */
 export function is3dSupported(): boolean {
-  // AnyDuringMigration because:  Property 'cached_' does not exist on type '()
-  // => boolean'.
-  if ((is3dSupported as AnyDuringMigration).cached_ !== undefined) {
-    // AnyDuringMigration because:  Property 'cached_' does not exist on type
-    // '() => boolean'.
-    return (is3dSupported as AnyDuringMigration).cached_;
+  if (is3dSupportedCached !== undefined) {
+    return is3dSupportedCached;
   }
   // CC-BY-SA Lorenzo Polidori
+  // Based on
   // stackoverflow.com/questions/5661671/detecting-transform-translate3d-support
-  if (!globalThis['getComputedStyle']) {
-    return false;
-  }
 
   const el = document.createElement('p');
   let has3d = 'none';
-  const transforms = {
-    'webkitTransform': '-webkit-transform',
-    'OTransform': '-o-transform',
-    'msTransform': '-ms-transform',
-    'MozTransform': '-moz-transform',
-    'transform': 'transform',
-  };
+  const transform = 'transform';
 
   // Add it to the body to get the computed style.
   document.body.insertBefore(el, null);
 
-  for (const t in transforms) {
-    if ((el.style as AnyDuringMigration)[t] !== undefined) {
-      (el.style as AnyDuringMigration)[t] = 'translate3d(1px,1px,1px)';
-      const computedStyle = globalThis['getComputedStyle'](el);
-      if (!computedStyle) {
-        // getComputedStyle in Firefox returns null when Blockly is loaded
-        // inside an iframe with display: none.  Returning false and not
-        // caching is3dSupported means we try again later.  This is most likely
-        // when users are interacting with blocks which should mean Blockly is
-        // visible again.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=548397
-        document.body.removeChild(el);
-        return false;
-      }
-      has3d =
-          computedStyle.getPropertyValue((transforms as AnyDuringMigration)[t]);
+  if ((el.style as AnyDuringMigration)[transform] !== undefined) {
+    (el.style as AnyDuringMigration)[transform] = 'translate3d(1px,1px,1px)';
+    const computedStyle = window.getComputedStyle(el);
+    if (!computedStyle) {
+      // getComputedStyle in Firefox returns null when Blockly is loaded
+      // inside an iframe with display: none.  Returning false and not
+      // caching is3dSupported means we try again later.  This is most likely
+      // when users are interacting with blocks which should mean Blockly is
+      // visible again.
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+      document.body.removeChild(el);
+      return false;
     }
+    has3d = computedStyle.getPropertyValue(transform);
   }
   document.body.removeChild(el);
-  // AnyDuringMigration because:  Property 'cached_' does not exist on type '()
-  // => boolean'.
-  (is3dSupported as AnyDuringMigration).cached_ = has3d !== 'none';
-  // AnyDuringMigration because:  Property 'cached_' does not exist on type '()
-  // => boolean'.
-  return (is3dSupported as AnyDuringMigration).cached_;
+  is3dSupportedCached = (has3d !== 'none');
+  return is3dSupportedCached;
 }
 
 /**

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -124,8 +124,7 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
      * Whether to move the comment to the drag surface when it is dragged.
      * True if it should move, false if it should be translated directly.
      */
-    this.useDragSurface_ =
-        svgMath.is3dSupported() && !!workspace.getBlockDragSurface();
+    this.useDragSurface_ = !!workspace.getBlockDragSurface();
 
     this.render();
   }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -373,8 +373,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       this.workspaceDragSurface_ = opt_wsDragSurface;
     }
 
-    this.useWorkspaceDragSurface_ =
-        !!this.workspaceDragSurface_ && svgMath.is3dSupported();
+    this.useWorkspaceDragSurface_ = !!this.workspaceDragSurface_;
 
     /**
      * Object in charge of loading, storing, and playing audio for a workspace.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6325

### Proposed Changes

Stop checking whether `translate3d` is supported--it's fine on all browsers in 2022.
Deprecate `is3dSupported` in preparation for deleting it.

#### Behavior Before Change

Checked for support using a variety of browser prefixes, because there was not a standard way to check.

#### Behavior After Change

Always assume it's supported and act accordingly.

### Reason for Changes

Remove workarounds for old browser behaviour.

### Test Coverage

Checked in Chrome and Firefox.
I made the change in several pieces so that I could check functionality at an intermediate point.

### Documentation

None

### Additional Information

We might be able to make block and workspace drag surfaces always get built, or else decide they don't improve performance and delete them entirely. Either case would be nice since it would let us reduce the number of available code paths. But that's tricky because it requires performance analysis and because the block and drag surfaces are currently optional arguments to the (public) `WorkspaceSvg` constructor.