### PR TITLE
feat: Make 'workspace' param optional on load/save

### DIFF
--- a/core/serialization/workspaces.ts
+++ b/core/serialization/workspaces.ts
@@ -11,6 +11,7 @@
  * @namespace Blockly.serialization.workspaces
  */
 import * as goog from '../../closure/goog/goog.js';
+import {getMainWorkspace} from '../common.js';
 goog.declareModuleId('Blockly.serialization.workspaces');
 
 import * as eventUtils from '../events/utils.js';
@@ -26,10 +27,11 @@ import {WorkspaceSvg} from '../workspace_svg.js';
  * Returns the state of the workspace as a plain JavaScript object.
  *
  * @param workspace The workspace to serialize.
+ *     Defaults to main workspace.
  * @returns The serialized state of the workspace.
  * @alias Blockly.serialization.workspaces.save
  */
-export function save(workspace: Workspace):
+export function save(workspace: Workspace = getMainWorkspace()):
     {[key: string]: AnyDuringMigration} {
   const state = Object.create(null);
   const serializerMap = registry.getAllItems(registry.Type.SERIALIZER, true);
@@ -47,12 +49,14 @@ export function save(workspace: Workspace):
  *
  * @param state The state of the workspace to deserialize into the workspace.
  * @param workspace The workspace to add the new state to.
+ *     Defaults to main workspace.
  * @param param1 recordUndo: If true, events triggered by this function will be
  *     undo-able by the user. False by default.
  * @alias Blockly.serialization.workspaces.load
  */
 export function load(
-    state: {[key: string]: AnyDuringMigration}, workspace: Workspace,
+    state: {[key: string]: AnyDuringMigration},
+    workspace: Workspace = getMainWorkspace(),
     {recordUndo = false}: {recordUndo?: boolean} = {}) {
   const serializerMap = registry.getAllItems(registry.Type.SERIALIZER, true);
   if (!serializerMap) {

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -294,7 +294,7 @@ Code.tabClick = function(clickedName) {
       }
     }
     if (json) {
-      Blockly.serialization.workspaces.load(json, Code.workspace);
+      Blockly.serialization.workspaces.load(json);
     }
   }
 
@@ -353,7 +353,7 @@ Code.renderContent = function() {
   } else if (content.id === 'content_json') {
     var jsonTextarea = document.getElementById('content_json');
     jsonTextarea.value = JSON.stringify(
-        Blockly.serialization.workspaces.save(Code.workspace), null, 2);
+        Blockly.serialization.workspaces.save(), null, 2);
     jsonTextarea.focus();
   } else if (content.id === 'content_javascript') {
     Code.attemptCodeGeneration(Blockly.JavaScript);

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -160,7 +160,7 @@ function saveXml() {
 
 function saveJson() {
   var output = document.getElementById('importExport');
-  var state = Blockly.serialization.workspaces.save(workspace);
+  var state = Blockly.serialization.workspaces.save();
   output.value = JSON.stringify(state, null, 2);
   output.focus();
   output.select();
@@ -175,7 +175,7 @@ function load() {
   var valid = saveIsValid(input.value);
   if (valid.json) {
     var state = JSON.parse(input.value);
-    Blockly.serialization.workspaces.load(state, workspace);
+    Blockly.serialization.workspaces.load(state);
   } else if (valid.xml) {
     var xml = Blockly.Xml.textToDom(input.value);
     Blockly.Xml.domToWorkspace(xml, workspace);
@@ -345,7 +345,7 @@ var spaghettiXml = [
       }
     };
     console.time('Spaghetti serialization');
-    Blockly.serialization.workspaces.load(obj, workspace);
+    Blockly.serialization.workspaces.load(obj);
     console.timeEnd('Spaghetti serialization');
   }
   var spaghettiJs = JSON.stringify({


### PR DESCRIPTION
Virtually 100% of calls to load and save (outside of tests) target the main workspace.  So do we need the developer to specify it every time?

Just a thought.  No big deal either way.