### PR TITLE
chore: work on refactoring gesture code

### DIFF
--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -239,6 +239,10 @@ export class Gesture {
    * @returns True if a block is being dragged from the flyout.
    */
   private updateIsDraggingFromFlyout_(): boolean {
+    if (!this.targetBlock_ ||
+        !this.flyout_?.isBlockCreatable(this.targetBlock_)) {
+      return false;
+    }
     if (!this.flyout_) {
       throw new Error('Cannot update dragging from the flyout because the ' +
           'flyout is undefined');
@@ -246,10 +250,6 @@ export class Gesture {
     if (!this.flyout_.targetWorkspace) {
       throw new Error(`Cannot update dragging from the flyout because the ' +
           'flyout's target workspace is undefined`);
-    }
-    if (!this.targetBlock_ ||
-        !this.flyout_.isBlockCreatable(this.targetBlock_)) {
-      return false;
     }
     if (!this.flyout_.isScrollable() ||
         this.flyout_.isDragTowardWorkspace(this.currentDragDeltaXY_)) {

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -243,11 +243,6 @@ export class Gesture {
         !this.flyout_?.isBlockCreatable(this.targetBlock_)) {
       return false;
     }
-    if (!this.flyout_) {
-      throw new Error(
-          'Cannot update dragging from the flyout because the ' +
-          'flyout is undefined');
-    }
     if (!this.flyout_.targetWorkspace) {
       throw new Error(`Cannot update dragging from the flyout because the ' +
           'flyout's target workspace is undefined`);
@@ -289,7 +284,10 @@ export class Gesture {
   }
 
   /**
-   * Update this gesture to record whether a block is being dragged.
+   * Check whether to start a block drag. If a block should be dragged, either
+   * from the flyout or in the workspace, create the necessary BlockDragger and
+   * start the drag.
+   *
    * This function should be called on a mouse/touch move event the first time
    * the drag radius is exceeded.  It should be called no more than once per
    * gesture. If a block should be dragged, either from the flyout or in the
@@ -315,7 +313,9 @@ export class Gesture {
   }
 
   /**
-   * Update this gesture to record whether a workspace is being dragged.
+   * Check whether to start a workspace drag. If a workspace is being dragged,
+   * create the necessary WorkspaceDragger and start the drag.
+   *
    * This function should be called on a mouse/touch move event the first time
    * the drag radius is exceeded.  It should be called no more than once per
    * gesture. If a workspace is being dragged this function creates the
@@ -408,15 +408,16 @@ export class Gesture {
       this.cancel();
       return;
     }
-    this.hasStarted_ = true;
-
-    blockAnimations.disconnectUiStop();
 
     if (!this.startWorkspace_) {
       throw new Error(
           'Cannot start the gesture because the start ' +
           'workspace is undefined');
     }
+
+    this.hasStarted_ = true;
+
+    blockAnimations.disconnectUiStop();
 
     this.startWorkspace_.updateScreenCalculationsIfScrolled();
     if (this.startWorkspace_.isMutator) {

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -244,7 +244,8 @@ export class Gesture {
       return false;
     }
     if (!this.flyout_) {
-      throw new Error('Cannot update dragging from the flyout because the ' +
+      throw new Error(
+          'Cannot update dragging from the flyout because the ' +
           'flyout is undefined');
     }
     if (!this.flyout_.targetWorkspace) {
@@ -322,7 +323,8 @@ export class Gesture {
    */
   private updateIsDraggingWorkspace_() {
     if (!this.startWorkspace_) {
-      throw new Error('Cannot update dragging the workspace because the ' +
+      throw new Error(
+          'Cannot update dragging the workspace because the ' +
           'start workspace is undefined');
     }
 
@@ -377,11 +379,13 @@ export class Gesture {
   /** Create a bubble dragger and start dragging the selected bubble. */
   private startDraggingBubble_() {
     if (!this.startBubble_) {
-      throw new Error('Cannot update dragging the bubble because the start ' +
+      throw new Error(
+          'Cannot update dragging the bubble because the start ' +
           'bubble is undefined');
     }
     if (!this.startWorkspace_) {
-      throw new Error('Cannot update dragging the bubble because the start ' +
+      throw new Error(
+          'Cannot update dragging the bubble because the start ' +
           'workspace is undefined');
     }
 
@@ -409,7 +413,8 @@ export class Gesture {
     blockAnimations.disconnectUiStop();
 
     if (!this.startWorkspace_) {
-      throw new Error('Cannot start the gesture because the start ' +
+      throw new Error(
+          'Cannot start the gesture because the start ' +
           'workspace is undefined');
     }
 
@@ -685,7 +690,8 @@ export class Gesture {
   /** Execute a field click. */
   private doFieldClick_() {
     if (!this.startField_) {
-      throw new Error('Cannot do a field click because the start field is ' +
+      throw new Error(
+          'Cannot do a field click because the start field is ' +
           'undefined');
     }
     this.startField_.showEditor(this.mostRecentEvent_);
@@ -697,7 +703,8 @@ export class Gesture {
     // Block click in an autoclosing flyout.
     if (this.flyout_ && this.flyout_.autoClose) {
       if (!this.targetBlock_) {
-        throw new Error('Cannot do a block click because the target block is ' +
+        throw new Error(
+            'Cannot do a block click because the target block is ' +
             'undefined');
       }
       if (this.targetBlock_.isEnabled()) {
@@ -709,7 +716,8 @@ export class Gesture {
       }
     } else {
       if (!this.startWorkspace_) {
-        throw new Error('Cannot do a block click because the start workspace ' +
+        throw new Error(
+            'Cannot do a block click because the start workspace ' +
             'is undefined');
       }
       // Clicks events are on the start block, even if it was a shadow.

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -53,7 +53,7 @@ export class RenderedConnection extends Connection {
   private readonly dbOpposite_: ConnectionDB;
   private readonly offsetInBlock_: Coordinate;
   private trackedState_: TrackedState;
-  private highlightPath: SVGPathElement | null = null;
+  private highlightPath: SVGPathElement|null = null;
 
   /** Connection this connection connects to.  Null if not connected. */
   override targetConnection: RenderedConnection|null = null;
@@ -304,13 +304,13 @@ export class RenderedConnection extends Connection {
     const x = this.x - xy.x;
     const y = this.y - xy.y;
     this.highlightPath = dom.createSvgElement(
-      Svg.PATH, {
-        'class': 'blocklyHighlightedConnectionPath',
-        'd': steps,
-        'transform': 'translate(' + x + ',' + y + ')' +
-            (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
-      },
-      this.sourceBlock_.getSvgRoot());
+        Svg.PATH, {
+          'class': 'blocklyHighlightedConnectionPath',
+          'd': steps,
+          'transform': 'translate(' + x + ',' + y + ')' +
+              (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
+        },
+        this.sourceBlock_.getSvgRoot());
   }
 
   /** Remove the highlighting around this connection. */

--- a/core/touch_gesture.ts
+++ b/core/touch_gesture.ts
@@ -61,8 +61,8 @@ export class TouchGesture extends Gesture {
 
   /** Boolean for whether or not the workspace supports pinch-zoom. */
   private isPinchZoomEnabled_: boolean|null = null;
-  override onMoveWrapper_: AnyDuringMigration;
-  override onUpWrapper_: AnyDuringMigration;
+  override onMoveWrapper_: browserEvents.Data|null = null;
+  override onUpWrapper_: browserEvents.Data|null = null;
 
   /**
    * Start a gesture: update the workspace to indicate that a gesture is in
@@ -72,6 +72,10 @@ export class TouchGesture extends Gesture {
    * @internal
    */
   override doStart(e: MouseEvent) {
+    if (!this.startWorkspace_) {
+      throw new Error('Cannot start the touch event becauase the start ' +
+          'workspace is undefined');
+    }
     this.isPinchZoomEnabled_ = this.startWorkspace_.options.zoomOptions &&
         this.startWorkspace_.options.zoomOptions.pinch;
     super.doStart(e);
@@ -254,6 +258,10 @@ export class TouchGesture extends Gesture {
       const gestureScale = scale - this.previousScale_;
       const delta = gestureScale > 0 ? gestureScale * ZOOM_IN_MULTIPLIER :
                                        gestureScale * ZOOM_OUT_MULTIPLIER;
+      if (!this.startWorkspace_) {
+        throw new Error('Cannot handle a pinch because the start workspace ' +
+            'is undefined');
+      }
       const workspace = this.startWorkspace_;
       const position = browserEvents.mouseToSvg(
           e, workspace.getParentSvg(), workspace.getInverseScreenCTM());

--- a/core/touch_gesture.ts
+++ b/core/touch_gesture.ts
@@ -73,7 +73,8 @@ export class TouchGesture extends Gesture {
    */
   override doStart(e: MouseEvent) {
     if (!this.startWorkspace_) {
-      throw new Error('Cannot start the touch event becauase the start ' +
+      throw new Error(
+          'Cannot start the touch event becauase the start ' +
           'workspace is undefined');
     }
     this.isPinchZoomEnabled_ = this.startWorkspace_.options.zoomOptions &&
@@ -259,7 +260,8 @@ export class TouchGesture extends Gesture {
       const delta = gestureScale > 0 ? gestureScale * ZOOM_IN_MULTIPLIER :
                                        gestureScale * ZOOM_OUT_MULTIPLIER;
       if (!this.startWorkspace_) {
-        throw new Error('Cannot handle a pinch because the start workspace ' +
+        throw new Error(
+            'Cannot handle a pinch because the start workspace ' +
             'is undefined');
       }
       const workspace = this.startWorkspace_;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #5857 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes `AnyDuringMigration` from the gesture code (mostly, I left it in where I think type guards are the correct solution, or where it deals with touch/mouse events being derpy).

Removes the different booleans tracking if a dragger exists, and instead just checks if the dagger exists.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Should be no change in behavior.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Should be no change in behavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Types === good?

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
Tested dragging things around and clicking things etc. Gestures appear to work, but who really knows.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
