### PR TITLE
fix: don't splice into unmovable stacks

### DIFF
--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -251,7 +251,8 @@ export class ConnectionChecker implements IConnectionChecker {
           return false;
         }
 
-        // Don't offer to splice into a stack where the connected block is immovable.
+        // Don't offer to splice into a stack where the connected block is
+        // immovable.
         if (b.targetBlock() && !b.targetBlock()!.isMovable()) {
           return false;
         }

--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -250,6 +250,11 @@ export class ConnectionChecker implements IConnectionChecker {
             !b.targetBlock()!.isShadow() && b.targetBlock()!.nextConnection) {
           return false;
         }
+
+        // Don't offer to splice into an immovable block.
+        if (b.targetBlock() && !b.targetBlock()!.isMovable()) {
+          return false;
+        }
         break;
       }
       default:

--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -203,7 +203,7 @@ export class ConnectionChecker implements IConnectionChecker {
   /**
    * Check whether this connection can be made by dragging.
    *
-   * @param a Connection to compare.
+   * @param a Connection to compare (on the block that's being dragged).
    * @param b Connection to compare against.
    * @param distance The maximum allowable distance between connections.
    * @returns True if the connection is allowed during a drag.
@@ -251,7 +251,7 @@ export class ConnectionChecker implements IConnectionChecker {
           return false;
         }
 
-        // Don't offer to splice into an immovable block.
+        // Don't offer to splice into a stack where the connected block is immovable.
         if (b.targetBlock() && !b.targetBlock()!.isMovable()) {
           return false;
         }

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -403,17 +403,12 @@ suite('Connection checker', function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
         Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
-        <block type="math_single" id="A" x="-87" y="-188">
-          <field name="OP">ROOT</field>
-          <value name="NUM">
-            <block type="math_number" movable="false" id="B">
-              <field name="NUM">123</field>
-            </block>
+        <block type="test_basic_row" id="A" x="38" y="37">
+          <value name="INPUT">
+            <block type="test_basic_row" id="B" movable="false"></block>
           </value>
         </block>
-        <block type="math_single" id="C" x="138" y="-188">
-          <field name="OP">ROOT</field>
-        </block>
+        <block type="test_basic_row" id="C" x="38" y="87"></block>
       </xml>`), this.workspace);
       [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
       this.checker = this.workspace.connectionChecker;

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -347,14 +347,13 @@ suite('Connection checker', function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load in three blocks: A and B are connected (next/prev); B is unmovable.
         Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
-        <block type="text_print" id="wlc#l2D-,6mSLKY=E$VL" x="-76" y="-112">
+        <block type="text_print" id="A" x="-76" y="-112">
           <next>
-            <block type="text_print" id="T9cdR}mwDn3Xl!*g|mw8" movable="false">
-              <comment pinned="true" h="32" w="88.5333251953125">Immovable</comment>
+            <block type="text_print" id="B" movable="false">
             </block>
           </next>
         </block>
-        <block type="text_print" id="ZgFlirwB{~}%l/BZ+j?R" x="47" y="-118"/>
+        <block type="text_print" id="C" x="47" y="-118"/>
       </xml>`), this.workspace);
       [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
       this.checker = this.workspace.connectionChecker;
@@ -404,15 +403,15 @@ suite('Connection checker', function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
         Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
-        <block type="math_single" id="4L?aLhveXpvYaYq.n,!p" x="-87" y="-188">
+        <block type="math_single" id="A" x="-87" y="-188">
           <field name="OP">ROOT</field>
           <value name="NUM">
-            <block type="math_number" movable="false" id="U)q;b^J7HKl$(5sKtOuT">
+            <block type="math_number" movable="false" id="B">
               <field name="NUM">123</field>
             </block>
           </value>
         </block>
-        <block type="math_single" id="u|{o,wAaGRvlFB((U}h=" x="138" y="-188">
+        <block type="math_single" id="C" x="138" y="-188">
           <field name="OP">ROOT</field>
         </block>
       </xml>`), this.workspace);

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -369,17 +369,17 @@ suite('Connection checker', function() {
       });
 
       test('Do not splice into unmovable stack', function() {
-        // Try to connect blockC above blockB.
-        // It shouldn't work because B is not movable and is already connected to A.
+        // Try to connect blockC above blockB. It shouldn't work because B is not movable
+        // and is already connected to A's nextConnection.
         chai.assert.isFalse(
           this.checker.doDragChecks(
-            this.blockC.nextConnection, this.blockB.previousConnection, 9000),
+            this.blockC.previousConnection, this.blockA.nextConnection, 9000),
           'Should not splice in a block above an unmovable block');
       });
 
       test('Connect to bottom of unmovable stack', function() {
         // Try to connect blockC below blockB.
-        // This is allowed even though B is not movable.
+        // This is allowed even though B is not movable because it is on B's nextConnection.
         chai.assert.isTrue(
           this.checker.doDragChecks(
             this.blockC.previousConnection, this.blockB.nextConnection, 9000),
@@ -421,10 +421,11 @@ suite('Connection checker', function() {
       });
 
       test('Do not splice into unmovable block row', function() {
-        // Try to connect C's input to B's output. Should fail because B is unmovable.
-        const inputConnection = this.blockC.inputList[0].connection;
+        // Try to connect C's output to A's input. Should fail because
+        // A is already connected to B, which is unmovable.
+        const inputConnection = this.blockA.inputList[0].connection;
         chai.assert.isFalse(
-          this.checker.doDragChecks(inputConnection, this.blockB.outputConnection, 9000),
+          this.checker.doDragChecks(this.blockC.outputConnection, inputConnection, 9000),
           'Should not splice in a block before an unmovable block'
         );
       });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2988 

### Proposed Changes

- Changes connection checker to disallow splicing into stacks where the next block is unmovable
- Adds tests for some dragging checks (not all of them, just the unmovable checks)

#### Behavior Before Change

See linked issue

#### Behavior After Change

No valid connection is found when trying to splice. Matches behavior of rows.
You can still connect after an unmovable block, and before an unmovable block that isn't already connected. I am not sure that either behavior is desirable, but decided making them match input connections made the most sense.

### Reason for Changes

Fixes a problem where it's possible to drag a block into a stack and then not be allowed to drag it away. (Mostly fixes the problem. Theoretically can occur by connecting a block to an empty previous connection of an unmovable block, but 99% of unmovable blocks probably do not have empty previous connections)

### Test Coverage

Added new unit tests and tested in the playground by loading the XML from the linked issue.

### Documentation

no

### Additional Information

#2988 flows into a discussion about the semantics of the deletable and movable properties and how they interact. That discussion is not super relevant to the original issue. We can open a new bug for it if needed, but I think at this point the semantics of those two properties are far too entrenched to change, and I would rather just open a new feature request if anyone ever actually wanted new behavior.
