### PR TITLE
fix: call remove instead of dom.removeNode

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -70,7 +70,7 @@ function disposeUiStep(
   const ms = new Date().getTime() - start.getTime();
   const percent = ms / 150;
   if (percent > 1) {
-    dom.removeNode(clone);
+    clone.remove();
   } else {
     const x =
         rect.x + (rtl ? -1 : 1) * rect.width * workspaceScale / 2 * percent;
@@ -133,7 +133,7 @@ function connectionUiStep(ripple: SVGElement, start: Date, scale: number) {
   const ms = new Date().getTime() - start.getTime();
   const percent = ms / 150;
   if (percent > 1) {
-    dom.removeNode(ripple);
+    ripple.remove();
   } else {
     ripple.setAttribute('r', (percent * 25 * scale).toString());
     ripple.style.opacity = (1 - percent).toString();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -914,13 +914,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     }
 
     super.dispose(!!healStack);
-
-    dom.removeNode(this.svgGroup_);
+    this.svgGroup_.remove();
     blockWorkspace.resizeContents();
-    // Sever JavaScript to DOM connections.
-    // AnyDuringMigration because:  Type 'null' is not assignable to type
-    // 'SVGGElement'.
-    this.svgGroup_ = null as AnyDuringMigration;
     dom.stopTextWidthCache();
   }
 

--- a/core/bubble.ts
+++ b/core/bubble.ts
@@ -780,7 +780,7 @@ export class Bubble implements IBubble {
       browserEvents.unbind(this.onMouseDownResizeWrapper_);
     }
     Bubble.unbindDragEvents_();
-    dom.removeNode(this.bubbleGroup_);
+    this.bubbleGroup_?.remove();
     this.disposed = true;
   }
 

--- a/core/field.ts
+++ b/core/field.ts
@@ -479,8 +479,7 @@ export abstract class Field implements IASTNodeLocationSvg,
     if (this.mouseDownWrapper_) {
       browserEvents.unbind(this.mouseDownWrapper_);
     }
-
-    dom.removeNode(this.fieldGroup_);
+    this.fieldGroup_.remove();
 
     this.disposed = true;
   }

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -411,10 +411,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       this.workspace_.getThemeManager().unsubscribe(this.svgBackground_!);
       this.workspace_.dispose();
     }
-    if (this.svgGroup_) {
-      dom.removeNode(this.svgGroup_);
-      this.svgGroup_ = null;
-    }
+    this.svgGroup_?.remove();
     this.svgBackground_ = null;
   }
 
