### PR TITLE
fix: Don't spellcheck number fields.

### DIFF
--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -47,6 +47,9 @@ export class FieldNumber extends FieldInput<number> {
    */
   override SERIALIZABLE = true;
 
+  /** Don't spellcheck numbers.  Our validator does a better job. */
+  protected override spellcheck_ = false;
+
   /**
    * @param opt_value The initial value of the field. Should cast to a number.
    *     Defaults to 0. Also accepts Field.SKIP_SETUP if you wish to skip setup


### PR DESCRIPTION
For the most part spellcheckers ignore numbers so this isn't an issue.  But (for example) 'Infinity' is an English word that's hardcoded into Blockly, and other languages may spellcheck it as wrong.