### PR TITLE
fix: Deep copy options used by dropdown fields

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -125,6 +125,8 @@ export class FieldDropdown extends Field {
 
     if (Array.isArray(menuGenerator)) {
       validateOptions(menuGenerator);
+      // Deep copy the option structure so it doesn't change.
+      menuGenerator = JSON.parse(JSON.stringify(menuGenerator));
     }
 
     /**

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -275,7 +275,7 @@ suite('JSON Block Definitions', function() {
 
       const image1 = options[1][0];
       assertImageEquals(IMAGE1, image1);
-      chai.assert.equal(IMAGE1.alt, IMAGE1_ALT_TEXT);  // Via Msg reference
+      chai.assert.equal(image1.alt, IMAGE1_ALT_TEXT);  // Via Msg reference
       chai.assert.equal(VALUE1, options[1][1]);
 
       const image2 = options[2][0];


### PR DESCRIPTION
Previously the options data structure passed to the dropdown constructor was sometimes copied (in the case of prefix/suffix trimming), but other times it was merely referenced. This meant if options data was used to create one dropdown, then the options data was modified and a second dropdown was created, the first dropdown's options would mysteriously change as well.

This uncovered a broken test that was only passing because of a side effect of the dropdown option data getting modified.