### PR TITLE
chore: update release notes config and tagging

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,12 +4,16 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+      - "PR: chore"
     authors:
       - dependabot
   categories:
     - title: Breaking Changes 🛠
       labels:
         - breaking change
+    - title: Deprecating Changes
+      labels:
+        - deprecation
     - title: New Features
       labels:
         - "PR: feature"
@@ -18,9 +22,11 @@ changelog:
         - "PR: fix"
     - title: Cleanup ♻️
       labels:
-        - "PR: chore"
         - "PR: docs"
         - "PR: refactor"
+    - title: Reverted changes
+      labels:
+        - "PR: revert"
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,25 +8,25 @@ changelog:
     authors:
       - dependabot
   categories:
-    - title: Breaking Changes 🛠
+    - title: Breaking changes 🛠
       labels:
         - breaking change
-    - title: Deprecating Changes
+    - title: Deprecations 🧹 - APIs that may be removed in future releases
       labels:
         - deprecation
-    - title: New Features
+    - title: New features ✨
       labels:
         - "PR: feature"
-    - title: Bug fixes
+    - title: Bug fixes 🐛
       labels:
         - "PR: fix"
     - title: Cleanup ♻️
       labels:
         - "PR: docs"
         - "PR: refactor"
-    - title: Reverted changes
+    - title: Reverted changes ⎌
       labels:
         - "PR: revert"
-    - title: Other Changes
+    - title: Other changes
       labels:
         - "*"

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,6 +1,8 @@
 on:
   pull_request_target:
-    types: [ opened, edited ]
+    types:
+      - opened
+      - edited
 name: conventional-release-labels
 jobs:
   label:
@@ -8,5 +10,7 @@ jobs:
     steps:
       - uses: bcoe/conventional-release-labels@v1
         with:
-          type_labels: '{"feat": "PR: feature", "fix": "PR: fix", "breaking": "breaking change", "chore": "PR: chore", "docs": "PR: docs", "refactor": "PR: refactor"}'
+          type_labels: '{"feat": "PR: feature", "fix": "PR: fix", "breaking": "breaking
+            change", "chore": "PR: chore", "docs": "PR: docs", "refactor": "PR:
+            refactor", "revert": "PR: revert", "deprecate": "deprecation"}'
           ignored_types: '[]'


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes

- Tags conventional commits labelled "revert:" and "deprecation:" appropriately
- Adds section in the release notes for the above two categories
- Removes PRs labelled "chore" from the release notes
- Adds emojis

### Reason for Changes

More usable release notes. Points for discussion:

- I don't think anyone has ever used the "deprecation" conventional commit type but it's on our devsite: https://developers.google.com/blockly/guides/contribute/get-started/commits but I also try to keep an eye out for this in PRs and suggest folks tag it manually. 
- Currently most revert PRs just use the default PR title which is `Revert "PR title" (#9999)` but conventional commits website suggests using the `revert` type, though doesn't suggest what to do next
- I added a section at the bottom of the notes for reverted PRs because I think it is confusing when reverted changes appear in the release notes. So I would propose that whoever is creating the release actually removes the Reverted Changes section from the notes after removing the original PRs from their respective sections, if the reverted change was in the same release. That way the release notes stay clean.
- Added a section at the top for changes that deprecate things, so it's easier for users to locate changes they need to make in the future.
- Unfortunately, it is not possible to add text to the automated release notes template, outside of the header. If it were possible, I would have added text explaining what is meant by "deprecating change" to that section
    - I fear without any explanation, this category of changes may be confusing. So I also propose that whoever creates the release notes adds a sentence of context for this section. In the future we may switch tools to one that allows a more robust template.
    - If we don't want to do that and think this would be too confusing I can remove it from this PR
- Removes chores from the release notes. The reasoning being that chores are meant to be changes that aren't user visible and don't affect the release, things like this PR right here. It just clutters the release notes to include them. And removing from the release notes also means people shouldn't sneak in actual meaningful changes into PRs simply labelled chore; they will have to create more distinct PRs or choose a more suitable type.
    - Looking back through recent PRs, there are some marked chore that should have been either `fix` or `refactor` and this is something we should keep an eye on going forward if you are reviewing PRs.

### Additional Information

Currently "PR: revert" doesn't exist as a tag. no idea if it will create it for us or if it needs to be manually created first.
