### PR TITLE
test: add tests for the insertion marker manager

### DIFF
--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -83,6 +83,7 @@
           'Blockly.test.gesture',
           'Blockly.test.input',
           'Blockly.test.insertionMarker',
+          'Blockly.test.insertionMarkerManager',
           'Blockly.test.jsoDeserialization',
           'Blockly.test.jsoSerialization',
           'Blockly.test.json',

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -20,14 +20,14 @@ suite('Insertion marker manager', function() {
       sharedTestTeardown.call(this);
     });
 
-    function createBlocksAndManager(workspace, state) {
-        Blockly.serialization.workspaces.load(state, workspace);
-        const block = workspace.getBlockById('first');
-        const manager = new Blockly.InsertionMarkerManager(block);
-        return manager;
-    }
-
     suite('Create markers', function() {
+        function createBlocksAndManager(workspace, state) {
+            Blockly.serialization.workspaces.load(state, workspace);
+            const block = workspace.getBlockById('first');
+            const manager = new Blockly.InsertionMarkerManager(block);
+            return manager;
+        }
+
         test('One stack block', function() {
             const state = {
               'blocks': {
@@ -49,11 +49,11 @@ suite('Insertion marker manager', function() {
                 'blocks': {
                     'blocks': [
                     {
-                      'type': 'text_print',
+                      'type': 'stack_block',
                       'id': 'first',
                       'next': {
                         'block': {
-                          'type': 'text_print',
+                          'type': 'stack_block',
                           'id': 'second',
                         },
                       },
@@ -71,15 +71,15 @@ suite('Insertion marker manager', function() {
                 'blocks': {
                     'blocks': [
                     {
-                      'type': 'text_print',
+                      'type': 'stack_block',
                       'id': 'first',
                       'next': {
                         'block': {
-                          'type': 'text_print',
+                          'type': 'stack_block',
                           'id': 'second',
                           'next': {
                             'block': {
-                              'type': 'text_print',
+                              'type': 'stack_block',
                               'id': 'third',
                             },
                           },
@@ -132,6 +132,198 @@ suite('Insertion marker manager', function() {
             const manager = createBlocksAndManager(this.workspace, state);
             const markers = manager.getInsertionMarkers();
             chai.assert.equal(markers.length, 1);
+        });
+    });
+
+    suite('Would delete block', function() {
+        setup(function() {
+            const state = {
+                'blocks': {
+                  'blocks': [
+                    {
+                      'type': 'stack_block',
+                      'id': 'first',
+                    },
+                  ],
+                },
+              };
+            Blockly.serialization.workspaces.load(state, this.workspace);
+            this.block = this.workspace.getBlockById('first');
+            this.manager = new Blockly.InsertionMarkerManager(this.block);
+        });
+        
+        function stubComponentManager(workspace) {
+            const componentManager = workspace.getComponentManager();
+            const stub = sinon.stub(componentManager, 'hasCapability');
+            return stub;
+        }
+
+        test('Over delete area: accepted', function() {
+            const dxy = new Blockly.utils.Coordinate(0, 0);
+            const stub = stubComponentManager(this.workspace);
+            stub.withArgs('fakeDragTarget',
+                Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+            const fakeDragTarget = {
+                wouldDelete: sinon.fake.returns(true),
+                id: 'fakeDragTarget',
+            };
+            this.manager.update(dxy, fakeDragTarget);
+            chai.assert.isTrue(this.manager.wouldDeleteBlock());
+            chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
+        });
+
+        test('Over delete area: rejected', function() {
+            const dxy = new Blockly.utils.Coordinate(0, 0);
+            const stub = stubComponentManager(this.workspace);
+            stub.withArgs('fakeDragTarget',
+                Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+            const fakeDragTarget = {
+                wouldDelete: sinon.fake.returns(false),
+                id: 'fakeDragTarget',
+            };
+            this.manager.update(dxy, fakeDragTarget);
+            chai.assert.isFalse(this.manager.wouldDeleteBlock());
+            chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
+        });
+
+        test('Drag target is not a delete area', function() {
+            const dxy = new Blockly.utils.Coordinate(0, 0);
+            const stub = stubComponentManager(this.workspace);
+            stub.withArgs('fakeDragTarget',
+                Blockly.ComponentManager.Capability.DELETE_AREA).returns(false);
+            const fakeDragTarget = {
+                wouldDelete: sinon.fake.returns(false),
+                id: 'fakeDragTarget',
+            };
+            this.manager.update(dxy, fakeDragTarget);
+            chai.assert.isFalse(this.manager.wouldDeleteBlock());
+            chai.assert.isFalse(fakeDragTarget.wouldDelete.called);
+        });
+
+        test('Not over drag target', function() {
+            const dxy = new Blockly.utils.Coordinate(0, 0);
+            this.manager.update(dxy, null);
+            chai.assert.isFalse(this.manager.wouldDeleteBlock());
+        });
+    });
+
+    suite('Would connect stack blocks', function() {
+        setup(function() {
+            const state = {
+                'blocks': {
+                  'blocks': [
+                    {
+                      'type': 'stack_block',
+                      'id': 'first',
+                      'x': 0,
+                      'y': 0,
+                    },
+                    {
+                      'type': 'stack_block',
+                      'id': 'other',
+                      'x': 200,
+                      'y': 200,
+                    },
+                  ],
+                },
+              };
+            Blockly.serialization.workspaces.load(state, this.workspace);
+            this.block = this.workspace.getBlockById('first');
+            this.block.setDragging(true);
+            this.manager = new Blockly.InsertionMarkerManager(this.block);
+        });
+
+        test('No other blocks nearby', function() {
+            this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
+            chai.assert.isFalse(this.manager.wouldConnectBlock());
+        });
+
+        test('Near other block: above', function() {
+            this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+            const markers = this.manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+            const marker = markers[0];
+            chai.assert.isTrue(marker.nextConnection.isConnected());
+        });
+
+        test('Near other block: below', function() {
+            this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+            const markers = this.manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+            const marker = markers[0];
+            chai.assert.isTrue(marker.previousConnection.isConnected());
+        });
+
+        test('Near other block: left', function() {
+            this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+        });
+
+        test('Near other block: right', function() {
+            this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+        });
+    });
+
+    suite('Would connect row blocks', function() {
+        setup(function() {
+            const state = {
+                'blocks': {
+                  'blocks': [
+                    {
+                      'type': 'row_block',
+                      'id': 'first',
+                      'x': 0,
+                      'y': 0,
+                    },
+                    {
+                      'type': 'row_block',
+                      'id': 'other',
+                      'x': 200,
+                      'y': 200,
+                    },
+                  ],
+                },
+              };
+            Blockly.serialization.workspaces.load(state, this.workspace);
+            this.block = this.workspace.getBlockById('first');
+            this.block.setDragging(true);
+            this.manager = new Blockly.InsertionMarkerManager(this.block);
+        });
+
+        test('No other blocks nearby', function() {
+            this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
+            chai.assert.isFalse(this.manager.wouldConnectBlock());
+        });
+
+        test('Near other block: above', function() {
+            this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+        });
+
+        test('Near other block: below', function() {
+            this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+        });
+        
+        test('Near other block: left', function() {
+            this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+            const markers = this.manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+            const marker = markers[0];
+            chai.assert.isTrue(marker.getInput('INPUT').connection.isConnected());
+        });
+
+        test('Near other block: right', function() {
+            this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
+            chai.assert.isTrue(this.manager.wouldConnectBlock());
+            const markers = this.manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+            const marker = markers[0];
+            chai.assert.isTrue(marker.outputConnection.isConnected());
         });
     });
 });

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -7,13 +7,14 @@
 goog.declareModuleId('Blockly.test.insertionMarkerManager');
 
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
-import {defineRowBlock, defineStackBlock} from './test_helpers/block_definitions.js';
+import {defineRowBlock, defineRowToStackBlock, defineStackBlock} from './test_helpers/block_definitions.js';
 
 suite('Insertion marker manager', function() {
   setup(function() {
     sharedTestSetup.call(this);
     defineRowBlock();
     defineStackBlock();
+    defineRowToStackBlock();
     this.workspace = Blockly.inject('blocklyDiv');
   });
   teardown(function() {
@@ -132,6 +133,44 @@ suite('Insertion marker manager', function() {
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
       chai.assert.equal(markers.length, 1);
+    });
+
+    test('One row to stack block creates one marker', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'row_to_stack_block',
+              'id': 'first',
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+    });
+
+    test('Row to stack block with child creates two markers', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'row_to_stack_block',
+              'id': 'first',
+              'next': {
+                'block': {
+                  'type': 'stack_block',
+                  'id': 'second',
+                },
+              },
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 2);
     });
   });
 

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -150,59 +150,55 @@ suite('Insertion marker manager', function() {
       Blockly.serialization.workspaces.load(state, this.workspace);
       this.block = this.workspace.getBlockById('first');
       this.manager = new Blockly.InsertionMarkerManager(this.block);
+
+      const componentManager = this.workspace.getComponentManager();
+      this.stub = sinon.stub(componentManager, 'hasCapability');
+      this.dxy = new Blockly.utils.Coordinate(0, 0);
     });
 
-    function stubComponentManager(workspace) {
-      const componentManager = workspace.getComponentManager();
-      const stub = sinon.stub(componentManager, 'hasCapability');
-      return stub;
-    }
-
     test('Over delete area: accepted', function() {
-      const dxy = new Blockly.utils.Coordinate(0, 0);
-      const stub = stubComponentManager(this.workspace);
-      stub.withArgs('fakeDragTarget',
-        Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+      this.stub
+          .withArgs(
+              'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
+          .returns(true);
       const fakeDragTarget = {
         wouldDelete: sinon.fake.returns(true),
         id: 'fakeDragTarget',
       };
-      this.manager.update(dxy, fakeDragTarget);
+      this.manager.update(this.dxy, fakeDragTarget);
       chai.assert.isTrue(this.manager.wouldDeleteBlock());
       chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
     test('Over delete area: rejected', function() {
-      const dxy = new Blockly.utils.Coordinate(0, 0);
-      const stub = stubComponentManager(this.workspace);
-      stub.withArgs('fakeDragTarget',
-        Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+      this.stub
+          .withArgs(
+              'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
+          .returns(true);
       const fakeDragTarget = {
         wouldDelete: sinon.fake.returns(false),
         id: 'fakeDragTarget',
       };
-      this.manager.update(dxy, fakeDragTarget);
+      this.manager.update(this.dxy, fakeDragTarget);
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
       chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
     test('Drag target is not a delete area', function() {
-      const dxy = new Blockly.utils.Coordinate(0, 0);
-      const stub = stubComponentManager(this.workspace);
-      stub.withArgs('fakeDragTarget',
-        Blockly.ComponentManager.Capability.DELETE_AREA).returns(false);
+      this.stub
+          .withArgs(
+              'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
+          .returns(false);
       const fakeDragTarget = {
         wouldDelete: sinon.fake.returns(false),
         id: 'fakeDragTarget',
       };
-      this.manager.update(dxy, fakeDragTarget);
+      this.manager.update(this.dxy, fakeDragTarget);
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
-      chai.assert.isFalse(fakeDragTarget.wouldDelete.called);
     });
 
     test('Not over drag target', function() {
-      const dxy = new Blockly.utils.Coordinate(0, 0);
-      this.manager.update(dxy, null);
+      this.manager.update(this.dxy, null);
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
     });
   });

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.declareModuleId('Blockly.test.insertionMarkerManager');
+
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {defineRowBlock, defineStackBlock} from './test_helpers/block_definitions.js';
+
+suite('Insertion marker manager', function() {
+    setup(function() {
+      sharedTestSetup.call(this);
+      defineRowBlock();
+      defineStackBlock();
+      this.workspace = Blockly.inject('blocklyDiv');
+    });
+    teardown(function() {
+      sharedTestTeardown.call(this);
+    });
+
+    function createBlocksAndManager(workspace, state) {
+        Blockly.serialization.workspaces.load(state, workspace);
+        const block = workspace.getBlockById('first');
+        const manager = new Blockly.InsertionMarkerManager(block);
+        return manager;
+    }
+
+    suite('Create markers', function() {
+        test('One stack block', function() {
+            const state = {
+              'blocks': {
+                'blocks': [
+                  {
+                    'type': 'stack_block',
+                    'id': 'first',
+                  },
+                ],
+              },
+            };
+            const manager = createBlocksAndManager(this.workspace, state);
+            const markers = manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+        });
+        
+        test('Two stack blocks', function() {
+            const state = {
+                'blocks': {
+                    'blocks': [
+                    {
+                      'type': 'text_print',
+                      'id': 'first',
+                      'next': {
+                        'block': {
+                          'type': 'text_print',
+                          'id': 'second',
+                        },
+                      },
+                    },
+                ],
+                },
+            };
+            const manager = createBlocksAndManager(this.workspace, state);
+            const markers = manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 2);
+        });
+
+        test('Three stack blocks', function() {
+            const state = {
+                'blocks': {
+                    'blocks': [
+                    {
+                      'type': 'text_print',
+                      'id': 'first',
+                      'next': {
+                        'block': {
+                          'type': 'text_print',
+                          'id': 'second',
+                          'next': {
+                            'block': {
+                              'type': 'text_print',
+                              'id': 'third',
+                            },
+                          },
+                        },
+                      },
+                    },
+                ],
+                },
+            };
+            const manager = createBlocksAndManager(this.workspace, state);
+            const markers = manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 2);
+        });
+
+        test('One value block', function() {
+            const state = {
+              'blocks': {
+                'blocks': [
+                  {
+                    'type': 'row_block',
+                    'id': 'first',
+                  },
+                ],
+              },
+            };
+            const manager = createBlocksAndManager(this.workspace, state);
+            const markers = manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+        });
+
+        test('Two value blocks', function() {
+            const state = {
+              'blocks': {
+                'blocks': [
+                  {
+                    'type': 'row_block',
+                    'id': 'first',
+                    'inputs': {
+                        'INPUT': {
+                          'block': {
+                            'type': 'row_block',
+                            'id': 'second',
+                          },
+                        },
+                      },
+                  },
+                ],
+              },
+            };
+            const manager = createBlocksAndManager(this.workspace, state);
+            const markers = manager.getInsertionMarkers();
+            chai.assert.equal(markers.length, 1);
+        });
+    });
+});

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -10,320 +10,320 @@ import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown
 import {defineRowBlock, defineStackBlock} from './test_helpers/block_definitions.js';
 
 suite('Insertion marker manager', function() {
+  setup(function() {
+    sharedTestSetup.call(this);
+    defineRowBlock();
+    defineStackBlock();
+    this.workspace = Blockly.inject('blocklyDiv');
+  });
+  teardown(function() {
+    sharedTestTeardown.call(this);
+  });
+
+  suite('Creating markers', function() {
+    function createBlocksAndManager(workspace, state) {
+      Blockly.serialization.workspaces.load(state, workspace);
+      const block = workspace.getBlockById('first');
+      const manager = new Blockly.InsertionMarkerManager(block);
+      return manager;
+    }
+
+    test('One stack block', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'stack_block',
+              'id': 'first',
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+    });
+
+    test('Two stack blocks', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'stack_block',
+              'id': 'first',
+              'next': {
+                'block': {
+                  'type': 'stack_block',
+                  'id': 'second',
+                },
+              },
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 2);
+    });
+
+    test('Three stack blocks', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'stack_block',
+              'id': 'first',
+              'next': {
+                'block': {
+                  'type': 'stack_block',
+                  'id': 'second',
+                  'next': {
+                    'block': {
+                      'type': 'stack_block',
+                      'id': 'third',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 2);
+    });
+
+    test('One value block', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'row_block',
+              'id': 'first',
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+    });
+
+    test('Two value blocks', function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'row_block',
+              'id': 'first',
+              'inputs': {
+                'INPUT': {
+                  'block': {
+                    'type': 'row_block',
+                    'id': 'second',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+      const manager = createBlocksAndManager(this.workspace, state);
+      const markers = manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+    });
+  });
+
+  suite('Would delete block', function() {
     setup(function() {
-      sharedTestSetup.call(this);
-      defineRowBlock();
-      defineStackBlock();
-      this.workspace = Blockly.inject('blocklyDiv');
-    });
-    teardown(function() {
-      sharedTestTeardown.call(this);
-    });
-
-    suite('Create markers', function() {
-        function createBlocksAndManager(workspace, state) {
-            Blockly.serialization.workspaces.load(state, workspace);
-            const block = workspace.getBlockById('first');
-            const manager = new Blockly.InsertionMarkerManager(block);
-            return manager;
-        }
-
-        test('One stack block', function() {
-            const state = {
-              'blocks': {
-                'blocks': [
-                  {
-                    'type': 'stack_block',
-                    'id': 'first',
-                  },
-                ],
-              },
-            };
-            const manager = createBlocksAndManager(this.workspace, state);
-            const markers = manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-        });
-        
-        test('Two stack blocks', function() {
-            const state = {
-                'blocks': {
-                    'blocks': [
-                    {
-                      'type': 'stack_block',
-                      'id': 'first',
-                      'next': {
-                        'block': {
-                          'type': 'stack_block',
-                          'id': 'second',
-                        },
-                      },
-                    },
-                ],
-                },
-            };
-            const manager = createBlocksAndManager(this.workspace, state);
-            const markers = manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 2);
-        });
-
-        test('Three stack blocks', function() {
-            const state = {
-                'blocks': {
-                    'blocks': [
-                    {
-                      'type': 'stack_block',
-                      'id': 'first',
-                      'next': {
-                        'block': {
-                          'type': 'stack_block',
-                          'id': 'second',
-                          'next': {
-                            'block': {
-                              'type': 'stack_block',
-                              'id': 'third',
-                            },
-                          },
-                        },
-                      },
-                    },
-                ],
-                },
-            };
-            const manager = createBlocksAndManager(this.workspace, state);
-            const markers = manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 2);
-        });
-
-        test('One value block', function() {
-            const state = {
-              'blocks': {
-                'blocks': [
-                  {
-                    'type': 'row_block',
-                    'id': 'first',
-                  },
-                ],
-              },
-            };
-            const manager = createBlocksAndManager(this.workspace, state);
-            const markers = manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-        });
-
-        test('Two value blocks', function() {
-            const state = {
-              'blocks': {
-                'blocks': [
-                  {
-                    'type': 'row_block',
-                    'id': 'first',
-                    'inputs': {
-                        'INPUT': {
-                          'block': {
-                            'type': 'row_block',
-                            'id': 'second',
-                          },
-                        },
-                      },
-                  },
-                ],
-              },
-            };
-            const manager = createBlocksAndManager(this.workspace, state);
-            const markers = manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-        });
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'stack_block',
+              'id': 'first',
+            },
+          ],
+        },
+      };
+      Blockly.serialization.workspaces.load(state, this.workspace);
+      this.block = this.workspace.getBlockById('first');
+      this.manager = new Blockly.InsertionMarkerManager(this.block);
     });
 
-    suite('Would delete block', function() {
-        setup(function() {
-            const state = {
-                'blocks': {
-                  'blocks': [
-                    {
-                      'type': 'stack_block',
-                      'id': 'first',
-                    },
-                  ],
-                },
-              };
-            Blockly.serialization.workspaces.load(state, this.workspace);
-            this.block = this.workspace.getBlockById('first');
-            this.manager = new Blockly.InsertionMarkerManager(this.block);
-        });
-        
-        function stubComponentManager(workspace) {
-            const componentManager = workspace.getComponentManager();
-            const stub = sinon.stub(componentManager, 'hasCapability');
-            return stub;
-        }
+    function stubComponentManager(workspace) {
+      const componentManager = workspace.getComponentManager();
+      const stub = sinon.stub(componentManager, 'hasCapability');
+      return stub;
+    }
 
-        test('Over delete area: accepted', function() {
-            const dxy = new Blockly.utils.Coordinate(0, 0);
-            const stub = stubComponentManager(this.workspace);
-            stub.withArgs('fakeDragTarget',
-                Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
-            const fakeDragTarget = {
-                wouldDelete: sinon.fake.returns(true),
-                id: 'fakeDragTarget',
-            };
-            this.manager.update(dxy, fakeDragTarget);
-            chai.assert.isTrue(this.manager.wouldDeleteBlock());
-            chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
-        });
-
-        test('Over delete area: rejected', function() {
-            const dxy = new Blockly.utils.Coordinate(0, 0);
-            const stub = stubComponentManager(this.workspace);
-            stub.withArgs('fakeDragTarget',
-                Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
-            const fakeDragTarget = {
-                wouldDelete: sinon.fake.returns(false),
-                id: 'fakeDragTarget',
-            };
-            this.manager.update(dxy, fakeDragTarget);
-            chai.assert.isFalse(this.manager.wouldDeleteBlock());
-            chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
-        });
-
-        test('Drag target is not a delete area', function() {
-            const dxy = new Blockly.utils.Coordinate(0, 0);
-            const stub = stubComponentManager(this.workspace);
-            stub.withArgs('fakeDragTarget',
-                Blockly.ComponentManager.Capability.DELETE_AREA).returns(false);
-            const fakeDragTarget = {
-                wouldDelete: sinon.fake.returns(false),
-                id: 'fakeDragTarget',
-            };
-            this.manager.update(dxy, fakeDragTarget);
-            chai.assert.isFalse(this.manager.wouldDeleteBlock());
-            chai.assert.isFalse(fakeDragTarget.wouldDelete.called);
-        });
-
-        test('Not over drag target', function() {
-            const dxy = new Blockly.utils.Coordinate(0, 0);
-            this.manager.update(dxy, null);
-            chai.assert.isFalse(this.manager.wouldDeleteBlock());
-        });
+    test('Over delete area: accepted', function() {
+      const dxy = new Blockly.utils.Coordinate(0, 0);
+      const stub = stubComponentManager(this.workspace);
+      stub.withArgs('fakeDragTarget',
+        Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+      const fakeDragTarget = {
+        wouldDelete: sinon.fake.returns(true),
+        id: 'fakeDragTarget',
+      };
+      this.manager.update(dxy, fakeDragTarget);
+      chai.assert.isTrue(this.manager.wouldDeleteBlock());
+      chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
-    suite('Would connect stack blocks', function() {
-        setup(function() {
-            const state = {
-                'blocks': {
-                  'blocks': [
-                    {
-                      'type': 'stack_block',
-                      'id': 'first',
-                      'x': 0,
-                      'y': 0,
-                    },
-                    {
-                      'type': 'stack_block',
-                      'id': 'other',
-                      'x': 200,
-                      'y': 200,
-                    },
-                  ],
-                },
-              };
-            Blockly.serialization.workspaces.load(state, this.workspace);
-            this.block = this.workspace.getBlockById('first');
-            this.block.setDragging(true);
-            this.manager = new Blockly.InsertionMarkerManager(this.block);
-        });
-
-        test('No other blocks nearby', function() {
-            this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
-            chai.assert.isFalse(this.manager.wouldConnectBlock());
-        });
-
-        test('Near other block: above', function() {
-            this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-            const markers = this.manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-            const marker = markers[0];
-            chai.assert.isTrue(marker.nextConnection.isConnected());
-        });
-
-        test('Near other block: below', function() {
-            this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-            const markers = this.manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-            const marker = markers[0];
-            chai.assert.isTrue(marker.previousConnection.isConnected());
-        });
-
-        test('Near other block: left', function() {
-            this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-        });
-
-        test('Near other block: right', function() {
-            this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-        });
+    test('Over delete area: rejected', function() {
+      const dxy = new Blockly.utils.Coordinate(0, 0);
+      const stub = stubComponentManager(this.workspace);
+      stub.withArgs('fakeDragTarget',
+        Blockly.ComponentManager.Capability.DELETE_AREA).returns(true);
+      const fakeDragTarget = {
+        wouldDelete: sinon.fake.returns(false),
+        id: 'fakeDragTarget',
+      };
+      this.manager.update(dxy, fakeDragTarget);
+      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+      chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
-    suite('Would connect row blocks', function() {
-        setup(function() {
-            const state = {
-                'blocks': {
-                  'blocks': [
-                    {
-                      'type': 'row_block',
-                      'id': 'first',
-                      'x': 0,
-                      'y': 0,
-                    },
-                    {
-                      'type': 'row_block',
-                      'id': 'other',
-                      'x': 200,
-                      'y': 200,
-                    },
-                  ],
-                },
-              };
-            Blockly.serialization.workspaces.load(state, this.workspace);
-            this.block = this.workspace.getBlockById('first');
-            this.block.setDragging(true);
-            this.manager = new Blockly.InsertionMarkerManager(this.block);
-        });
-
-        test('No other blocks nearby', function() {
-            this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
-            chai.assert.isFalse(this.manager.wouldConnectBlock());
-        });
-
-        test('Near other block: above', function() {
-            this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-        });
-
-        test('Near other block: below', function() {
-            this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-        });
-        
-        test('Near other block: left', function() {
-            this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-            const markers = this.manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-            const marker = markers[0];
-            chai.assert.isTrue(marker.getInput('INPUT').connection.isConnected());
-        });
-
-        test('Near other block: right', function() {
-            this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
-            chai.assert.isTrue(this.manager.wouldConnectBlock());
-            const markers = this.manager.getInsertionMarkers();
-            chai.assert.equal(markers.length, 1);
-            const marker = markers[0];
-            chai.assert.isTrue(marker.outputConnection.isConnected());
-        });
+    test('Drag target is not a delete area', function() {
+      const dxy = new Blockly.utils.Coordinate(0, 0);
+      const stub = stubComponentManager(this.workspace);
+      stub.withArgs('fakeDragTarget',
+        Blockly.ComponentManager.Capability.DELETE_AREA).returns(false);
+      const fakeDragTarget = {
+        wouldDelete: sinon.fake.returns(false),
+        id: 'fakeDragTarget',
+      };
+      this.manager.update(dxy, fakeDragTarget);
+      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+      chai.assert.isFalse(fakeDragTarget.wouldDelete.called);
     });
+
+    test('Not over drag target', function() {
+      const dxy = new Blockly.utils.Coordinate(0, 0);
+      this.manager.update(dxy, null);
+      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+    });
+  });
+
+  suite('Would connect stack blocks', function() {
+    setup(function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'stack_block',
+              'id': 'first',
+              'x': 0,
+              'y': 0,
+            },
+            {
+              'type': 'stack_block',
+              'id': 'other',
+              'x': 200,
+              'y': 200,
+            },
+          ],
+        },
+      };
+      Blockly.serialization.workspaces.load(state, this.workspace);
+      this.block = this.workspace.getBlockById('first');
+      this.block.setDragging(true);
+      this.manager = new Blockly.InsertionMarkerManager(this.block);
+    });
+
+    test('No other blocks nearby', function() {
+      this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
+      chai.assert.isFalse(this.manager.wouldConnectBlock());
+    });
+
+    test('Near other block: above', function() {
+      this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      const markers = this.manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+      const marker = markers[0];
+      chai.assert.isTrue(marker.nextConnection.isConnected());
+    });
+
+    test('Near other block: below', function() {
+      this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      const markers = this.manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+      const marker = markers[0];
+      chai.assert.isTrue(marker.previousConnection.isConnected());
+    });
+
+    test('Near other block: left', function() {
+      this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+    });
+
+    test('Near other block: right', function() {
+      this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+    });
+  });
+
+  suite('Would connect row blocks', function() {
+    setup(function() {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'row_block',
+              'id': 'first',
+              'x': 0,
+              'y': 0,
+            },
+            {
+              'type': 'row_block',
+              'id': 'other',
+              'x': 200,
+              'y': 200,
+            },
+          ],
+        },
+      };
+      Blockly.serialization.workspaces.load(state, this.workspace);
+      this.block = this.workspace.getBlockById('first');
+      this.block.setDragging(true);
+      this.manager = new Blockly.InsertionMarkerManager(this.block);
+    });
+
+    test('No other blocks nearby', function() {
+      this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
+      chai.assert.isFalse(this.manager.wouldConnectBlock());
+    });
+
+    test('Near other block: above', function() {
+      this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+    });
+
+    test('Near other block: below', function() {
+      this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+    });
+
+    test('Near other block: left', function() {
+      this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      const markers = this.manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+      const marker = markers[0];
+      chai.assert.isTrue(marker.getInput('INPUT').connection.isConnected());
+    });
+
+    test('Near other block: right', function() {
+      this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
+      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      const markers = this.manager.getInsertionMarkers();
+      chai.assert.equal(markers.length, 1);
+      const marker = markers[0];
+      chai.assert.isTrue(marker.outputConnection.isConnected());
+    });
+  });
 });

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -28,7 +28,7 @@ suite('Insertion marker manager', function() {
       return manager;
     }
 
-    test('One stack block', function() {
+    test('One stack block creates one marker', function() {
       const state = {
         'blocks': {
           'blocks': [
@@ -44,7 +44,7 @@ suite('Insertion marker manager', function() {
       chai.assert.equal(markers.length, 1);
     });
 
-    test('Two stack blocks', function() {
+    test('Two stack blocks create two markers', function() {
       const state = {
         'blocks': {
           'blocks': [
@@ -66,7 +66,7 @@ suite('Insertion marker manager', function() {
       chai.assert.equal(markers.length, 2);
     });
 
-    test('Three stack blocks', function() {
+    test('Three stack blocks create two markers', function() {
       const state = {
         'blocks': {
           'blocks': [
@@ -94,7 +94,7 @@ suite('Insertion marker manager', function() {
       chai.assert.equal(markers.length, 2);
     });
 
-    test('One value block', function() {
+    test('One value block creates one marker', function() {
       const state = {
         'blocks': {
           'blocks': [
@@ -110,7 +110,7 @@ suite('Insertion marker manager', function() {
       chai.assert.equal(markers.length, 1);
     });
 
-    test('Two value blocks', function() {
+    test('Two value blocks create one marker', function() {
       const state = {
         'blocks': {
           'blocks': [
@@ -156,7 +156,7 @@ suite('Insertion marker manager', function() {
       this.dxy = new Blockly.utils.Coordinate(0, 0);
     });
 
-    test('Over delete area: accepted', function() {
+    test('Over delete area and accepted would delete', function() {
       this.stub
           .withArgs(
               'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
@@ -167,10 +167,9 @@ suite('Insertion marker manager', function() {
       };
       this.manager.update(this.dxy, fakeDragTarget);
       chai.assert.isTrue(this.manager.wouldDeleteBlock());
-      chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
-    test('Over delete area: rejected', function() {
+    test('Over delete area and rejected would not delete', function() {
       this.stub
           .withArgs(
               'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
@@ -181,10 +180,9 @@ suite('Insertion marker manager', function() {
       };
       this.manager.update(this.dxy, fakeDragTarget);
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
-      chai.assert.isTrue(fakeDragTarget.wouldDelete.called);
     });
 
-    test('Drag target is not a delete area', function() {
+    test('Drag target is not a delete area would not delete', function() {
       this.stub
           .withArgs(
               'fakeDragTarget', Blockly.ComponentManager.Capability.DELETE_AREA)
@@ -197,7 +195,7 @@ suite('Insertion marker manager', function() {
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
     });
 
-    test('Not over drag target', function() {
+    test('Not over drag target would not delete', function() {
       this.manager.update(this.dxy, null);
       chai.assert.isFalse(this.manager.wouldDeleteBlock());
     });
@@ -229,12 +227,12 @@ suite('Insertion marker manager', function() {
       this.manager = new Blockly.InsertionMarkerManager(this.block);
     });
 
-    test('No other blocks nearby', function() {
+    test('No other blocks nearby would not connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
       chai.assert.isFalse(this.manager.wouldConnectBlock());
     });
 
-    test('Near other block: above', function() {
+    test('Near other block and above would connect before', function() {
       this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
@@ -243,7 +241,7 @@ suite('Insertion marker manager', function() {
       chai.assert.isTrue(marker.nextConnection.isConnected());
     });
 
-    test('Near other block: below', function() {
+    test('Near other block and below would connect after', function() {
       this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
@@ -252,12 +250,12 @@ suite('Insertion marker manager', function() {
       chai.assert.isTrue(marker.previousConnection.isConnected());
     });
 
-    test('Near other block: left', function() {
+    test('Near other block and left would connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
     });
 
-    test('Near other block: right', function() {
+    test('Near other block and right would connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
     });
@@ -289,37 +287,33 @@ suite('Insertion marker manager', function() {
       this.manager = new Blockly.InsertionMarkerManager(this.block);
     });
 
-    test('No other blocks nearby', function() {
+    test('No other blocks nearby would not connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
       chai.assert.isFalse(this.manager.wouldConnectBlock());
     });
 
-    test('Near other block: above', function() {
+    test('Near other block and above would connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
     });
 
-    test('Near other block: below', function() {
+    test('Near other block and below would connect', function() {
       this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
     });
 
-    test('Near other block: left', function() {
+    test('Near other block and left would connect before', function() {
       this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
-      const marker = markers[0];
-      chai.assert.isTrue(marker.getInput('INPUT').connection.isConnected());
+      chai.assert.isTrue(markers[0].getInput('INPUT').connection.isConnected());
     });
 
-    test('Near other block: right', function() {
+    test('Near other block and right would connect after', function() {
       this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
       chai.assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
-      const marker = markers[0];
-      chai.assert.isTrue(marker.outputConnection.isConnected());
+      chai.assert.isTrue(markers[0].outputConnection.isConnected());
     });
   });
 });

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -30,6 +30,15 @@ export function defineRowBlock(name = 'row_block') {
   }]);
 }
 
+export function defineRowToStackBlock(name = 'row_to_stack_block') {
+  Blockly.defineBlocksWithJsonArray([{
+    "type": name,
+    "message0": "",
+    "output": null,
+    "nextStatement": null,
+  }]);
+}
+
 export function defineStatementBlock(name = 'statement_block') {
   Blockly.defineBlocksWithJsonArray([{
     "type": name,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Just improving test coverage.

### Proposed Changes

Add tests.

### Test Coverage

There are four test suites.

The first one checks that the constructor works when given various blocks and block stacks, and that the appropriate number of markers is created (i.e. one marker for the first block, and sometimes another for the last block in the stack).

The second suite checks logic controlling whether a block is deleted when the drag ends. I stubbed the capability manager and drag target to force it down various paths. `wouldDeleteBlock` is one of the few public methods available to get information out of the insertion marker manager.

The third and fourth suites check that the insertion marker manager can find an appropriate connection in the middle of a drag. I faked dragging the block above, below, left, and right from the stationary block, and then checked the connections on the marker to make sure it was connected in the correct place.

### Documentation

No documentation needed.

### Additional Information

These tests will hopefully catch any bugs in an upcoming cleanup of the insertion marker manager.

Live footage of me working on this PR: 
![penguin-angry](https://user-images.githubusercontent.com/13686399/199360600-88dc0607-c82f-4ccb-80c2-a2eb5f578070.gif)
