### PR TITLE
chore: fixed tsdoc missing deprecation messages

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -379,11 +379,6 @@
       },
       "tsdoc-escape-right-brace": {
         "logLevel": "none"
-      },
-
-      // Needs to be fixed
-      "tsdoc-missing-deprecation-message": {
-        "logLevel": "none"
       }
     }
   }

--- a/core/extensions.ts
+++ b/core/extensions.ts
@@ -350,7 +350,7 @@ function mutatorPropertiesMatch(
  *
  * @param fn Function to run.
  * @throws Error Will throw if no global document can be found (e.g., Node.js).
- * @alias Blockly.extensions.runAfterPageLoad
+ * @internal
  */
 export function runAfterPageLoad(fn: () => void) {
   if (typeof document !== 'object') {

--- a/core/extensions.ts
+++ b/core/extensions.ts
@@ -350,7 +350,7 @@ function mutatorPropertiesMatch(
  *
  * @param fn Function to run.
  * @throws Error Will throw if no global document can be found (e.g., Node.js).
- * @internal
+ * @alias Blockly.extensions.runAfterPageLoad
  */
 export function runAfterPageLoad(fn: () => void) {
   if (typeof document !== 'object') {

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -54,7 +54,7 @@ import {Renderer} from './renderer.js';
  *
  * @returns Whether the debugger is turned on.
  * @alias Blockly.blockRendering.isDebuggerEnabled
- * @deprecated
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function isDebuggerEnabled(): boolean {
@@ -90,7 +90,7 @@ export function unregister(name: string) {
  * Turn on the blocks debugger.
  *
  * @alias Blockly.blockRendering.startDebugger
- * @deprecated
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function startDebugger() {
@@ -105,7 +105,7 @@ export function startDebugger() {
  * Turn off the blocks debugger.
  *
  * @alias Blockly.blockRendering.stopDebugger
- * @deprecated
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function stopDebugger() {

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -54,7 +54,8 @@ import {Renderer} from './renderer.js';
  *
  * @returns Whether the debugger is turned on.
  * @alias Blockly.blockRendering.isDebuggerEnabled
- * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link
+ *     https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function isDebuggerEnabled(): boolean {
@@ -90,7 +91,8 @@ export function unregister(name: string) {
  * Turn on the blocks debugger.
  *
  * @alias Blockly.blockRendering.startDebugger
- * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link
+ *     https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function startDebugger() {
@@ -105,7 +107,8 @@ export function startDebugger() {
  * Turn off the blocks debugger.
  *
  * @alias Blockly.blockRendering.stopDebugger
- * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link https://www.npmjs.com/package/@blockly/dev-tools}.)
+ * @deprecated Use the debug renderer in **\@blockly/dev-tools** (See {@link
+ *     https://www.npmjs.com/package/@blockly/dev-tools}.)
  * @internal
  */
 export function stopDebugger() {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -293,7 +293,8 @@ export function getViewportBBox(): Rect {
  */
 export function arrayRemove<T>(arr: Array<T>, value: T): boolean {
   deprecation.warn(
-      'Blockly.utils.arrayRemove', 'December 2021', 'December 2022', 'Blockly.array.removeElem');
+      'Blockly.utils.arrayRemove', 'December 2021', 'December 2022',
+      'Blockly.array.removeElem');
   return arrayUtils.removeElem(arr, value);
 }
 
@@ -378,6 +379,7 @@ export function parseBlockColour(colour: number|
  */
 export function runAfterPageLoad(fn: () => void) {
   deprecation.warn(
-      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022', 'Blockly.extensions.runAfterPageLoad');
+      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022',
+      'Blockly.extensions.runAfterPageLoad');
   extensions.runAfterPageLoad(fn);
 }

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -72,7 +72,7 @@ export {
  * Halts the propagation of the event without doing anything else.
  *
  * @param e An event.
- * @deprecated This is no longer needed.
+ * @deprecated No longer provided by Blockly.
  * @alias Blockly.utils.noEvent
  */
 export function noEvent(e: Event) {
@@ -374,12 +374,11 @@ export function parseBlockColour(colour: number|
  *
  * @param fn Function to run.
  * @throws Error Will throw if no global document can be found (e.g., Node.js).
- * @deprecated Use **Blockly.extensions.runAfterPageLoad** instead.
+ * @deprecated No longer provided by Blockly.
  * @alias Blockly.utils.runAfterPageLoad
  */
 export function runAfterPageLoad(fn: () => void) {
   deprecation.warn(
-      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022',
-      'Blockly.extensions.runAfterPageLoad');
+      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022');
   extensions.runAfterPageLoad(fn);
 }

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -72,7 +72,7 @@ export {
  * Halts the propagation of the event without doing anything else.
  *
  * @param e An event.
- * @deprecated
+ * @deprecated This is no longer needed.
  * @alias Blockly.utils.noEvent
  */
 export function noEvent(e: Event) {
@@ -87,7 +87,7 @@ export function noEvent(e: Event) {
  *
  * @param e An event.
  * @returns True if text input.
- * @deprecated Use Blockly.browserEvents.isTargetInput instead.
+ * @deprecated Use **Blockly.browserEvents.isTargetInput** instead.
  * @alias Blockly.utils.isTargetInput
  */
 export function isTargetInput(e: Event): boolean {
@@ -103,7 +103,7 @@ export function isTargetInput(e: Event): boolean {
  *
  * @param element SVG element to find the coordinates of.
  * @returns Object with .x and .y properties.
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.getRelativeXY** instead.
  * @alias Blockly.utils.getRelativeXY
  */
 export function getRelativeXY(element: Element): Coordinate {
@@ -120,7 +120,7 @@ export function getRelativeXY(element: Element): Coordinate {
  * @param element SVG element to find the coordinates of. If this is not a child
  *     of the div Blockly was injected into, the behaviour is undefined.
  * @returns Object with .x and .y properties.
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.getInjectionDivXY** instead.
  * @alias Blockly.utils.getInjectionDivXY_
  */
 function getInjectionDivXY(element: Element): Coordinate {
@@ -136,7 +136,7 @@ export const getInjectionDivXY_ = getInjectionDivXY;
  *
  * @param e Mouse event.
  * @returns True if right-click.
- * @deprecated Use Blockly.browserEvents.isRightButton instead.
+ * @deprecated Use **Blockly.browserEvents.isRightButton** instead.
  * @alias Blockly.utils.isRightButton
  */
 export function isRightButton(e: Event): boolean {
@@ -154,7 +154,7 @@ export function isRightButton(e: Event): boolean {
  * @param svg SVG element.
  * @param matrix Inverted screen CTM to use.
  * @returns Object with .x and .y properties.
- * @deprecated Use Blockly.browserEvents.mouseToSvg instead;
+ * @deprecated Use **Blockly.browserEvents.mouseToSvg** instead;
  * @alias Blockly.utils.mouseToSvg
  */
 export function mouseToSvg(
@@ -170,7 +170,7 @@ export function mouseToSvg(
  *
  * @param e Mouse event.
  * @returns Scroll delta object with .x and .y properties.
- * @deprecated Use Blockly.browserEvents.getScrollDeltaPixels instead.
+ * @deprecated Use **Blockly.browserEvents.getScrollDeltaPixels** instead.
  * @alias Blockly.utils.getScrollDeltaPixels
  */
 export function getScrollDeltaPixels(e: WheelEvent): {x: number, y: number} {
@@ -190,7 +190,7 @@ export function getScrollDeltaPixels(e: WheelEvent): {x: number, y: number} {
  * @param message Text which might contain string table references and
  *     interpolation tokens.
  * @returns Array of strings and numbers.
- * @deprecated
+ * @deprecated Use **Blockly.utils.parsing.tokenizeInterpolation** instead.
  * @alias Blockly.utils.tokenizeInterpolation
  */
 export function tokenizeInterpolation(message: string): Array<string|number> {
@@ -208,7 +208,7 @@ export function tokenizeInterpolation(message: string): Array<string|number> {
  * @param message Message, which may be a string that contains string table
  *     references.
  * @returns String with message references replaced.
- * @deprecated
+ * @deprecated Use **Blockly.utils.parsing.replaceMessageReferences** instead.
  * @alias Blockly.utils.replaceMessageReferences
  */
 export function replaceMessageReferences(message: string|any): string {
@@ -225,7 +225,7 @@ export function replaceMessageReferences(message: string|any): string {
  * @param message Text which might contain string table references.
  * @returns True if all message references have matching values.
  *     Otherwise, false.
- * @deprecated
+ * @deprecated Use **Blockly.utils.parsing.checkMessageReferences** instead.
  * @alias Blockly.utils.checkMessageReferences
  */
 export function checkMessageReferences(message: string): boolean {
@@ -239,7 +239,7 @@ export function checkMessageReferences(message: string): boolean {
  * Generate a unique ID.
  *
  * @returns A globally unique ID string.
- * @deprecated Use Blockly.utils.idGenerator.genUid instead.
+ * @deprecated Use **Blockly.utils.idGenerator.genUid** instead.
  * @alias Blockly.utils.genUid
  */
 export function genUid(): string {
@@ -254,7 +254,7 @@ export function genUid(): string {
  * and attempting to set the property.
  *
  * @returns True if 3D transforms are supported.
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.is3dSupported** instead.
  * @alias Blockly.utils.is3dSupported
  */
 export function is3dSupported(): boolean {
@@ -271,7 +271,7 @@ export function is3dSupported(): boolean {
  * @returns An object containing window width, height, and scroll position in
  *     window coordinates.
  * @alias Blockly.utils.getViewportBBox
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.getViewportBBox** instead.
  * @internal
  */
 export function getViewportBBox(): Rect {
@@ -288,12 +288,12 @@ export function getViewportBBox(): Rect {
  * @param value Value to remove.
  * @returns True if an element was removed.
  * @alias Blockly.utils.arrayRemove
- * @deprecated
+ * @deprecated Use **Blockly.array.removeElem** instead.
  * @internal
  */
 export function arrayRemove<T>(arr: Array<T>, value: T): boolean {
   deprecation.warn(
-      'Blockly.utils.arrayRemove', 'December 2021', 'December 2022');
+      'Blockly.utils.arrayRemove', 'December 2021', 'December 2022', 'Blockly.array.removeElem');
   return arrayUtils.removeElem(arr, value);
 }
 
@@ -302,7 +302,7 @@ export function arrayRemove<T>(arr: Array<T>, value: T): boolean {
  * Copied from Closure's goog.dom.getDocumentScroll.
  *
  * @returns Object with values 'x' and 'y'.
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.getDocumentScroll** instead.
  * @alias Blockly.utils.getDocumentScroll
  */
 export function getDocumentScroll(): Coordinate {
@@ -320,7 +320,7 @@ export function getDocumentScroll(): Coordinate {
  * @param opt_stripFollowing Optionally ignore all following statements (blocks
  *     that are not inside a value or statement input of the block).
  * @returns Map of types to type counts for descendants of the bock.
- * @deprecated
+ * @deprecated Use **Blockly.common.getBlockTypeCounts** instead.
  * @alias Blockly.utils.getBlockTypeCounts
  */
 export function getBlockTypeCounts(
@@ -337,7 +337,7 @@ export function getBlockTypeCounts(
  * @param ws The workspace to find the coordinates on.
  * @param screenCoordinates The screen coordinates to be converted to workspace
  *     coordinates
- * @deprecated
+ * @deprecated Use **Blockly.utils.svgMath.screenToWsCoordinates** instead.
  * @returns The workspace coordinates.
  */
 export function screenToWsCoordinates(
@@ -357,7 +357,7 @@ export function screenToWsCoordinates(
  * @returns An object containing the colour as a #RRGGBB string, and the hue if
  *     the input was an HSV hue value.
  * @throws {Error} If the colour cannot be parsed.
- * @deprecated
+ * @deprecated Use **Blockly.utils.parsing.parseBlockColour** instead.
  * @alias Blockly.utils.parseBlockColour
  */
 export function parseBlockColour(colour: number|
@@ -373,11 +373,11 @@ export function parseBlockColour(colour: number|
  *
  * @param fn Function to run.
  * @throws Error Will throw if no global document can be found (e.g., Node.js).
- * @deprecated
+ * @deprecated Use **Blockly.extensions.runAfterPageLoad** instead.
  * @alias Blockly.utils.runAfterPageLoad
  */
 export function runAfterPageLoad(fn: () => void) {
   deprecation.warn(
-      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022');
+      'Blockly.utils.runAfterPageLoad', 'December 2021', 'December 2022', 'Blockly.extensions.runAfterPageLoad');
   extensions.runAfterPageLoad(fn);
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

This resolves missing deprecation messages.

### Proposed Changes

- Added `@deprecated` messages and updated `./api-extractor.json` to no longer ignore logs for `"tsdoc-missing-deprecation-message"`
- Updated the blockly alias to be bolded for some deprecation messages in `./core/utils.ts`.
- Removed `@internal` from **runAfterPageLoad** in `./core/extensions.ts`

#### Behavior Before Change

- Some `@deprecated` notices did not have messages to display.

#### Behavior After Change

- All `@deprecated` notices have messages to display.
- Deprecation messages display in **bold**.

### Reason for Changes

This is a cleanup task to provide more information to function descriptions and, by extension, the documentation.

### Test Coverage

N/A for automated tests, though I manually tested this change by running `npx @microsoft/api-extractor run --local` from the root. I used that command to identify the missing messages and confirmed it was good to go after the updates.

### Documentation

General documentation needs to be updated, though no new documentation needs to be created.

### Additional Information

- See the commits `@deprecated` was added to the core utils functions below:
  - #5464
  - #5706
  - #5714 

There are a few minor tweaks which I made assumptions for, though I'm not entirely sure if they're correct:

- (1) In `./core/utils.ts`, the message for `noEvent` and comments around its replacement suggest it's no longer needed. 
  - Is that correct? 
  - If so, is including the reason for for deprecation in the message important here?
  - See [the function replacing noEvent when @deprecated was added](https://github.com/google/blockly/pull/5464/files#diff-b90a52c956a6a24371cbdf76158bf3b1fda8e00cc6837e2fb14feb4be6fe82f9L198) (In #5714)
- (2) In `./core/utils.ts`, updated the deprecation warning for `arrayRemove` to include the alternate function to use. 
  - Is this correct? Alternatively, I could see the lack of the lack of use intending to convey it shouldn't be used externally.
  - See [the commit @deprecated was added to arrayRemove](https://github.com/google/blockly/commit/075385c87c3dc8bdbec2e9b5e088c11e90ad13a7#diff-b38443a799aded73b7d8beaf0e6e75fb890a36fb2fb4912e5da6d16eb4350f98R292) (In #5714)
- (3) In `./core/utils.ts`, same as with (2) for `runAfterPageLoad`. The catch is the function that replaces it was marked internal.
  - Linked to this is the update in `./core/extensions.ts` to mark `runAfterPageLoad` with an alias instead of internal.
  - See [the commit @deprecated was added to runAfterPageLoad](https://github.com/google/blockly/commit/075385c87c3dc8bdbec2e9b5e088c11e90ad13a7#diff-b38443a799aded73b7d8beaf0e6e75fb890a36fb2fb4912e5da6d16eb4350f98) (In #5714)

