### PR TITLE
refactor: Don't use skew_ and translate_ attributes on SVGs to animate blocks.

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -205,7 +205,8 @@ export function disconnectUiStop() {
       clearTimeout(disconnectPid);
       disconnectPid = null;
     }
-    wobblingBlock.getSvgRoot().setAttribute('transform', wobblingBlock.getTranslation());
+    wobblingBlock.getSvgRoot().setAttribute(
+        'transform', wobblingBlock.getTranslation());
     wobblingBlock = null;
   }
 }

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -200,13 +200,12 @@ function disconnectUiStep(block: BlockSvg, magnitude: number, start: Date) {
  * @internal
  */
 export function disconnectUiStop() {
-  if (wobblingBlock) {
-    if (disconnectPid) {
-      clearTimeout(disconnectPid);
-      disconnectPid = null;
-    }
-    wobblingBlock.getSvgRoot().setAttribute(
-        'transform', wobblingBlock.getTranslation());
-    wobblingBlock = null;
+  if (!wobblingBlock) return;
+  if (disconnectPid) {
+    clearTimeout(disconnectPid);
+    disconnectPid = null;
   }
+  wobblingBlock.getSvgRoot().setAttribute(
+      'transform', wobblingBlock.getTranslation());
+  wobblingBlock = null;
 }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -143,7 +143,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   override previousConnection!: RenderedConnection;
   private readonly useDragSurface_: boolean;
-  
+
   private translation = '';
 
   /**
@@ -439,9 +439,10 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     this.translation = `translate(${x}, ${y})`;
     this.getSvgRoot().setAttribute('transform', this.getTranslation());
   }
-  
+
   /**
    * Returns the SVG translation of this block.
+   *
    * @internal
    */
   getTranslation(): string {
@@ -779,7 +780,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    */
   setDragging(adding: boolean) {
     if (adding) {
-      const group = this.getSvgRoot();
       this.translation = '';
       common.draggingConnections.push(...this.getConnections_(true));
       dom.addClass(this.svgGroup_, 'blocklyDragging');

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -143,6 +143,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   override previousConnection!: RenderedConnection;
   private readonly useDragSurface_: boolean;
+  
+  private translation = '';
 
   /**
    * @param workspace The block's workspace.
@@ -183,7 +185,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     /** An optional method for defining custom block context menu items. */
     this.customContextMenu = this.customContextMenu;
     this.svgGroup_ = dom.createSvgElement(Svg.G, {});
-    (this.svgGroup_ as AnyDuringMigration).translate_ = '';
 
     /** A block style object. */
     this.style = workspace.getRenderer().getConstants().getBlockStyle(null);
@@ -435,8 +436,16 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @param y The y coordinate of the translation in workspace units.
    */
   translate(x: number, y: number) {
-    this.getSvgRoot().setAttribute(
-        'transform', 'translate(' + x + ',' + y + ')');
+    this.translation = `translate(${x}, ${y})`;
+    this.getSvgRoot().setAttribute('transform', this.getTranslation());
+  }
+  
+  /**
+   * Returns the SVG translation of this block.
+   * @internal
+   */
+  getTranslation(): string {
+    return this.translation;
   }
 
   /**
@@ -506,13 +515,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       this.workspace.getBlockDragSurface()!.translateSurface(
           newLoc.x, newLoc.y);
     } else {
-      (this.svgGroup_ as AnyDuringMigration).translate_ =
-          'translate(' + newLoc.x + ',' + newLoc.y + ')';
-      (this.svgGroup_ as AnyDuringMigration)
-          .setAttribute(
-              'transform',
-              (this.svgGroup_ as AnyDuringMigration).translate_ +
-                  (this.svgGroup_ as AnyDuringMigration).skew_);
+      this.translate(newLoc.x, newLoc.y);
+      this.getSvgRoot().setAttribute('transform', this.getTranslation());
     }
   }
 
@@ -776,8 +780,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   setDragging(adding: boolean) {
     if (adding) {
       const group = this.getSvgRoot();
-      (group as AnyDuringMigration).translate_ = '';
-      (group as AnyDuringMigration).skew_ = '';
+      this.translation = '';
       common.draggingConnections.push(...this.getConnections_(true));
       dom.addClass(this.svgGroup_, 'blocklyDragging');
     } else {

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -108,7 +108,6 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
       opt_id?: string) {
     super(workspace, content, height, width, opt_id);
     this.svgGroup_ = dom.createSvgElement(Svg.G, {'class': 'blocklyComment'});
-    (this.svgGroup_ as AnyDuringMigration).translate_ = '';
     this.workspace = workspace;
 
     this.svgRect_ = dom.createSvgElement(Svg.RECT, {
@@ -408,13 +407,8 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
     if (dragSurface) {
       dragSurface.translateSurface(newLoc.x, newLoc.y);
     } else {
-      (this.svgGroup_ as AnyDuringMigration).translate_ =
-          'translate(' + newLoc.x + ',' + newLoc.y + ')';
-      (this.svgGroup_ as AnyDuringMigration)
-          .setAttribute(
-              'transform',
-              (this.svgGroup_ as AnyDuringMigration).translate_ +
-                  (this.svgGroup_ as AnyDuringMigration).skew_);
+      const translation = `translate(${newLoc.x}, ${newLoc.y})`;
+      this.getSvgRoot().setAttribute('transform', translation);
     }
   }
 
@@ -511,12 +505,9 @@ export class WorkspaceCommentSvg extends WorkspaceComment implements
    */
   setDragging(adding: boolean) {
     if (adding) {
-      const group = this.getSvgRoot();
-      (group as AnyDuringMigration).translate_ = '';
-      (group as AnyDuringMigration).skew_ = '';
-      dom.addClass(this.svgGroup_, 'blocklyDragging');
+      dom.addClass(this.getSvgRoot(), 'blocklyDragging');
     } else {
-      dom.removeClass(this.svgGroup_, 'blocklyDragging');
+      dom.removeClass(this.getSvgRoot(), 'blocklyDragging');
     }
   }
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
Fixes #6595

### Proposed Changes
This change stops setting skew_ and translation_ attributes on SVGs for blocks. It introduces an internal getter for the translation, and stores it in a proper field on BlockSvg.

skew_ was only being set to a non-'' value in one place, and then immediately read back to set the transform. Instead, the transform is simply setting using the directly-calculated skew value, so there's no need to carry it around and clear it at other points.

WorkspaceCommentSvg also maintained the skew_ and translate_ attributes, but they appear to be vestigial from a long-ago copy-paste and not actually used, so they were removed.