### PR TITLE
chore: clean up code in field_angle.ts

### DIFF
--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -70,19 +70,36 @@ export class FieldAngle extends FieldTextInput {
    * otherwise SVG crops off half the border at the edges.
    */
   static readonly RADIUS: number = FieldAngle.HALF - 1;
-  private clockwise_: boolean;
-  private offset_: number;
-  private wrap_: number;
-  private round_: number;
+
+  /**
+   * Whether the angle should increase as the angle picker is moved clockwise
+   * (true) or counterclockwise (false).
+   */
+  private clockwise_ = FieldAngle.CLOCKWISE;
+
+  /**
+   * The offset of zero degrees (and all other angles).
+   */
+  private offset_ = FieldAngle.OFFSET;
+
+  /**
+   * The maximum angle to allow before wrapping.
+   */
+  private wrap_ = FieldAngle.WRAP;
+
+  /**
+   * The amount to round angles to when using a mouse or keyboard nav input.
+   */
+  private round_ = FieldAngle.ROUND;
 
   /** The angle picker's SVG element. */
-  private editor_: SVGElement|null = null;
+  private editor_: SVGSVGElement|null = null;
 
   /** The angle picker's gauge path depending on the value. */
-  gauge_: SVGElement|null = null;
+  gauge_: SVGPathElement|null = null;
 
   /** The angle picker's line drawn representing the value's angle. */
-  line_: SVGElement|null = null;
+  line_: SVGLineElement|null = null;
 
   /** The degree symbol for this field. */
   // AnyDuringMigration because:  Type 'null' is not assignable to type
@@ -121,35 +138,6 @@ export class FieldAngle extends FieldTextInput {
       opt_value?: string|number|Sentinel, opt_validator?: Function,
       opt_config?: FieldAngleConfig) {
     super(Field.SKIP_SETUP);
-
-    /**
-     * Should the angle increase as the angle picker is moved clockwise (true)
-     * or counterclockwise (false)
-     *
-     * @see FieldAngle.CLOCKWISE
-     */
-    this.clockwise_ = FieldAngle.CLOCKWISE;
-
-    /**
-     * The offset of zero degrees (and all other angles).
-     *
-     * @see FieldAngle.OFFSET
-     */
-    this.offset_ = FieldAngle.OFFSET;
-
-    /**
-     * The maximum angle to allow before wrapping.
-     *
-     * @see FieldAngle.WRAP
-     */
-    this.wrap_ = FieldAngle.WRAP;
-
-    /**
-     * The amount to round angles to when using a mouse or keyboard nav input.
-     *
-     * @see FieldAngle.ROUND
-     */
-    this.round_ = FieldAngle.ROUND;
 
     if (opt_value === Field.SKIP_SETUP) {
       return;
@@ -223,9 +211,7 @@ export class FieldAngle extends FieldTextInput {
     super.showEditor_(opt_e, noFocus);
 
     this.dropdownCreate_();
-    // AnyDuringMigration because:  Argument of type 'SVGElement | null' is not
-    // assignable to parameter of type 'Node'.
-    dropDownDiv.getContentDiv().appendChild(this.editor_ as AnyDuringMigration);
+    dropDownDiv.getContentDiv().appendChild(this.editor_!);
 
     if (this.sourceBlock_ instanceof BlockSvg) {
       dropDownDiv.setColour(
@@ -427,25 +413,18 @@ export class FieldAngle extends FieldTextInput {
   protected override onHtmlInputKeyDown_(e: Event) {
     super.onHtmlInputKeyDown_(e);
 
+    const keyboardEvent = e as KeyboardEvent;
     let multiplier;
-    // AnyDuringMigration because:  Property 'keyCode' does not exist on type
-    // 'Event'.
-    if ((e as AnyDuringMigration).keyCode === KeyCodes.LEFT) {
+    if (keyboardEvent.keyCode === KeyCodes.LEFT) {
       // decrement (increment in RTL)
       multiplier = this.getSourceBlock().RTL ? 1 : -1;
-      // AnyDuringMigration because:  Property 'keyCode' does not exist on type
-      // 'Event'.
-    } else if ((e as AnyDuringMigration).keyCode === KeyCodes.RIGHT) {
+    } else if (keyboardEvent.keyCode === KeyCodes.RIGHT) {
       // increment (decrement in RTL)
       multiplier = this.getSourceBlock().RTL ? -1 : 1;
-      // AnyDuringMigration because:  Property 'keyCode' does not exist on type
-      // 'Event'.
-    } else if ((e as AnyDuringMigration).keyCode === KeyCodes.DOWN) {
+    } else if (keyboardEvent.keyCode === KeyCodes.DOWN) {
       // decrement
       multiplier = -1;
-      // AnyDuringMigration because:  Property 'keyCode' does not exist on type
-      // 'Event'.
-    } else if ((e as AnyDuringMigration).keyCode === KeyCodes.UP) {
+    } else if (keyboardEvent.keyCode === KeyCodes.UP) {
       // increment
       multiplier = 1;
     }


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Removes some `AnyDuringMigrations`.

### Proposed Changes

Remove some uses of `AnyDuringMigration` and set default values in the class declaration instead of the constructor. Also move property comments to the class declaration, which I think will make them show up in our generated documentation, and make some SVG element types more accurate.

I tried to also rename properties to not have underscores, but we're checking those properties a lot in the tests, so more work is needed there.

#### Behavior Before Change

No change.

#### Behavior After Change

No change.

### Reason for Changes

Incremental cleanup.

### Test Coverage

Mocha tests.

### Documentation

Should slightly improve generated documentation.

### Additional Information

Angle field tests check private properties, specifically while checking that the constructor runs correctly.
