### PR TITLE
fix: undoing and redoing deleting procedures

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -308,6 +308,7 @@ const procedureDefGetDefMixin = function() {
      * disposed.
      */
     destroy: function() {
+      if (this.isInsertionMarker()) return;
       this.workspace.getProcedureMap().delete(this.getProcedureModel().getId());
     },
   };
@@ -602,6 +603,8 @@ const procedureDefMutator = {
     if (!params.length && this.hasStatements_) return null;
 
     const state = Object.create(null);
+    state['procedureId'] = this.getProcedureModel().getId();
+
     if (params.length) {
       state['params'] = params.map((p) => {
         return {
@@ -625,6 +628,15 @@ const procedureDefMutator = {
    *     statements.
    */
   loadExtraState: function(state) {
+    const map = this.workspace.getProcedureMap();
+    if (state['procedureId'] && state['procedureId'] != this.model_.getId() &&
+        map.has(state['procedureId'])) {
+      if (map.has(this.model_.getId())) {
+        map.delete(this.model_.getId());
+      }
+      this.model_ = map.get(state['procedureId']);
+    }
+
     if (state['params']) {
       for (let i = 0; i < state['params'].length; i++) {
         const {name, id, paramId} = state['params'][i];

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -629,8 +629,9 @@ const procedureDefMutator = {
    */
   loadExtraState: function(state) {
     const map = this.workspace.getProcedureMap();
-    if (state['procedureId'] && state['procedureId'] != this.model_.getId() &&
-        map.has(state['procedureId'])) {
+    const procedureId = state['procedureId'];
+    if (procedureId && procedureId != this.model_.getId() &&
+        map.has(procedureId)) {
       if (map.has(this.model_.getId())) {
         map.delete(this.model_.getId());
       }

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -599,11 +599,11 @@ const procedureDefMutator = {
    *     parameters and statements.
    */
   saveExtraState: function() {
-    const params = this.getProcedureModel().getParameters();
-    if (!params.length && this.hasStatements_) return null;
-
     const state = Object.create(null);
     state['procedureId'] = this.getProcedureModel().getId();
+
+    const params = this.getProcedureModel().getParameters();
+    if (!params.length && this.hasStatements_) return state;
 
     if (params.length) {
       state['params'] = params.map((p) => {
@@ -635,7 +635,7 @@ const procedureDefMutator = {
       if (map.has(this.model_.getId())) {
         map.delete(this.model_.getId());
       }
-      this.model_ = map.get(state['procedureId']);
+      this.model_ = map.get(procedureId);
     }
 
     if (state['params']) {

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -193,7 +193,9 @@ export function rename(this: Field, name: string): string {
   name = name.trim();
 
   const legalName = findLegalName(name, block);
-  if (isProcedureBlock(block)) block.getProcedureModel().setName(legalName);
+  if (isProcedureBlock(block) && !block.isInsertionMarker()) {
+    block.getProcedureModel().setName(legalName);
+  }
   const oldName = this.getValue();
   if (oldName !== name && oldName !== legalName) {
     // Rename any callers.

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1346,24 +1346,26 @@ suite('Procedures', function() {
           createProcCallBlock(this.workspace);
           // TODO: Apparently we need to call checkAndDelete to handle event
           //   grouping, this seems like possibly a bug.
+          const oldModel = defBlock.getProcedureModel();
           defBlock.checkAndDelete();
           this.clock.runAll();
 
           this.workspace.undo();
           this.clock.runAll();
 
-          console.log(this.workspace.getTopBlocks());
-
           const newDefBlock =
               this.workspace.getBlocksByType('procedures_defnoreturn')[0];
           const newCallBlock =
               this.workspace.getBlocksByType('procedures_callnoreturn')[0];
-          console.log(newDefBlock, newCallBlock);
 
           chai.assert.equal(
               newDefBlock.getProcedureModel(),
               newCallBlock.getProcedureModel(),
               'Expected both new blocks to be associated with the same model');
+          chai.assert.equal(
+            oldModel.getId(),
+            newDefBlock.getProcedureModel().getId(),
+            'Expected the new model to have the same ID as the old model');
         });
   });
 

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1338,6 +1338,33 @@ suite('Procedures', function() {
           chai.assert.isTrue(
               callBlock2.disposed, 'Expected the second caller to be disposed');
         });
+
+    test('undoing and a procedure delete will still associate procedure ' +
+        'and caller with the same model',
+        function() {
+          const defBlock = createProcDefBlock(this.workspace);
+          createProcCallBlock(this.workspace);
+          // TODO: Apparently we need to call checkAndDelete to handle event
+          //   grouping, this seems like possibly a bug.
+          defBlock.checkAndDelete();
+          this.clock.runAll();
+
+          this.workspace.undo();
+          this.clock.runAll();
+
+          console.log(this.workspace.getTopBlocks());
+
+          const newDefBlock =
+              this.workspace.getBlocksByType('procedures_defnoreturn')[0];
+          const newCallBlock =
+              this.workspace.getBlocksByType('procedures_callnoreturn')[0];
+          console.log(newDefBlock, newCallBlock);
+
+          chai.assert.equal(
+              newDefBlock.getProcedureModel(),
+              newCallBlock.getProcedureModel(),
+              'Expected both new blocks to be associated with the same model');
+        });
   });
 
   suite('caller blocks creating new def blocks', function() {

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1339,8 +1339,8 @@ suite('Procedures', function() {
               callBlock2.disposed, 'Expected the second caller to be disposed');
         });
 
-    test('undoing and a procedure delete will still associate procedure ' +
-        'and caller with the same model',
+    test('undoing and redoing a procedure delete will still associate ' +
+        'procedure and caller with the same model',
         function() {
           const defBlock = createProcDefBlock(this.workspace);
           createProcCallBlock(this.workspace);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #6526 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Discovered that when a procedure was deleted, and then the action was undone, procedure callers that were deleted with the definition were not properly reassociated with the procedure definition when they were deserialized. So e.g. when the definition was renamed, callers would not be renamed with it.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixing bugs is rad!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Added tests for undoing and redoing deleting procedures.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #6721 
