### PR TITLE
fix(tests): generator tests on linux

### DIFF
--- a/scripts/gulpfiles/test_tasks.js
+++ b/scripts/gulpfiles/test_tasks.js
@@ -24,8 +24,8 @@ const runMochaTestsInBrowser =
 const runGeneratorsInBrowser =
   require('../../tests/generators/run_generators_in_browser.js');
 
-const OUTPUT_DIR = 'build/generators/';
-const GOLDEN_DIR = 'tests/generators/golden/';
+const OUTPUT_DIR = 'build/generators';
+const GOLDEN_DIR = 'tests/generators/golden';
 
 const BOLD_GREEN = '\x1b[1;32m';
 const BOLD_RED = '\x1b[1;31m';


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes an issue where the generator tests fail on Linux with 

```
fenichel@fenichel-glaptop2:~/Documents/gblockly-rr$ npm run test:generators

> blockly@9.0.1 test:generators
> gulp --silent testGenerators

=======================================
== generators
Cannot read properties of null (reading 'code')
FAILED: generators
fenichel@fenichel-glaptop2:~/Documents/gblockly-rr$
```

### Proposed Changes

Remove trailing slashes from calls to `rimraf`.

#### Behavior Before Change

Crashes on linux

#### Behavior After Change

Tests run and don't crash.

### Reason for Changes

Rimraf didn't like the trailing slash, which is surprising to me.


### Additional Information

Caused by #6431 so we'll need to verify it still works on windows after this fix.