### PR TITLE
feat: add option to disable modal inputs on mobile

### DIFF
--- a/core/blockly_options.ts
+++ b/core/blockly_options.ts
@@ -32,6 +32,7 @@ export interface BlocklyOptions {
   maxBlocks?: number;
   maxInstances?: {[blockType: string]: number};
   media?: string;
+  modalInputs?: boolean;
   move?: MoveOptions;
   oneBasedIndex?: boolean;
   readOnly?: boolean;

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -273,7 +273,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
   }
 
   /**
-   * Show the inline free-text editor on top of the text.
+   * Show an editor for the field.
+   * Shows the inline free-text editor on top of the text by default.
+   * Shows a prompt editor for mobile browsers if the modalInputs option is
+   * enabled.
    *
    * @param _opt_e Optional mouse event that triggered the field to open, or
    *     undefined if triggered programmatically.
@@ -283,7 +286,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
   protected override showEditor_(_opt_e?: Event, opt_quietInput?: boolean) {
     this.workspace_ = (this.sourceBlock_ as BlockSvg).workspace;
     const quietInput = opt_quietInput || false;
-    if (!quietInput &&
+    if (!quietInput && this.workspace_.options.modalInputs &&
         (userAgent.MOBILE || userAgent.ANDROID || userAgent.IPAD)) {
       this.showPromptEditor_();
     } else {
@@ -293,7 +296,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
 
   /**
    * Create and show a text input editor that is a prompt (usually a popup).
-   * Mobile browsers have issues with in-line textareas (focus and keyboards).
+   * Mobile browsers may have issues with in-line textareas (focus and
+   * keyboards).
    */
   private showPromptEditor_() {
     dialog.prompt(

--- a/core/options.ts
+++ b/core/options.ts
@@ -38,6 +38,7 @@ export class Options {
   readOnly: boolean;
   maxBlocks: number;
   maxInstances: {[key: string]: number}|null;
+  modalInputs: boolean;
   pathToMedia: string;
   hasCategories: boolean;
   moveOptions: MoveOptions;
@@ -155,6 +156,11 @@ export class Options {
 
     const plugins = options['plugins'] || {};
 
+    let modalInputs = options['modalInputs'];
+    if (modalInputs === undefined) {
+      modalInputs = true;
+    }
+
     this.RTL = rtl;
     this.oneBasedIndex = oneBasedIndex;
     this.collapse = hasCollapse;
@@ -163,6 +169,7 @@ export class Options {
     this.readOnly = readOnly;
     this.maxBlocks = options['maxBlocks'] || Infinity;
     this.maxInstances = options['maxInstances'] ?? null;
+    this.modalInputs = modalInputs;
     this.pathToMedia = pathToMedia;
     this.hasCategories = hasCategories;
     this.moveOptions = Options.parseMoveOptions_(options, hasCategories);

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -173,6 +173,7 @@ suite('Text Input Fields', function() {
               };
             },
             markFocused: function() {},
+            options: {},
           };
           field.sourceBlock_ = {
             workspace: workspace,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6608 

### Proposed Changes

Adds an option called `modalInputs` to BlocklyOptions (and Options). Default is true. If false, then FieldTextInput and its subclasses will not show the modal prompt editor when on mobile browsers. 

#### Behavior Before Change

Always show the modal editor if on mobile browser.

#### Behavior After Change

Default is to show modal editor if on mobile, but this can be disabled by setting the new option to false. If it's false, we'll show the inline editor like we would on desktop.

### Reason for Changes

Not everyone wants the modal UI, especially these days when the mobile keyboard experience is not as bad as it used to be (e.g. smart bumping of content now)

### Alternatives Considered

- Not adding a new BlocklyOption to the giant config struct... but ultimately this is a piece of configuration so it needs to be configured somewhere, and the least surprising place would be the options struct.
- Making people subclass FieldTextInput to not show the prompt editor. This would be fine, except you also then have to subclass all of its children as well, and add the exact same logic to each of those classes, which is pretty messy for something that should be a single boolean check.
- Somehow taking advantage of the logic for setting a custom prompt, and letting people set a custom prompt that would return false or something and then we'd know to show the inline editor instead. This would require more changes than the chosen solution and is quite convoluted logic, plus has the ability to interfere with other custom prompts a user may want to keep.

### Test Coverage

Tested manually in the playground. I looked at adding this to the advanced playground UI in core but as far as I can tell you can't modify the existing folders and I didn't want to make another new one. After this is released, it could be added as an option in the advanced playground in samples.

### Documentation

Needs to be documented in the devsite article about the configuration struct.

### Additional Information

Please fight over the name of the option in the comments.
