### PR TITLE
fix: change assertFieldValue in test helpers to use deepEqual

### DIFF
--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -126,7 +126,7 @@ suite('Angle Fields', function() {
             function() {
               return null;
             },
-        value: 2, expectedValue: 1},
+        value: 2, expectedValue: '1'},
       {title: 'Force Mult of 30 Validator',
         validator:
             function(newValue) {
@@ -150,7 +150,7 @@ suite('Angle Fields', function() {
         });
         test('When Not Editing', function() {
           this.field.setValue(suiteInfo.value);
-          assertFieldValue(this.field, suiteInfo.expectedValue);
+          assertFieldValue(this.field, +suiteInfo.expectedValue);
         });
       });
     });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -202,11 +202,11 @@ suite('Number Fields', function() {
             function() {
               return null;
             },
-        value: 2, expectedValue: 1},
+        value: 2, expectedValue: '1'},
       {title: 'Force End with 6 Validator',
         validator:
             function(newValue) {
-              return String(newValue).replace(/.$/, '6');
+              return +String(newValue).replace(/.$/, '6');
             },
         value: 25, expectedValue: 26},
       {title: 'Returns Undefined Validator', validator: function() {}, value: 2,
@@ -226,7 +226,7 @@ suite('Number Fields', function() {
         });
         test('When Not Editing', function() {
           this.field.setValue(suiteInfo.value);
-          assertFieldValue(this.field, suiteInfo.expectedValue);
+          assertFieldValue(this.field, +suiteInfo.expectedValue);
         });
       });
     });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -187,7 +187,7 @@ suite('Number Fields', function() {
   });
   suite('Validators', function() {
     setup(function() {
-      this.field = new Blockly.FieldNumber('1');
+      this.field = new Blockly.FieldNumber(1);
       this.field.htmlInput_ = document.createElement('input');
       this.field.htmlInput_.setAttribute('data-old-value', '1');
       this.field.htmlInput_.setAttribute('data-untyped-default-value', '1');

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -187,7 +187,7 @@ suite('Number Fields', function() {
   });
   suite('Validators', function() {
     setup(function() {
-      this.field = new Blockly.FieldNumber(1);
+      this.field = new Blockly.FieldNumber('1');
       this.field.htmlInput_ = document.createElement('input');
       this.field.htmlInput_.setAttribute('data-old-value', '1');
       this.field.htmlInput_.setAttribute('data-untyped-default-value', '1');

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -73,8 +73,8 @@ export function assertFieldValue(field, expectedValue, expectedText = undefined)
   if (expectedText === undefined) {
     expectedText = String(expectedValue);
   }
-  chai.assert.deepEqual(actualValue, expectedValue);
-  chai.assert.deepEqual(actualText, expectedText);
+  chai.assert.equal(actualValue, expectedValue, 'Value');
+  chai.assert.equal(actualText, expectedText, 'Text');
 }
 
 /**

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -73,8 +73,8 @@ export function assertFieldValue(field, expectedValue, expectedText = undefined)
   if (expectedText === undefined) {
     expectedText = String(expectedValue);
   }
-  chai.assert.equal(actualValue, expectedValue, 'Value');
-  chai.assert.equal(actualText, expectedText, 'Text');
+  chai.assert.deepEqual(actualValue, expectedValue);
+  chai.assert.deepEqual(actualText, expectedText);
 }
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6180 

### Proposed Changes

#### Changes Done

- Updated `tests/mocha/test_helpers/elds.js`
