### PR TITLE
feat: Display a 'wait' cursor when opening trashcan

### DIFF
--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -275,7 +275,13 @@ export class Trashcan extends DeleteArea implements IAutoHideable,
     const contents = this.contents_.map(function(string) {
       return JSON.parse(string);
     });
-    this.flyout?.show(contents);
+    // Trashcans with lots of blocks can take a second to render.
+    const blocklyStyle = this.workspace.getParentSvg().style;
+    blocklyStyle.cursor = 'wait';
+    setTimeout(() => {
+      this.flyout?.show(contents);
+      blocklyStyle.cursor = '';
+    }, 10);
     this.fireUiEvent_(true);
   }
 


### PR DESCRIPTION
No visible change for regular case.  But if there's thousands of blocks in the trash, the visual feedback that something's happening is needed.  Otherwise the user will click in confusion, and that click will cause some random block to be spawned out of the trash.
