### PR TITLE
fix(appengine): Restore build products to previous location

### DIFF
--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -51,8 +51,32 @@ function copyStaticSrc(done) {
  * Prerequisite: clean, build.
  */
 function copyBuilt(done) {
-  return gulp.src(['build/msg/**/*', 'dist/*_compressed.js*'], {base: '.'})
+  return gulp.src(['build/msg/*', 'dist/*_compressed.js*'], {base: '.'})
       .pipe(gulp.dest(demoStaticTmpDir));
+}
+
+/**
+ * Copies compressed files into the places they used to be used from, for the
+ * benefit of our Developers site and (for now) any other websites that
+ * hotlink them.  Delete this once devsite is fixed.
+ *
+ * Prerequisite: clean, build.
+ */
+function copyCompressedToOldLocation(done) {
+  return gulp.src(['dist/*_compressed.js*'])
+      .pipe(gulp.dest(demoStaticTmpDir));
+}
+
+/**
+ * Copies messages files into the places they used to be used from, for the
+ * benefit of our Developers site and (for now) any other websites that
+ * hotlink them.  Delete this once devsite is fixed.
+ *
+ * Prerequisite: clean, build.
+ */
+function copyMessagesToOldLocation(done) {
+  return gulp.src(['build/msg/*'])
+      .pipe(gulp.dest(demoStaticTmpDir + '/msg/js'));
 }
 
 /**
@@ -153,7 +177,9 @@ const prepareDemos = gulp.series(
             gulp.parallel(buildTasks.cleanBuildDir,
                           packageTasks.cleanReleaseDir),
             buildTasks.build,
-            copyBuilt),
+            gulp.parallel(copyBuilt,
+                          copyCompressedToOldLocation,
+                          copyMessagesToOldLocation)),
         copyPlaygroundDeps));
 
 /**


### PR DESCRIPTION
## The basics

- [X] I branched from ~~develop~~**master**
- [X] My pull request is against ~~develop~~**master**
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Temporary fix for #6609, fixing 404 errors on devsite that break the homepage demo (for languages other than English, which has already been successfully fixed by making changes to devsite).

### Proposed Changes

Modify the `prepareDemos` script to copy the messages and compressed files to their previous locations in the deploy directory

#### Behaviour Before Change

Build products are copied to `_deploy/static/build/msg/` and `_deploy/static/dist/`, matching their usual locations in the Blockly repo.

#### Behaviour After Change

Build products are additionally copied to `_deploy/static/msg/js/` and `_deploy/static/`, matching their locations in the Blockly repo prior to PR #6475.

### Reason for Changes

The demo on [the Blockly Developers website homepage](https://developers.google.com/blockly/) was broken by #6475 and we have only been able to fix by updating devsite for English so far; it remains broken in other languages due delays in updating the other languages.

### Additional Information

This change should be reverted once devsite is fully updated.
