### PR TITLE
fix: parent blocks not bumping neighbours

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1565,9 +1565,12 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       }
 
       for (const neighbour of conn.neighbours(config.snapRadius)) {
+        // Don't bump away from things that are in our stack.
         if (neighbourIsInStack(neighbour)) continue;
+        // If both connections are connected, that's fine.
         if (conn.isConnected() && neighbour.isConnected()) continue;
 
+        // Always bump the inferior connection.
         if (conn.isSuperior()) {
           neighbour.bumpAwayFrom(conn);
         } else {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1535,45 +1535,43 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   }
 
   /**
-   * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
-   * connected should not coincidentally line up on screen.
+   * Bumps unconnected blocks out of alignment.
+   *
+   * Two blocks which aren't actually connected should not coincidentally line
+   * up on screen, because that creates confusion for end-users.
    */
   override bumpNeighbours() {
-    if (this.isDeadOrDying()) {
+    this.getRootBlock().bumpNeighboursInternal();
+  }
+
+  /**
+   * Bumps unconnected blocks out of alignment.
+   */
+  private bumpNeighboursInternal() {
+    const root = this.getRootBlock();
+    if (this.isDeadOrDying() || this.workspace.isDragging() ||
+        root.isInFlyout) {
       return;
     }
-    if (this.workspace.isDragging()) {
-      return;
+
+    function neighbourIsInStack(neighbour: RenderedConnection) {
+      return neighbour.getSourceBlock().getRootBlock() === root;
     }
-    const rootBlock = this.getRootBlock();
-    if (rootBlock.isInFlyout) {
-      return;
-    }
-    // Don't move blocks around in a flyout.
-    // Loop through every connection on this block.
-    const myConnections = this.getConnections_(false);
-    for (let i = 0, connection; connection = myConnections[i]; i++) {
-      const renderedConn = (connection);
-      // Spider down from this block bumping all sub-blocks.
-      if (renderedConn.isConnected() && renderedConn.isSuperior()) {
-        renderedConn.targetBlock()!.bumpNeighbours();
+
+    for (const conn of this.getConnections_(false)) {
+      if (conn.isSuperior()) {
+        // Recurse down the block stack.
+        conn.targetBlock()?.bumpNeighboursInternal();
       }
 
-      const neighbours = connection.neighbours(config.snapRadius);
-      for (let j = 0, otherConnection; otherConnection = neighbours[j]; j++) {
-        const renderedOther = otherConnection as RenderedConnection;
-        // If both connections are connected, that's probably fine.  But if
-        // either one of them is unconnected, then there could be confusion.
-        if (!renderedConn.isConnected() || !renderedOther.isConnected()) {
-          // Only bump blocks if they are from different tree structures.
-          if (renderedOther.getSourceBlock().getRootBlock() !== rootBlock) {
-            // Always bump the inferior block.
-            if (renderedConn.isSuperior()) {
-              renderedOther.bumpAwayFrom(renderedConn);
-            } else {
-              renderedConn.bumpAwayFrom(renderedOther);
-            }
-          }
+      for (const neighbour of conn.neighbours(config.snapRadius)) {
+        if (neighbourIsInStack(neighbour)) continue;
+        if (conn.isConnected() && neighbour.isConnected()) continue;
+
+        if (conn.isSuperior()) {
+          neighbour.bumpAwayFrom(conn);
+        } else {
+          conn.bumpAwayFrom(neighbour);
         }
       }
     }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -499,7 +499,7 @@ export class RenderedConnection extends Connection {
    * @returns List of connections.
    * @internal
    */
-  override neighbours(maxLimit: number): Connection[] {
+  override neighbours(maxLimit: number): RenderedConnection[] {
     return this.dbOpposite_.getNeighbours(this, maxLimit);
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#6017 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
makes it so that whenever a block in a block stack has `bumpNeighbours` called on it, all of the connections in the block stack bump.

We have to bump every single connection, because with custom renderers, we can't predict how blocks will be shaped based on other blocks. E.g. in geras higher sibling connections don't move, but in other renderers they might. So we have to trigger bumping on everything.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Parent blocks would not bump neighbours when a child block was rerendered.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Parent blocks do bump neighbours when a child block is rerendered.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Having blocks appear tto be connected (visually) without actually being connected (in terms of code generation) can cause confusing results and frustration for end-users. This helps eliminate that.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Also did some code cleanup of `bumpNeighbours` while I was in the area.