### PR TITLE
chore: fix mutator blocks jumping

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -188,7 +188,11 @@ function disconnectUiStep(group: SVGElement, magnitude: number, start: Date) {
     skew = `skewX(${val})`;
     disconnectPid = setTimeout(disconnectUiStep, 10, group, magnitude, start);
   }
-  group.setAttribute('transform', skew);
+  (group as AnyDuringMigration).skew_ = skew;
+  group.setAttribute(
+    'transform',
+    (group as AnyDuringMigration).translate_ +
+    (group as AnyDuringMigration).skew_);
 }
 
 /**
@@ -202,7 +206,9 @@ export function disconnectUiStop() {
     if (disconnectPid) {
       clearTimeout(disconnectPid);
     }
-    disconnectGroup.setAttribute('transform', '');
+    const group = disconnectGroup;
+    (group as AnyDuringMigration).skew_ = '';
+    group.setAttribute('transform', (group as AnyDuringMigration).translate_);
     disconnectGroup = null;
   }
 }

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -190,9 +190,9 @@ function disconnectUiStep(group: SVGElement, magnitude: number, start: Date) {
   }
   (group as AnyDuringMigration).skew_ = skew;
   group.setAttribute(
-    'transform',
-    (group as AnyDuringMigration).translate_ +
-    (group as AnyDuringMigration).skew_);
+      'transform',
+      (group as AnyDuringMigration).translate_ +
+          (group as AnyDuringMigration).skew_);
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6541 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Reverts changes made in #6301 that caused jumping.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs are bad.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested the repro steps from #6541 

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Thank you to Maribeth for the bisect + cherrypick idea!

Also for now I've just reverted the bug-causing changes. But I'm also going to file a bug for actually refactoring this system to be more testable + less stateful + not use private properties on svg elements.
