### PR TITLE
chore: stop linter from whining about no return

### DIFF
--- a/core/variables.ts
+++ b/core/variables.ts
@@ -222,7 +222,7 @@ export function generateUniqueNameFromOptions(
       }
     }
     if (!inUse) {
-      return potName;
+      break;
     }
 
     letterIndex++;
@@ -233,6 +233,7 @@ export function generateUniqueNameFromOptions(
     }
     potName = letters.charAt(letterIndex) + suffix;
   }
+  return potName;
 }
 
 /**


### PR DESCRIPTION
No functional change, just jumping through hoops due to tooling.

"JSDoc @returns declaration present but return expression not available in function"
