### PR TITLE
fix: not being able to set field values to empty

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -186,6 +186,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
    */
   protected override doValueInvalid_(_invalidValue: AnyDuringMigration) {
     if (this.isBeingEdited_) {
+      this.isDirty_ = true;
       this.isTextValid_ = false;
       const oldValue = this.value_;
       // Revert value when the text becomes invalid.
@@ -207,12 +208,9 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
    *     that this is a string.
    */
   protected override doValueUpdate_(newValue: AnyDuringMigration) {
+    this.isDirty_ = true;
     this.isTextValid_ = true;
     this.value_ = newValue;
-    if (!this.isBeingEdited_) {
-      // This should only occur if setValue is triggered programmatically.
-      this.isDirty_ = true;
-    }
   }
 
   /**
@@ -383,7 +381,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
 
     htmlInput.value = htmlInput.defaultValue = this.getEditorText_(this.value_);
     htmlInput.setAttribute('data-untyped-default-value', this.value_);
-    htmlInput.setAttribute('data-old-value', '');
 
     this.resizeEditor_();
 
@@ -493,15 +490,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<T> {
    * @param _e Keyboard event.
    */
   private onHtmlInputChange_(_e: Event) {
-    const text = this.htmlInput_!.value;
-    if (text !== this.htmlInput_!.getAttribute('data-old-value')) {
-      this.htmlInput_!.setAttribute('data-old-value', text);
-
-      const value = this.getValueFromEditorText_(text);
-      this.setValue(value);
-      this.forceRerender();
-      this.resizeEditor_();
-    }
+    this.setValue(this.getValueFromEditorText_(this.htmlInput_!.value));
   }
 
   /**

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -484,10 +484,9 @@ suite('Procedures', function() {
         test('Simple, Input', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
-          defInput.htmlInput_.value = defInput.htmlInput_.getAttribute('data-old-value') + '2';
+          defInput.htmlInput_.value = 'proc name2';
           defInput.onHtmlInputChange_(null);
           chai.assert.equal(
               this.defBlock.getFieldValue('NAME'), 'proc name2');
@@ -497,7 +496,6 @@ suite('Procedures', function() {
         test('lower -> CAPS', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = 'PROC NAME';
@@ -512,7 +510,6 @@ suite('Procedures', function() {
           this.callBlock.setFieldValue('PROC NAME', 'NAME');
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'PROC NAME');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'PROC NAME');
 
           defInput.htmlInput_.value = 'proc name';
@@ -525,10 +522,9 @@ suite('Procedures', function() {
         test('Whitespace', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
-          defInput.htmlInput_.value = defInput.htmlInput_.getAttribute('data-old-value') + ' ';
+          defInput.htmlInput_.value = 'proc name ';
           defInput.onHtmlInputChange_(null);
           chai.assert.equal(
               this.defBlock.getFieldValue('NAME'), 'proc name');
@@ -538,12 +534,11 @@ suite('Procedures', function() {
         test('Whitespace then Text', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
-          defInput.htmlInput_.value = defInput.htmlInput_.getAttribute('data-old-value') + ' ';
+          defInput.htmlInput_.value = 'proc name ';
           defInput.onHtmlInputChange_(null);
-          defInput.htmlInput_.value = defInput.htmlInput_.getAttribute('data-old-value') + '2';
+          defInput.htmlInput_.value = 'proc name 2';
           defInput.onHtmlInputChange_(null);
           chai.assert.equal(
               this.defBlock.getFieldValue('NAME'), 'proc name 2');
@@ -553,7 +548,6 @@ suite('Procedures', function() {
         test('Set Empty', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = '';
@@ -568,7 +562,6 @@ suite('Procedures', function() {
         test('Set Empty, and Create New', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-old-value', 'proc name');
           defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = '';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6701 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that you can set a text field to empty.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Sometimes the empty string is useful!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Mostly manual testing. Also updated some change-detector tests to not fail. (gah past self)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I think the issue started here: https://github.com/google/blockly/pull/6073

Basically, we used to be checking the text value against `null` and then we were checking it against `''` (to see if it had changed), which was failing.

So now, instead of trying to do this weird thing to check if the value had changed, just let `setValue` handle it like a normal field, and set `isDirty_` in the `doValueUpdate_` and `doValueInvalid_` functions instead of forcing a layout "manually".
