### PR TITLE
fix: Increase generator test timeout

### DIFF
--- a/scripts/gulpfiles/test_tasks.js
+++ b/scripts/gulpfiles/test_tasks.js
@@ -299,7 +299,7 @@ async function generators() {
     rimraf.sync(OUTPUT_DIR);
     fs.mkdirSync(OUTPUT_DIR);
 
-    await runGeneratorsInBrowser(OUTPUT_DIR).catch(() => {});
+    await runGeneratorsInBrowser(OUTPUT_DIR);
 
     const generatorSuffixes = ['js', 'py', 'dart', 'lua', 'php'];
     let failed = 0;

--- a/tests/generators/webdriver.js
+++ b/tests/generators/webdriver.js
@@ -66,6 +66,10 @@ async function runGeneratorsInBrowser(outputDir) {
 
   console.log('Starting webdriverio...');
   const browser = await webdriverio.remote(options);
+
+  // Increase the script timeouts to 2 minutes to allow the generators to finish.
+  await browser.setTimeout({ 'script': 120000 })
+
   console.log('Loading url: ' + url);
   await browser.url(url);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6757 

### Proposed Changes

- Removes an empty `catch` block from the generator tests. If that function throws, the test actually should fail.
- Increases the script timeout for the generator tests, which is the root cause of the flaky tests. The default value is 30 seconds; I increased it to 2 minutes.

#### Behavior Before Change

Flaky tests

#### Behavior After Change

Consistently passing tests

### Reason for Changes

Not wanting to disable the CI every time you make a PR

### Test Coverage

Tested both `npm run test` and `npm run test:generators` after intentionally adding a thrown error

### Documentation

no

### Additional Information

Christopher, assigning this to you so that you may merge it on Monday if it does not require changes, so that you can be less annoyed at your own PRs then
