### PR TITLE
fix: disposing of a workspace that has overwritten shadows

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -319,7 +319,6 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.disposed) {
       return;
     }
-    this.disposed = true;
 
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
@@ -339,6 +338,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       this.workspace.removeTypedBlock(this);
       // Remove from block database.
       this.workspace.removeBlockById(this.id);
+      this.disposed = true;
 
       // First, dispose of all my children.
       for (let i = this.childBlocks_.length - 1; i >= 0; i--) {

--- a/core/block.ts
+++ b/core/block.ts
@@ -181,6 +181,13 @@ export class Block implements IASTNodeLocation, IDeletable {
   protected outputShape_: number|null = null;
 
   /**
+   * Is the current block currently in the process of being disposed?
+   *
+   * @internal
+   */
+  disposing = false;
+
+  /**
    * A string representing the comment attached to this block.
    *
    * @deprecated August 2019. Use getCommentText instead.
@@ -316,7 +323,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @suppress {checkTypes}
    */
   dispose(healStack: boolean) {
-    if (this.disposed) {
+    if (this.disposing || this.disposed) {
       return;
     }
 
@@ -338,7 +345,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       this.workspace.removeTypedBlock(this);
       // Remove from block database.
       this.workspace.removeBlockById(this.id);
-      this.disposed = true;
+      this.disposing = true;
 
       // First, dispose of all my children.
       for (let i = this.childBlocks_.length - 1; i >= 0; i--) {
@@ -357,6 +364,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       }
     } finally {
       eventUtils.enable();
+      this.disposed = true;
     }
   }
 
@@ -774,8 +782,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if deletable.
    */
   isDeletable(): boolean {
-    return this.deletable_ && !this.isShadow_ && !this.disposed &&
-        !this.workspace.options.readOnly;
+    return this.deletable_ && !this.isShadow_ && !this.disposing &&
+        !this.disposed && !this.workspace.options.readOnly;
   }
 
   /**
@@ -793,8 +801,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if movable.
    */
   isMovable(): boolean {
-    return this.movable_ && !this.isShadow_ && !this.disposed &&
-        !this.workspace.options.readOnly;
+    return this.movable_ && !this.isShadow_ && !this.disposing &&
+        !this.disposed && !this.workspace.options.readOnly;
   }
 
   /**
@@ -867,7 +875,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if editable.
    */
   isEditable(): boolean {
-    return this.editable_ && !this.disposed && !this.workspace.options.readOnly;
+    return this.editable_ && !this.disposing && !this.disposed &&
+        !this.workspace.options.readOnly;
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -323,7 +323,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @suppress {checkTypes}
    */
   dispose(healStack: boolean) {
-    if (this.disposing || this.disposed) {
+    if (this.isDeadOrDying()) {
       return;
     }
 
@@ -366,6 +366,16 @@ export class Block implements IASTNodeLocation, IDeletable {
       eventUtils.enable();
       this.disposed = true;
     }
+  }
+
+  /**
+   * Returns true if the block is either in the process of being disposed, or
+   * is disposed.
+   *
+   * @internal
+   */
+  isDeadOrDying(): boolean {
+    return this.disposing || this.disposed;
   }
 
   /**
@@ -782,8 +792,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if deletable.
    */
   isDeletable(): boolean {
-    return this.deletable_ && !this.isShadow_ && !this.disposing &&
-        !this.disposed && !this.workspace.options.readOnly;
+    return this.deletable_ && !this.isShadow_ && !this.isDeadOrDying() &&
+        !this.workspace.options.readOnly;
   }
 
   /**
@@ -801,8 +811,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if movable.
    */
   isMovable(): boolean {
-    return this.movable_ && !this.isShadow_ && !this.disposing &&
-        !this.disposed && !this.workspace.options.readOnly;
+    return this.movable_ && !this.isShadow_ && !this.isDeadOrDying() &&
+        !this.workspace.options.readOnly;
   }
 
   /**
@@ -875,7 +885,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns True if editable.
    */
   isEditable(): boolean {
-    return this.editable_ && !this.disposing && !this.disposed &&
+    return this.editable_ && !this.isDeadOrDying() &&
         !this.workspace.options.readOnly;
   }
 

--- a/core/block.ts
+++ b/core/block.ts
@@ -319,6 +319,7 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.disposed) {
       return;
     }
+    this.disposed = true;
 
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
@@ -356,7 +357,6 @@ export class Block implements IASTNodeLocation, IDeletable {
       }
     } finally {
       eventUtils.enable();
-      this.disposed = true;
     }
   }
 

--- a/core/block.ts
+++ b/core/block.ts
@@ -182,10 +182,8 @@ export class Block implements IASTNodeLocation, IDeletable {
 
   /**
    * Is the current block currently in the process of being disposed?
-   *
-   * @internal
    */
-  disposing = false;
+  private disposing = false;
 
   /**
    * A string representing the comment attached to this block.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -527,7 +527,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
 
   /** Snap this block to the nearest grid point. */
   snapToGrid() {
-    if (this.disposing || this.disposed) {
+    if (this.isDeadOrDying()) {
       return;  // Deleted block.
     }
     if (this.workspace.isDragging()) {
@@ -868,7 +868,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @suppress {checkTypes}
    */
   override dispose(healStack?: boolean, animate?: boolean) {
-    if (this.disposing || this.disposed) {
+    if (this.isDeadOrDying()) {
       return;
     }
     Tooltip.dispose();
@@ -1078,7 +1078,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       // Don't change the warning text during a drag.
       // Wait until the drag finishes.
       this.warningTextDb.set(id, setTimeout(() => {
-                               if (!this.disposing && !this.disposed) {
+                               if (!this.isDeadOrDying()) {
                                  this.warningTextDb.delete(id);
                                  this.setWarningText(text, id);
                                }
@@ -1552,7 +1552,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * connected should not coincidentally line up on screen.
    */
   override bumpNeighbours() {
-    if (this.disposing || this.disposed) {
+    if (this.isDeadOrDying()) {
       return;
     }
     if (this.workspace.isDragging()) {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -527,7 +527,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
 
   /** Snap this block to the nearest grid point. */
   snapToGrid() {
-    if (this.disposed) {
+    if (this.disposing || this.disposed) {
       return;  // Deleted block.
     }
     if (this.workspace.isDragging()) {
@@ -868,8 +868,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @suppress {checkTypes}
    */
   override dispose(healStack?: boolean, animate?: boolean) {
-    if (this.disposed) {
-      // The block has already been deleted.
+    if (this.disposing || this.disposed) {
       return;
     }
     Tooltip.dispose();
@@ -1078,13 +1077,12 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     if (this.workspace.isDragging()) {
       // Don't change the warning text during a drag.
       // Wait until the drag finishes.
-      this.warningTextDb.set(
-          id, setTimeout(() => {
-            if (!this.disposed) {  // Check block wasn't deleted.
-              this.warningTextDb.delete(id);
-              this.setWarningText(text, id);
-            }
-          }, 100));
+      this.warningTextDb.set(id, setTimeout(() => {
+                               if (!this.disposing && !this.disposed) {
+                                 this.warningTextDb.delete(id);
+                                 this.setWarningText(text, id);
+                               }
+                             }, 100));
       return;
     }
     if (this.isInFlyout) {
@@ -1554,11 +1552,11 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * connected should not coincidentally line up on screen.
    */
   override bumpNeighbours() {
-    if (this.disposed) {
-      return;  // Deleted block.
+    if (this.disposing || this.disposed) {
+      return;
     }
     if (this.workspace.isDragging()) {
-      return;  // Don't bump blocks during a drag.
+      return;
     }
     const rootBlock = this.getRootBlock();
     if (rootBlock.isInFlyout) {

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -571,7 +571,8 @@ export class Connection implements IASTNodeLocationWithBlock {
     const parentBlock = this.getSourceBlock();
     const shadowState = this.getShadowState();
     const shadowDom = this.getShadowDom();
-    if (parentBlock.disposed || !shadowState && !shadowDom) {
+    if (parentBlock.disposing || parentBlock.disposed ||
+        !shadowState && !shadowDom) {
       return null;
     }
 

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -571,8 +571,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     const parentBlock = this.getSourceBlock();
     const shadowState = this.getShadowState();
     const shadowDom = this.getShadowDom();
-    if (parentBlock.disposing || parentBlock.disposed ||
-        !shadowState && !shadowDom) {
+    if (parentBlock.isDeadOrDying() || !shadowState && !shadowDom) {
       return null;
     }
 

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -249,7 +249,7 @@ function deleteNext_(deleteList: BlockSvg[], eventGroup: string) {
   eventUtils.setGroup(eventGroup);
   const block = deleteList.shift();
   if (block) {
-    if (!block.disposed) {
+    if (!block.disposing && !block.disposed) {
       block.dispose(false, true);
       setTimeout(deleteNext_, DELAY, deleteList, eventGroup);
     } else {

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -249,7 +249,7 @@ function deleteNext_(deleteList: BlockSvg[], eventGroup: string) {
   eventUtils.setGroup(eventGroup);
   const block = deleteList.shift();
   if (block) {
-    if (!block.disposing && !block.disposed) {
+    if (!block.isDeadOrDying()) {
       block.dispose(false, true);
       setTimeout(deleteNext_, DELAY, deleteList, eventGroup);
     } else {

--- a/core/field.ts
+++ b/core/field.ts
@@ -258,8 +258,8 @@ export abstract class Field implements IASTNodeLocationSvg,
    * @returns The renderer constant provider.
    */
   getConstants(): ConstantProvider|null {
-    if (!this.constants_ && this.sourceBlock_ && !this.sourceBlock_.disposed &&
-        this.sourceBlock_.workspace.rendered) {
+    if (!this.constants_ && this.sourceBlock_ && !this.sourceBlock_.disposing &&
+        !this.sourceBlock_.disposed && this.sourceBlock_.workspace.rendered) {
       this.constants_ = (this.sourceBlock_.workspace as WorkspaceSvg)
                             .getRenderer()
                             .getConstants();
@@ -1050,7 +1050,8 @@ export abstract class Field implements IASTNodeLocationSvg,
    * @param e Mouse down event.
    */
   protected onMouseDown_(e: Event) {
-    if (!this.sourceBlock_ || this.sourceBlock_.disposed) {
+    if (!this.sourceBlock_ || this.sourceBlock_.disposing ||
+        this.sourceBlock_.disposed) {
       return;
     }
     const gesture = (this.sourceBlock_.workspace as WorkspaceSvg).getGesture(e);

--- a/core/field.ts
+++ b/core/field.ts
@@ -258,8 +258,9 @@ export abstract class Field implements IASTNodeLocationSvg,
    * @returns The renderer constant provider.
    */
   getConstants(): ConstantProvider|null {
-    if (!this.constants_ && this.sourceBlock_ && !this.sourceBlock_.disposing &&
-        !this.sourceBlock_.disposed && this.sourceBlock_.workspace.rendered) {
+    if (!this.constants_ && this.sourceBlock_ &&
+        !this.sourceBlock_.isDeadOrDying() &&
+        this.sourceBlock_.workspace.rendered) {
       this.constants_ = (this.sourceBlock_.workspace as WorkspaceSvg)
                             .getRenderer()
                             .getConstants();
@@ -1050,8 +1051,7 @@ export abstract class Field implements IASTNodeLocationSvg,
    * @param e Mouse down event.
    */
   protected onMouseDown_(e: Event) {
-    if (!this.sourceBlock_ || this.sourceBlock_.disposing ||
-        this.sourceBlock_.disposed) {
+    if (!this.sourceBlock_ || this.sourceBlock_.isDeadOrDying()) {
       return;
     }
     const gesture = (this.sourceBlock_.workspace as WorkspaceSvg).getGesture(e);

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -377,7 +377,8 @@ export class FieldVariable extends FieldDropdown {
     let variableTypes = this.variableTypes;
     if (variableTypes === null) {
       // If variableTypes is null, return all variable types.
-      if (this.sourceBlock_ && !this.sourceBlock_.disposed) {
+      if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
+          !this.sourceBlock_.disposed) {
         return this.sourceBlock_.workspace.getVariableTypes();
       }
     }
@@ -456,7 +457,8 @@ export class FieldVariable extends FieldDropdown {
   protected override onItemSelected_(menu: Menu, menuItem: MenuItem) {
     const id = menuItem.getValue();
     // Handle special cases.
-    if (this.sourceBlock_ && !this.sourceBlock_.disposed) {
+    if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
+        !this.sourceBlock_.disposed) {
       if (id === internalConstants.RENAME_VARIABLE_ID) {
         // Rename variable.
         Variables.renameVariable(
@@ -515,7 +517,8 @@ export class FieldVariable extends FieldDropdown {
     }
     const name = this.getText();
     let variableModelList: AnyDuringMigration[] = [];
-    if (this.sourceBlock_ && !this.sourceBlock_.disposed) {
+    if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
+        !this.sourceBlock_.disposed) {
       const variableTypes = this.getVariableTypes_();
       // Get a copy of the list, so that adding rename and new variable options
       // doesn't modify the workspace's list.

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -377,8 +377,7 @@ export class FieldVariable extends FieldDropdown {
     let variableTypes = this.variableTypes;
     if (variableTypes === null) {
       // If variableTypes is null, return all variable types.
-      if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
-          !this.sourceBlock_.disposed) {
+      if (this.sourceBlock_ && !this.sourceBlock_.isDeadOrDying()) {
         return this.sourceBlock_.workspace.getVariableTypes();
       }
     }
@@ -457,8 +456,7 @@ export class FieldVariable extends FieldDropdown {
   protected override onItemSelected_(menu: Menu, menuItem: MenuItem) {
     const id = menuItem.getValue();
     // Handle special cases.
-    if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
-        !this.sourceBlock_.disposed) {
+    if (this.sourceBlock_ && !this.sourceBlock_.isDeadOrDying()) {
       if (id === internalConstants.RENAME_VARIABLE_ID) {
         // Rename variable.
         Variables.renameVariable(
@@ -517,8 +515,7 @@ export class FieldVariable extends FieldDropdown {
     }
     const name = this.getText();
     let variableModelList: AnyDuringMigration[] = [];
-    if (this.sourceBlock_ && !this.sourceBlock_.disposing &&
-        !this.sourceBlock_.disposed) {
+    if (this.sourceBlock_ && !this.sourceBlock_.isDeadOrDying()) {
       const variableTypes = this.getVariableTypes_();
       // Get a copy of the list, so that adding rename and new variable options
       // doesn't modify the workspace's list.

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -275,8 +275,7 @@ export class ASTNode {
     // TODO(#6097): Use instanceof checks to exit early for values of
     // curLocation that don't make sense.
     const curLocationAsBlock = curLocation as Block;
-    if (!curLocationAsBlock || curLocationAsBlock.disposing ||
-        curLocationAsBlock.disposed) {
+    if (!curLocationAsBlock || curLocationAsBlock.isDeadOrDying()) {
       return null;
     }
     const curRoot = curLocationAsBlock.getRootBlock();

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -275,7 +275,8 @@ export class ASTNode {
     // TODO(#6097): Use instanceof checks to exit early for values of
     // curLocation that don't make sense.
     const curLocationAsBlock = curLocation as Block;
-    if (!curLocationAsBlock || curLocationAsBlock.disposed) {
+    if (!curLocationAsBlock || curLocationAsBlock.disposing ||
+        curLocationAsBlock.disposed) {
       return null;
     }
     const curRoot = curLocationAsBlock.getRootBlock();

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -997,10 +997,6 @@ suite('Events', function() {
             this.eventsFireSpy, 0, Blockly.Events.BlockDelete,
             {oldXml: expectedOldXml, group: ''},
             workspaceSvg.id, expectedId);
-        assertNthCallEventArgEquals(
-            changeListenerSpy, 0, Blockly.Events.BlockDelete,
-            {oldXml: expectedOldXml, group: ''},
-            workspaceSvg.id, expectedId);
 
         // Expect the workspace to not have a variable with ID 'test_block_id'.
         chai.assert.isNull(this.workspace.getVariableById(TEST_BLOCK_ID));

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -167,6 +167,7 @@ export function createTestBlock() {
     },
     'renameVarById': Blockly.Block.prototype.renameVarById,
     'updateVarName': Blockly.Block.prototype.updateVarName,
+    'isDeadOrDying': () => false,
   };
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Part of #6358 


### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Change where we set `block.disposed` to `true`. I audited all of the places where `disposed` is referenced, and I don't *think* this will break anything. But let's be honest, it probably will break something.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
If you disposed of a workspace that had an overwritten shadow block in it, the workspace would throw an error. See https://github.com/google/blockly/issues/6358#issuecomment-1244375899

No end-user-facing change in behavior.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No Error!

No end-user-facing change in behavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Errors are sad =(

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->
Manually tested that disposing of a workspace with the following blocks in it did not cause an error to be thrown:
```
{
  "blocks": {
    "languageVersion": 0,
    "blocks": [
      {
        "type": "math_single",
        "id": "f#E]:l@J;BJ;N(?;KQ5T",
        "x": 138,
        "y": 138,
        "fields": {
          "OP": "ROOT"
        },
        "inputs": {
          "NUM": {
            "shadow": {
              "type": "math_number",
              "id": "wr:jE3$@EZ(/{pNSq92C",
              "fields": {
                "NUM": 9
              }
            },
            "block": {
              "type": "math_number",
              "id": "5A]oz4Gd$y]!BUkH/i~@",
              "fields": {
                "NUM": 123
              }
            }
          }
        }
      }
    ]
  }
}
```

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Caused by https://github.com/google/blockly/pull/6300/files#diff-dd85563e074ebb74e4c34eee01568971430f3cb7a6b846feef8044ad8d5dcd61L566

The issue is that `workspace` used to be set to `null` before the blocks were disposed, so that would properly cause `createShadowBlock_` to short circuit. But because `createShadowBlock_` was now looking at `disposed` it wasn't short circuiting, because `disposed` was set after the blocks were disposed.
