### PR TITLE
fix: Multiline field not correctly size in parent block when copy/paste or load.

### DIFF
--- a/core/field_multilineinput.ts
+++ b/core/field_multilineinput.ts
@@ -270,11 +270,15 @@ export class FieldMultilineInput extends FieldTextInput {
   /** Updates the size of the field based on the text. */
   protected override updateSize_() {
     const nodes = this.textGroup_.childNodes;
+    const fontSize = this.getConstants()!.FIELD_TEXT_FONTSIZE;
+    const fontWeight = this.getConstants()!.FIELD_TEXT_FONTWEIGHT;
+    const fontFamily = this.getConstants()!.FIELD_TEXT_FONTFAMILY;
     let totalWidth = 0;
     let totalHeight = 0;
     for (let i = 0; i < nodes.length; i++) {
       const tspan = nodes[i] as SVGTextElement;
-      const textWidth = dom.getTextWidth(tspan);
+      const textWidth =
+          dom.getFastTextWidth(tspan, fontSize, fontWeight, fontFamily);
       if (textWidth > totalWidth) {
         totalWidth = textWidth;
       }
@@ -290,9 +294,6 @@ export class FieldMultilineInput extends FieldTextInput {
       const actualEditorLines = this.value_.split('\n');
       const dummyTextElement = dom.createSvgElement(
           Svg.TEXT, {'class': 'blocklyText blocklyMultilineText'});
-      const fontSize = this.getConstants()!.FIELD_TEXT_FONTSIZE;
-      const fontWeight = this.getConstants()!.FIELD_TEXT_FONTWEIGHT;
-      const fontFamily = this.getConstants()!.FIELD_TEXT_FONTFAMILY;
 
       for (let i = 0; i < actualEditorLines.length; i++) {
         if (actualEditorLines[i].length > this.maxDisplayLength) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
- #6165 
- #6071 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changing size calculation in `updateSize_`  from `getTextWidth` to `getFastTextWidth`.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

Multiline field not correctly size in parent block when copy/paste or load.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

Multiline field correctly size in parent block when copy/paste or load.
