### PR TITLE
feat: add destroy lifecycle hook to blocks

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -96,7 +96,7 @@ export class Block implements IASTNodeLocation, IDeletable {
   init?: (() => AnyDuringMigration)|null = undefined;
 
   /** An optional method called during disposal. */
-  destroy?: (() => AnyDuringMigration)|null = undefined;
+  destroy?: (() => void) = undefined;
 
   /**
    * An optional serialization method for defining how to serialize the

--- a/core/block.ts
+++ b/core/block.ts
@@ -95,6 +95,9 @@ export class Block implements IASTNodeLocation, IDeletable {
   /** An optional method called during initialization. */
   init?: (() => AnyDuringMigration)|null = undefined;
 
+  /** An optional method called during disposal. */
+  destroy?: (() => AnyDuringMigration)|null = undefined;
+
   /**
    * An optional serialization method for defining how to serialize the
    * mutation state to XML. This must be coupled with defining
@@ -361,6 +364,9 @@ export class Block implements IASTNodeLocation, IDeletable {
       }
     } finally {
       eventUtils.enable();
+      if (typeof this.destroy === 'function') {
+        this.destroy();
+      }
       this.disposed = true;
     }
   }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -199,7 +199,7 @@ suite('Blocks', function() {
       });
     });
   });
-  suite.only('Disposal', function() {
+  suite('Disposal', function() {
     suite('calling destroy', function() {
       setup(function() {
         Blockly.Blocks['destroyable_block'] = {

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -20,6 +20,18 @@ export function createChangeListenerSpy(workspace) {
 }
 
 /**
+ * Creates a mock event for testing if arbitrary events get fired/received.
+ * @param {!Blockly.Workspace} workspace The workspace to create the mock in.
+ * @return {!Object} A mock event that can be fired via Blockly.Events.fire
+ */
+export function createMockEvent(workspace) {
+  return {
+    isNull: () => false,
+    workspaceId: workspace.id,
+  };
+}
+
+/**
  * Asserts whether the given xml property has the expected property.
  * @param {!Node} xmlValue The xml value to check.
  * @param {!Node|string} expectedValue The expected value.

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -105,6 +105,8 @@ function wrapDefineBlocksWithJsonArrayWithCleanup_(sharedCleanupObj) {
  *
  * @param {Object<string, boolean>} options Options to enable/disable setup
  *    of certain stubs.
+ * @return {{clock: *}} The fake clock (as part of an object to make refactoring
+ *     easier).
  */
 export function sharedTestSetup(options = {}) {
   this.sharedSetupCalled_ = true;
@@ -122,6 +124,9 @@ export function sharedTestSetup(options = {}) {
   this.blockTypesCleanup_ = this.sharedCleanup.blockTypesCleanup_;
   this.messagesCleanup_ = this.sharedCleanup.messagesCleanup_;
   wrapDefineBlocksWithJsonArrayWithCleanup_(this.sharedCleanup);
+  return {
+    clock: this.clock,
+  };
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6319 maybe actually finally

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a new `destroy` lifecycle hook that is called at the end of `dispose` which can be used for cleanup (e.g. of any backing data models for the block).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Sometimes you need to clean data up!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Adds tests to make sure dispose gets called at the proper time, and events fired from it are actually fired.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Putting this up as a draft until we're sure we're definitely happy with the design.
