### PR TITLE
fix: Make metadata tests more resilient.

### DIFF
--- a/scripts/gulpfiles/test_tasks.js
+++ b/scripts/gulpfiles/test_tasks.js
@@ -165,7 +165,11 @@ function compareSize(file, expected) {
   const stat = fs.statSync(name);
   const size = stat.size;
 
-  if (size > compare) {
+  if (!compare) {
+    const message = `Failed: Previous size of ${name} is undefined.`;
+    console.log(`${BOLD_RED}${message}${ANSI_RESET}`);
+    return 1;
+  } else if (size > compare) {
     const message = `Failed: ` +
         `Size of ${name} has grown more than 10%. ${size} vs ${expected}`;
     console.log(`${BOLD_RED}${message}${ANSI_RESET}`);

--- a/scripts/gulpfiles/test_tasks.js
+++ b/scripts/gulpfiles/test_tasks.js
@@ -169,17 +169,19 @@ function compareSize(file, expected) {
     const message = `Failed: Previous size of ${name} is undefined.`;
     console.log(`${BOLD_RED}${message}${ANSI_RESET}`);
     return 1;
-  } else if (size > compare) {
+  } 
+  
+  if (size > compare) {
     const message = `Failed: ` +
         `Size of ${name} has grown more than 10%. ${size} vs ${expected}`;
     console.log(`${BOLD_RED}${message}${ANSI_RESET}`);
     return 1;
-  } else {
-    const message =
-        `Size of ${name} at ${size} compared to previous ${expected}`;
-    console.log(`${BOLD_GREEN}${message}${ANSI_RESET}`);
-    return 0;
   }
+
+  const message =
+      `Size of ${name} at ${size} compared to previous ${expected}`;
+  console.log(`${BOLD_GREEN}${message}${ANSI_RESET}`);
+  return 0;
 }
 
 /**

--- a/tests/scripts/check_metadata.sh
+++ b/tests/scripts/check_metadata.sh
@@ -33,7 +33,7 @@ readonly RELEASE_DIR='dist'
 # Q3 2022	8.0.0	1040413 (mid-quarter typescript conversion)
 # Q4 2022	8.0.0	  870104
 # Q4 2022	9.1.1	  903357
-readonly BLOCKLY_SIZE_EXPECTED=  903357
+readonly BLOCKLY_SIZE_EXPECTED=903357
 
 # Size of blocks_compressed.js
 # Q2 2019	2.20190722.0	75618
@@ -52,7 +52,7 @@ readonly BLOCKLY_SIZE_EXPECTED=  903357
 # Q3 2022	8.0.0	102176 (mid-quarter typescript conversion)
 # Q4 2022	8.0.0	  102213
 # Q4 2022	9.1.1	  102190
-readonly BLOCKS_SIZE_EXPECTED=  102190
+readonly BLOCKS_SIZE_EXPECTED=102190
 
 # Size of blockly_compressed.js.gz
 # Q2 2019	2.20190722.0	180925
@@ -72,7 +72,7 @@ readonly BLOCKS_SIZE_EXPECTED=  102190
 # Q3 2022	8.0.0	185766 (mid-quarter typescript conversion)
 # Q4 2022	8.0.0	  175140
 # Q4 2022	9.1.1	  179306
-readonly BLOCKLY_GZ_SIZE_EXPECTED=  179306
+readonly BLOCKLY_GZ_SIZE_EXPECTED=179306
 
 # Size of blocks_compressed.js.gz
 # Q2 2019	2.20190722.0	14552
@@ -91,7 +91,7 @@ readonly BLOCKLY_GZ_SIZE_EXPECTED=  179306
 # Q3 2022	8.0.0	17016 (mid-quarter typescript conversion)
 # Q4 2022	8.0.0	   17188
 # Q4 2022	9.1.1	   17182
-readonly BLOCKS_GZ_SIZE_EXPECTED=   17182
+readonly BLOCKS_GZ_SIZE_EXPECTED=17182
 
 # ANSI colors
 readonly BOLD_GREEN='\033[1;32m'

--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -12,10 +12,10 @@ readonly RELEASE_DIR='dist'
 gzip -k "${RELEASE_DIR}/blockly_compressed.js"
 gzip -k "${RELEASE_DIR}/blocks_compressed.js"
 
-blockly_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js")
-blocks_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js")
-blockly_gz_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js.gz")
-blocks_gz_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js.gz")
+blockly_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js" | xargs)
+blocks_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js" | xargs)
+blockly_gz_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js.gz" | xargs)
+blocks_gz_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js.gz" |  xargs)
 quarters=(1 1 1 2 2 2 3 3 3 4 4 4)
 month=$(date +%-m)
 quarter=$(echo Q${quarters[$month - 1]} $(date +%Y))

--- a/tests/scripts/update_metadata.sh
+++ b/tests/scripts/update_metadata.sh
@@ -12,10 +12,12 @@ readonly RELEASE_DIR='dist'
 gzip -k "${RELEASE_DIR}/blockly_compressed.js"
 gzip -k "${RELEASE_DIR}/blocks_compressed.js"
 
-blockly_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js" | xargs)
-blocks_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js" | xargs)
-blockly_gz_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js.gz" | xargs)
-blocks_gz_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js.gz" |  xargs)
+# wc prefixes the file size with whitespace; xargs strips that and the -n flag to
+# echo removes the newline.
+blockly_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js" | xargs echo -n)
+blocks_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js" | xargs echo -n)
+blockly_gz_size=$(wc -c < "${RELEASE_DIR}/blockly_compressed.js.gz" | xargs echo -n)
+blocks_gz_size=$(wc -c < "${RELEASE_DIR}/blocks_compressed.js.gz" |  xargs echo -n)
 quarters=(1 1 1 2 2 2 3 3 3 4 4 4)
 month=$(date +%-m)
 quarter=$(echo Q${quarters[$month - 1]} $(date +%Y))


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#6768

### Proposed Changes
This PR updates the metadata test to verify that the previous size of the files is not undefined, in order to trigger an explicit test failure in the situation reported in #6768. It also updates the check_metadata.sh file to remove errant whitespace before the file sizes that was causing the regex in test_tasks.js to fail to identify the old file sizes when running the test. Finally, it updates update_metadata.sh to strip whitespace when updating the file sizes in check_metadata.sh to avoid this issue recurring.

#### Behavior Before Change
Metadata test scripts didn't actually check the change in filesize and passed regardless.

#### Behavior After Change
Metadata test scripts work properly.