### PR TITLE
chore: Merge branch 'master' back into develop after v9.0.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blockly",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blockly",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "15.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockly",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Blockly is a library for building visual programming editors.",
   "keywords": [
     "blockly"

--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1360,7 +1360,7 @@
     {
       oldName: 'Blockly.PHP',
       newExport: 'phpGenerator',
-      newPath: 'Blockly.php',
+      newPath: 'Blockly.PHP',
     },
     {
       oldName: 'Blockly.Python',


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Merge changes made in the master branch since the v9.0.0 release.  This merges a substantial number of commits, but most are either rolled back by other later commits or are cherry-picks of changes already in `develop`, leaving just two actual changes:

* Updating the version number to 9.0.1, and
* Correcting an error in `renamings.json5`.

### Reason for Changes

Keep `develop` up-to-date with respect to changes in `master`, and thereby reduce the likelihood of merge conflicts when we next release (i.e. merge from `develop` to `master`).


### Additional Information

* There were conflicts in
  * `core/field_angle.ts`
  * `core/field_dropdown.ts`
  * `core/field_variable.ts`

  that were due to having cherry-picked changes from `develop` into `master` for the 9.0.1 release; these were "resolved" by resetting those files to the `develop` version, since the "changes" thereby lost were just adapting the cherry-picks to fit code in `master` that had not had various intermediate PRs applied to it yet.
* Similarly, conflicts in `blockly_compressed.js` and `.js.map` were "resolved" by resetting those files; I note that we could do a rebuild to update the pre-built files in `develop` but they will soon be deleted anyway, and in any case rebuilding them would not make them the same as the 9.0.1 release as many other PRs have landed in the meantime.
* A conflict in `package-lock.json` was resolved by resetting that file to the develop version and then running `npm install` to update `package-lock.json` with the change to the blockly version number.
