### PR TITLE
fix: fix pinch to zoom

### DIFF
--- a/core/touch.ts
+++ b/core/touch.ts
@@ -158,18 +158,18 @@ export function shouldHandleEvent(e: Event|PseudoEvent): boolean {
  * Get the touch identifier from the given event.  If it was a mouse event, the
  * identifier is the string 'mouse'.
  *
- * @param e Mouse event or touch event.
- * @returns The touch identifier from the first changed touch, if defined.
+ * @param e Pointer event, mouse event, or touch event.
+ * @returns The pointerId, or touch identifier from the first changed touch, if defined.
  *     Otherwise 'mouse'.
  * @alias Blockly.Touch.getTouchIdentifierFromEvent
  */
 export function getTouchIdentifierFromEvent(e: Event|PseudoEvent): string {
-  if (e instanceof MouseEvent) {
-    return 'mouse';
-  }
-
   if (e instanceof PointerEvent) {
     return String(e.pointerId);
+  }
+  
+  if (e instanceof MouseEvent) {
+    return 'mouse';
   }
 
   /**

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -159,15 +159,15 @@ export function shouldHandleEvent(e: Event|PseudoEvent): boolean {
  * identifier is the string 'mouse'.
  *
  * @param e Pointer event, mouse event, or touch event.
- * @returns The pointerId, or touch identifier from the first changed touch, if defined.
- *     Otherwise 'mouse'.
+ * @returns The pointerId, or touch identifier from the first changed touch, if
+ *     defined. Otherwise 'mouse'.
  * @alias Blockly.Touch.getTouchIdentifierFromEvent
  */
 export function getTouchIdentifierFromEvent(e: Event|PseudoEvent): string {
   if (e instanceof PointerEvent) {
     return String(e.pointerId);
   }
-  
+
   if (e instanceof MouseEvent) {
     return 'mouse';
   }

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -97,6 +97,7 @@
           'Blockly.test.registry',
           'Blockly.test.serialization',
           'Blockly.test.shortcutRegistry',
+          'Blockly.test.touch',
           'Blockly.test.theme',
           'Blockly.test.toolbox',
           'Blockly.test.tooltip',

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ goog.declareModuleId('Blockly.test.touch');
+
+ import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+ 
+ suite('Touch', function() {
+    setup(function() {
+        sharedTestSetup.call(this);
+    });
+
+    teardown(function() {
+        Blockly.Touch.clearTouchIdentifier();
+        sharedTestTeardown.call(this);
+    });
+
+    suite('shouldHandleTouch', function() {
+        test('handles mousedown event', function() {
+            const mouseEvent = new MouseEvent('mousedown');
+            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(mouseEvent));
+        });
+
+        test('handles multiple mousedown events', function() {
+            const mouseEvent1 = new MouseEvent('mousedown');
+            const mouseEvent2 = new MouseEvent('mousedown');
+            Blockly.Touch.shouldHandleEvent(mouseEvent1);
+            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(mouseEvent2));
+        });
+
+        test('does not handle mouseup if not tracking touch', function() {
+            const mouseEvent = new MouseEvent('mouseup');
+            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(mouseEvent));
+        });
+
+        test('handles mouseup if already tracking a touch', function() {
+            const mousedown = new MouseEvent('mousedown');
+            const mouseup = new MouseEvent('mouseup');
+            // Register the mousedown event first
+            Blockly.Touch.shouldHandleEvent(mousedown);
+            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(mouseup));
+        });
+
+        test('handles pointerdown if this is a new touch', function() {
+            const pointerdown = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerdown));
+        });
+
+        test('does not handle pointerdown if part of a different touch', function() {
+            const pointerdown1 = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+            const pointerdown2 = new PointerEvent('pointerdown', {pointerId: 2, pointerType: 'touch'});
+            Blockly.Touch.shouldHandleEvent(pointerdown1);
+            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown2));
+        });
+
+        test('does not handle pointerdown after a mousedown', function() {
+            const mouseEvent = new MouseEvent('mousedown');
+            const pointerdown = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+            Blockly.Touch.shouldHandleEvent(mouseEvent);
+            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown));
+        });
+
+        test('does not handle pointerup if not tracking touch', function() {
+            const pointerup = new PointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'});
+            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerup));
+        });
+
+        test('handles pointerup if part of existing touch', function() {
+            const pointerdown = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+            const pointerup = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+            Blockly.Touch.shouldHandleEvent(pointerdown);
+            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
+        });
+    });
+
+    suite('getTouchIdentifierFromEvent', function() {
+        test('is mouse for MouseEvents', function() {
+            const mousedown = new MouseEvent('mousedown');
+            chai.assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(mousedown), 'mouse');
+        });
+
+        test('is pointerId for mouse PointerEvents', function() {
+            const pointerdown = new PointerEvent('pointerdown', {pointerId: 7, pointerType: 'mouse'});
+            chai.assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 7);
+        });
+
+        test('is pointerId for touch PointerEvents', function() {
+            const pointerdown = new PointerEvent('pointerdown', {pointerId: 42, pointerType: 'touch'});
+            chai.assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 42);
+        });
+    });
+ });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

fixes #6508 

### Proposed Changes

- Correctly sets the current gesture id the same way it did before #6099 (if the pointerId exists, use that, mostly)
- Adds tests for Blockly.Touch. I didn't write any tests for `TouchEvent`s because I literally couldn't test Blockly in a browser that doesn't support Pointer Events (even IE 10 mostly supports them, and we can't even test in IE11 because we no longer support it in other ways). The MouseEvent tests are also pretty useless for that reason, but it was easier to write a fake MouseEvent.

#### Behavior Before Change

Pinch to zoom is broken because `Touch.getTouchIdentifierFromEvent` always returns the string `'mouse'` for all pointer events, which is all events in modern browsers. The reason it always returns that is because `PointerEvent` is actually a subclass of `MouseEvent` so we always enter the first if statement.

#### Behavior After Change

`Touch.getTouchIdentifierFromEvent` returns `event.pointerId` for `PointerEvent`s first. If somehow we don't have a PointerEvent, which is extremely unlikely, then we fall back to the old behavior of 'mouse' if it's a `MouseEvent` and checking `changedTouches` if it's a `TouchEvent`. Note that even if we have a `PointerEvent` where the `pointerType` is `mouse`, we still use the `pointerId` and not the string `'mouse'` as that matches the old behavior from before #6099.

### Reason for Changes

fixes broken pinch to zoom

### Test Coverage

- Added unit tests 
- Manually tested using BrowserStack in iOS, Android, and Windows. Also tested in local playground using mouse. Note that all of these manual tests use `PointerEvent`s as Blockly isn't actually supported in any environment that doesn't support `PointerEvent`s.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I'm 99% certain that we could change `getTouchIdentifierFromEvent` to simply `return e.pointerId`, since PointerEvents are now robustly supported. But I'll leave that to #6543.
