### PR TITLE
Fix: `//` isn't a legal comment in CSS

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -171,7 +171,7 @@ let content = `
 }
 
 .blocklyDropDownContent {
-  max-height: 300px;  // @todo: spec for maximum height.
+  max-height: 300px;  /* @todo: spec for maximum height. */
   overflow: auto;
   overflow-x: hidden;
   position: relative;


### PR DESCRIPTION
Noticed this when Firefox whined about it in the developer tools.  I ran the CSS through W3's CSS validator and there were no other errors.