### PR TITLE
feat: make the variable map return early for noops

### DIFF
--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -184,6 +184,8 @@ export class VariableMap {
     this.variableMap.delete(type);
     this.variableMap.set(type, variables);
 
+    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))(variable));
+
     return variable;
   }
   /* Begin functions for variable deletion. */

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -59,6 +59,7 @@ export class VariableMap {
    * @internal
    */
   renameVariable(variable: VariableModel, newName: string) {
+    if (variable.name === newName) return;
     const type = variable.type;
     const conflictVar = this.getVariable(newName, type);
     const blocks = this.workspace.getAllBlocks(false);

--- a/core/variable_model.ts
+++ b/core/variable_model.ts
@@ -15,7 +15,6 @@ goog.declareModuleId('Blockly.VariableModel');
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_var_create.js';
 
-import * as eventUtils from './events/utils.js';
 import * as idGenerator from './utils/idgenerator.js';
 import type {Workspace} from './workspace.js';
 
@@ -58,8 +57,6 @@ export class VariableModel {
      * UUID.
      */
     this.id_ = opt_id || idGenerator.genUid();
-
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))(this));
   }
 
   /** @returns The ID for the variable. */

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -255,7 +255,7 @@ suite('Variable Map', function() {
     });
   });
 
-  suite.only('event firing', function() {
+  suite('event firing', function() {
     setup(function() {
       this.eventSpy = createChangeListenerSpy(this.workspace);
     });

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -442,15 +442,13 @@ suite('Variable Map', function() {
             });
   
         test(
-            'rename events are not fired if the variable does not exist',
+            'renaming throws if the variable does not exist',
             function() {
-              this.variableMap.renameVariable('test id', 'test name');
-    
-              assertEventNotFired(
-                this.eventSpy,
-                Blockly.Events.VarRename,
-                {},
-                this.workspace.id);
+              // Not sure why this throws when the other one doesn't but might
+              // as well test it.
+              chai.assert.throws(() => {
+                this.variableMap.renameVariableById('test id', 'test name');
+              }, `Tried to rename a variable that didn't exist`);
             });
       });
     });

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -8,6 +8,7 @@ goog.declareModuleId('Blockly.test.variableMap');
 
 import {assertVariableValues} from './test_helpers/variables.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {assertEventFired, assertEventNotFired, createChangeListenerSpy} from './test_helpers/events.js';
 
 
 suite('Variable Map', function() {
@@ -251,6 +252,207 @@ suite('Variable Map', function() {
     test('None', function() {
       const resultArray = this.variableMap.getAllVariables();
       chai.assert.deepEqual(resultArray, []);
+    });
+  });
+
+  suite.only('event firing', function() {
+    setup(function() {
+      this.eventSpy = createChangeListenerSpy(this.workspace);
+    });
+
+    teardown(function() {
+      this.workspace.removeChangeListener(this.eventSpy);
+    });
+
+    suite('variable create events', function() {
+      test('create events are fired when a variable is created', function() {
+        this.variableMap.createVariable('test name', 'test type', 'test id');
+
+        assertEventFired(
+          this.eventSpy,
+          Blockly.Events.VarCreate,
+          {
+            varType: 'test type',
+            varName: 'test name',
+            varId: 'test id',
+          },
+          this.workspace.id);
+      });
+
+      test(
+          'create events are not fired if a variable is already exists',
+          function() {
+            this.variableMap.createVariable('test name', 'test type', 'test id');
+
+            this.eventSpy.resetHistory();
+            this.variableMap.createVariable('test name', 'test type', 'test id');
+
+            assertEventNotFired(
+              this.eventSpy,
+              Blockly.Events.VarCreate,
+              {},
+              this.workspace.id);
+          });
+    });
+
+    suite('variable delete events', function() {
+      suite('deleting with a variable', function() {
+        test('delete events are fired when a variable is deleted', function() {
+          const variable =
+              this.variableMap.createVariable('test name', 'test type', 'test id');
+          this.variableMap.deleteVariable(variable);
+  
+          assertEventFired(
+            this.eventSpy,
+            Blockly.Events.VarDelete,
+            {
+              varType: 'test type',
+              varName: 'test name',
+              varId: 'test id',
+            },
+            this.workspace.id);
+        });
+
+        test(
+            'delete events are not fired when a variable does not exist',
+            function() {
+          const variable =
+              new Blockly.VariableModel(
+                  this.workspace, 'test name', 'test type', 'test id');
+          this.variableMap.deleteVariable(variable);
+  
+          assertEventNotFired(
+            this.eventSpy,
+            Blockly.Events.VarDelete,
+            {},
+            this.workspace.id);
+        });
+      });
+
+      suite('deleting by ID', function() {
+        test(
+            'delete events are fired when a variable is deleted',
+            function() {
+              this.variableMap.createVariable('test name', 'test type', 'test id');
+              this.variableMap.deleteVariableById('test id');
+      
+              assertEventFired(
+                this.eventSpy,
+                Blockly.Events.VarDelete,
+                {
+                  varType: 'test type',
+                  varName: 'test name',
+                  varId: 'test id',
+                },
+                this.workspace.id);
+            });
+
+        test(
+            'delete events are not fired when a variable does not exist',
+            function() {
+              this.variableMap.deleteVariableById('test id');
+      
+              assertEventNotFired(
+                this.eventSpy,
+                Blockly.Events.VarDelete,
+                {},
+                this.workspace.id);
+            });
+      });
+    });
+
+    suite('variable rename events', function() {
+      suite('renaming with variable', function() {
+        test('rename events are fired when a variable is renamed', function() {
+          const variable =
+              this.variableMap.createVariable(
+                  'test name', 'test type', 'test id');
+          this.variableMap.renameVariable(variable, 'new test name');
+
+          assertEventFired(
+            this.eventSpy,
+            Blockly.Events.VarRename,
+            {
+              oldName: 'test name',
+              newName: 'new test name',
+              varId: 'test id',
+            },
+            this.workspace.id);
+        });
+  
+        test(
+            'rename events are not fired if the variable name already matches',
+            function() {
+              const variable =
+                  this.variableMap.createVariable(
+                      'test name', 'test type', 'test id');
+              this.variableMap.renameVariable(variable, 'test name');
+    
+              assertEventNotFired(
+                this.eventSpy,
+                Blockly.Events.VarRename,
+                {},
+                this.workspace.id);
+            });
+  
+        test(
+            'rename events are not fired if the variable does not exist',
+            function() {
+              const variable =
+                  new Blockly.VariableModel(
+                      'test name', 'test type', 'test id');
+              this.variableMap.renameVariable(variable, 'test name');
+    
+              assertEventNotFired(
+                this.eventSpy,
+                Blockly.Events.VarRename,
+                {},
+                this.workspace.id);
+            });
+      });
+
+      suite('renaming by ID', function() {
+        test('rename events are fired when a variable is renamed', function() {
+          this.variableMap.createVariable('test name', 'test type', 'test id');
+          this.variableMap.renameVariableById('test id', 'new test name');
+
+          assertEventFired(
+            this.eventSpy,
+            Blockly.Events.VarRename,
+            {
+              oldName: 'test name',
+              newName: 'new test name',
+              varId: 'test id',
+            },
+            this.workspace.id);
+        });
+  
+        test(
+            'rename events are not fired if the variable name already matches',
+            function() {
+              this.variableMap.createVariable(
+                  'test name', 'test type', 'test id');
+              this.variableMap.renameVariableById('test id', 'test name');
+    
+              assertEventNotFired(
+                this.eventSpy,
+                Blockly.Events.VarRename,
+                {},
+                this.workspace.id);
+            });
+  
+        test(
+            'rename events are not fired if the variable does not exist',
+            function() {
+              this.variableMap.renameVariable('test id', 'test name');
+    
+              assertEventNotFired(
+                this.eventSpy,
+                Blockly.Events.VarRename,
+                {},
+                this.workspace.id);
+            });
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6524 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1) Makes it so that the variable map returns early in cases where renames are noops (other modificiations already did this correctly).
2) Moves firing create events from the `VariableModel` to the `VariableMap`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) This prevents us from getting into infinite event loops when sharing events between multiple workspaces. See [here](https://github.com/google/blockly/pull/6650#discussion_r1036554356) for an example/explanation.
2)  This allows us to use variable models as backing data models without actually having them (e.g.) show up in the flyout.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Added unit tests for creating, deleting, and renaming, and when they should fire events vs not fire events.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This is not dependent on any parent branches, so it's ready for review!
