### PR TITLE
feat: return element from menu.render

### DIFF
--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -178,9 +178,8 @@ function createWidget_(menu: Menu) {
   if (!div) {
     throw Error('Attempting to create a context menu when widget div is null');
   }
-  menu.render(div);
-  const menuDom = menu.getElement();
-  menuDom?.classList.add('blocklyContextMenu');
+  const menuDom = menu.render(div);
+  menuDom.classList.add('blocklyContextMenu');
   // Prevent system context menu when right-clicking a Blockly context menu.
   browserEvents.conditionalBind(
       (menuDom as EventTarget), 'contextmenu', null, haltPropagation);

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -273,8 +273,7 @@ export class FieldDropdown extends Field {
     // Remove any pre-existing elements in the dropdown.
     dropDownDiv.clearContent();
     // Element gets created in render.
-    this.menu_!.render(dropDownDiv.getContentDiv());
-    const menuElement = this.menu_!.getElement() as Element;
+    const menuElement = this.menu_!.render(dropDownDiv.getContentDiv());
     menuElement.classList.add('blocklyDropdownMenu');
 
     if (this.getConstants()!.FIELD_DROPDOWN_COLOURED_DIV) {

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -86,7 +86,7 @@ export class Menu {
    *
    * @param container Element upon which to append this menu.
    */
-  render(container: Element) : HTMLDivElement {
+  render(container: Element): HTMLDivElement {
     const element = (document.createElement('div'));
     // goog-menu is deprecated, use blocklyMenu.  May 2020.
     element.className = 'blocklyMenu goog-menu blocklyNonSelectable';

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -85,6 +85,7 @@ export class Menu {
    * Creates the menu DOM.
    *
    * @param container Element upon which to append this menu.
+   * @returns The menu's root DOM element.
    */
   render(container: Element): HTMLDivElement {
     const element = (document.createElement('div'));

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -86,7 +86,7 @@ export class Menu {
    *
    * @param container Element upon which to append this menu.
    */
-  render(container: Element) {
+  render(container: Element) : HTMLDivElement {
     const element = (document.createElement('div'));
     // goog-menu is deprecated, use blocklyMenu.  May 2020.
     element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
@@ -114,6 +114,7 @@ export class Menu {
         element, 'keydown', this, this.handleKeyEvent_);
 
     container.appendChild(element);
+    return element;
   }
 
   /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Removes a need for `?.`

### Proposed Changes

Return the div from `menu.render` so that it can be used immediately and guaranteed to be non-null in calling code.

#### Behavior Before Change

No return value, so you had to call `getElement`, which could return null.

#### Behavior After Change


### Reason for Changes
Noticed while working on `addClass`.

### Test Coverage


### Documentation
### Additional Information

