### PR TITLE
fix: move Theme to use a Partial type for BlockStyle

### DIFF
--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -228,10 +228,6 @@ export class FieldAngle extends FieldTextInput {
     dropDownDiv.getContentDiv().appendChild(this.editor_ as AnyDuringMigration);
 
     if (this.sourceBlock_ instanceof BlockSvg) {
-      if (!this.sourceBlock_.style.colourTertiary) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       dropDownDiv.setColour(
           this.sourceBlock_.style.colourPrimary,
           this.sourceBlock_.style.colourTertiary);

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -285,10 +285,6 @@ export class FieldDropdown extends Field {
       const borderColour = this.getSourceBlock().isShadow() ?
           (this.getSourceBlock().getParent() as BlockSvg).style.colourTertiary :
           (this.sourceBlock_ as BlockSvg).style.colourTertiary;
-      if (!borderColour) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       dropDownDiv.setColour(primaryColour, borderColour);
     }
 
@@ -503,14 +499,6 @@ export class FieldDropdown extends Field {
    */
   override applyColour() {
     const style = (this.sourceBlock_ as BlockSvg).style;
-    if (!style.colourSecondary) {
-      throw new Error(
-          'The renderer did not properly initialize the block style');
-    }
-    if (!style.colourTertiary) {
-      throw new Error(
-          'The renderer did not properly initialize the block style');
-    }
     if (this.borderRect_) {
       this.borderRect_.setAttribute('stroke', style.colourTertiary);
       if (this.menu_) {

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -222,10 +222,6 @@ export class FieldTextInput extends Field {
     const source = this.sourceBlock_ as BlockSvg;
 
     if (this.borderRect_) {
-      if (!source.style.colourTertiary) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       this.borderRect_.setAttribute('stroke', source.style.colourTertiary);
     } else {
       source.pathObject.svgPath.setAttribute(

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -658,12 +658,7 @@ export class ConstantProvider {
    * @param blockStyle A full or partial block style object.
    * @returns A full block style object, with all required properties populated.
    */
-  protected validatedBlockStyle_(blockStyle: {
-    colourPrimary: string,
-    colourSecondary?: string,
-    colourTertiary?: string,
-    hat?: string
-  }): BlockStyle {
+  protected validatedBlockStyle_(blockStyle: Partial<BlockStyle>): BlockStyle {
     // Make a new object with all of the same properties.
     const valid = {} as BlockStyle;
     if (blockStyle) {

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -137,10 +137,6 @@ export class PathObject implements IPathObject {
    * @internal
    */
   applyColour(block: BlockSvg) {
-    if (!this.style.colourTertiary) {
-      throw new Error(
-          'The renderer did not properly initialize the block style');
-    }
     this.svgPath.setAttribute('stroke', this.style.colourTertiary);
     this.svgPath.setAttribute('fill', this.style.colourPrimary);
 
@@ -199,10 +195,6 @@ export class PathObject implements IPathObject {
    */
   protected updateShadow_(shadow: boolean) {
     if (shadow) {
-      if (!this.style.colourSecondary) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       this.svgPath.setAttribute('stroke', 'none');
       this.svgPath.setAttribute('fill', this.style.colourSecondary);
     }

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -77,19 +77,11 @@ export class PathObject extends BasePathObject {
     // Set shadow stroke colour.
     const parent = block.getParent();
     if (block.isShadow() && parent) {
-      if (!parent.style.colourTertiary) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       this.svgPath.setAttribute('stroke', parent.style.colourTertiary);
     }
 
     // Apply colour to outlines.
     for (const outline of this.outlines.values()) {
-      if (!this.style.colourTertiary) {
-        throw new Error(
-            'The renderer did not properly initialize the block style');
-      }
       outline.setAttribute('fill', this.style.colourTertiary);
     }
   }
@@ -183,10 +175,6 @@ export class PathObject extends BasePathObject {
   setOutlinePath(name: string, pathString: string) {
     const outline = this.getOutlinePath_(name);
     outline.setAttribute('d', pathString);
-    if (!this.style.colourTertiary) {
-      throw new Error(
-          'The renderer did not properly initialize the block style');
-    }
     outline.setAttribute('fill', this.style.colourTertiary);
   }
 

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -17,7 +17,7 @@ import * as object from './utils/object.js';
 
 
 export interface ITheme {
-  blockStyles?: {[key: string]: BlockStyle};
+  blockStyles?: {[key: string]: Partial<BlockStyle>};
   categoryStyles?: {[key: string]: CategoryStyle};
   componentStyles?: ComponentStyle;
   fontStyle?: FontStyle;
@@ -58,9 +58,11 @@ export class Theme implements ITheme {
    * @param opt_componentStyles A map of Blockly component names to style value.
    */
   constructor(
-      public name: string, opt_blockStyles?: {[key: string]: BlockStyle},
+      public name: string,
+      opt_blockStyles?: {[key: string]: Partial<BlockStyle>},
       opt_categoryStyles?: {[key: string]: CategoryStyle},
-      opt_componentStyles?: ComponentStyle) {
+      opt_componentStyles?: ComponentStyle
+  ) {
     /** The block styles map. */
     this.blockStyles = opt_blockStyles || Object.create(null);
 
@@ -187,9 +189,9 @@ export class Theme implements ITheme {
 export namespace Theme {
   export interface BlockStyle {
     colourPrimary: string;
-    colourSecondary?: string;
-    colourTertiary?: string;
-    hat?: string;
+    colourSecondary: string;
+    colourTertiary: string;
+    hat: string;
   }
 
   export interface CategoryStyle {

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -61,8 +61,7 @@ export class Theme implements ITheme {
       public name: string,
       opt_blockStyles?: {[key: string]: Partial<BlockStyle>},
       opt_categoryStyles?: {[key: string]: CategoryStyle},
-      opt_componentStyles?: ComponentStyle
-  ) {
+      opt_componentStyles?: ComponentStyle) {
     /** The block styles map. */
     this.blockStyles = opt_blockStyles || Object.create(null);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #4774 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves the `BlockStyle` type to have required properties, and use `Partial` where necessary.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Code health

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
