### PR TITLE
fix(renamings): Small correction to renaming of `Blockly.utils.global`

### DIFF
--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1339,8 +1339,13 @@
 
   '9.0.0': [
     {
-      'oldName': 'Blockly.utils.global',
-      'newPath': 'globalThis',
+      oldName: 'Blockly.utils.global',
+      exports: {
+        globalThis: {
+          oldPath: 'Blockly.utils.global',
+          newPath: 'globalThis',
+        }
+      }
     },
     {
       oldName: 'Blockly.Dart',
@@ -1366,7 +1371,7 @@
       oldName: 'Blockly.Python',
       newExport: 'pythonGenerator',
       newPath: 'Blockly.Python',
-      'oldName': 'Blockly.ContextMenuRegistry',
+      oldName: 'Blockly.ContextMenuRegistry',
       exports: {
         'ContextMenuRegistry.ScopeType': {
           oldPath: 'Blockly.ContextMenuRegistry.ScopeType',
@@ -1396,7 +1401,7 @@
       },
     },
     {
-      'oldName': 'Blockly.Input',
+      oldName: 'Blockly.Input',
       exports: {
         'Input.Align': {
           oldPath: 'Blockly.Input.Align',
@@ -1406,7 +1411,7 @@
       },
     },
     {
-      'oldName': 'Blockly.Names',
+      oldName: 'Blockly.Names',
       exports: {
         'Names.NameType': {
           oldPath: 'Blockly.Names.NameType',


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

A small error in the entry for `Blockly.utils.global`, that failed to account for the fact that this (former) module had a named export.

### Proposed Changes

Adjust the entry to make it clear that `globalThis` was a named export, not the default export.

Also remove some unnecessary quoting of keywords.

#### Behaviour Before Change

It would have worked anyway.

#### Behaviour After Change

It will work correctly, and now for the right reason.

### Reason for Changes

I am pedantic.

### Additional Information

This change doesn't make any difference in practice to the behaviour of the renamings script, so there is no reason to push it to `master` immediately for the benefit of the renamings script.