@@ -853,7 +850,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       const rect = this.mats_[j];
       if (rect) {
         Tooltip.unbindMouseEvents(rect);
-        dom.removeNode(rect);
+        rect.remove();
       }
     }
     this.mats_.length = 0;

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -233,9 +233,7 @@ export class FlyoutButton {
     if (this.onMouseUpWrapper_) {
       browserEvents.unbind(this.onMouseUpWrapper_);
     }
-    if (this.svgGroup_) {
-      dom.removeNode(this.svgGroup_);
-    }
+    this.svgGroup_?.remove();
     if (this.svgText_) {
       this.workspace.getThemeManager().unsubscribe(this.svgText_);
     }

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -75,8 +75,8 @@ export abstract class Icon {
 
   /** Dispose of this icon. */
   dispose() {
-    dom.removeNode(this.iconGroup_);  // Dispose of and unlink the icon.
-    this.setVisible(false);           // Dispose of and unlink the bubble.
+    this.iconGroup_?.remove();  // Dispose of and unlink the icon.
+    this.setVisible(false);     // Dispose of and unlink the bubble.
   }
 
   /** Add or remove the UI indicating if this icon may be clicked or not. */

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -316,7 +316,7 @@ export class RenderedConnection extends Connection {
   /** Remove the highlighting around this connection. */
   unhighlight() {
     if (this.highlightPath) {
-      dom.removeNode(this.highlightPath);
+      this.highlightPath.remove();
       this.highlightPath = null;
     }
   }

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -711,15 +711,9 @@ export class ConstantProvider {
    * @internal
    */
   dispose() {
-    if (this.embossFilter_) {
-      dom.removeNode(this.embossFilter_);
-    }
-    if (this.disabledPattern_) {
-      dom.removeNode(this.disabledPattern_);
-    }
-    if (this.debugFilter_) {
-      dom.removeNode(this.debugFilter_);
-    }
+    this.embossFilter_?.remove();
+    this.disabledPattern_?.remove();
+    this.debugFilter_?.remove();
     this.cssNode_ = null;
   }
 

--- a/core/renderers/common/debugger.ts
+++ b/core/renderers/common/debugger.ts
@@ -75,8 +75,7 @@ export class Debug {
    */
   clearElems() {
     for (let i = 0; i < this.debugElements_.length; i++) {
-      const elem = this.debugElements_[i];
-      dom.removeNode(elem);
+      this.debugElements_[i].remove();
     }
 
     this.debugElements_ = [];

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -674,8 +674,6 @@ export class MarkerSvg {
 
   /** Dispose of this marker. */
   dispose() {
-    if (this.svgGroup_) {
-      dom.removeNode(this.svgGroup_);
-    }
+    this.svgGroup_?.remove();
   }
 }

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -287,12 +287,8 @@ export class ConstantProvider extends BaseConstantProvider {
 
   override dispose() {
     super.dispose();
-    if (this.selectedGlowFilter_) {
-      dom.removeNode(this.selectedGlowFilter_);
-    }
-    if (this.replacementGlowFilter_) {
-      dom.removeNode(this.replacementGlowFilter_);
-    }
+    this.selectedGlowFilter_?.remove();
+    this.replacementGlowFilter_?.remove();
   }
 
   override makeStartHat() {

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -188,8 +188,7 @@ export class Scrollbar {
       this.onMouseDownHandleWrapper_ = null;
     }
 
-    dom.removeNode(this.outerSvg_);
-    this.outerSvg_ = null;
+    this.outerSvg_?.remove();
     this.svgGroup_ = null;
     this.svgBackground_ = null;
     if (this.svgHandle_) {

--- a/core/scrollbar_pair.ts
+++ b/core/scrollbar_pair.ts
@@ -74,8 +74,7 @@ export class ScrollbarPair {
    * @suppress {checkTypes}
    */
   dispose() {
-    dom.removeNode(this.corner_);
-    this.corner_ = null;
+    this.corner_?.remove();
     this.oldHostMetrics_ = null;
     if (this.hScroll) {
       this.hScroll.dispose();

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -614,6 +614,7 @@ export class ToolboxCategory extends ToolboxItem implements
 
   override dispose() {
     dom.removeNode(this.htmlDiv_);
+    this.htmlDiv_?.remove();
   }
 }
 

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -15,7 +15,6 @@ goog.declareModuleId('Blockly.ToolboxSeparator');
 import * as Css from '../css.js';
 import type {IToolbox} from '../interfaces/i_toolbox.js';
 import * as registry from '../registry.js';
-import * as dom from '../utils/dom.js';
 import type * as toolbox from '../utils/toolbox.js';
 
 import {ToolboxItem} from './toolbox_item.js';
@@ -72,7 +71,7 @@ export class ToolboxSeparator extends ToolboxItem {
   }
 
   override dispose() {
-    dom.removeNode(this.htmlDiv_ as HTMLDivElement);
+    this.htmlDiv_?.remove();
   }
 }
 

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -1048,7 +1048,7 @@ export class Toolbox extends DeleteArea implements IAutoHideable,
     // not assignable to parameter of type 'Element'.
     this.workspace_.getThemeManager().unsubscribe(
         this.HtmlDiv as AnyDuringMigration);
-    dom.removeNode(this.HtmlDiv);
+    this.HtmlDiv?.remove();
   }
 }
 

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -239,10 +239,7 @@ export class Trashcan extends DeleteArea implements IAutoHideable,
    */
   dispose() {
     this.workspace.getComponentManager().removeComponent('trashcan');
-    if (this.svgGroup_) {
-      dom.removeNode(this.svgGroup_);
-      this.svgGroup_ = null;
-    }
+    this.svgGroup_?.remove();
     this.svgLid_ = null;
     if (this.lidTask_) {
       clearTimeout(this.lidTask_);

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -148,7 +148,7 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
       eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))(this));
     }
 
-    dom.removeNode(this.svgGroup_);
+    this.svgGroup_?.remove();
     // Dispose of any rendered components
     this.disposeInternal_();
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -817,9 +817,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     if (this.currentGesture_) {
       this.currentGesture_.cancel();
     }
-    if (this.svgGroup_) {
-      dom.removeNode(this.svgGroup_);
-    }
+    this.svgGroup_?.remove();
     if (this.toolbox_) {
       this.toolbox_.dispose();
       this.toolbox_ = null;

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -143,9 +143,7 @@ export class ZoomControls implements IPositionable {
    */
   dispose() {
     this.workspace.getComponentManager().removeComponent('zoomControls');
-    if (this.svgGroup) {
-      dom.removeNode(this.svgGroup);
-    }
+    this.svgGroup?.remove();
     if (this.onZoomResetWrapper_) {
       browserEvents.unbind(this.onZoomResetWrapper_);
     }


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6325
### Proposed Changes

Use `element.remove()` instead of our `dom.removeNode` function.

#### Behavior Before Change

No change

#### Behavior After Change

No change

### Reason for Changes

Get rid of code that worked around IE issues.

### Test Coverage

<!-- TODO: Please do one of the following:
  -    * Create unit tests, and explain here how they cover your changes.
  -    * List steps you used for manual testing, and explain how they cover
  -      your changes.
  -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
