### PR TITLE
feat: make `getWorkspace`, `getFlyout`, and `getToolbox` public

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -450,7 +450,6 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
    * Get the workspace inside the flyout.
    *
    * @returns The workspace inside the flyout.
-   * @internal
    */
   getWorkspace(): WorkspaceSvg {
     return this.workspace_;

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -959,7 +959,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    *
    * @param opt_own Whether to only return the workspace's own flyout.
    * @returns The flyout on this workspace.
-   * @internal
    */
   getFlyout(opt_own?: boolean): IFlyout|null {
     if (this.flyout || opt_own) {
@@ -975,7 +974,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    * Getter for the toolbox associated with this workspace, if one exists.
    *
    * @returns The toolbox on this workspace.
-   * @internal
    */
   getToolbox(): IToolbox|null {
     return this.toolbox_;


### PR DESCRIPTION
Amusingly Flyout.isVisible and .setVisible are public, but there's no way to access a flyout given that getFlyout was not public.
