### PR TITLE
fix: copying and pasting procedure definitions

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -27,6 +27,7 @@ const {Block} = goog.requireType('Blockly.Block');
 // TODO (6248): Properly import the BlockDefinition type.
 /* eslint-disable-next-line no-unused-vars */
 const BlockDefinition = Object;
+const {isProcedureBlock} = goog.require('Blockly.procedures.IProcedureModel');
 const {ObservableProcedureModel} = goog.require('Blockly.procedures.ObservableProcedureModel');
 const {ObservableParameterModel} = goog.require('Blockly.procedures.ObservableParameterModel');
 const {config} = goog.require('Blockly.config');
@@ -576,7 +577,9 @@ const procedureDefMutator = {
     const map = this.workspace.getProcedureMap();
     const procedureId = state['procedureId'];
     if (procedureId && procedureId != this.model_.getId() &&
-        map.has(procedureId)) {
+        map.has(procedureId) &&
+        (this.isInsertionMarker() ||
+         this.noBlockHasClaimedModel_(procedureId))) {
       if (map.has(this.model_.getId())) {
         map.delete(this.model_.getId());
       }
@@ -596,6 +599,21 @@ const procedureDefMutator = {
 
     // Call mutate callers for backwards compatibility.
     Procedures.mutateCallers(this);
+  },
+
+  /**
+   * Returns true if there is no definition block currently associated with the
+   * given procedure ID. False otherwise.
+   * @param {string} procedureId The ID of the procedure to check for a claiming
+   *     block.
+   * @return {boolean} True if there is no definition block currently associated
+   *     with the given procedure ID. False otherwise.
+   */
+  noBlockHasClaimedModel_(procedureId) {
+    const model = this.workspace.getProcedureMap().get(procedureId);
+    return this.workspace.getAllBlocks(false).every(
+        (b) => !isProcedureBlock(b) || !b.isProcedureDef() ||
+            b.getProcedureModel() !== model);
   },
 
   /**

--- a/core/interfaces/i_procedure_block.ts
+++ b/core/interfaces/i_procedure_block.ts
@@ -6,6 +6,8 @@
 
 import type {Block} from '../block.js';
 import {IProcedureModel} from './i_procedure_model.js';
+import * as goog from '../../closure/goog/goog.js';
+goog.declareModuleId('Blockly.procedures.IProcedureModel');
 
 
 /** The interface for a block which models a procedure. */

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1985,7 +1985,7 @@ suite('Procedures', function() {
     });
   });
 
-  suite('extra serialization test cases', function() {
+  suite('full workspace serialization test cases', function() {
     test('definitions with parameters are properly rendered', function() {
       Blockly.serialization.workspaces.load({
         "blocks": {
@@ -2032,6 +2032,58 @@ suite('Procedures', function() {
       assertDefBlockStructure(
           this.workspace.getTopBlocks(false)[0], false, ['x'], ['varId']);
     });
+    test(
+        'multiple definitions pointing to the same model end up with ' +
+        'different models',
+        function() {
+          Blockly.serialization.workspaces.load({
+            "blocks": {
+              "languageVersion": 0,
+              "blocks": [
+                {
+                  "type": "procedures_defnoreturn",
+                  "extraState": {
+                    "procedureId": "procId",
+                  },
+                  "fields": {
+                    "NAME": "do something",
+                  },
+                },
+                {
+                  "type": "procedures_defnoreturn",
+                  "y": 10,
+                  "extraState": {
+                    "procedureId": "procId",
+                  },
+                  "fields": {
+                    "NAME": "do something",
+                  },
+                },
+              ],
+            },
+            "procedures": [
+              {
+                "id": "procId",
+                "name": "do something",
+                "returnTypes": null,
+              },
+            ],
+          }, this.workspace);
+          const def1 = this.workspace.getTopBlocks(true)[0];
+          const def2 = this.workspace.getTopBlocks(true)[1];
+          chai.assert.equal(
+              def1.getProcedureModel().getName(),
+              'do something',
+              'Expected the first procedure definition to have the name in XML');
+          chai.assert.equal(
+              def2.getProcedureModel().getName(),
+              'do something2',
+              'Expected the second procedure definition to be renamed');
+          chai.assert.notEqual(
+              def1.getProcedureModel(),
+              def2.getProcedureModel(),
+              'Expected the procedures to have different models');
+        });
   });
 
   const testSuites = [


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6749 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Before when you would load two procedure definition blocks that point to the same procedure ID (e.g. when copy pasting) they would both be associated with the same procedure model, which is not what you want. This makes sure that each individual procedure definition block (excluding insertion markers) is associated with its own procedure model.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Added a test for deserializing two procedure definition blocks that are both associated with the same procedure model.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #6746 
