### PR TITLE
fix: set default field to any and fix validator function return type

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -53,9 +53,9 @@ export type FieldValidator<T = any> = (value?: T) => T|null|undefined;
  * @alias Blockly.Field
  */
 export abstract class Field<T = any> implements IASTNodeLocationSvg,
-                                                    IASTNodeLocationWithBlock,
-                                                    IKeyboardAccessible,
-                                                    IRegistrable {
+                                                IASTNodeLocationWithBlock,
+                                                IKeyboardAccessible,
+                                                IRegistrable {
   /**
    * To overwrite the default value which is set in **Field**, directly update
    * the prototype.

--- a/core/field.ts
+++ b/core/field.ts
@@ -45,14 +45,14 @@ import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import * as Xml from './xml.js';
 
-export type FieldValidator<T = unknown> = (value: T) => void;
+export type FieldValidator<T = any> = (value?: T) => T|null|undefined;
 
 /**
  * Abstract class for an editable field.
  *
  * @alias Blockly.Field
  */
-export abstract class Field<T = unknown> implements IASTNodeLocationSvg,
+export abstract class Field<T = any> implements IASTNodeLocationSvg,
                                                     IASTNodeLocationWithBlock,
                                                     IKeyboardAccessible,
                                                     IRegistrable {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Although the default Field type `T` should eventually be `unknown`, set it to `any` so it does not break users with subclasses extending from `Field` in the meantime.

### Proposed Changes

- Update `core/field.ts` - `FieldValidator` to provide the correct return type.
- Update `core/field.ts` - `T = unknown` to `T = any`

#### Behavior Before Change

TypeScript users with classes extending from `Field` would have to fill in a type for `Field` or their code will break.

#### Behavior After Change

TypeScript users can now extend from `Field` without providing the value type.

### Reason for Changes

This is for introducing the Field type information in multiple stages.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

Nope!
