### PR TITLE
fix: Fix the compiler test.

### DIFF
--- a/tests/compile/index.html
+++ b/tests/compile/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>Blockly: Advanced Compilation Test</title>
-  <script src="main_compressed.js"></script>
   <script src="../../msg/js/en.js"></script>
+  <script src="main_compressed.js"></script>
   <style>
     body {
       background-color: #fff;
@@ -22,7 +22,7 @@
 <body>
   <h1>Blockly: Advanced Compilation Test</h1>
 
-  <p>To run this test manually, run `npm run test:compile:advanced`
+  <p>To run this test manually, run `node tsick.js` and `npm run test:compile:advanced`
   from the command line, then open this file in your web browser.</p>
 
   <p>Measure the size of main_compressed.js (295kb as of October 2017), then reload

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -16,6 +16,9 @@ const {inject} = goog.require('Blockly.inject');
 goog.require('Blockly.geras.Renderer');
 /** @suppress {extraRequire} */
 goog.require('Blockly.VerticalFlyout');
+/** @suppress {extraRequire} */
+const {Msg} = goog.require('Blockly.Msg');
+
 // Blocks
 /** @suppress {extraRequire} */
 goog.require('Blockly.libraryBlocks.logic');
@@ -30,6 +33,7 @@ goog.require('testBlocks');
 
 
 function init() {
+  Object.assign(Msg, window['Blockly']['Msg']);
   inject('blocklyDiv', /** @type {BlocklyOptions} */ ({
            'toolbox': document.getElementById('toolbox')
          }));

--- a/tests/compile/tsick.js
+++ b/tests/compile/tsick.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Lightweight conversion from tsc to Closure Compiler.
+ */
+'use strict';
+
+const fs = require('fs');
+
+const DIR = '../../build/src/core/';
+
+function spider(dir) {
+  const data = fs.readdirSync(dir, {withFileTypes: true});
+  for (const datum of data) {
+    if (datum.isDirectory()) {
+      spider(dir + datum.name + '/')
+    } else if (datum.name.endsWith('.js')) {
+      rewriteFile(dir + datum.name);
+    }
+  }
+}
+
+function rewriteFile(path) {
+  const oldCode = fs.readFileSync(path, 'utf8');
+  const newCode = rewriteEnum(oldCode);
+  if (newCode !== oldCode) {
+    console.log('Rewrote: ' + path);
+    fs.writeFileSync(path, newCode);
+  }
+}
+
+function rewriteEnum(code) {
+  while (true) {
+    // Extract the entire enum structure.
+    const m = code.match(/\s+\(function \((\w+)\) \{\n[^\}]*\}\)\(\1 [^)]+\1 = \{\}\)\);/);
+    if (!m) {
+      break;
+    }
+    // m[0] looks like a bunch of lines in one of these two formats:
+    //   ScopeType["BLOCK"] = "block";
+    //   KeyCodes[KeyCodes["TAB"] = 9] = "TAB";
+    // We need to unquote them to look like one of these two formats:
+    //   ScopeType.BLOCK = "block";
+    //   KeyCodes[KeyCodes.TAB = 9] = "TAB";
+    const oldSnippet = m[0];
+    let newSnippet = oldSnippet.replace(/\["(\w+)"\]/g, '.$1');
+    // Add a comment so we don't keep trying to modify this enum.
+    newSnippet = newSnippet.replace(') {', ') {  // Converted by tsick.');
+    code = code.replace(oldSnippet, newSnippet);
+  }
+  return code;
+}
+
+spider(DIR);


### PR DESCRIPTION
The TypeScript compiler generates some code relating to enums that's not compatible with the Closure Compiler's advanced optimizations.  This PR adds a lightweight converter that fixes these enums and restores the functionality of this test.

Where the converter will live and what form it should take is a matter of future discussion.  But for now it's just in the tests/compile directory.