### PR TITLE
fix: Rename Generator to CodeGenerator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -160,7 +160,6 @@
             "jsdoc/check-param-names": ["off", {"checkDestructured": false}],
             // Allow any text in the license tag. Other checks are not relevant.
             "jsdoc/check-values": ["off"]
-                       
         }
     }]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,9 +29,9 @@ All submissions, including submissions by project members, require review. We
 use Github pull requests for this purpose.
 
 ### Browser compatibility
-We care strongly about making Blockly work on all browsers.  As of 2022 we 
+We care strongly about making Blockly work on all browsers.  As of 2022 we
 support Edge, Chrome, Safari, and Firefox.  We will not accept changes that only
-work on a subset of those browsers.  You can check [caniuse.com](https://caniuse.com/) 
+work on a subset of those browsers.  You can check [caniuse.com](https://caniuse.com/)
 for compatibility information.
 
 ### The small print

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       - "PR: chore"
       - "PR: dependencies"
   - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" 
+    directory: "/"
     target-branch: "develop"
     schedule:
       interval: "weekly"

--- a/.github/workflows/tag_module_cleanup.yml
+++ b/.github/workflows/tag_module_cleanup.yml
@@ -5,14 +5,14 @@ name: Tag module cleanup
 
 # Trigger on pull requests against goog_module branch only
 # Uses pull_request_target to get write permissions so that it can write labels.
-on: 
+on:
   pull_request_target:
     branches:
       - goog_module
 
 jobs:
   tag-module-cleanup:
-  
+
     # Add the type: cleanup label
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
-    runs-on: ubuntu-latest        
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check Out Blockly

--- a/closure/goog/base_minimal.js
+++ b/closure/goog/base_minimal.js
@@ -23,7 +23,7 @@ var goog = goog || {};
 /**
  * Reference to the global object.  This is provided as 'root' by the
  * UMD wrapper, but prefer globalThis if it is defined.
- * 
+ *
  * https://www.ecma-international.org/ecma-262/9.0/index.html#sec-global-object
  *
  * @const

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -71,7 +71,7 @@ import {FlyoutButton} from './flyout_button.js';
 import {HorizontalFlyout} from './flyout_horizontal.js';
 import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
 import {VerticalFlyout} from './flyout_vertical.js';
-import {Generator} from './generator.js';
+import {CodeGenerator} from './generator.js';
 import {Gesture} from './gesture.js';
 import {Grid} from './grid.js';
 import {Icon} from './icon.js';
@@ -567,12 +567,12 @@ WorkspaceCommentSvg.prototype.showContextMenu =
         return;
       }
       const menuOptions = [];
-    
+
       if (this.isDeletable() && this.isMovable()) {
         menuOptions.push(ContextMenu.commentDuplicateOption(this));
         menuOptions.push(ContextMenu.commentDeleteOption(this));
       }
-    
+
       ContextMenu.show(e, menuOptions, this.RTL);
     };
 
@@ -663,7 +663,8 @@ export {FieldVariable};
 export {Flyout};
 export {FlyoutButton};
 export {FlyoutMetricsManager};
-export {Generator};
+export {CodeGenerator};
+export {CodeGenerator as Generator};  // Deprecated name, October 2022.
 export {Gesture};
 export {Grid};
 export {HorizontalFlyout};

--- a/core/generator.ts
+++ b/core/generator.ts
@@ -11,7 +11,7 @@
  * @class
  */
 import * as goog from '../closure/goog/goog.js';
-goog.declareModuleId('Blockly.Generator');
+goog.declareModuleId('Blockly.CodeGenerator');
 
 import type {Block} from './block.js';
 import * as common from './common.js';
@@ -24,14 +24,14 @@ import type {Workspace} from './workspace.js';
  * Class for a code generator that translates the blocks into a language.
  *
  * @unrestricted
- * @alias Blockly.Generator
+ * @alias Blockly.CodeGenerator
  */
-export class Generator {
+export class CodeGenerator {
   name_: string;
 
   /**
    * This is used as a placeholder in functions defined using
-   * Generator.provideFunction_.  It must not be legal code that could
+   * CodeGenerator.provideFunction_.  It must not be legal code that could
    * legitimately appear in a function definition (or comment), and it must
    * not confuse the regular expression parser.
    */
@@ -205,7 +205,7 @@ export class Generator {
       |[string, number] {
     if (this.isInitialized === false) {
       console.warn(
-          'Generator init was not called before blockToCode was called.');
+          'CodeGenerator init was not called before blockToCode was called.');
     }
     if (!block) {
       return '';
@@ -414,7 +414,7 @@ export class Generator {
    * "listRandom", not "random").  There is no danger of colliding with reserved
    * words, or user-defined variable or procedure names.
    *
-   * The code gets output when Generator.finish() is called.
+   * The code gets output when CodeGenerator.finish() is called.
    *
    * @param desiredName The desired name of the function (e.g. mathIsPrime).
    * @param code A list of statements or one multi-line code string.  Use '  '
@@ -514,23 +514,23 @@ export class Generator {
   }
 }
 
-Object.defineProperties(Generator.prototype, {
+Object.defineProperties(CodeGenerator.prototype, {
   /**
    * A database of variable names.
    *
-   * @name Blockly.Generator.prototype.variableDB_
+   * @name Blockly.CodeGenerator.prototype.variableDB_
    * @deprecated 'variableDB_' was renamed to 'nameDB_' (May 2021).
    * @suppress {checkTypes}
    */
   variableDB_: ({
     /** @returns Name database. */
-    get(this: Generator): Names |
+    get(this: CodeGenerator): Names |
         undefined {
           deprecation.warn('variableDB_', 'version 9', 'version 10', 'nameDB_');
           return this.nameDB_;
         },
     /** @param nameDb New name database. */
-    set(this: Generator, nameDb: Names|undefined) {
+    set(this: CodeGenerator, nameDb: Names|undefined) {
       deprecation.warn('variableDB_', 'version 9', 'version 10', 'nameDB_');
       this.nameDB_ = nameDb;
     },

--- a/demos/blockfactory/analytics.js
+++ b/demos/blockfactory/analytics.js
@@ -194,4 +194,3 @@ BlocklyDevTools.Analytics.sendQueued = function() {
   // stub
   this.LOG_TO_CONSOLE_ && console.log('Analytics.sendQueued');
 };
-

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -373,7 +373,7 @@ Code.renderContent = function() {
 
 /**
  * Attempt to generate the code and display it in the UI, pretty printed.
- * @param generator {!Blockly.Generator} The generator to use.
+ * @param generator {!Blockly.CodeGenerator} The generator to use.
  */
 Code.attemptCodeGeneration = function(generator) {
   var content = document.getElementById('content_' + Code.selected);
@@ -388,7 +388,7 @@ Code.attemptCodeGeneration = function(generator) {
 
 /**
  * Check whether all blocks in use have generator functions.
- * @param generator {!Blockly.Generator} The generator to use.
+ * @param generator {!Blockly.CodeGenerator} The generator to use.
  */
 Code.checkAllGeneratorFunctionsDefined = function(generator) {
   var blocks = Code.workspace.getAllBlocks(false);

--- a/demos/mobile/android/build.gradle
+++ b/demos/mobile/android/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
-        
+
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demos/mobile/ios/Blockly WebView/ViewController.swift
+++ b/demos/mobile/ios/Blockly WebView/ViewController.swift
@@ -15,9 +15,9 @@ class ViewController: UIViewController, WKUIDelegate {
     /// The name used to reference this iOS object when executing callbacks from the JS code.
     /// If this value is changed, it should also be changed in the `CODE_GENERATOR_BRIDGE_JS` file.
     fileprivate static let HOST_HTML = "Blockly/webview.html"
-    
+
     @IBOutlet weak var webView: WKWebView!
- 
+
     /// Additional setup after loading the UI NIB.
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,7 +25,7 @@ class ViewController: UIViewController, WKUIDelegate {
         // Do any additional setup after loading the view, typically from a nib.
         loadWebContent()
     }
-    
+
     /// Load the root HTML page into the webview.
     func loadWebContent() {
         if let htmlUrl = Bundle.main.url(forResource: "webview", withExtension: "html",
@@ -41,7 +41,7 @@ class ViewController: UIViewController, WKUIDelegate {
                  runJavaScriptAlertPanelWithMessage message: String,
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping () -> Void) {
-        
+
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let title = NSLocalizedString("OK", comment: "OK Button")
         let ok = UIAlertAction(title: title, style: .default) { (action: UIAlertAction) -> Void in
@@ -51,25 +51,25 @@ class ViewController: UIViewController, WKUIDelegate {
         present(alert, animated: true)
         completionHandler()
     }
-    
+
     /// Handle window.confirm() with a native dialog.
     func webView(_ webView: WKWebView,
                  runJavaScriptConfirmPanelWithMessage message: String,
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping (Bool) -> Void) {
-        
+
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let closeAndHandle = { (okayed: Bool) in
             alert.dismiss(animated: true, completion: nil)
             completionHandler(okayed)
         }
-        
+
         let okTitle = NSLocalizedString("OK", comment: "OK button title")
         let ok = UIAlertAction(title: okTitle, style: .default) { (action: UIAlertAction) -> Void in
             closeAndHandle(true)
         }
         alert.addAction(ok)
-        
+
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
         let cancel = UIAlertAction(title: cancelTitle, style: .default) {
             (action: UIAlertAction) -> Void in
@@ -78,34 +78,33 @@ class ViewController: UIViewController, WKUIDelegate {
         alert.addAction(cancel)
         present(alert, animated: true)
     }
-    
+
     /// Handle window.prompt() with a native dialog.
     func webView(_ webView: WKWebView,
                  runJavaScriptTextInputPanelWithPrompt prompt: String,
                  defaultText: String?,
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping (String?) -> Void) {
-        
+
         let alert = UIAlertController(title: prompt, message: nil, preferredStyle: .alert)
-        
+
         alert.addTextField { (textField) in
             textField.text = defaultText
         }
-        
+
         let okTitle = NSLocalizedString("OK", comment: "OK button title")
         let okAction = UIAlertAction(title: okTitle, style: .default) { (_) in
             let textInput = alert.textFields![0] as UITextField
             completionHandler(textInput.text)
         }
         alert.addAction(okAction)
-        
+
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
         let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { (_) in
             completionHandler(nil)
         }
         alert.addAction(cancelAction)
-        
+
         present(alert, animated: true)
     }
 }
-

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -15,7 +15,7 @@ goog.module('Blockly.Dart');
 const Variables = goog.require('Blockly.Variables');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
-const {Generator} = goog.require('Blockly.Generator');
+const {CodeGenerator} = goog.require('Blockly.CodeGenerator');
 const {Names, NameType} = goog.require('Blockly.Names');
 const {Workspace} = goog.requireType('Blockly.Workspace');
 const {inputTypes} = goog.require('Blockly.inputTypes');
@@ -23,9 +23,9 @@ const {inputTypes} = goog.require('Blockly.inputTypes');
 
 /**
  * Dart code generator.
- * @type {!Generator}
+ * @type {!CodeGenerator}
  */
-const Dart = new Generator('Dart');
+const Dart = new CodeGenerator('Dart');
 
 /**
  * List of illegal variable names.
@@ -86,7 +86,7 @@ Dart.isInitialized = false;
  * @param {!Workspace} workspace Workspace to generate code from.
  */
 Dart.init = function(workspace) {
-  // Call Blockly.Generator's init.
+  // Call Blockly.CodeGenerator's init.
   Object.getPrototypeOf(this).init.call(this);
 
   if (!this.nameDB_) {
@@ -145,7 +145,7 @@ Dart.finish = function(code) {
       definitions.push(def);
     }
   }
-  // Call Blockly.Generator's finish.
+  // Call Blockly.CodeGenerator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;
 

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -15,7 +15,7 @@ goog.module('Blockly.JavaScript');
 const Variables = goog.require('Blockly.Variables');
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
-const {Generator} = goog.require('Blockly.Generator');
+const {CodeGenerator} = goog.require('Blockly.CodeGenerator');
 const {inputTypes} = goog.require('Blockly.inputTypes');
 const {Names, NameType} = goog.require('Blockly.Names');
 const {Workspace} = goog.requireType('Blockly.Workspace');
@@ -23,9 +23,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 
 /**
  * JavaScript code generator.
- * @type {!Generator}
+ * @type {!CodeGenerator}
  */
-const JavaScript = new Generator('JavaScript');
+const JavaScript = new CodeGenerator('JavaScript');
 
 /**
  * List of illegal variable names.
@@ -127,7 +127,7 @@ JavaScript.isInitialized = false;
  * @param {!Workspace} workspace Workspace to generate code from.
  */
 JavaScript.init = function(workspace) {
-  // Call Blockly.Generator's init.
+  // Call Blockly.CodeGenerator's init.
   Object.getPrototypeOf(this).init.call(this);
 
   if (!this.nameDB_) {
@@ -169,7 +169,7 @@ JavaScript.init = function(workspace) {
 JavaScript.finish = function(code) {
   // Convert the definitions dictionary into a list.
   const definitions = Object.values(this.definitions_);
-  // Call Blockly.Generator's finish.
+  // Call Blockly.CodeGenerator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;
 

--- a/generators/lua.js
+++ b/generators/lua.js
@@ -15,7 +15,7 @@ goog.module('Blockly.Lua');
 
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
-const {Generator} = goog.require('Blockly.Generator');
+const {CodeGenerator} = goog.require('Blockly.CodeGenerator');
 const {inputTypes} = goog.require('Blockly.inputTypes');
 const {Names} = goog.require('Blockly.Names');
 const {Workspace} = goog.requireType('Blockly.Workspace');
@@ -23,9 +23,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 
 /**
  * Lua code generator.
- * @type {!Generator}
+ * @type {!CodeGenerator}
  */
-const Lua = new Generator('Lua');
+const Lua = new CodeGenerator('Lua');
 
 /**
  * List of illegal variable names.
@@ -92,7 +92,7 @@ Lua.isInitialized = false;
  * @param {!Workspace} workspace Workspace to generate code from.
  */
 Lua.init = function(workspace) {
-  // Call Blockly.Generator's init.
+  // Call Blockly.CodeGenerator's init.
   Object.getPrototypeOf(this).init.call(this);
 
   if (!this.nameDB_) {
@@ -115,7 +115,7 @@ Lua.init = function(workspace) {
 Lua.finish = function(code) {
   // Convert the definitions dictionary into a list.
   const definitions = Object.values(this.definitions_);
-  // Call Blockly.Generator's finish.
+  // Call Blockly.CodeGenerator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;
 

--- a/generators/php.js
+++ b/generators/php.js
@@ -14,7 +14,7 @@ goog.module('Blockly.PHP');
 
 const stringUtils = goog.require('Blockly.utils.string');
 const {Block} = goog.requireType('Blockly.Block');
-const {Generator} = goog.require('Blockly.Generator');
+const {CodeGenerator} = goog.require('Blockly.CodeGenerator');
 const {inputTypes} = goog.require('Blockly.inputTypes');
 const {Names} = goog.require('Blockly.Names');
 const {Workspace} = goog.requireType('Blockly.Workspace');
@@ -22,9 +22,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 
 /**
  * PHP code generator.
- * @type {!Generator}
+ * @type {!CodeGenerator}
  */
-const PHP = new Generator('PHP');
+const PHP = new CodeGenerator('PHP');
 
 /**
  * List of illegal variable names.
@@ -130,7 +130,7 @@ PHP.isInitialized = false;
  * @param {!Workspace} workspace Workspace to generate code from.
  */
 PHP.init = function(workspace) {
-  // Call Blockly.Generator's init.
+  // Call Blockly.CodeGenerator's init.
   Object.getPrototypeOf(this).init.call(this);
 
   if (!this.nameDB_) {
@@ -154,7 +154,7 @@ PHP.init = function(workspace) {
 PHP.finish = function(code) {
   // Convert the definitions dictionary into a list.
   const definitions = Object.values(this.definitions_);
-  // Call Blockly.Generator's finish.
+  // Call Blockly.CodeGenerator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;
 

--- a/generators/python.js
+++ b/generators/python.js
@@ -15,7 +15,7 @@ goog.module('Blockly.Python');
 const stringUtils = goog.require('Blockly.utils.string');
 const Variables = goog.require('Blockly.Variables');
 const {Block} = goog.requireType('Blockly.Block');
-const {Generator} = goog.require('Blockly.Generator');
+const {CodeGenerator} = goog.require('Blockly.CodeGenerator');
 const {inputTypes} = goog.require('Blockly.inputTypes');
 const {Names, NameType} = goog.require('Blockly.Names');
 const {Workspace} = goog.requireType('Blockly.Workspace');
@@ -23,9 +23,9 @@ const {Workspace} = goog.requireType('Blockly.Workspace');
 
 /**
  * Python code generator.
- * @type {!Generator}
+ * @type {!CodeGenerator}
  */
-const Python = new Generator('Python');
+const Python = new CodeGenerator('Python');
 
 /**
  * List of illegal variable names.
@@ -137,10 +137,10 @@ Python.isInitialized = false;
 /**
  * Initialise the database of variable names.
  * @param {!Workspace} workspace Workspace to generate code from.
- * @this {Generator}
+ * @this {CodeGenerator}
  */
 Python.init = function(workspace) {
-  // Call Blockly.Generator's init.
+  // Call Blockly.CodeGenerator's init.
   Object.getPrototypeOf(this).init.call(this);
 
   /**
@@ -196,7 +196,7 @@ Python.finish = function(code) {
       definitions.push(def);
     }
   }
-  // Call Blockly.Generator's finish.
+  // Call Blockly.CodeGenerator's finish.
   code = Object.getPrototypeOf(this).finish.call(this, code);
   this.isInitialized = false;
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -174,7 +174,7 @@ function stripApacheLicense() {
  * For a full list of closure compiler groups, consult the output of
  * google-closure-compiler --help or look in the source  here:
  * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/DiagnosticGroups.java#L117
- * 
+ *
  * The list in JSCOMP_ERROR contains all the diagnostic groups we know
  * about, but some are commented out if we don't want them, and may
  * appear in JSCOMP_WARNING or JSCOMP_OFF instead.  Items not
@@ -277,7 +277,7 @@ var JSCOMP_OFF = [
    * core/utils/*. We were downgrading access control violations
    * (including @private) to warnings, but this ends up being so
    * spammy that it makes the compiler output nearly useless.
-   * 
+   *
    * Once ES module migration is complete, they will be re-enabled and
    * an alternative to @package will be established.
    */
@@ -464,7 +464,7 @@ function chunkWrapper(chunk) {
     browserDepsExpr = `root.${chunk.parent.reexport}`;
     factoryArgs = '__parent__';
     namespaceExpr = `${factoryArgs}.${NAMESPACE_PROPERTY}`;
-  }    
+  }
 
   // Code to assign the result of the factory function to the desired
   // export location when running in a browser.  When

--- a/scripts/package/README.md
+++ b/scripts/package/README.md
@@ -36,9 +36,9 @@ For samples on how to integrate Blockly into your project, view the list of samp
 ### Importing Blockly
 
 When you import Blockly with ``import * as Blockly from 'blockly';`` you'll get the default modules:
-Blockly core, Blockly built-in blocks, the JavaScript generator and the English lang files. 
+Blockly core, Blockly built-in blocks, the JavaScript generator and the English lang files.
 
-If you need more flexibility, you'll want to define your imports more carefully: 
+If you need more flexibility, you'll want to define your imports more carefully:
 
 #### Blockly Core
 

--- a/scripts/package/templates/node.template
+++ b/scripts/package/templates/node.template
@@ -2,4 +2,4 @@
 (function (<%= param %>){
 <%= contents %>
 module.exports = <%= exports %>;
-})(<%= cjs %>); 
+})(<%= cjs %>);

--- a/scripts/package/templates/umd-msg.template
+++ b/scripts/package/templates/umd-msg.template
@@ -13,4 +13,4 @@
 }(this, function() {
 <%= contents %>
 return Blockly.Msg;
-})); 
+}));

--- a/scripts/package/templates/umd.template
+++ b/scripts/package/templates/umd.template
@@ -10,4 +10,4 @@
 }(this, function(<%= param %>) {
 <%= contents %>
 return <%= exports %>;
-})); 
+}));

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -68,7 +68,7 @@
     depsFiles: [
       'build/deps.js',
     ],
-    
+
     // List of goog.modules to goog.require.
     requires: [
       'Blockly',

--- a/tests/generators/run_generators_in_browser.js
+++ b/tests/generators/run_generators_in_browser.js
@@ -52,8 +52,8 @@ async function runGeneratorsInBrowser() {
     };
   } else {
     // --disable-gpu is needed to prevent Chrome from hanging on Linux with
-    // NVIDIA drivers older than v295.20. See 
-    // https://github.com/google/blockly/issues/5345 for details.   
+    // NVIDIA drivers older than v295.20. See
+    // https://github.com/google/blockly/issues/5345 for details.
     options.capabilities['goog:chromeOptions'] = {
       args: ['--allow-file-access-from-files', '--disable-gpu']
     };

--- a/tests/mocha/block_change_event_test.js
+++ b/tests/mocha/block_change_event_test.js
@@ -25,12 +25,12 @@ suite('Block Change Event', function() {
       setup(function() {
         defineMutatorBlocks();
       });
-  
+
       teardown(function() {
         Blockly.Extensions.unregister('xml_mutator');
         Blockly.Extensions.unregister('jso_mutator');
       });
-      
+
       suite('XML', function() {
         test('Undo', function() {
           const block = this.workspace.newBlock('xml_block', 'block_id');

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -323,7 +323,7 @@ suite('Angle Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldAngle(value);

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -217,7 +217,7 @@ suite('Checkbox Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldCheckbox(value);

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -290,7 +290,7 @@ suite('Colour Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldColour(value);

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -166,7 +166,6 @@ suite('Dropdown Fields', function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
 
-      
       this.assertValue = (value, field) => {
         const block = this.workspace.newBlock('row_block');
         field.setValue(value);

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -194,7 +194,7 @@ suite('Label Serializable Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldLabelSerializable(value);

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -172,7 +172,7 @@ suite('Multiline Input Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldMultilineInput(value);

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -346,7 +346,7 @@ suite('Number Fields', function() {
     setup(function() {
       this.workspace = new Blockly.Workspace();
       defineRowBlock();
-      
+
       this.assertValue = (value) => {
         const block = this.workspace.newBlock('row_block');
         const field = new Blockly.FieldNumber(value);

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -93,7 +93,7 @@ suite('Field Registry', function() {
       };
 
       const field = Blockly.fieldRegistry.fromJson(json);
-      
+
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');
     });

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -192,13 +192,13 @@ suite('Abstract Fields', function() {
           const value = field.saveState();
           chai.assert.equal(value, 'test value');
         });
-  
+
         test('Xml implementations', function() {
           const field = new CustomXmlField('test value');
           const value = field.saveState();
           chai.assert.equal(value, '<field name="">custom value</field>');
         });
-  
+
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('test value');
           const value = field.saveState();
@@ -206,13 +206,13 @@ suite('Abstract Fields', function() {
               value,
               '<field name="" attribute="custom value">test value</field>');
         });
-  
+
         test('JSO implementations', function() {
           const field = new CustomJsoField('test value');
           const value = field.saveState();
           chai.assert.equal(value, 'custom value');
         });
-  
+
         test('JSO super implementations', function() {
           const field = new CustomJsoCallSuperField('test value');
           const value = field.saveState();
@@ -236,7 +236,7 @@ suite('Abstract Fields', function() {
               value,
               '<field xmlns="http://www.w3.org/1999/xhtml">test value</field>');
         });
-  
+
         test('Xml implementations', function() {
           const field = new CustomXmlField('test value');
           const element = document.createElement('field');
@@ -246,7 +246,7 @@ suite('Abstract Fields', function() {
               '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>'
           );
         });
-  
+
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('test value');
           const element = document.createElement('field');
@@ -276,13 +276,13 @@ suite('Abstract Fields', function() {
           field.loadState('test value');
           chai.assert.equal(field.getValue(), 'test value');
         });
-  
+
         test('Xml implementations', function() {
           const field = new CustomXmlField('');
           field.loadState('<field name="">custom value</field>');
           chai.assert.equal(field.someProperty, 'custom value');
         });
-  
+
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('');
           field.loadState(
@@ -290,20 +290,20 @@ suite('Abstract Fields', function() {
           chai.assert.equal(field.getValue(), 'test value');
           chai.assert.equal(field.someProperty, 'custom value');
         });
-  
+
         test('JSO implementations', function() {
           const field = new CustomJsoField('');
           field.loadState('custom value');
           chai.assert.equal(field.someProperty, 'custom value');
         });
-  
+
         test('JSO super implementations', function() {
           const field = new CustomJsoCallSuperField('');
           field.loadState({default: 'test value', val: 'custom value'});
           chai.assert.equal(field.getValue(), 'test value');
           chai.assert.equal(field.someProperty, 'custom value');
         });
-        
+
         test('Xml and JSO implementations', function() {
           const field = new CustomXmlAndJsoField('');
           field.loadState('custom value');
@@ -318,14 +318,14 @@ suite('Abstract Fields', function() {
               Blockly.Xml.textToDom('<field name="">test value</field>'));
           chai.assert.equal(field.getValue(), 'test value');
         });
-  
+
         test('Xml implementations', function() {
           const field = new CustomXmlField('');
           field.fromXml(
               Blockly.Xml.textToDom('<field name="">custom value</field>'));
           chai.assert.equal(field.someProperty, 'custom value');
         });
-  
+
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('');
           field.fromXml(

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -406,7 +406,7 @@ suite('Variable Fields', function() {
         chai.assert.deepEqual(
             jso['fields'], {'VAR': {'id': 'id2', 'name': 'x', 'type': ''}});
       });
-  
+
       test('Typed', function() {
         const block = this.workspace.newBlock('row_block');
         const field =
@@ -429,7 +429,7 @@ suite('Variable Fields', function() {
         chai.assert.isUndefined(jso['fields']['VAR']['name']);
         chai.assert.isUndefined(jso['fields']['VAR']['type']);
       });
-  
+
       test('Typed', function() {
         const block = this.workspace.newBlock('row_block');
         const field =

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -27,7 +27,7 @@ suite('Generator', function() {
 
   suite('prefix', function() {
     setup(function() {
-      this.generator = new Blockly.Generator('INTERCAL');
+      this.generator = new Blockly.CodeGenerator('INTERCAL');
     });
 
     test('Nothing', function() {

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -729,47 +729,47 @@ suite('JSO Deserialization', function() {
         this.name = name;
         return this;
       }
-    
+
       insertParameter(parameterModel, index) {
         this.parameters.splice(index, 0, parameterModel);
         return this;
       }
-    
+
       deleteParameter(index) {
         this.parameters.splice(index, 1);
         return this;
       }
-    
+
       setReturnTypes(types) {
         this.returnTypes = types;
         return this;
       }
-    
+
       setEnabled(enabled) {
         this.enabled = enabled;
         return this;
       }
-    
+
       getId() {
         return this.id;
       }
-    
+
       getName() {
         return this.name;
       }
-    
+
       getParameter(index) {
         return this.parameters[index];
       }
-    
+
       getParameters() {
         return [...this.parameters];
       }
-    
+
       getReturnTypes() {
         return this.returnTypes;
       }
-    
+
       getEnabled() {
         return this.enabled;
       }

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -388,21 +388,21 @@ suite('JSO Serialization', function() {
                   '<shadow type="' + blockType + '" id="test"></shadow>'));
           return block;
         };
-  
+
         this.assertChild = function(blockType, inputName) {
           const block = this.createBlockWithChild(blockType, inputName);
           const jso = Blockly.serialization.blocks.save(block);
           this.assertInput(
               jso, inputName, {'block': {'type': blockType, 'id': 'id2'}});
         };
-  
+
         this.assertShadow = function(blockType, inputName) {
           const block = this.createBlockWithShadow(blockType, inputName);
           const jso = Blockly.serialization.blocks.save(block);
           this.assertInput(
               jso, inputName, {'shadow': {'type': blockType, 'id': 'test'}});
         };
-  
+
         this.assertOverwrittenShadow = function(blockType, inputName) {
           const block =
               this.createBlockWithShadowAndChild(blockType, inputName);
@@ -428,14 +428,14 @@ suite('JSO Serialization', function() {
               Blockly.serialization.blocks.save(block, {addInputBlocks: false});
           chai.assert.isUndefined(jso['inputs']);
         };
-  
+
         this.assertNoShadow = function(blockType, inputName) {
           const block = this.createBlockWithShadow(blockType, inputName);
           const jso =
               Blockly.serialization.blocks.save(block, {addInputBlocks: false});
           chai.assert.isUndefined(jso['inputs']);
         };
-  
+
         this.assertNoOverwrittenShadow = function(blockType, inputName) {
           const block =
               this.createBlockWithShadowAndChild(blockType, inputName);
@@ -506,11 +506,11 @@ suite('JSO Serialization', function() {
           test('Child', function() {
             this.assertChild('row_block', 'INPUT');
           });
-  
+
           test('Shadow', function() {
             this.assertShadow('row_block', 'INPUT');
           });
-  
+
           test('Overwritten shadow', function() {
             this.assertOverwrittenShadow('row_block', 'INPUT');
           });
@@ -520,11 +520,11 @@ suite('JSO Serialization', function() {
           test('Child', function() {
             this.assertNoChild('row_block', 'INPUT');
           });
-  
+
           test('Shadow', function() {
             this.assertNoShadow('row_block', 'INPUT');
           });
-  
+
           test('Overwritten shadow', function() {
             this.assertNoOverwrittenShadow('row_block', 'INPUT');
           });
@@ -536,11 +536,11 @@ suite('JSO Serialization', function() {
           test('Child', function() {
             this.assertChild('statement_block', 'NAME');
           });
-  
+
           test('Shadow', function() {
             this.assertShadow('statement_block', 'NAME');
           });
-  
+
           test('Overwritten shadow', function() {
             this.assertOverwrittenShadow('statement_block', 'NAME');
           });
@@ -577,11 +577,11 @@ suite('JSO Serialization', function() {
           test('Child', function() {
             this.assertNoChild('statement_block', 'NAME');
           });
-  
+
           test('Shadow', function() {
             this.assertNoShadow('statement_block', 'NAME');
           });
-  
+
           test('Overwritten shadow', function() {
             this.assertNoOverwrittenShadow('statement_block', 'NAME');
           });
@@ -624,14 +624,14 @@ suite('JSO Serialization', function() {
             chai.assert.deepInclude(
                 jso['next'], {'block': {'type': 'stack_block', 'id': 'id2'}});
           });
-  
+
           test('Shadow', function() {
             const block = this.createNextWithShadow();
             const jso = Blockly.serialization.blocks.save(block);
             chai.assert.deepInclude(
                 jso['next'], {'shadow': {'type': 'stack_block', 'id': 'test'}});
           });
-  
+
           test('Overwritten shadow', function() {
             const block = this.createNextWithShadowAndChild();
             const jso = Blockly.serialization.blocks.save(block);
@@ -684,7 +684,7 @@ suite('JSO Serialization', function() {
                 block, {addNextBlocks: false});
             chai.assert.isUndefined(jso['next']);
           });
-  
+
           test('Shadow', function() {
             const block = this.createNextWithShadow();
             const jso = Blockly.serialization.blocks.save(
@@ -810,47 +810,47 @@ suite('JSO Serialization', function() {
         this.name = name;
         return this;
       }
-    
+
       insertParameter(parameterModel, index) {
         this.parameters.splice(index, 0, parameterModel);
         return this;
       }
-    
+
       deleteParameter(index) {
         this.parameters.splice(index, 1);
         return this;
       }
-    
+
       setReturnTypes(types) {
         this.returnTypes = types;
         return this;
       }
-    
+
       setEnabled(enabled) {
         this.enabled = enabled;
         return this;
       }
-    
+
       getId() {
         return this.id;
       }
-    
+
       getName() {
         return this.name;
       }
-    
+
       getParameter(index) {
         return this.parameters[index];
       }
-    
+
       getParameters() {
         return [...this.parameters];
       }
-    
+
       getReturnTypes() {
         return this.returnTypes;
       }
-    
+
       getEnabled() {
         return this.enabled;
       }

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -80,7 +80,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('setting the return type triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(
@@ -92,7 +92,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('removing the return type triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(
@@ -106,7 +106,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('disabling the procedure triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(
@@ -118,7 +118,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('enabling the procedure triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(
@@ -145,7 +145,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('deleting a parameter triggers an update', function() {
         const procedureModel =
             new Blockly.procedures.ObservableProcedureModel(
@@ -179,7 +179,7 @@ suite('Procedure Map', function() {
         chai.assert.isTrue(
             this.updateSpy.calledOnce, 'Expected an update to be triggered');
       });
-  
+
       test('modifying the variable model does not trigger an update', function() {
         const parameterModel =
             new Blockly.procedures.ObservableParameterModel(

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -26,7 +26,7 @@ suite('Registry', function() {
       Blockly.registry.unregister('test', 'test_name');
     }
   });
-  
+
   suite('Registration', function() {
     test('Simple', function() {
       Blockly.registry.register('test', 'test_name', TestClass);

--- a/tests/mocha/run_mocha_tests_in_browser.js
+++ b/tests/mocha/run_mocha_tests_in_browser.js
@@ -37,7 +37,7 @@ async function runMochaTestsInBrowser() {
     };
   } else {
     // --disable-gpu is needed to prevent Chrome from hanging on Linux with
-    // NVIDIA drivers older than v295.20. See 
+    // NVIDIA drivers older than v295.20. See
     // https://github.com/google/blockly/issues/5345 for details.
     options.capabilities['goog:chromeOptions'] = {
       args: ['--allow-file-access-from-files', '--disable-gpu']

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -55,7 +55,7 @@ export class CodeGenerationTestSuite {
    */
   constructor() {
     /**
-     * @type {!Blockly.Generator} The generator to use for running test cases.
+     * @type {!Blockly.CodeGenerator} The generator to use for running test cases.
      */
     this.generator;
   }
@@ -64,7 +64,7 @@ export class CodeGenerationTestSuite {
 /**
  * Returns mocha test callback for code generation based on provided
  *    generator.
- * @param {!Blockly.Generator} generator The generator to use in test.
+ * @param {!Blockly.CodeGenerator} generator The generator to use in test.
  * @return {function(!CodeGenerationTestCase):!Function} Function that
  *    returns mocha test callback based on test case.
  * @private

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -7,7 +7,7 @@
  goog.declareModuleId('Blockly.test.touch');
 
  import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
- 
+
  suite('Touch', function() {
     setup(function() {
         sharedTestSetup.call(this);

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -64,7 +64,7 @@ suite('WidgetDiv', function() {
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
-  
+
       test('topConflict', function() {
         // Anchor close to the top.
         const anchorBBox =
@@ -75,7 +75,7 @@ suite('WidgetDiv', function() {
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
-  
+
       test('bottomConflict', function() {
         // Anchor placed close to the bottom.
         const anchorBBox =
@@ -86,7 +86,7 @@ suite('WidgetDiv', function() {
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
-  
+
       test('leftConflict', function() {
         // Anchor placed close to the left side.
         const anchorBBox =
@@ -97,7 +97,7 @@ suite('WidgetDiv', function() {
         this.testWidgetPosition(
             anchorBBox, false, expectedX, expectedY, this.widgetSize.height);
       });
-  
+
       test('rightConflict', function() {
         // Anchor placed close to the right side.
         const anchorBBox =

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -436,7 +436,7 @@ function addEventHandlers() {
   document.getElementById('hide')
       .addEventListener('click', function() { workspace.setVisible(false); });
 }
-  
+
 // Call start().  Because this <script> has type=module, it is
 // automatically deferred, so it will not be run until after the
 // document has been parsed, but before firing DOMContentLoaded.

--- a/tests/scripts/setup_osx_env.sh
+++ b/tests/scripts/setup_osx_env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-  
+
 if [ "${RUNNER_OS}" == "macOS" ]
   then
     export CHROME_BIN="/Applications/Google Chrome.app"


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Naming collision between Blockly.Generator and ES6's Generator.

### Proposed Changes

Rename our Generator to CodeGenerator (it's a more descriptive name anyway).

#### Behaviour Before Change

TypeScript would get confused think that our code generators only had .next .return and .throw methods.

#### Behaviour After Change

TypeScript should be less grumpy.

### Reason for Changes

TypeScript is pretending to be Java.

### Test Coverage

I left the tests unchanged after the rename to verify that the old name still works.  Then I updated the tests to the new name.

### Documentation

We currently don't have any documentation about creating a new CodeGenerator.  This is a separate issue.

### Additional Information

In a separate commit on this PR I stripped out all the trailing whitespace from our codebase.