### PR TITLE
fix: blocks not receiving their own delete events

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -20,6 +20,7 @@ import './events/events_block_create.js';
 import './events/events_block_delete.js';
 
 import {Blocks} from './blocks.js';
+import {BlockDelete} from './events/events_block_delete.js';
 import type {Comment} from './comment.js';
 import * as common from './common.js';
 import {Connection} from './connection.js';
@@ -328,10 +329,6 @@ export class Block implements IASTNodeLocation, IDeletable {
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
       eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
-    }
-
-    if (this.onchangeWrapper_) {
-      this.workspace.removeChangeListener(this.onchangeWrapper_);
     }
 
     eventUtils.disable();
@@ -1027,7 +1024,13 @@ export class Block implements IASTNodeLocation, IDeletable {
       this.workspace.removeChangeListener(this.onchangeWrapper_);
     }
     this.onchange = onchangeFn;
-    this.onchangeWrapper_ = onchangeFn.bind(this);
+    this.onchangeWrapper_ = (e) => {
+      onchangeFn.call(this, e);
+      if (e.type === eventUtils.BLOCK_DELETE &&
+          (e as BlockDelete).blockId === this.id) {
+        this.workspace.removeChangeListener(this.onchangeWrapper_!);
+      }
+    };
     this.workspace.addChangeListener(this.onchangeWrapper_);
   }
 

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -10,9 +10,9 @@ import * as eventUtils from '../../build/src/core/events/utils.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
-suite('Block Delete Event', function() {
+suite.only('Block Delete Event', function() {
   setup(function() {
-    sharedTestSetup.call(this);
+    sharedTestSetup.call(this, {useFakeTimers: false});
     defineRowBlock();
     this.workspace = new Blockly.Workspace();
   });
@@ -22,9 +22,9 @@ suite('Block Delete Event', function() {
   });
 
   suite('Receiving', function() {
-    test('blocks receive their own delete events', function() {
+    test('blocks receive their own delete events', function(done) {
       Blockly.Blocks['test'] = {
-        onchange: function(e) {},
+        onchange: function(e) { },
       };
       // Need to stub the definition, because the property on the definition is
       // what gets registered as an event listener.
@@ -34,8 +34,10 @@ suite('Block Delete Event', function() {
       testBlock.dispose();
 
       const deleteClass = eventUtils.get(eventUtils.BLOCK_DELETE);
-      chai.assert.isTrue(spy.calledOnce);
-      chai.assert.isTrue(spy.getCall(0).args[0] instanceof deleteClass);
+      setTimeout(function() {
+        chai.assert.isTrue(spy.calledWith(sinon.match.instanceOf(deleteClass)));
+        done();
+      }, 1);
     });
   });
 

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -12,7 +12,8 @@ import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown
 
 suite('Block Delete Event', function() {
   setup(function() {
-    sharedTestSetup.call(this, {useFakeTimers: false});
+    const {clock} = sharedTestSetup.call(this, {fireEventsNow: false});
+    this.clock = clock;
     defineRowBlock();
     this.workspace = new Blockly.Workspace();
   });
@@ -32,12 +33,13 @@ suite('Block Delete Event', function() {
       const testBlock = this.workspace.newBlock('test');
 
       testBlock.dispose();
+      this.clock.tick(2);  // Fire events. The built-in timeout is 0.
 
       const deleteClass = eventUtils.get(eventUtils.BLOCK_DELETE);
-      setTimeout(function() {
-        chai.assert.isTrue(spy.calledWith(sinon.match.instanceOf(deleteClass)));
-        done();
-      }, 1);
+      chai.assert.isTrue(
+          spy.calledWith(sinon.match.instanceOf(deleteClass)),
+          'Expected the block to receive its own delete event.');
+      done();
     });
   });
 

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -10,7 +10,7 @@ import * as eventUtils from '../../build/src/core/events/utils.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
-suite.only('Block Delete Event', function() {
+suite('Block Delete Event', function() {
   setup(function() {
     sharedTestSetup.call(this, {useFakeTimers: false});
     defineRowBlock();

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -110,10 +110,12 @@ export function sharedTestSetup(options = {}) {
   this.sharedSetupCalled_ = true;
   // Sandbox created for greater control when certain stubs are cleared.
   this.sharedSetupSandbox_ = sinon.createSandbox();
-  this.clock = this.sharedSetupSandbox_.useFakeTimers();
-  if (options['fireEventsNow'] === undefined || options['fireEventsNow']) {
-    // Stubs event firing unless passed option "fireEventsNow: false"
-    this.eventsFireStub = createEventsFireStubFireImmediately_(this.clock);
+  if (options['useFakeTimers'] === undefined || options['useFakeTimers']) {
+    this.clock = this.sharedSetupSandbox_.useFakeTimers();
+    if (options['fireEventsNow'] === undefined || options['fireEventsNow']) {
+      // Stubs event firing unless passed option "fireEventsNow: false"
+      this.eventsFireStub = createEventsFireStubFireImmediately_(this.clock);
+    }
   }
   this.sharedCleanup = {
     blockTypesCleanup_: [],

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -105,17 +105,17 @@ function wrapDefineBlocksWithJsonArrayWithCleanup_(sharedCleanupObj) {
  *
  * @param {Object<string, boolean>} options Options to enable/disable setup
  *    of certain stubs.
+ * @return {{clock: *}} The fake clock (as part of an object to make refactoring
+ *     easier).
  */
 export function sharedTestSetup(options = {}) {
   this.sharedSetupCalled_ = true;
   // Sandbox created for greater control when certain stubs are cleared.
   this.sharedSetupSandbox_ = sinon.createSandbox();
-  if (options['useFakeTimers'] === undefined || options['useFakeTimers']) {
-    this.clock = this.sharedSetupSandbox_.useFakeTimers();
-    if (options['fireEventsNow'] === undefined || options['fireEventsNow']) {
-      // Stubs event firing unless passed option "fireEventsNow: false"
-      this.eventsFireStub = createEventsFireStubFireImmediately_(this.clock);
-    }
+  this.clock = this.sharedSetupSandbox_.useFakeTimers();
+  if (options['fireEventsNow'] === undefined || options['fireEventsNow']) {
+    // Stubs event firing unless passed option "fireEventsNow: false"
+    this.eventsFireStub = createEventsFireStubFireImmediately_(this.clock);
   }
   this.sharedCleanup = {
     blockTypesCleanup_: [],
@@ -124,6 +124,9 @@ export function sharedTestSetup(options = {}) {
   this.blockTypesCleanup_ = this.sharedCleanup.blockTypesCleanup_;
   this.messagesCleanup_ = this.sharedCleanup.messagesCleanup_;
   wrapDefineBlocksWithJsonArrayWithCleanup_(this.sharedCleanup);
+  return {
+    clock: this.clock,
+  };
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6319 

but actually this time.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that block change listeners unregister themselves when they receive the delete event for the block they are associated with. This ensures they actually receive that event (i.e. they're not getting removed too early).

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Blocks were not receiving their own delete events.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
Blocks are receiving their own delete events.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Sometimes you want to trigger cleanup / other operations when a block is deleted.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Fixed test to actually wait for the delay built-in to the events system. Before the tests were passing incorrectly because we'd stubbed the fire method to fire immediately.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
