### PR TITLE
docs: Add notice to use unpkg instead of demos.

### DIFF
--- a/appengine/blockly_compressed.js
+++ b/appengine/blockly_compressed.js
@@ -2,7 +2,7 @@
 // their Blockly applications to https://blockly-demo.appspot.com/
 // Delete this file in early 2024.
 var msg = 'Compiled Blockly files should be loaded from https://unpkg.com/blockly/\n' +
-    'For help, contact https://groups.google.com/g/blockly'
+    'For help, contact https://groups.google.com/g/blockly';
 console.log(msg);
 try {
   alert(msg);

--- a/appengine/blockly_compressed.js
+++ b/appengine/blockly_compressed.js
@@ -1,5 +1,11 @@
 // Added November 2022 after discovering that a number of orgs were hot-linking
 // their Blockly applications to https://blockly-demo.appspot.com/
 // Delete this file in early 2024.
-alert('Compiled Blockly files should be loaded from https://unpkg.com/blockly/\n' +
-    'For help, contact https://groups.google.com/g/blockly');
+var msg = 'Compiled Blockly files should be loaded from https://unpkg.com/blockly/\n' +
+    'For help, contact https://groups.google.com/g/blockly'
+console.log(msg);
+try {
+  alert(msg);
+} catch (_e) {
+  // Can't alert?  Probably node.js.
+}

--- a/appengine/blockly_compressed.js
+++ b/appengine/blockly_compressed.js
@@ -1,0 +1,5 @@
+// Added November 2022 after discovering that a number of orgs were hot-linking
+// their Blockly applications to https://blockly-demo.appspot.com/
+// Delete this file in early 2024.
+alert('Compiled Blockly files should be loaded from https://unpkg.com/blockly/\n' +
+    'For help, contact https://groups.google.com/g/blockly');


### PR DESCRIPTION
Logs show about a dozen orgs actively using Blockly instances that are hot-linked to blockly-demo.appspot.com

These files disappeared on 25 November 2022, breaking a bunch of people.  This alert should point developers in the right direction.
