### PR TITLE
chore: remove underscores from private properties in workspace.ts

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -101,15 +101,15 @@ export class Workspace implements IASTNodeLocation {
   connectionDBList: ConnectionDB[] = [];
   connectionChecker: IConnectionChecker;
 
-  private readonly topBlocks_: Block[] = [];
-  private readonly topComments_: WorkspaceComment[] = [];
+  private readonly topBlocks: Block[] = [];
+  private readonly topComments: WorkspaceComment[] = [];
   private readonly commentDB = new Map<string, WorkspaceComment>();
-  private readonly listeners_: Function[] = [];
+  private readonly listeners: Function[] = [];
   protected undoStack_: Abstract[] = [];
   protected redoStack_: Abstract[] = [];
   private readonly blockDB = new Map<string, Block>();
   private readonly typedBlocksDB = new Map<string, Block[]>();
-  private variableMap_: VariableMap;
+  private variableMap: VariableMap;
 
   /**
    * Blocks in the flyout can refer to variables that don't exist in the main
@@ -119,7 +119,7 @@ export class Workspace implements IASTNodeLocation {
    * these by tracking "potential" variables in the flyout.  These variables
    * become real when references to them are dragged into the main workspace.
    */
-  private potentialVariableMap_: VariableMap|null = null;
+  private potentialVariableMap: VariableMap|null = null;
 
   /** @param opt_options Dictionary of options. */
   constructor(opt_options?: Options) {
@@ -142,7 +142,7 @@ export class Workspace implements IASTNodeLocation {
      * all of the named variables in the workspace, including variables that are
      * not currently in use.
      */
-    this.variableMap_ = new VariableMap(this);
+    this.variableMap = new VariableMap(this);
   }
 
   /**
@@ -152,7 +152,7 @@ export class Workspace implements IASTNodeLocation {
    * @suppress {checkTypes}
    */
   dispose() {
-    this.listeners_.length = 0;
+    this.listeners.length = 0;
     this.clear();
     // Remove from workspace database.
     common.unregisterWorkpace(this);
@@ -193,7 +193,7 @@ export class Workspace implements IASTNodeLocation {
    * @param block Block to add.
    */
   addTopBlock(block: Block) {
-    this.topBlocks_.push(block);
+    this.topBlocks.push(block);
   }
 
   /**
@@ -202,7 +202,7 @@ export class Workspace implements IASTNodeLocation {
    * @param block Block to remove.
    */
   removeTopBlock(block: Block) {
-    if (!arrayUtils.removeElem(this.topBlocks_, block)) {
+    if (!arrayUtils.removeElem(this.topBlocks, block)) {
       throw Error('Block not present in workspace\'s list of top-most blocks.');
     }
   }
@@ -215,8 +215,8 @@ export class Workspace implements IASTNodeLocation {
    * @returns The top-level block objects.
    */
   getTopBlocks(ordered: boolean): Block[] {
-    // Copy the topBlocks_ list.
-    const blocks = (new Array<Block>()).concat(this.topBlocks_);
+    // Copy the topBlocks list.
+    const blocks = (new Array<Block>()).concat(this.topBlocks);
     if (ordered && blocks.length > 1) {
       // AnyDuringMigration because:  Property 'offset' does not exist on type
       // '(a: Block | WorkspaceComment, b: Block | WorkspaceComment) => number'.
@@ -296,7 +296,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   addTopComment(comment: WorkspaceComment) {
-    this.topComments_.push(comment);
+    this.topComments.push(comment);
 
     // Note: If the comment database starts to hold block comments, this may
     // need to move to a separate function.
@@ -315,7 +315,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   removeTopComment(comment: WorkspaceComment) {
-    if (!arrayUtils.removeElem(this.topComments_, comment)) {
+    if (!arrayUtils.removeElem(this.topComments, comment)) {
       throw Error(
           'Comment not present in workspace\'s list of top-most ' +
           'comments.');
@@ -334,8 +334,8 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   getTopComments(ordered: boolean): WorkspaceComment[] {
-    // Copy the topComments_ list.
-    const comments = (new Array<WorkspaceComment>()).concat(this.topComments_);
+    // Copy the topComments list.
+    const comments = (new Array<WorkspaceComment>()).concat(this.topComments);
     if (ordered && comments.length > 1) {
       // AnyDuringMigration because:  Property 'offset' does not exist on type
       // '(a: Block | WorkspaceComment, b: Block | WorkspaceComment) => number'.
@@ -393,18 +393,18 @@ export class Workspace implements IASTNodeLocation {
       if (!existingGroup) {
         eventUtils.setGroup(true);
       }
-      while (this.topBlocks_.length) {
-        this.topBlocks_[0].dispose(false);
+      while (this.topBlocks.length) {
+        this.topBlocks[0].dispose(false);
       }
-      while (this.topComments_.length) {
-        this.topComments_[this.topComments_.length - 1].dispose();
+      while (this.topComments.length) {
+        this.topComments[this.topComments.length - 1].dispose();
       }
       if (!existingGroup) {
         eventUtils.setGroup(false);
       }
-      this.variableMap_.clear();
-      if (this.potentialVariableMap_) {
-        this.potentialVariableMap_.clear();
+      this.variableMap.clear();
+      if (this.potentialVariableMap) {
+        this.potentialVariableMap.clear();
       }
     } finally {
       this.isClearing = false;
@@ -420,7 +420,7 @@ export class Workspace implements IASTNodeLocation {
    * @param newName New variable name.
    */
   renameVariableById(id: string, newName: string) {
-    this.variableMap_.renameVariableById(id, newName);
+    this.variableMap.renameVariableById(id, newName);
   }
 
   /**
@@ -436,7 +436,7 @@ export class Workspace implements IASTNodeLocation {
    */
   createVariable(name: string, opt_type?: string|null, opt_id?: string|null):
       VariableModel {
-    return this.variableMap_.createVariable(name, opt_type, opt_id);
+    return this.variableMap.createVariable(name, opt_type, opt_id);
   }
 
   /**
@@ -446,7 +446,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns Array of block usages.
    */
   getVariableUsesById(id: string): Block[] {
-    return this.variableMap_.getVariableUsesById(id);
+    return this.variableMap.getVariableUsesById(id);
   }
 
   /**
@@ -456,7 +456,7 @@ export class Workspace implements IASTNodeLocation {
    * @param id ID of variable to delete.
    */
   deleteVariableById(id: string) {
-    this.variableMap_.deleteVariableById(id);
+    this.variableMap.deleteVariableById(id);
   }
 
   /**
@@ -470,7 +470,7 @@ export class Workspace implements IASTNodeLocation {
    */
   getVariable(name: string, opt_type?: string): VariableModel|null {
     // TODO (#1559): Possibly delete this function after resolving #1559.
-    return this.variableMap_.getVariable(name, opt_type);
+    return this.variableMap.getVariable(name, opt_type);
   }
 
   /**
@@ -480,7 +480,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns The variable with the given ID.
    */
   getVariableById(id: string): VariableModel|null {
-    return this.variableMap_.getVariableById(id);
+    return this.variableMap.getVariableById(id);
   }
 
   /**
@@ -492,7 +492,7 @@ export class Workspace implements IASTNodeLocation {
    *     if none are found.
    */
   getVariablesOfType(type: string|null): VariableModel[] {
-    return this.variableMap_.getVariablesOfType(type);
+    return this.variableMap.getVariablesOfType(type);
   }
 
   /**
@@ -502,7 +502,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   getVariableTypes(): string[] {
-    return this.variableMap_.getVariableTypes(this);
+    return this.variableMap.getVariableTypes(this);
   }
 
   /**
@@ -511,7 +511,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns List of variable models.
    */
   getAllVariables(): VariableModel[] {
-    return this.variableMap_.getAllVariables();
+    return this.variableMap.getAllVariables();
   }
 
   /**
@@ -520,7 +520,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns List of all variable names of all types.
    */
   getAllVariableNames(): string[] {
-    return this.variableMap_.getAllVariableNames();
+    return this.variableMap.getAllVariableNames();
   }
   /* End functions that are just pass-throughs to the variable map. */
   /**
@@ -697,7 +697,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns Obsolete return value, ignore.
    */
   addChangeListener(func: Function): Function {
-    this.listeners_.push(func);
+    this.listeners.push(func);
     return func;
   }
 
@@ -707,7 +707,7 @@ export class Workspace implements IASTNodeLocation {
    * @param func Function to stop calling.
    */
   removeChangeListener(func: Function) {
-    arrayUtils.removeElem(this.listeners_, func);
+    arrayUtils.removeElem(this.listeners, func);
   }
 
   /**
@@ -723,8 +723,8 @@ export class Workspace implements IASTNodeLocation {
         this.undoStack_.shift();
       }
     }
-    for (let i = 0; i < this.listeners_.length; i++) {
-      const func = this.listeners_[i];
+    for (let i = 0; i < this.listeners.length; i++) {
+      const func = this.listeners[i];
       func(event);
     }
   }
@@ -798,7 +798,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   getPotentialVariableMap(): VariableMap|null {
-    return this.potentialVariableMap_;
+    return this.potentialVariableMap;
   }
 
   /**
@@ -807,7 +807,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   createPotentialVariableMap() {
-    this.potentialVariableMap_ = new VariableMap(this);
+    this.potentialVariableMap = new VariableMap(this);
   }
 
   /**
@@ -816,7 +816,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns The variable map.
    */
   getVariableMap(): VariableMap {
-    return this.variableMap_;
+    return this.variableMap;
   }
 
   /**
@@ -826,7 +826,7 @@ export class Workspace implements IASTNodeLocation {
    * @internal
    */
   setVariableMap(variableMap: VariableMap) {
-    this.variableMap_ = variableMap;
+    this.variableMap = variableMap;
   }
 
   /**

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -43,7 +43,7 @@ suite('Gesture', function() {
   }
 
   function getTopFlyoutBlock(flyout) {
-    return flyout.workspace_.topBlocks_[0];
+    return flyout.workspace_.getTopBlocks(false)[0];
   }
 
   setup(function() {

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -37,14 +37,14 @@ export function testAWorkspace() {
   });
 
   function assertBlockVarModelName(workspace, blockIndex, name) {
-    const block = workspace.topBlocks_[blockIndex];
-    chai.assert.exists(block, 'Block at topBlocks_[' + blockIndex + ']');
+    const block = workspace.getTopBlocks(false)[blockIndex];
+    chai.assert.exists(block, 'Block at topBlocks[' + blockIndex + ']');
     const varModel = block.getVarModels()[0];
     chai.assert.exists(varModel,
-        'VariableModel for block at topBlocks_[' + blockIndex + ']');
+        'VariableModel for block at topBlocks[' + blockIndex + ']');
     const blockVarName = varModel.name;
     chai.assert.equal(blockVarName, name,
-        'VariableModel name for block at topBlocks_[' + blockIndex + ']');
+        'VariableModel name for block at topBlocks[' + blockIndex + ']');
   }
 
   function createVarBlocksNoEvents(workspace, ids) {
@@ -68,8 +68,8 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
 
       this.workspace.clear();
-      chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      const varMapLength = this.workspace.variableMap_.variableMap.size;
+      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      const varMapLength = this.workspace.getVariableMap().variableMap.size;
       chai.assert.equal(varMapLength, 0);
     });
 
@@ -78,8 +78,8 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
 
       this.workspace.clear();
-      chai.assert.equal(this.workspace.topBlocks_.length, 0);
-      const varMapLength = this.workspace.variableMap_.variableMap.size;
+      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      const varMapLength = this.workspace.getVariableMap().variableMap.size;
       chai.assert.equal(varMapLength, 0);
     });
   });
@@ -1272,7 +1272,7 @@ export function testAWorkspace() {
 
           this.workspace.undo(true);
           // Expect that both variables are deleted
-          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
           chai.assert.isNull(this.workspace.getVariableById('id1'));
           chai.assert.isNull(this.workspace.getVariableById('id2'));
 
@@ -1338,12 +1338,12 @@ export function testAWorkspace() {
 
           // Redo delete
           this.workspace.undo(true);
-          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
           chai.assert.isNull(this.workspace.getVariableById('id1'));
 
           // Redo delete, nothing should happen
           this.workspace.undo(true);
-          chai.assert.equal(this.workspace.topBlocks_.length, 0);
+          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
           chai.assert.isNull(this.workspace.getVariableById('id1'));
         });
       });


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

General cleanup.

### Proposed Changes

Renames private properties in `workspace.ts` to remove underscores.

In the process, I found many tests that accessed private properties directly instead of using getters, and fixed them. This means those tests are now using external APIs.

#### Behavior Before Change

No change

#### Behavior After Change

No change

### Reason for Changes

General cleanup, and conformance with the google style guide.

### Test Coverage

Standard Mocha tests

### Documentation
None

### Additional Information

<!-- Anything else we should know? -->
