### PR TITLE
chore: clean up insertion marker code

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -187,7 +187,7 @@ export class BlockDragger implements IBlockDragger {
 
     this.draggedConnectionManager_.update(delta, this.dragTarget_);
     const oldWouldDeleteBlock = this.wouldDeleteBlock_;
-    this.wouldDeleteBlock_ = this.draggedConnectionManager_.wouldDeleteBlock();
+    this.wouldDeleteBlock_ = this.draggedConnectionManager_.wouldDeleteBlock;
     if (oldWouldDeleteBlock !== this.wouldDeleteBlock_) {
       // Prevent unnecessary add/remove class calls.
       this.updateCursorDuringBlockDrag_();

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -51,7 +51,17 @@ const DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
  * @alias Blockly.InsertionMarkerManager
  */
 export class InsertionMarkerManager {
+
+  /**
+   * The top block in the stack being dragged.
+   * Does not change during a drag.
+   */
   private readonly topBlock_: BlockSvg;
+
+  /**
+   * The workspace on which these connections are being dragged.
+   * Does not change during a drag.
+   */
   private readonly workspace_: WorkspaceSvg;
 
   /**
@@ -67,6 +77,11 @@ export class InsertionMarkerManager {
    * Set in initAvailableConnections, if at all
    */
   private lastMarker_: BlockSvg|null = null;
+
+  /**
+   * The insertion marker that shows up between blocks to show where a block
+   * would go if dropped immediately.
+   */
   private firstMarker_: BlockSvg;
 
   /**
@@ -101,36 +116,24 @@ export class InsertionMarkerManager {
 
   /** The block being faded to indicate replacement, or null. */
   private fadedBlock_: BlockSvg|null = null;
+
+  /**
+   * The connections on the dragging blocks that are available to connect to
+   * other blocks.  This includes all open connections on the top block, as
+   * well as the last connection on the block stack. Does not change during a
+   * drag.
+   */
   private availableConnections_: RenderedConnection[];
 
   /** @param block The top block in the stack being dragged. */
   constructor(block: BlockSvg) {
     common.setSelected(block);
-
-    /**
-     * The top block in the stack being dragged.
-     * Does not change during a drag.
-     */
     this.topBlock_ = block;
 
-    /**
-     * The workspace on which these connections are being dragged.
-     * Does not change during a drag.
-     */
     this.workspace_ = block.workspace;
 
-    /**
-     * The insertion marker that shows up between blocks to show where a block
-     * would go if dropped immediately.
-     */
     this.firstMarker_ = this.createMarkerBlock_(this.topBlock_);
 
-    /**
-     * The connections on the dragging blocks that are available to connect to
-     * other blocks.  This includes all open connections on the top block, as
-     * well as the last connection on the block stack. Does not change during a
-     * drag.
-     */
     this.availableConnections_ = this.initAvailableConnections_();
   }
 

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -195,7 +195,7 @@ export class InsertionMarkerManager {
    * @internal
    */
   applyConnections() {
-    if (!this.activeCandidate)return;
+    if (!this.activeCandidate) return;
     // Don't fire events for insertion markers.
     eventUtils.disable();
     this.hidePreview();
@@ -207,9 +207,7 @@ export class InsertionMarkerManager {
     if (this.topBlock.rendered) {
       // Trigger a connection animation.
       // Determine which connection is inferior (lower in the source stack).
-      const inferiorConnection = local.isSuperior() ?
-          closest :
-          local;
+      const inferiorConnection = local.isSuperior() ? closest : local;
       blockAnimations.connectionUiEffect(inferiorConnection.getSourceBlock());
       // Bring the just-edited stack to the front.
       const rootBlock = this.topBlock.getRootBlock();
@@ -337,8 +335,8 @@ export class InsertionMarkerManager {
    * @param dxy Position relative to drag start, in workspace units.
    * @returns Whether the preview should be updated.
    */
-  private shouldUpdatePreviews(candidate: CandidateConnection|null, dxy: Coordinate):
-      boolean {
+  private shouldUpdatePreviews(
+      candidate: CandidateConnection|null, dxy: Coordinate): boolean {
     // Found a connection!
     if (candidate) {
       const candidateLocal = candidate.local;
@@ -351,7 +349,7 @@ export class InsertionMarkerManager {
         const activeLocal = this.activeCandidate.local;
         // The connection was the same as the current connection.
         if (activeClosest === candidateClosest &&
-           activeLocal === candidateLocal) {
+            activeLocal === candidateLocal) {
           return false;
         }
         const xDiff = activeLocal.x + dxy.x - activeClosest.x;
@@ -380,7 +378,6 @@ export class InsertionMarkerManager {
    *     a radius.
    */
   private getCandidate(dxy: Coordinate): CandidateConnection|null {
-
     // It's possible that a block has added or removed connections during a
     // drag, (e.g. in a drag/move event handler), so let's update the available
     // connections. Note that this will be called on every move while dragging,
@@ -399,10 +396,10 @@ export class InsertionMarkerManager {
       const neighbour = myConnection.closest(radius, dxy);
       if (neighbour.connection) {
         candidate = {
-          closest: neighbour.connection, 
-          local: myConnection, 
-          radius: neighbour.radius
-        }
+          closest: neighbour.connection,
+          local: myConnection,
+          radius: neighbour.radius,
+        };
         radius = neighbour.radius;
       }
     }
@@ -437,7 +434,8 @@ export class InsertionMarkerManager {
    * @returns Whether dropping the block immediately would delete the block.
    */
   private shouldDelete(
-      candidate: CandidateConnection|null, dragTarget: IDragTarget|null): boolean {
+      candidate: CandidateConnection|null,
+      dragTarget: IDragTarget|null): boolean {
     if (dragTarget) {
       const componentManager = this.workspace.getComponentManager();
       const isDeleteArea = componentManager.hasCapability(
@@ -529,18 +527,19 @@ export class InsertionMarkerManager {
       this.hidePreview();
     } else {
       if (this.activeCandidate) {
-      const closestChanged = this.activeCandidate.closest !== candidate.closest;
-      const localChanged = this.activeCandidate.local !== candidate.local;
+        const closestChanged =
+            this.activeCandidate.closest !== candidate.closest;
+        const localChanged = this.activeCandidate.local !== candidate.local;
 
-      // If there's a new preview and there was an preview before, and either
-      // connection has changed, remove the old preview.
-      // Also hide if we had a preview before but now we're going to delete
-      // instead.
-      if ((closestChanged || localChanged || this.wouldDeleteBlockInternal)) {
-      this.hidePreview();
+        // If there's a new preview and there was an preview before, and either
+        // connection has changed, remove the old preview.
+        // Also hide if we had a preview before but now we're going to delete
+        // instead.
+        if ((closestChanged || localChanged || this.wouldDeleteBlockInternal)) {
+          this.hidePreview();
+        }
       }
     }
-  }
 
     // Either way, clear out old state.
     this.markerConnection = null;
@@ -554,9 +553,8 @@ export class InsertionMarkerManager {
   private hidePreview() {
     const closest = this.activeCandidate?.closest;
     if (closest && closest.targetBlock() &&
-        this.workspace.getRenderer().shouldHighlightConnection(
-          closest)) {
-            closest.unhighlight();
+        this.workspace.getRenderer().shouldHighlightConnection(closest)) {
+      closest.unhighlight();
     }
     if (this.fadedBlock) {
       this.hideReplacementFade(this.fadedBlock);
@@ -706,7 +704,8 @@ export class InsertionMarkerManager {
           'Cannot hide the insertion marker outline because ' +
           'there is no active candidate');
     }
-    highlightedBlock.highlightShapeForInput(this.activeCandidate.closest, false);
+    highlightedBlock.highlightShapeForInput(
+        this.activeCandidate.closest, false);
     this.highlightedBlock = null;
   }
 

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -101,8 +101,10 @@ export class InsertionMarkerManager {
   /**
    * Whether the block would be deleted if it were dropped immediately.
    * Updated on every mouse move.
+   *
+   * @internal
    */
-  private wouldDeleteOnDrop = false;
+  public wouldDeleteBlock = false;
 
   /**
    * Connection on the insertion marker block that corresponds to
@@ -167,17 +169,6 @@ export class InsertionMarkerManager {
   }
 
   /**
-   * Return whether the block would be deleted if dropped immediately, based on
-   * information from the most recent move event.
-   *
-   * @returns True if the block would be deleted if dropped immediately.
-   * @internal
-   */
-  wouldDeleteBlock(): boolean {
-    return this.wouldDeleteOnDrop;
-  }
-
-  /**
    * Return whether the block would be connected if dropped immediately, based
    * on information from the most recent move event.
    *
@@ -224,10 +215,10 @@ export class InsertionMarkerManager {
   update(dxy: Coordinate, dragTarget: IDragTarget|null) {
     const newCandidate = this.getCandidate(dxy);
 
-    this.wouldDeleteOnDrop = this.shouldDelete(!!newCandidate, dragTarget);
+    this.wouldDeleteBlock = this.shouldDelete(!!newCandidate, dragTarget);
 
     const shouldUpdate =
-        this.wouldDeleteOnDrop || this.shouldUpdatePreviews(newCandidate, dxy);
+        this.wouldDeleteBlock || this.shouldUpdatePreviews(newCandidate, dxy);
 
     if (shouldUpdate) {
       // Don't fire events for insertion marker creation or movement.
@@ -444,7 +435,7 @@ export class InsertionMarkerManager {
    *     best candidate.
    */
   private maybeShowPreview(newCandidate: CandidateConnection|null) {
-    if (this.wouldDeleteOnDrop) return;  // Nope, don't add a marker.
+    if (this.wouldDeleteBlock) return;  // Nope, don't add a marker.
     if (!newCandidate) return;           // Nothing to connect to.
 
     const closest = newCandidate.closest;
@@ -516,7 +507,7 @@ export class InsertionMarkerManager {
         // connection has changed, remove the old preview.
         // Also hide if we had a preview before but now we're going to delete
         // instead.
-        if ((closestChanged || localChanged || this.wouldDeleteOnDrop)) {
+        if ((closestChanged || localChanged || this.wouldDeleteBlock)) {
           this.hidePreview();
         }
       }

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -200,8 +200,7 @@ export class InsertionMarkerManager {
     eventUtils.disable();
     this.hidePreview();
     eventUtils.enable();
-    const local = this.activeCandidate.local;
-    const closest = this.activeCandidate.closest;
+    const {local, closest} = this.activeCandidate;
     // Connect two blocks together.
     local.connect(closest);
     if (this.topBlock.rendered) {
@@ -349,8 +348,7 @@ export class InsertionMarkerManager {
 
     // We're already showing an insertion marker.
     // Decide whether the new connection has higher priority.
-    const activeClosest = this.activeCandidate.closest;
-    const activeLocal = this.activeCandidate.local;
+    const {local: activeLocal, closest: activeClosest} = this.activeCandidate;
     if (activeClosest === newCandidate.closest &&
         activeLocal === newCandidate.local) {
       // The connection was the same as the current connection.
@@ -571,8 +569,7 @@ export class InsertionMarkerManager {
    *     immediately.
    */
   private showInsertionMarker(activeCandidate: CandidateConnection) {
-    const local = activeCandidate.local;
-    const closest = activeCandidate.closest;
+    const {local, closest} = activeCandidate;
 
     const isLastInStack = this.lastOnStack && local === this.lastOnStack;
     let insertionMarker = isLastInStack ? this.lastMarker : this.firstMarker;

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -224,7 +224,7 @@ export class InsertionMarkerManager {
   update(dxy: Coordinate, dragTarget: IDragTarget|null) {
     const newCandidate = this.getCandidate(dxy);
 
-    this.wouldDeleteOnDrop = this.shouldDelete(newCandidate, dragTarget);
+    this.wouldDeleteOnDrop = this.shouldDelete(!!newCandidate, dragTarget);
 
     const shouldUpdate =
         this.wouldDeleteOnDrop || this.shouldUpdatePreviews(newCandidate, dxy);
@@ -416,21 +416,20 @@ export class InsertionMarkerManager {
   /**
    * Whether ending the drag would delete the block.
    *
-   * @param newCandidate A new candidate connection that may replace the current
-   *     best candidate.
+   * @param newCandidate Whether there is a candidate connection that the
+   *     block could connect to if the drag ended immediately.
    * @param dragTarget The drag target that the block is currently over.
    * @returns Whether dropping the block immediately would delete the block.
    */
-  private shouldDelete(
-      newCandidate: CandidateConnection|null,
-      dragTarget: IDragTarget|null): boolean {
+  private shouldDelete(newCandidate: boolean, dragTarget: IDragTarget|null):
+      boolean {
     if (dragTarget) {
       const componentManager = this.workspace.getComponentManager();
       const isDeleteArea = componentManager.hasCapability(
           dragTarget.id, ComponentManager.Capability.DELETE_AREA);
       if (isDeleteArea) {
         return (dragTarget as IDeleteArea)
-            .wouldDelete(this.topBlock, !!newCandidate);
+            .wouldDelete(this.topBlock, newCandidate);
       }
     }
     return false;

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -336,15 +336,11 @@ export class InsertionMarkerManager {
    */
   private shouldUpdatePreviews(
       newCandidate: CandidateConnection|null, dxy: Coordinate): boolean {
-    if (!newCandidate) {
-      // Only need to update if we were showing a preview before.
-      return !!this.activeCandidate;
-    }
+    // Only need to update if we were showing a preview before.
+    if (!newCandidate) return !!this.activeCandidate;
 
     // We weren't showing a preview before, but we should now.
-    if (!this.activeCandidate) {
-      return true;
-    }
+    if (!this.activeCandidate) return true;
 
     // We're already showing an insertion marker.
     // Decide whether the new connection has higher priority.
@@ -409,14 +405,12 @@ export class InsertionMarkerManager {
   private getStartRadius(): number {
     // If there is already a connection highlighted,
     // increase the radius we check for making new connections.
-    // Why? When a connection is highlighted, blocks move around when the
+    // When a connection is highlighted, blocks move around when the
     // insertion marker is created, which could cause the connection became out
     // of range. By increasing radiusConnection when a connection already
     // exists, we never "lose" the connection from the offset.
-    if (this.activeCandidate) {
-      return config.connectingSnapRadius;
-    }
-    return config.snapRadius;
+    return this.activeCandidate ? config.connectingSnapRadius :
+                                  config.snapRadius;
   }
 
   /**
@@ -445,22 +439,14 @@ export class InsertionMarkerManager {
   /**
    * Show an insertion marker or replacement highlighting during a drag, if
    * needed.
-   * At the beginning of this function, this.localConnection and
-   * this.closestConnection should both be null.
+   * At the beginning of this function, this.activeConnection should be null.
    *
    * @param newCandidate A new candidate connection that may replace the current
    *     best candidate.
    */
   private maybeShowPreview(newCandidate: CandidateConnection|null) {
-    // Nope, don't add a marker.
-    if (this.wouldDeleteBlockInternal) {
-      return;
-    }
-
-    // Nothing to connect to.
-    if (!newCandidate) {
-      return;
-    }
+    if (this.wouldDeleteBlockInternal) return;  // Nope, don't add a marker.
+    if (!newCandidate) return;                  // Nothing to connect to.
 
     const closest = newCandidate.closest;
 
@@ -527,7 +513,7 @@ export class InsertionMarkerManager {
             this.activeCandidate.closest !== newCandidate.closest;
         const localChanged = this.activeCandidate.local !== newCandidate.local;
 
-        // If there's a new preview and there was an preview before, and either
+        // If there's a new preview and there was a preview before, and either
         // connection has changed, remove the old preview.
         // Also hide if we had a preview before but now we're going to delete
         // instead.
@@ -544,7 +530,7 @@ export class InsertionMarkerManager {
 
   /**
    * A preview should be hidden.  This function figures out if it is a block
-   *  highlight or an insertion marker, and hides the appropriate one.
+   * highlight or an insertion marker, and hides the appropriate one.
    */
   private hidePreview() {
     const closest = this.activeCandidate?.closest;

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -51,45 +51,44 @@ const DUPLICATE_BLOCK_ERROR = 'The insertion marker ' +
  * @alias Blockly.InsertionMarkerManager
  */
 export class InsertionMarkerManager {
-
   /**
    * The top block in the stack being dragged.
    * Does not change during a drag.
    */
-  private readonly topBlock_: BlockSvg;
+  private readonly topBlock: BlockSvg;
 
   /**
    * The workspace on which these connections are being dragged.
    * Does not change during a drag.
    */
-  private readonly workspace_: WorkspaceSvg;
+  private readonly workspace: WorkspaceSvg;
 
   /**
    * The last connection on the stack, if it's not the last connection on the
    * first block.
    * Set in initAvailableConnections, if at all.
    */
-  private lastOnStack_: RenderedConnection|null = null;
+  private lastOnStack: RenderedConnection|null = null;
 
   /**
    * The insertion marker corresponding to the last block in the stack, if
    * that's not the same as the first block in the stack.
    * Set in initAvailableConnections, if at all
    */
-  private lastMarker_: BlockSvg|null = null;
+  private lastMarker: BlockSvg|null = null;
 
   /**
    * The insertion marker that shows up between blocks to show where a block
    * would go if dropped immediately.
    */
-  private firstMarker_: BlockSvg;
+  private firstMarker: BlockSvg;
 
   /**
    * The connection that this block would connect to if released immediately.
    * Updated on every mouse move.
    * This is not on any of the blocks that are being dragged.
    */
-  private closestConnection_: RenderedConnection|null = null;
+  private closestConnection: RenderedConnection|null = null;
 
   /**
    * The connection that would connect to this.closestConnection_ if this
@@ -97,7 +96,7 @@ export class InsertionMarkerManager {
    * the top block that is being dragged or the last block in the dragging
    * stack.
    */
-  private localConnection_: RenderedConnection|null = null;
+  private localConnection: RenderedConnection|null = null;
 
   /**
    * Whether the block would be deleted if it were dropped immediately.
@@ -115,7 +114,7 @@ export class InsertionMarkerManager {
   private highlightedBlock_: BlockSvg|null = null;
 
   /** The block being faded to indicate replacement, or null. */
-  private fadedBlock_: BlockSvg|null = null;
+  private fadedBlock: BlockSvg|null = null;
 
   /**
    * The connections on the dragging blocks that are available to connect to
@@ -123,18 +122,18 @@ export class InsertionMarkerManager {
    * well as the last connection on the block stack. Does not change during a
    * drag.
    */
-  private availableConnections_: RenderedConnection[];
+  private availableConnections: RenderedConnection[];
 
   /** @param block The top block in the stack being dragged. */
   constructor(block: BlockSvg) {
     common.setSelected(block);
-    this.topBlock_ = block;
+    this.topBlock = block;
 
-    this.workspace_ = block.workspace;
+    this.workspace = block.workspace;
 
-    this.firstMarker_ = this.createMarkerBlock_(this.topBlock_);
+    this.firstMarker = this.createMarkerBlock_(this.topBlock);
 
-    this.availableConnections_ = this.initAvailableConnections_();
+    this.availableConnections = this.initAvailableConnections_();
   }
 
   /**
@@ -143,15 +142,15 @@ export class InsertionMarkerManager {
    * @internal
    */
   dispose() {
-    this.availableConnections_.length = 0;
+    this.availableConnections.length = 0;
 
     eventUtils.disable();
     try {
-      if (this.firstMarker_) {
-        this.firstMarker_.dispose();
+      if (this.firstMarker) {
+        this.firstMarker.dispose();
       }
-      if (this.lastMarker_) {
-        this.lastMarker_.dispose();
+      if (this.lastMarker) {
+        this.lastMarker.dispose();
       }
     } finally {
       eventUtils.enable();
@@ -165,7 +164,7 @@ export class InsertionMarkerManager {
    * @internal
    */
   updateAvailableConnections() {
-    this.availableConnections_ = this.initAvailableConnections_();
+    this.availableConnections = this.initAvailableConnections_();
   }
 
   /**
@@ -187,7 +186,7 @@ export class InsertionMarkerManager {
    * @internal
    */
   wouldConnectBlock(): boolean {
-    return !!this.closestConnection_;
+    return !!this.closestConnection;
   }
 
   /**
@@ -197,8 +196,8 @@ export class InsertionMarkerManager {
    * @internal
    */
   applyConnections() {
-    if (!this.closestConnection_) return;
-    if (!this.localConnection_) {
+    if (!this.closestConnection) return;
+    if (!this.localConnection) {
       throw new Error(
           'Cannot apply connections because there is no local connection');
     }
@@ -207,16 +206,16 @@ export class InsertionMarkerManager {
     this.hidePreview_();
     eventUtils.enable();
     // Connect two blocks together.
-    this.localConnection_.connect(this.closestConnection_);
-    if (this.topBlock_.rendered) {
+    this.localConnection.connect(this.closestConnection);
+    if (this.topBlock.rendered) {
       // Trigger a connection animation.
       // Determine which connection is inferior (lower in the source stack).
-      const inferiorConnection = this.localConnection_.isSuperior() ?
-          this.closestConnection_ :
-          this.localConnection_;
+      const inferiorConnection = this.localConnection.isSuperior() ?
+          this.closestConnection :
+          this.localConnection;
       blockAnimations.connectionUiEffect(inferiorConnection.getSourceBlock());
       // Bring the just-edited stack to the front.
-      const rootBlock = this.topBlock_.getRootBlock();
+      const rootBlock = this.topBlock.getRootBlock();
       rootBlock.bringToFront();
     }
   }
@@ -257,7 +256,7 @@ export class InsertionMarkerManager {
     eventUtils.disable();
     let result: BlockSvg;
     try {
-      result = this.workspace_.newBlock(imType);
+      result = this.workspace.newBlock(imType);
       result.setInsertionMarker(true);
       if (sourceBlock.saveExtraState) {
         const state = sourceBlock.saveExtraState();
@@ -313,21 +312,21 @@ export class InsertionMarkerManager {
    * @returns A list of available connections.
    */
   private initAvailableConnections_(): RenderedConnection[] {
-    const available = this.topBlock_.getConnections_(false);
+    const available = this.topBlock.getConnections_(false);
     // Also check the last connection on this stack
-    const lastOnStack = this.topBlock_.lastConnectionInStack(true);
-    if (lastOnStack && lastOnStack !== this.topBlock_.nextConnection) {
+    const lastOnStack = this.topBlock.lastConnectionInStack(true);
+    if (lastOnStack && lastOnStack !== this.topBlock.nextConnection) {
       available.push(lastOnStack);
-      this.lastOnStack_ = lastOnStack;
-      if (this.lastMarker_) {
+      this.lastOnStack = lastOnStack;
+      if (this.lastMarker) {
         eventUtils.disable();
         try {
-          this.lastMarker_.dispose();
+          this.lastMarker.dispose();
         } finally {
           eventUtils.enable();
         }
       }
-      this.lastMarker_ = this.createMarkerBlock_(lastOnStack.getSourceBlock());
+      this.lastMarker = this.createMarkerBlock_(lastOnStack.getSourceBlock());
     }
     return available;
   }
@@ -351,22 +350,22 @@ export class InsertionMarkerManager {
     if (candidateLocal && candidateClosest) {
       // We're already showing an insertion marker.
       // Decide whether the new connection has higher priority.
-      if (this.localConnection_ && this.closestConnection_) {
+      if (this.localConnection && this.closestConnection) {
         // The connection was the same as the current connection.
-        if (this.closestConnection_ === candidateClosest &&
-            this.localConnection_ === candidateLocal) {
+        if (this.closestConnection === candidateClosest &&
+            this.localConnection === candidateLocal) {
           return false;
         }
         const xDiff =
-            this.localConnection_.x + dxy.x - this.closestConnection_.x;
+            this.localConnection.x + dxy.x - this.closestConnection.x;
         const yDiff =
-            this.localConnection_.y + dxy.y - this.closestConnection_.y;
+            this.localConnection.y + dxy.y - this.closestConnection.y;
         const curDistance = Math.sqrt(xDiff * xDiff + yDiff * yDiff);
         // Slightly prefer the existing preview over a new preview.
         return !(
             candidateClosest &&
             radius > curDistance - config.currentConnectionPreference);
-      } else if (!this.localConnection_ && !this.closestConnection_) {
+      } else if (!this.localConnection && !this.closestConnection) {
         // We weren't showing a preview before, but we should now.
         return true;
       } else {
@@ -375,7 +374,7 @@ export class InsertionMarkerManager {
       }
     } else {  // No connection found.
       // Only need to update if we were showing a preview before.
-      return !!(this.localConnection_ && this.closestConnection_);
+      return !!(this.localConnection && this.closestConnection);
     }
 
     console.error(
@@ -407,8 +406,8 @@ export class InsertionMarkerManager {
       this.updateAvailableConnections();
     }
 
-    for (let i = 0; i < this.availableConnections_.length; i++) {
-      const myConnection = this.availableConnections_[i];
+    for (let i = 0; i < this.availableConnections.length; i++) {
+      const myConnection = this.availableConnections[i];
       const neighbour = myConnection.closest(radius, dxy);
       if (neighbour.connection) {
         candidateClosest = neighbour.connection;
@@ -432,7 +431,7 @@ export class InsertionMarkerManager {
     // insertion marker is created, which could cause the connection became out
     // of range. By increasing radiusConnection when a connection already
     // exists, we never "lose" the connection from the offset.
-    if (this.closestConnection_ && this.localConnection_) {
+    if (this.closestConnection && this.localConnection) {
       return config.connectingSnapRadius;
     }
     return config.snapRadius;
@@ -449,12 +448,12 @@ export class InsertionMarkerManager {
   private shouldDelete_(
       candidate: CandidateConnection, dragTarget: IDragTarget|null): boolean {
     if (dragTarget) {
-      const componentManager = this.workspace_.getComponentManager();
+      const componentManager = this.workspace.getComponentManager();
       const isDeleteArea = componentManager.hasCapability(
           dragTarget.id, ComponentManager.Capability.DELETE_AREA);
       if (isDeleteArea) {
         return (dragTarget as IDeleteArea)
-            .wouldDelete(this.topBlock_, candidate && !!candidate.closest);
+            .wouldDelete(this.topBlock, candidate && !!candidate.closest);
       }
     }
     return false;
@@ -484,14 +483,14 @@ export class InsertionMarkerManager {
 
     // Something went wrong and we're trying to connect to an invalid
     // connection.
-    if (closest === this.closestConnection_ ||
+    if (closest === this.closestConnection ||
         closest.getSourceBlock().isInsertionMarker()) {
       console.log('Trying to connect to an insertion marker');
       return;
     }
     // Add an insertion marker or replacement marker.
-    this.closestConnection_ = closest;
-    this.localConnection_ = local;
+    this.closestConnection = closest;
+    this.localConnection = local;
     this.showPreview_();
   }
 
@@ -500,18 +499,18 @@ export class InsertionMarkerManager {
    * block highlight or an insertion marker, and shows the appropriate one.
    */
   private showPreview_() {
-    if (!this.closestConnection_) {
+    if (!this.closestConnection) {
       throw new Error(
           'Cannot show the preview because there is no closest connection');
     }
-    if (!this.localConnection_) {
+    if (!this.localConnection) {
       throw new Error(
           'Cannot show the preview because there is no local connection');
     }
-    const closest = this.closestConnection_;
-    const renderer = this.workspace_.getRenderer();
+    const closest = this.closestConnection;
+    const renderer = this.workspace.getRenderer();
     const method = renderer.getConnectionPreviewMethod(
-        closest, this.localConnection_, this.topBlock_);
+        closest, this.localConnection, this.topBlock);
 
     switch (method) {
       case InsertionMarkerManager.PREVIEW_TYPE.INPUT_OUTLINE:
@@ -550,9 +549,9 @@ export class InsertionMarkerManager {
     } else {
       // If there's a new preview and there was an preview before, and either
       // connection has changed, remove the old preview.
-      const hadPreview = this.closestConnection_ && this.localConnection_;
-      const closestChanged = this.closestConnection_ !== candidate.closest;
-      const localChanged = this.localConnection_ !== candidate.local;
+      const hadPreview = this.closestConnection && this.localConnection;
+      const closestChanged = this.closestConnection !== candidate.closest;
+      const localChanged = this.localConnection !== candidate.local;
 
       // Also hide if we had a preview before but now we're going to delete
       // instead.
@@ -564,8 +563,8 @@ export class InsertionMarkerManager {
 
     // Either way, clear out old state.
     this.markerConnection_ = null;
-    this.closestConnection_ = null;
-    this.localConnection_ = null;
+    this.closestConnection = null;
+    this.localConnection = null;
   }
 
   /**
@@ -573,12 +572,12 @@ export class InsertionMarkerManager {
    *  highlight or an insertion marker, and hides the appropriate one.
    */
   private hidePreview_() {
-    if (this.closestConnection_ && this.closestConnection_.targetBlock() &&
-        this.workspace_.getRenderer().shouldHighlightConnection(
-            this.closestConnection_)) {
-      this.closestConnection_.unhighlight();
+    if (this.closestConnection && this.closestConnection.targetBlock() &&
+        this.workspace.getRenderer().shouldHighlightConnection(
+            this.closestConnection)) {
+      this.closestConnection.unhighlight();
     }
-    if (this.fadedBlock_) {
+    if (this.fadedBlock) {
       this.hideReplacementFade_();
     } else if (this.highlightedBlock_) {
       this.hideInsertionInputOutline_();
@@ -592,21 +591,21 @@ export class InsertionMarkerManager {
    * manager state).
    */
   private showInsertionMarker_() {
-    if (!this.localConnection_) {
+    if (!this.localConnection) {
       throw new Error(
           'Cannot show the insertion marker because there is no local ' +
           'connection');
     }
-    if (!this.closestConnection_) {
+    if (!this.closestConnection) {
       throw new Error(
           'Cannot show the insertion marker because there is no closest ' +
           'connection');
     }
-    const local = this.localConnection_;
-    const closest = this.closestConnection_;
+    const local = this.localConnection;
+    const closest = this.closestConnection;
 
-    const isLastInStack = this.lastOnStack_ && local === this.lastOnStack_;
-    let insertionMarker = isLastInStack ? this.lastMarker_ : this.firstMarker_;
+    const isLastInStack = this.lastOnStack && local === this.lastOnStack;
+    let insertionMarker = isLastInStack ? this.lastMarker : this.firstMarker;
     if (!insertionMarker) {
       throw new Error(
           'Cannot show the insertion marker because there is no insertion ' +
@@ -623,8 +622,8 @@ export class InsertionMarkerManager {
       // probably recreate the marker block (e.g. in getCandidate_), which is
       // called more often during the drag, but creating a block that often
       // might be too slow, so we only do it if necessary.
-      this.firstMarker_ = this.createMarkerBlock_(this.topBlock_);
-      insertionMarker = isLastInStack ? this.lastMarker_ : this.firstMarker_;
+      this.firstMarker = this.createMarkerBlock_(this.topBlock);
+      insertionMarker = isLastInStack ? this.lastMarker : this.firstMarker;
       if (!insertionMarker) {
         throw new Error(
             'Cannot show the insertion marker because there is no insertion ' +
@@ -725,12 +724,12 @@ export class InsertionMarkerManager {
 
   /** Shows an outline around the input the closest connection belongs to. */
   private showInsertionInputOutline_() {
-    if (!this.closestConnection_) {
+    if (!this.closestConnection) {
       throw new Error(
           'Cannot show the insertion marker outline because ' +
           'there is no closest connection');
     }
-    const closest = this.closestConnection_;
+    const closest = this.closestConnection;
     this.highlightedBlock_ = closest.getSourceBlock();
     this.highlightedBlock_.highlightShapeForInput(closest, true);
   }
@@ -742,13 +741,13 @@ export class InsertionMarkerManager {
           'Cannot hide the insertion marker outline because ' +
           'there is no highlighted block');
     }
-    if (!this.closestConnection_) {
+    if (!this.closestConnection) {
       throw new Error(
           'Cannot hide the insertion marker outline because ' +
           'there is no closest connection');
     }
     this.highlightedBlock_.highlightShapeForInput(
-        this.closestConnection_, false);
+        this.closestConnection, false);
     this.highlightedBlock_ = null;
   }
 
@@ -757,29 +756,29 @@ export class InsertionMarkerManager {
    * (the block that is currently connected to it).
    */
   private showReplacementFade_() {
-    if (!this.closestConnection_) {
+    if (!this.closestConnection) {
       throw new Error(
           'Cannot show the replacement fade because there ' +
           'is no closest connection');
     }
-    this.fadedBlock_ = this.closestConnection_.targetBlock();
-    if (!this.fadedBlock_) {
+    this.fadedBlock = this.closestConnection.targetBlock();
+    if (!this.fadedBlock) {
       throw new Error(
           'Cannot show the replacement fade because the ' +
           'closest connection does not have a target block');
     }
-    this.fadedBlock_.fadeForReplacement(true);
+    this.fadedBlock.fadeForReplacement(true);
   }
 
   /** Hides/Removes any visible fade affects. */
   private hideReplacementFade_() {
-    if (!this.fadedBlock_) {
+    if (!this.fadedBlock) {
       throw new Error(
           'Cannot hide the replacement because there is no ' +
           'faded block');
     }
-    this.fadedBlock_.fadeForReplacement(false);
-    this.fadedBlock_ = null;
+    this.fadedBlock.fadeForReplacement(false);
+    this.fadedBlock = null;
   }
 
   /**
@@ -791,11 +790,11 @@ export class InsertionMarkerManager {
    */
   getInsertionMarkers(): BlockSvg[] {
     const result = [];
-    if (this.firstMarker_) {
-      result.push(this.firstMarker_);
+    if (this.firstMarker) {
+      result.push(this.firstMarker);
     }
-    if (this.lastMarker_) {
-      result.push(this.lastMarker_);
+    if (this.lastMarker) {
+      result.push(this.lastMarker);
     }
     return result;
   }

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -436,7 +436,7 @@ export class InsertionMarkerManager {
    */
   private maybeShowPreview(newCandidate: CandidateConnection|null) {
     if (this.wouldDeleteBlock) return;  // Nope, don't add a marker.
-    if (!newCandidate) return;           // Nothing to connect to.
+    if (!newCandidate) return;          // Nothing to connect to.
 
     const closest = newCandidate.closest;
 

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -231,8 +231,8 @@ export class InsertionMarkerManager {
 
     this.wouldDeleteBlockInternal = this.shouldDelete(candidate, dragTarget);
 
-    const shouldUpdate =
-        this.wouldDeleteBlockInternal || this.shouldUpdatePreviews(candidate, dxy);
+    const shouldUpdate = this.wouldDeleteBlockInternal ||
+        this.shouldUpdatePreviews(candidate, dxy);
 
     if (shouldUpdate) {
       // Don't fire events for insertion marker creation or movement.
@@ -339,8 +339,8 @@ export class InsertionMarkerManager {
    * @param dxy Position relative to drag start, in workspace units.
    * @returns Whether the preview should be updated.
    */
-  private shouldUpdatePreviews(
-      candidate: CandidateConnection, dxy: Coordinate): boolean {
+  private shouldUpdatePreviews(candidate: CandidateConnection, dxy: Coordinate):
+      boolean {
     const candidateLocal = candidate.local;
     const candidateClosest = candidate.closest;
     const radius = candidate.radius;
@@ -355,10 +355,8 @@ export class InsertionMarkerManager {
             this.localConnection === candidateLocal) {
           return false;
         }
-        const xDiff =
-            this.localConnection.x + dxy.x - this.closestConnection.x;
-        const yDiff =
-            this.localConnection.y + dxy.y - this.closestConnection.y;
+        const xDiff = this.localConnection.x + dxy.x - this.closestConnection.x;
+        const yDiff = this.localConnection.y + dxy.y - this.closestConnection.y;
         const curDistance = Math.sqrt(xDiff * xDiff + yDiff * yDiff);
         // Slightly prefer the existing preview over a new preview.
         return !(
@@ -704,13 +702,12 @@ export class InsertionMarkerManager {
         previousBlockNextConnection.connect(innerConnection);
       }
     } else {
-      imBlock.unplug(/* healStack */
-                     true);
+      imBlock.unplug(/* healStack */ true);
     }
 
     if (imConn.targetConnection) {
       throw Error(
-          'markerConnection_ still connected at the end of ' +
+          'markerConnection still connected at the end of ' +
           'disconnectInsertionMarker');
     }
 
@@ -745,8 +742,7 @@ export class InsertionMarkerManager {
           'Cannot hide the insertion marker outline because ' +
           'there is no closest connection');
     }
-    this.highlightedBlock.highlightShapeForInput(
-        this.closestConnection, false);
+    this.highlightedBlock.highlightShapeForInput(this.closestConnection, false);
     this.highlightedBlock = null;
   }
 

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -102,7 +102,7 @@ export class InsertionMarkerManager {
    * Whether the block would be deleted if it were dropped immediately.
    * Updated on every mouse move.
    */
-  private wouldDeleteBlockInternal = false;
+  private wouldDeleteOnDrop = false;
 
   /**
    * Connection on the insertion marker block that corresponds to
@@ -174,7 +174,7 @@ export class InsertionMarkerManager {
    * @internal
    */
   wouldDeleteBlock(): boolean {
-    return this.wouldDeleteBlockInternal;
+    return this.wouldDeleteOnDrop;
   }
 
   /**
@@ -224,10 +224,10 @@ export class InsertionMarkerManager {
   update(dxy: Coordinate, dragTarget: IDragTarget|null) {
     const newCandidate = this.getCandidate(dxy);
 
-    this.wouldDeleteBlockInternal = this.shouldDelete(newCandidate, dragTarget);
+    this.wouldDeleteOnDrop = this.shouldDelete(newCandidate, dragTarget);
 
-    const shouldUpdate = this.wouldDeleteBlockInternal ||
-        this.shouldUpdatePreviews(newCandidate, dxy);
+    const shouldUpdate =
+        this.wouldDeleteOnDrop || this.shouldUpdatePreviews(newCandidate, dxy);
 
     if (shouldUpdate) {
       // Don't fire events for insertion marker creation or movement.
@@ -445,8 +445,8 @@ export class InsertionMarkerManager {
    *     best candidate.
    */
   private maybeShowPreview(newCandidate: CandidateConnection|null) {
-    if (this.wouldDeleteBlockInternal) return;  // Nope, don't add a marker.
-    if (!newCandidate) return;                  // Nothing to connect to.
+    if (this.wouldDeleteOnDrop) return;  // Nope, don't add a marker.
+    if (!newCandidate) return;           // Nothing to connect to.
 
     const closest = newCandidate.closest;
 
@@ -517,7 +517,7 @@ export class InsertionMarkerManager {
         // connection has changed, remove the old preview.
         // Also hide if we had a preview before but now we're going to delete
         // instead.
-        if ((closestChanged || localChanged || this.wouldDeleteBlockInternal)) {
+        if ((closestChanged || localChanged || this.wouldDeleteOnDrop)) {
           this.hidePreview();
         }
       }
@@ -716,7 +716,7 @@ export class InsertionMarkerManager {
    */
   private hideReplacementFade() {
     if (!this.fadedBlock) return;
-    
+
     this.fadedBlock.fadeForReplacement(false);
     this.fadedBlock = null;
   }

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -205,7 +205,7 @@ suite('Insertion marker manager', function() {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isTrue(this.manager.wouldDeleteBlock());
+      chai.assert.isTrue(this.manager.wouldDeleteBlock);
     });
 
     test('Over delete area and rejected would not delete', function() {
@@ -218,7 +218,7 @@ suite('Insertion marker manager', function() {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+      chai.assert.isFalse(this.manager.wouldDeleteBlock);
     });
 
     test('Drag target is not a delete area would not delete', function() {
@@ -231,12 +231,12 @@ suite('Insertion marker manager', function() {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+      chai.assert.isFalse(this.manager.wouldDeleteBlock);
     });
 
     test('Not over drag target would not delete', function() {
       this.manager.update(this.dxy, null);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock());
+      chai.assert.isFalse(this.manager.wouldDeleteBlock);
     });
   });
 


### PR DESCRIPTION

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6548 

### Proposed Changes

There are several rounds of changes in here. I did my best to have separate commits for basic naming changes, whitespace changes, and actual changes. I suggest reviewing one commit at a time.

The first bunch are fairly mechanical.
- Move documentation comments out of the constructor and onto property declarations. This should also improve tsdoc.
- Remove underscores from private property names
- Remove underscores from private properties and methods
- Format/lint

After that things get more complicated. The code previously had many checks for null that happened because a property could be null _at some point_, even though the relevant method was only called once and the relevant properties would never be null. Also, the information about the potential connection to make (the candidate connection) was stored in two separate properties, but hey always changed together. The code assumed that in multiple places before we had strict null checks. After turning on strict null checks, we needed lots of unnecessary checks.

How I resolved this:
- When no candidate is found, return `null` from `getCandidate` instead of a `CandidateConnection` object with `null` properties. As a result, when anything non-null is returned, I know the properties it contains are also non-null (and so does the compiler).
- Store the `CandidateConnection` as a single object, rather than storing the `localConnection` and `closestConnection` as separate properties. This means I don't have to coerce the compiler into believing that if one is non-null, the other is also non-null.
- Pass values into methods when I know they are non-null, instead of accessing them as properties. 

After that, I did assorted cleanup on the new code, including removing some errors that said things like "the code should never get here but the compiler insists that it could."

#### Behavior Before Change

No change.

#### Behavior After Change

No change.

### Reason for Changes

Part of general tidying made possible by knowing which properties are internal and which are external.

### Test Coverage
I wrote tests for this in #6596 and made sure they worked with the previous implementation and also worked after my changes.

I also opened up the advanced playground and manually looked at cases where the block would be inserted vs replaced, because the tests check whether a connection would be made, but not what happens to the previously connected block.

I don't have tests for inserting vs replacing because that's internal to the insertion marker. I could look at the state of the workspace after running `applyConnections`, though, if I trust my test setup enough. :thinking: 

### Documentation

None

### Additional Information

