### PR TITLE
chore: clean up field default values

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -56,6 +56,17 @@ export abstract class Field<T = unknown> implements IASTNodeLocationSvg,
                                                     IASTNodeLocationWithBlock,
                                                     IKeyboardAccessible,
                                                     IRegistrable {
+  /**
+   * To overwrite the default value which is set in **Field**, directly update
+   * the prototype.
+   *
+   * Example:
+   * ```typescript
+   * FieldImage.prototype.DEFAULT_VALUE = null;
+   * ```
+   */
+  DEFAULT_VALUE: T|null = null;
+
   /** Non-breaking space. */
   static readonly NBSP = '\u00A0';
 
@@ -189,9 +200,9 @@ export abstract class Field<T = unknown> implements IASTNodeLocationSvg,
      * A generic value possessed by the field.
      * Should generally be non-null, only null when the field is created.
      */
-    this.value_ = ('DEFAULT_VALUE' in (new.target).prototype) ?
-        ((new.target).prototype as AnyDuringMigration).DEFAULT_VALUE :
-        null;
+    this.value_ = 'DEFAULT_VALUE' in new.target.prototype ?
+        new.target.prototype.DEFAULT_VALUE :
+        this.DEFAULT_VALUE;
 
     /** The size of the area rendered by the field. */
     this.size_ = new Size(0, 0);

--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -35,9 +35,6 @@ export type FieldAngleValidator = FieldInputValidator<number>;
  * @alias Blockly.FieldAngle
  */
 export class FieldAngle extends FieldInput<number> {
-  /** The default value for this field. */
-  // protected override DEFAULT_VALUE = 0;
-
   /**
    * The default amount to round angles to when using a mouse or keyboard nav
    * input. Must be a positive integer to support keyboard navigation.
@@ -518,7 +515,7 @@ Css.register(`
 
 fieldRegistry.register('field_angle', FieldAngle);
 
-(FieldAngle.prototype as AnyDuringMigration).DEFAULT_VALUE = 0;
+FieldAngle.prototype.DEFAULT_VALUE = 0;
 
 /**
  * The two main modes of the angle field.

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -238,7 +238,7 @@ export class FieldCheckbox extends Field<boolean> {
 
 fieldRegistry.register('field_checkbox', FieldCheckbox);
 
-(FieldCheckbox.prototype as AnyDuringMigration).DEFAULT_VALUE = false;
+FieldCheckbox.prototype.DEFAULT_VALUE = false;
 
 /**
  * Config options for the checkbox field.

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -589,10 +589,7 @@ export class FieldColour extends Field<string> {
 }
 
 /** The default value for this field. */
-// AnyDuringMigration because:  Property 'DEFAULT_VALUE' is protected and only
-// accessible within class 'FieldColour' and its subclasses.
-(FieldColour.prototype as AnyDuringMigration).DEFAULT_VALUE =
-    FieldColour.COLOURS[0];
+FieldColour.prototype.DEFAULT_VALUE = FieldColour.COLOURS[0];
 
 /** CSS for colour picker.  See css.js for use. */
 Css.register(`

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -268,7 +268,7 @@ export class FieldImage extends Field<string> {
 
 fieldRegistry.register('field_image', FieldImage);
 
-(FieldImage.prototype as AnyDuringMigration).DEFAULT_VALUE = '';
+FieldImage.prototype.DEFAULT_VALUE = '';
 
 /**
  * Config options for the image field.

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -129,7 +129,7 @@ export class FieldLabel extends Field<string> {
 
 fieldRegistry.register('field_label', FieldLabel);
 
-(FieldLabel.prototype as AnyDuringMigration).DEFAULT_VALUE = '';
+FieldLabel.prototype.DEFAULT_VALUE = '';
 
 // clang-format off
 // Clang does not like the 'class' keyword being used as a property.

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -322,7 +322,7 @@ export class FieldNumber extends FieldInput<number> {
 
 fieldRegistry.register('field_number', FieldNumber);
 
-(FieldNumber.prototype as AnyDuringMigration).DEFAULT_VALUE = 0;
+FieldNumber.prototype.DEFAULT_VALUE = 0;
 
 /**
  * Config options for the number field.

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -62,7 +62,7 @@ export class FieldTextInput extends FieldInput<string> {
 
 fieldRegistry.register('field_input', FieldTextInput);
 
-(FieldTextInput.prototype as AnyDuringMigration).DEFAULT_VALUE = '';
+FieldTextInput.prototype.DEFAULT_VALUE = '';
 
 /**
  * fromJson config options for the text input field.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

This update provides handling for `AnyDuringMigration` for `DEFAULT_VALUE` in `core/field.ts` and its descendants.

### Proposed Changes

- Adds `DEFAULT_VALUE` to base `core/field.ts` of type `T|null`

#### Behavior Before Change

- `DEFAULT_VALUE` was hidden in the corresponding classes before
- Had to use `AnyDuringMigration` to set `DEFAULT_VALUE`

#### Behavior After Change

- No longer need `AnyDuringMigration` for `DEFAULT_VALUE`

### Reason for Changes

Code health! :)

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

Nothing!
