### PR TITLE
chore: remove some underscores in icon-related classes

### DIFF
--- a/core/comment.ts
+++ b/core/comment.ts
@@ -213,14 +213,17 @@ export class Comment extends Icon {
    * the size of the bubble).
    */
   private resizeTextarea() {
+    if (!this.textarea_ || !this.foreignObject) {
+      return;
+    }
     const size = this.model.size;
     const doubleBorderWidth = 2 * Bubble.BORDER_WIDTH;
     const widthMinusBorder = size.width - doubleBorderWidth;
     const heightMinusBorder = size.height - doubleBorderWidth;
-    this.foreignObject!.setAttribute('width', `${widthMinusBorder}`);
-    this.foreignObject!.setAttribute('height', `${heightMinusBorder}`);
-    this.textarea_!.style.width = widthMinusBorder - 4 + 'px';
-    this.textarea_!.style.height = heightMinusBorder - 4 + 'px';
+    this.foreignObject.setAttribute('width', `${widthMinusBorder}`);
+    this.foreignObject.setAttribute('height', `${heightMinusBorder}`);
+    this.textarea_.style.width = widthMinusBorder - 4 + 'px';
+    this.textarea_.style.height = heightMinusBorder - 4 + 'px';
   }
 
   /**

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -85,7 +85,7 @@ export class Comment extends Icon {
    *
    * @param group The icon group.
    */
