### PR TITLE
fix: export Abstract event class directly

### DIFF
--- a/core/events/events.ts
+++ b/core/events/events.ts
@@ -13,7 +13,7 @@ import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.Events');
 
 
-import {Abstract as AbstractEvent, AbstractEventJson} from './events_abstract.js';
+import {Abstract, AbstractEventJson} from './events_abstract.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
 import {BlockChange, BlockChangeJson} from './events_block_change.js';
 import {BlockCreate, BlockCreateJson} from './events_block_create.js';
@@ -54,7 +54,7 @@ import {FinishedLoading, FinishedLoadingJson} from './workspace_events.js';
 
 
 // Events.
-export const Abstract = AbstractEvent;
+export {Abstract};
 export {AbstractEventJson};
 export {BubbleOpen};
 export {BubbleOpenJson};


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes Blockly.Events.Abstract not being documented: https://developers.google.com/blockly/reference/js/blockly.events_namespace.abstract_variable.md

### Proposed Changes

exports the class directly instead of importing it under a different name and then exporting it under the original name

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Tested by packaging, linking to blockly-typescript-libcheck, and making sure Blockly.Events.Abstract is still valid

Also checked the generated documentation is fixed

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
