### PR TITLE
fix: remove deprecated use of objectUtils from generators

### DIFF
--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -13,7 +13,6 @@
 goog.module('Blockly.JavaScript');
 
 const Variables = goog.require('Blockly.Variables');
-const objectUtils = goog.require('Blockly.utils.object');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
 const {Generator} = goog.require('Blockly.Generator');
@@ -169,7 +168,7 @@ JavaScript.init = function(workspace) {
  */
 JavaScript.finish = function(code) {
   // Convert the definitions dictionary into a list.
-  const definitions = objectUtils.values(this.definitions_);
+  const definitions = Object.values(this.definitions_);
   // Call Blockly.Generator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -13,7 +13,6 @@
 
 goog.module('Blockly.Lua');
 
-const objectUtils = goog.require('Blockly.utils.object');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
 const {Generator} = goog.require('Blockly.Generator');
@@ -115,7 +114,7 @@ Lua.init = function(workspace) {
  */
 Lua.finish = function(code) {
   // Convert the definitions dictionary into a list.
-  const definitions = objectUtils.values(this.definitions_);
+  const definitions = Object.values(this.definitions_);
   // Call Blockly.Generator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;

--- a/generators/php.js
+++ b/generators/php.js
@@ -12,7 +12,6 @@
 
 goog.module('Blockly.PHP');
 
-const objectUtils = goog.require('Blockly.utils.object');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
 const {Generator} = goog.require('Blockly.Generator');
@@ -154,7 +153,7 @@ PHP.init = function(workspace) {
  */
 PHP.finish = function(code) {
   // Convert the definitions dictionary into a list.
-  const definitions = objectUtils.values(this.definitions_);
+  const definitions = Object.values(this.definitions_);
   // Call Blockly.Generator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Some generators give a deprecation warning when used.

### Proposed Changes

Uses `Object.values` instead of deprecated objectUtils.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

No change.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested in the Code demo in core. Previously, got deprecation warnings in JS, Lua, and PHP generators. Now, no warnings.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Checked and objectUtils is not used anywhere else in core.

We should consider patching this as it will affect almost all developers and they have no way of addressing this warning on their end. It's just a console message so it's probably not worth starting a patch just for this, but if we have to do one for another reason I think we should include it.
