### PR TITLE
fix(tests): Have `npm start` run a full build

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "publish:beta": "npm ci && gulp publishBeta",
     "recompile": "gulp recompile",
     "release": "gulp gitCreateRC",
-    "start": "npm run deps && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir 'build/src' --declarationDir 'build/declarations'\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
+    "start": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir 'build/src' --declarationDir 'build/declarations'\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
     "tsc": "gulp tsc",
     "test": "gulp test",
     "test:generators": "gulp testGenerators",


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Doing `npm start` in a clean checkout loads a broken playground, because the `deps` script does not run `buildLangfiles`.

### Proposed Changes

To fix this have the `start` script run the `build` script rather than just `deps`.  This also ensures that compressed playground loading would work too (though uncompressed is the default).