### PR TITLE
chore: update procedure map tests to match the refactored API

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -602,6 +602,7 @@ export {Css};
 export {Events};
 export {Extensions};
 export {Procedures};
+export {Procedures as procedures};
 export {ShortcutItems};
 export {Themes};
 export {Tooltip};

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -25,6 +25,9 @@ import * as eventUtils from './events/utils.js';
 import {Field, UnattachedFieldError} from './field.js';
 import {Msg} from './msg.js';
 import {Names} from './names.js';
+import {ObservableProcedureMap} from './procedures/observable_procedure_map.js';
+import {ObservableProcedureModel} from './procedures/observable_procedure_model.js';
+import {ObservableParameterModel} from './procedures/observable_parameter_model.js';
 import * as utilsXml from './utils/xml.js';
 import * as Variables from './variables.js';
 import type {Workspace} from './workspace.js';
@@ -449,4 +452,10 @@ export function getDefinition(name: string, workspace: Workspace): Block|null {
     }
   }
   return null;
+}
+
+export {
+  ObservableProcedureMap,
+  ObservableProcedureModel,
+  ObservableParameterModel,
 }

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -458,4 +458,4 @@ export {
   ObservableProcedureMap,
   ObservableProcedureModel,
   ObservableParameterModel,
-}
+};

