### PR TITLE
ci: clang format version bump

### DIFF
--- a/.github/workflows/check_clang_format.yml
+++ b/.github/workflows/check_clang_format.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: DoozyX/clang-format-lint-action@v0.14
+    - uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: 'core'
         extensions: 'js,ts'
         # This should be as close as possible to the version that the npm
         # package supports. This can be found by running:
         # npx clang-format --version.
-        clangFormatVersion: 13
+        clangFormatVersion: 15
 
     # The Report clang format workflow (report_clang_format.yml) will
     # run (if required) after this one to post a comment to the PR.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

clang-format 1.8.0 uses format 15

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

format 13 used
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

format 15 used
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

ci version should be as close as possible to the version that the npm package supports
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
