### PR TITLE
fix(tests): revert change in marker_svg to keep keyboard nav tests working

### DIFF
--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -181,7 +181,8 @@ export class MarkerSvg {
     // Ensures the marker will be visible immediately after the move.
     const animate = this.currentMarkerSvg!.childNodes[0];
     if (animate !== undefined) {
-      animate instanceof SVGAnimationElement && animate.beginElement();
+      (animate as SVGAnimationElement).beginElement &&
+          (animate as SVGAnimationElement).beginElement();
     }
   }
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Resolves one of the issues blocking https://github.com/google/blockly-samples/pull/1297#issuecomment-1261527686

### Proposed Changes

Use a cast and checking for a property, rather than an `instanceof` check, to make it safe to call `beginElement()` on a marker. This avoids breaking tests when run in jsdom.

#### Behavior Before Change

Tests broke becuase `SVGAnimationElement` was not defined when running with jsdom.

#### Behavior After Change

These tests pass (although a different set of tests fails >.<)

### Reason for Changes

The tests are running in Mocha, and using jsdom to pretend that they are in a rendered page. The marker SVG and similar elements are created but certain classes don't exist. `SVGAnimationElement` is one of them, which triggered a failure.

Note that the tests running rendered in jsdom is a bit weird, but they cannot run in headless mode because keyboard navigation is not built for non-rendered workspaces.

### Test Coverage

I built, packaged, and [linked](https://developers.google.com/blockly/guides/contribute/samples/debugging#method_1_npm_link) changes so that I could run keyboard navigation tests. The tests no longer fail on `SVGAnimationElement`, although two tests still fail.

### Documentation


### Additional Information

Once this change is in Beka will cut a beta so that we can test it over on samples and move the `blocky-9-beta` branch one step closer to working.