### PR TITLE
fix(deps): Don't use global variables for jsdom injection in `scripts/package/node/core.js` and `core/utils/xml.ts`

### DIFF
--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -27,13 +27,24 @@ import * as deprecation from './deprecation.js';
 let {document, DOMParser, XMLSerializer} = globalThis;
 
 /**
- * Inject dependencies.  Used by the Node.js wrapper for Blockly (see
- * scripts/package/node/core.js) to supply implementations from the
- * jsdom package instead.  While they may be set individually, it is
- * normally the case that all three should be supplied and sourced
- * from the same JSDOM instance.
+ * Inject implementations of document, DOMParser and/or XMLSerializer
+ * to use instead of the default ones.
  *
- * @param dependencies Options object contianing dependencies to set.
+ * Used by the Node.js wrapper for Blockly (see
+ * scripts/package/node/core.js) to supply implementations from the
+ * jsdom package instead.
+ *
+ * While they may be set individually, it is normally the case that
+ * all three will be sourced from the same JSDOM instance.  They MUST
+ * at least come from the same copy of the jsdom package.  (Typically
+ * this is hard to avoid satsifying this requirement, but it can be
+ * inadvertently violated by using webpack to build multiple bundles
+ * containing Blockly and jsdom, and then loading more than one into
+ * the same JavaScript runtime.  See
+ * https://github.com/google/blockly-samples/pull/1452#issuecomment-1364442135
+ * for an example of how this happened.)
+ *
+ * @param dependencies Options object containing dependencies to set.
  */
 export function injectDependencies(dependencies: {
   document?: Document,

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -14,6 +14,8 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.utils.xml');
 
+import * as deprecation from './deprecation.js';
+
 
 /**
  * Injected dependencies.  By default these are just (and have the
@@ -57,9 +59,11 @@ export const NAME_SPACE = 'https://developers.google.com/blockly/xml';
  * Get the document object to use for XML serialization.
  *
  * @returns The document object.
+ * @deprecated No longer provided by Blockly.
  * @alias Blockly.utils.xml.getDocument
  */
 export function getDocument(): Document {
+  deprecation.warn('Blockly.utils.xml.getDocument', 'version 9', 'version 10');
   return document;
 }
 
@@ -67,9 +71,11 @@ export function getDocument(): Document {
  * Get the document object to use for XML serialization.
  *
  * @param xmlDocument The document object to use.
+ * @deprecated No longer provided by Blockly.
  * @alias Blockly.utils.xml.setDocument
  */
 export function setDocument(xmlDocument: Document) {
+  deprecation.warn('Blockly.utils.xml.setDocument', 'version 9', 'version 10');
   document = xmlDocument;
 }
 

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -16,19 +16,42 @@ goog.declareModuleId('Blockly.utils.xml');
 
 
 /**
+ * Injected dependencies.  By default these are just (and have the
+ * same types as) the corresponding DOM Window properties, but the
+ * Node.js wrapper for Blockly (see scripts/package/node/core.js)
+ * calls injectDependencies to supply implementations from the jsdom
+ * package instead.
+ */
+let {document, DOMParser, XMLSerializer} = globalThis;
+
+/**
+ * Inject dependencies.  Used by the Node.js wrapper for Blockly (see
+ * scripts/package/node/core.js) to supply implementations from the
+ * jsdom package instead.  While they may be set individually, it is
+ * normally the case that all three should be supplied and sourced
+ * from the same JSDOM instance.
+ *
+ * @param dependencies Options object contianing dependencies to set.
+ */
+export function injectDependencies(dependencies: {
+  document?: Document,
+  DOMParser?: typeof DOMParser,
+  XMLSerializer?: typeof XMLSerializer,
+}) {
+  ({
+    // Default to existing value if option not supplied.
+    document = document,
+    DOMParser = DOMParser,
+    XMLSerializer = XMLSerializer,
+  } = dependencies);
+}
+
+/**
  * Namespace for Blockly's XML.
  *
  * @alias Blockly.utils.xml.NAME_SPACE
  */
 export const NAME_SPACE = 'https://developers.google.com/blockly/xml';
-
-/**
- * The Document object to use.  By default this is just document, but
- * the Node.js build of Blockly (see scripts/package/node/core.js)
- * calls setDocument to supply a Document implementation from the
- * jsdom package instead.
- */
-let xmlDocument: Document = globalThis['document'];
 
 /**
  * Get the document object to use for XML serialization.
@@ -37,17 +60,17 @@ let xmlDocument: Document = globalThis['document'];
  * @alias Blockly.utils.xml.getDocument
  */
 export function getDocument(): Document {
-  return xmlDocument;
+  return document;
 }
 
 /**
  * Get the document object to use for XML serialization.
  *
- * @param document The document object to use.
+ * @param xmlDocument The document object to use.
  * @alias Blockly.utils.xml.setDocument
  */
-export function setDocument(document: Document) {
-  xmlDocument = document;
+export function setDocument(xmlDocument: Document) {
+  document = xmlDocument;
 }
 
 /**
@@ -58,7 +81,7 @@ export function setDocument(document: Document) {
  * @alias Blockly.utils.xml.createElement
  */
 export function createElement(tagName: string): Element {
-  return xmlDocument.createElementNS(NAME_SPACE, tagName);
+  return document.createElementNS(NAME_SPACE, tagName);
 }
 
 /**
@@ -69,7 +92,7 @@ export function createElement(tagName: string): Element {
  * @alias Blockly.utils.xml.createTextNode
  */
 export function createTextNode(text: string): Text {
-  return xmlDocument.createTextNode(text);
+  return document.createTextNode(text);
 }
 
 /**

--- a/scripts/package/node/core.js
+++ b/scripts/package/node/core.js
@@ -18,9 +18,6 @@
 if (typeof globalThis.document !== 'object') {
   const {JSDOM} = require('jsdom');
   const {window} = new JSDOM(`<!DOCTYPE html>`);
-  globalThis.DOMParser = window.DOMParser;
-  globalThis.XMLSerializer = window.XMLSerializer;
-  const xmlDocument = Blockly.utils.xml.textToDomDocument(
-      `<xml xmlns="${Blockly.utils.xml.NAME_SPACE}"></xml>`);
-  Blockly.utils.xml.setDocument(xmlDocument);
+  Blockly.utils.xml.injectDependencies(window);
+  Blockly.utils.xml.injectDependencies({document: window.document});
 }

--- a/scripts/package/node/core.js
+++ b/scripts/package/node/core.js
@@ -19,5 +19,4 @@ if (typeof globalThis.document !== 'object') {
   const {JSDOM} = require('jsdom');
   const {window} = new JSDOM(`<!DOCTYPE html>`);
   Blockly.utils.xml.injectDependencies(window);
-  Blockly.utils.xml.injectDependencies({document: window.document});
 }


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6725.

### Proposed Changes

1. Introduce a mechanism for injecting arbitrary dependencies into modules, specifically in this case
to inject required bits of [jsdom](https://github.com/jsdom/jsdom)'s `Window` and `Document` implementations into `core/utils/xml.js` when running in node.js or other environments lacking a DOM.

0. Rename the `xmlDocument` local variable back to `document` (was renamed in #5461) so that the name used in this module corresponds to the [usual global variable](https://developer.mozilla.org/en-US/docs/Web/API/Window/document) it replaces.

0. Change the injection in `scripts/package/node/core.js` to use `injectDependencies` instead of `setDocument` + global variables for `DOMParser` and `XMLSerializer`; also eliminate apparently-unnecessary creation of a special
`Document` instance, using the default one supplied by jsdom instead.

0. Mark `getDocument` and `setDocument` as `@deprecated`, with suitable calls to `deprecation.warn()`.

   There are no remaining callers to either function within this repository—`setDocument` was only used by [the node.js wrapper](https://github.com/google/blockly/blob/develop/scripts/package/node/core.js), and apparently `getDocument` was never used anywhere—and we do not anticipate that either were used by external developers.

#### Behaviour Before Change

If a runtime included multiple separate copies of the blockly package and its dependency jsdom, then [XML serialisation and deserialisation would break](https://github.com/google/blockly-samples/pull/1452#issuecomment-1364442135).

#### Behaviour After Change

It is safe (but still not advisable) to load multiple separate copies of blockly and jsdom into the same runtime.

### Reason for Changes

Fix #6725; allow tests in blockly-samples to pass after updating to Blockly v9.x (e.g. in google/blockly-samples#1452).

### Test Coverage

* Passes `npm test`
* Tests in the branch for google/blockly-samples#1452 pass after using `npm link blockly` to include these changes.

No changes in manual test procedures anticipated.

### Documentation

No changes beyond automatic update including `@deprecation` notice.

### Additional Information

The `injectDependencies` function is intended to be a prototype for a generally applicable mechanism for dependency injection—for example, this approach could be used in other modules to break the circular dependencies that currently cause loading errors when trying to load Blockly via `import * as Blockly from './build/src/core/blockly.js'` without support from the Closure module tooling.  As such, it uses an options object and destructuring-with-defaults to facilitate injecting arbitrarily-named dependencies either one-at-a-time or (as here in `core.js`) in bulk.
