### PR TITLE
chore(tests): re-enable some skipped tests

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -53,7 +53,7 @@ export class RenderedConnection extends Connection {
   private readonly dbOpposite_: ConnectionDB;
   private readonly offsetInBlock_: Coordinate;
   private trackedState_: TrackedState;
-  private highlightPath: SVGPathElement | null = null;
+  private highlightPath: SVGPathElement|null = null;
 
   /** Connection this connection connects to.  Null if not connected. */
   override targetConnection: RenderedConnection|null = null;
@@ -304,13 +304,13 @@ export class RenderedConnection extends Connection {
     const x = this.x - xy.x;
     const y = this.y - xy.y;
     this.highlightPath = dom.createSvgElement(
-      Svg.PATH, {
-        'class': 'blocklyHighlightedConnectionPath',
-        'd': steps,
-        'transform': 'translate(' + x + ',' + y + ')' +
-            (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
-      },
-      this.sourceBlock_.getSvgRoot());
+        Svg.PATH, {
+          'class': 'blocklyHighlightedConnectionPath',
+          'd': steps,
+          'transform': 'translate(' + x + ',' + y + ')' +
+              (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
+        },
+        this.sourceBlock_.getSvgRoot());
   }
 
   /** Remove the highlighting around this connection. */

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -168,7 +168,6 @@ Serializer.Attributes.testSuites = [
 ];
 
 Serializer.Fields = new SerializerTestSuite('Fields');
-Serializer.Fields.skip = true;
 
 Serializer.Fields.Angle = new SerializerTestSuite('Angle');
 Serializer.Fields.Angle.Simple = new SerializerTestCase('Simple',

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -558,7 +558,7 @@ export function testAWorkspace() {
     });
   });
 
-  suite.skip('getById', function() {
+  suite('getById', function() {
     setup(function() {
       this.workspaceB = this.workspace.rendered ?
           new Blockly.WorkspaceSvg(new Blockly.Options({})) :


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

I noticed some tests were not running while testing another change.

### Proposed Changes

Enable two test suites.

### Test Coverage
Re-enables tests for serializers and `getById`

### Documentation
None

### Additional Information

<!-- Anything else we should know? -->
