### PR TITLE
fix!(connection): Correctly handle multiple highlighted RenderedConnections

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -53,6 +53,7 @@ export class RenderedConnection extends Connection {
   private readonly dbOpposite_: ConnectionDB;
   private readonly offsetInBlock_: Coordinate;
   private trackedState_: TrackedState;
+  private highlightPath: SVGPathElement | null = null;
 
   /** Connection this connection connects to.  Null if not connected. */
   override targetConnection: RenderedConnection|null = null;
@@ -302,26 +303,22 @@ export class RenderedConnection extends Connection {
     const xy = this.sourceBlock_.getRelativeToSurfaceXY();
     const x = this.x - xy.x;
     const y = this.y - xy.y;
-    // AnyDuringMigration because:  Property 'highlightedPath_' does not exist
-    // on type 'typeof Connection'.
-    (Connection as AnyDuringMigration).highlightedPath_ = dom.createSvgElement(
-        Svg.PATH, {
-          'class': 'blocklyHighlightedConnectionPath',
-          'd': steps,
-          'transform': 'translate(' + x + ',' + y + ')' +
-              (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
-        },
-        this.sourceBlock_.getSvgRoot());
+    this.highlightPath = dom.createSvgElement(
+      Svg.PATH, {
+        'class': 'blocklyHighlightedConnectionPath',
+        'd': steps,
+        'transform': 'translate(' + x + ',' + y + ')' +
+            (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
+      },
+      this.sourceBlock_.getSvgRoot());
   }
 
   /** Remove the highlighting around this connection. */
   unhighlight() {
-    // AnyDuringMigration because:  Property 'highlightedPath_' does not exist
-    // on type 'typeof Connection'.
-    dom.removeNode((Connection as AnyDuringMigration).highlightedPath_);
-    // AnyDuringMigration because:  Property 'highlightedPath_' does not exist
-    // on type 'typeof Connection'.
-    delete (Connection as AnyDuringMigration).highlightedPath_;
+    if (this.highlightPath) {
+      dom.removeNode(this.highlightPath);
+      this.highlightPath = null;
+    }
   }
 
   /**


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

[Issue reported in forum](https://groups.google.com/g/blockly/c/lYbTqXR2yq4).

### Proposed Changes

Modify `RenderedConnection.prototype.highlight` and `.unhighlight` to store the highlight path on `this` rather than as a static property on `Connection` (which is where it had been stored since this functionality was originally created, apaprently prior to RenderedConnection and Connection being split).

#### Behaviour Before Change

Calling `.unhighlight` on a `RenderedConnection` instance unhighlighted the most recently-highlighted connection, not necessarily `this` one.

#### Behaviour After Change

Calling `.unhighlight` on a `RenderedConnection` unhighlights `this` connection, if it was highlighted (and does nothing if not).

### Reason for Changes

To make it possible to highlight more than one connection at a time—and, critically,  to then be able to unhighlight any/all of them later.

### Test Coverage

Passes `npm test`.  

Manual testing: I have done a basic check in the playground to verify that connection highlighting appears to be working as expected, but being alert to any issues about this in manual testing would be great.

### Documentation

The documentation already documented the new behaviour.

### BREAKING CHANGE:

This change will break any third-party code which incorrectly relied on `.unhighlight` unconditionally removing the most recently-created highlight.