### PR TITLE
fix: correct docs for flyout metrics

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -975,7 +975,7 @@ const procedureCallerGetDefMixin = function() {
         'fields': {'NAME': newName},
       };
       return serialization.blocks.append(blockDef, this.getTargetWorkspace_())
-              .getProcedureModel();
+          .getProcedureModel();
     },
 
     /**

--- a/core/interfaces/i_metrics_manager.ts
+++ b/core/interfaces/i_metrics_manager.ts
@@ -47,11 +47,14 @@ export interface IMetricsManager {
       opt_contentMetrics?: ContainerRegion): ContainerRegion;
 
   /**
-   * Gets the width and the height of the flyout on the workspace in pixel
-   * coordinates. Returns 0 for the width and height if the workspace has a
-   * category toolbox instead of a simple toolbox.
+   * Gets the width and the height of the flyout in pixel
+   * coordinates. By default, will get metrics for either a simple flyout (owned
+   * directly by the workspace) or for the flyout owned by the toolbox. If you
+   * pass `opt_own` as `true` then only metrics for the simple flyout will be
+   * returned, and it will return 0 for the width and height if the workspace
+   * has a category toolbox instead of a simple toolbox.
    *
-   * @param opt_own Whether to only return the workspace's own flyout.
+   * @param opt_own Whether to only return the workspace's own flyout metrics.
    * @returns The width and height of the flyout.
    */
   getFlyoutMetrics(opt_own?: boolean): ToolboxMetrics;
@@ -60,8 +63,7 @@ export interface IMetricsManager {
    * Gets the width, height and position of the toolbox on the workspace in
    * pixel coordinates. Returns 0 for the width and height if the workspace has
    * a simple toolbox instead of a category toolbox. To get the width and height
-   * of a
-   * simple toolbox @see {@link IMetricsManager#getFlyoutMetrics}.
+   * of a simple toolbox, see {@link IMetricsManager#getFlyoutMetrics}.
    *
    * @returns The object with the width, height and position of the toolbox.
    */

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -55,11 +55,14 @@ export class MetricsManager implements IMetricsManager {
   }
 
   /**
-   * Gets the width and the height of the flyout on the workspace in pixel
-   * coordinates. Returns 0 for the width and height if the workspace has a
-   * category toolbox instead of a simple toolbox.
+   * Gets the width and the height of the flyout in pixel
+   * coordinates. By default, will get metrics for either a simple flyout (owned
+   * directly by the workspace) or for the flyout owned by the toolbox. If you
+   * pass `opt_own` as `true` then only metrics for the simple flyout will be
+   * returned, and it will return 0 for the width and height if the workspace
+   * has a category toolbox instead of a simple toolbox.
    *
-   * @param opt_own Whether to only return the workspace's own flyout.
+   * @param opt_own Whether to only return the workspace's own flyout metrics.
    * @returns The width and height of the flyout.
    */
   getFlyoutMetrics(opt_own?: boolean): ToolboxMetrics {
@@ -76,8 +79,7 @@ export class MetricsManager implements IMetricsManager {
    * Gets the width, height and position of the toolbox on the workspace in
    * pixel coordinates. Returns 0 for the width and height if the workspace has
    * a simple toolbox instead of a category toolbox. To get the width and height
-   * of a
-   * simple toolbox @see {@link MetricsManager#getFlyoutMetrics}.
+   * of a simple toolbox, see {@link MetricsManager#getFlyoutMetrics}.
    *
    * @returns The object with the width, height and position of the toolbox.
    */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

incorrect documentation

### Proposed Changes

- Corrects the information for `getFlyoutMetrics`. This was incorrect before unless you pass `true` as the parameter.
- Fixes syntax for the `@see` tag in `getToolboxMetrics`. `@see` is a block tag, which means it expects to be on its own line. Other usages of the `@see` tag in the codebase appear to be fine after quick inspection
- The change in `procedures.js` was just from running `npm run format`

#### Behavior Before Change

incorrect docs and broken for this function: https://developers.google.com/blockly/reference/js/blockly.metricsmanager_class.gettoolboxmetrics_1_method.md

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