-  protected override drawIcon_(group: SVGGElement) {
+  protected override drawIcon_(group: Element) {
     // Circle.
     dom.createSvgElement(
         Svg.CIRCLE,

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -36,30 +36,30 @@ import {Svg} from './utils/svg.js';
  * @alias Blockly.Comment
  */
 export class Comment extends Icon {
-  private readonly model_: CommentModel;
+  private readonly model: CommentModel;
 
   /**
    * The model's text value at the start of an edit.
    * Used to tell if an event should be fired at the end of an edit.
    */
-  private cachedText_: string|null = '';
+  private cachedText: string|null = '';
 
   /** Mouse up event data. */
-  private onMouseUpWrapper_: browserEvents.Data|null = null;
+  private onMouseUpWrapper: browserEvents.Data|null = null;
 
   /** Wheel event data. */
-  private onWheelWrapper_: browserEvents.Data|null = null;
+  private onWheelWrapper: browserEvents.Data|null = null;
 
   /** Change event data. */
-  private onChangeWrapper_: browserEvents.Data|null = null;
+  private onChangeWrapper: browserEvents.Data|null = null;
 
   /** Input event data. */
-  private onInputWrapper_: browserEvents.Data|null = null;
+  private onInputWrapper: browserEvents.Data|null = null;
 
   /**
    * The SVG element that contains the text edit area, or null if not created.
    */
-  private foreignObject_: SVGForeignObjectElement|null = null;
+  private foreignObject: SVGForeignObjectElement|null = null;
 
   /** The editable text area, or null if not created. */
   private textarea_: HTMLTextAreaElement|null = null;
@@ -72,10 +72,10 @@ export class Comment extends Icon {
     super(block);
 
     /** The model for this comment. */
-    this.model_ = block.commentModel;
+    this.model = block.commentModel;
     // If someone creates the comment directly instead of calling
     // block.setCommentText we want to make sure the text is non-null;
-    this.model_.text = this.model_.text ?? '';
+    this.model.text = this.model.text ?? '';
 
     this.createIcon();
   }
@@ -117,7 +117,7 @@ export class Comment extends Icon {
    *
    * @returns The top-level node of the editor.
    */
-  private createEditor_(): SVGElement {
+  private createEditor(): SVGElement {
     /* Create the editor.  Here's the markup that will be generated in
          * editable mode:
           <foreignObject x="8" y="8" width="164" height="164">
@@ -130,7 +130,7 @@ export class Comment extends Icon {
          * For non-editable mode see Warning.textToDom_.
          */
 
-    this.foreignObject_ = dom.createSvgElement(
+    this.foreignObject = dom.createSvgElement(
         Svg.FOREIGNOBJECT,
         {'x': Bubble.BORDER_WIDTH, 'y': Bubble.BORDER_WIDTH});
 
@@ -143,46 +143,46 @@ export class Comment extends Icon {
     const textarea = this.textarea_;
     textarea.className = 'blocklyCommentTextarea';
     textarea.setAttribute('dir', this.getBlock().RTL ? 'RTL' : 'LTR');
-    textarea.value = this.model_.text ?? '';
-    this.resizeTextarea_();
+    textarea.value = this.model.text ?? '';
+    this.resizeTextarea();
 
     body.appendChild(textarea);
-    this.foreignObject_!.appendChild(body);
+    this.foreignObject!.appendChild(body);
 
     // Ideally this would be hooked to the focus event for the comment.
     // However doing so in Firefox swallows the cursor for unknown reasons.
     // So this is hooked to mouseup instead.  No big deal.
-    this.onMouseUpWrapper_ = browserEvents.conditionalBind(
-        textarea, 'mouseup', this, this.startEdit_, true, true);
+    this.onMouseUpWrapper = browserEvents.conditionalBind(
+        textarea, 'mouseup', this, this.startEdit, true, true);
     // Don't zoom with mousewheel.
-    this.onWheelWrapper_ = browserEvents.conditionalBind(
+    this.onWheelWrapper = browserEvents.conditionalBind(
         textarea, 'wheel', this, function(e: Event) {
           e.stopPropagation();
         });
-    this.onChangeWrapper_ = browserEvents.conditionalBind(
+    this.onChangeWrapper = browserEvents.conditionalBind(
         textarea, 'change', this,
         /**
          * @param _e Unused event parameter.
          */
         function(this: Comment, _e: Event) {
-          if (this.cachedText_ !== this.model_.text) {
+          if (this.cachedText !== this.model.text) {
             eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
-                this.getBlock(), 'comment', null, this.cachedText_,
-                this.model_.text));
+                this.getBlock(), 'comment', null, this.cachedText,
+                this.model.text));
           }
         });
-    this.onInputWrapper_ = browserEvents.conditionalBind(
+    this.onInputWrapper = browserEvents.conditionalBind(
         textarea, 'input', this,
         /**
          * @param _e Unused event parameter.
          */
         function(this: Comment, _e: Event) {
-          this.model_.text = textarea.value;
+          this.model.text = textarea.value;
         });
 
     setTimeout(textarea.focus.bind(textarea), 0);
 
-    return this.foreignObject_;
+    return this.foreignObject;
   }
 
   /** Add or remove editability of the comment. */
@@ -190,8 +190,8 @@ export class Comment extends Icon {
     super.updateEditable();
     if (this.isVisible()) {
       // Recreate the bubble with the correct UI.
-      this.disposeBubble_();
-      this.createBubble_();
+      this.disposeBubble();
+      this.createBubble();
     }
   }
 
@@ -199,26 +199,26 @@ export class Comment extends Icon {
    * Callback function triggered when the bubble has resized.
    * Resize the text area accordingly.
    */
-  private onBubbleResize_() {
+  private onBubbleResize() {
     if (!this.isVisible() || !this.bubble_) {
       return;
     }
 
-    this.model_.size = this.bubble_.getBubbleSize();
-    this.resizeTextarea_();
+    this.model.size = this.bubble_.getBubbleSize();
+    this.resizeTextarea();
   }
 
   /**
    * Resizes the text area to match the size defined on the model (which is
    * the size of the bubble).
    */
-  private resizeTextarea_() {
-    const size = this.model_.size;
+  private resizeTextarea() {
+    const size = this.model.size;
     const doubleBorderWidth = 2 * Bubble.BORDER_WIDTH;
     const widthMinusBorder = size.width - doubleBorderWidth;
     const heightMinusBorder = size.height - doubleBorderWidth;
-    this.foreignObject_!.setAttribute('width', `${widthMinusBorder}`);
-    this.foreignObject_!.setAttribute('height', `${heightMinusBorder}`);
+    this.foreignObject!.setAttribute('width', `${widthMinusBorder}`);
+    this.foreignObject!.setAttribute('height', `${heightMinusBorder}`);
     this.textarea_!.style.width = widthMinusBorder - 4 + 'px';
     this.textarea_!.style.height = heightMinusBorder - 4 + 'px';
   }
@@ -234,33 +234,33 @@ export class Comment extends Icon {
     }
     eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
         this.getBlock(), visible, 'comment'));
-    this.model_.pinned = visible;
+    this.model.pinned = visible;
     if (visible) {
-      this.createBubble_();
+      this.createBubble();
     } else {
-      this.disposeBubble_();
+      this.disposeBubble();
     }
   }
 
   /** Show the bubble. Handles deciding if it should be editable or not. */
-  private createBubble_() {
+  private createBubble() {
     if (!this.getBlock().isEditable()) {
-      this.createNonEditableBubble_();
+      this.createNonEditableBubble();
     } else {
-      this.createEditableBubble_();
+      this.createEditableBubble();
     }
   }
 
   /** Show an editable bubble. */
-  private createEditableBubble_() {
+  private createEditableBubble() {
     const block = this.getBlock();
     this.bubble_ = new Bubble(
-        block.workspace, this.createEditor_(), block.pathObject.svgPath,
-        (this.iconXY_ as Coordinate), this.model_.size.width,
-        this.model_.size.height);
+        block.workspace, this.createEditor(), block.pathObject.svgPath,
+        (this.iconXY_ as Coordinate), this.model.size.width,
+        this.model.size.height);
     // Expose this comment's block's ID on its top-level SVG group.
     this.bubble_.setSvgId(block.id);
-    this.bubble_.registerResizeEvent(this.onBubbleResize_.bind(this));
+    this.bubble_.registerResizeEvent(this.onBubbleResize.bind(this));
     this.applyColour();
   }
 
@@ -269,9 +269,9 @@ export class Comment extends Icon {
    *
    * @suppress {checkTypes} Suppress `this` type mismatch.
    */
-  private createNonEditableBubble_() {
+  private createNonEditableBubble() {
     // TODO (#2917): It would be great if the comment could support line breaks.
-    this.paragraphElement_ = Bubble.textToDom(this.model_.text ?? '');
+    this.paragraphElement_ = Bubble.textToDom(this.model.text ?? '');
     this.bubble_ = Bubble.createNonEditableBubble(
         this.paragraphElement_, this.getBlock(), this.iconXY_ as Coordinate);
     this.applyColour();
@@ -282,29 +282,29 @@ export class Comment extends Icon {
    *
    * @suppress {checkTypes} Suppress `this` type mismatch.
    */
-  private disposeBubble_() {
-    if (this.onMouseUpWrapper_) {
-      browserEvents.unbind(this.onMouseUpWrapper_);
-      this.onMouseUpWrapper_ = null;
+  private disposeBubble() {
+    if (this.onMouseUpWrapper) {
+      browserEvents.unbind(this.onMouseUpWrapper);
+      this.onMouseUpWrapper = null;
     }
-    if (this.onWheelWrapper_) {
-      browserEvents.unbind(this.onWheelWrapper_);
-      this.onWheelWrapper_ = null;
+    if (this.onWheelWrapper) {
+      browserEvents.unbind(this.onWheelWrapper);
+      this.onWheelWrapper = null;
     }
-    if (this.onChangeWrapper_) {
-      browserEvents.unbind(this.onChangeWrapper_);
-      this.onChangeWrapper_ = null;
+    if (this.onChangeWrapper) {
+      browserEvents.unbind(this.onChangeWrapper);
+      this.onChangeWrapper = null;
     }
-    if (this.onInputWrapper_) {
-      browserEvents.unbind(this.onInputWrapper_);
-      this.onInputWrapper_ = null;
+    if (this.onInputWrapper) {
+      browserEvents.unbind(this.onInputWrapper);
+      this.onInputWrapper = null;
     }
     if (this.bubble_) {
       this.bubble_.dispose();
       this.bubble_ = null;
     }
     this.textarea_ = null;
-    this.foreignObject_ = null;
+    this.foreignObject = null;
     this.paragraphElement_ = null;
   }
 
@@ -316,14 +316,14 @@ export class Comment extends Icon {
    *
    * @param _e Mouse up event.
    */
-  private startEdit_(_e: Event) {
+  private startEdit(_e: Event) {
     if (this.bubble_?.promote()) {
       // Since the act of moving this node within the DOM causes a loss of
       // focus, we need to reapply the focus.
       this.textarea_!.focus();
     }
 
-    this.cachedText_ = this.model_.text;
+    this.cachedText = this.model.text;
   }
 
   /**
@@ -332,7 +332,7 @@ export class Comment extends Icon {
    * @returns Object with width and height properties.
    */
   getBubbleSize(): Size {
-    return this.model_.size;
+    return this.model.size;
   }
 
   /**
@@ -345,8 +345,8 @@ export class Comment extends Icon {
     if (this.bubble_) {
       this.bubble_.setBubbleSize(width, height);
     } else {
-      this.model_.size.width = width;
-      this.model_.size.height = height;
+      this.model.size.width = width;
+      this.model.size.height = height;
     }
   }
 
@@ -357,11 +357,11 @@ export class Comment extends Icon {
    */
   updateText() {
     if (this.textarea_) {
-      this.textarea_.value = this.model_.text ?? '';
+      this.textarea_.value = this.model.text ?? '';
     } else if (this.paragraphElement_) {
       // Non-Editable mode.
       // TODO (#2917): If 2917 gets added this will probably need to be updated.
-      this.paragraphElement_.firstChild!.textContent = this.model_.text;
+      this.paragraphElement_.firstChild!.textContent = this.model.text;
     }
   }
 

--- a/core/comment.ts
+++ b/core/comment.ts
@@ -85,7 +85,7 @@ export class Comment extends Icon {
    *
    * @param group The icon group.
    */
-  protected override drawIcon_(group: Element) {
+  protected override drawIcon_(group: SVGGElement) {
     // Circle.
     dom.createSvgElement(
         Svg.CIRCLE,
@@ -266,8 +266,6 @@ export class Comment extends Icon {
 
   /**
    * Show a non-editable bubble.
-   *
-   * @suppress {checkTypes} Suppress `this` type mismatch.
    */
   private createNonEditableBubble() {
     // TODO (#2917): It would be great if the comment could support line breaks.
@@ -279,8 +277,6 @@ export class Comment extends Icon {
 
   /**
    * Dispose of the bubble.
-   *
-   * @suppress {checkTypes} Suppress `this` type mismatch.
    */
   private disposeBubble() {
     if (this.onMouseUpWrapper) {

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -175,7 +175,7 @@ export abstract class Icon {
    *
    * @param _group The icon group.
    */
-  protected drawIcon_(_group: SVGGElement) {}
+  protected drawIcon_(_group: Element) {}
   // No-op on base class.
 
   /**

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -175,7 +175,7 @@ export abstract class Icon {
    *
    * @param _group The icon group.
    */
-  protected drawIcon_(_group: Element) {}
+  protected drawIcon_(_group: SVGGElement) {}
   // No-op on base class.
 
   /**

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -162,7 +162,7 @@ export class Mutator extends Icon {
    *
    * @returns The top-level node of the editor.
    */
-  private createEditor(): SVGElement {
+  private createEditor(): SVGSVGElement {
     /* Create the editor.  Here's the markup that will be generated:
         <svg>
           [Workspace]
@@ -217,7 +217,7 @@ export class Mutator extends Icon {
       // dragging work properly.
       background.insertBefore(flyoutSvg, this.workspace.svgBlockCanvas_);
     }
-    this.svgDialog!.appendChild(background);
+    this.svgDialog.appendChild(background);
 
     return this.svgDialog;
   }
@@ -248,18 +248,21 @@ export class Mutator extends Icon {
 
   /** Resize the bubble to match the size of the workspace. */
   private resizeBubble() {
+    // If the bubble exists, the workspace also exists.
+    const ws = this.workspace as WorkspaceSvg;
     const doubleBorderWidth = 2 * Bubble.BORDER_WIDTH;
-    const workspaceSize = this.workspace!.getCanvas().getBBox();
+    const workspaceSize = ws.getCanvas().getBBox();
     let width = workspaceSize.width + workspaceSize.x;
     let height = workspaceSize.height + doubleBorderWidth * 3;
-    const flyout = this.workspace!.getFlyout();
+    const flyout = ws.getFlyout();
     if (flyout) {
       const flyoutScrollMetrics =
           flyout.getWorkspace().getMetricsManager().getScrollMetrics();
       height = Math.max(height, flyoutScrollMetrics.height + 20);
       width += flyout.getWidth();
     }
-    if (this.getBlock().RTL) {
+    const isRtl = this.getBlock().RTL;
+    if (isRtl) {
       width = -workspaceSize.x;
     }
     width += doubleBorderWidth * 3;
@@ -275,16 +278,15 @@ export class Mutator extends Icon {
           width + doubleBorderWidth, height + doubleBorderWidth);
       this.svgDialog!.setAttribute('width', `${this.workspaceWidth}`);
       this.svgDialog!.setAttribute('height', `${this.workspaceHeight}`);
-      this.workspace!.setCachedParentSvgSize(
-          this.workspaceWidth, this.workspaceHeight);
+      ws.setCachedParentSvgSize(this.workspaceWidth, this.workspaceHeight);
     }
 
-    if (this.getBlock().RTL) {
+    if (isRtl) {
       // Scroll the workspace to always left-align.
       const translation = 'translate(' + this.workspaceWidth + ',0)';
-      this.workspace!.getCanvas().setAttribute('transform', translation);
+      ws.getCanvas().setAttribute('transform', translation);
     }
-    this.workspace!.resize();
+    ws.resize();
   }
 
   /** A method handler for when the bubble is moved. */
@@ -328,13 +330,13 @@ export class Mutator extends Icon {
         child.render();
       }
       // The root block should not be draggable or deletable.
-      this.rootBlock!.setMovable(false);
-      this.rootBlock!.setDeletable(false);
+      this.rootBlock.setMovable(false);
+      this.rootBlock.setDeletable(false);
       let margin;
       let x;
       if (flyout) {
         margin = flyout.CORNER_RADIUS * 2;
-        x = this.rootBlock!.RTL ? flyout.getWidth() + margin : margin;
+        x = this.rootBlock.RTL ? flyout.getWidth() + margin : margin;
       } else {
         margin = 16;
         x = margin;
@@ -342,7 +344,7 @@ export class Mutator extends Icon {
       if (block.RTL) {
         x = -x;
       }
-      this.rootBlock!.moveBy(x, margin);
+      this.rootBlock.moveBy(x, margin);
       // Save the initial connections, then listen for further changes.
       if (block.saveConnections) {
         const thisRootBlock = this.rootBlock;

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -42,40 +42,40 @@ import type {WorkspaceSvg} from './workspace_svg.js';
  * @alias Blockly.Mutator
  */
 export class Mutator extends Icon {
-  private quarkNames_: string[];
+  private quarkNames: string[];
 
   /** Workspace in the mutator's bubble. */
-  private workspace_: WorkspaceSvg|null = null;
+  private workspace: WorkspaceSvg|null = null;
 
   /** Width of workspace. */
-  private workspaceWidth_ = 0;
+  private workspaceWidth = 0;
 
   /** Height of workspace. */
-  private workspaceHeight_ = 0;
+  private workspaceHeight = 0;
 
   /**
    * The SVG element that is the parent of the mutator workspace, or null if
    * not created.
    */
-  private svgDialog_: SVGSVGElement|null = null;
+  private svgDialog: SVGSVGElement|null = null;
 
   /**
    * The root block of the mutator workspace, created by decomposing the
    * source block.
    */
-  private rootBlock_: BlockSvg|null = null;
+  private rootBlock: BlockSvg|null = null;
 
   /**
    * Function registered on the main workspace to update the mutator contents
    * when the main workspace changes.
    */
-  private sourceListener_: Function|null = null;
+  private sourceListener: Function|null = null;
 
   /**
    * The PID associated with the updateWorkpace_ timeout, or null if no timeout
    * is currently running.
    */
-  private updateWorkspacePid_: ReturnType<typeof setTimeout>|null = null;
+  private updateWorkspacePid: ReturnType<typeof setTimeout>|null = null;
 
   /** @param quarkNames List of names of sub-blocks for flyout. */
   constructor(quarkNames: string[], block?: BlockSvg) {
@@ -86,7 +86,7 @@ export class Mutator extends Icon {
           'the constructor by passing the list of subblocks and the block instance to attach the mutator to');
     }
     super(block ?? null);
-    this.quarkNames_ = quarkNames;
+    this.quarkNames = quarkNames;
   }
 
   /**
@@ -107,7 +107,7 @@ export class Mutator extends Icon {
    * @internal
    */
   getWorkspace(): WorkspaceSvg|null {
-    return this.workspace_;
+    return this.workspace;
   }
 
   /**
@@ -115,7 +115,7 @@ export class Mutator extends Icon {
    *
    * @param group The icon group.
    */
-  protected override drawIcon_(group: Element) {
+  protected override drawIcon_(group: SVGGElement) {
     // Square with rounded corners.
     dom.createSvgElement(
         Svg.RECT, {
@@ -162,19 +162,19 @@ export class Mutator extends Icon {
    *
    * @returns The top-level node of the editor.
    */
-  private createEditor_(): SVGElement {
+  private createEditor(): SVGElement {
     /* Create the editor.  Here's the markup that will be generated:
         <svg>
           [Workspace]
         </svg>
         */
-    this.svgDialog_ = dom.createSvgElement(
+    this.svgDialog = dom.createSvgElement(
         Svg.SVG, {'x': Bubble.BORDER_WIDTH, 'y': Bubble.BORDER_WIDTH});
     // Convert the list of names into a list of XML objects for the flyout.
     let quarkXml;
-    if (this.quarkNames_.length) {
+    if (this.quarkNames.length) {
       quarkXml = xml.createElement('xml');
-      for (let i = 0, quarkName; quarkName = this.quarkNames_[i]; i++) {
+      for (let i = 0, quarkName; quarkName = this.quarkNames[i]; i++) {
         const element = xml.createElement('block');
         element.setAttribute('type', quarkName);
         quarkXml.appendChild(element);
@@ -200,26 +200,26 @@ export class Mutator extends Icon {
     if (hasFlyout) {
       workspaceOptions.languageTree = toolbox.convertToolboxDefToJson(quarkXml);
     }
-    this.workspace_ = this.newWorkspaceSvg(workspaceOptions);
-    this.workspace_.internalIsMutator = true;
-    this.workspace_.addChangeListener(eventUtils.disableOrphans);
+    this.workspace = this.newWorkspaceSvg(workspaceOptions);
+    this.workspace.internalIsMutator = true;
+    this.workspace.addChangeListener(eventUtils.disableOrphans);
 
     // Mutator flyouts go inside the mutator workspace's <g> rather than in
     // a top level SVG. Instead of handling scale themselves, mutators
     // inherit scale from the parent workspace.
     // To fix this, scale needs to be applied at a different level in the DOM.
-    const flyoutSvg = hasFlyout ? this.workspace_.addFlyout(Svg.G) : null;
-    const background = this.workspace_.createDom('blocklyMutatorBackground');
+    const flyoutSvg = hasFlyout ? this.workspace.addFlyout(Svg.G) : null;
+    const background = this.workspace.createDom('blocklyMutatorBackground');
 
     if (flyoutSvg) {
       // Insert the flyout after the <rect> but before the block canvas so that
       // the flyout is underneath in z-order.  This makes blocks layering during
       // dragging work properly.
-      background.insertBefore(flyoutSvg, this.workspace_.svgBlockCanvas_);
+      background.insertBefore(flyoutSvg, this.workspace.svgBlockCanvas_);
     }
-    this.svgDialog_!.appendChild(background);
+    this.svgDialog!.appendChild(background);
 
-    return this.svgDialog_;
+    return this.svgDialog;
   }
 
   /**
@@ -236,27 +236,23 @@ export class Mutator extends Icon {
   override updateEditable() {
     super.updateEditable();
     if (!this.getBlock().isInFlyout) {
-      if (this.getBlock().isEditable()) {
-        if (this.iconGroup_) {
-          dom.removeClass(this.iconGroup_, 'blocklyIconGroupReadonly');
-        }
-      } else {
+      if (!this.getBlock().isEditable) {
         // Close any mutator bubble.  Icon is not clickable.
         this.setVisible(false);
-        if (this.iconGroup_) {
-          dom.addClass(this.iconGroup_, 'blocklyIconGroupReadonly');
-        }
+      }
+      if (this.iconGroup_) {
+        dom.removeClass(this.iconGroup_, 'blocklyIconGroupReadonly');
       }
     }
   }
 
   /** Resize the bubble to match the size of the workspace. */
-  private resizeBubble_() {
+  private resizeBubble() {
     const doubleBorderWidth = 2 * Bubble.BORDER_WIDTH;
-    const workspaceSize = this.workspace_!.getCanvas().getBBox();
+    const workspaceSize = this.workspace!.getCanvas().getBBox();
     let width = workspaceSize.width + workspaceSize.x;
     let height = workspaceSize.height + doubleBorderWidth * 3;
-    const flyout = this.workspace_!.getFlyout();
+    const flyout = this.workspace!.getFlyout();
     if (flyout) {
       const flyoutScrollMetrics =
           flyout.getWorkspace().getMetricsManager().getScrollMetrics();
@@ -269,32 +265,32 @@ export class Mutator extends Icon {
     width += doubleBorderWidth * 3;
     // Only resize if the size difference is significant.  Eliminates
     // shuddering.
-    if (Math.abs(this.workspaceWidth_ - width) > doubleBorderWidth ||
-        Math.abs(this.workspaceHeight_ - height) > doubleBorderWidth) {
+    if (Math.abs(this.workspaceWidth - width) > doubleBorderWidth ||
+        Math.abs(this.workspaceHeight - height) > doubleBorderWidth) {
       // Record some layout information for workspace metrics.
-      this.workspaceWidth_ = width;
-      this.workspaceHeight_ = height;
+      this.workspaceWidth = width;
+      this.workspaceHeight = height;
       // Resize the bubble.
       this.bubble_!.setBubbleSize(
           width + doubleBorderWidth, height + doubleBorderWidth);
-      this.svgDialog_!.setAttribute('width', `${this.workspaceWidth_}`);
-      this.svgDialog_!.setAttribute('height', `${this.workspaceHeight_}`);
-      this.workspace_!.setCachedParentSvgSize(
-          this.workspaceWidth_, this.workspaceHeight_);
+      this.svgDialog!.setAttribute('width', `${this.workspaceWidth}`);
+      this.svgDialog!.setAttribute('height', `${this.workspaceHeight}`);
+      this.workspace!.setCachedParentSvgSize(
+          this.workspaceWidth, this.workspaceHeight);
     }
 
     if (this.getBlock().RTL) {
       // Scroll the workspace to always left-align.
-      const translation = 'translate(' + this.workspaceWidth_ + ',0)';
-      this.workspace_!.getCanvas().setAttribute('transform', translation);
+      const translation = 'translate(' + this.workspaceWidth + ',0)';
+      this.workspace!.getCanvas().setAttribute('transform', translation);
     }
-    this.workspace_!.resize();
+    this.workspace!.resize();
   }
 
   /** A method handler for when the bubble is moved. */
-  private onBubbleMove_() {
-    if (this.workspace_) {
-      this.workspace_.recordDragTargets();
+  private onBubbleMove() {
+    if (this.workspace) {
+      this.workspace.recordDragTargets();
     }
   }
 
@@ -314,31 +310,31 @@ export class Mutator extends Icon {
     if (visible) {
       // Create the bubble.
       this.bubble_ = new Bubble(
-          block.workspace, this.createEditor_(), block.pathObject.svgPath,
+          block.workspace, this.createEditor(), block.pathObject.svgPath,
           (this.iconXY_ as Coordinate), null, null);
       // Expose this mutator's block's ID on its top-level SVG group.
       this.bubble_.setSvgId(block.id);
-      this.bubble_.registerMoveEvent(this.onBubbleMove_.bind(this));
-      const tree = this.workspace_!.options.languageTree;
-      const flyout = this.workspace_!.getFlyout();
+      this.bubble_.registerMoveEvent(this.onBubbleMove.bind(this));
+      const tree = this.workspace!.options.languageTree;
+      const flyout = this.workspace!.getFlyout();
       if (tree) {
-        flyout!.init(this.workspace_!);
+        flyout!.init(this.workspace!);
         flyout!.show(tree);
       }
 
-      this.rootBlock_ = block.decompose!(this.workspace_!)!;
-      const blocks = this.rootBlock_!.getDescendants(false);
+      this.rootBlock = block.decompose!(this.workspace!)!;
+      const blocks = this.rootBlock!.getDescendants(false);
       for (let i = 0, child; child = blocks[i]; i++) {
         child.render();
       }
       // The root block should not be draggable or deletable.
-      this.rootBlock_!.setMovable(false);
-      this.rootBlock_!.setDeletable(false);
+      this.rootBlock!.setMovable(false);
+      this.rootBlock!.setDeletable(false);
       let margin;
       let x;
       if (flyout) {
         margin = flyout.CORNER_RADIUS * 2;
-        x = this.rootBlock_!.RTL ? flyout.getWidth() + margin : margin;
+        x = this.rootBlock!.RTL ? flyout.getWidth() + margin : margin;
       } else {
         margin = 16;
         x = margin;
@@ -346,38 +342,38 @@ export class Mutator extends Icon {
       if (block.RTL) {
         x = -x;
       }
-      this.rootBlock_!.moveBy(x, margin);
+      this.rootBlock!.moveBy(x, margin);
       // Save the initial connections, then listen for further changes.
       if (block.saveConnections) {
-        const thisRootBlock = this.rootBlock_;
+        const thisRootBlock = this.rootBlock;
         block.saveConnections(thisRootBlock);
-        this.sourceListener_ = () => {
+        this.sourceListener = () => {
           const currentBlock = this.getBlock();
           if (currentBlock.saveConnections) {
             currentBlock.saveConnections(thisRootBlock);
           }
         };
-        block.workspace.addChangeListener(this.sourceListener_);
+        block.workspace.addChangeListener(this.sourceListener);
       }
-      this.resizeBubble_();
+      this.resizeBubble();
       // When the mutator's workspace changes, update the source block.
-      this.workspace_!.addChangeListener(this.workspaceChanged_.bind(this));
+      this.workspace!.addChangeListener(this.workspaceChanged.bind(this));
       // Update the source block immediately after the bubble becomes visible.
-      this.updateWorkspace_();
+      this.updateWorkspace();
       this.applyColour();
     } else {
       // Dispose of the bubble.
-      this.svgDialog_ = null;
-      this.workspace_!.dispose();
-      this.workspace_ = null;
-      this.rootBlock_ = null;
+      this.svgDialog = null;
+      this.workspace!.dispose();
+      this.workspace = null;
+      this.rootBlock = null;
       this.bubble_?.dispose();
       this.bubble_ = null;
-      this.workspaceWidth_ = 0;
-      this.workspaceHeight_ = 0;
-      if (this.sourceListener_) {
-        block.workspace.removeChangeListener(this.sourceListener_);
-        this.sourceListener_ = null;
+      this.workspaceWidth = 0;
+      this.workspaceHeight = 0;
+      if (this.sourceListener) {
+        block.workspace.removeChangeListener(this.sourceListener);
+        this.sourceListener = null;
       }
     }
   }
@@ -387,11 +383,11 @@ export class Mutator extends Icon {
    *
    * @param e Custom data for event.
    */
-  private workspaceChanged_(e: Abstract) {
-    if (!this.shouldIgnoreMutatorEvent_(e) && !this.updateWorkspacePid_) {
-      this.updateWorkspacePid_ = setTimeout(() => {
-        this.updateWorkspacePid_ = null;
-        this.updateWorkspace_();
+  private workspaceChanged(e: Abstract) {
+    if (!this.shouldIgnoreMutatorEvent_(e) && !this.updateWorkspacePid) {
+      this.updateWorkspacePid = setTimeout(() => {
+        this.updateWorkspacePid = null;
+        this.updateWorkspace();
       }, 0);
     }
   }
@@ -413,9 +409,9 @@ export class Mutator extends Icon {
    * Updates the source block when the mutator's blocks are changed.
    * Bump down any block that's too high.
    */
-  private updateWorkspace_() {
-    if (!this.workspace_!.isDragging()) {
-      const blocks = this.workspace_!.getTopBlocks(false);
+  private updateWorkspace() {
+    if (!this.workspace!.isDragging()) {
+      const blocks = this.workspace!.getTopBlocks(false);
       const MARGIN = 20;
 
       for (let b = 0, block; block = blocks[b]; b++) {
@@ -428,7 +424,7 @@ export class Mutator extends Icon {
         // Bump any block overlapping the flyout back inside.
         if (block.RTL) {
           let right = -MARGIN;
-          const flyout = this.workspace_!.getFlyout();
+          const flyout = this.workspace!.getFlyout();
           if (flyout) {
             right -= flyout.getWidth();
           }
@@ -442,7 +438,7 @@ export class Mutator extends Icon {
     }
 
     // When the mutator's workspace changes, update the source block.
-    if (this.rootBlock_ && this.rootBlock_.workspace === this.workspace_) {
+    if (this.rootBlock && this.rootBlock.workspace === this.workspace) {
       const existingGroup = eventUtils.getGroup();
       if (!existingGroup) {
         eventUtils.setGroup(true);
@@ -456,7 +452,7 @@ export class Mutator extends Icon {
       block.rendered = false;
 
       // Allow the source block to rebuild itself.
-      block.compose!(this.rootBlock_);
+      block.compose!(this.rootBlock);
       // Restore rendering and show the changes.
       block.rendered = savedRendered;
       // Mutation may have added some elements that need initializing.
@@ -482,8 +478,8 @@ export class Mutator extends Icon {
 
       // Don't update the bubble until the drag has ended, to avoid moving
       // blocks under the cursor.
-      if (!this.workspace_!.isDragging()) {
-        setTimeout(() => this.resizeBubble_(), 0);
+      if (!this.workspace!.isDragging()) {
+        setTimeout(() => this.resizeBubble(), 0);
       }
       eventUtils.setGroup(existingGroup);
     }
@@ -497,7 +493,7 @@ export class Mutator extends Icon {
 
   /** Update the styles on all blocks in the mutator. */
   updateBlockStyle() {
-    const ws = this.workspace_;
+    const ws = this.workspace;
 
     if (ws && ws.getAllBlocks(false)) {
       const workspaceBlocks = ws.getAllBlocks(false);

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -30,10 +30,10 @@ import {Svg} from './utils/svg.js';
  * @alias Blockly.Warning
  */
 export class Warning extends Icon {
-  private text_: {[key: string]: string};
+  private text: {[key: string]: string};
 
   /** The top-level node of the warning text, or null if not created. */
-  private paragraphElement_: SVGTextElement|null = null;
+  private paragraphElement: SVGTextElement|null = null;
 
   /** Does this icon get hidden when the block is collapsed? */
   override collapseHidden = false;
@@ -42,8 +42,8 @@ export class Warning extends Icon {
   constructor(block: BlockSvg) {
     super(block);
     this.createIcon();
-    // The text_ object can contain multiple warnings.
-    this.text_ = Object.create(null);
+    // The text object can contain multiple warnings.
+    this.text = Object.create(null);
   }
 
   /**
@@ -51,7 +51,7 @@ export class Warning extends Icon {
    *
    * @param group The icon group.
    */
-  protected override drawIcon_(group: Element) {
+  protected override drawIcon_(group: SVGGElement) {
     // Triangle with rounded corners.
     dom.createSvgElement(
         Svg.PATH, {
@@ -91,27 +91,27 @@ export class Warning extends Icon {
     eventUtils.fire(new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
         this.getBlock(), visible, 'warning'));
     if (visible) {
-      this.createBubble_();
+      this.createBubble();
     } else {
-      this.disposeBubble_();
+      this.disposeBubble();
     }
   }
 
   /** Show the bubble. */
-  private createBubble_() {
-    this.paragraphElement_ = Bubble.textToDom(this.getText());
+  private createBubble() {
+    this.paragraphElement = Bubble.textToDom(this.getText());
     this.bubble_ = Bubble.createNonEditableBubble(
-        this.paragraphElement_, this.getBlock(), this.iconXY_ as Coordinate);
+        this.paragraphElement, this.getBlock(), this.iconXY_ as Coordinate);
     this.applyColour();
   }
 
   /** Dispose of the bubble and references to it. */
-  private disposeBubble_() {
+  private disposeBubble() {
     if (this.bubble_) {
       this.bubble_.dispose();
       this.bubble_ = null;
     }
-    this.paragraphElement_ = null;
+    this.paragraphElement = null;
   }
 
   /**
@@ -122,13 +122,13 @@ export class Warning extends Icon {
    *     warnings.
    */
   setText(text: string, id: string) {
-    if (this.text_[id] === text) {
+    if (this.text[id] === text) {
       return;
     }
     if (text) {
-      this.text_[id] = text;
+      this.text[id] = text;
     } else {
-      delete this.text_[id];
+      delete this.text[id];
     }
     if (this.isVisible()) {
       this.setVisible(false);
@@ -143,8 +143,8 @@ export class Warning extends Icon {
    */
   getText(): string {
     const allWarnings = [];
-    for (const id in this.text_) {
-      allWarnings.push(this.text_[id]);
+    for (const id in this.text) {
+      allWarnings.push(this.text[id]);
     }
     return allWarnings.join('\n');
   }

--- a/core/warning.ts
+++ b/core/warning.ts
@@ -51,7 +51,7 @@ export class Warning extends Icon {
    *
    * @param group The icon group.
    */
-  protected override drawIcon_(group: SVGGElement) {
+  protected override drawIcon_(group: Element) {
     // Triangle with rounded corners.
     dom.createSvgElement(
         Svg.PATH, {

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -9,6 +9,7 @@ goog.declareModuleId('Blockly.test.mutator');
 
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {createRenderedBlock, defineMutatorBlocks} from './test_helpers/block_definitions.js';
+import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 
 
 suite('Mutator', function() {
@@ -34,11 +35,8 @@ suite('Mutator', function() {
       const mutatorWorkspace = block.mutator.getWorkspace();
       // Trigger mutator change listener.
       createRenderedBlock(mutatorWorkspace, 'checkbox_block');
-      chai.assert.isTrue(
-          this.eventsFireStub.getCalls().every(
-              ({args}) =>
-                args[0].type !== Blockly.Events.BLOCK_CHANGE ||
-                args[0].element !== 'mutation'));
+      assertEventNotFired(this.eventsFireStub, Blockly.Events.BlockChange,
+        {element: 'mutation'});
     });
 
     test('XML', function() {
@@ -61,12 +59,12 @@ suite('Mutator', function() {
       const mutatorWorkspace = block.mutator.getWorkspace();
       mutatorWorkspace.getBlockById('check_block')
           .setFieldValue('TRUE', 'CHECK');
-      chai.assert.isTrue(
-          this.eventsFireStub.getCalls().some(
-              ({args}) =>
-                args[0].type === Blockly.Events.BLOCK_CHANGE &&
-                args[0].element === 'mutation' &&
-                args[0].newValue === '{"hasInput":true}'));
+      assertEventFired(this.eventsFireStub, Blockly.Events.BlockChange,
+        {
+          element: 'mutation',
+          newValue: '{"hasInput":true}',
+        }, this.workspace.id, block.id);
     });
   });
 });
+


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/6548

### Proposed Changes

Remove underscores from private property names and method names, where they weren't being used by tests.
Also cleans up some nullability indicators.

#### Behavior Before Change

No change.

#### Behavior After Change

No change.

### Reason for Changes

General cleanup, as a way of reading through code and understanding icon architecture.

### Test Coverage

Mocha tests, and also opened up the playground and played around with comments and mutators.

### Documentation

None.

### Additional Information

`comment.textarea_` and `comment.paragraphElement_` are being accessed directly in tests, so I left them alone.