### PR TITLE
feat: Add support for centering on a block itself vs its stack.

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1983,11 +1983,13 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
   /**
    * Scroll the workspace to center on the given block. If the block has other
-   * blocks stacked below it, the workspace will be centered on the stack.
+   * blocks stacked below it, the workspace will be centered on the stack,
+   * unless blockOnly is true.
    *
    * @param id ID of block center on.
+   * @param blockOnly True to center only on the block itself, not its stack.
    */
-  centerOnBlock(id: string|null) {
+  centerOnBlock(id: string|null, blockOnly?: boolean) {
     if (!this.isMovable()) {
       console.warn(
           'Tried to move a non-movable workspace. This could result' +
@@ -2003,7 +2005,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     // XY is in workspace coordinates.
     const xy = block.getRelativeToSurfaceXY();
     // Height/width is in workspace units.
-    const heightWidth = block.getHeightWidth();
+    const heightWidth = blockOnly ? {height: block.height, width: block.width} :
+                                    block.getHeightWidth();
 
     // Find the enter of the block in workspace units.
     const blockCenterY = xy.y + heightWidth.height / 2;

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -209,7 +209,7 @@ suite('WorkspaceSvg', function() {
         const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
-        runViewportEventTest(() => this.workspace.zoomToFit(block.id),
+        runViewportEventTest(() => this.workspace.centerOnBlock(block.id),
             this.eventsFireStub, this.changeListenerSpy, this.workspace,
             this.clock);
       });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#5432 

### Proposed Changes
Adds an optional argument to centerOnBlock() that, if set to true, will center the workspace on the block itself, rather than the default behavior of centering on that block's stack.