### PR TITLE
chore: refactor procedures namespace

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -286,6 +286,10 @@ const procedureDefGetDefMixin = function() {
       return this.model_;
     },
 
+    isProcedureDef() {
+      return true;
+    },
+
     /**
      * Return all variables referenced by this block.
      * @return {!Array<string>} List of variable names.
@@ -995,6 +999,10 @@ const procedureCallerGetDefMixin = function() {
     getProcedureCall: function() {
       // The NAME field is guaranteed to exist, null will never be returned.
       return /** @type {string} */ (this.getFieldValue('NAME'));
+    },
+
+    isProcedureDef() {
+      return false;
     },
 
     /**

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -286,6 +286,11 @@ const procedureDefGetDefMixin = function() {
       return this.model_;
     },
 
+    /**
+     * True if this is a procedure definition block, false otherwise (i.e.
+     * it is a caller).
+     * @return {boolean} True because this is a procedure definition block.
+     */
     isProcedureDef() {
       return true;
     },
@@ -1001,6 +1006,11 @@ const procedureCallerGetDefMixin = function() {
       return /** @type {string} */ (this.getFieldValue('NAME'));
     },
 
+    /**
+     * True if this is a procedure definition block, false otherwise (i.e.
+     * it is a caller).
+     * @return {boolean} False because this is not a procedure definition block.
+     */
     isProcedureDef() {
       return false;
     },

--- a/core/interfaces/i_procedure_block.ts
+++ b/core/interfaces/i_procedure_block.ts
@@ -10,12 +10,15 @@ import {IProcedureModel} from './i_procedure_model.js';
 
 /** The interface for a block which models a procedure. */
 export interface IProcedureBlock {
-  doProcedureUpdate(): void;
   getProcedureModel(): IProcedureModel;
+  doProcedureUpdate(): void;
+  isProcedureDef(): boolean;
 }
 
 /** A type guard which checks if the given block is a procedure block. */
 export function isProcedureBlock(block: Block|
                                  IProcedureBlock): block is IProcedureBlock {
-  return (block as IProcedureBlock).doProcedureUpdate !== undefined;
+  return (block as IProcedureBlock).getProcedureModel !== undefined &&
+      (block as IProcedureBlock).doProcedureUpdate !== undefined &&
+      (block as IProcedureBlock).isProcedureDef !== undefined;
 }

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -422,11 +422,20 @@ function mutatorChangeListener(e: Abstract) {
  */
 export function getCallers(name: string, workspace: Workspace): Block[] {
   return workspace.getAllBlocks(false).filter((block) => {
-    return (isProcedureBlock(block) && !block.isProcedureDef() &&
-            Names.equals(block.getProcedureModel().getName(), name)) ||
+    return blockIsModernCallerFor(block, name) ||
         (isLegacyProcedureCallBlock(block) &&
          Names.equals(block.getProcedureCall(), name));
   });
+}
+
+/**
+ * @returns True if the given block is a modern-style caller block of the given
+ *     procedure name.
+ */
+function blockIsModernCallerFor(block: Block, procName: string): boolean {
+  return isProcedureBlock(block) && !block.isProcedureDef() &&
+      block.getProcedureModel() &&
+      Names.equals(block.getProcedureModel().getName(), procName);
 }
 
 /**

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -25,6 +25,8 @@ suite('Procedure Map', function() {
       Blockly.Blocks['procedure_mock'] = {
         init: function() { },
         doProcedureUpdate: function() { },
+        getProcedureModel: function() { },
+        isProcedureDef: function() { },
       };
 
       this.procedureBlock = this.workspace.newBlock('procedure_mock');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6525 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Refactors the procedures namespace to use the new procedure block interface methods instead of the old ones.

Should be no change in behavior.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Realized I actually did need to refactor this so that external devs don't have to implement the old `getProcedureDef` and `getProcedureCall` methods.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Passes all existing tests.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #6736 