--- a/core/procedures/observable_parameter_model.ts
+++ b/core/procedures/observable_parameter_model.ts
@@ -25,6 +25,7 @@ export class ObservableParameterModel implements IParameterModel {
    * Sets the name of this parameter to the given name.
    */
   setName(name: string): this {
+    // TODO(#6516): Fire events.
     if (name == this.variable.name) return this;
     this.variable =
         this.workspace.getVariable(name) ?? this.workspace.createVariable(name);

--- a/core/procedures/observable_procedure_model.ts
+++ b/core/procedures/observable_procedure_model.ts
@@ -23,6 +23,7 @@ export class ObservableProcedureModel implements IProcedureModel {
 
   /** Sets the human-readable name of the procedure. */
   setName(name: string): this {
+    // TODO(#6516): Fire events.
     this.name = name;
     return this;
   }
@@ -33,12 +34,14 @@ export class ObservableProcedureModel implements IProcedureModel {
    * To move a parameter, first delete it, and then re-insert.
    */
   insertParameter(parameterModel: IParameterModel, index: number): this {
+    // TODO(#6516): Fire events.
     this.parameters.splice(index, 0, parameterModel);
     return this;
   }
 
   /** Removes the parameter at the given index from the parameter list. */
   deleteParameter(index: number): this {
+    // TODO(#6516): Fire events.
     this.parameters.splice(index, 1);
     return this;
   }
@@ -49,6 +52,7 @@ export class ObservableProcedureModel implements IProcedureModel {
    * Pass null to represent a procedure that does not return.
    */
   setReturnTypes(types: string[]|null): this {
+    // TODO(#6516): Fire events.
     this.returnTypes = types;
     return this;
   }
@@ -58,6 +62,7 @@ export class ObservableProcedureModel implements IProcedureModel {
    * all procedure caller blocks should be disabled as well.
    */
   setEnabled(enabled: boolean): this {
+    // TODO(#6516): Fire events.
     this.enabled = enabled;
     return this;
   }

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -73,7 +73,7 @@ suite('Procedure Map', function() {
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
         this.procedureMap.addProcedure(procedureModel);
 
-        procedureModel.setReturnType(['return type 1', 'return type 2']);
+        procedureModel.setReturnTypes(['return type 1', 'return type 2']);
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -84,9 +84,9 @@ suite('Procedure Map', function() {
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
         this.procedureMap.addProcedure(procedureModel);
 
-        procedureModel.setReturnType(['return type']);
+        procedureModel.setReturnTypes(['return type']);
         this.updateSpy.reset();
-        procedureModel.setReturnType(null);
+        procedureModel.setReturnTypes(null);
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -144,17 +144,16 @@ suite('Procedure Map', function() {
     });
 
     suite('parameter model updates', function() {
-      test('setting the variable model triggers an update', function() {
+      test('setting the name triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
         this.procedureMap.addProcedure(procedureModel);
-        const parameterModel =
-            new Blockly.procedures.ObservableParameterModel(this.workspace);
+        const parameterModel = new Blockly.procedures.ObservableParameterModel(
+            this.workspace, 'test1');
         procedureModel.insertParameter(parameterModel);
         this.updateSpy.reset();
 
-        parameterModel.setVariable(
-            new Blockly.VariableModel(this.workspace, 'variable'));
+        parameterModel.setName('test2');
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -164,12 +163,9 @@ suite('Procedure Map', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
         this.procedureMap.addProcedure(procedureModel);
-        const parameterModel =
-            new Blockly.procedures.ObservableParameterModel(this.workspace);
+        const parameterModel = new Blockly.procedures.ObservableParameterModel(
+            this.workspace, 'test1');
         procedureModel.insertParameter(parameterModel);
-        const variableModel =
-            new Blockly.VariableModel(this.workspace, 'variable');
-        parameterModel.setVariable(variableModel);
         this.updateSpy.reset();
 
         variableModel.name = 'some name';

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -8,18 +8,18 @@ import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown
 
 goog.declareModuleId('Blockly.test.procedureMap');
 
-suite.skip('Procedure Map', function() {
+suite('Procedure Map', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
-    this.procedureMap = this.workspace.getProcedureMap();
+    //this.procedureMap = this.workspace.getProcedureMap();
   });
 
   teardown(function() {
     sharedTestTeardown.call(this);
   });
 
-  suite('triggering block updates', function() {
+  suite.skip('triggering block updates', function() {
     setup(function() {
       Blockly.Blocks['procedure_mock'] = {
         init: function() { },
@@ -184,4 +184,67 @@ suite.skip('Procedure Map', function() {
   suite('event firing', function() {
     // TBA after the procedure map is implemented
   });
+
+  suite('backing variable to parameters', function() {
+    test(
+        'construction references an existing variable if available',
+        function() {
+          const variable = this.workspace.createVariable('test1');
+          const param = new Blockly.procedures.ObservableParameterModel(
+              this.workspace, 'test1');
+
+          console.log(param);
+
+          chai.assert.equal(
+              variable,
+              param.getVariableModel(),
+              'Expected the parameter model to reference the existing variable');
+        });
+
+    test('construction creates a variable if none exists', function() {
+      const param = new Blockly.procedures.ObservableParameterModel(
+          this.workspace, 'test1');
+
+      chai.assert.equal(
+          this.workspace.getVariable('test1'),
+          param.getVariableModel(),
+          'Expected the parameter model to create a variable');
+    });
+
+    test('setName references an existing variable if available', function() {
+      const variable = this.workspace.createVariable('test2');
+      const param = new Blockly.procedures.ObservableParameterModel(
+          this.workspace, 'test1');
+
+      param.setName('test2');
+
+      chai.assert.equal(
+          variable,
+          param.getVariableModel(),
+          'Expected the parameter model to reference the existing variable');
+    });
+
+    test('setName creates a variable if none exits', function() {
+      const param = new Blockly.procedures.ObservableParameterModel(
+          this.workspace, 'test1');
+
+      param.setName('test2');
+
+      chai.assert.equal(
+          this.workspace.getVariable('test2'),
+          param.getVariableModel(),
+          'Expected the parameter model to create a variable');
+    });
+
+    test('setTypes is unimplemented', function() {
+      const param = new Blockly.procedures.ObservableParameterModel(
+          this.workspace, 'test1');
+
+      chai.assert.throws(
+        () => {
+          param.setTypes(['some', 'types']);
+        },
+        'The built-in ParameterModel does not support typing');
+    });
+  })
 });

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -12,7 +12,7 @@ suite('Procedure Map', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
-    this.procedureMap = this.workspace.getProcedureMap();
+    // this.procedureMap = this.workspace.getProcedureMap();
   });
 
   teardown(function() {

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -13,6 +13,8 @@ suite('Procedure Map', function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
     //this.procedureMap = this.workspace.getProcedureMap();
+    this.procedureMap =
+        new Blockly.procedures.ObservableProcedureMap(this.workspace);
   });
 
   teardown(function() {
@@ -36,8 +38,17 @@ suite('Procedure Map', function() {
     });
 
     suite('procedure map updates', function() {
+      test('inserting a procedure does not trigger an update', function() {
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
+        this.procedureMap.set(procedureModel.getId(), procedureModel);
+
+        chai.assert.isFalse(
+            this.updateSpy.called, 'Expected no update to be triggered');
+      });
+
       test('adding a procedure does not trigger an update', function() {
-        this.procedureMap.addProcedure(
+        this.procedureMap.add(
             new Blockly.procedures.ObservableProcedureModel(this.workspace));
 
         chai.assert.isFalse(
@@ -47,9 +58,9 @@ suite('Procedure Map', function() {
       test('deleting a procedure triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
 
-        this.procedureMap.deleteProcedure(procedureModel.getId());
+        this.procedureMap.delete(procedureModel.getId());
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -60,7 +71,7 @@ suite('Procedure Map', function() {
       test('setting the name triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setName('new name');
 
@@ -71,7 +82,7 @@ suite('Procedure Map', function() {
       test('setting the return type triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setReturnTypes(['return type 1', 'return type 2']);
 
@@ -82,10 +93,11 @@ suite('Procedure Map', function() {
       test('removing the return type triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
-
+        this.procedureMap.add(procedureModel);
         procedureModel.setReturnTypes(['return type']);
-        this.updateSpy.reset();
+        console.log(this.updateSpy);
+        this.updateSpy.resetHistory();
+
         procedureModel.setReturnTypes(null);
 
         chai.assert.isTrue(
@@ -95,7 +107,7 @@ suite('Procedure Map', function() {
       test('disabling the procedure triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setEnabled(false);
 
@@ -106,9 +118,9 @@ suite('Procedure Map', function() {
       test('enabling the procedure triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
         procedureModel.setEnabled(false);
-        this.updateSpy.reset();
+        this.updateSpy.resetHistory();
 
         procedureModel.setEnabled(true);
 
@@ -119,7 +131,7 @@ suite('Procedure Map', function() {
       test('inserting a parameter triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.insertParameter(
             new Blockly.procedures.ObservableParameterModel(this.workspace));
@@ -131,10 +143,10 @@ suite('Procedure Map', function() {
       test('deleting a parameter triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
         procedureModel.insertParameter(
             new Blockly.procedures.ObservableParameterModel(this.workspace));
-        this.updateSpy.reset();
+        this.updateSpy.resetHistory();
 
         procedureModel.deleteParameter(0);
 
@@ -147,11 +159,11 @@ suite('Procedure Map', function() {
       test('setting the name triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
         const parameterModel = new Blockly.procedures.ObservableParameterModel(
             this.workspace, 'test1');
         procedureModel.insertParameter(parameterModel);
-        this.updateSpy.reset();
+        this.updateSpy.resetHistory();
 
         parameterModel.setName('test2');
 
@@ -162,11 +174,12 @@ suite('Procedure Map', function() {
       test('modifying the variable model does not trigger an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.addProcedure(procedureModel);
+        this.procedureMap.add(procedureModel);
         const parameterModel = new Blockly.procedures.ObservableParameterModel(
             this.workspace, 'test1');
         procedureModel.insertParameter(parameterModel);
-        this.updateSpy.reset();
+        const variableModel = parameterModel.getVariableModel();
+        this.updateSpy.resetHistory();
 
         variableModel.name = 'some name';
         variableModel.type = 'some type';

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -19,6 +19,7 @@ suite('Procedure Map', function() {
     sharedTestTeardown.call(this);
   });
 
+  // TODO (#6515): Unskip tests.
   suite.skip('triggering block updates', function() {
     setup(function() {
       Blockly.Blocks['procedure_mock'] = {

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -55,7 +55,7 @@ suite('Procedure Map', function() {
 
       test('deleting a procedure triggers an update', function() {
         const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
         this.procedureMap.add(procedureModel);
 
         this.procedureMap.delete(procedureModel.getId());

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -54,10 +54,11 @@ suite('Procedure Map', function() {
       });
 
       test('deleting a procedure triggers an update', function() {
-        this.procedureMap.add(
-            new Blockly.procedures.ObservableProcedureModel(this.workspace));
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+        this.procedureMap.add(procedureModel);
 
-        this.procedureMap.delete([...this.procedureMap.values()][0].getId());
+        this.procedureMap.delete(procedureModel.getId());
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -66,9 +67,9 @@ suite('Procedure Map', function() {
 
     suite('procedure model updates', function() {
       test('setting the name triggers an update', function() {
-        this.procedureMap.add(
-            new Blockly.procedures.ObservableProcedureModel(this.workspace));
-        const procedureModel = [...this.procedureMap.values()][0];
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setName('new name');
 
@@ -77,9 +78,9 @@ suite('Procedure Map', function() {
       });
   
       test('setting the return type triggers an update', function() {
-        this.procedureMap.add(
-            new Blockly.procedures.ObservableProcedureModel(this.workspace));
-        const procedureModel = [...this.procedureMap.values()][0];
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setReturnTypes(['return type 1', 'return type 2']);
 
@@ -88,10 +89,10 @@ suite('Procedure Map', function() {
       });
   
       test('removing the return type triggers an update', function() {
-        this.procedureMap.add(
+        const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace)
-                .setReturnTypes(['return type']));
-        const procedureModel = [...this.procedureMap.values()][0];
+                .setReturnTypes(['return type']);
+        this.procedureMap.add(procedureModel);
         this.updateSpy.resetHistory();
 
         procedureModel.setReturnTypes(null);
@@ -101,9 +102,9 @@ suite('Procedure Map', function() {
       });
   
       test('disabling the procedure triggers an update', function() {
-        this.procedureMap.add(
-            new Blockly.procedures.ObservableProcedureModel(this.workspace));
-        const procedureModel = [...this.procedureMap.values()][0];
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.setEnabled(false);
 
@@ -112,10 +113,10 @@ suite('Procedure Map', function() {
       });
   
       test('enabling the procedure triggers an update', function() {
-        this.procedureMap.add(
+        const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace)
-                .setEnabled(false));
-        const procedureModel = [...this.procedureMap.values()][0];
+                .setEnabled(false);
+        this.procedureMap.add(procedureModel);
         this.updateSpy.resetHistory();
 
         procedureModel.setEnabled(true);
@@ -125,9 +126,9 @@ suite('Procedure Map', function() {
       });
 
       test('inserting a parameter triggers an update', function() {
-        this.procedureMap.add(
-            new Blockly.procedures.ObservableProcedureModel(this.workspace));
-        const procedureModel = [...this.procedureMap.values()][0];
+        const procedureModel =
+            new Blockly.procedures.ObservableProcedureModel(this.workspace);
+        this.procedureMap.add(procedureModel);
 
         procedureModel.insertParameter(
             new Blockly.procedures.ObservableParameterModel(this.workspace));
@@ -137,12 +138,12 @@ suite('Procedure Map', function() {
       });
   
       test('deleting a parameter triggers an update', function() {
-        this.procedureMap.add(
+        const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(this.workspace)
                 .insertParameter(
                     new Blockly.procedures.ObservableParameterModel(
-                        this.workspace)));
-        const procedureModel = [...this.procedureMap.values()][0];
+                        this.workspace));
+        this.procedureMap.add(procedureModel);
         this.updateSpy.resetHistory();
 
         procedureModel.deleteParameter(0);
@@ -154,13 +155,12 @@ suite('Procedure Map', function() {
 
     suite('parameter model updates', function() {
       test('setting the name triggers an update', function() {
+        const parameterModel =
+            new Blockly.procedures.ObservableParameterModel(
+                this.workspace, 'test1');
         this.procedureMap.add(
             new Blockly.procedures.ObservableProcedureModel(this.workspace)
-                .insertParameter(
-                    new Blockly.procedures.ObservableParameterModel(
-                        this.workspace, 'test1')));
-        const parameterModel =
-            [...this.procedureMap.values()][0].getParameter(0);
+                .insertParameter(parameterModel));
         this.updateSpy.resetHistory();
 
         parameterModel.setName('test2');
@@ -170,15 +170,15 @@ suite('Procedure Map', function() {
       });
   
       test('modifying the variable model does not trigger an update', function() {
+        const parameterModel =
+            new Blockly.procedures.ObservableParameterModel(
+                this.workspace, 'test1');
         this.procedureMap.add(
             new Blockly.procedures.ObservableProcedureModel(this.workspace)
-                .insertParameter(
-                    new Blockly.procedures.ObservableParameterModel(
-                        this.workspace, 'test1')));
-        const variableModel =
-            [...this.procedureMap.values()][0].getParameter(0).getVariableModel();
+                .insertParameter(parameterModel));
         this.updateSpy.resetHistory();
 
+        const variableModel = parameterModel.getVariableModel();
         variableModel.name = 'some name';
         variableModel.type = 'some type';
 
@@ -199,8 +199,6 @@ suite('Procedure Map', function() {
           const variable = this.workspace.createVariable('test1');
           const param = new Blockly.procedures.ObservableParameterModel(
               this.workspace, 'test1');
-
-          console.log(param);
 
           chai.assert.equal(
               variable,

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -56,11 +56,10 @@ suite('Procedure Map', function() {
       });
 
       test('deleting a procedure triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace));
 
-        this.procedureMap.delete(procedureModel.getId());
+        this.procedureMap.delete([...this.procedureMap.values()][0].getId());
 
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
@@ -69,9 +68,9 @@ suite('Procedure Map', function() {
 
     suite('procedure model updates', function() {
       test('setting the name triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace));
+        const procedureModel = [...this.procedureMap.values()][0];
 
         procedureModel.setName('new name');
 
@@ -80,9 +79,9 @@ suite('Procedure Map', function() {
       });
   
       test('setting the return type triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace));
+        const procedureModel = [...this.procedureMap.values()][0];
 
         procedureModel.setReturnTypes(['return type 1', 'return type 2']);
 
@@ -91,11 +90,10 @@ suite('Procedure Map', function() {
       });
   
       test('removing the return type triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
-        procedureModel.setReturnTypes(['return type']);
-        console.log(this.updateSpy);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+                .setReturnTypes(['return type']));
+        const procedureModel = [...this.procedureMap.values()][0];
         this.updateSpy.resetHistory();
 
         procedureModel.setReturnTypes(null);
@@ -105,9 +103,9 @@ suite('Procedure Map', function() {
       });
   
       test('disabling the procedure triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace));
+        const procedureModel = [...this.procedureMap.values()][0];
 
         procedureModel.setEnabled(false);
 
@@ -116,10 +114,10 @@ suite('Procedure Map', function() {
       });
   
       test('enabling the procedure triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
-        procedureModel.setEnabled(false);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+                .setEnabled(false));
+        const procedureModel = [...this.procedureMap.values()][0];
         this.updateSpy.resetHistory();
 
         procedureModel.setEnabled(true);
@@ -129,9 +127,9 @@ suite('Procedure Map', function() {
       });
 
       test('inserting a parameter triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace));
+        const procedureModel = [...this.procedureMap.values()][0];
 
         procedureModel.insertParameter(
             new Blockly.procedures.ObservableParameterModel(this.workspace));
@@ -141,11 +139,12 @@ suite('Procedure Map', function() {
       });
   
       test('deleting a parameter triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
-        procedureModel.insertParameter(
-            new Blockly.procedures.ObservableParameterModel(this.workspace));
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+                .insertParameter(
+                    new Blockly.procedures.ObservableParameterModel(
+                        this.workspace)));
+        const procedureModel = [...this.procedureMap.values()][0];
         this.updateSpy.resetHistory();
 
         procedureModel.deleteParameter(0);
@@ -157,12 +156,13 @@ suite('Procedure Map', function() {
 
     suite('parameter model updates', function() {
       test('setting the name triggers an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
-        const parameterModel = new Blockly.procedures.ObservableParameterModel(
-            this.workspace, 'test1');
-        procedureModel.insertParameter(parameterModel);
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+                .insertParameter(
+                    new Blockly.procedures.ObservableParameterModel(
+                        this.workspace, 'test1')));
+        const parameterModel =
+            [...this.procedureMap.values()][0].getParameter(0);
         this.updateSpy.resetHistory();
 
         parameterModel.setName('test2');
@@ -172,13 +172,13 @@ suite('Procedure Map', function() {
       });
   
       test('modifying the variable model does not trigger an update', function() {
-        const procedureModel =
-            new Blockly.procedures.ObservableProcedureModel(this.workspace);
-        this.procedureMap.add(procedureModel);
-        const parameterModel = new Blockly.procedures.ObservableParameterModel(
-            this.workspace, 'test1');
-        procedureModel.insertParameter(parameterModel);
-        const variableModel = parameterModel.getVariableModel();
+        this.procedureMap.add(
+            new Blockly.procedures.ObservableProcedureModel(this.workspace)
+                .insertParameter(
+                    new Blockly.procedures.ObservableParameterModel(
+                        this.workspace, 'test1')));
+        const variableModel =
+            [...this.procedureMap.values()][0].getParameter(0).getVariableModel();
         this.updateSpy.resetHistory();
 
         variableModel.name = 'some name';

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -12,9 +12,7 @@ suite('Procedure Map', function() {
   setup(function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
-    //this.procedureMap = this.workspace.getProcedureMap();
-    this.procedureMap =
-        new Blockly.procedures.ObservableProcedureMap(this.workspace);
+    this.procedureMap = this.workspace.getProcedureMap();
   });
 
   teardown(function() {
@@ -255,5 +253,5 @@ suite('Procedure Map', function() {
         },
         'The built-in ParameterModel does not support typing');
     });
-  })
+  });
 });


### PR DESCRIPTION
Dupe of #6562 (but this time actually waiting for dependent things)

Fixes #6561 